### PR TITLE
Upgrade Federation version in `apollo-federation` snapshot tests

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -12,9 +12,9 @@ use apollo_federation::query_plan::TopLevelPlanNode;
 use apollo_federation::schema::ValidFederationSchema;
 use sha1::Digest;
 
-const ROVER_FEDERATION_VERSION: &str = "2.7.4";
+const ROVER_FEDERATION_VERSION: &str = "2.9.0";
 
-const DEFAULT_LINK_DIRECTIVE: &str = r#"@link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"])"#;
+const DEFAULT_LINK_DIRECTIVE: &str = r#"@link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject", "@context", "@fromContext", "@cost", "@listSize"])"#;
 
 /// Runs composition on the given subgraph schemas and return `(api_schema, query_planner)`
 ///

--- a/apollo-federation/tests/query_plan/supergraphs/add_back_sibling_typename_to_interface_object.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/add_back_sibling_typename_to_interface_object.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 9c69e32dbbd50fb46ea218c3581b08f4f084b9b9
+# Composed from subgraphs with hash: 36b8aac0fd3b63ab6a2e4d913ce66381d9c97df2
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -46,9 +46,18 @@ interface Item
   name: String! @join__field(graph: SUBGRAPH1)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/adjacent_mutations_get_merged.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/adjacent_mutations_get_merged.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 54adb76945715a2ce0e068d2635d71ca4166b289
+# Composed from subgraphs with hash: e7bdd5a089836a642476b6cb289e21dfe867b4ab
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -32,9 +32,18 @@ type Foo
   baz: Int @join__field(graph: SUBGRAPHB)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/allows_setting_down_to_1.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/allows_setting_down_to_1.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 91d4d0661d413b60ae2ed463c074c4180d7b849e
+# Composed from subgraphs with hash: a9236eee956ed7fc219b2212696478159ced7eea
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/another_mix_of_fragments_indirection_and_unions.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/another_mix_of_fragments_indirection_and_unions.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: b0bcf31c6c8c64e53e4286dbf397738e41ecbda7
+# Composed from subgraphs with hash: 7e1730cfe16f02de891d008c1310a8355a4b90ab
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ interface I
   id2: ID!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/avoid_considering_indirect_paths_from_the_root_when_a_more_direct_one_exists.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/avoid_considering_indirect_paths_from_the_root_when_a_more_direct_one_exists.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 9df3e1f539626e2d33ad1aeab8fa51e27fd1f441
+# Composed from subgraphs with hash: 5fba714136085371e4c18ce29483c028c1bcb461
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/avoids_unnecessary_fetches.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/avoids_unnecessary_fetches.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 8ba19e06c01ab40b92eda93ac77de08c57856299
+# Composed from subgraphs with hash: f7159b1ede74b4019a8e8f7dfb58369fb4890797
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -32,9 +32,18 @@ type A
   idA1: ID! @join__field(graph: SUBGRAPH3) @join__field(graph: SUBGRAPH4)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/basic_subscription_query_plan.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/basic_subscription_query_plan.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f7613316e8b925d2e1fb7f78b351920adfa4a595
