### PR TITLE
do not count the wait time in deduplication as processing time

### DIFF
--- a/.changesets/fix_geal_deduplication_processing_time.md
+++ b/.changesets/fix_geal_deduplication_processing_time.md
@@ -1,0 +1,5 @@
+### do not count the wait time in deduplication as processing time ([PR #6207](https://github.com/apollographql/router/pull/6207))
+
+waiting for a deduplicated request was incorrectly counted as time spent in the router overhead, while most of it was actually spent waiting for the subgraph response.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/6207

--- a/apollo-router/src/plugins/traffic_shaping/deduplication.rs
+++ b/apollo-router/src/plugins/traffic_shaping/deduplication.rs
@@ -98,6 +98,7 @@ where
                     let mut receiver = waiter.subscribe();
                     drop(locked_wait_map);
 
+                    let _guard = request.context.enter_active_request();
                     match receiver.recv().await {
                         Ok(value) => {
                             return value


### PR DESCRIPTION
<!-- [ROUTER-791] -->
waiting for a deduplicated request was incorrectly counted as time spent in the router overhead, so even the subgraph request time was measured

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-791]: https://apollographql.atlassian.net/browse/ROUTER-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