### PR TITLE
[JSONSelection] Support conditional `...` fragment selections

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/README.md
+++ b/apollo-federation/src/sources/connect/json_selection/README.md
@@ -83,11 +83,18 @@ below.
 ```ebnf
 JSONSelection        ::= PathSelection | NamedSelection*
 SubSelection         ::= "{" NamedSelection* "}"
-NamedSelection       ::= NamedPathSelection | PathWithSubSelection | NamedFieldSelection | NamedGroupSelection
+NamedSelection       ::= NamedPathSelection
+                       | PathWithSubSelection
+                       | NamedFieldSelection
+                       | NamedGroupSelection
+                       | ConditionalSelection
 NamedPathSelection   ::= Alias PathSelection
 NamedFieldSelection  ::= Alias? Key SubSelection?
 NamedGroupSelection  ::= Alias SubSelection
 Alias                ::= Key ":"
+ConditionalSelection ::= "..." ConditionalTest
+ConditionalTest      ::= "if" "(" Path ")" SubSelection ConditionalElse?
+ConditionalElse      ::= "else" (ConditionalTest | SubSelection)
 Path                 ::= VarPath | KeyPath | AtPath | ExprPath
 PathSelection        ::= Path SubSelection?
 PathWithSubSelection ::= Path SubSelection
@@ -350,6 +357,37 @@ from the input JSON to match the desired output shape.
 
 In addition to renaming, `Alias` can provide names to otherwise anonymous
 structures, such as those selected by `PathSelection` or `NamedGroupSelection`.
+
+### `ConditionalSelection ::=`
+
+![ConditionalSelection](./grammar/ConditionalSelection.svg)
+
+The `...` token signifies the beginning of a `ConditionalSelection` element,
+which is a kind of named selection that may appear multiple times within any
+`SubSelection`.
+
+The `...` is always followed by a `ConditionalTest`, since unconditional spreads
+are rarely useful in this language, and can almost always be rewritten by
+unwrapping the fields and removing the `...`.
+
+### `ConditionalTest ::=`
+
+![ConditionalTest](./grammar/ConditionalTest.svg)
+
+`ConditionalTest` uses the `if` keyword followed by a parenthesized `Path` that
+should evaluate to a boolean value. The `Path` is used to determine whether the
+`SubSelection` or `ConditionalElse` should be selected.
+
+### `ConditionalElse ::=`
+
+![ConditionalElse](./grammar/ConditionalElse.svg)
+
+`ConditionalElse` is an optional trailing clause of `ConditionalTest`, which
+allows for typical `if`/`else`-style boolean control flow.
+
+Note that `ConditionalElse` may expand to an `else` keyword followed by a
+`ConditionalTest`, so the `ConditionalTest` and `ConditionalElse` rules are
+mutually recursive.
 
 ### `Path ::=`
 

--- a/apollo-federation/src/sources/connect/json_selection/grammar/ConditionalElse.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/ConditionalElse.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="283" height="81">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="46" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">else</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#ConditionalTest"
+      xlink:title="ConditionalTest">
+      <rect x="117" y="3" width="118" height="32"/>
+      <rect x="115" y="1" width="118" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="125" y="21">ConditionalTest</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#SubSelection"
+      xlink:title="SubSelection">
+      <rect x="117" y="47" width="102" height="32"/>
+      <rect x="115" y="45" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="125" y="65">SubSelection</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m46 0 h10 m20 0 h10 m118 0 h10 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v24 m158 0 v-24 m-158 24 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m102 0 h10 m0 0 h16 m23 -44 h-3"/>
+   <polygon points="273 17 281 13 281 21"/>
+   <polygon points="273 17 265 13 265 21"/>
+</svg>

--- a/apollo-federation/src/sources/connect/json_selection/grammar/ConditionalSelection.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/ConditionalSelection.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="229" height="37">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="32" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="32"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">...</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#ConditionalTest"
+      xlink:title="ConditionalTest">
+      <rect x="83" y="3" width="118" height="32"/>
+      <rect x="81" y="1" width="118" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="91" y="21">ConditionalTest</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m32 0 h10 m0 0 h10 m118 0 h10 m3 0 h-3"/>
+   <polygon points="219 17 227 13 227 21"/>
+   <polygon points="219 17 211 13 211 21"/>
+</svg>

--- a/apollo-federation/src/sources/connect/json_selection/grammar/ConditionalTest.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/ConditionalTest.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="547" height="69">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="28" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">if</text>
+   <rect x="79" y="3" width="26" height="32" rx="10"/>
+   <rect x="77"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="87" y="21">(</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#Path"
+      xlink:title="Path">
+      <rect x="125" y="3" width="48" height="32"/>
+      <rect x="123" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="133" y="21">Path</text>
+   </a>
+   <rect x="193" y="3" width="26" height="32" rx="10"/>
+   <rect x="191"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="21">)</text>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#SubSelection"
+      xlink:title="SubSelection">
+      <rect x="239" y="3" width="102" height="32"/>
+      <rect x="237" y="1" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="247" y="21">SubSelection</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#ConditionalElse"
+      xlink:title="ConditionalElse">
+      <rect x="381" y="35" width="118" height="32"/>
+      <rect x="379" y="33" width="118" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="389" y="53">ConditionalElse</text>
+   </a>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m28 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m23 -32 h-3"/>
+   <polygon points="537 17 545 13 545 21"/>
+   <polygon points="537 17 529 13 529 21"/>
+</svg>

--- a/apollo-federation/src/sources/connect/json_selection/grammar/NamedSelection.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/NamedSelection.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="259" height="169">
+<svg xmlns="http://www.w3.org/2000/svg" width="259" height="213">
    <defs>
       <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -59,8 +59,15 @@
       <rect x="49" y="133" width="160" height="32" class="nonterminal"/>
       <text class="nonterminal" x="59" y="153">NamedGroupSelection</text>
    </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#ConditionalSelection"
+      xlink:title="ConditionalSelection">
+      <rect x="51" y="179" width="150" height="32"/>
+      <rect x="49" y="177" width="150" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="197">ConditionalSelection</text>
+   </a>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m152 0 h10 m0 0 h8 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m160 0 h10 m-190 -10 v20 m200 0 v-20 m-200 20 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m152 0 h10 m0 0 h8 m-190 -10 v20 m200 0 v-20 m-200 20 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m160 0 h10 m23 -132 h-3"/>
+         d="m17 17 h2 m20 0 h10 m152 0 h10 m0 0 h8 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m160 0 h10 m-190 -10 v20 m200 0 v-20 m-200 20 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m152 0 h10 m0 0 h8 m-190 -10 v20 m200 0 v-20 m-200 20 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m160 0 h10 m-190 -10 v20 m200 0 v-20 m-200 20 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m150 0 h10 m0 0 h10 m23 -176 h-3"/>
    <polygon points="249 17 257 13 257 21"/>
    <polygon points="249 17 241 13 241 21"/>
 </svg>

--- a/apollo-federation/src/sources/connect/json_selection/helpers.rs
+++ b/apollo-federation/src/sources/connect/json_selection/helpers.rs
@@ -1,10 +1,10 @@
 use nom::character::complete::multispace0;
-use nom::IResult;
 use nom::Slice;
 use serde_json_bytes::Value as JSON;
 
 use super::location::Span;
 use super::location::WithRange;
+use super::ParseResult;
 
 // This macro is handy for tests, but it absolutely should never be used with
 // dynamic input at runtime, since it panics if the selection string fails to
@@ -26,7 +26,7 @@ macro_rules! selection {
 
 // Consumes any amount of whitespace and/or comments starting with # until the
 // end of the line.
-pub(crate) fn spaces_or_comments(input: Span) -> IResult<Span, WithRange<&str>> {
+pub(crate) fn spaces_or_comments(input: Span) -> ParseResult<WithRange<&str>> {
     let mut suffix = input;
     loop {
         let mut made_progress = false;
@@ -87,11 +87,12 @@ pub(crate) fn vec_push<T>(mut vec: Vec<T>, item: T) -> Vec<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sources::connect::json_selection::location::new_span;
 
     #[test]
     fn test_spaces_or_comments() {
         fn check(input: &str, (exp_remainder, exp_spaces): (&str, &str)) {
-            match spaces_or_comments(Span::new(input)) {
+            match spaces_or_comments(new_span(input)) {
                 Ok((remainder, parsed)) => {
                     assert_eq!(*remainder.fragment(), exp_remainder);
                     assert_eq!(*parsed.as_ref(), exp_spaces);

--- a/apollo-federation/src/sources/connect/json_selection/location.rs
+++ b/apollo-federation/src/sources/connect/json_selection/location.rs
@@ -183,6 +183,30 @@ pub(crate) mod strip_ranges {
                     Self::Path(stripped_alias, path.strip_ranges())
                 }
                 Self::Group(alias, sub) => Self::Group(alias.strip_ranges(), sub.strip_ranges()),
+                Self::Spread(spread) => Self::Spread(WithRange::new(spread.strip_ranges(), None)),
+            }
+        }
+    }
+
+    impl StripRanges for ConditionalTest {
+        fn strip_ranges(&self) -> Self {
+            Self {
+                test: self.test.strip_ranges(),
+                when_true: self.when_true.strip_ranges(),
+                when_else: self
+                    .when_else
+                    .as_ref()
+                    .map(|w| WithRange::new(w.strip_ranges(), None)),
+                range: None,
+            }
+        }
+    }
+
+    impl StripRanges for ConditionalElse {
+        fn strip_ranges(&self) -> Self {
+            match self {
+                Self::Else(sub) => Self::Else(sub.strip_ranges()),
+                Self::ElseIf(test) => Self::ElseIf(test.strip_ranges()),
             }
         }
     }

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -8,6 +8,7 @@ use nom::combinator::all_consuming;
 use nom::combinator::map;
 use nom::combinator::opt;
 use nom::combinator::recognize;
+use nom::error::ParseError;
 use nom::multi::many0;
 use nom::sequence::pair;
 use nom::sequence::preceded;
@@ -21,11 +22,52 @@ use super::helpers::spaces_or_comments;
 use super::known_var::KnownVariable;
 use super::lit_expr::LitExpr;
 use super::location::merge_ranges;
+use super::location::new_span;
 use super::location::ranged_span;
 use super::location::OffsetRange;
 use super::location::Ranged;
 use super::location::Span;
 use super::location::WithRange;
+
+// ParseResult is the internal type returned by most ::parse methods, as it is
+// convenient to use with nom's combinators. The top-level JSONSelection::parse
+// method returns a slightly different IResult type that hides implementation
+// details of the nom-specific types.
+//
+// TODO Consider switching the third IResult type parameter to VerboseError
+// here, if error messages can be improved with additional context.
+pub(super) type ParseResult<'a, T> = IResult<Span<'a>, T>;
+
+// Generates a non-fatal error with the given suffix and message, allowing the
+// parser to recover and continue.
+pub(super) fn nom_error_message<'a>(
+    suffix: Span<'a>,
+    // This message type forbids computing error messages with format!, which
+    // might be worthwhile in the future. For now, it's convenient to avoid
+    // String messages so the Span type can remain Copy, so we don't have to
+    // clone spans frequently in the parsing code. In most cases, the suffix
+    // provides the dynamic context needed to interpret the static message.
+    message: &'static str,
+) -> nom::Err<nom::error::Error<Span<'a>>> {
+    nom::Err::Error(nom::error::Error::from_error_kind(
+        suffix.map_extra(|_| Some(message)),
+        nom::error::ErrorKind::IsNot,
+    ))
+}
+
+// Generates a fatal error with the given suffix Span and message, causing the
+// parser to abort with the given error message, which is useful after
+// recognizing syntax that completely constrains what follows (like the -> token
+// before a method name), and what follows does not parse as required.
+pub(super) fn nom_fail_message<'a>(
+    suffix: Span<'a>,
+    message: &'static str,
+) -> nom::Err<nom::error::Error<Span<'a>>> {
+    nom::Err::Failure(nom::error::Error::from_error_kind(
+        suffix.map_extra(|_| Some(message)),
+        nom::error::ErrorKind::IsNot,
+    ))
+}
 
 pub(crate) trait ExternalVarPaths {
     fn external_var_paths(&self) -> Vec<&PathSelection>;
@@ -43,6 +85,40 @@ pub enum JSONSelection {
     Path(PathSelection),
 }
 
+// To keep JSONSelection::parse consumers from depending on details of the nom
+// error types, JSONSelection::parse reports this custom error type. Other
+// ::parse methods still internally report nom::error::Error for the most part.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct JSONSelectionParseError {
+    // The message will be a meaningful error message in many cases, but may
+    // fall back to a formatted nom::error::ErrorKind in some cases, e.g. when
+    // an alt(...) runs out of options and we can't determine which underlying
+    // error was "most" responsible.
+    pub message: String,
+
+    // Since we are not exposing the nom_locate-specific Span type, we report
+    // span.fragment() and span.location_offset() here.
+    pub fragment: String,
+
+    // While it might be nice to report a range rather than just an offset, not
+    // all parsing errors have an unambiguous end offset, so the best we can do
+    // is point to the suffix of the input that failed to parse (which
+    // corresponds to where the fragment starts).
+    pub offset: usize,
+}
+
+impl std::error::Error for JSONSelectionParseError {}
+
+impl Display for JSONSelectionParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} at offset {}: {}",
+            self.message, self.offset, self.fragment
+        )
+    }
+}
+
 impl JSONSelection {
     pub fn empty() -> Self {
         JSONSelection::Named(SubSelection {
@@ -58,9 +134,43 @@ impl JSONSelection {
         }
     }
 
-    pub fn parse(input: &str) -> IResult<&str, Self> {
-        let input_span = Span::new(input);
+    // JSONSelection::parse is possibly the "most public" method in the entire
+    // file, so it's important that the method signature can remain stable even
+    // if we drastically change implementation details. That's why we use &str
+    // as the input type and a custom JSONSelectionParseError type as the error
+    // type, rather than using Span or nom::error::Error directly.
+    pub fn parse(input: &str) -> IResult<&str, Self, JSONSelectionParseError> {
+        match JSONSelection::parse_span(new_span(input)) {
+            Ok((remainder, selection)) => {
+                // To avoid exposing the implementation details of nom_locate's
+                // LocatedSpan, we report the remainder as a &str instead.
+                Ok((remainder.fragment(), selection))
+            }
 
+            Err(e) => match e {
+                nom::Err::Error(e) | nom::Err::Failure(e) => {
+                    // If a non-fatal nom::Err::Error bubbles all the way up
+                    // here, then it becomes a fatal nom::Err::Failure.
+                    Err(nom::Err::Failure(JSONSelectionParseError {
+                        message: if let Some(message_str) = e.input.extra {
+                            message_str.to_string()
+                        } else {
+                            // These errors aren't the most user-friendly, but
+                            // with any luck we can gradually replace them with
+                            // custom error messages over time.
+                            format!("nom::error::ErrorKind::{:?}", e.code)
+                        },
+                        fragment: e.input.fragment().to_string(),
+                        offset: e.input.location_offset(),
+                    }))
+                }
+
+                nom::Err::Incomplete(_) => unreachable!("nom::Err::Incomplete not expected here"),
+            },
+        }
+    }
+
+    fn parse_span(input: Span) -> ParseResult<Self> {
         match alt((
             all_consuming(terminated(
                 map(PathSelection::parse, Self::Path),
@@ -80,22 +190,24 @@ impl JSONSelection {
                 // input, which is caught by the first all_consuming above.
                 spaces_or_comments,
             )),
-        ))(input_span)
+        ))(input)
         {
             Ok((remainder, selection)) => {
                 if remainder.fragment().is_empty() {
-                    Ok(("", selection))
+                    Ok((remainder, selection))
                 } else {
-                    Err(nom::Err::Error(nom::error::Error::new(
-                        *input_span.fragment(),
-                        nom::error::ErrorKind::IsNot,
-                    )))
+                    Err(nom_fail_message(
+                        // Usually our nom errors report the original input that
+                        // failed to parse, but that's not helpful here, since
+                        // input corresponds to the entire string, whereas this
+                        // error message is reporting junk at the end of the
+                        // string that should not be there.
+                        remainder,
+                        "Unexpected trailing characters",
+                    ))
                 }
             }
-            Err(_) => Err(nom::Err::Error(nom::error::Error::new(
-                input,
-                nom::error::ErrorKind::IsNot,
-            ))),
+            Err(e) => Err(e),
         }
     }
 
@@ -169,7 +281,7 @@ impl Ranged<NamedSelection> for NamedSelection {
 }
 
 impl NamedSelection {
-    pub(crate) fn parse(input: Span) -> IResult<Span, Self> {
+    pub(crate) fn parse(input: Span) -> ParseResult<Self> {
         alt((
             // We must try parsing NamedPathSelection before NamedFieldSelection
             // and NamedQuotedSelection because a NamedPathSelection without a
@@ -185,7 +297,7 @@ impl NamedSelection {
         ))(input)
     }
 
-    fn parse_field(input: Span) -> IResult<Span, Self> {
+    fn parse_field(input: Span) -> ParseResult<Self> {
         tuple((
             opt(Alias::parse),
             Key::parse,
@@ -198,21 +310,21 @@ impl NamedSelection {
     }
 
     // Parses either NamedPathSelection or PathWithSubSelection.
-    fn parse_path(input: Span) -> IResult<Span, Self> {
+    fn parse_path(input: Span) -> ParseResult<Self> {
         let (remainder, (alias_opt, path)) =
             tuple((opt(Alias::parse), PathSelection::parse))(input)?;
 
         if alias_opt.is_none() && !path.has_subselection() {
-            Err(nom::Err::Error(nom::error::Error::new(
+            Err(nom_fail_message(
                 input,
-                nom::error::ErrorKind::IsNot,
-            )))
+                "Named path selection must either begin with alias or end with subselection",
+            ))
         } else {
             Ok((remainder, Self::Path(alias_opt, path)))
         }
     }
 
-    fn parse_group(input: Span) -> IResult<Span, Self> {
+    fn parse_group(input: Span) -> ParseResult<Self> {
         tuple((Alias::parse, SubSelection::parse))(input)
             .map(|(input, (alias, group))| (input, Self::Group(alias, group)))
     }
@@ -309,7 +421,7 @@ impl Ranged<PathSelection> for PathSelection {
 }
 
 impl PathSelection {
-    pub fn parse(input: Span) -> IResult<Span, Self> {
+    pub fn parse(input: Span) -> ParseResult<Self> {
         PathList::parse(input).map(|(input, path)| (input, Self { path }))
     }
 
@@ -409,10 +521,19 @@ pub(super) enum PathList {
 }
 
 impl PathList {
-    pub(crate) fn parse(input: Span) -> IResult<Span, WithRange<Self>> {
+    pub(super) fn parse(input: Span) -> ParseResult<WithRange<Self>> {
         match Self::parse_with_depth(input, 0) {
-            Ok((remainder, parsed)) if matches!(*parsed, Self::Empty) => Err(nom::Err::Error(
-                nom::error::Error::new(remainder, nom::error::ErrorKind::IsNot),
+            Ok((_, parsed)) if matches!(*parsed, Self::Empty) => Err(nom_error_message(
+                input,
+                // As a small technical note, you could consider
+                // NamedGroupSelection (an Alias followed by a SubSelection) as
+                // a kind of NamedPathSelection where the path is empty, but
+                // it's still useful to distinguish groups in the grammar so we
+                // can forbid empty paths in general. In fact, when parsing a
+                // NamedGroupSelection, this error message is likely to be the
+                // reason we abandon parsing NamedPathSelection and correctly
+                // fall back to NamedGroupSelection.
+                "Path selection cannot be empty",
             )),
             otherwise => otherwise,
         }
@@ -423,7 +544,7 @@ impl PathList {
         WithRange::new(self, None)
     }
 
-    fn parse_with_depth(input: Span, depth: usize) -> IResult<Span, WithRange<Self>> {
+    fn parse_with_depth(input: Span, depth: usize) -> ParseResult<WithRange<Self>> {
         // If the input is empty (i.e. this method will end up returning
         // PathList::Empty), we want the OffsetRange to be an empty range at the
         // end of the previously parsed PathList elements, not separated from
@@ -477,12 +598,20 @@ impl PathList {
                             WithRange::new(Self::Var(ranged_known_var, rest), full_range),
                         ))
                     } else {
-                        // Reject unknown variables at parse time.
-                        // TODO Improve these parse error messages.
-                        Err(nom::Err::Error(nom::error::Error::new(
+                        Err(nom_fail_message(
                             input,
-                            nom::error::ErrorKind::IsNot,
-                        )))
+                            // Here's an error where we might like to use
+                            // format! to include the full_name of the unknown
+                            // variable in the error message, but that means
+                            // we'd have to store the message as an owned
+                            // String, which would make Span no longer Copy,
+                            // which leads to more cloning of Spans in the
+                            // parser code. For now, the input Span reported
+                            // with the error will begin with the unknown
+                            // variable name, which should be enough to
+                            // interpret this static message.
+                            "Unknown variable",
+                        ))
                     }
                 } else {
                     let ranged_dollar_var =
@@ -509,8 +638,16 @@ impl PathList {
             if let Ok((suffix, key)) = Key::parse(input) {
                 let (remainder, rest) = Self::parse_with_depth(suffix, depth + 1)?;
                 return match rest.as_ref() {
-                    Self::Empty | Self::Selection(_) => Err(nom::Err::Error(
-                        nom::error::Error::new(remainder, nom::error::ErrorKind::IsNot),
+                    // We use nom_error_message rather than nom_fail_message
+                    // here because the key might actually be a field selection,
+                    // which means we want to unwind parsing the path and fall
+                    // back to parsing other kinds of NamedSelection.
+                    Self::Empty | Self::Selection(_) => Err(nom_error_message(
+                        input,
+                        // Another place where format! might be useful to
+                        // suggest .{key}, which would require storing error
+                        // messages as owned Strings.
+                        "Single-key path must be prefixed with $. to avoid ambiguity with field name",
                     )),
                     _ => {
                         let full_range = merge_ranges(key.range(), rest.range());
@@ -523,19 +660,26 @@ impl PathList {
         if depth == 0 {
             // If the PathSelection does not start with a $var (or $ or @), a
             // key., or $(expr), it is not a valid PathSelection.
-            //
-            // TODO When we improve these parse error messages, we may want to
-            // detect the .key case and suggest using $.key instead.
-            return Err(nom::Err::Error(nom::error::Error::new(
+            if tuple((ranged_span("."), Key::parse))(input).is_ok() {
+                // Since we previously allowed starting key paths with .key but
+                // now forbid that syntax (because it can be ambiguous), suggest
+                // the unambiguous $.key syntax instead.
+                return Err(nom_fail_message(
+                    input,
+                    "Key paths cannot start with just .key (use $.key instead)",
+                ));
+            }
+            // This error technically covers the case above, but doesn't suggest
+            // a helpful solution.
+            return Err(nom_error_message(
                 input,
-                nom::error::ErrorKind::IsNot,
-            )));
+                "Path selection must start with key., $variable, $, @, or $(expression)",
+            ));
         }
 
         // In previous versions of this code, a .key could appear at depth 0 (at
         // the beginning of a path), which was useful to disambiguate a KeyPath
-        // consisting of a single key from a field selection (though this case
-        // was never explicitly allowed by the formal grammar in the README.md).
+        // consisting of a single key from a field selection.
         //
         // Now that key paths can appear alongside/after named selections within
         // a SubSelection, the .key syntax is potentially unsafe because it may
@@ -544,32 +688,45 @@ impl PathList {
         //
         // In order to prevent this ambiguity, we now require that a single .key
         // be written as a subproperty of the $ variable, e.g. $.key, which is
-        // equivalent to the old behavior without any parsing ambiguities. In
-        // terms of this code, that means we allow a .key only at depths > 0.
-        if let Ok((suffix, (dot, _, key))) =
-            tuple((ranged_span("."), spaces_or_comments, Key::parse))(input)
-        {
-            let (remainder, rest) = Self::parse_with_depth(suffix, depth + 1)?;
-            let dot_key_range = merge_ranges(dot.range(), key.range());
-            let full_range = merge_ranges(dot_key_range, rest.range());
-            return Ok((remainder, WithRange::new(Self::Key(key, rest), full_range)));
+        // equivalent to the old behavior, but parses unambiguously. In terms of
+        // this code, that means we allow a .key only at depths > 0.
+        if let Ok((suffix, dot)) = ranged_span(".")(input) {
+            // As soon as we see a leading ., we know what follows must be a
+            // Key, so we can unconditionally return based on what Key::parse
+            // tells us. Note: Key::parse consumes any spaces/comments between
+            // the . and the key.
+            return match Key::parse(suffix) {
+                Ok((remainder, key)) => {
+                    let (remainder, rest) = Self::parse_with_depth(remainder, depth + 1)?;
+                    let dot_key_range = merge_ranges(dot.range(), key.range());
+                    let full_range = merge_ranges(dot_key_range, rest.range());
+                    Ok((remainder, WithRange::new(Self::Key(key, rest), full_range)))
+                }
+                Err(_) => Err(nom_fail_message(
+                    input,
+                    "Path selection . must be followed by key (identifier or quoted string literal)",
+                )),
+            };
         }
 
         // PathSelection can never start with a naked ->method (instead, use
         // $->method or @->method if you want to operate on the current value).
-        if let Ok((suffix, (arrow, _, method, args))) = tuple((
-            ranged_span("->"),
-            spaces_or_comments,
-            parse_identifier,
-            opt(MethodArgs::parse),
-        ))(input)
-        {
-            let (remainder, rest) = Self::parse_with_depth(suffix, depth + 1)?;
-            let full_range = merge_ranges(arrow.range(), rest.range());
-            return Ok((
-                remainder,
-                WithRange::new(Self::Method(method, args, rest), full_range),
-            ));
+        if let Ok((suffix, arrow)) = ranged_span("->")(input) {
+            // As soon as we see a -> token, we know what follows must be a
+            // method name, so we can unconditionally return based on what
+            // parse_identifier tells us. since MethodArgs::parse is optional,
+            // the absence of args will never trigger the error case.
+            return match tuple((parse_identifier, opt(MethodArgs::parse)))(suffix) {
+                Ok((suffix, (method, args))) => {
+                    let (remainder, rest) = Self::parse_with_depth(suffix, depth + 1)?;
+                    let full_range = merge_ranges(arrow.range(), rest.range());
+                    Ok((
+                        remainder,
+                        WithRange::new(Self::Method(method, args, rest), full_range),
+                    ))
+                }
+                Err(_) => Err(nom_fail_message(input, "Method name must follow ->")),
+            };
         }
 
         // Likewise, if the PathSelection has a SubSelection, it must appear at
@@ -699,7 +856,7 @@ impl Ranged<SubSelection> for SubSelection {
 }
 
 impl SubSelection {
-    pub(crate) fn parse(input: Span) -> IResult<Span, Self> {
+    pub(crate) fn parse(input: Span) -> ParseResult<Self> {
         tuple((
             spaces_or_comments,
             ranged_span("{"),
@@ -719,7 +876,7 @@ impl SubSelection {
         })
     }
 
-    fn parse_naked(input: Span) -> IResult<Span, Self> {
+    fn parse_naked(input: Span) -> ParseResult<Self> {
         preceded(spaces_or_comments, many0(NamedSelection::parse))(input).map(
             |(remainder, selections)| {
                 let range = merge_ranges(
@@ -816,7 +973,7 @@ impl Alias {
         }
     }
 
-    fn parse(input: Span) -> IResult<Span, Self> {
+    fn parse(input: Span) -> ParseResult<Self> {
         tuple((Key::parse, spaces_or_comments, ranged_span(":")))(input).map(
             |(input, (name, _, colon))| {
                 let range = merge_ranges(name.range(), colon.range());
@@ -839,7 +996,7 @@ pub enum Key {
 }
 
 impl Key {
-    pub fn parse(input: Span) -> IResult<Span, WithRange<Self>> {
+    pub fn parse(input: Span) -> ParseResult<WithRange<Self>> {
         alt((
             map(parse_identifier, |id| id.take_as(Key::Field)),
             map(parse_string_literal, |s| s.take_as(Key::Quoted)),
@@ -914,11 +1071,11 @@ impl Display for Key {
 
 // Identifier ::= [a-zA-Z_] NO_SPACE [0-9a-zA-Z_]*
 
-fn parse_identifier(input: Span) -> IResult<Span, WithRange<String>> {
+fn parse_identifier(input: Span) -> ParseResult<WithRange<String>> {
     preceded(spaces_or_comments, parse_identifier_no_space)(input)
 }
 
-fn parse_identifier_no_space(input: Span) -> IResult<Span, WithRange<String>> {
+fn parse_identifier_no_space(input: Span) -> ParseResult<WithRange<String>> {
     recognize(pair(
         one_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"),
         many0(one_of(
@@ -935,7 +1092,7 @@ fn parse_identifier_no_space(input: Span) -> IResult<Span, WithRange<String>> {
 //   | "'" ("\\'" | [^'])* "'"
 //   | '"' ('\\"' | [^"])* '"'
 
-pub(crate) fn parse_string_literal(input: Span) -> IResult<Span, WithRange<String>> {
+pub(crate) fn parse_string_literal(input: Span) -> ParseResult<WithRange<String>> {
     let input = spaces_or_comments(input)?.0;
     let start = input.location_offset();
     let mut input_char_indices = input.char_indices();
@@ -944,7 +1101,7 @@ pub(crate) fn parse_string_literal(input: Span) -> IResult<Span, WithRange<Strin
         Some((0, quote @ '\'')) | Some((0, quote @ '"')) => {
             let mut escape_next = false;
             let mut chars: Vec<char> = vec![];
-            let mut remainder: Option<Span> = None;
+            let mut remainder_opt: Option<Span> = None;
 
             for (i, c) in input_char_indices {
                 if escape_next {
@@ -960,13 +1117,13 @@ pub(crate) fn parse_string_literal(input: Span) -> IResult<Span, WithRange<Strin
                     continue;
                 }
                 if c == quote {
-                    remainder = Some(input.slice(i + 1..));
+                    remainder_opt = Some(input.slice(i + 1..));
                     break;
                 }
                 chars.push(c);
             }
 
-            if let Some(remainder) = remainder {
+            if let Some(remainder) = remainder_opt {
                 Ok((
                     remainder,
                     WithRange::new(
@@ -975,17 +1132,11 @@ pub(crate) fn parse_string_literal(input: Span) -> IResult<Span, WithRange<Strin
                     ),
                 ))
             } else {
-                Err(nom::Err::Error(nom::error::Error::new(
-                    input,
-                    nom::error::ErrorKind::Eof,
-                )))
+                Err(nom_fail_message(input, "Unterminated string literal"))
             }
         }
 
-        _ => Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::IsNot,
-        ))),
+        _ => Err(nom_error_message(input, "Not a string literal")),
     }
 }
 
@@ -1006,7 +1157,7 @@ impl Ranged<MethodArgs> for MethodArgs {
 // the PathSelection::Method will be None, so we can safely define MethodArgs
 // using a Vec<LitExpr> in all cases (possibly empty but never missing).
 impl MethodArgs {
-    fn parse(input: Span) -> IResult<Span, Self> {
+    fn parse(input: Span) -> ParseResult<Self> {
         tuple((
             spaces_or_comments,
             ranged_span("("),
@@ -1051,11 +1202,12 @@ mod tests {
     use super::*;
     use crate::selection;
     use crate::sources::connect::json_selection::helpers::span_is_all_spaces_or_comments;
+    use crate::sources::connect::json_selection::location::new_span;
 
     #[test]
     fn test_identifier() {
         fn check(input: &str, expected_name: &str) {
-            let (remainder, name) = parse_identifier(Span::new(input)).unwrap();
+            let (remainder, name) = parse_identifier(new_span(input)).unwrap();
             assert!(span_is_all_spaces_or_comments(remainder));
             assert_eq!(name.as_ref(), expected_name);
         }
@@ -1067,26 +1219,32 @@ mod tests {
         check(" hello ", "hello");
 
         fn check_no_space(input: &str, expected_name: &str) {
-            let name = parse_identifier_no_space(Span::new(input)).unwrap().1;
+            let name = parse_identifier_no_space(new_span(input)).unwrap().1;
             assert_eq!(name.as_ref(), expected_name);
         }
 
         check_no_space("oyez", "oyez");
         check_no_space("oyez   ", "oyez");
 
-        assert_eq!(
-            parse_identifier_no_space(Span::new("  oyez   ")),
-            Err(nom::Err::Error(nom::error::Error::new(
-                Span::new("  oyez   "),
-                nom::error::ErrorKind::OneOf
-            ))),
-        );
+        {
+            let identifier_with_leading_space = new_span("  oyez   ");
+            assert_eq!(
+                parse_identifier_no_space(identifier_with_leading_space),
+                Err(nom::Err::Error(nom::error::Error::from_error_kind(
+                    // The parse_identifier_no_space function does not provide a
+                    // custom error message, since it's only used internally.
+                    // Testing it directly here is somewhat contrived.
+                    identifier_with_leading_space,
+                    nom::error::ErrorKind::OneOf,
+                ))),
+            );
+        }
     }
 
     #[test]
     fn test_string_literal() {
         fn check(input: &str, expected: &str) {
-            let (remainder, lit) = parse_string_literal(Span::new(input)).unwrap();
+            let (remainder, lit) = parse_string_literal(new_span(input)).unwrap();
             assert!(span_is_all_spaces_or_comments(remainder));
             assert_eq!(lit.as_ref(), expected);
         }
@@ -1100,7 +1258,7 @@ mod tests {
     #[test]
     fn test_key() {
         fn check(input: &str, expected: &Key) {
-            let (remainder, key) = Key::parse(Span::new(input)).unwrap();
+            let (remainder, key) = Key::parse(new_span(input)).unwrap();
             assert!(span_is_all_spaces_or_comments(remainder));
             assert_eq!(key.as_ref(), expected);
         }
@@ -1115,7 +1273,7 @@ mod tests {
     #[test]
     fn test_alias() {
         fn check(input: &str, alias: &str) {
-            let (remainder, parsed) = Alias::parse(Span::new(input)).unwrap();
+            let (remainder, parsed) = Alias::parse(new_span(input)).unwrap();
             assert!(span_is_all_spaces_or_comments(remainder));
             assert_eq!(parsed.name(), alias);
         }
@@ -1130,7 +1288,7 @@ mod tests {
     #[test]
     fn test_named_selection() {
         fn assert_result_and_names(input: &str, expected: NamedSelection, names: &[&str]) {
-            let (remainder, selection) = NamedSelection::parse(Span::new(input)).unwrap();
+            let (remainder, selection) = NamedSelection::parse(new_span(input)).unwrap();
             assert!(span_is_all_spaces_or_comments(remainder));
             let selection = selection.strip_ranges();
             assert_eq!(selection, expected);
@@ -1453,7 +1611,7 @@ mod tests {
 
     #[track_caller]
     fn check_path_selection(input: &str, expected: PathSelection) {
-        let (remainder, path_selection) = PathSelection::parse(Span::new(input)).unwrap();
+        let (remainder, path_selection) = PathSelection::parse(new_span(input)).unwrap();
         assert!(span_is_all_spaces_or_comments(remainder));
         assert_eq!(&path_selection.strip_ranges(), &expected);
         assert_eq!(
@@ -1908,38 +2066,66 @@ mod tests {
             },
         );
 
-        {
-            let input = Span::new("naked");
-            assert_eq!(
-                PathSelection::parse(input),
-                Err(nom::Err::Error(nom::error::Error::new(
-                    input.slice(5..),
-                    nom::error::ErrorKind::IsNot,
-                ))),
-            );
+        #[track_caller]
+        fn check_path_parse_error(input: &str, expected_offset: usize, expected_message: &str) {
+            match PathSelection::parse(new_span(input)) {
+                Ok((remainder, path)) => {
+                    panic!(
+                        "Expected error at offset {} with message '{}', but got path {:?} and remainder {:?}",
+                        expected_offset,
+                        expected_message,
+                        path,
+                        remainder,
+                    );
+                }
+                Err(nom::Err::Error(e) | nom::Err::Failure(e)) => {
+                    assert_eq!(&input[expected_offset..], *e.input.fragment());
+                    // The PartialEq implementation for LocatedSpan
+                    // unfortunately ignores span.extra, so we have to check
+                    // e.input.extra manually.
+                    assert_eq!(e.input.extra, Some(expected_message));
+                }
+                Err(e) => {
+                    panic!("Unexpected error {:?}", e);
+                }
+            }
         }
 
-        {
-            let input = Span::new("naked { hi }");
-            assert_eq!(
-                PathSelection::parse(input),
-                Err(nom::Err::Error(nom::error::Error::new(
-                    input.slice(12..),
-                    nom::error::ErrorKind::IsNot,
-                ))),
-            );
-        }
+        let single_key_path_error_message =
+            "Single-key path must be prefixed with $. to avoid ambiguity with field name";
+        check_path_parse_error(
+            new_span("naked").fragment(),
+            0,
+            single_key_path_error_message,
+        );
+        check_path_parse_error(
+            new_span("naked { hi }").fragment(),
+            0,
+            single_key_path_error_message,
+        );
+        check_path_parse_error(
+            new_span("  naked { hi }").fragment(),
+            2,
+            single_key_path_error_message,
+        );
 
-        {
-            let input = Span::new("valid.$invalid");
-            assert_eq!(
-                PathSelection::parse(input),
-                Err(nom::Err::Error(nom::error::Error::new(
-                    input.slice(5..),
-                    nom::error::ErrorKind::IsNot,
-                ))),
-            );
-        }
+        let path_key_ambiguity_error_message =
+            "Path selection . must be followed by key (identifier or quoted string literal)";
+        check_path_parse_error(
+            new_span("valid.$invalid").fragment(),
+            5,
+            path_key_ambiguity_error_message,
+        );
+        check_path_parse_error(
+            new_span("  valid.$invalid").fragment(),
+            7,
+            path_key_ambiguity_error_message,
+        );
+        check_path_parse_error(
+            new_span("  valid . $invalid").fragment(),
+            8,
+            path_key_ambiguity_error_message,
+        );
 
         assert_eq!(
             selection!("$").strip_ranges(),
@@ -2031,6 +2217,23 @@ mod tests {
                 ..Default::default()
             }),
         );
+    }
+
+    #[test]
+    fn test_error_snapshots() {
+        // The .data shorthand is no longer allowed, since it can be mistakenly
+        // parsed as a continuation of a previous selection. Instead, use $.data
+        // to achieve the same effect without ambiguity.
+        assert_debug_snapshot!(JSONSelection::parse(".data"));
+
+        // We statically verify that all variables are KnownVariables, and
+        // $bogus is not one of them.
+        assert_debug_snapshot!(JSONSelection::parse("$bogus"));
+
+        // If you want to mix a path selection with other named selections, the
+        // path selection must have a trailing subselection, to enforce that it
+        // returns an object with statically known keys.
+        assert_debug_snapshot!(JSONSelection::parse("id $.object"));
     }
 
     #[test]
@@ -2455,7 +2658,7 @@ mod tests {
     #[test]
     fn test_subselection() {
         fn check_parsed(input: &str, expected: SubSelection) {
-            let (remainder, parsed) = SubSelection::parse(Span::new(input)).unwrap();
+            let (remainder, parsed) = SubSelection::parse(new_span(input)).unwrap();
             assert!(span_is_all_spaces_or_comments(remainder));
             assert_eq!(parsed.strip_ranges(), expected);
         }
@@ -2538,7 +2741,7 @@ mod tests {
     #[test]
     fn test_external_var_paths() {
         fn parse(input: &str) -> PathSelection {
-            PathSelection::parse(Span::new(input))
+            PathSelection::parse(new_span(input))
                 .unwrap()
                 .1
                 .strip_ranges()

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -300,7 +300,7 @@ impl PrettyPrintable for NamedSelection {
 
 #[cfg(test)]
 mod tests {
-    use super::super::location::Span;
+    use crate::sources::connect::json_selection::location::new_span;
     use crate::sources::connect::json_selection::pretty::indent_chars;
     use crate::sources::connect::json_selection::NamedSelection;
     use crate::sources::connect::json_selection::PrettyPrintable;
@@ -354,7 +354,7 @@ mod tests {
             "cool: {\n  a\n  b\n}",
         ];
         for selection in selections {
-            let (unmatched, named_selection) = NamedSelection::parse(Span::new(selection)).unwrap();
+            let (unmatched, named_selection) = NamedSelection::parse(new_span(selection)).unwrap();
             assert!(
                 unmatched.is_empty(),
                 "static named selection was not fully parsed: '{selection}' ({named_selection:?}) had unmatched '{unmatched}'"
@@ -384,7 +384,7 @@ mod tests {
             "$($args.unnecessary.parens)->eq(42)",
         ];
         for path in paths {
-            let (unmatched, path_selection) = PathSelection::parse(Span::new(path)).unwrap();
+            let (unmatched, path_selection) = PathSelection::parse(new_span(path)).unwrap();
             assert!(
                 unmatched.is_empty(),
                 "static path was not fully parsed: '{path}' ({path_selection:?}) had unmatched '{unmatched}'"
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn it_prints_a_sub_selection() {
         let sub = "{\n  a\n  b\n}";
-        let (unmatched, sub_selection) = SubSelection::parse(Span::new(sub)).unwrap();
+        let (unmatched, sub_selection) = SubSelection::parse(new_span(sub)).unwrap();
         assert!(
             unmatched.is_empty(),
             "static path was not fully parsed: '{sub}' ({sub_selection:?}) had unmatched '{unmatched}'"
@@ -418,7 +418,7 @@ mod tests {
         let sub_indented = "{\n  a {\n    b {\n      c\n    }\n  }\n}";
         let sub_super_indented = "        {\n          a {\n            b {\n              c\n            }\n          }\n        }";
 
-        let (unmatched, sub_selection) = SubSelection::parse(Span::new(sub)).unwrap();
+        let (unmatched, sub_selection) = SubSelection::parse(new_span(sub)).unwrap();
 
         assert!(
             unmatched.is_empty(),

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -8,6 +8,8 @@
 use itertools::Itertools;
 
 use super::lit_expr::LitExpr;
+use super::ConditionalElse;
+use super::ConditionalTest;
 use crate::sources::connect::json_selection::JSONSelection;
 use crate::sources::connect::json_selection::MethodArgs;
 use crate::sources::connect::json_selection::NamedSelection;
@@ -292,7 +294,57 @@ impl PrettyPrintable for NamedSelection {
                 let sub = sub.pretty_print_with_indentation(true, indentation);
                 result.push_str(sub.as_str());
             }
+            Self::Spread(test) => {
+                let test = test.pretty_print_with_indentation(inline, indentation);
+                result.push_str("... ");
+                result.push_str(test.as_str());
+            }
         };
+
+        result
+    }
+}
+
+impl PrettyPrintable for ConditionalTest {
+    fn pretty_print_with_indentation(&self, inline: bool, indentation: usize) -> String {
+        let mut result = String::new();
+
+        if !inline {
+            result.push_str(indent_chars(indentation).as_str());
+        }
+
+        result.push_str("if (");
+        let test = self.test.pretty_print_with_indentation(inline, indentation);
+        result.push_str(test.as_str());
+        result.push_str(") ");
+
+        let when_true = self
+            .when_true
+            .pretty_print_with_indentation(inline, indentation);
+        result.push_str(when_true.as_str());
+
+        if let Some(when_else) = &self.when_else {
+            result.push_str(" else ");
+            let when_else = when_else.pretty_print_with_indentation(inline, indentation);
+            result.push_str(when_else.as_str());
+        }
+
+        result
+    }
+}
+
+impl PrettyPrintable for ConditionalElse {
+    fn pretty_print_with_indentation(&self, inline: bool, indentation: usize) -> String {
+        let mut result = String::new();
+
+        result.push_str("else ");
+        result.push_str(
+            match self {
+                Self::Else(sub) => sub.pretty_print_with_indentation(inline, indentation),
+                Self::ElseIf(test) => test.pretty_print_with_indentation(inline, indentation),
+            }
+            .as_str(),
+        );
 
         result
     }

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__conditional_selections-2.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__conditional_selections-2.snap
@@ -1,0 +1,161 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "selection!(r#\"\n            id\n            ... if (kind->eq(\"book\")) {\n                isbn\n                title\n                author { name }\n            }\n            \"#)"
+---
+Named(
+    SubSelection {
+        selections: [
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "id",
+                    ),
+                    range: Some(
+                        13..15,
+                    ),
+                },
+                None,
+            ),
+            Spread(
+                WithRange {
+                    node: ConditionalTest {
+                        test: WithRange {
+                            node: Path(
+                                PathSelection {
+                                    path: WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "kind",
+                                                ),
+                                                range: Some(
+                                                    36..40,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Method(
+                                                    WithRange {
+                                                        node: "eq",
+                                                        range: Some(
+                                                            42..44,
+                                                        ),
+                                                    },
+                                                    Some(
+                                                        MethodArgs {
+                                                            args: [
+                                                                WithRange {
+                                                                    node: String(
+                                                                        "book",
+                                                                    ),
+                                                                    range: Some(
+                                                                        45..51,
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            range: Some(
+                                                                44..52,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    WithRange {
+                                                        node: Empty,
+                                                        range: Some(
+                                                            52..52,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    40..52,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            36..52,
+                                        ),
+                                    },
+                                },
+                            ),
+                            range: Some(
+                                36..52,
+                            ),
+                        },
+                        when_true: SubSelection {
+                            selections: [
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "isbn",
+                                        ),
+                                        range: Some(
+                                            72..76,
+                                        ),
+                                    },
+                                    None,
+                                ),
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "title",
+                                        ),
+                                        range: Some(
+                                            93..98,
+                                        ),
+                                    },
+                                    None,
+                                ),
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "author",
+                                        ),
+                                        range: Some(
+                                            115..121,
+                                        ),
+                                    },
+                                    Some(
+                                        SubSelection {
+                                            selections: [
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "name",
+                                                        ),
+                                                        range: Some(
+                                                            124..128,
+                                                        ),
+                                                    },
+                                                    None,
+                                                ),
+                                            ],
+                                            range: Some(
+                                                122..130,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ],
+                            range: Some(
+                                54..144,
+                            ),
+                        },
+                        when_else: None,
+                        range: Some(
+                            32..144,
+                        ),
+                    },
+                    range: Some(
+                        28..144,
+                    ),
+                },
+            ),
+        ],
+        range: Some(
+            13..144,
+        ),
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__conditional_selections-3.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__conditional_selections-3.snap
@@ -1,0 +1,301 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "selection!(r#\"\n            ... if (kind->eq(\"book\")) {\n                isbn\n                title\n                author { name }\n            } else if (kind->eq(\"movie\")) {\n                title\n                director { name }\n            } else {\n                title\n            }\n            \"#)"
+---
+Named(
+    SubSelection {
+        selections: [
+            Spread(
+                WithRange {
+                    node: ConditionalTest {
+                        test: WithRange {
+                            node: Path(
+                                PathSelection {
+                                    path: WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "kind",
+                                                ),
+                                                range: Some(
+                                                    21..25,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Method(
+                                                    WithRange {
+                                                        node: "eq",
+                                                        range: Some(
+                                                            27..29,
+                                                        ),
+                                                    },
+                                                    Some(
+                                                        MethodArgs {
+                                                            args: [
+                                                                WithRange {
+                                                                    node: String(
+                                                                        "book",
+                                                                    ),
+                                                                    range: Some(
+                                                                        30..36,
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            range: Some(
+                                                                29..37,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    WithRange {
+                                                        node: Empty,
+                                                        range: Some(
+                                                            37..37,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    25..37,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            21..37,
+                                        ),
+                                    },
+                                },
+                            ),
+                            range: Some(
+                                21..37,
+                            ),
+                        },
+                        when_true: SubSelection {
+                            selections: [
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "isbn",
+                                        ),
+                                        range: Some(
+                                            57..61,
+                                        ),
+                                    },
+                                    None,
+                                ),
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "title",
+                                        ),
+                                        range: Some(
+                                            78..83,
+                                        ),
+                                    },
+                                    None,
+                                ),
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "author",
+                                        ),
+                                        range: Some(
+                                            100..106,
+                                        ),
+                                    },
+                                    Some(
+                                        SubSelection {
+                                            selections: [
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "name",
+                                                        ),
+                                                        range: Some(
+                                                            109..113,
+                                                        ),
+                                                    },
+                                                    None,
+                                                ),
+                                            ],
+                                            range: Some(
+                                                107..115,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ],
+                            range: Some(
+                                39..129,
+                            ),
+                        },
+                        when_else: Some(
+                            WithRange {
+                                node: ElseIf(
+                                    ConditionalTest {
+                                        test: WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Key(
+                                                            WithRange {
+                                                                node: Field(
+                                                                    "kind",
+                                                                ),
+                                                                range: Some(
+                                                                    139..143,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Method(
+                                                                    WithRange {
+                                                                        node: "eq",
+                                                                        range: Some(
+                                                                            145..147,
+                                                                        ),
+                                                                    },
+                                                                    Some(
+                                                                        MethodArgs {
+                                                                            args: [
+                                                                                WithRange {
+                                                                                    node: String(
+                                                                                        "movie",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        148..155,
+                                                                                    ),
+                                                                                },
+                                                                            ],
+                                                                            range: Some(
+                                                                                147..156,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            156..156,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    143..156,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            139..156,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                139..156,
+                                            ),
+                                        },
+                                        when_true: SubSelection {
+                                            selections: [
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "title",
+                                                        ),
+                                                        range: Some(
+                                                            176..181,
+                                                        ),
+                                                    },
+                                                    None,
+                                                ),
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "director",
+                                                        ),
+                                                        range: Some(
+                                                            198..206,
+                                                        ),
+                                                    },
+                                                    Some(
+                                                        SubSelection {
+                                                            selections: [
+                                                                Field(
+                                                                    None,
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "name",
+                                                                        ),
+                                                                        range: Some(
+                                                                            209..213,
+                                                                        ),
+                                                                    },
+                                                                    None,
+                                                                ),
+                                                            ],
+                                                            range: Some(
+                                                                207..215,
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                            range: Some(
+                                                158..229,
+                                            ),
+                                        },
+                                        when_else: Some(
+                                            WithRange {
+                                                node: Else(
+                                                    SubSelection {
+                                                        selections: [
+                                                            Field(
+                                                                None,
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "title",
+                                                                    ),
+                                                                    range: Some(
+                                                                        253..258,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                        ],
+                                                        range: Some(
+                                                            235..272,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    230..272,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            135..272,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    130..272,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            17..272,
+                        ),
+                    },
+                    range: Some(
+                        13..272,
+                    ),
+                },
+            ),
+        ],
+        range: Some(
+            13..272,
+        ),
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__conditional_selections-4.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__conditional_selections-4.snap
@@ -1,0 +1,325 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "selection!(r#\"\n            id\n            ... if (kind->eq(\"book\")) {\n                isbn\n                title\n                author { name }\n            } else if (kind->eq(\"movie\")) {\n                title\n                director { name }\n            } else {\n                title\n            }\n            year\n            \"#)"
+---
+Named(
+    SubSelection {
+        selections: [
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "id",
+                    ),
+                    range: Some(
+                        13..15,
+                    ),
+                },
+                None,
+            ),
+            Spread(
+                WithRange {
+                    node: ConditionalTest {
+                        test: WithRange {
+                            node: Path(
+                                PathSelection {
+                                    path: WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "kind",
+                                                ),
+                                                range: Some(
+                                                    36..40,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Method(
+                                                    WithRange {
+                                                        node: "eq",
+                                                        range: Some(
+                                                            42..44,
+                                                        ),
+                                                    },
+                                                    Some(
+                                                        MethodArgs {
+                                                            args: [
+                                                                WithRange {
+                                                                    node: String(
+                                                                        "book",
+                                                                    ),
+                                                                    range: Some(
+                                                                        45..51,
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            range: Some(
+                                                                44..52,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    WithRange {
+                                                        node: Empty,
+                                                        range: Some(
+                                                            52..52,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    40..52,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            36..52,
+                                        ),
+                                    },
+                                },
+                            ),
+                            range: Some(
+                                36..52,
+                            ),
+                        },
+                        when_true: SubSelection {
+                            selections: [
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "isbn",
+                                        ),
+                                        range: Some(
+                                            72..76,
+                                        ),
+                                    },
+                                    None,
+                                ),
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "title",
+                                        ),
+                                        range: Some(
+                                            93..98,
+                                        ),
+                                    },
+                                    None,
+                                ),
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "author",
+                                        ),
+                                        range: Some(
+                                            115..121,
+                                        ),
+                                    },
+                                    Some(
+                                        SubSelection {
+                                            selections: [
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "name",
+                                                        ),
+                                                        range: Some(
+                                                            124..128,
+                                                        ),
+                                                    },
+                                                    None,
+                                                ),
+                                            ],
+                                            range: Some(
+                                                122..130,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ],
+                            range: Some(
+                                54..144,
+                            ),
+                        },
+                        when_else: Some(
+                            WithRange {
+                                node: ElseIf(
+                                    ConditionalTest {
+                                        test: WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Key(
+                                                            WithRange {
+                                                                node: Field(
+                                                                    "kind",
+                                                                ),
+                                                                range: Some(
+                                                                    154..158,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Method(
+                                                                    WithRange {
+                                                                        node: "eq",
+                                                                        range: Some(
+                                                                            160..162,
+                                                                        ),
+                                                                    },
+                                                                    Some(
+                                                                        MethodArgs {
+                                                                            args: [
+                                                                                WithRange {
+                                                                                    node: String(
+                                                                                        "movie",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        163..170,
+                                                                                    ),
+                                                                                },
+                                                                            ],
+                                                                            range: Some(
+                                                                                162..171,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            171..171,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    158..171,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            154..171,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                154..171,
+                                            ),
+                                        },
+                                        when_true: SubSelection {
+                                            selections: [
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "title",
+                                                        ),
+                                                        range: Some(
+                                                            191..196,
+                                                        ),
+                                                    },
+                                                    None,
+                                                ),
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "director",
+                                                        ),
+                                                        range: Some(
+                                                            213..221,
+                                                        ),
+                                                    },
+                                                    Some(
+                                                        SubSelection {
+                                                            selections: [
+                                                                Field(
+                                                                    None,
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "name",
+                                                                        ),
+                                                                        range: Some(
+                                                                            224..228,
+                                                                        ),
+                                                                    },
+                                                                    None,
+                                                                ),
+                                                            ],
+                                                            range: Some(
+                                                                222..230,
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                            range: Some(
+                                                173..244,
+                                            ),
+                                        },
+                                        when_else: Some(
+                                            WithRange {
+                                                node: Else(
+                                                    SubSelection {
+                                                        selections: [
+                                                            Field(
+                                                                None,
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "title",
+                                                                    ),
+                                                                    range: Some(
+                                                                        268..273,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                        ],
+                                                        range: Some(
+                                                            250..287,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    245..287,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            150..287,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    145..287,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            32..287,
+                        ),
+                    },
+                    range: Some(
+                        28..287,
+                    ),
+                },
+            ),
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "year",
+                    ),
+                    range: Some(
+                        300..304,
+                    ),
+                },
+                None,
+            ),
+        ],
+        range: Some(
+            13..304,
+        ),
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__conditional_selections.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__conditional_selections.snap
@@ -1,0 +1,149 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "selection!(r#\"\n            ... if (kind->eq(\"book\")) {\n                isbn\n                title\n                author { name }\n            }\n            \"#)"
+---
+Named(
+    SubSelection {
+        selections: [
+            Spread(
+                WithRange {
+                    node: ConditionalTest {
+                        test: WithRange {
+                            node: Path(
+                                PathSelection {
+                                    path: WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "kind",
+                                                ),
+                                                range: Some(
+                                                    21..25,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Method(
+                                                    WithRange {
+                                                        node: "eq",
+                                                        range: Some(
+                                                            27..29,
+                                                        ),
+                                                    },
+                                                    Some(
+                                                        MethodArgs {
+                                                            args: [
+                                                                WithRange {
+                                                                    node: String(
+                                                                        "book",
+                                                                    ),
+                                                                    range: Some(
+                                                                        30..36,
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            range: Some(
+                                                                29..37,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    WithRange {
+                                                        node: Empty,
+                                                        range: Some(
+                                                            37..37,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    25..37,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            21..37,
+                                        ),
+                                    },
+                                },
+                            ),
+                            range: Some(
+                                21..37,
+                            ),
+                        },
+                        when_true: SubSelection {
+                            selections: [
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "isbn",
+                                        ),
+                                        range: Some(
+                                            57..61,
+                                        ),
+                                    },
+                                    None,
+                                ),
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "title",
+                                        ),
+                                        range: Some(
+                                            78..83,
+                                        ),
+                                    },
+                                    None,
+                                ),
+                                Field(
+                                    None,
+                                    WithRange {
+                                        node: Field(
+                                            "author",
+                                        ),
+                                        range: Some(
+                                            100..106,
+                                        ),
+                                    },
+                                    Some(
+                                        SubSelection {
+                                            selections: [
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "name",
+                                                        ),
+                                                        range: Some(
+                                                            109..113,
+                                                        ),
+                                                    },
+                                                    None,
+                                                ),
+                                            ],
+                                            range: Some(
+                                                107..115,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ],
+                            range: Some(
+                                39..129,
+                            ),
+                        },
+                        when_else: None,
+                        range: Some(
+                            17..129,
+                        ),
+                    },
+                    range: Some(
+                        13..129,
+                    ),
+                },
+            ),
+        ],
+        range: Some(
+            13..129,
+        ),
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__error_snapshots-2.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__error_snapshots-2.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "JSONSelection::parse(\"$bogus\")"
+---
+Err(
+    Failure(
+        JSONSelectionParseError {
+            message: "Unknown variable",
+            fragment: "$bogus",
+            offset: 0,
+        },
+    ),
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__error_snapshots-3.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__error_snapshots-3.snap
@@ -1,13 +1,13 @@
 ---
 source: apollo-federation/src/sources/connect/json_selection/parser.rs
-expression: "JSONSelection::parse(r#\"\n            id\n            created\n            choices->first.message\n            model\n        \"#)"
+expression: "JSONSelection::parse(\"id $.object\")"
 ---
 Err(
     Failure(
         JSONSelectionParseError {
             message: "Named path selection must either begin with alias or end with subselection",
-            fragment: "choices->first.message\n            model\n        ",
-            offset: 48,
+            fragment: "$.object",
+            offset: 3,
         },
     ),
 )

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__error_snapshots.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__error_snapshots.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "JSONSelection::parse(\".data\")"
+---
+Err(
+    Failure(
+        JSONSelectionParseError {
+            message: "Key paths cannot start with just .key (use $.key instead)",
+            fragment: ".data",
+            offset: 0,
+        },
+    ),
+)

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_syntax.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_syntax.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
 [
     Message {
         code: InvalidJsonSelection,
-        message: "`@connect(selection:)` on `Query.something` is not a valid JSONSelection: Parsing Error: Error { input: \"&how\", code: IsNot }",
+        message: "`@connect(selection:)` on `Query.something` is not a valid JSONSelection: Parsing Failure: JSONSelectionParseError { message: \"nom::error::ErrorKind::Eof\", fragment: \"&how\", offset: 0 }",
         locations: [
             8:86..8:92,
         ],


### PR DESCRIPTION
In order to handle REST endpoints that return a union of possible result types, it's often necessary to consider various discriminator fields in the response, select different fields depending on those discriminator fields, and (when working with GraphQL) specify concrete `__typename` strings to resolve abstract types. This PR introduces a new JSONSelection syntax to address these use cases.

To keep the new syntax unambiguous, a conditional fragment is always introduced by a `...` token, followed by `if (expression) { included fields }`. Unconditional fragment spreads are not currently supported with this syntax. Optionally, additional `else if` and `else` clauses may follow.

In this example, we're using the runtime value of the `kind` field to determine which conditional fragment to apply:
```graphql
id
title
... if (kind->eq("book")) {
  isbn
  author { name }
} else if (kind->eq("movie")) {
  director { name }
} else {
  kind
}
year
```

When working with GraphQL, this type discrimination syntax provides an easy place to specify concrete `__typename` strings based on the `kind` values:
```graphql
id
title
... if (kind->eq("book")) {
  __typename: $("Book")
  isbn
  author { name }
} else if (kind->eq("movie")) {
  __typename: $("Movie")
  director { name }
} else {
  __typename: $("Unknown")
  kind
}
year
```

In the future, we may want to extend this syntax to allow named fragments (to reduce repetition across `selection` strings), as in GraphQL, but that seemed too ambitious for this initial PR.