### PR TITLE
Add fields referenced only in entity arguments to split subgraphs

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.graphql
@@ -57,8 +57,11 @@ enum link__Purpose {
 type Query
   @join__type(graph: ONE)
 {
-  t(id: ID!): T @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/ts/{$args.id}"}, selection: "id id2", entity: true})
-  t2(id: ID!, id2: ID!): T @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/ts/{$args.id}?id2={$args.id2}"}, selection: "id id2", entity: true})
+  t(id: ID!): T @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/ts/{$args.id}"}, selection: "id id2 unselected", entity: true})
+  t2(id: ID!, id2: ID!): T @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/ts/{$args.id}?id2={$args.id2}"}, selection: "id id2 unselected", entity: true})
+
+  """ Uses the `unselected` field as a key, but doesn't select it """
+  unselected(unselected: ID!): T @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/ts/{$args.unselected}"}, selection: "id id2 accessibleByUnselected", entity: true})
 }
 
 type R
@@ -71,9 +74,12 @@ type R
 type T
   @join__type(graph: ONE, key: "id")
   @join__type(graph: ONE, key: "id id2")
+  @join__type(graph: ONE, key: "unselected")
 {
   id: ID!
   id2: ID!
+  unselected: ID!
+  accessibleByUnselected: ID!
   r1: R @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/rs/{$this.id}"}, selection: "id id2"})
   r2: R @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/rs/{$this.id}?id2={$this.id2}"}, selection: "id id2"})
   r3: R @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/rs/{$this.id}"}, selection: "id id2: $this.id2"})

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.yaml
@@ -4,25 +4,34 @@ subgraphs:
     schema:
       sdl: |
         extend schema
-          @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key"])
+          @link(url: "https://specs.apollo.dev/federation/v2.10", import: ["@key"])
           @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
         type Query {
           t(id: ID!): T
             @connect(                                                                                                   # expect `key: "id"`
               http: { GET: "http://localhost/ts/{$$args.id}" }
-              selection: "id id2"
+              selection: "id id2 unselected"
               entity: true
             )
-          t2(id: ID! id2: ID!): T
+          t2(id: ID!, id2: ID!): T
             @connect(                                                                                                   # expect `key: "id id2"`
               http: { GET: "http://localhost/ts/{$$args.id}?id2={$$args.id2}" }
-              selection: "id id2"
+              selection: "id id2 unselected"
+              entity: true
+            )
+          """ Uses the `unselected` field as a key, but doesn't select it """
+          unselected(unselected: ID!): T
+            @connect(
+              http: { GET: "http://localhost/ts/{$$args.unselected}" }
+              selection: "id id2 accessibleByUnselected"
               entity: true
             )
         }
-        type T @key(fields: "id") @key(fields: "id id2") {
+        type T @key(fields: "id") @key(fields: "id id2") @key(fields: "unselected") {
           id: ID!
           id2: ID!
+          unselected: ID!
+          accessibleByUnselected: ID!
           r1: R @connect(http: { GET: "http://localhost/rs/{$$this.id}" }, selection: "id id2")                         # expect `key: "id"``
           r2: R @connect(http: { GET: "http://localhost/rs/{$$this.id}?id2={$$this.id2}" }, selection: "id id2")        # expect `key: "id id2"`
           r3: R @connect(http: { GET: "http://localhost/rs/{$$this.id}" }, selection: "id id2: $$this.id2")             # expect `key: "id id2"`

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/regenerate.sh
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/regenerate.sh
@@ -1,8 +1,26 @@
+# Composes a single supergraph config file passed as an argument or all `.yaml` files in any subdirectories.
+# For each supergraph config, outputs a `.graphql` file in the same directory.
+# Optionally, you can set `FEDERATION_VERSION` to override the supergraph binary used
 set -euo pipefail
 
-for supergraph_config in */*.yaml; do
+if [ -z "${FEDERATION_VERSION:-}" ]; then
+  FEDERATION_VERSION="2.10.0-preview.0"
+fi
+
+regenerate_graphql() {
+  local supergraph_config=$1
+  local test_name
   test_name=$(basename "$supergraph_config" .yaml)
+  local dir_name
   dir_name=$(dirname "$supergraph_config")
   echo "Regenerating $dir_name/$test_name.graphql"
-  rover supergraph compose --federation-version "=2.10.0-preview.0" --config "$supergraph_config" > "$dir_name/$test_name.graphql"
-done
+  rover supergraph compose --federation-version "=$FEDERATION_VERSION" --config "$supergraph_config" > "$dir_name/$test_name.graphql"
+}
+
+if [ -z "${1:-}" ]; then
+  for supergraph_config in */*.yaml; do
+    regenerate_graphql "$supergraph_config"
+  done
+else
+  regenerate_graphql "$1"
+fi

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-2.snap
@@ -88,9 +88,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                         },
                         None,
                     ),
+                    Field(
+                        None,
+                        WithRange {
+                            node: Field(
+                                "unselected",
+                            ),
+                            range: Some(
+                                7..17,
+                            ),
+                        },
+                        None,
+                    ),
                 ],
                 range: Some(
-                    0..6,
+                    0..17,
                 ),
             },
         ),
