### PR TITLE
Snapshot improvements for `FetchDependencyGraph` and open branches

### DIFF
--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -591,6 +591,12 @@ pub(crate) struct SimultaneousPathsWithLazyIndirectPaths {
     pub(crate) lazily_computed_indirect_paths: Vec<Option<OpIndirectPaths>>,
 }
 
+impl Display for SimultaneousPathsWithLazyIndirectPaths {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.paths)
+    }
+}
+
 /// A "set" of excluded destinations (i.e. subgraph names). Note that we use a `Vec` instead of set
 /// because this is used in pretty hot paths (the whole path computation is CPU intensive) and will
 /// basically always be tiny (it's bounded by the number of distinct key on a given type, so usually

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3443,7 +3443,11 @@ pub(crate) fn compute_nodes_for_tree(
             }
         }
     }
-    snapshot!(dependency_graph, "updated_dependency_graph");
+    snapshot!(
+        "FetchDependencyGraph",
+        dependency_graph.to_dot(),
+        "Fetch dependency graph updated by compute_nodes_for_tree"
+    );
     Ok(created_nodes)
 }
 

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3352,11 +3352,7 @@ pub(crate) fn compute_nodes_for_tree(
     initial_defer_context: DeferContext,
     initial_conditions: &OpGraphPathContext,
 ) -> Result<IndexSet<NodeIndex>, FederationError> {
-    snapshot!(
-        "OpPathTree",
-        serde_json_bytes::json!(initial_tree.to_string()).to_string(),
-        "path_tree"
-    );
+    snapshot!("OpPathTree", initial_tree.to_string(), "path_tree");
     let mut stack = vec![ComputeNodesStackItem {
         tree: initial_tree,
         node_id: initial_node_id,

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -716,7 +716,11 @@ pub(crate) fn compute_root_fetch_groups(
             root_kind,
             root_type.clone(),
         )?;
-        snapshot!(dependency_graph, "tree_with_root_node");
+        snapshot!(
+            "FetchDependencyGraph",
+            dependency_graph.to_dot(),
+            "tree_with_root_node"
+        );
         compute_nodes_for_tree(
             dependency_graph,
             &child.tree,
@@ -739,14 +743,15 @@ fn compute_root_parallel_dependency_graph(
 ) -> Result<FetchDependencyGraph, FederationError> {
     snapshot!(
         "FetchDependencyGraph",
-        "Empty",
-        "Starting process to construct a parallel fetch dependency graph"
+        "digraph {}", // empty graph (in GraphViz Dot format)
+        "Starting process to construct a parallel fetch dependency graph (empty graph)"
     );
     let selection_set = parameters.operation.selection_set.clone();
     let best_plan = compute_root_parallel_best_plan(parameters, selection_set, has_defers)?;
     snapshot!(
-        best_plan.fetch_dependency_graph,
-        "Plan returned from compute_root_parallel_best_plan"
+        "FetchDependencyGraph",
+        best_plan.fetch_dependency_graph.to_dot(),
+        "Fetch dependency graph returned from compute_root_parallel_best_plan"
     );
     Ok(best_plan.fetch_dependency_graph)
 }
@@ -807,7 +812,8 @@ fn compute_plan_internal(
 
         let (main, deferred) = dependency_graph.process(&mut *processor, root_kind)?;
         snapshot!(
-            dependency_graph,
+            "FetchDependencyGraph",
+            dependency_graph.to_dot(),
             "Plan after calling FetchDependencyGraph::process"
         );
         // XXX(@goto-bus-stop) Maybe `.defer_tracking` should be on the return value of `process()`..?

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -551,7 +551,15 @@ impl QueryPlanner {
             statistics,
         };
 
-        snapshot!(plan, "query plan");
+        snapshot!(
+            "QueryPlan",
+            plan.to_string(),
+            "QueryPlan from build_query_plan"
+        );
+        snapshot!(
+            plan.statistics,
+            "QueryPlanningStatistics from build_query_plan"
+        );
 
         Ok(plan)
     }

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -11,6 +11,7 @@ use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Name;
 use itertools::Itertools;
 use serde::Serialize;
+use tracing::trace;
 
 use super::fetch_dependency_graph::FetchIdGenerator;
 use super::ConditionNode;
@@ -749,11 +750,7 @@ fn compute_root_parallel_dependency_graph(
     parameters: &QueryPlanningParameters,
     has_defers: bool,
 ) -> Result<FetchDependencyGraph, FederationError> {
-    snapshot!(
-        "FetchDependencyGraph",
-        "digraph {}", // empty graph (in GraphViz Dot format)
-        "Starting process to construct a parallel fetch dependency graph (empty graph)"
-    );
+    trace!("Starting process to construct a parallel fetch dependency graph");
     let selection_set = parameters.operation.selection_set.clone();
     let best_plan = compute_root_parallel_best_plan(parameters, selection_set, has_defers)?;
     snapshot!(

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -52,6 +52,7 @@ use crate::utils::logging::snapshot;
 #[cfg(feature = "snapshot_tracing")]
 mod snapshot_helper {
     // A module to import functions only used within `snapshot!(...)` macros.
+    pub(crate) use crate::utils::logging::closed_branches_to_string;
     pub(crate) use crate::utils::logging::open_branch_to_string;
     pub(crate) use crate::utils::logging::open_branches_to_string;
 }
@@ -650,8 +651,8 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
     )]
     fn compute_best_plan_from_closed_branches(&mut self) -> Result<(), FederationError> {
         snapshot!(
-            name = "ClosedBranches",
-            self.closed_branches,
+            "ClosedBranches",
+            snapshot_helper::closed_branches_to_string(&self.closed_branches),
             "closed_branches"
         );
 
@@ -662,8 +663,8 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         self.reduce_options_if_needed();
 
         snapshot!(
-            name = "ClosedBranches",
-            self.closed_branches,
+            "ClosedBranches",
+            snapshot_helper::closed_branches_to_string(&self.closed_branches),
             "closed_branches_after_reduce"
         );
 
@@ -693,11 +694,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         let (first_group, second_group) = self.closed_branches.split_at(sole_path_branch_index);
 
         let initial_tree;
-        snapshot!(
-            "FetchDependencyGraph",
-            "digraph {}", // empty graph (in GraphViz Dot format)
-            "Generating initial dep graph (empty graph)"
-        );
+        trace!("Generating initial fetch dependency graph");
         let mut initial_dependency_graph = self.new_dependency_graph();
         let federated_query_graph = &self.parameters.federated_query_graph;
         let root = &self.parameters.head;

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -404,7 +404,11 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             }
         }
 
-        snapshot!(new_options, "new_options");
+        snapshot!(
+            "OpenBranch",
+            snapshot_helper::open_branch_to_string(selection, &new_options),
+            "new_options"
+        );
 
         if no_followups {
             // This operation element is valid from this option, but is guarantee to yield no result
@@ -725,15 +729,25 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             if first_group.is_empty() {
                 // Well, we have the only possible plan; it's also the best.
                 let cost = self.cost(&mut initial_dependency_graph)?;
-                self.best_plan = BestQueryPlanInfo {
+                let best_plan = BestQueryPlanInfo {
                     fetch_dependency_graph: initial_dependency_graph,
                     path_tree: initial_tree.into(),
                     cost,
-                }
-                .into();
+                };
 
-                snapshot!(self.best_plan, "best_plan");
+                snapshot!(
+                    "FetchDependencyGraph",
+                    best_plan.fetch_dependency_graph.to_dot(),
+                    "best_plan.fetch_dependency_graph"
+                );
+                snapshot!(
+                    "OpPathTree",
+                    best_plan.path_tree.to_string(),
+                    "best_plan.path_tree"
+                );
+                snapshot!(best_plan.cost, "best_plan.cost");
 
+                self.best_plan = best_plan.into();
                 return Ok(());
             }
         }
@@ -764,14 +778,25 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             other_trees,
             /*plan_builder*/ self,
         )?;
-        self.best_plan = BestQueryPlanInfo {
+        let best_plan = BestQueryPlanInfo {
             fetch_dependency_graph: best.fetch_dependency_graph,
             path_tree: best.path_tree,
             cost,
-        }
-        .into();
+        };
 
-        snapshot!(self.best_plan, "best_plan");
+        snapshot!(
+            "FetchDependencyGraph",
+            best_plan.fetch_dependency_graph.to_dot(),
+            "best_plan.fetch_dependency_graph"
+        );
+        snapshot!(
+            "OpPathTree",
+            best_plan.path_tree.to_string(),
+            "best_plan.path_tree"
+        );
+        snapshot!(best_plan.cost, "best_plan.cost");
+
+        self.best_plan = best_plan.into();
         Ok(())
     }
 

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -305,7 +305,6 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             f: &mut std::fmt::Formatter<'_>,
             data: &QueryPlanningTraversal,
         ) -> std::fmt::Result {
-            writeln!(f, "Query planning open branches:")?;
             for branch in &data.open_branches {
                 let selection = branch.selections.last().unwrap();
                 format_open_branch(f, &(selection, &branch.open_branch.0))?;
@@ -329,7 +328,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             snapshot!(
                 "BranchStack",
                 self.branch_stack_to_string(),
-                "Query planning open branches:"
+                "Query planning open branches"
             );
             let Some(mut current_branch) = self.open_branches.pop() else {
                 return Err(FederationError::internal(
@@ -380,18 +379,6 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         let operation_element = selection.element()?;
         let mut new_options = vec![];
         let mut no_followups: bool = false;
-
-        snapshot!(
-            "OpenBranch",
-            open_branch_to_string(selection, options),
-            "open branch"
-        );
-
-        snapshot!(
-            "OperationElement",
-            operation_element.to_string(),
-            "Handling open branch"
-        );
 
         for option in options.iter_mut() {
             let followups_for_option = option.advance_with_operation_element(

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -653,7 +653,11 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         let (first_group, second_group) = self.closed_branches.split_at(sole_path_branch_index);
 
         let initial_tree;
-        snapshot!("FetchDependencyGraph", "", "Generating initial dep graph");
+        snapshot!(
+            "FetchDependencyGraph",
+            "digraph {}", // empty graph (in GraphViz Dot format)
+            "Generating initial dep graph (empty graph)"
+        );
         let mut initial_dependency_graph = self.new_dependency_graph();
         let federated_query_graph = &self.parameters.federated_query_graph;
         let root = &self.parameters.head;
@@ -678,7 +682,8 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 self.parameters.config.type_conditioned_fetching,
             )?;
             snapshot!(
-                initial_dependency_graph,
+                "FetchDependencyGraph",
+                initial_dependency_graph.to_dot(),
                 "Updated dep graph with initial tree"
             );
             if first_group.is_empty() {
@@ -975,7 +980,11 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             )?;
         }
 
-        snapshot!(dependency_graph, "updated_dependency_graph");
+        snapshot!(
+            "FetchDependencyGraph",
+            dependency_graph.to_dot(),
+            "updated_dependency_graph"
+        );
         Ok(())
     }
 

--- a/apollo-federation/src/utils/logging.rs
+++ b/apollo-federation/src/utils/logging.rs
@@ -79,7 +79,7 @@ pub(crate) fn make_string<T: ?Sized>(
 // PORT_NOTE: This is a (partial) port of `QueryPlanningTraversal.debugStack` JS method.
 pub(crate) fn format_open_branch(
     f: &mut std::fmt::Formatter<'_>,
-    (selection, options): &(&Selection, &Vec<SimultaneousPathsWithLazyIndirectPaths>),
+    (selection, options): &(&Selection, &[SimultaneousPathsWithLazyIndirectPaths]),
 ) -> std::fmt::Result {
     writeln!(f, "{selection}")?;
     writeln!(f, " * Options:")?;
@@ -91,7 +91,7 @@ pub(crate) fn format_open_branch(
 
 pub(crate) fn open_branch_to_string(
     selection: &Selection,
-    options: &Vec<SimultaneousPathsWithLazyIndirectPaths>,
+    options: &[SimultaneousPathsWithLazyIndirectPaths],
 ) -> String {
     make_string(&(selection, options), format_open_branch)
 }

--- a/apollo-federation/src/utils/logging.rs
+++ b/apollo-federation/src/utils/logging.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use crate::operation::Selection;
+use crate::query_graph::graph_path::ClosedBranch;
 use crate::query_graph::graph_path::SimultaneousPathsWithLazyIndirectPaths;
 use crate::query_plan::query_planning_traversal::OpenBranchAndSelections;
 
@@ -28,17 +29,6 @@ use crate::query_plan::query_planning_traversal::OpenBranchAndSelections;
 /// ```
 macro_rules! snapshot {
     ($value:expr, $msg:literal) => {
-        #[cfg(feature = "snapshot_tracing")]
-        tracing::trace!(
-            snapshot = std::any::type_name_of_val(&$value),
-            data = ron::ser::to_string(&$value).expect(concat!(
-                "Could not serialize value for a snapshot with message: ",
-                $msg
-            )),
-            $msg
-        );
-    };
-    (name = $name:literal, $value:expr, $msg:literal) => {
         #[cfg(feature = "snapshot_tracing")]
         tracing::trace!(
             snapshot = std::any::type_name_of_val(&$value),
@@ -110,4 +100,22 @@ pub(crate) fn format_open_branches(
 
 pub(crate) fn open_branches_to_string(open_branches: &[OpenBranchAndSelections]) -> String {
     make_string(open_branches, format_open_branches)
+}
+
+pub(crate) fn format_closed_branches(
+    f: &mut std::fmt::Formatter<'_>,
+    closed_branches: &[ClosedBranch],
+) -> std::fmt::Result {
+    writeln!(f, "All branches:")?;
+    for (i, closed_branch) in closed_branches.iter().enumerate() {
+        writeln!(f, "{i}:")?;
+        for closed_path in &closed_branch.0 {
+            writeln!(f, " - {closed_path}")?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn closed_branches_to_string(closed_branches: &[ClosedBranch]) -> String {
+    make_string(closed_branches, format_closed_branches)
 }

--- a/apollo-federation/src/utils/logging.rs
+++ b/apollo-federation/src/utils/logging.rs
@@ -50,3 +50,23 @@ macro_rules! snapshot {
 }
 
 pub(crate) use snapshot;
+
+#[allow(unreachable_pub)] // suppress warning: tracing utility
+pub fn make_string<T>(
+    data: &T,
+    writer: fn(&mut std::fmt::Formatter<'_>, &T) -> std::fmt::Result,
+) -> String {
+    // One-off struct to implement `Display` for `data` using `writer`.
+    struct Stringify<'a, T> {
+        data: &'a T,
+        writer: fn(&mut std::fmt::Formatter<'_>, &T) -> std::fmt::Result,
+    }
+
+    impl<'a, T> std::fmt::Display for Stringify<'a, T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            (self.writer)(f, self.data)
+        }
+    }
+
+    Stringify { data, writer }.to_string()
+}


### PR DESCRIPTION
- `FetchDependencyGraph` snapshots are formatted in GraphViz dot format.
- Open branch snapshots are pretty printed in plain text format.

Those changes are in separate commits. It may be easier to review commit by commit.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests