### PR TITLE
fix(federation): recompose test supergraph

### DIFF
--- a/apollo-federation/tests/query_plan/supergraphs/rebase_non_intersecting_without_dropping_inline_fragment_due_to_directive.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/rebase_non_intersecting_without_dropping_inline_fragment_due_to_directive.graphql
@@ -1,7 +1,7 @@
-# Composed from subgraphs with hash: 8312d6d045a731f70fd2c9ced19d38ac8ae32ff5
+# Composed from subgraphs with hash: 9f65288304601b6cf28091f55f98c58ca3c82972
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
 {
   query: Query
 }
@@ -10,7 +10,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -28,9 +28,18 @@ interface I
   i: Int
 }
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -500,7 +500,7 @@ mod test {
                 .or_else(|| ctx.lookup_current())
                 .expect("current span expected");
             let extracted = extract_dd_trace_id(&current_span);
-            assert_eq!(extracted, Some("1234".to_string()));
+            assert_eq!(extracted, Some("1234".to_string()), "should have trace id");
         }
     }
 
@@ -535,7 +535,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "should have trace id")]
     fn test_missing_dd_attribute() {
         subscriber::with_default(
             Registry::default()


### PR DESCRIPTION
Due to the merge order of #6237 and #6242, this supergraph was using the wrong federation version, causing tests to fail on CI.