### PR TITLE
Enable remote proxy binary downloads

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 
 set -u
 
-BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/download"
+BINARY_DOWNLOAD_PREFIX="${APOLLO_ROUTER_DOWNLOAD_GITHUB_HOST:="https://github.com/apollographql/router/releases/download"}"
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,9 +55,7 @@ download_binary() {
     _file="$_dir/input.tar.gz"
     _router="$_dir/router$_ext"
 
-    local _safe_url
-    _safe_url=$(echo "$_url" | sed  -E 's|https://[^@]+@|https://|')
-    say "Downloading router from $_safe_url ..." 1>&2
+    say "Downloading router from $_url ..." 1>&2
 
     ensure mkdir -p "$_dir"
     downloader "$_url" "$_file"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,7 +55,9 @@ download_binary() {
     _file="$_dir/input.tar.gz"
     _router="$_dir/router$_ext"
 
-    say "Downloading router from $_url ..." 1>&2
+    local _safe_url
+    _safe_url=$(echo "$_url" | sed  -E 's|https://[^@]+@|https://|')
+    say "Downloading router from $_safe_url ..." 1>&2
 
     ensure mkdir -p "$_dir"
     downloader "$_url" "$_file"


### PR DESCRIPTION
*Description here*

This enables users without direct download access to specify a remote proxy mirror location for the github download of the Apollo Router releases.

Note: I will be making a similar request for the bash binary install script for rover. Which will address https://github.com/apollographql/rover/issues/1895

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

For manual testing, I set the `APOLLO_ROUTER_BINARY_REMOTE` url locally, and ran the `./scripts/install.sh` script, verifying that the router was installed from github using the remote proxy instead of a direct connection.  

I also tested _without_ the `APOLLO_ROUTER_BINARY_REMOTE` set, to verify current behavior of installer remains unchanged.

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