@@ -202,9 +214,129 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                         },
                         None,
                     ),
+                    Field(
+                        None,
+                        WithRange {
+                            node: Field(
+                                "unselected",
+                            ),
+                            range: Some(
+                                7..17,
+                            ),
+                        },
+                        None,
+                    ),
                 ],
                 range: Some(
-                    0..6,
+                    0..17,
+                ),
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Explicit,
+        ),
+    },
+    "one_Query_unselected_0": Connector {
+        id: ConnectId {
+            label: "one. http: GET http://localhost/ts/{$args.unselected}",
+            subgraph_name: "one",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.unselected),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "localhost",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    Component {
+                        parts: [
+                            Text(
+                                "ts",
+                            ),
+                        ],
+                    },
+                    Component {
+                        parts: [
+                            Var(
+                                Variable {
+                                    var_type: Args,
+                                    path: "unselected",
+                                    location: 21..37,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        WithRange {
+                            node: Field(
+                                "id",
+                            ),
+                            range: Some(
+                                0..2,
+                            ),
+                        },
+                        None,
+                    ),
+                    Field(
+                        None,
+                        WithRange {
+                            node: Field(
+                                "id2",
+                            ),
+                            range: Some(
+                                3..6,
+                            ),
+                        },
+                        None,
+                    ),
+                    Field(
+                        None,
+                        WithRange {
+                            node: Field(
+                                "accessibleByUnselected",
+                            ),
+                            range: Some(
+                                7..29,
+                            ),
+                        },
+                        None,
+                    ),
+                ],
+                range: Some(
+                    0..29,
                 ),
             },
         ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-3.snap
@@ -43,6 +43,7 @@ scalar join__DirectiveArguments
 enum join__Graph {
   ONE_QUERY_T2_0 @join__graph(name: "one_Query_t2_0", url: "none")
   ONE_QUERY_T_0 @join__graph(name: "one_Query_t_0", url: "none")
+  ONE_QUERY_UNSELECTED_0 @join__graph(name: "one_Query_unselected_0", url: "none")
   ONE_T_R1_0 @join__graph(name: "one_T_r1_0", url: "none")
   ONE_T_R2_0 @join__graph(name: "one_T_r2_0", url: "none")
   ONE_T_R3_0 @join__graph(name: "one_T_r3_0", url: "none")
@@ -50,9 +51,11 @@ enum join__Graph {
   ONE_T_R5_0 @join__graph(name: "one_T_r5_0", url: "none")
 }
 
-type T @join__type(graph: ONE_QUERY_T2_0, key: "id id2") @join__type(graph: ONE_QUERY_T_0, key: "id") @join__type(graph: ONE_T_R1_0, key: "id") @join__type(graph: ONE_T_R2_0, key: "id id2") @join__type(graph: ONE_T_R3_0, key: "id id2") @join__type(graph: ONE_T_R4_0, key: "id") @join__type(graph: ONE_T_R5_0, key: "id id2") {
-  id: ID! @join__field(graph: ONE_QUERY_T2_0) @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_T_R1_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R4_0) @join__field(graph: ONE_T_R5_0)
-  id2: ID! @join__field(graph: ONE_QUERY_T2_0) @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R5_0)
+type T @join__type(graph: ONE_QUERY_T2_0, key: "id id2") @join__type(graph: ONE_QUERY_T_0, key: "id") @join__type(graph: ONE_QUERY_UNSELECTED_0, key: "unselected") @join__type(graph: ONE_T_R1_0, key: "id") @join__type(graph: ONE_T_R2_0, key: "id id2") @join__type(graph: ONE_T_R3_0, key: "id id2") @join__type(graph: ONE_T_R4_0, key: "id") @join__type(graph: ONE_T_R5_0, key: "id id2") {
+  id: ID! @join__field(graph: ONE_QUERY_T2_0) @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_QUERY_UNSELECTED_0) @join__field(graph: ONE_T_R1_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R4_0) @join__field(graph: ONE_T_R5_0)
+  id2: ID! @join__field(graph: ONE_QUERY_T2_0) @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_QUERY_UNSELECTED_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R5_0)
+  unselected: ID! @join__field(graph: ONE_QUERY_T2_0) @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_QUERY_UNSELECTED_0)
+  accessibleByUnselected: ID! @join__field(graph: ONE_QUERY_UNSELECTED_0)
   r1: R @join__field(graph: ONE_T_R1_0)
   r2: R @join__field(graph: ONE_T_R2_0)
   r3: R @join__field(graph: ONE_T_R3_0)
