### PR TITLE
Fix introspection query deduplication

### DIFF
--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -560,6 +560,10 @@ where
                                     tokio::spawn(async move {
                                         entry.insert(Ok(content)).await;
                                     });
+                                } else {
+                                    tokio::spawn(async move {
+                                        entry.send(Ok(content)).await;
+                                    });
                                 }
                             }
 


### PR DESCRIPTION
Introspection queries are not supposed to be cached, but their result still needds to be sent to deduplicated queries

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
