### PR TITLE
Added logic to parse `@context` in `FederatedQueryGraphBuilder::build`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "multimap 0.10.0",
  "nom",
  "petgraph",
+ "regex",
  "ron",
  "serde",
  "serde_json_bytes",
@@ -2927,8 +2928,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5288,14 +5289,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5309,13 +5310,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5332,9 +5333,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -37,6 +37,7 @@ url = "2"
 tracing = "0.1.40"
 ron = { version = "0.8.1", optional = true }
 either = "1.13.0"
+regex = "1.11.1"
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -26,8 +26,6 @@
     unconditional_panic,
     // clippy::all
 )]
-// TODO: After we are done prototyping the context feature, we need to remove this.
-#![allow(dead_code)]
 
 mod api_schema;
 mod compat;

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -27,6 +27,9 @@
     // clippy::all
 )]
 
+// TODO: After we are done prototyping the context feature, we need to remove this.
+#![allow(dead_code)]
+
 mod api_schema;
 mod compat;
 mod display_helpers;

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -26,7 +26,6 @@
     unconditional_panic,
     // clippy::all
 )]
-
 // TODO: After we are done prototyping the context feature, we need to remove this.
 #![allow(dead_code)]
 

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -58,6 +58,14 @@ pub(crate) struct ProvidesDirectiveArguments<'doc> {
     pub(crate) fields: &'doc str,
 }
 
+pub(crate) struct ContextDirectiveArguments<'doc> {
+    pub(crate) name: &'doc str,
+}
+
+pub(crate) struct FromContextDirectiveArguments<'doc> {
+    pub(crate) field: &'doc str,
+}
+
 pub(crate) struct OverrideDirectiveArguments<'doc> {
     pub(crate) from: &'doc str,
     pub(crate) label: Option<&'doc str>,
@@ -338,6 +346,27 @@ impl FederationSpecDefinition {
                 name: FEDERATION_FIELDS_ARGUMENT_NAME,
                 value: Node::new(Value::String(fields)),
             })],
+        })
+    }
+
+    pub(crate) fn context_directive_arguments<'doc>(
+        &self,
+        application: &'doc Node<Directive>,
+    ) -> Result<ContextDirectiveArguments<'doc>, FederationError> {
+        Ok(ContextDirectiveArguments {
+            name: directive_required_string_argument(application, &FEDERATION_NAME_ARGUMENT_NAME)?,
+        })
+    }
+
+    pub(crate) fn from_context_directive_arguments<'doc>(
+        &self,
+        application: &'doc Node<Directive>,
+    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
+        Ok(FromContextDirectiveArguments {
+            field: directive_required_string_argument(
+                application,
+                &FEDERATION_FIELD_ARGUMENT_NAME,
+            )?,
         })
     }
 

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -71,14 +71,6 @@ pub(crate) struct OverrideDirectiveArguments<'doc> {
     pub(crate) label: Option<&'doc str>,
 }
 
-pub(crate) struct ContextDirectiveArguments<'doc> {
-    pub(crate) name: &'doc str,
-}
-
-pub(crate) struct FromContextDirectiveArguments<'doc> {
-    pub(crate) field: &'doc str,
-}
-
 #[derive(Debug)]
 pub(crate) struct FederationSpecDefinition {
     url: Url,
@@ -349,27 +341,6 @@ impl FederationSpecDefinition {
         })
     }
 
-    pub(crate) fn context_directive_arguments<'doc>(
-        &self,
-        application: &'doc Node<Directive>,
-    ) -> Result<ContextDirectiveArguments<'doc>, FederationError> {
-        Ok(ContextDirectiveArguments {
-            name: directive_required_string_argument(application, &FEDERATION_NAME_ARGUMENT_NAME)?,
-        })
-    }
-
-    pub(crate) fn from_context_directive_arguments<'doc>(
-        &self,
-        application: &'doc Node<Directive>,
-    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
-        Ok(FromContextDirectiveArguments {
-            field: directive_required_string_argument(
-                application,
-                &FEDERATION_FIELD_ARGUMENT_NAME,
-            )?,
-        })
-    }
-
     pub(crate) fn provides_directive_arguments<'doc>(
         &self,
         application: &'doc Node<Directive>,
@@ -521,6 +492,18 @@ impl FederationSpecDefinition {
             })
     }
 
