### PR TITLE
Add metrics for preview_connectors configuration

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -405,6 +405,23 @@ impl InstrumentData {
             "$.metrics_reference_mode"
         );
 
+        populate_config_instrument!(
+            apollo.router.config.connectors,
+            "$.preview_connectors",
+            opt.debug_extensions,
+            "$[?(@.debug_extensions == true)]",
+            opt.expose_sources_in_context,
+            "$[?(@.expose_sources_in_context == true)]",
+            opt.max_requests_per_operation_per_source,
+            "$[?(@.max_requests_per_operation_per_source)]",
+            opt.subgraph.config,
+            "$[?(@.subgraphs..['$config'])]",
+            opt.source.override_url,
+            "$[?(@.subgraphs..sources..override_url)]",
+            opt.source.max_requests_per_operation,
+            "$[?(@.subgraphs..sources..max_requests_per_operation)]"
+        );
+
         // We need to update the entry we just made because the selected strategy is a named object in the config.
         // The jsonpath spec doesn't include a utility for getting the keys out of an object, so we do it manually.
         if let Some((_, demand_control_attributes)) =

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@connectors.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@connectors.router.yaml.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.config.connectors
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.debug_extensions: true
+          opt.expose_sources_in_context: true
+          opt.max_requests_per_operation_per_source: true
+          opt.source.max_requests_per_operation: true
+          opt.source.override_url: true
+          opt.subgraph.config: true

--- a/apollo-router/src/configuration/testdata/metrics/connectors.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/connectors.router.yaml
@@ -1,0 +1,12 @@
+preview_connectors:
+  debug_extensions: true
+  expose_sources_in_context: true
+  max_requests_per_operation_per_source: 100
+  subgraphs:
+    subgraph_name:
+      $config:
+        name_of_the_variable: variable_value
+      sources:
+        source_name:
+          max_requests_per_operation: 50
+          override_url: 'http://localhost'


### PR DESCRIPTION
Add metrics for usage of `preview_connectors` configuration.

<!-- [CNN-511] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-511]: https://apollographql.atlassian.net/browse/CNN-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