+# Composed from subgraphs with hash: c8a41e00d374bc7c77184e0ffa9fae7d65868f14
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   subscription: Subscription
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -23,9 +23,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/basic_subscription_with_single_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/basic_subscription_with_single_subgraph.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 409fcb3d17fb926642cf9483b5c1db292c219eb1
+# Composed from subgraphs with hash: 8588d7e3fac21b6a30d96678baaf1b49eda0fc99
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   subscription: Subscription
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -23,9 +23,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/can_be_set_to_an_arbitrary_number.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_be_set_to_an_arbitrary_number.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 91d4d0661d413b60ae2ed463c074c4180d7b849e
+# Composed from subgraphs with hash: a9236eee956ed7fc219b2212696478159ced7eea
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fetch.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fetch.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 24f37faeded16eb10b0ffc6c3c2a0e936f406801
+# Composed from subgraphs with hash: f8053ffafe0a672063ce2538526e3eccba5c20dc
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: d4c3168300df54a934d76deb9884e98ba647a676
+# Composed from subgraphs with hash: fe011bd445bfbe40ce53510ba9799480136421c3
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_from_an_interface_object_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_from_an_interface_object_type.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: da551e74f6885542cefc64ed31d2b00579dce2cd
+# Composed from subgraphs with hash: 2d8573a4a560444417df271ed0a39b18c366dbc0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   y: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_type.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: da551e74f6885542cefc64ed31d2b00579dce2cd
+# Composed from subgraphs with hash: 2d8573a4a560444417df271ed0a39b18c366dbc0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   y: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_type_even_for_a_concrete_implementation.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_type_even_for_a_concrete_implementation.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: da551e74f6885542cefc64ed31d2b00579dce2cd
+# Composed from subgraphs with hash: 2d8573a4a560444417df271ed0a39b18c366dbc0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   y: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/can_use_same_root_operation_from_multiple_subgraphs_in_parallel.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_use_same_root_operation_from_multiple_subgraphs_in_parallel.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 34751a1a79473dcec3aad139f107e5b73a855e0d
+# Composed from subgraphs with hash: 40f5afa1d1f5960b7758506956c002b7f3bb3f96
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/condition_order_router799.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/condition_order_router799.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 3ebe0e8c55ad21763879da6341617f14953e80d7
+# Composed from subgraphs with hash: 315fa785fb98377a538827892fc251e5278411df
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -23,9 +23,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   BOOKS @join__graph(name: "books", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/correctly_generate_plan_built_from_some_non_individually_optimal_branch_options.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/correctly_generate_plan_built_from_some_non_individually_optimal_branch_options.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 6ca9a3e7d089605b227c291630c3f089dde1f38d
+# Composed from subgraphs with hash: 2a54a92bba655ef6aba52073886d8834898e3f9e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/correctly_handle_case_where_there_is_too_many_plans_to_consider.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/correctly_handle_case_where_there_is_too_many_plans_to_consider.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 8a8e74cff42f95e71955aa96d62ef9f9589739d5
+# Composed from subgraphs with hash: 50c5a3e3aada2517a4ded58b107fb6c1f368a9e2
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_gets_stripped_out.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_gets_stripped_out.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 3e20191edc9bb3ef7d687ce811c347718e6e4100
+# Composed from subgraphs with hash: 71f5545b94f1467afa42deb9d802e13d0d6af30f
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_can_request_typename_in_fragment.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_can_request_typename_in_fragment.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: e2543fc649c80a566b573ebfad36fc0f7458a3a4
+# Composed from subgraphs with hash: 4650b586dd619bfef02a467d67602c065d4b0ed2
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_everything_within_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_everything_within_entity.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 428d657ed6389527be73c6ad949cd2fc4da01b20
+# Composed from subgraphs with hash: 22e24356e106228bb20c17c7dabbf476fde27e22
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_multiple_fields_in_different_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_multiple_fields_in_different_subgraphs.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 6de814e8aeb455e136ac8627284d67ef4806de57
+# Composed from subgraphs with hash: 15876cef8879238c8dad83fa7976f2925553a806
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_enity_but_with_unuseful_key.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_enity_but_with_unuseful_key.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: e9d8806fbdfd92a23a7dd2af1e343ff3b6de4a7c
+# Composed from subgraphs with hash: a8cdce83720ad36769df084cc55e8b418099bca5
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_everything_queried.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_everything_queried.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 428d657ed6389527be73c6ad949cd2fc4da01b20
+# Composed from subgraphs with hash: 22e24356e106228bb20c17c7dabbf476fde27e22
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_multi_dependency_deferred_section.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_multi_dependency_deferred_section.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: cb3bc5e47277ef2c4a364fa62067cfc2426974ec
+# Composed from subgraphs with hash: cf4534a5c50af23995f1e5aa82b79e9a858b92bf
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_in_same_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_in_same_subgraph.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: e33e3ea89ff4340ccd53321764ac7f1a2684eb3f
+# Composed from subgraphs with hash: 078a72747c6fbfb51e60cd9f7959b3b158495800
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -23,9 +23,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_on_different_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_on_different_subgraphs.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 557c634741b7e9f2f4288edb43724e47f1983d19
+# Composed from subgraphs with hash: d44e187a9a459bd70767ee503e7a1dc4c783d0bf
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -23,9 +23,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_query_root_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_query_root_type.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 0a1dc62b0c2282030c10f0e0f777f635d6abd3ba
+# Composed from subgraphs with hash: 02b05d7c673780361314e10cefea62f6d79d8e3b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -30,9 +30,18 @@ type A
   next: Query
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_value_types.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_value_types.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 01170823ab6c07812976d0983a101d49a319af5c
+# Composed from subgraphs with hash: 5cea36a97a40394811ab9ccf97df46c40dcd8ebc
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_only_the_key_of_an_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_only_the_key_of_an_entity.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 176bb27a622184464209652e70141da92aeef370
+# Composed from subgraphs with hash: 6b693215fbaac31a45aba14a606333aad808ef8e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_resuming_in_the_same_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_resuming_in_the_same_subgraph.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 0e99f2e41acb0f707744e78845a55271589146e6
+# Composed from subgraphs with hash: ead6b9a76f52b7caba51acba21fdd37fa52e369a
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_condition_on_single_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_condition_on_single_subgraph.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 59e305d633b6e337422f6431c32cc58defa07302
+# Composed from subgraphs with hash: 6da68bcd4562ba2b8aea44307e29b2b409da8920
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_conditions_and_labels.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_conditions_and_labels.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: e2543fc649c80a566b573ebfad36fc0f7458a3a4
+# Composed from subgraphs with hash: 4650b586dd619bfef02a467d67602c065d4b0ed2
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_mutliple_conditions_and_labels.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_mutliple_conditions_and_labels.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 2135cbed03439b8658c0113e4663849c991e244b
+# Composed from subgraphs with hash: 21f2df1c19b833341b4f9643d34ea0b9cef55ab4
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_entity.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 355f15f0f2699fd21731b0403286c513357860d3
+# Composed from subgraphs with hash: 929471dddc80c1a51b87f346eb2f416084d542eb
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_value_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_value_type.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f507628640adf8891453e78dbd4280a132706b11
+# Composed from subgraphs with hash: e99d2671927f9c6a1ee42f44d3c386ade3094009
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_do_not_merge_query_branches_with_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_do_not_merge_query_branches_with_defer.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 6af2331e8c3844fbee6c3888b80b44f51cd5bd3d
+# Composed from subgraphs with hash: e3be845f74566fd4e434d5d8bf76f6bc7ea62166
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_fragments_expand_into_same_field_regardless_of_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_fragments_expand_into_same_field_regardless_of_defer.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5382aae137e16d1dfb9955e2a5118b49c75320ea
+# Composed from subgraphs with hash: 98071a61d2822a625067b9d1f84c36ca368801d9
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_with_defer_enabled.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_with_defer_enabled.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f7c59d88291d4be94f4c484dc849118a08361e69
+# Composed from subgraphs with hash: 6f4f2bbb16236373f2eba847b503d19498249c01
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_without_defer_enabled.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_without_defer_enabled.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f7c59d88291d4be94f4c484dc849118a08361e69
+# Composed from subgraphs with hash: 6f4f2bbb16236373f2eba847b503d19498249c01
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_interface_has_different_definitions_between_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_interface_has_different_definitions_between_subgraphs.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: d280d3aae78ad7080c8df8b5a8982d70a4000a78
+# Composed from subgraphs with hash: f2201cf706257dc01dcf09fb0ae827af3b9fa88e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -31,9 +31,18 @@ interface I
   b: Int @join__field(graph: SUBGRAPH2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_multiple_non_nested_defer_plus_label_handling.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_multiple_non_nested_defer_plus_label_handling.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 09643fc5e0d3abcab8a0f25c0c1e4e16da4169a4
+# Composed from subgraphs with hash: 4c287523c033f1b01e358623f51eb8b9ac3dcd85
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_named_fragments_simple.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_named_fragments_simple.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 395eb0d8e844d7a54e82eec772f007fafcc37a8e
+# Composed from subgraphs with hash: 5f3018ae7e7b98a497ce4fbe8dcd5180c065da06
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_nested_defer_on_entities.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_nested_defer_on_entities.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 1ddb9374f772bf962933f20e08543315e8df2b01
+# Composed from subgraphs with hash: b5d17f8a99a3b6c92c1c3f78456e46fadc515cf5
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer_case_one.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer_case_one.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 3bee990c996344aa1eb3a7211e3f497fcbe5e1a6
+# Composed from subgraphs with hash: 3c1a8e679e219bea6bc85b846327ff42bdfac701
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer_case_three.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer_case_three.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: c6019a1bd80338506615bb1b60a44fc384586a47
+# Composed from subgraphs with hash: 29206c46cff52b5aadce1935a0f3175d5aacb8dd
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer_case_two.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer_case_two.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: fc9fa92848d4ab0e200dcfd09762db2e4281efae
+# Composed from subgraphs with hash: a985245292473d8c3e90fc33a9c69754285492cc
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_normalizes_if_false.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_normalizes_if_false.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f7c59d88291d4be94f4c484dc849118a08361e69
+# Composed from subgraphs with hash: 6f4f2bbb16236373f2eba847b503d19498249c01
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_normalizes_if_true.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_normalizes_if_true.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f7c59d88291d4be94f4c484dc849118a08361e69
+# Composed from subgraphs with hash: 6f4f2bbb16236373f2eba847b503d19498249c01
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_provides_are_ignored_for_deferred_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_provides_are_ignored_for_deferred_fields.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 39be4a27050623ad7a03d8ae9fed684d1e0f3088
+# Composed from subgraphs with hash: d4bf20edb94edf0cfe2d81956633e26905b36c4e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_requirements_of_deferred_fields_are_deferred.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_requirements_of_deferred_fields_are_deferred.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: b3f138a89fd35476e9e36002ae4c8c1ab51c4530
+# Composed from subgraphs with hash: b8bd40a365081d5870913002ff2d4bf0dba0af58
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_the_path_in_defer_includes_traversed_fragments.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_the_path_in_defer_includes_traversed_fragments.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: eea1ddd3f3e944aaeb5f39f8f9018fd32bcdaaf6
+# Composed from subgraphs with hash: 195dbb671585fe1c25717d53d9d35239abd2e09f
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -36,9 +36,18 @@ interface I
   x: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/does_not_error_on_some_complex_fetch_group_dependencies.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/does_not_error_on_some_complex_fetch_group_dependencies.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 604dead6fd018b16380a1abf51ba199acbdb82f2
+# Composed from subgraphs with hash: c32793dd157c67a6637ceabda719536fc3c703d3
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/does_not_error_out_handling_fragments_when_interface_subtyping_is_involved.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/does_not_error_out_handling_fragments_when_interface_subtyping_is_involved.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 85a2b796ad6f1553ddbc0bf5f4722e602f475090
+# Composed from subgraphs with hash: 7a5c84b7ae6162a788aa569091fcd5a8fe8c4771
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -49,9 +49,18 @@ interface IB
   v1: Int!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/does_not_evaluate_plans_relying_on_a_key_field_to_fetch_that_same_field.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/does_not_evaluate_plans_relying_on_a_key_field_to_fetch_that_same_field.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: e4cc087ad60a261439df7beadccbe9b4a31eaa8d
+# Composed from subgraphs with hash: 408f5bf6c20bc49fa52320c529af66fbb36287dd
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/does_not_rely_on_an_interface_object_directly_for_typename.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/does_not_rely_on_an_interface_object_directly_for_typename.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: da551e74f6885542cefc64ed31d2b00579dce2cd
+# Composed from subgraphs with hash: 2d8573a4a560444417df271ed0a39b18c366dbc0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   y: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/does_not_rely_on_an_interface_object_directly_if_a_specific_implementation_is_requested.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/does_not_rely_on_an_interface_object_directly_if_a_specific_implementation_is_requested.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: da551e74f6885542cefc64ed31d2b00579dce2cd
+# Composed from subgraphs with hash: 2d8573a4a560444417df271ed0a39b18c366dbc0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   y: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/ensures_sanitization_applies_repeatedly.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/ensures_sanitization_applies_repeatedly.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5a37dc86c56cab4caab8bb5d9606eb4c7df0d804
+# Composed from subgraphs with hash: bb70b30ff3918c2d33483331b733c724cbd8631d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/field_covariance_and_type_explosion.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/field_covariance_and_type_explosion.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 2254345d779de0a2850b6c7a5db722f1989a774c
+# Composed from subgraphs with hash: 184d4f82c7a51478107e30ce8aee3d1862c804c2
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -28,9 +28,18 @@ interface Interface
   field: Interface
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/fields_are_not_overwritten_when_directives_are_removed.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/fields_are_not_overwritten_when_directives_are_removed.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 654c7bcba86c6f5845a7cb520710cfa37b678e3d
+# Composed from subgraphs with hash: 8afd32067575aaae505bac05752941b0314b3cf0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -35,9 +35,18 @@ type Foo
   bar: Bar
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHSKIP @join__graph(name: "SubgraphSkip", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/fragment_with_intersecting_parent_type_and_directive_condition.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/fragment_with_intersecting_parent_type_and_directive_condition.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: e2393609250b71261acc4089006bc8a14627d488
+# Composed from subgraphs with hash: 60b6f32feef51579a2b534cc06e803a7fd2aa5d8
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -37,9 +37,18 @@ interface I2
   title: String
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   A @join__graph(name: "A", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/fragments_that_share_a_hash_but_are_not_identical_generate_their_own_fragment_definitions.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/fragments_that_share_a_hash_but_are_not_identical_generate_their_own_fragment_definitions.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 62d7e50e5ef7c204246ba7c0cefcef3e9e5bef0c
+# Composed from subgraphs with hash: d87fc8c7d88d7ddc316b4109f5c0f08a3319255b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -12,7 +12,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -39,9 +39,18 @@ type B
   z: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handle_subgraph_with_hypen_in_the_name.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handle_subgraph_with_hypen_in_the_name.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: c2ea0958d4d930ae3bf3535692a966af9f3af063
+# Composed from subgraphs with hash: dceeff5b8cc9eef0d5d67d90dcad47c9d2bcdeee
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handle_very_non_graph_subgraph_name.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handle_very_non_graph_subgraph_name.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 2ad000b79369f5b833cec8d6e5e62e99db89585c
+# Composed from subgraphs with hash: 008d1087d7fbef647f430c6050718ba5fd3247db
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   _42_ @join__graph(name: "42!", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_case_of_key_chains_in_parallel_requires.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_case_of_key_chains_in_parallel_requires.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 6f7dd1a877d5de533c98948e91197cb3526ed446
+# Composed from subgraphs with hash: 657939f9f9642f8874ed6a99f6d8f0b724c29d6b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_fragments_with_interface_field_subtyping.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_fragments_with_interface_field_subtyping.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: cd5671782860ad7353fd02dfb07664cdc89a5809
+# Composed from subgraphs with hash: 631090cf03bf148115fe36abae4e705737e27a73
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ interface I
   other: I!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_mix_of_fragments_indirection_and_unions.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_mix_of_fragments_indirection_and_unions.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 0b61d90468ba75e031fdc3c1abe0ac8e87674cc7
+# Composed from subgraphs with hash: 2bc15991aebf8f895f3eb5d24040154b20447182
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -41,9 +41,18 @@ type Child
   id: ID!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_multiple_conditions_on_abstract_types.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_multiple_conditions_on_abstract_types.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 2bb5218456c710b3aeaf9c5a9a7d87eee258917f
+# Composed from subgraphs with hash: ef4b999f84fcdb4baba65f1a44c84d1e4267d948
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -36,9 +36,18 @@ type Book implements Product
   reviews: [Review!]! @join__field(graph: REVIEWS)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   BOOKS @join__graph(name: "books", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_multiple_requires_involving_different_nestedness.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_multiple_requires_involving_different_nestedness.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 6120a9371b90c378d13d977d19bad9e17c6875cb
+# Composed from subgraphs with hash: 6912a71c206209826d59e92decbc10df806b4164
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -33,9 +33,18 @@ type Item
   computed2: String @join__field(graph: SUBGRAPH2, requires: "user { value }")
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_non_intersecting_fragment_conditions.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_non_intersecting_fragment_conditions.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: cc0d8d93561b6e20d87ae1541b16037be17333ef
+# Composed from subgraphs with hash: 3c577bdcdfd12b97d2b265e5ccd5ddf286addb71
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -44,9 +44,18 @@ interface Fruit
   edible: Boolean!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_non_matching_value_types_under_interface_field.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_non_matching_value_types_under_interface_field.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 9959b044b8b84e47c4559354eb1d87299be28495
+# Composed from subgraphs with hash: 2c44fca1dca09f3611b2c3d037001fdcb2bd607c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -28,9 +28,18 @@ interface I
   s: S
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_query_of_an_interface_field_for_a_specific_implementation_when_query_starts_with_interface_object.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_query_of_an_interface_field_for_a_specific_implementation_when_query_starts_with_interface_object.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: da551e74f6885542cefc64ed31d2b00579dce2cd
+# Composed from subgraphs with hash: 2d8573a4a560444417df271ed0a39b18c366dbc0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   y: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_requires_from_supergraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_requires_from_supergraph.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: c980fbf8b4a77ab38f828719197c4878658aa92c
+# Composed from subgraphs with hash: aa3ba9dce3c336c185aea3d559466b7d5a3d6602
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ interface I
   name: String
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_root_operation_shareable_in_many_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_root_operation_shareable_in_many_subgraphs.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: dece71b67cd54bf5e3bf43988e99a638876d52e5
+# Composed from subgraphs with hash: f03aecdc91efa05b3b7a659e31c58bfcd905fb73
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_simple_requires.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_simple_requires.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: a2964ea427e664c7c007a258b54d68db9abae8f4
+# Composed from subgraphs with hash: d4af614c7debcf4bf2aa8a18f0f23f04412be82d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_spread_unions_correctly.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_spread_unions_correctly.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 361121049969085d46eae818d8c9d8da18d3cf6c
+# Composed from subgraphs with hash: cf0557ca376939819cf4d2f4f7e46d4b3d7836d7
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -47,9 +47,18 @@ type C
   c2: Int @join__field(graph: SUBGRAPH2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/handles_types_with_no_common_supertype_at_the_same_merge_at.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_types_with_no_common_supertype_at_the_same_merge_at.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 98f941b67e6dc18205c3148808a6bce2b64c775f
+# Composed from subgraphs with hash: 8a740dea36b9a39b79632385c08dd53e07af0cbb
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -40,9 +40,18 @@ type Foo
   y: Int @join__field(graph: SUBGRAPH2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/interface_interface_interaction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/interface_interface_interaction.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 6ac1ca5a8c7d1596024e97bb378f1f829788fd71
+# Composed from subgraphs with hash: aad30ec98d465ca592dcfb7b6493a1721589fda7
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -60,9 +60,18 @@ interface I2
   v: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/interface_interface_interaction_but_no_need_to_type_explode.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/interface_interface_interaction_but_no_need_to_type_explode.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5073ac23b2d2f5657028261e837e26e4370a3cf4
+# Composed from subgraphs with hash: 6bcf7c1079cc0111e6fc2f4134333b73fc319248
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -60,9 +60,18 @@ interface I2
   v: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/interface_union_interaction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/interface_union_interaction.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 43ca669a61b756dfac8bec5822d87393bc9f3544
+# Composed from subgraphs with hash: 92c4a98434a66db1d0a5cc563bea94c0faaa1a55
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -50,9 +50,18 @@ interface I
   v: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/interface_union_interaction_but_no_need_to_type_explode.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/interface_union_interaction_but_no_need_to_type_explode.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 2548adb14fdc2eacf229834ee87327873c15cb8d
+# Composed from subgraphs with hash: e851cb374aa6dea60bffafd658bccd2e017af6f1
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   v: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_allow_providing_fields_for_only_some_subtype.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_allow_providing_fields_for_only_some_subtype.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 7225f76e0549cfa72d92ea3d954fbfa4f5325cff
+# Composed from subgraphs with hash: 799c11349d958543e444e53c4ed186a8e7f820f6
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ interface I
   b: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_avoid_fragments_usable_only_once.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_avoid_fragments_usable_only_once.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 57cf5fd9ee4bd6e69d9976aef7ff289a74c757c4
+# Composed from subgraphs with hash: 3ea57c667516dce90ad8a2331832f8be1f86f197
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_avoids_buffering_interface_object_results_that_may_have_to_be_filtered_with_lists.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_avoids_buffering_interface_object_results_that_may_have_to_be_filtered_with_lists.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 885b71f276ed574d24895695bddb2bd130640f65
+# Composed from subgraphs with hash: 803bcb0fbcd87892a96ce14b10f3c11256f2870b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -48,9 +48,18 @@ interface I
   expansiveField: String @join__field(graph: S1)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_can_require_at_inaccessible_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_can_require_at_inaccessible_fields.graphql
@@ -1,8 +1,8 @@
-# Composed from subgraphs with hash: 49f8443a5ff323a1ffed6b7122a1d61e6225d235
+# Composed from subgraphs with hash: 8d7a727bb1c4430ee3ee6df729a5c72ac0a7e181
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", import: ["@inaccessible"], for: SECURITY)
 {
   query: Query
 }
@@ -13,7 +13,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -25,9 +25,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_does_not_needlessly_consider_options_for_typename.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_does_not_needlessly_consider_options_for_typename.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: ee7dda36e9dc663f9750f86da48822e8f6f6ea8f
+# Composed from subgraphs with hash: 665427c4bfc0c14e12d92d34229628661820a58b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_does_not_override_unset_labels_on_entity_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_does_not_override_unset_labels_on_entity_fields.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: ea1fd23b849053c0b7cfbf9a192453c71e70f889
+# Composed from subgraphs with hash: 898d84a7356419fd51e15c565a45b3ba121f272f
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "s1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_does_not_override_unset_labels_on_nested_entity_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_does_not_override_unset_labels_on_nested_entity_fields.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: ea1fd23b849053c0b7cfbf9a192453c71e70f889
+# Composed from subgraphs with hash: 898d84a7356419fd51e15c565a45b3ba121f272f
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "s1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_does_not_override_unset_labels_on_root_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_does_not_override_unset_labels_on_root_fields.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: b409284c35003f62c7c83675734478b1970effb2
+# Composed from subgraphs with hash: 876e9aeacdff38ab69fae92ab4830e10f28b6fd3
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "s1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgraph.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 11ffa462805ad28daecca693ed1a45d931d3cac8
+# Composed from subgraphs with hash: 48933e92f90d5670a9f24349a530c214cf89fbbc
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -30,9 +30,18 @@ interface I
   b: Int @join__field(graph: SUBGRAPH2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_executes_mutation_operations_in_sequence.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_executes_mutation_operations_in_sequence.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: ff6534336a58b9a72232e43fdb66c4769ac4ae66
+# Composed from subgraphs with hash: 167da40652f362ea1ee23360c16a7a706369148d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -23,9 +23,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handes_diamond_shape_depedencies.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handes_diamond_shape_depedencies.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 2a90ec602bc41c24462757dc66b2e37e1d96dbf4
+# Composed from subgraphs with hash: a7228e28b556a2f72545f7993f3b68d25944b04d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   A @join__graph(name: "A", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_a_simple_at_requires_triggered_within_a_conditional.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_a_simple_at_requires_triggered_within_a_conditional.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 88de1465b4ef08a76a910cff26136f931b69eca4
+# Composed from subgraphs with hash: a5459e4976ee54fb002ab54de666b70cd01c9805
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_an_at_requires_triggered_conditionally.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_an_at_requires_triggered_conditionally.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 88de1465b4ef08a76a910cff26136f931b69eca4
+# Composed from subgraphs with hash: a5459e4976ee54fb002ab54de666b70cd01c9805
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_an_at_requires_where_multiple_conditional_are_involved.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_an_at_requires_where_multiple_conditional_are_involved.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 213ee593775b6e4a22a852a35da688bc2e85d710
+# Composed from subgraphs with hash: 8d562727336acf24ddefa337d51f03c88d6634de
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -39,9 +39,18 @@ type B
   c: Int @join__field(graph: SUBGRAPH3, requires: "required")
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_complex_require_chain.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_complex_require_chain.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: eeb0b0963b210e2f82e6f40f535037882afb96db
+# Composed from subgraphs with hash: f82048b558e108214a7bd9b888b7cd19868588b4
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -40,9 +40,18 @@ type Inner4Type
   inner4_nested: Int! @join__field(graph: SUBGRAPH5, requires: "inner4_required")
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_differs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_differs.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 0545139260d6549f4e32906bce43c37742fdff80
+# Composed from subgraphs with hash: b2221050efb89f6e4df71823675d2ea1fbe66a31
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -38,9 +38,18 @@ type Inner implements I
   w: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relation_differs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relation_differs.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 2be5cb3476eaeac718ff9d77f717b70fe9f344a2
+# Composed from subgraphs with hash: 94b7e94d03865ae730e8e7b6165d4deeed218c72
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ type Inner
   w: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_fragments_with_one_non_leaf_field.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_fragments_with_one_non_leaf_field.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 62d7e50e5ef7c204246ba7c0cefcef3e9e5bef0c
+# Composed from subgraphs with hash: d87fc8c7d88d7ddc316b4109f5c0f08a3319255b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -12,7 +12,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -39,9 +39,18 @@ type B
   z: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_interface_object_in_nested_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_interface_object_in_nested_entity.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 3881ebaea69bd73941780a88cffefd7f909c77d1
+# Composed from subgraphs with hash: 2dd159285f3b564dab13310cf19c753575fbf1d6
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -49,9 +49,18 @@ interface I
   a: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_interface_object_input_rewrites_when_cloning_dependency_graph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_interface_object_input_rewrites_when_cloning_dependency_graph.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 3799eb12e6387413ef90a73d8848b5c48e40cbca
+# Composed from subgraphs with hash: 1b82052bbef41bea0b8cc6650bfd42149af666b5
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -31,9 +31,18 @@ interface I
   i3: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_longer_require_chain.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_longer_require_chain.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 00470b1d89f783a11f9b05f82d8377c0d5e3f89d
+# Composed from subgraphs with hash: 13b9f66e51175713b45f58b5c9cb1bf93123c731
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_multiple_requires_with_multiple_fetches.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_multiple_requires_with_multiple_fetches.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 55b2cd6d674b743ae99fa918dce065759899f51d
+# Composed from subgraphs with hash: d9d299269fc1b12c334504cd1ba44d173360c498
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -31,9 +31,18 @@ interface I
   name: String!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "s1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_multiple_requires_within_the_same_entity_fetch.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_multiple_requires_within_the_same_entity_fetch.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 151440cab35934f002ebab673ce5f8bd86966772
+# Composed from subgraphs with hash: 6670829507adac060bea0af75f139243611c4359
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -30,9 +30,18 @@ interface I
   g: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_nested_fragment_generation.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_nested_fragment_generation.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 62d7e50e5ef7c204246ba7c0cefcef3e9e5bef0c
+# Composed from subgraphs with hash: d87fc8c7d88d7ddc316b4109f5c0f08a3319255b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -12,7 +12,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -39,9 +39,18 @@ type B
   z: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_progressive_override_on_entity_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_progressive_override_on_entity_fields.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: ea1fd23b849053c0b7cfbf9a192453c71e70f889
+# Composed from subgraphs with hash: 898d84a7356419fd51e15c565a45b3ba121f272f
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "s1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_progressive_override_on_nested_entity_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_progressive_override_on_nested_entity_fields.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: ea1fd23b849053c0b7cfbf9a192453c71e70f889
+# Composed from subgraphs with hash: 898d84a7356419fd51e15c565a45b3ba121f272f
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "s1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_progressive_override_on_root_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_progressive_override_on_root_fields.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: b409284c35003f62c7c83675734478b1970effb2
+# Composed from subgraphs with hash: 876e9aeacdff38ab69fae92ab4830e10f28b6fd3
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "s1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_require_chain_not_ending_in_original_group.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_require_chain_not_ending_in_original_group.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: ff92849ceafa9aaccab960b8b5ce0e98a13e6a00
+# Composed from subgraphs with hash: b700dc9de06af55918612c3c23975613c7625ab0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_requires_on_concrete_type_of_field_provided_by_interface_object.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_requires_on_concrete_type_of_field_provided_by_interface_object.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 209a0436ca69cb640450ef4fc7c204a5b5fc6058
+# Composed from subgraphs with hash: 2a2bbbfde2d57ed4fb71a1b63682f2c3ea5f27e5
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -47,9 +47,18 @@ interface I
   x: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_simple_require_chain.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_simple_require_chain.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 244af51d2d8ba7d87e4b9fec74bbb49dc7b00e4d
+# Composed from subgraphs with hash: 457e28f8e650826536a34aec9a0d7e7f938609a2
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_identifies_and_reuses_equivalent_fragments_that_arent_identical.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_identifies_and_reuses_equivalent_fragments_that_arent_identical.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 62d7e50e5ef7c204246ba7c0cefcef3e9e5bef0c
+# Composed from subgraphs with hash: d87fc8c7d88d7ddc316b4109f5c0f08a3319255b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -12,7 +12,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -39,9 +39,18 @@ type B
   z: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_migrates_skip_include.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_migrates_skip_include.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 62d7e50e5ef7c204246ba7c0cefcef3e9e5bef0c
+# Composed from subgraphs with hash: d87fc8c7d88d7ddc316b4109f5c0f08a3319255b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -12,7 +12,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -39,9 +39,18 @@ type B
   z: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_overrides_f1_to_s3_when_label_is_provided.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_overrides_f1_to_s3_when_label_is_provided.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5f73656f77e5320839ceba43507ea13060eea5e1
+# Composed from subgraphs with hash: 58136a8ddfdf60b78598ff5b86f5b4ae3193a41c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_overrides_to_s2_when_label_is_provided.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_overrides_to_s2_when_label_is_provided.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5f73656f77e5320839ceba43507ea13060eea5e1
+# Composed from subgraphs with hash: 58136a8ddfdf60b78598ff5b86f5b4ae3193a41c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_preservers_aliased_typename.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_preservers_aliased_typename.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: d7fe5a716fee436faefb289f7ba4a8bd05bd7d34
+# Composed from subgraphs with hash: ce2557f5278c94808d1e49ad488bf60d0355e98d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_preserves_directives_when_fragment_is_reused.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_preserves_directives_when_fragment_is_reused.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 75955b009750aae84f92b194eddcb553f0e44656
+# Composed from subgraphs with hash: 136ac120ab3c0a9b8ea4cb22cb440886a1b4a961
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_preserves_directives_when_fragment_not_used.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_preserves_directives_when_fragment_not_used.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 75955b009750aae84f92b194eddcb553f0e44656
+# Composed from subgraphs with hash: 136ac120ab3c0a9b8ea4cb22cb440886a1b4a961
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_preserves_nested_fragments_when_outer_one_has_directives_and_is_eliminated.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_preserves_nested_fragments_when_outer_one_has_directives_and_is_eliminated.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f580fdce2d5df285d6e12633d4355b51e2fd52fd
+# Composed from subgraphs with hash: fd162a5fc982fc2cd0a8d33e271831822b681137
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_preserves_typename_with_directives.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_preserves_typename_with_directives.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5781ed69d05761a7c894a8aac04728581a2475d9
+# Composed from subgraphs with hash: feb9a6756ae190fe90dc2297767c2b4b08fb56a9
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_require_of_multiple_field_when_one_is_also_a_key_to_reach_another.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_require_of_multiple_field_when_one_is_also_a_key_to_reach_another.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 3766e23446d1f1881fb155fefa8036726c6f34c4
+# Composed from subgraphs with hash: 01a8e1dfb199705050c7be5bc0f6efb3da20e92e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   A @join__graph(name: "A", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_resolves_f1_in_s1_when_label_is_not_provided.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_resolves_f1_in_s1_when_label_is_not_provided.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5f73656f77e5320839ceba43507ea13060eea5e1
+# Composed from subgraphs with hash: 58136a8ddfdf60b78598ff5b86f5b4ae3193a41c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_resolves_in_s1_when_label_is_not_provided.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_resolves_in_s1_when_label_is_not_provided.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5f73656f77e5320839ceba43507ea13060eea5e1
+# Composed from subgraphs with hash: 58136a8ddfdf60b78598ff5b86f5b4ae3193a41c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_respects_generate_query_fragments_option.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_respects_generate_query_fragments_option.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 62d7e50e5ef7c204246ba7c0cefcef3e9e5bef0c
+# Composed from subgraphs with hash: d87fc8c7d88d7ddc316b4109f5c0f08a3319255b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -12,7 +12,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -39,9 +39,18 @@ type B
   z: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_works_on_interfaces.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_works_on_interfaces.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: d654244e34da1e73ea47f5325e371614408d38ae
+# Composed from subgraphs with hash: d2db7329336a011305d153d60031e5fe634adedb
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -28,9 +28,18 @@ interface I
   v: Value
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_works_on_unions.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_works_on_unions.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 87210bff4bf720ff0fe68c22dae1d3e5520d7980
+# Composed from subgraphs with hash: aa33c34a78654942627b836a960f9da314ca826e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_fragments_1.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_fragments_1.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 18fc379a3170731963d1ec9f54f8b002b0f5d874
+# Composed from subgraphs with hash: 0b52a1cc2cdc06e7b2bb3c438672662d0f80de68
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -64,9 +64,18 @@ interface Foo
   child2: Foo
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_fragments_when_only_the_nested_fragment_gets_preserved.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_fragments_when_only_the_nested_fragment_gets_preserved.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 197c4ea5c04d17ec60cb084c49efe2f9d662079b
+# Composed from subgraphs with hash: af8642bd2cc335a2823e7c95f48ce005d3c809f0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_provides.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_provides.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: fb1513832764f051dd663a966309809fb58e4519
+# Composed from subgraphs with hash: d2ea3c5c49010cc58bc83d22cf064d8e307ad23e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/it_works_with_type_condition_even_for_types_only_reachable_by_the_at_provides.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_works_with_type_condition_even_for_types_only_reachable_by_the_at_provides.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 0556f39f18edcd446ffee2af4cec39d408bf7b7d
+# Composed from subgraphs with hash: bb2856a3e0e2f066120553ce903effcc593c7907
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -37,9 +37,18 @@ interface I
   a: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/key_where_at_external_is_not_at_top_level_of_selection_of_requires.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/key_where_at_external_is_not_at_top_level_of_selection_of_requires.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 3035e486a3ec94c91ff841c2eb464b287fead177
+# Composed from subgraphs with hash: 3517f40ed88e4d3fad368bc9dc78a52173c3f827
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   A @join__graph(name: "A", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_multiple_applications_differing_order.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_multiple_applications_differing_order.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: fbbe470b5e40af130de42043f74772ec30ee60ff
+# Composed from subgraphs with hash: 00f8a26b066b234394aed3ca1e140a534b0364a8
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ type Hello
   goodbye: String!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHSKIP @join__graph(name: "SubgraphSkip", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_multiple_applications_differing_quantity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_multiple_applications_differing_quantity.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: fbbe470b5e40af130de42043f74772ec30ee60ff
+# Composed from subgraphs with hash: 00f8a26b066b234394aed3ca1e140a534b0364a8
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ type Hello
   goodbye: String!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHSKIP @join__graph(name: "SubgraphSkip", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_multiple_applications_identical.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_multiple_applications_identical.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: fbbe470b5e40af130de42043f74772ec30ee60ff
+# Composed from subgraphs with hash: 00f8a26b066b234394aed3ca1e140a534b0364a8
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ type Hello
   goodbye: String!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHSKIP @join__graph(name: "SubgraphSkip", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_with_fragment.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_with_fragment.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: fbbe470b5e40af130de42043f74772ec30ee60ff
+# Composed from subgraphs with hash: 00f8a26b066b234394aed3ca1e140a534b0364a8
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ type Hello
   goodbye: String!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHSKIP @join__graph(name: "SubgraphSkip", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_without_fragment.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/merging_skip_and_include_directives_without_fragment.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: fbbe470b5e40af130de42043f74772ec30ee60ff
+# Composed from subgraphs with hash: 00f8a26b066b234394aed3ca1e140a534b0364a8
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ type Hello
   goodbye: String!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHSKIP @join__graph(name: "SubgraphSkip", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/multiplication_overflow_in_reduce_options_if_needed.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/multiplication_overflow_in_reduce_options_if_needed.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 91d4d0661d413b60ae2ed463c074c4180d7b849e
+# Composed from subgraphs with hash: a9236eee956ed7fc219b2212696478159ced7eea
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/nested_fragment_with_intersecting_parent_type_and_directive_condition.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/nested_fragment_with_intersecting_parent_type_and_directive_condition.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: e2393609250b71261acc4089006bc8a14627d488
+# Composed from subgraphs with hash: 60b6f32feef51579a2b534cc06e803a7fd2aa5d8
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -37,9 +37,18 @@ interface I2
   title: String
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   A @join__graph(name: "A", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/non_adjacent_mutations_do_not_get_merged.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/non_adjacent_mutations_do_not_get_merged.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 54adb76945715a2ce0e068d2635d71ca4166b289
+# Composed from subgraphs with hash: e7bdd5a089836a642476b6cb289e21dfe867b4ab
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -32,9 +32,18 @@ type Foo
   baz: Int @join__field(graph: SUBGRAPHB)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/only_uses_an_interface_object_if_it_can.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/only_uses_an_interface_object_if_it_can.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: da551e74f6885542cefc64ed31d2b00579dce2cd
+# Composed from subgraphs with hash: 2d8573a4a560444417df271ed0a39b18c366dbc0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   y: Int @join__field(graph: S2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/pick_keys_that_minimize_fetches.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/pick_keys_that_minimize_fetches.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 454b3fc41adce04fc670f06030743d521d09096d
+# Composed from subgraphs with hash: 477d072dba9eac87f14e07f061eef2003d803291
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -37,9 +37,18 @@ type Currency
   sign: String!
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/redundant_typename_for_inline_fragments_without_type_condition.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/redundant_typename_for_inline_fragments_without_type_condition.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f02b27ab5f92e1e70c07bf7d5ce65e620637ef35
+# Composed from subgraphs with hash: 926811cf9f8aa69f79e2143ad129969648ca0b75
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/respects_query_planner_option_reuse_query_fragments_false.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/respects_query_planner_option_reuse_query_fragments_false.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 4fc759c1b39c54d520a6868db43813e4a38bbaf3
+# Composed from subgraphs with hash: d072d5c57a6c4387ebe527d2ad00a30cbceac34b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ type A
   y: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/respects_query_planner_option_reuse_query_fragments_true.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/respects_query_planner_option_reuse_query_fragments_true.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 4fc759c1b39c54d520a6868db43813e4a38bbaf3
+# Composed from subgraphs with hash: d072d5c57a6c4387ebe527d2ad00a30cbceac34b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -29,9 +29,18 @@ type A
   y: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/same_as_js_router798.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/same_as_js_router798.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: ee7fce9eb672edf9b036a25bcae0b056ccf5f451
+# Composed from subgraphs with hash: 3606ac3a1b1064419fe78425582e73b5ce3b5369
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -28,9 +28,18 @@ interface Interface
   a: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/selections_are_not_overwritten_after_removing_directives.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/selections_are_not_overwritten_after_removing_directives.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 56ab651bf30bcb3ac7a9fb826fa6b03a57288859
+# Composed from subgraphs with hash: 0d8bac977a97888c29d1c90cff65ea818522aeec
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -38,9 +38,18 @@ type Foo
   bar: Bar
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/skip_type_explosion_early_if_unnecessary.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/skip_type_explosion_early_if_unnecessary.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 63eb1eb88aa472162170c24e74ca47c7c4ac1866
+# Composed from subgraphs with hash: 22a84f887ef58f251ff2c8f6439dcdfbdc1395fd
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -28,9 +28,18 @@ interface I
   s: S
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/subgraph_query_retains_the_query_variables_used_in_the_directives_applied_to_the_query.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/subgraph_query_retains_the_query_variables_used_in_the_directives_applied_to_the_query.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 64759e825a65c99c54fedcbf511cc7bf0735d4e2
+# Composed from subgraphs with hash: b577e09c4cb52223182c48413d146f984b798808
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -24,9 +24,18 @@ directive @link(url: String, as: String, for: link__Purpose, import: [link__Impo
 
 directive @withArgs(arg1: String) on QUERY
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/test_if_directives_at_the_operation_level_are_passed_down_to_subgraph_queries.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_if_directives_at_the_operation_level_are_passed_down_to_subgraph_queries.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: a0524dbe1bbd3a7450a2e15f5c25c5cf2eed4242
+# Composed from subgraphs with hash: cc7760ea5772ca757685d5802613391331d0bb89
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -13,7 +13,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -37,9 +37,18 @@ type Foo
   baz: Int @join__field(graph: SUBGRAPHB)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHA @join__graph(name: "subgraphA", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/test_if_directives_on_mutations_are_passed_down_to_subgraph_queries.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_if_directives_on_mutations_are_passed_down_to_subgraph_queries.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: a0524dbe1bbd3a7450a2e15f5c25c5cf2eed4242
+# Composed from subgraphs with hash: cc7760ea5772ca757685d5802613391331d0bb89
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -13,7 +13,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -37,9 +37,18 @@ type Foo
   baz: Int @join__field(graph: SUBGRAPHB)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHA @join__graph(name: "subgraphA", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/test_if_directives_with_arguments_applied_on_queries_are_ok.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_if_directives_with_arguments_applied_on_queries_are_ok.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 5338f8c604ab7c2103bdf58ee6752a40d4b62ed8
+# Composed from subgraphs with hash: 835b813ecafe8b6b6bbffd9b802895d83cacac08
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -26,9 +26,18 @@ directive @noArgs on QUERY
 
 directive @withArgs(arg1: String) on QUERY
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/test_indirect_branch_merging_with_typename_sibling.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_indirect_branch_merging_with_typename_sibling.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 9be0826e3b911556466c2c410f7df8b53c241774
+# Composed from subgraphs with hash: efc8cbf9c39df8acdc21d7cb3fb9e23700650a82
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -42,9 +42,18 @@ type B implements T
   f: Int! @join__field(graph: SUBGRAPH2)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/test_interface_object_advance_with_non_collecting_and_type_preserving_transitions_ordering.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_interface_object_advance_with_non_collecting_and_type_preserving_transitions_ordering.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 415e22ad50245441330e67dc6637cf09714a4831
+# Composed from subgraphs with hash: 7c59bdaefc39d7e88a603f0560376a398e5b7e93
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -57,9 +57,18 @@ interface I
   data: String! @join__field(graph: Z)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   S1 @join__graph(name: "S1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/test_merging_fetches_do_not_create_cycle_in_fetch_dependency_graph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_merging_fetches_do_not_create_cycle_in_fetch_dependency_graph.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 0b567f1d7e0089a146e8499a2c5e412b78a98498
+# Composed from subgraphs with hash: 806d47884a3b16cd6552156d332df34cb74e0ffc
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   A @join__graph(name: "A", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/test_merging_fetches_reset_cached_costs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_merging_fetches_reset_cached_costs.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 7c07647747a84fd6c839bb603948dddcadf654fd
+# Composed from subgraphs with hash: 0cd24ae6074a39994c982e5fa519acabfe2dcdac
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   A @join__graph(name: "A", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/test_provides_edge_ordering.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_provides_edge_ordering.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: f5cb1210587d45fee11b9c57247d6c570d0ae7fd
+# Composed from subgraphs with hash: 44564f95d87b3306e4c708b71f30f050c48d3a2d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -31,9 +31,18 @@ type A
   data: String! @join__field(graph: SUBGRAPHX) @join__field(graph: SUBGRAPHY)
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHQ @join__graph(name: "SubgraphQ", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/trying_to_use_defer_with_a_subcription_results_in_an_error.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/trying_to_use_defer_with_a_subcription_results_in_an_error.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 4c8b155cb8183b493b5c2862a2bd4ce0261642f9
+# Composed from subgraphs with hash: ebc3c557daba5b588e6f31c98db4dea0296b99e7
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
   subscription: Subscription
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -23,9 +23,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/union_interface_interaction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/union_interface_interaction.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 336400b353f835910c178a10eb77371f8700396b
+# Composed from subgraphs with hash: a36c94877a2b170f973a35c58634ef4ee999c103
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -51,9 +51,18 @@ interface I
   v: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/union_interface_interaction_but_no_need_to_type_explode.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/union_interface_interaction_but_no_need_to_type_explode.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 0457b8e67ae0ea99ead4c13318c4ac89e821aac3
+# Composed from subgraphs with hash: 82e74064026e626dde5798a7eaa1e6426c2c51d9
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -50,9 +50,18 @@ interface I
   v: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/union_union_interaction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/union_union_interaction.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 997336a5c7996069d8c10d0b9be46a72b46459c1
+# Composed from subgraphs with hash: 02b257e0662ad5b58d0147cb3c34c295418df23c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -41,9 +41,18 @@ type C
   v: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/union_union_interaction_but_no_need_to_type_explode.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/union_union_interaction_but_no_need_to_type_explode.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 241b1f7314833f7c2a97da8176e258c40322b0d7
+# Composed from subgraphs with hash: affd505df6fdd709ffe38651ddc517c8f33ec727
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -41,9 +41,18 @@ type C
   v: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/unnecessary_include_is_stripped_from_fragments.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/unnecessary_include_is_stripped_from_fragments.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: e6c72fb53e93abe8f8aed4982aca6f6109fe1171
+# Composed from subgraphs with hash: 7267ff8701477b9b37e32de3063a369f4a7e2af3
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -37,9 +37,18 @@ type Foo
   bar: Bar
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/works_when_unset.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/works_when_unset.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 91d4d0661d413b60ae2ed463c074c4180d7b849e
+# Composed from subgraphs with hash: a9236eee956ed7fc219b2212696478159ced7eea
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-federation/tests/query_plan/supergraphs/works_with_key_chains.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/works_with_key_chains.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 4387e2f917c7748296b92799227648747e453bec
+# Composed from subgraphs with hash: 2a34e202493c546249d10e9e361038512dd0e213
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -22,9 +22,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")


### PR DESCRIPTION
This PR upgrades the federation version used `apollo-federation`'s snapshot tests from 2.7.4 to 2.9. This upgrade requires all schemas to be rebuilt.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
