### PR TITLE
Fix fake selection for nested fields in expansion

### DIFF
--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -525,7 +525,7 @@ mod helpers {
                         let (_, parsed) = JSONSelection::parse(&field_and_selection.sub_selection)
                             .map_err(|e| {
                                 FederationError::internal(format!(
-                                    "could not parse fake selection for sibling field: {e}"
+                                    "error creating key from `$this` variable: {e}"
                                 ))
                             })?;
 

--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -192,11 +192,11 @@ mod helpers {
     use itertools::Itertools;
 
     use super::filter_directives;
-    use super::path_to_selection;
     use super::visitors::try_insert;
     use super::visitors::try_pre_insert;
     use super::visitors::GroupVisitor;
     use super::visitors::SchemaVisitor;
+    use super::FieldAndSelection;
     use crate::error::FederationError;
     use crate::link::spec::Identity;
     use crate::link::Link;
@@ -489,8 +489,8 @@ mod helpers {
                 //
                 // All sibling fields marked by $this in a transport must be carried over to the output type
                 // regardless of its use in the output selection.
-                let (field_name_str, selection) = path_to_selection(&path);
-                let field_name = Name::new(&field_name_str)?;
+                let field_and_selection = FieldAndSelection::from_path(&path);
+                let field_name = Name::new(field_and_selection.field_name)?;
                 let field: Box<dyn Field> = match &key_for_type {
                     TypeDefinitionPosition::Object(o)  => Box::new(o.field(field_name)),
                     TypeDefinitionPosition::Interface(i) => Box::new(i.field(field_name)),
@@ -510,7 +510,7 @@ mod helpers {
                 let field_def = field.get(self.original_schema.schema())?;
 
                 // Mark it as a required key for the output type
-                if !selection.is_empty() {
+                if !field_and_selection.sub_selection.is_empty() {
                     // We'll also need to carry over the output type of this sibling if there is a sub
                     // selection.
                     let field_output = field_def.ty.inner_named_type();
@@ -522,11 +522,12 @@ mod helpers {
                             to_schema,
                             &self.directive_deny_list,
                         );
-                        let (_, parsed) = JSONSelection::parse(&selection).map_err(|e| {
-                            FederationError::internal(format!(
-                                "could not parse fake selection for sibling field: {e}"
-                            ))
-                        })?;
+                        let (_, parsed) = JSONSelection::parse(&field_and_selection.sub_selection)
+                            .map_err(|e| {
+                                FederationError::internal(format!(
+                                    "could not parse fake selection for sibling field: {e}"
+                                ))
+                            })?;
 
                         let output_type = match self
                             .original_schema
@@ -548,7 +549,7 @@ mod helpers {
                     }
                 }
 
-                keys.push(format!("{field_name_str}{selection}"));
+                keys.push(field_and_selection.to_key());
 
                 // Add the field if not already present in the output schema
                 if field.get(to_schema.schema()).is_err() {
@@ -833,22 +834,75 @@ mod helpers {
     }
 }
 
-/// Turn a path like a.b.c into a selection like (a,  { b { c } }). Join together to get a key.
-fn path_to_selection(path: &str) -> (String, String) {
-    let mut parts = path.split('.').peekable();
-    let field = parts.next().unwrap_or_default().to_string();
-    let mut selection = String::new();
-    let mut closing_braces = 0;
-    for sub_path in parts {
-        // Generate nested { a { b { c } } }
-        selection.push_str(" { ");
-        selection.push_str(sub_path);
-        closing_braces += 1;
+/// Represents a field and the subselection of that field, which can then be joined together into
+/// a full named selection (which is the same as a key, in simple cases).
+struct FieldAndSelection<'a> {
+    field_name: &'a str,
+    sub_selection: String,
+}
+
+impl<'a> FieldAndSelection<'a> {
+    /// Extract from a path like `a.b.c` into `a` and `b { c }`
+    fn from_path(path: &'a str) -> Self {
+        let mut parts = path.split('.').peekable();
+        let field_name = parts.next().unwrap_or_default();
+        let mut sub_selection = String::new();
+        let mut closing_braces = 0;
+        while let Some(sub_path) = parts.next() {
+            sub_selection.push_str(sub_path);
+            if parts.peek().is_some() {
+                sub_selection.push_str(" { ");
+                closing_braces += 1;
+            }
+        }
+        for _ in 0..closing_braces {
+            sub_selection.push_str(" }");
+        }
+        FieldAndSelection {
+            field_name,
+            sub_selection,
+        }
     }
-    for _ in 0..closing_braces {
-        selection.push_str(" }");
+
+    fn to_key(&self) -> String {
+        if self.sub_selection.is_empty() {
+            self.field_name.to_string()
+        } else {
+            format!("{} {{ {} }}", self.field_name, self.sub_selection)
+        }
     }
-    (field, selection)
+}
+
+#[cfg(test)]
+mod test_field_and_selection {
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::simple("a", "a", "")]
+    #[case::one("a.b", "a", "b")]
+    #[case::two("a.b.c", "a", "b { c }")]
+    #[case::three("a.b.c.d", "a", "b { c { d } }")]
+    fn from_path(
+        #[case] path: &str,
+        #[case] expected_field: &str,
+        #[case] expected_selection: &str,
+    ) {
+        let result = super::FieldAndSelection::from_path(path);
+        assert_eq!(result.field_name, expected_field);
+        assert_eq!(result.sub_selection, expected_selection);
+    }
+
+    #[rstest]
+    #[case::simple("a", "", "a")]
+    #[case::one("a", "b", "a { b }")]
+    #[case::two("a", "b { c }", "a { b { c } }")]
+    fn to_key(#[case] field_name: &str, #[case] sub_selection: &str, #[case] expected_key: &str) {
+        let result = super::FieldAndSelection {
+            field_name,
+            sub_selection: sub_selection.to_string(),
+        };
+        assert_eq!(result.to_key(), expected_key);
+    }
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/expand/sibling_fields.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/expand/sibling_fields.graphql
@@ -1,0 +1,75 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "v1", http: {baseURL: "https://rt-airlock-services-listing.herokuapp.com"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+type K
+  @join__type(graph: CONNECTORS)
+{
+  id: ID!
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  f: T @join__directive(graphs: [CONNECTORS], name: "connect", args: {http: {GET: "https://my.api/t"}, selection: "k { id }"})
+}
+
+type T
+  @join__type(graph: CONNECTORS)
+{
+  k: K
+  b: String @join__directive(graphs: [CONNECTORS], name: "connect", args: {http: {GET: "https://my.api/t/{$this.k.id}"}, selection: "b"})
+}

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/expand/sibling_fields.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/expand/sibling_fields.yaml
@@ -1,0 +1,35 @@
+subgraphs:
+  connectors:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+        @link(url: "https://specs.apollo.dev/federation/v2.10", import: ["@key"])
+        @link(
+          url: "https://specs.apollo.dev/connect/v0.1"
+          import: ["@connect", "@source"]
+        )
+        @source(
+          name: "v1"
+          http: { baseURL: "https://rt-airlock-services-listing.herokuapp.com" }
+        )
+        
+        type T {
+          k: K
+          b: String
+            @connect(http: { GET: "https://my.api/t/{$$this.k.id}" }, selection: "b")
+        }
+        
+        type K {
+          id: ID!
+        }
+        
+        type Query {
+          f: T
+            @connect(
+              http: { GET: "https://my.api/t" }
+              selection: """
+              k { id }
+              """
+            )
+        }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@sibling_fields.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@sibling_fields.graphql-2.snap
@@ -1,0 +1,182 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: connectors.by_service_name
+input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/sibling_fields.graphql
+---
+{
+    "connectors_Query_f_0": Connector {
+        id: ConnectId {
+            label: "connectors. http: GET https://my.api/t",
+            subgraph_name: "connectors",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.f),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "my.api",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    Component {
+                        parts: [
+                            Text(
+                                "t",
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        WithRange {
+                            node: Field(
+                                "k",
+                            ),
+                            range: Some(
+                                0..1,
+                            ),
+                        },
+                        Some(
+                            SubSelection {
+                                selections: [
+                                    Field(
+                                        None,
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                4..6,
+                                            ),
+                                        },
+                                        None,
+                                    ),
+                                ],
+                                range: Some(
+                                    2..8,
+                                ),
+                            },
+                        ),
+                    ),
+                ],
+                range: Some(
+                    0..8,
+                ),
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: None,
+    },
+    "connectors_T_b_0": Connector {
+        id: ConnectId {
+            label: "connectors. http: GET https://my.api/t/{$this.k.id}",
+            subgraph_name: "connectors",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(T.b),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "my.api",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    Component {
+                        parts: [
+                            Text(
+                                "t",
+                            ),
+                        ],
+                    },
+                    Component {
+                        parts: [
+                            Var(
+                                Variable {
+                                    var_type: This,
+                                    path: "k.id",
+                                    location: 18..28,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        WithRange {
+                            node: Field(
+                                "b",
+                            ),
+                            range: Some(
+                                0..1,
+                            ),
+                        },
+                        None,
+                    ),
+                ],
+                range: Some(
+                    0..1,
+                ),
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Implicit,
+        ),
+    },
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@sibling_fields.graphql-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@sibling_fields.graphql-3.snap
@@ -1,0 +1,60 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: raw_sdl
+input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/sibling_fields.graphql
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @join__directive(graphs: [], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1"}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+enum join__Graph {
+  CONNECTORS_QUERY_F_0 @join__graph(name: "connectors_Query_f_0", url: "none")
+  CONNECTORS_T_B_0 @join__graph(name: "connectors_T_b_0", url: "none")
+}
+
+type K @join__type(graph: CONNECTORS_QUERY_F_0) @join__type(graph: CONNECTORS_T_B_0) {
+  id: ID! @join__field(graph: CONNECTORS_QUERY_F_0) @join__field(graph: CONNECTORS_T_B_0)
+}
+
+type T @join__type(graph: CONNECTORS_QUERY_F_0) @join__type(graph: CONNECTORS_T_B_0, key: "k { id }") {
+  k: K @join__field(graph: CONNECTORS_QUERY_F_0) @join__field(graph: CONNECTORS_T_B_0)
+  b: String @join__field(graph: CONNECTORS_T_B_0)
+}
+
+type Query @join__type(graph: CONNECTORS_QUERY_F_0) @join__type(graph: CONNECTORS_T_B_0) {
+  f: T @join__field(graph: CONNECTORS_QUERY_F_0)
+  _: ID @inaccessible @join__field(graph: CONNECTORS_T_B_0)
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@sibling_fields.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@sibling_fields.graphql.snap
@@ -1,0 +1,19 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: api_schema
+input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/sibling_fields.graphql
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type K {
+  id: ID!
+}
+
+type Query {
+  f: T
+}
+
+type T {
+  k: K
+  b: String
+}


### PR DESCRIPTION
We generate a fake selection for path-like variables (e.g., `$this.a.b`) so that we can use the same visitor code as elsewhere to collect fields to carry over to intermediate subgraphs. That selection was broken for any nested fields, since `{b}` is not valid selection on its own. This corrects that problem by omitting the surrounding braces at the first level of nesting, and only putting them back when creating the `@key`.

<!-- CNN-487 -->