### PR TITLE
[JSONSelection] Add `->mapValues` method to `future::` namespace

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/methods.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods.rs
@@ -55,6 +55,7 @@ lazy_static! {
         public_methods.insert("match");
         // public_methods.insert("matchIf");
         // public_methods.insert("match_if");
+        // public_methods.insert("mapValues");
         // public_methods.insert("add");
         // public_methods.insert("sub");
         // public_methods.insert("mul");
@@ -114,6 +115,11 @@ lazy_static! {
         // easy, since the last pair can be [true, <default>].
         methods.insert("matchIf".to_string(), future::match_if_method);
         methods.insert("match_if".to_string(), future::match_if_method);
+
+        // Takes an object with unknown keys, binds @ to each of those keys'
+        // values, evaluates the first argument against each @ value, then
+        // produces a new object with the same keys but newly mapped values.
+        methods.insert("mapValues".to_string(), future::map_values_method);
 
         // Arithmetic methods
         methods.insert("add".to_string(), future::add_method);

--- a/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
@@ -363,6 +363,67 @@ fn test_match_methods() {
 }
 
 #[test]
+fn test_map_values_method() {
+    assert_eq!(
+        selection!("$->mapValues(@->add(10))").apply_to(&json!({
+            "a": 1,
+            "b": 2,
+            "c": 3,
+        })),
+        (
+            Some(json!({
+                "a": 11,
+                "b": 12,
+                "c": 13,
+            })),
+            vec![],
+        ),
+    );
+
+    assert_eq!(
+        selection!("$->mapValues(@->typeof)").apply_to(&json!({
+            "a": 1,
+            "b": "two",
+            "c": false,
+        })),
+        (
+            Some(json!({
+                "a": "number",
+                "b": "string",
+                "c": "boolean",
+            })),
+            vec![],
+        ),
+    );
+
+    assert_eq!(
+        selection!("$->mapValues(@->typeof)").apply_to(&json!({})),
+        (Some(json!({})), vec![]),
+    );
+
+    assert_eq!(
+        selection!("$->map(@->mapValues(@->typeof))").apply_to(&json!([])),
+        (Some(json!([])), vec![]),
+    );
+
+    assert_eq!(
+        selection!("$->map(@->mapValues(@->typeof))").apply_to(&json!([{
+            "x": 1,
+            "y": "two",
+            "z": false,
+        }])),
+        (
+            Some(json!([{
+                "x": "number",
+                "y": "string",
+                "z": "boolean",
+            }])),
+            vec![],
+        ),
+    );
+}
+
+#[test]
 fn test_arithmetic_methods() {
     assert_eq!(
         selection!("$->add(1)").apply_to(&json!(2)),


### PR DESCRIPTION
PR #6185 removed support for the following syntax for preserving dynamic keys of dictionary objects while mapping their values:
```graphql
booksByISBN: books { * { title author }}
```

As suggested in the description of PR #6185, this pattern can be replaced with a `->mapValues` method call:
```graphql
booksByISBN: books->mapValues(@ { title author })
```

This PR tentatively implements that `->mapValues` method, filing it away in the `future::` namespace to indicate it hasn't been shipped yet.