+    pub(crate) fn from_context_directive_arguments<'doc>(
+        &self,
+        application: &'doc Node<Directive>,
+    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
+        Ok(FromContextDirectiveArguments {
+            field: directive_required_string_argument(
+                application,
+                &FEDERATION_FIELD_ARGUMENT_NAME,
+            )?,
+        })
+    }
+
     pub(crate) fn from_context_directive(
         &self,
         schema: &FederationSchema,
@@ -540,18 +523,6 @@ impl FederationSpecDefinition {
         Ok(Directive {
             name: name_in_schema,
             arguments,
-        })
-    }
-
-    pub(crate) fn from_context_directive_arguments<'doc>(
-        &self,
-        application: &'doc Node<Directive>,
-    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
-        Ok(FromContextDirectiveArguments {
-            field: directive_required_string_argument(
-                application,
-                &FEDERATION_FIELD_ARGUMENT_NAME,
-            )?,
         })
     }
 

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1026,7 +1026,7 @@ impl FederatedQueryGraphBuilder {
             .root_kinds_to_nodes_by_source
             .iter()
             .filter(|(source, _)| **source != self.base.query_graph.current_source)
-            .flat_map(|(_, root_kind_to_notes)| root_kind_to_notes.keys().copied())
+            .flat_map(|(_, root_kind_to_nodes)| root_kind_to_nodes.keys().copied())
             .collect::<IndexSet<_>>();
         for root_kind in root_kinds {
             self.base.create_root_node(root_kind.into(), root_kind)?;

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1536,9 +1536,7 @@ impl FederatedQueryGraphBuilder {
             for object_def_pos in &context_refs.object_types {
                 let object = object_def_pos.get(subgraph.schema())?;
                 for dir in object.directives.get_all(&CONTEXT_DIRECTIVE_NAME) {
-                    let application = subgraph_data
-                        .federation_spec_definition
-                        .context_directive_arguments(dir)?;
+                    let application = FederationSpecDefinition::context_directive_arguments(dir)?;
                     context_name_to_types
                         .entry(application.name)
                         .or_default()

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1509,8 +1509,7 @@ impl FederatedQueryGraphBuilder {
                 continue;
             };
 
-            // For @context
-            // subgraph -> referencers -> iter through object_types and interface_types
+            // Collect data for @context
             let mut context_name_to_types: HashMap<&str, HashSet<&ObjectTypeDefinitionPosition>> =
                 HashMap::default();
             for object_def_pos in &context_refs.object_types {
@@ -1524,8 +1523,7 @@ impl FederatedQueryGraphBuilder {
                 }
             }
 
-            // For @fromContext
-            // subgraph -> referencers -> iter through object_field_arguments and interface_field_arguments
+            // Collect data for @fromContext
             let coordinate_map = coordinate_map.entry(subgraph_name.clone()).or_default();
             for object_field_arg in &from_context_refs.object_field_arguments {
                 let input_value = object_field_arg.get(subgraph.schema())?;
@@ -1560,6 +1558,7 @@ impl FederatedQueryGraphBuilder {
                 }
             }
         }
+
         for edge in self.base.query_graph.graph.edge_indices() {
             let edge_weight = self.base.query_graph.edge_weight(edge)?;
             let QueryGraphEdgeTransition::FieldCollection {

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -40,6 +40,7 @@ pub(crate) enum ConditionResolution {
 #[derive(Debug, Clone)]
 pub(crate) enum UnsatisfiedConditionReason {
     NoPostRequireKey,
+    NoSetContext,
 }
 
 impl ConditionResolution {

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -9,7 +9,6 @@ use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::schema::NamedType;
 use apollo_compiler::Name;
-use multimap::MultiMap;
 use petgraph::graph::DiGraph;
 use petgraph::graph::EdgeIndex;
 use petgraph::graph::EdgeReference;
@@ -135,7 +134,8 @@ impl TryFrom<QueryGraphNodeType> for ObjectTypeDefinitionPosition {
     }
 }
 
-// TODO: Add docs.
+/// Contains all of the data necessary to connect the object field (`coordinate`) with the
+/// `@fromContext` to its (grand)parent types contain a matching selection.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ContextCondition {
     context: String,
@@ -169,8 +169,8 @@ pub(crate) struct QueryGraphEdge {
     /// one of them has an @override with a label. If the override condition
     /// matches the query plan parameters, this edge can be taken.
     pub(crate) override_condition: Option<OverrideCondition>,
-    // TODO: Add docs
-    // TODO: Should this be a set?
+    /// All fields with `@fromContext` that need access to parental type with corresponding
+    /// `@context`.
     pub(crate) required_contexts: Vec<ContextCondition>,
 }
 
@@ -399,9 +399,9 @@ pub struct QueryGraph {
     /// lowered composition validation on a big composition (100+ subgraphs) from ~4 minutes to
     /// ~10 seconds.
     non_trivial_followup_edges: IndexMap<EdgeIndex, Vec<EdgeIndex>>,
-    // TODO: Are these duplicate fields??
-    // TODO: If not, write docs
+    /// Maps each subgraph name to each field argument of `@fromContext`.
     subgraph_to_args: IndexMap<Arc<str>, Vec<ObjectFieldArgumentDefinitionPosition>>,
+    /// Like `self.subgraph_to_args` but pairs each field argument with a unique identifier string.
     subgraph_to_arg_indices:
         IndexMap<Arc<str>, IndexMap<ObjectFieldArgumentDefinitionPosition, String>>,
 }

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -401,9 +401,9 @@ pub struct QueryGraph {
     non_trivial_followup_edges: IndexMap<EdgeIndex, Vec<EdgeIndex>>,
     // TODO: Are these duplicate fields??
     // TODO: If not, write docs
-    subgraph_to_args: MultiMap<Arc<str>, ObjectFieldArgumentDefinitionPosition>,
+    subgraph_to_args: IndexMap<Arc<str>, Vec<ObjectFieldArgumentDefinitionPosition>>,
     subgraph_to_arg_indices:
-        HashMap<Arc<str>, HashMap<ObjectFieldArgumentDefinitionPosition, String>>,
+        IndexMap<Arc<str>, IndexMap<ObjectFieldArgumentDefinitionPosition, String>>,
 }
 
 impl QueryGraph {

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -141,7 +141,7 @@ pub struct ContextCondition {
     context: String,
     subgraph_name: Arc<str>,
     selection: String,
-    types_with_context_set: HashSet<ObjectTypeDefinitionPosition>,
+    types_with_context_set: HashSet<CompositeTypeDefinitionPosition>,
     coordinate: ObjectFieldDefinitionPosition,
 }
 

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -2086,7 +2086,7 @@ impl Debug for ObjectFieldDefinitionPosition {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct ObjectFieldArgumentDefinitionPosition {
     pub(crate) type_name: Name,
     pub(crate) field_name: Name,

--- a/apollo-federation/src/utils/fallible_iterator.rs
+++ b/apollo-federation/src/utils/fallible_iterator.rs
@@ -405,6 +405,28 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     {
         self.process_results(|mut results| results.find(predicate))
     }
+
+    fn fallible_fold<F, O, T, E>(&mut self, mut init: O, mut mapper: F) -> Result<O, E>
+        where
+        Self: Iterator<Item = T>,
+        F: FnMut(O, T) -> Result<O, E>,
+    {
+        for item in self {
+            init = mapper(init, item)?;
+        }
+        Ok(init)
+    }
+
+    fn and_then_fold<F, O, T, E>(&mut self, mut init: O, mut mapper: F) -> Result<O, E>
+    where
+        Self: Iterator<Item = Result<T, E>>,
+        F: FnMut(O, T) -> Result<O, E>,
+    {
+        for item in self {
+            init = mapper(init, item?)?
+        }
+        Ok(init)
+    }
 }
 
 impl<I: Itertools> FallibleIterator for I {}

--- a/apollo-federation/src/utils/fallible_iterator.rs
+++ b/apollo-federation/src/utils/fallible_iterator.rs
@@ -407,7 +407,7 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     }
 
     fn fallible_fold<F, O, T, E>(&mut self, mut init: O, mut mapper: F) -> Result<O, E>
-        where
+    where
         Self: Iterator<Item = T>,
         F: FnMut(O, T) -> Result<O, E>,
     {


### PR DESCRIPTION
There are still a few TODOs. The regular expression that is used will fail to build because looking around is not supported. The logic inside the `simpleTraversal` for the context has also not been ported. Lastly, the definition position types might be off and need to be tested.