@@ -60,9 +63,10 @@ type T @join__type(graph: ONE_QUERY_T2_0, key: "id id2") @join__type(graph: ONE_
   r5: R @join__field(graph: ONE_T_R5_0)
 }
 
-type Query @join__type(graph: ONE_QUERY_T2_0) @join__type(graph: ONE_QUERY_T_0) @join__type(graph: ONE_T_R1_0) @join__type(graph: ONE_T_R2_0) @join__type(graph: ONE_T_R3_0) @join__type(graph: ONE_T_R4_0) @join__type(graph: ONE_T_R5_0) {
+type Query @join__type(graph: ONE_QUERY_T2_0) @join__type(graph: ONE_QUERY_T_0) @join__type(graph: ONE_QUERY_UNSELECTED_0) @join__type(graph: ONE_T_R1_0) @join__type(graph: ONE_T_R2_0) @join__type(graph: ONE_T_R3_0) @join__type(graph: ONE_T_R4_0) @join__type(graph: ONE_T_R5_0) {
   t2(id: ID!, id2: ID!): T @join__field(graph: ONE_QUERY_T2_0)
   t(id: ID!): T @join__field(graph: ONE_QUERY_T_0)
+  unselected(unselected: ID!): T @join__field(graph: ONE_QUERY_UNSELECTED_0)
   _: ID @inaccessible @join__field(graph: ONE_T_R1_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R4_0) @join__field(graph: ONE_T_R5_0)
 }
 

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql.snap
@@ -8,6 +8,8 @@ directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE
 type Query {
   t(id: ID!): T
   t2(id: ID!, id2: ID!): T
+  " Uses the `unselected` field as a key, but doesn't select it "
+  unselected(unselected: ID!): T
 }
 
 type R {
@@ -18,6 +20,8 @@ type R {
 type T {
   id: ID!
   id2: ID!
+  unselected: ID!
+  accessibleByUnselected: ID!
   r1: R
   r2: R
   r3: R


### PR DESCRIPTION
<!-- [CNN-485](https://apollographql.atlassian.net/browse/CNN-485) -->

Technically also allows some interface stuff that won't work, but it's caught in validation! Based on #6201 which should be merged first.

[CNN-485]: https://apollographql.atlassian.net/browse/CNN-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