### PR TITLE
fix(federation): fixed a rebase error during flattening the input query

### DIFF
--- a/apollo-federation/tests/query_plan/supergraphs/rebase_non_intersecting_without_dropping_inline_fragment_due_to_directive.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/rebase_non_intersecting_without_dropping_inline_fragment_due_to_directive.graphql
@@ -1,0 +1,71 @@
+# Composed from subgraphs with hash: 8312d6d045a731f70fd2c9ced19d38ac8ae32ff5
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+interface I
+  @join__type(graph: SUBGRAPH1)
+{
+  i: Int
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  test: X
+}
+
+type X implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__type(graph: SUBGRAPH1)
+{
+  i: Int
+}
+
+type Y implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__type(graph: SUBGRAPH1)
+{
+  i: Int
+}


### PR DESCRIPTION
This is an unhandled corner case where an inline fragment's selections are flattened into an empty selection set, but the fragment itself can't go away due to some reason (such as having a directive on it).

Example:
```graphql
#!subgraph
type Query {
  test: X
}

interface I {
  i: Int
}

type X implements I {
  i: Int
}

type Y implements I {
  i: Int
}

#!operation
{
  test { # subselection type: X
    ... on I { # upcast to I
      ... @skip(if: true) {
        ... on Y { # downcast to Y (which is non-intersecting)
          i
        }
      }
    }
  }
}
```

This PR is related to https://github.com/apollographql/router/pull/5370, which has a similar fix in a different part of the same method.

<!-- ROUTER-603 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests
