### PR TITLE
Provide single-character locations for `selection` parse errors

### DIFF
--- a/apollo-federation/src/sources/connect/validation/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/selection.rs
@@ -4,7 +4,6 @@ use std::ops::Range;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::parser::LineColumn;
-use apollo_compiler::parser::SourceMap;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::ExtendedType;
@@ -36,7 +35,7 @@ pub(super) fn validate_selection(
     schema: &SchemaInfo,
     seen_fields: &mut IndexSet<(Name, Name)>,
 ) -> Result<(), Message> {
-    let (selection_arg, json_selection) = get_json_selection(coordinate, &schema.sources)?;
+    let (selection_arg, json_selection) = get_json_selection(coordinate, schema)?;
     let field = coordinate.field_coordinate.field;
 
     let Some(return_type) = schema.get_object(field.ty.inner_named_type()) else {
@@ -102,7 +101,7 @@ pub(super) fn validate_body_selection(
 
 fn get_json_selection<'a>(
     connect_directive: ConnectDirectiveCoordinate<'a>,
-    source_map: &'a SourceMap,
+    schema: &'a SchemaInfo<'a>,
 ) -> Result<(SelectionArg<'a>, JSONSelection), Message> {
     let coordinate = SelectionCoordinate::from(connect_directive);
     let selection_arg = connect_directive
@@ -115,16 +114,16 @@ fn get_json_selection<'a>(
             message: format!("{coordinate} is required."),
             locations: connect_directive
                 .directive
-                .line_column_range(source_map)
+                .line_column_range(&schema.sources)
                 .into_iter()
                 .collect(),
         })?;
     let selection_str =
-        GraphQLString::new(&selection_arg.value, source_map).map_err(|_| Message {
+        GraphQLString::new(&selection_arg.value, &schema.sources).map_err(|_| Message {
             code: Code::GraphQLError,
             message: format!("{coordinate} must be a string."),
             locations: selection_arg
-                .line_column_range(source_map)
+                .line_column_range(&schema.sources)
                 .into_iter()
                 .collect(),
         })?;
@@ -132,9 +131,8 @@ fn get_json_selection<'a>(
     let selection = JSONSelection::parse(selection_str.as_str()).map_err(|err| Message {
         code: Code::InvalidJsonSelection,
         message: format!("{coordinate} is not a valid JSONSelection: {err}",),
-        locations: selection_arg
-            .value
-            .line_column_range(source_map)
+        locations: selection_str
+            .line_col_for_subslice(err.offset..err.offset + 1, schema)
             .into_iter()
             .collect(),
     })?;
@@ -145,7 +143,7 @@ fn get_json_selection<'a>(
             message: format!("{coordinate} is empty",),
             locations: selection_arg
                 .value
-                .line_column_range(source_map)
+                .line_column_range(&schema.sources)
                 .into_iter()
                 .collect(),
         });

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_syntax.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_syntax.graphql.snap
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
         code: InvalidJsonSelection,
         message: "`@connect(selection:)` on `Query.something` is not a valid JSONSelection: nom::error::ErrorKind::Eof at offset 0: &how",
         locations: [
-            8:86..8:92,
+            8:87..8:88,
         ],
     },
 ]


### PR DESCRIPTION
Currently, we highlight the entire string when `selection` can't be parsed. This limits the highlight to just the offset identified by the parser (as of #6089).

An alternative could be to highlight the entire string after the offset, which might make the error more visible in-editor.

Before:
![Screenshot 2024-11-06 at 12 25 07 PM](https://github.com/user-attachments/assets/91c66127-2146-42fa-9b2e-c1567f82e172)

After:
![Screenshot 2024-11-06 at 12 25 23 PM](https://github.com/user-attachments/assets/bfae2cb3-237e-4231-8943-7cc55b76dd8a)
