### PR TITLE
Reusable variable validation

### DIFF
--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -488,7 +488,7 @@ mod helpers {
                 //
                 // All sibling fields marked by $this in a transport must be carried over to the output type
                 // regardless of its use in the output selection.
-                let parts = path.iter().map(|part| part.part.as_str());
+                let parts = path.iter().map(|part| part.part.as_ref());
                 let field_and_selection = FieldAndSelection::from_path(parts);
                 let field_name = Name::new(field_and_selection.field_name)?;
                 let field: Box<dyn Field> = match &key_for_type {

--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -488,8 +488,8 @@ mod helpers {
                 //
                 // All sibling fields marked by $this in a transport must be carried over to the output type
                 // regardless of its use in the output selection.
-                let joined = path.iter().map(|part| part.to_string()).join(".");
-                let field_and_selection = FieldAndSelection::from_path(&joined);
+                let parts = path.iter().map(|part| part.part.as_str());
+                let field_and_selection = FieldAndSelection::from_path(parts);
                 let field_name = Name::new(field_and_selection.field_name)?;
                 let field: Box<dyn Field> = match &key_for_type {
                     TypeDefinitionPosition::Object(o)  => Box::new(o.field(field_name)),
@@ -821,8 +821,8 @@ struct FieldAndSelection<'a> {
 
 impl<'a> FieldAndSelection<'a> {
     /// Extract from a path like `a.b.c` into `a` and `b { c }`
-    fn from_path(path: &'a str) -> Self {
-        let mut parts = path.split('.').peekable();
+    fn from_path<I: IntoIterator<Item = &'a str>>(parts: I) -> Self {
+        let mut parts = parts.into_iter().peekable();
         let field_name = parts.next().unwrap_or_default();
         let mut sub_selection = String::new();
         let mut closing_braces = 0;
@@ -865,7 +865,7 @@ mod test_field_and_selection {
         #[case] expected_field: &str,
         #[case] expected_selection: &str,
     ) {
-        let result = super::FieldAndSelection::from_path(path);
+        let result = super::FieldAndSelection::from_path(path.split('.'));
         assert_eq!(result.field_name, expected_field);
         assert_eq!(result.sub_selection, expected_selection);
     }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@carryover.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@carryover.graphql-2.snap
@@ -205,9 +205,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ca
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 4..9,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 10..12,
+                                        },
+                                    ],
                                     location: 4..12,
                                 },
                             ),
@@ -375,9 +383,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ca
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: This,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $this,
+                                        location: 4..9,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 10..12,
+                                        },
+                                    ],
                                     location: 4..12,
                                 },
                             ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-2.snap
@@ -46,9 +46,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 21..26,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 27..29,
+                                        },
+                                    ],
                                     location: 21..29,
                                 },
                             ),
@@ -154,9 +162,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 21..26,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 27..29,
+                                        },
+                                    ],
                                     location: 21..29,
                                 },
                             ),
@@ -173,9 +189,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     }: Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "id2",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 36..41,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id2",
+                                            location: 42..45,
+                                        },
+                                    ],
                                     location: 36..45,
                                 },
                             ),
@@ -280,9 +304,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "unselected",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 21..26,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "unselected",
+                                            location: 27..37,
+                                        },
+                                    ],
                                     location: 21..37,
                                 },
                             ),
@@ -388,9 +420,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: This,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $this,
+                                        location: 21..26,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 27..29,
+                                        },
+                                    ],
                                     location: 21..29,
                                 },
                             ),
@@ -484,9 +524,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: This,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $this,
+                                        location: 21..26,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 27..29,
+                                        },
+                                    ],
                                     location: 21..29,
                                 },
                             ),
@@ -503,9 +551,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     }: Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: This,
-                                    path: "id2",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $this,
+                                        location: 36..41,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id2",
+                                            location: 42..45,
+                                        },
+                                    ],
                                     location: 36..45,
                                 },
                             ),
@@ -598,9 +654,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: This,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $this,
+                                        location: 21..26,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 27..29,
+                                        },
+                                    ],
                                     location: 21..29,
                                 },
                             ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@nested_inputs.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@nested_inputs.graphql-2.snap
@@ -41,9 +41,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ne
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "bar",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 2..7,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "bar",
+                                            location: 8..11,
+                                        },
+                                    ],
                                     location: 2..11,
                                 },
                             ),
@@ -52,9 +60,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ne
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "doubleBaz.buzz",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 14..19,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "doubleBaz",
+                                            location: 20..29,
+                                        },
+                                        VariablePathPart {
+                                            part: "buzz",
+                                            location: 30..34,
+                                        },
+                                    ],
                                     location: 14..34,
                                 },
                             ),
@@ -63,9 +83,25 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ne
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "baz.quux.quaz",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 37..42,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "baz",
+                                            location: 43..46,
+                                        },
+                                        VariablePathPart {
+                                            part: "quux",
+                                            location: 47..51,
+                                        },
+                                        VariablePathPart {
+                                            part: "quaz",
+                                            location: 52..56,
+                                        },
+                                    ],
                                     location: 37..56,
                                 },
                             ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@normalize_names.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@normalize_names.graphql-2.snap
@@ -118,9 +118,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/no
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 2..7,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 8..10,
+                                        },
+                                    ],
                                     location: 2..10,
                                 },
                             ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@realistic.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@realistic.graphql-2.snap
@@ -490,9 +490,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "company.name",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 13..18,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "company",
+                                            location: 19..26,
+                                        },
+                                        VariablePathPart {
+                                            part: "name",
+                                            location: 27..31,
+                                        },
+                                    ],
                                     location: 13..31,
                                 },
                             ),
@@ -635,9 +647,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 2..7,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 8..10,
+                                        },
+                                    ],
                                     location: 2..10,
                                 },
                             ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@sibling_fields.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@sibling_fields.graphql-2.snap
@@ -137,9 +137,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: This,
-                                    path: "k.id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $this,
+                                        location: 18..23,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "k",
+                                            location: 24..25,
+                                        },
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 26..28,
+                                        },
+                                    ],
                                     location: 18..28,
                                 },
                             ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@simple.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@simple.graphql-2.snap
@@ -118,9 +118,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 2..7,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 8..10,
+                                        },
+                                    ],
                                     location: 2..10,
                                 },
                             ),
@@ -221,9 +229,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: This,
-                                    path: "c",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $this,
+                                        location: 2..7,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "c",
+                                            location: 8..9,
+                                        },
+                                    ],
                                     location: 2..9,
                                 },
                             ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@steelthread.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@steelthread.graphql-2.snap
@@ -133,9 +133,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/st
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: Args,
-                                    path: "id",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $args,
+                                        location: 8..13,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "id",
+                                            location: 14..16,
+                                        },
+                                    ],
                                     location: 8..16,
                                 },
                             ),
@@ -243,9 +251,17 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/st
                     Component {
                         parts: [
                             Var(
-                                Variable {
-                                    var_type: This,
-                                    path: "c",
+                                VariableReference {
+                                    namespace: VariableNamespace {
+                                        namespace: $this,
+                                        location: 8..13,
+                                    },
+                                    path: [
+                                        VariablePathPart {
+                                            part: "c",
+                                            location: 14..15,
+                                        },
+                                    ],
                                     location: 8..15,
                                 },
                             ),

--- a/apollo-federation/src/sources/connect/json_selection/known_var.rs
+++ b/apollo-federation/src/sources/connect/json_selection/known_var.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 #[cfg(test)]
 use super::location::WithRange;
 use crate::sources::connect::variable::Namespace;
@@ -57,7 +59,7 @@ impl std::fmt::Display for KnownVariable {
     }
 }
 
-impl TryFrom<(&KnownVariable, Vec<&str>)> for VariableReference<Namespace> {
+impl TryFrom<(&KnownVariable, Vec<&str>)> for VariableReference<'static, Namespace> {
     type Error = ();
 
     fn try_from((variable, path): (&KnownVariable, Vec<&str>)) -> Result<Self, Self::Error> {
@@ -82,8 +84,8 @@ impl TryFrom<(&KnownVariable, Vec<&str>)> for VariableReference<Namespace> {
             },
             path: path
                 .iter()
-                .map(|key| VariablePathPart {
-                    part: key.to_string(),
+                .map(|&key| VariablePathPart {
+                    part: Cow::from(key.to_owned()),
                     location: Default::default(),
                 })
                 .collect(),
@@ -111,11 +113,11 @@ mod tests {
                 },
                 path: vec![
                     VariablePathPart {
-                        part: "foo".to_string(),
+                        part: Cow::from("foo"),
                         location: Default::default(),
                     },
                     VariablePathPart {
-                        part: "bar".to_string(),
+                        part: Cow::from("bar"),
                         location: Default::default(),
                     },
                 ],

--- a/apollo-federation/src/sources/connect/json_selection/known_var.rs
+++ b/apollo-federation/src/sources/connect/json_selection/known_var.rs
@@ -1,5 +1,9 @@
 #[cfg(test)]
 use super::location::WithRange;
+use crate::sources::connect::variable::Namespace;
+use crate::sources::connect::variable::VariableNamespace;
+use crate::sources::connect::variable::VariablePathPart;
+use crate::sources::connect::variable::VariableReference;
 
 #[derive(PartialEq, Eq, Clone, Hash)]
 pub(crate) enum KnownVariable {
@@ -50,5 +54,76 @@ impl std::fmt::Debug for KnownVariable {
 impl std::fmt::Display for KnownVariable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+impl TryFrom<(&KnownVariable, Vec<&str>)> for VariableReference<Namespace> {
+    type Error = ();
+
+    fn try_from((variable, path): (&KnownVariable, Vec<&str>)) -> Result<Self, Self::Error> {
+        let namespace = match variable {
+            KnownVariable::Args => Namespace::Args,
+            KnownVariable::This => Namespace::This,
+            KnownVariable::Config => Namespace::Config,
+            KnownVariable::Status => Namespace::Status,
+            // To get the safety benefits of the KnownVariable enum, we need
+            // to enumerate all the cases explicitly, without wildcard
+            // matches. However, body.external_var_paths() only returns free
+            // (externally-provided) variables like $this, $args, and
+            // $config. The $ and @ variables, by contrast, are always bound
+            // to something within the input data.
+            KnownVariable::Dollar | KnownVariable::AtSign => return Err(()),
+        };
+
+        Ok(VariableReference {
+            namespace: VariableNamespace {
+                namespace,
+                location: Default::default(),
+            },
+            path: path
+                .iter()
+                .map(|key| VariablePathPart {
+                    part: key.to_string(),
+                    location: Default::default(),
+                })
+                .collect(),
+            location: Default::default(), // Doesn't matter for this case, we won't report errors here
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_from_variable_reference() {
+        let variable = KnownVariable::This;
+        let path = vec!["foo", "bar"];
+        let result = VariableReference::<Namespace>::try_from((&variable, path));
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            VariableReference {
+                namespace: VariableNamespace {
+                    namespace: Namespace::This,
+                    location: Default::default(),
+                },
+                path: vec![
+                    VariablePathPart {
+                        part: "foo".to_string(),
+                        location: Default::default(),
+                    },
+                    VariablePathPart {
+                        part: "bar".to_string(),
+                        location: Default::default(),
+                    },
+                ],
+                location: Default::default(),
+            }
+        );
+        assert!(
+            VariableReference::<Namespace>::try_from((&KnownVariable::Dollar, vec![])).is_err()
+        );
     }
 }

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -13,7 +13,6 @@ pub use apply_to::*;
 // Pretty code is currently only used in tests, so this cfg is to suppress the
 // unused lint warning. If pretty code is needed in not test code, feel free to
 // remove the `#[cfg(test)]`.
-pub(crate) use known_var::*;
 pub(crate) use location::Ranged;
 pub use parser::*;
 #[cfg(test)]

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -11,6 +11,7 @@ mod models;
 pub(crate) mod spec;
 mod url_template;
 pub mod validation;
+pub(crate) mod variable;
 
 use apollo_compiler::name;
 pub use json_selection::ApplyToError;
@@ -21,7 +22,6 @@ pub use json_selection::SubSelection;
 pub use models::CustomConfiguration;
 pub(crate) use spec::ConnectSpecDefinition;
 pub use url_template::URLTemplate;
-pub use url_template::Variable;
 
 pub use self::models::Connector;
 pub use self::models::EntityResolver;

--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -183,11 +183,12 @@ impl HttpJsonTransport {
 
         Ok(Self {
             source_url: source.map(|s| s.base_url.clone()),
-            connect_template: connect_url.parse().map_err(
-                |url_template::Error { message, .. }| {
-                    FederationError::internal(format!("could not parse URL template: {message}"))
-                },
-            )?,
+            connect_template: connect_url.parse().map_err(|e: url_template::Error| {
+                FederationError::internal(format!(
+                    "could not parse URL template: {message}",
+                    message = e.message()
+                ))
+            })?,
             method,
             headers,
             body: http.body.clone(),

--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -226,7 +226,7 @@ impl HTTPMethod {
 #[derive(Clone, Debug)]
 pub enum HeaderSource {
     From(String),
-    Value(HeaderValue),
+    Value(HeaderValue<'static>),
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__absolute_url_with_path_variable.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__absolute_url_with_path_variable.snap
@@ -25,9 +25,17 @@ Ok(
             Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Args,
-                            path: "abc",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $args,
+                                location: 20..25,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "abc",
+                                    location: 26..29,
+                                },
+                            ],
                             location: 20..29,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__absolute_url_with_query_variable.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__absolute_url_with_query_variable.snap
@@ -32,9 +32,17 @@ Ok(
             }: Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Args,
-                            path: "abc",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $args,
+                                location: 24..29,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "abc",
+                                    location: 30..33,
+                                },
+                            ],
                             location: 24..33,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__path_list-3.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__path_list-3.snap
@@ -16,9 +16,17 @@ Ok(
             Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Args,
-                            path: "def",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $args,
+                                location: 6..11,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "def",
+                                    location: 12..15,
+                                },
+                            ],
                             location: 6..15,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__path_list-4.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__path_list-4.snap
@@ -16,9 +16,21 @@ Ok(
             Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: This,
-                            path: "def.thing",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $this,
+                                location: 6..11,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "def",
+                                    location: 12..15,
+                                },
+                                VariablePathPart {
+                                    part: "thing",
+                                    location: 16..21,
+                                },
+                            ],
                             location: 6..21,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__url_path_template_parse-2.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__url_path_template_parse-2.snap
@@ -16,9 +16,17 @@ Ok(
             Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: This,
-                            path: "user_id",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $this,
+                                location: 8..13,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "user_id",
+                                    location: 14..21,
+                                },
+                            ],
                             location: 8..21,
                         },
                     ),
@@ -35,9 +43,17 @@ Ok(
             }: Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Args,
-                            path: "b",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $args,
+                                location: 26..31,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "b",
+                                    location: 32..33,
+                                },
+                            ],
                             location: 26..33,
                         },
                     ),
@@ -52,9 +68,17 @@ Ok(
             }: Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Args,
-                            path: "d",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $args,
+                                location: 38..43,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "d",
+                                    location: 44..45,
+                                },
+                            ],
                             location: 38..45,
                         },
                     ),
@@ -69,9 +93,21 @@ Ok(
             }: Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Args,
-                            path: "f.g",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $args,
+                                location: 50..55,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "f",
+                                    location: 56..57,
+                                },
+                                VariablePathPart {
+                                    part: "g",
+                                    location: 58..59,
+                                },
+                            ],
                             location: 50..59,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__url_path_template_parse-3.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__url_path_template_parse-3.snap
@@ -16,9 +16,17 @@ Ok(
             Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: This,
-                            path: "id",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $this,
+                                location: 8..13,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "id",
+                                    location: 14..16,
+                                },
+                            ],
                             location: 8..16,
                         },
                     ),
@@ -35,9 +43,17 @@ Ok(
             }: Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Config,
-                            path: "b",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $config,
+                                location: 21..28,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "b",
+                                    location: 29..30,
+                                },
+                            ],
                             location: 21..30,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__url_path_template_parse-4.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__url_path_template_parse-4.snap
@@ -16,9 +16,17 @@ Ok(
             Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: This,
-                            path: "lat",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $this,
+                                location: 11..16,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "lat",
+                                    location: 17..20,
+                                },
+                            ],
                             location: 11..20,
                         },
                     ),
@@ -26,9 +34,17 @@ Ok(
                         ",",
                     ),
                     Var(
-                        Variable {
-                            var_type: This,
-                            path: "lon",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $this,
+                                location: 23..28,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "lon",
+                                    location: 29..32,
+                                },
+                            ],
                             location: 23..32,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__url_path_template_parse.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__url_path_template_parse.snap
@@ -16,9 +16,17 @@ Ok(
             Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Config,
-                            path: "user_id",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $config,
+                                location: 8..15,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "user_id",
+                                    location: 16..23,
+                                },
+                            ],
                             location: 8..23,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__variable_param_key.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__url_template__test_parse__variable_param_key.snap
@@ -10,9 +10,21 @@ Ok(
             Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Args,
-                            path: "filter.field",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $args,
+                                location: 2..7,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "filter",
+                                    location: 8..14,
+                                },
+                                VariablePathPart {
+                                    part: "field",
+                                    location: 15..20,
+                                },
+                            ],
                             location: 2..20,
                         },
                     ),
@@ -20,9 +32,21 @@ Ok(
             }: Component {
                 parts: [
                     Var(
-                        Variable {
-                            var_type: Args,
-                            path: "filter.value",
+                        VariableReference {
+                            namespace: VariableNamespace {
+                                namespace: $args,
+                                location: 23..28,
+                            },
+                            path: [
+                                VariablePathPart {
+                                    part: "filter",
+                                    location: 29..35,
+                                },
+                                VariablePathPart {
+                                    part: "value",
+                                    location: 36..41,
+                                },
+                            ],
                             location: 23..41,
                         },
                     ),

--- a/apollo-federation/src/sources/connect/spec/directives.rs
+++ b/apollo-federation/src/sources/connect/spec/directives.rs
@@ -244,9 +244,9 @@ fn node_to_header(value: &Node<Value>) -> Result<(HeaderName, HeaderSource), Fed
         Ok((
             name,
             HeaderSource::Value(
-                value
-                    .parse::<HeaderValue>()
-                    .map_err(|e| internal!(format!("Invalid header value: {}", e.message())))?,
+                HeaderValue::from_str(value)
+                    .map_err(|e| internal!(format!("Invalid header value: {}", e.message())))?
+                    .into_owned(),
             ),
         ))
     } else {

--- a/apollo-federation/src/sources/connect/spec/directives.rs
+++ b/apollo-federation/src/sources/connect/spec/directives.rs
@@ -246,7 +246,7 @@ fn node_to_header(value: &Node<Value>) -> Result<(HeaderName, HeaderSource), Fed
             HeaderSource::Value(
                 value
                     .parse::<HeaderValue>()
-                    .map_err(|e| internal!(format!("Invalid header value: {}", e.message)))?,
+                    .map_err(|e| internal!(format!("Invalid header value: {}", e.message())))?,
             ),
         ))
     } else {

--- a/apollo-federation/src/sources/connect/spec/directives.rs
+++ b/apollo-federation/src/sources/connect/spec/directives.rs
@@ -244,9 +244,9 @@ fn node_to_header(value: &Node<Value>) -> Result<(HeaderName, HeaderSource), Fed
         Ok((
             name,
             HeaderSource::Value(
-                value.parse::<HeaderValue>().map_err(|err| {
-                    internal!(format!("Invalid header value: {}", err.to_string()))
-                })?,
+                value
+                    .parse::<HeaderValue>()
+                    .map_err(|e| internal!(format!("Invalid header value: {}", e.message)))?,
             ),
         ))
     } else {

--- a/apollo-federation/src/sources/connect/url_template.rs
+++ b/apollo-federation/src/sources/connect/url_template.rs
@@ -37,7 +37,7 @@ pub(crate) struct Component {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum ValuePart {
     Text(String),
-    Var(VariableReference<Namespace>),
+    Var(VariableReference<'static, Namespace>),
 }
 
 impl URLTemplate {
@@ -238,7 +238,9 @@ impl Component {
 
             if let Some((var, suffix)) = remaining.split_once('}') {
                 let start_offset = var.as_ptr() as usize - url_template.as_ptr() as usize;
-                parts.push(ValuePart::Var(VariableReference::parse(var, start_offset)?));
+                let reference: VariableReference<'static, Namespace> =
+                    VariableReference::parse(var, start_offset)?.into_owned();
+                parts.push(ValuePart::Var(reference));
                 remaining = suffix;
             } else {
                 return Err(Error::ParseError {

--- a/apollo-federation/src/sources/connect/url_template.rs
+++ b/apollo-federation/src/sources/connect/url_template.rs
@@ -205,7 +205,7 @@ impl Component {
                 parts.push(ValuePart::Var(
                     VariableReference::parse(var, start_offset).map_err(|e| Error {
                         message: e.message,
-                        location: e.location.clone(),
+                        location: e.location,
                     })?,
                 ));
                 remaining = suffix;

--- a/apollo-federation/src/sources/connect/validation/coordinates.rs
+++ b/apollo-federation/src/sources/connect/validation/coordinates.rs
@@ -19,6 +19,7 @@ use crate::sources::connect::spec::schema::HEADERS_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::HTTP_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::SOURCE_BASE_URL_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::SOURCE_NAME_ARGUMENT_NAME;
+use crate::sources::connect::variable;
 
 /// The location of a field within an object.
 #[derive(Clone, Copy)]
@@ -45,6 +46,15 @@ pub(super) struct ConnectDirectiveCoordinate<'a> {
     pub(super) directive: &'a Node<Directive>,
     pub(super) connect_directive_name: &'a Name,
     pub(super) field_coordinate: FieldCoordinate<'a>,
+}
+
+impl<'a> From<ConnectDirectiveCoordinate<'a>> for variable::Directive<'a> {
+    fn from(value: ConnectDirectiveCoordinate<'a>) -> Self {
+        variable::Directive::Connect {
+            field: value.field_coordinate.field,
+            object: value.field_coordinate.object,
+        }
+    }
 }
 
 impl Display for ConnectDirectiveCoordinate<'_> {
@@ -196,7 +206,7 @@ pub(super) enum HttpHeadersCoordinate<'a> {
         directive_name: &'a Name,
     },
     Connect {
-        directive_name: &'a Name,
+        connect: ConnectDirectiveCoordinate<'a>,
         object: &'a Name,
         field: &'a Name,
     },
@@ -206,13 +216,18 @@ impl Display for HttpHeadersCoordinate<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::Connect {
-                directive_name,
+                connect:
+                    ConnectDirectiveCoordinate {
+                        directive: _,
+                        connect_directive_name,
+                        field_coordinate: _,
+                    },
                 object,
                 field,
             } => {
                 write!(
                     f,
-                    "`@{directive_name}({HTTP_ARGUMENT_NAME}.{HEADERS_ARGUMENT_NAME}:)` on `{}.{}`",
+                    "`@{connect_directive_name}({HTTP_ARGUMENT_NAME}.{HEADERS_ARGUMENT_NAME}:)` on `{}.{}`",
                     object, field
                 )
             }

--- a/apollo-federation/src/sources/connect/validation/extended_type.rs
+++ b/apollo-federation/src/sources/connect/validation/extended_type.rs
@@ -301,7 +301,6 @@ fn validate_field(
             headers::validate_arg(
                 http_arg,
                 schema,
-                source_map,
                 HttpHeadersCoordinate::Connect {
                     connect: connect_coordinate,
                     object: &object.name,

--- a/apollo-federation/src/sources/connect/validation/extended_type.rs
+++ b/apollo-federation/src/sources/connect/validation/extended_type.rs
@@ -300,9 +300,10 @@ fn validate_field(
         errors.extend(
             headers::validate_arg(
                 http_arg,
+                schema,
                 source_map,
                 HttpHeadersCoordinate::Connect {
-                    directive_name: schema.connect_directive_name,
+                    connect: connect_coordinate,
                     object: &object.name,
                     field: &field.name,
                 },

--- a/apollo-federation/src/sources/connect/validation/http/headers.rs
+++ b/apollo-federation/src/sources/connect/validation/http/headers.rs
@@ -21,6 +21,7 @@ use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
 use crate::sources::connect::variable::ConnectorsContext;
 use crate::sources::connect::variable::Directive;
+use crate::sources::connect::variable::Phase;
 use crate::sources::connect::variable::Target;
 
 pub(crate) fn validate_arg<'a>(
@@ -139,11 +140,11 @@ fn validate_value(
 
     let variable_resolver = match coordinate {
         HttpHeadersCoordinate::Source { .. } => VariableResolver::new(
-            ConnectorsContext::new(Directive::Source, Target::RequestHeader),
+            ConnectorsContext::new(Directive::Source, Phase::Request, Target::Header),
             schema,
         ),
         HttpHeadersCoordinate::Connect { connect, .. } => VariableResolver::new(
-            ConnectorsContext::new(connect.into(), Target::RequestHeader),
+            ConnectorsContext::new(connect.into(), Phase::Request, Target::Header),
             schema,
         ),
     };

--- a/apollo-federation/src/sources/connect/validation/http/headers.rs
+++ b/apollo-federation/src/sources/connect/validation/http/headers.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::str::FromStr;
 
 use apollo_compiler::ast::Value;
 use apollo_compiler::parser::SourceMap;

--- a/apollo-federation/src/sources/connect/validation/http/url.rs
+++ b/apollo-federation/src/sources/connect/validation/http/url.rs
@@ -13,6 +13,7 @@ use crate::sources::connect::validation::variable::VariableResolver;
 use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
 use crate::sources::connect::variable::ConnectorsContext;
+use crate::sources::connect::variable::Phase;
 use crate::sources::connect::variable::Target;
 use crate::sources::connect::URLTemplate;
 
@@ -31,7 +32,7 @@ pub(crate) fn validate_template(
     }
 
     let variable_resolver = VariableResolver::new(
-        ConnectorsContext::new(coordinate.connect.into(), Target::RequestUrl),
+        ConnectorsContext::new(coordinate.connect.into(), Phase::Request, Target::Url),
         schema,
     );
     for variable in template.path_variables() {

--- a/apollo-federation/src/sources/connect/validation/http/url.rs
+++ b/apollo-federation/src/sources/connect/validation/http/url.rs
@@ -1,24 +1,20 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use apollo_compiler::ast::FieldDefinition;
-use apollo_compiler::ast::Type;
 use apollo_compiler::ast::Value;
-use apollo_compiler::schema::Component;
-use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::Node;
-use apollo_compiler::Schema;
 use url::Url;
 
 use crate::sources::connect::url_template;
-use crate::sources::connect::url_template::VariableType;
 use crate::sources::connect::validation::coordinates::HttpMethodCoordinate;
 use crate::sources::connect::validation::graphql::GraphQLString;
 use crate::sources::connect::validation::graphql::SchemaInfo;
+use crate::sources::connect::validation::variable::VariableResolver;
 use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
+use crate::sources::connect::variable::ConnectorsContext;
+use crate::sources::connect::variable::Target;
 use crate::sources::connect::URLTemplate;
-use crate::sources::connect::Variable;
 
 pub(crate) fn validate_template(
     coordinate: HttpMethodCoordinate,
@@ -34,29 +30,45 @@ pub(crate) fn validate_template(
             .extend(validate_base_url(base, coordinate, coordinate.node, str_value, schema).err());
     }
 
+    let variable_resolver = VariableResolver::new(
+        ConnectorsContext::new(coordinate.connect.into(), Target::RequestUrl),
+        schema,
+    );
     for variable in template.path_variables() {
-        match validate_variable(variable, str_value, coordinate, schema) {
-            Err(err) => messages.push(err),
-            Ok(Some(ty)) if !ty.is_non_null() => {
+        match variable_resolver.resolve(variable, str_value) {
+            Err(message) => {
                 messages.push(Message {
-                    code: Code::NullablePathVariable,
-                    message: format!(
-                        "Variables in path parameters should be non-null, but {coordinate} contains `{{{variable}}}` which is nullable. \
-                         If a null value is provided at runtime, the request will fail.",
-                    ),
-                    locations: str_value.line_col_for_subslice(
-                        variable.location.clone(),
-                        schema,
-                    ).into_iter().collect(),
-                });
+                    code: message.code,
+                    message: format!("{coordinate} contains an invalid variable reference {{{variable}}} - {message}", message = message.message),
+                    locations: message.locations,
+                })
+            },
+            Ok(Some(ty)) => {
+                if !ty.is_non_null() {
+                    messages.push(Message {
+                        code: Code::NullablePathVariable,
+                        message: format!(
+                            "Variables in path parameters should be non-null, but {coordinate} contains `{{{variable}}}` which is nullable. \
+                             If a null value is provided at runtime, the request will fail.",
+                        ),
+                        locations: str_value
+                            .line_col_for_subslice(variable.location.clone(), schema)
+                            .into_iter()
+                            .collect(),
+                    });
+                }
             }
-            Ok(_) => {} // Type is non-null, or unknowable
+            Ok(_) => {} // Type cannot be resolved
         }
     }
 
     for variable in template.query_variables() {
-        if let Err(err) = validate_variable(variable, str_value, coordinate, schema) {
-            messages.push(err);
+        if let Err(message) = variable_resolver.resolve(variable, str_value) {
+            messages.push(Message {
+                code: message.code,
+                message: format!("{coordinate} contains an invalid variable reference {{{variable}}} - {message}", message = message.message),
+                locations: message.locations,
+            })
         }
     }
 
@@ -116,112 +128,4 @@ pub(crate) fn validate_base_url(
     } else {
         Ok(())
     }
-}
-
-fn validate_variable<'schema>(
-    variable: &'schema Variable,
-    url_value: GraphQLString,
-    coordinate: HttpMethodCoordinate<'schema>,
-    schema: &'schema SchemaInfo,
-) -> Result<Option<Type>, Message> {
-    let field_coordinate = coordinate.connect.field_coordinate;
-    let field = field_coordinate.field;
-    let mut path = variable.path.split('.');
-    let path_root = path.next().unwrap_or(&variable.path);
-    let mut path_component_start = variable.location.start + variable.var_type.as_str().len() + 1;
-    let mut path_component_end = path_component_start + path_root.len();
-    let mut variable_type = match variable.var_type {
-        VariableType::Config => {
-            return Ok(None); // We don't validate Router config yet
-        }
-        VariableType::Args => {
-            field.arguments.iter().find(|arg| arg.name == path_root).ok_or_else( || {
-                Message {
-                    code: Code::UndefinedArgument,
-                    message: format!(
-                        "{coordinate} contains `{{{variable}}}`, but {field_coordinate} does not have an argument named `{path_root}`.",
-                    ),
-                    locations: url_value.line_col_for_subslice(
-                        path_component_start..path_component_end,
-                        schema,
-                    ).into_iter().collect()
-                }
-            }).map(|arg| arg.ty.as_ref().clone())?
-        }
-        VariableType::This => {
-            field_coordinate.object.fields.get(path_root).ok_or_else(||Message {
-                    code: Code::UndefinedField,
-                    message: format!(
-                        "{coordinate} contains `{{{variable}}}`, but {object} does not have a field named `{path_root}`.",
-                        object = field_coordinate.object.name,
-                    ),
-                    locations: url_value.line_col_for_subslice(
-                        path_component_start..path_component_end,
-                        schema,
-                    ).into_iter().collect()
-                }).map(|field| field.ty.clone())?
-        }
-    };
-
-    for nested_field_name in path {
-        path_component_start = path_component_end + 1; // Past the last component and its dot
-        path_component_end = path_component_start + nested_field_name.len();
-        let parent_is_nullable = !variable_type.is_non_null();
-        variable_type = resolve_type(schema, &variable_type, field_coordinate.field)
-            .and_then(|extended_type| {
-                match extended_type {
-                    ExtendedType::Enum(_) | ExtendedType::Scalar(_) => None,
-                    ExtendedType::Object(object) => object.fields.get(nested_field_name).map(|field| &field.ty),
-                    ExtendedType::InputObject(input_object) => input_object.fields.get(nested_field_name).map(|field| field.ty.as_ref()),
-                    // TODO: at the time of writing, you can't declare interfaces or unions in connectors schemas at all, so these aren't tested
-                    ExtendedType::Interface(interface) => interface.fields.get(nested_field_name).map(|field| &field.ty),
-                    ExtendedType::Union(_) => {
-                        return Err(Message {
-                            code: Code::UnsupportedVariableType,
-                            message: format!(
-                                "The type {variable_type} is a union, which is not supported in variables yet.",
-                            ),
-                            locations: field_coordinate
-                                .field
-                                .line_column_range(&schema.sources)
-                                .into_iter()
-                                .collect(),
-                        })
-                    },
-                }
-                    .ok_or_else(|| Message {
-                        code: Code::UndefinedField,
-                        message: format!(
-                            "{coordinate} contains `{{{variable}}}`, but `{variable_type}` does not have a field named `{nested_field_name}`.",
-                        ),
-                        locations: url_value.line_col_for_subslice(
-                            path_component_start..path_component_end,
-                            schema,
-                        ).into_iter().collect(),
-                    })
-            })?.clone();
-        if parent_is_nullable && variable_type.is_non_null() {
-            variable_type = variable_type.nullable();
-        }
-    }
-
-    Ok(Some(variable_type))
-}
-
-fn resolve_type<'schema>(
-    schema: &'schema Schema,
-    ty: &Type,
-    definition: &Component<FieldDefinition>,
-) -> Result<&'schema ExtendedType, Message> {
-    schema
-        .types
-        .get(ty.inner_named_type())
-        .ok_or_else(|| Message {
-            code: Code::GraphQLError,
-            message: format!("The type {ty} is referenced but not defined in the schema.",),
-            locations: definition
-                .line_column_range(&schema.sources)
-                .into_iter()
-                .collect(),
-        })
 }

--- a/apollo-federation/src/sources/connect/validation/http/url.rs
+++ b/apollo-federation/src/sources/connect/validation/http/url.rs
@@ -13,6 +13,7 @@ use crate::sources::connect::validation::variable::VariableResolver;
 use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
 use crate::sources::connect::variable::ConnectorsContext;
+use crate::sources::connect::variable::ExpressionContext;
 use crate::sources::connect::variable::Phase;
 use crate::sources::connect::variable::Target;
 use crate::sources::connect::URLTemplate;
@@ -21,7 +22,10 @@ pub(crate) fn validate_template(
     coordinate: HttpMethodCoordinate,
     schema: &SchemaInfo,
 ) -> Result<URLTemplate, Vec<Message>> {
-    let (template, str_value) = match parse_template(coordinate, schema) {
+    let expression_context =
+        ConnectorsContext::new(coordinate.connect.into(), Phase::Request, Target::Url);
+    let (template, str_value) = match parse_template(coordinate, schema, expression_context.clone())
+    {
         Ok(tuple) => tuple,
         Err(message) => return Err(vec![message]),
     };
@@ -31,23 +35,20 @@ pub(crate) fn validate_template(
             .extend(validate_base_url(base, coordinate, coordinate.node, str_value, schema).err());
     }
 
-    let variable_resolver = VariableResolver::new(
-        ConnectorsContext::new(coordinate.connect.into(), Phase::Request, Target::Url),
-        schema,
-    );
+    let variable_resolver = VariableResolver::new(expression_context, schema);
     for variable in template.path_variables() {
         match variable_resolver.resolve(variable, str_value) {
             Err(message) => {
                 messages.push(Message {
                     code: message.code,
-                    message: format!("{coordinate} contains an invalid variable reference {{{variable}}} - {message}", message = message.message),
+                    message: format!("{coordinate} contains an invalid variable reference `{{{variable}}}` - {message}", message = message.message),
                     locations: message.locations,
                 })
             },
             Ok(Some(ty)) => {
                 if !ty.is_non_null() {
                     messages.push(Message {
-                        code: Code::NullablePathVariable,
+                        code: Code::NullabilityMismatch,
                         message: format!(
                             "Variables in path parameters should be non-null, but {coordinate} contains `{{{variable}}}` which is nullable. \
                              If a null value is provided at runtime, the request will fail.",
@@ -67,7 +68,7 @@ pub(crate) fn validate_template(
         if let Err(message) = variable_resolver.resolve(variable, str_value) {
             messages.push(Message {
                 code: message.code,
-                message: format!("{coordinate} contains an invalid variable reference {{{variable}}} - {message}", message = message.message),
+                message: format!("{coordinate} contains an invalid variable reference `{{{variable}}}` - {message}", message = message.message),
                 locations: message.locations,
             })
         }
@@ -83,6 +84,7 @@ pub(crate) fn validate_template(
 fn parse_template<'schema>(
     coordinate: HttpMethodCoordinate<'schema>,
     schema: &'schema SchemaInfo,
+    expression_context: ConnectorsContext<'schema>,
 ) -> Result<(URLTemplate, GraphQLString<'schema>), Message> {
     let str_value = GraphQLString::new(coordinate.node, &schema.sources).map_err(|_| Message {
         code: Code::GraphQLError,
@@ -94,14 +96,30 @@ fn parse_template<'schema>(
             .collect(),
     })?;
     let template = URLTemplate::from_str(str_value.as_str()).map_err(
-        |url_template::Error { message, location }| Message {
-            code: Code::InvalidUrl,
-            message: format!("{coordinate} must be a valid URL template. {message}"),
-            locations: location
-                .and_then(|location| str_value.line_col_for_subslice(location, schema))
-                .into_iter()
-                .collect(),
-        },
+        |e: url_template::Error| match e {
+            url_template::Error::InvalidVariableNamespace { namespace, location } => {
+                Message {
+                    code: Code::InvalidUrl,
+                    message: format!(
+                        "{coordinate} must be a valid URL template. Invalid variable namespace `{namespace}`,  must be one of {available}",
+                        available = expression_context.namespaces_joined(),
+                    ),
+                    locations: str_value
+                        .line_col_for_subslice(location, schema)
+                        .into_iter()
+                        .collect(),
+                }
+            }
+            url_template::Error::ParseError { message, location } =>
+                Message {
+                    code: Code::InvalidUrl,
+                    message: format!("{coordinate} must be a valid URL template. {message}"),
+                    locations: location
+                    .and_then(|location| str_value.line_col_for_subslice(location, schema))
+                    .into_iter()
+                    .collect(),
+                },
+        }
     )?;
     Ok((template, str_value))
 }

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -21,6 +21,7 @@ mod graphql;
 mod http;
 mod selection;
 mod source_name;
+mod variable;
 
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -332,6 +333,7 @@ fn validate_source(directive: &Component<Directive>, schema: &SchemaInfo) -> Sou
         errors.extend(
             headers::validate_arg(
                 http_arg,
+                schema,
                 &schema.sources,
                 HttpHeadersCoordinate::Source {
                     directive_name: &directive.name,

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -334,7 +334,6 @@ fn validate_source(directive: &Component<Directive>, schema: &SchemaInfo) -> Sou
             headers::validate_arg(
                 http_arg,
                 schema,
-                &schema.sources,
                 HttpHeadersCoordinate::Source {
                     directive_name: &directive.name,
                 },
@@ -545,14 +544,14 @@ pub enum Code {
     UndefinedField,
     /// A type used in a variable is not yet supported (i.e., unions)
     UnsupportedVariableType,
-    /// A path variable is nullable, which can cause errors at runtime
-    NullablePathVariable,
+    /// A variable is nullable in a location which requires non-null at runtime
+    NullabilityMismatch,
 }
 
 impl Code {
     pub const fn severity(&self) -> Severity {
         match self {
-            Self::NoSourceImport | Self::NullablePathVariable => Severity::Warning,
+            Self::NoSourceImport | Self::NullabilityMismatch => Severity::Warning,
             _ => Severity::Error,
         }
     }

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid-path-parameter.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid-path-parameter.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid-p
 [
     Message {
         code: InvalidUrl,
-        message: "`GET` in `@connect(http:)` on `Query.resources` must be a valid URL template. Variable type must be one of $args, $this, $config, got `$blah`",
+        message: "`GET` in `@connect(http:)` on `Query.resources` must be a valid URL template. Unknown variable namespace `$blah`",
         locations: [
             12:23..12:28,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid-path-parameter.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid-path-parameter.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid-p
 [
     Message {
         code: InvalidUrl,
-        message: "`GET` in `@connect(http:)` on `Query.resources` must be a valid URL template. Unknown variable namespace `$blah`",
+        message: "`GET` in `@connect(http:)` on `Query.resources` must be a valid URL template. Invalid variable namespace `$blah`,  must be one of $args, $config, $context, $this",
         locations: [
             12:23..12:28,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_connect_http_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_connect_http_headers.graphql.snap
@@ -50,7 +50,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_c
     },
     Message {
         code: InvalidHttpHeaderValue,
-        message: "The value `\"  Value with 😊 emoji and newline  \\n \"` at `@connect(http.headers:)` on `Query.resources` is an invalid HTTP header",
+        message: "The value `  Value with 😊 emoji and newline  \n ` at `@connect(http.headers:)` on `Query.resources` is an invalid HTTP header",
         locations: [
             21:20..21:62,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_header_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_header_variables.graphql.snap
@@ -1,0 +1,35 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_header_variables.graphql
+---
+[
+    Message {
+        code: InvalidHttpHeaderValue,
+        message: "The value `{$foo.bar}` at `@source(http.headers:)` is an invalid HTTP header",
+        locations: [
+            11:47..11:59,
+        ],
+    },
+    Message {
+        code: GraphQLError,
+        message: "`@source(http.headers:)` contains an invalid variable reference {$this.bar} - Variable namespace `$this` is not valid at this location, must be one of $config, $context",
+        locations: [
+            12:62..12:67,
+        ],
+    },
+    Message {
+        code: InvalidHttpHeaderValue,
+        message: "The value `{$foo.bar}` at `@connect(http.headers:)` on `Query.scalar` is an invalid HTTP header",
+        locations: [
+            23:49..23:61,
+        ],
+    },
+    Message {
+        code: GraphQLError,
+        message: "`@connect(http.headers:)` on `Query.scalar` contains an invalid variable reference {$status} - Variable namespace `$status` is not valid at this location, must be one of $args, $config, $context, $this",
+        locations: [
+            24:64..24:71,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_header_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_header_variables.graphql.snap
@@ -12,7 +12,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
         ],
     },
     Message {
-        code: GraphQLError,
+        code: InvalidHttpHeaderValue,
         message: "`@source(http.headers:)` contains an invalid variable reference {$this.bar} - Variable namespace `$this` is not valid at this location, must be one of $config, $context",
         locations: [
             12:62..12:67,
@@ -26,7 +26,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
         ],
     },
     Message {
-        code: GraphQLError,
+        code: InvalidHttpHeaderValue,
         message: "`@connect(http.headers:)` on `Query.scalar` contains an invalid variable reference {$status} - Variable namespace `$status` is not valid at this location, must be one of $args, $config, $context, $this",
         locations: [
             24:64..24:71,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_header_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_header_variables.graphql.snap
@@ -6,30 +6,44 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
 [
     Message {
         code: InvalidHttpHeaderValue,
-        message: "The value `{$foo.bar}` at `@source(http.headers:)` is an invalid HTTP header - Unknown variable namespace `$foo`",
+        message: "The value `{$foo.bar}` at `@source(http.headers:)` is an invalid HTTP header - invalid variable namespace `$foo`, must be one of $config, $context",
         locations: [
             11:49..11:53,
         ],
     },
     Message {
         code: InvalidHttpHeaderValue,
-        message: "`@source(http.headers:)` contains an invalid variable reference {$this.bar} - Variable namespace `$this` is not valid at this location, must be one of $config, $context",
+        message: "`@source(http.headers:)` contains an invalid variable reference `{$this.bar}` - Variable namespace `$this` is not valid at this location, must be one of $config, $context",
         locations: [
             12:62..12:67,
         ],
     },
     Message {
         code: InvalidHttpHeaderValue,
-        message: "The value `{$foo.bar}` at `@connect(http.headers:)` on `Query.scalar` is an invalid HTTP header - Unknown variable namespace `$foo`",
+        message: "The value `{config.bar}` at `@source(http.headers:)` is an invalid HTTP header - invalid variable namespace `config`, must be one of $config, $context",
         locations: [
-            23:51..23:55,
+            13:56..13:62,
         ],
     },
     Message {
         code: InvalidHttpHeaderValue,
-        message: "`@connect(http.headers:)` on `Query.scalar` contains an invalid variable reference {$status} - Variable namespace `$status` is not valid at this location, must be one of $args, $config, $context, $this",
+        message: "The value `{$foo.bar}` at `@connect(http.headers:)` on `Query.scalar` is an invalid HTTP header - invalid variable namespace `$foo`, must be one of $args, $config, $context, $this",
         locations: [
-            24:64..24:71,
+            24:51..24:55,
+        ],
+    },
+    Message {
+        code: InvalidHttpHeaderValue,
+        message: "`@connect(http.headers:)` on `Query.scalar` contains an invalid variable reference `{$status}` - Variable namespace `$status` is not valid at this location, must be one of $args, $config, $context, $this",
+        locations: [
+            25:64..25:71,
+        ],
+    },
+    Message {
+        code: InvalidHttpHeaderValue,
+        message: "The value `{config.bar}` at `@connect(http.headers:)` on `Query.scalar` is an invalid HTTP header - invalid variable namespace `config`, must be one of $args, $config, $context, $this",
+        locations: [
+            26:58..26:64,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_header_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_header_variables.graphql.snap
@@ -6,9 +6,9 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
 [
     Message {
         code: InvalidHttpHeaderValue,
-        message: "The value `{$foo.bar}` at `@source(http.headers:)` is an invalid HTTP header",
+        message: "The value `{$foo.bar}` at `@source(http.headers:)` is an invalid HTTP header - Unknown variable namespace `$foo`",
         locations: [
-            11:47..11:59,
+            11:49..11:53,
         ],
     },
     Message {
@@ -20,9 +20,9 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
     },
     Message {
         code: InvalidHttpHeaderValue,
-        message: "The value `{$foo.bar}` at `@connect(http.headers:)` on `Query.scalar` is an invalid HTTP header",
+        message: "The value `{$foo.bar}` at `@connect(http.headers:)` on `Query.scalar` is an invalid HTTP header - Unknown variable namespace `$foo`",
         locations: [
-            23:49..23:61,
+            23:51..23:55,
         ],
     },
     Message {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_url_template_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_url_template_variables.graphql.snap
@@ -12,7 +12,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
         ],
     },
     Message {
-        code: GraphQLError,
+        code: InvalidUrl,
         message: "`GET` in `@connect(http:)` on `Query.invalid` contains an invalid variable reference {$status.bar} - Variable namespace `$status` is not valid at this location, must be one of $args, $config, $context, $this",
         locations: [
             18:33..18:40,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_url_template_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_url_template_variables.graphql.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_url_template_variables.graphql
+---
+[
+    Message {
+        code: InvalidUrl,
+        message: "`GET` in `@connect(http:)` on `Query.unknown` must be a valid URL template. Unknown variable namespace `$foo`",
+        locations: [
+            11:33..11:37,
+        ],
+    },
+    Message {
+        code: GraphQLError,
+        message: "`GET` in `@connect(http:)` on `Query.invalid` contains an invalid variable reference {$status.bar} - Variable namespace `$status` is not valid at this location, must be one of $args, $config, $context, $this",
+        locations: [
+            18:33..18:40,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_url_template_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_url_template_variables.graphql.snap
@@ -6,16 +6,23 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
 [
     Message {
         code: InvalidUrl,
-        message: "`GET` in `@connect(http:)` on `Query.unknown` must be a valid URL template. Unknown variable namespace `$foo`",
+        message: "`GET` in `@connect(http:)` on `Query.unknown` must be a valid URL template. Invalid variable namespace `$foo`,  must be one of $args, $config, $context, $this",
         locations: [
             11:33..11:37,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "`GET` in `@connect(http:)` on `Query.invalid` contains an invalid variable reference {$status.bar} - Variable namespace `$status` is not valid at this location, must be one of $args, $config, $context, $this",
+        message: "`GET` in `@connect(http:)` on `Query.invalid` contains an invalid variable reference `{$status.bar}` - Variable namespace `$status` is not valid at this location, must be one of $args, $config, $context, $this",
         locations: [
             18:33..18:40,
+        ],
+    },
+    Message {
+        code: InvalidUrl,
+        message: "`GET` in `@connect(http:)` on `Query.nodollar` must be a valid URL template. Invalid variable namespace `config`,  must be one of $args, $config, $context, $this",
+        locations: [
+            25:31..25:37,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_nested_paths_in_header_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_nested_paths_in_header_variables.graphql.snap
@@ -6,28 +6,28 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
 [
     Message {
         code: UndefinedField,
-        message: "`@connect(http.headers:)` on `Query.scalar` contains an invalid variable reference {$args.scalar.blah} - `String` does not have a field named `blah`.",
+        message: "`@connect(http.headers:)` on `Query.scalar` contains an invalid variable reference `{$args.scalar.blah}` - `String` does not have a field named `blah`.",
         locations: [
             13:60..13:64,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`@connect(http.headers:)` on `Query.object` contains an invalid variable reference {$args.input.fieldThatDoesntExist} - `InputObject` does not have a field named `fieldThatDoesntExist`.",
+        message: "`@connect(http.headers:)` on `Query.object` contains an invalid variable reference `{$args.input.fieldThatDoesntExist}` - `InputObject` does not have a field named `fieldThatDoesntExist`.",
         locations: [
             23:59..23:79,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`@connect(http.headers:)` on `Query.enum` contains an invalid variable reference {$args.enum.cantHaveFields} - `Enum` does not have a field named `cantHaveFields`.",
+        message: "`@connect(http.headers:)` on `Query.enum` contains an invalid variable reference `{$args.enum.cantHaveFields}` - `Enum` does not have a field named `cantHaveFields`.",
         locations: [
             33:56..33:70,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`@connect(http.headers:)` on `Object.newField` contains an invalid variable reference {$this.fieldThatDoesntExist} - `Object` does not have a field named `fieldThatDoesntExist`",
+        message: "`@connect(http.headers:)` on `Object.newField` contains an invalid variable reference `{$this.fieldThatDoesntExist}` - `Object` does not have a field named `fieldThatDoesntExist`",
         locations: [
             47:53..47:73,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_nested_paths_in_header_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_nested_paths_in_header_variables.graphql.snap
@@ -1,0 +1,35 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_nested_paths_in_header_variables.graphql
+---
+[
+    Message {
+        code: UndefinedField,
+        message: "`@connect(http.headers:)` on `Query.scalar` contains an invalid variable reference {$args.scalar.blah} - `String` does not have a field named `blah`.",
+        locations: [
+            13:60..13:64,
+        ],
+    },
+    Message {
+        code: UndefinedField,
+        message: "`@connect(http.headers:)` on `Query.object` contains an invalid variable reference {$args.input.fieldThatDoesntExist} - `InputObject` does not have a field named `fieldThatDoesntExist`.",
+        locations: [
+            23:59..23:79,
+        ],
+    },
+    Message {
+        code: UndefinedField,
+        message: "`@connect(http.headers:)` on `Query.enum` contains an invalid variable reference {$args.enum.cantHaveFields} - `Enum` does not have a field named `cantHaveFields`.",
+        locations: [
+            33:56..33:70,
+        ],
+    },
+    Message {
+        code: UndefinedField,
+        message: "`@connect(http.headers:)` on `Object.newField` contains an invalid variable reference {$this.fieldThatDoesntExist} - `Object` does not have a field named `fieldThatDoesntExist`",
+        locations: [
+            47:53..47:73,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_nested_paths_in_url_template_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_nested_paths_in_url_template_variables.graphql.snap
@@ -6,28 +6,28 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
 [
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.scalar` contains an invalid variable reference {$args.scalar.blah} - `String` does not have a field named `blah`.",
+        message: "`GET` in `@connect(http:)` on `Query.scalar` contains an invalid variable reference `{$args.scalar.blah}` - `String` does not have a field named `blah`.",
         locations: [
             10:62..10:66,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.object` contains an invalid variable reference {$args.input.fieldThatDoesntExist} - `InputObject` does not have a field named `fieldThatDoesntExist`.",
+        message: "`GET` in `@connect(http:)` on `Query.object` contains an invalid variable reference `{$args.input.fieldThatDoesntExist}` - `InputObject` does not have a field named `fieldThatDoesntExist`.",
         locations: [
             15:61..15:81,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.enum` contains an invalid variable reference {$args.enum.cantHaveFields} - `Enum` does not have a field named `cantHaveFields`.",
+        message: "`GET` in `@connect(http:)` on `Query.enum` contains an invalid variable reference `{$args.enum.cantHaveFields}` - `Enum` does not have a field named `cantHaveFields`.",
         locations: [
             20:58..20:72,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Object.newField` contains an invalid variable reference {$this.fieldThatDoesntExist} - `Object` does not have a field named `fieldThatDoesntExist`",
+        message: "`GET` in `@connect(http:)` on `Object.newField` contains an invalid variable reference `{$this.fieldThatDoesntExist}` - `Object` does not have a field named `fieldThatDoesntExist`",
         locations: [
             29:55..29:75,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_nested_paths_in_url_template_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_nested_paths_in_url_template_variables.graphql.snap
@@ -6,28 +6,28 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
 [
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.scalar` contains `{$args.scalar.blah}`, but `String` does not have a field named `blah`.",
+        message: "`GET` in `@connect(http:)` on `Query.scalar` contains an invalid variable reference {$args.scalar.blah} - `String` does not have a field named `blah`.",
         locations: [
             10:62..10:66,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.object` contains `{$args.input.fieldThatDoesntExist}`, but `InputObject` does not have a field named `fieldThatDoesntExist`.",
+        message: "`GET` in `@connect(http:)` on `Query.object` contains an invalid variable reference {$args.input.fieldThatDoesntExist} - `InputObject` does not have a field named `fieldThatDoesntExist`.",
         locations: [
             15:61..15:81,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.enum` contains `{$args.enum.cantHaveFields}`, but `Enum` does not have a field named `cantHaveFields`.",
+        message: "`GET` in `@connect(http:)` on `Query.enum` contains an invalid variable reference {$args.enum.cantHaveFields} - `Enum` does not have a field named `cantHaveFields`.",
         locations: [
             20:58..20:72,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Object.newField` contains `{$this.fieldThatDoesntExist}`, but Object does not have a field named `fieldThatDoesntExist`.",
+        message: "`GET` in `@connect(http:)` on `Object.newField` contains an invalid variable reference {$this.fieldThatDoesntExist} - `Object` does not have a field named `fieldThatDoesntExist`",
         locations: [
             29:55..29:75,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_source_http_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_source_http_headers.graphql.snap
@@ -50,7 +50,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
     },
     Message {
         code: InvalidHttpHeaderValue,
-        message: "The value `\"  Value with 😊 emoji and newline  \\n \"` at `@source(http.headers:)` is an invalid HTTP header",
+        message: "The value `  Value with 😊 emoji and newline  \n ` at `@source(http.headers:)` is an invalid HTTP header",
         locations: [
             22:18..22:60,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@nullable_path_var_hint.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@nullable_path_var_hint.graphql.snap
@@ -5,14 +5,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/nullable_
 ---
 [
     Message {
-        code: NullablePathVariable,
+        code: NullabilityMismatch,
         message: "Variables in path parameters should be non-null, but `GET` in `@connect(http:)` on `Query.something` contains `{$args.isNull}` which is nullable. If a null value is provided at runtime, the request will fail.",
         locations: [
             5:82..5:94,
         ],
     },
     Message {
-        code: NullablePathVariable,
+        code: NullabilityMismatch,
         message: "Variables in path parameters should be non-null, but `GET` in `@connect(http:)` on `Query.nestedNull` contains `{$args.nullabled.notNull}` which is nullable. If a null value is provided at runtime, the request will fail.",
         locations: [
             6:88..6:111,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@undefined_arg_in_url_template.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@undefined_arg_in_url_template.graphql.snap
@@ -6,14 +6,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/undefined
 [
     Message {
         code: UndefinedArgument,
-        message: "`GET` in `@connect(http:)` on `Query.resources` contains `{$args.blah}`, but `Query.resources` does not have an argument named `blah`.",
+        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference {$args.blah} - `resources` does not have an argument named `blah`",
         locations: [
             10:45..10:49,
         ],
     },
     Message {
         code: UndefinedArgument,
-        message: "`GET` in `@connect(http:)` on `Query.resources` contains `{$args.something}`, but `Query.resources` does not have an argument named `something`.",
+        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference {$args.something} - `resources` does not have an argument named `something`",
         locations: [
             10:68..10:77,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@undefined_arg_in_url_template.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@undefined_arg_in_url_template.graphql.snap
@@ -6,14 +6,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/undefined
 [
     Message {
         code: UndefinedArgument,
-        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference {$args.blah} - `resources` does not have an argument named `blah`",
+        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference `{$args.blah}` - `resources` does not have an argument named `blah`",
         locations: [
             10:45..10:49,
         ],
     },
     Message {
         code: UndefinedArgument,
-        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference {$args.something} - `resources` does not have an argument named `something`",
+        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference `{$args.something}` - `resources` does not have an argument named `something`",
         locations: [
             10:68..10:77,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@undefined_this_in_url_template.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@undefined_this_in_url_template.graphql.snap
@@ -6,14 +6,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/undefined
 [
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.resources` contains `{$this.blah}`, but Query does not have a field named `blah`.",
+        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference {$this.blah} - `Query` does not have a field named `blah`",
         locations: [
             10:45..10:49,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.resources` contains `{$this.something}`, but Query does not have a field named `something`.",
+        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference {$this.something} - `Query` does not have a field named `something`",
         locations: [
             10:68..10:77,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@undefined_this_in_url_template.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@undefined_this_in_url_template.graphql.snap
@@ -6,14 +6,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/undefined
 [
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference {$this.blah} - `Query` does not have a field named `blah`",
+        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference `{$this.blah}` - `Query` does not have a field named `blah`",
         locations: [
             10:45..10:49,
         ],
     },
     Message {
         code: UndefinedField,
-        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference {$this.something} - `Query` does not have a field named `something`",
+        message: "`GET` in `@connect(http:)` on `Query.resources` contains an invalid variable reference `{$this.something}` - `Query` does not have a field named `something`",
         locations: [
             10:68..10:77,
         ],

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_header_variables.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_header_variables.graphql
@@ -1,0 +1,28 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect", "@source"]
+  )
+  @source(
+    name: "v1"
+    http: {
+      baseURL: "https://127.0.0.1"
+      headers: [
+        { name: "x-unknown-namespace", value: "{$foo.bar}" }
+        { name: "x-invalid-location-for-namespace", value: "{$this.bar}" }
+      ]
+    }
+  )
+
+type Query {
+  scalar(bar: String): String
+    @connect(
+      http: {
+        GET: "http://127.0.0.1"
+        headers: [
+          { name: "x-unknown-namespace", value: "{$foo.bar}"}
+          { name: "x-invalid-location-for-namespace", value: "{$status}" }
+        ]
+      }
+      selection: "$"
+    )

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_header_variables.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_header_variables.graphql
@@ -10,6 +10,7 @@ extend schema
       headers: [
         { name: "x-unknown-namespace", value: "{$foo.bar}" }
         { name: "x-invalid-location-for-namespace", value: "{$this.bar}" }
+        { name: "x-namespace-missing-dollar", value: "{config.bar}" }
       ]
     }
   )
@@ -22,6 +23,7 @@ type Query {
         headers: [
           { name: "x-unknown-namespace", value: "{$foo.bar}"}
           { name: "x-invalid-location-for-namespace", value: "{$status}" }
+          { name: "x-namespace-missing-dollar", value: "{config.bar}" }
         ]
       }
       selection: "$"

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_url_template_variables.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_url_template_variables.graphql
@@ -1,0 +1,21 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+  )
+
+type Query {
+  unknown(bar: String): String
+    @connect(
+      http: {
+        GET: "http://127.0.0.1/{$foo.bar}"
+      }
+      selection: "$"
+    )
+  invalid(bar: String): String
+    @connect(
+      http: {
+        GET: "http://127.0.0.1/{$status.bar}"
+      }
+      selection: "$"
+    )

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_url_template_variables.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_namespace_in_url_template_variables.graphql
@@ -19,3 +19,10 @@ type Query {
       }
       selection: "$"
     )
+  nodollar(bar: String): String
+  @connect(
+    http: {
+      GET: "http://127.0.0.1/{config.bar}"
+    }
+    selection: "$"
+  )

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_nested_paths_in_header_variables.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_nested_paths_in_header_variables.graphql
@@ -1,0 +1,60 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect", "@source"]
+  )
+
+type Query {
+  scalar(scalar: String): String
+    @connect(
+      http: {
+        GET: "http://127.0.0.1"
+        headers: [
+          { name: "x-custom-header", value: "{$args.scalar.blah}"}
+        ]
+      }
+      selection: "$"
+    )
+  object(input: InputObject): Object
+    @connect(
+      http: {
+        GET: "http://127.0.0.1"
+        headers: [
+          { name: "x-custom-header", value: "{$args.input.fieldThatDoesntExist}"}
+        ]
+      }
+      selection: "id"
+    )
+  enum(enum: Enum): Enum
+  @connect(
+    http: {
+      GET: "http://127.0.0.1"
+      headers: [
+        { name: "x-custom-header", value: "{$args.enum.cantHaveFields}"}
+      ]
+    }
+    selection: "$"
+  )
+}
+
+type Object {
+  id: ID!
+  newField: String
+    @connect(
+      http: {
+        GET: "http://127.0.0.1"
+        headers: [
+          { name: "x-custom-header", value: "{$this.fieldThatDoesntExist}"}
+        ]
+      }
+      selection: "$"
+    )
+}
+
+input InputObject {
+  id: ID!
+}
+
+enum Enum {
+  VALUE
+}

--- a/apollo-federation/src/sources/connect/validation/variable/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/variable/mod.rs
@@ -58,11 +58,7 @@ impl<'a> VariableResolver<'a> {
                 message: format!(
                     "Variable namespace `{namespace}` is not valid at this location, must be one of {available}",
                     namespace = reference.namespace.namespace.as_str(),
-                    available = self.expression_context
-                        .available_namespaces()
-                        .map(|s| s.as_str())
-                        .sorted()
-                        .join(", ")
+                    available = self.expression_context.namespaces_joined(),
                 ),
                 locations: expression.line_col_for_subslice(reference.namespace.location.start..reference.namespace.location.end, self.schema).into_iter().collect(),
             })

--- a/apollo-federation/src/sources/connect/validation/variable/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/variable/mod.rs
@@ -1,0 +1,76 @@
+//! Variable validation.
+mod resolver;
+
+use std::collections::HashMap;
+
+use apollo_compiler::ast::Type;
+use itertools::Itertools;
+use resolver::args::ArgsResolver;
+use resolver::this::ThisResolver;
+use resolver::NamespaceResolver;
+
+use crate::sources::connect::validation::graphql::GraphQLString;
+use crate::sources::connect::validation::graphql::SchemaInfo;
+use crate::sources::connect::validation::Code;
+use crate::sources::connect::validation::Message;
+use crate::sources::connect::variable::ConnectorsContext;
+use crate::sources::connect::variable::Directive;
+use crate::sources::connect::variable::ExpressionContext;
+use crate::sources::connect::variable::Namespace;
+use crate::sources::connect::variable::VariableReference;
+
+pub(crate) struct VariableResolver<'a> {
+    expression_context: ConnectorsContext<'a>,
+    schema: &'a SchemaInfo<'a>,
+    resolvers: HashMap<Namespace, Box<dyn NamespaceResolver + 'a>>,
+}
+
+impl<'a> VariableResolver<'a> {
+    pub(super) fn new(
+        expression_context: ConnectorsContext<'a>,
+        schema: &'a SchemaInfo<'a>,
+    ) -> Self {
+        let mut resolvers = HashMap::<Namespace, Box<dyn NamespaceResolver + 'a>>::new();
+        if let Directive::Connect { object, field } = expression_context.directive {
+            resolvers.insert(Namespace::This, Box::new(ThisResolver::new(object, field)));
+            resolvers.insert(Namespace::Args, Box::new(ArgsResolver::new(field)));
+        }
+        Self {
+            expression_context,
+            schema,
+            resolvers,
+        }
+    }
+
+    pub(super) fn resolve(
+        &self,
+        reference: &VariableReference<Namespace>,
+        expression: GraphQLString,
+    ) -> Result<Option<Type>, Message> {
+        if !self
+            .expression_context
+            .available_namespaces()
+            .contains(&reference.namespace.namespace)
+        {
+            Err(Message {
+                code: Code::GraphQLError,
+                message: format!(
+                    "Variable namespace `{namespace}` is not valid at this location, must be one of {available}",
+                    namespace = reference.namespace.namespace.as_str(),
+                    available = self.expression_context
+                        .available_namespaces()
+                        .map(|s| s.as_str())
+                        .sorted()
+                        .join(", ")
+                ),
+                locations: expression.line_col_for_subslice(reference.namespace.location.start..reference.namespace.location.end, self.schema).into_iter().collect(),
+            })
+        } else {
+            self.resolvers
+                .get(&reference.namespace.namespace)
+                .map(|x| &**x)
+                .map(|resolver| resolver.resolve(reference, expression, self.schema))
+                .unwrap_or(Ok(None))
+        }
+    }
+}

--- a/apollo-federation/src/sources/connect/validation/variable/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/variable/mod.rs
@@ -17,6 +17,7 @@ use crate::sources::connect::variable::ConnectorsContext;
 use crate::sources::connect::variable::Directive;
 use crate::sources::connect::variable::ExpressionContext;
 use crate::sources::connect::variable::Namespace;
+use crate::sources::connect::variable::Target;
 use crate::sources::connect::variable::VariableReference;
 
 pub(crate) struct VariableResolver<'a> {
@@ -53,7 +54,7 @@ impl<'a> VariableResolver<'a> {
             .contains(&reference.namespace.namespace)
         {
             Err(Message {
-                code: Code::GraphQLError,
+                code: self.error_code(),
                 message: format!(
                     "Variable namespace `{namespace}` is not valid at this location, must be one of {available}",
                     namespace = reference.namespace.namespace.as_str(),
@@ -71,6 +72,14 @@ impl<'a> VariableResolver<'a> {
                 .map(|x| &**x)
                 .map(|resolver| resolver.resolve(reference, expression, self.schema))
                 .unwrap_or(Ok(None))
+        }
+    }
+
+    fn error_code(&self) -> Code {
+        match self.expression_context.target {
+            Target::RequestUrl => Code::InvalidUrl,
+            Target::RequestHeader => Code::InvalidHttpHeaderValue,
+            _ => Code::GraphQLError,
         }
     }
 }

--- a/apollo-federation/src/sources/connect/validation/variable/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/variable/mod.rs
@@ -77,8 +77,8 @@ impl<'a> VariableResolver<'a> {
 
     fn error_code(&self) -> Code {
         match self.expression_context.target {
-            Target::RequestUrl => Code::InvalidUrl,
-            Target::RequestHeader => Code::InvalidHttpHeaderValue,
+            Target::Url => Code::InvalidUrl,
+            Target::Header => Code::InvalidHttpHeaderValue,
             _ => Code::GraphQLError,
         }
     }

--- a/apollo-federation/src/sources/connect/validation/variable/resolver/args.rs
+++ b/apollo-federation/src/sources/connect/validation/variable/resolver/args.rs
@@ -1,0 +1,57 @@
+use std::format;
+
+use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::ast::Type;
+use apollo_compiler::schema::Component;
+
+use crate::sources::connect::validation::graphql::GraphQLString;
+use crate::sources::connect::validation::graphql::SchemaInfo;
+use crate::sources::connect::validation::variable::resolver;
+use crate::sources::connect::validation::variable::resolver::NamespaceResolver;
+use crate::sources::connect::validation::Code;
+use crate::sources::connect::validation::Message;
+use crate::sources::connect::variable::Namespace;
+use crate::sources::connect::variable::VariableReference;
+
+/// Resolves variables in the `$args` namespace
+pub(crate) struct ArgsResolver<'a> {
+    field: &'a Component<FieldDefinition>,
+}
+
+impl<'a> ArgsResolver<'a> {
+    pub(crate) fn new(field: &'a Component<FieldDefinition>) -> Self {
+        Self { field }
+    }
+}
+
+impl<'a> NamespaceResolver for ArgsResolver<'a> {
+    fn resolve(
+        &self,
+        reference: &VariableReference<Namespace>,
+        expression: GraphQLString,
+        schema: &SchemaInfo,
+    ) -> Result<Option<Type>, Message> {
+        let root = resolver::get_root(reference, expression, schema)?;
+
+        let field_type = self
+            .field
+            .arguments
+            .iter()
+            .find(|arg| arg.name == root.as_str())
+            .ok_or_else(|| Message {
+                code: Code::UndefinedArgument,
+                message: format!(
+                    "`{object}` does not have an argument named `{root}`",
+                    object = self.field.name,
+                    root = root.as_str(),
+                ),
+                locations: expression
+                    .line_col_for_subslice(root.location.start..root.location.end, schema)
+                    .into_iter()
+                    .collect(),
+            })
+            .map(|field| field.ty.clone())?;
+
+        resolver::resolve_path(schema, reference, expression, &field_type, self.field)
+    }
+}

--- a/apollo-federation/src/sources/connect/validation/variable/resolver/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/variable/resolver/mod.rs
@@ -1,0 +1,113 @@
+use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::ast::Type;
+use apollo_compiler::schema::Component;
+use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::Schema;
+
+use crate::sources::connect::validation::graphql::GraphQLString;
+use crate::sources::connect::validation::graphql::SchemaInfo;
+use crate::sources::connect::validation::Code;
+use crate::sources::connect::validation::Message;
+use crate::sources::connect::variable::Namespace;
+use crate::sources::connect::variable::VariablePathPart;
+use crate::sources::connect::variable::VariableReference;
+
+pub(super) mod args;
+pub(super) mod this;
+
+/// Resolves variables with a specific namespace
+pub(crate) trait NamespaceResolver {
+    fn resolve(
+        &self,
+        reference: &VariableReference<Namespace>,
+        expression: GraphQLString,
+        schema: &SchemaInfo,
+    ) -> Result<Option<Type>, Message>;
+}
+
+pub(super) fn resolve_type<'schema>(
+    schema: &'schema Schema,
+    ty: &Type,
+    field: &Component<FieldDefinition>,
+) -> Result<&'schema ExtendedType, Message> {
+    schema
+        .types
+        .get(ty.inner_named_type())
+        .ok_or_else(|| Message {
+            code: Code::GraphQLError,
+            message: format!("The type {ty} is referenced but not defined in the schema.",),
+            locations: field
+                .line_column_range(&schema.sources)
+                .into_iter()
+                .collect(),
+        })
+}
+
+/// Resolve a variable reference path relative to a type. Assumes that the first element of the
+/// path has already been resolved to the type, and validates any remainder.
+fn resolve_path(
+    schema: &SchemaInfo,
+    reference: &VariableReference<Namespace>,
+    expression: GraphQLString,
+    field_type: &Type,
+    field: &Component<FieldDefinition>,
+) -> Result<Option<Type>, Message> {
+    let mut variable_type = field_type.clone();
+    for nested_field_name in reference.path.clone().iter().skip(1) {
+        let path_component_range = nested_field_name.location.clone();
+        let nested_field_name = nested_field_name.as_str();
+        let parent_is_nullable = !field_type.is_non_null();
+        variable_type = resolve_type(schema, &variable_type, field)
+            .and_then(|extended_type| {
+                match extended_type {
+                    ExtendedType::Enum(_) | ExtendedType::Scalar(_) => None,
+                    ExtendedType::Object(object) => object.fields.get(nested_field_name).map(|field| &field.ty),
+                    ExtendedType::InputObject(input_object) => input_object.fields.get(nested_field_name).map(|field| field.ty.as_ref()),
+                    // TODO: at the time of writing, you can't declare interfaces or unions in connectors schemas at all, so these aren't tested
+                    ExtendedType::Interface(interface) => interface.fields.get(nested_field_name).map(|field| &field.ty),
+                    ExtendedType::Union(_) => {
+                        return Err(Message {
+                            code: Code::UnsupportedVariableType,
+                            message: format!(
+                                "The type {field_type} is a union, which is not supported in variables yet.",
+                            ),
+                            locations: field
+                                .line_column_range(&schema.sources)
+                                .into_iter()
+                                .collect(),
+                        })
+                    },
+                }
+                    .ok_or_else(|| Message {
+                        code: Code::UndefinedField,
+                        message: format!(
+                            "`{variable_type}` does not have a field named `{nested_field_name}`."
+                        ),
+                        locations: expression.line_col_for_subslice(path_component_range.start..path_component_range.end, schema).into_iter().collect(),
+                    })
+            })?.clone();
+        if parent_is_nullable && variable_type.is_non_null() {
+            variable_type = variable_type.nullable();
+        }
+    }
+    Ok(Some(variable_type))
+}
+
+/// Require a variable reference to have a path
+fn get_root(
+    reference: &VariableReference<Namespace>,
+    expression: GraphQLString,
+    schema: &SchemaInfo,
+) -> Result<VariablePathPart, Message> {
+    reference.path.first().cloned().ok_or(Message {
+        code: Code::GraphQLError,
+        message: format!(
+            "The variable `{}` must be followed by a path",
+            reference.namespace.namespace
+        ),
+        locations: expression
+            .line_col_for_subslice(reference.location.clone(), schema)
+            .into_iter()
+            .collect(),
+    })
+}

--- a/apollo-federation/src/sources/connect/validation/variable/resolver/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/variable/resolver/mod.rs
@@ -94,11 +94,11 @@ fn resolve_path(
 }
 
 /// Require a variable reference to have a path
-fn get_root(
-    reference: &VariableReference<Namespace>,
-    expression: GraphQLString,
-    schema: &SchemaInfo,
-) -> Result<VariablePathPart, Message> {
+fn get_root<'a>(
+    reference: &'a VariableReference<'a, Namespace>,
+    expression: GraphQLString<'a>,
+    schema: &'a SchemaInfo<'a>,
+) -> Result<VariablePathPart<'a>, Message> {
     reference.path.first().cloned().ok_or(Message {
         code: Code::GraphQLError,
         message: format!(

--- a/apollo-federation/src/sources/connect/validation/variable/resolver/this.rs
+++ b/apollo-federation/src/sources/connect/validation/variable/resolver/this.rs
@@ -1,0 +1,56 @@
+use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::ast::Type;
+use apollo_compiler::schema::Component;
+use apollo_compiler::schema::ObjectType;
+use apollo_compiler::Node;
+
+use crate::sources::connect::validation::graphql::GraphQLString;
+use crate::sources::connect::validation::graphql::SchemaInfo;
+use crate::sources::connect::validation::variable::resolver;
+use crate::sources::connect::validation::variable::resolver::NamespaceResolver;
+use crate::sources::connect::validation::Code;
+use crate::sources::connect::validation::Message;
+use crate::sources::connect::variable::Namespace;
+use crate::sources::connect::variable::VariableReference;
+
+/// Resolves variables in the `$this` namespace
+pub(crate) struct ThisResolver<'a> {
+    object: &'a Node<ObjectType>,
+    field: &'a Component<FieldDefinition>,
+}
+
+impl<'a> ThisResolver<'a> {
+    pub(crate) fn new(object: &'a Node<ObjectType>, field: &'a Component<FieldDefinition>) -> Self {
+        Self { object, field }
+    }
+}
+
+impl<'a> NamespaceResolver for ThisResolver<'a> {
+    fn resolve(
+        &self,
+        reference: &VariableReference<Namespace>,
+        expression: GraphQLString,
+        schema: &SchemaInfo,
+    ) -> Result<Option<Type>, Message> {
+        let root = resolver::get_root(reference, expression, schema)?;
+        let field_type = self
+            .object
+            .fields
+            .get(root.as_str())
+            .ok_or_else(|| Message {
+                code: Code::UndefinedField,
+                message: format!(
+                    "`{object}` does not have a field named `{root}`",
+                    object = self.object.name,
+                    root = root.as_str(),
+                ),
+                locations: expression
+                    .line_col_for_subslice(root.location.start..root.location.end, schema)
+                    .into_iter()
+                    .collect(),
+            })
+            .map(|field| field.ty.clone())?;
+
+        resolver::resolve_path(schema, reference, expression, &field_type, self.field)
+    }
+}

--- a/apollo-federation/src/sources/connect/variable.rs
+++ b/apollo-federation/src/sources/connect/variable.rs
@@ -1,0 +1,503 @@
+//! Variables used in connector directives `@connect` and `@source`.
+
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::ops::Range;
+use std::str::FromStr;
+
+use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::schema::Component;
+use apollo_compiler::schema::ObjectType;
+use apollo_compiler::Node;
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::alpha1;
+use nom::character::complete::alphanumeric1;
+use nom::character::complete::char;
+use nom::combinator::map;
+use nom::combinator::recognize;
+use nom::error::Error;
+use nom::error::ErrorKind;
+use nom::error::ParseError;
+use nom::multi::many0;
+use nom::sequence::pair;
+use nom::sequence::preceded;
+use nom::sequence::tuple;
+use nom::IResult;
+use nom_locate::LocatedSpan;
+
+/// The context of an expression containing variable references. The context determines what
+/// variable namespaces are available for use in the expression.
+pub(crate) trait ExpressionContext<N> {
+    /// Get the variable namespaces that are available in this context
+    fn available_namespaces(&self) -> impl Iterator<Item = N>;
+}
+
+/// A variable context for Apollo Connectors. Variables are used within a `@connect` or `@source`
+/// [`Directive`], and have a specific [`Target`].
+pub(crate) struct ConnectorsContext<'schema> {
+    pub(super) directive: Directive<'schema>,
+    pub(super) target: Target,
+}
+
+impl<'schema> ConnectorsContext<'schema> {
+    pub(crate) fn new(directive: Directive<'schema>, target: Target) -> Self {
+        Self { directive, target }
+    }
+}
+
+impl<'schema> ExpressionContext<Namespace> for ConnectorsContext<'schema> {
+    fn available_namespaces(&self) -> impl Iterator<Item = Namespace> {
+        match (&self.directive, &self.target) {
+            (Directive::Source, Target::ResponseBody) => {
+                vec![Namespace::Config, Namespace::Context, Namespace::Status]
+            }
+            (Directive::Source, _) => vec![Namespace::Config, Namespace::Context],
+            (Directive::Connect { .. }, Target::ResponseBody) => {
+                vec![
+                    Namespace::Args,
+                    Namespace::Config,
+                    Namespace::Context,
+                    Namespace::Status,
+                    Namespace::This,
+                ]
+            }
+            (Directive::Connect { .. }, _) => {
+                vec![
+                    Namespace::Config,
+                    Namespace::Context,
+                    Namespace::This,
+                    Namespace::Args,
+                ]
+            }
+        }
+        .into_iter()
+    }
+}
+
+/// An Apollo Connectors directive in a schema
+pub(crate) enum Directive<'schema> {
+    /// A `@source` directive
+    Source,
+
+    /// A `@connect` directive
+    Connect {
+        /// The object type containing the field the directive is on
+        object: &'schema Node<ObjectType>,
+
+        /// The field definition of the field the directive is on
+        field: &'schema Component<FieldDefinition>,
+    },
+}
+
+/// The target of an expression containing a variable reference
+#[allow(unused)]
+pub(crate) enum Target {
+    /// The expression is used in a request header
+    RequestHeader,
+
+    /// The expression is used in a request URL
+    RequestUrl,
+
+    /// The expression is used in a request body
+    RequestBody,
+
+    /// The expression is used in a response body
+    ResponseBody,
+}
+
+/// The variable namespaces defined for Apollo Connectors
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
+pub(crate) enum Namespace {
+    Args,
+    Config,
+    Context,
+    Status,
+    This,
+}
+
+impl Namespace {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Args => "$args",
+            Self::Config => "$config",
+            Self::Context => "$context",
+            Self::Status => "$status",
+            Self::This => "$this",
+        }
+    }
+}
+
+impl FromStr for Namespace {
+    type Err = VariableError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "$args" => Ok(Self::Args),
+            "$config" => Ok(Self::Config),
+            "$context" => Ok(Self::Context),
+            "$status" => Ok(Self::Status),
+            "$this" => Ok(Self::This),
+            _ => Err(VariableError {
+                message: format!("Unknown variable namespace `{s}`"),
+                location: Some(0..s.len()),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Debug for Namespace {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl Display for Namespace {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+type Span<'a> = LocatedSpan<&'a str>;
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum VariableParseError<I> {
+    InvalidNamespace {
+        namespace: String,
+        location: Range<usize>,
+    },
+    Nom(I, ErrorKind),
+}
+
+impl<I> ParseError<I> for VariableParseError<I> {
+    fn from_error_kind(input: I, kind: ErrorKind) -> Self {
+        VariableParseError::Nom(input, kind)
+    }
+
+    fn append(_: I, _: ErrorKind, other: Self) -> Self {
+        other
+    }
+}
+impl<I> From<nom::Err<Error<I>>> for VariableParseError<I> {
+    fn from(value: nom::Err<Error<I>>) -> Self {
+        match value {
+            nom::Err::Error(e) | nom::Err::Failure(e) => {
+                VariableParseError::from_error_kind(e.input, e.code)
+            }
+            nom::Err::Incomplete(e) => nom::Err::Incomplete(e).into(),
+        }
+    }
+}
+
+/// A variable reference. Consists of a namespace starting with a `$` and an optional path
+/// separated by '.' characters.
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub(crate) struct VariableReference<N: FromStr<Err = VariableError> + ToString> {
+    /// The namespace of the variable - `$this`, `$args`, `$status`, etc.
+    pub(crate) namespace: VariableNamespace<N>,
+
+    /// The path elements of this reference. For example, the reference `$this.a.b.c`
+    /// has path elements `a`, `b`, `c`. May be empty in some cases, as in the reference `$status`.
+    pub(crate) path: Vec<VariablePathPart>,
+
+    /// The location of the reference within the original text.
+    pub(crate) location: Range<usize>,
+}
+
+impl<N: FromStr<Err = VariableError> + ToString> VariableReference<N> {
+    /// Parse a variable reference at the given offset within the original text. The locations of
+    /// the variable and the parts within it will be based on the provided offset.
+    pub(crate) fn parse(reference: &str, start_offset: usize) -> Result<Self, VariableError> {
+        VariableReference::from_str(reference)
+            .map(|reference| Self {
+                namespace: VariableNamespace {
+                    namespace: reference.namespace.namespace,
+                    location: reference.namespace.location.start + start_offset
+                        ..reference.namespace.location.end + start_offset,
+                },
+                path: reference
+                    .path
+                    .into_iter()
+                    .map(|path_part| VariablePathPart {
+                        part: path_part.part,
+                        location: path_part.location.start + start_offset
+                            ..path_part.location.end + start_offset,
+                    })
+                    .collect(),
+                location: reference.location.start + start_offset
+                    ..reference.location.end + start_offset,
+            })
+            .map_err(|e| VariableError {
+                message: e.message,
+                location: e
+                    .location
+                    .map(|range| range.start + start_offset..range.end + start_offset),
+            })
+    }
+}
+
+impl<N: FromStr<Err = VariableError> + ToString> FromStr for VariableReference<N> {
+    type Err = VariableError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        variable_reference(Span::new(s))
+            .map(|(_, reference)| reference)
+            .map_err(move |e| match e {
+                nom::Err::Error(VariableParseError::Nom(span, _)) => VariableError {
+                    message: format!("Invalid variable reference `{s}`"),
+                    location: Some(
+                        span.location_offset()..span.location_offset() + span.fragment().len(),
+                    ),
+                },
+                nom::Err::Error(VariableParseError::InvalidNamespace {
+                    namespace,
+                    location,
+                }) => VariableError {
+                    message: format!("Unknown variable namespace `{namespace}`"),
+                    location: Some(location),
+                },
+                _ => VariableError {
+                    message: format!("Invalid variable reference `{s}`"),
+                    location: None,
+                },
+            })
+    }
+}
+impl<N: FromStr<Err = VariableError> + ToString> Display for VariableReference<N> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.namespace.namespace.to_string().as_str())?;
+        for part in &self.path {
+            f.write_str(".")?;
+            f.write_str(part.as_str())?;
+        }
+        Ok(())
+    }
+}
+
+/// A namespace in a variable reference, like `$this` in `$this.a.b.c`
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub(crate) struct VariableNamespace<N: FromStr<Err = VariableError> + ToString> {
+    pub(crate) namespace: N,
+    pub(crate) location: Range<usize>,
+}
+
+/// Part of a variable path, like `a` in `$this.a.b.c`
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub(crate) struct VariablePathPart {
+    pub(crate) part: String,
+    pub(crate) location: Range<usize>,
+}
+
+impl VariablePathPart {
+    pub(crate) fn as_str(&self) -> &str {
+        self.part.as_str()
+    }
+}
+
+impl Display for VariablePathPart {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.part.to_string().as_str())?;
+        Ok(())
+    }
+}
+
+pub(crate) fn variable_reference<N: FromStr<Err = VariableError> + ToString>(
+    input: Span,
+) -> IResult<Span, VariableReference<N>, VariableParseError<Span>> {
+    map(
+        tuple((namespace, many0(preceded(char('.'), path_part)))),
+        |(namespace, path)| {
+            let location = namespace.location.start
+                ..path
+                    .last()
+                    .map(|p| p.location.end)
+                    .unwrap_or(namespace.location.end);
+            VariableReference {
+                namespace,
+                path,
+                location,
+            }
+        },
+    )(input)
+}
+
+fn path_part(input: Span) -> IResult<Span, VariablePathPart, VariableParseError<Span>> {
+    map(identifier, |span| VariablePathPart {
+        part: span.fragment().to_string(),
+        location: span.location_offset()..span.location_offset() + span.fragment().len(),
+    })(input)
+    .map_err(|e| nom::Err::Error(e.into()))
+}
+
+fn namespace<N: FromStr<Err = VariableError> + ToString>(
+    input: Span,
+) -> IResult<Span, VariableNamespace<N>, VariableParseError<Span>> {
+    match recognize(pair(char('$'), identifier))(input) {
+        Ok((remaining, span)) => match span.fragment().parse::<N>() {
+            Ok(namespace) => Ok((
+                remaining,
+                VariableNamespace {
+                    namespace,
+                    location: span.location_offset()
+                        ..span.location_offset() + span.fragment().len(),
+                },
+            )),
+            Err(_) => Err(nom::Err::Error(VariableParseError::InvalidNamespace {
+                namespace: span.fragment().to_string(),
+                location: span.location_offset()..span.location_offset() + span.fragment().len(),
+            })),
+        },
+        Err(e) => Err(nom::Err::Error(e.into())),
+    }
+}
+
+fn identifier(input: Span) -> IResult<Span, Span> {
+    recognize(pair(
+        alt((alpha1, tag("_"))),
+        many0(alt((alphanumeric1, tag("_")))),
+    ))(input)
+}
+
+#[derive(Debug)]
+pub(crate) struct VariableError {
+    pub(crate) message: String,
+    pub(crate) location: Option<Range<usize>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_namespace() {
+        let result = namespace::<Namespace>(Span::new("$args")).unwrap().1;
+        assert_eq!(result.namespace, Namespace::Args);
+        assert_eq!(result.location, 0..5);
+
+        let result = namespace::<Namespace>(Span::new("$status")).unwrap().1;
+        assert_eq!(result.namespace, Namespace::Status);
+        assert_eq!(result.location, 0..7);
+
+        let error = namespace::<Namespace>(Span::new("$foobar")).unwrap_err();
+        assert_eq!(
+            error,
+            nom::Err::Error(VariableParseError::InvalidNamespace {
+                namespace: "$foobar".into(),
+                location: 0..7,
+            })
+        );
+
+        let error = namespace::<Namespace>(Span::new("")).unwrap_err();
+        assert_eq!(
+            error,
+            nom::Err::Error(VariableParseError::Nom(Span::new(""), ErrorKind::Char))
+        );
+    }
+
+    #[test]
+    fn test_variable_reference() {
+        let result = variable_reference::<Namespace>(Span::new("$this.a.b.c"))
+            .unwrap()
+            .1;
+        assert_eq!(result.namespace.namespace, Namespace::This);
+        assert_eq!(result.path.len(), 3);
+        assert_eq!(result.path[0].part, "a");
+        assert_eq!(result.path[1].part, "b");
+        assert_eq!(result.path[2].part, "c");
+        assert_eq!(result.location, 0..11);
+        assert_eq!(result.namespace.location, 0..5);
+        assert_eq!(result.path[0].location, 6..7);
+        assert_eq!(result.path[1].location, 8..9);
+        assert_eq!(result.path[2].location, 10..11);
+    }
+
+    #[test]
+    fn test_parse() {
+        let result = VariableReference::<Namespace>::parse("$this.a.b.c", 20).unwrap();
+        assert_eq!(result.namespace.namespace, Namespace::This);
+        assert_eq!(result.path.len(), 3);
+        assert_eq!(result.path[0].part, "a");
+        assert_eq!(result.path[1].part, "b");
+        assert_eq!(result.path[2].part, "c");
+        assert_eq!(result.location, 20..31);
+        assert_eq!(result.namespace.location, 20..25);
+        assert_eq!(result.path[0].location, 26..27);
+        assert_eq!(result.path[1].location, 28..29);
+        assert_eq!(result.path[2].location, 30..31);
+    }
+
+    #[test]
+    fn test_available_namespaces() {
+        assert_eq!(
+            ConnectorsContext::new(Directive::Source, Target::RequestUrl)
+                .available_namespaces()
+                .collect::<Vec<_>>(),
+            vec![Namespace::Config, Namespace::Context,]
+        );
+        assert_eq!(
+            ConnectorsContext::new(Directive::Source, Target::RequestHeader)
+                .available_namespaces()
+                .collect::<Vec<_>>(),
+            vec![Namespace::Config, Namespace::Context,]
+        );
+        assert_eq!(
+            ConnectorsContext::new(Directive::Source, Target::RequestBody)
+                .available_namespaces()
+                .collect::<Vec<_>>(),
+            vec![Namespace::Config, Namespace::Context,]
+        );
+        assert_eq!(
+            ConnectorsContext::new(Directive::Source, Target::ResponseBody)
+                .available_namespaces()
+                .collect::<Vec<_>>(),
+            vec![Namespace::Config, Namespace::Context, Namespace::Status,]
+        );
+    }
+
+    #[test]
+    fn test_generic_namespace() {
+        #[derive(Debug, PartialEq)]
+        enum MiddleEarth {
+            Mordor,
+            Gondor,
+            Rohan,
+        }
+
+        impl FromStr for MiddleEarth {
+            type Err = VariableError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    "$Mordor" => Ok(MiddleEarth::Mordor),
+                    "$Gondor" => Ok(MiddleEarth::Gondor),
+                    "$Rohan" => Ok(MiddleEarth::Rohan),
+                    _ => Err(VariableError {
+                        message: format!("Unknown realm `{s}`"),
+                        location: Some(0..s.len()),
+                    }),
+                }
+            }
+        }
+
+        impl Display for MiddleEarth {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    MiddleEarth::Mordor => f.write_str("$Mordor"),
+                    MiddleEarth::Gondor => f.write_str("$Gondor"),
+                    MiddleEarth::Rohan => f.write_str("$Rohan"),
+                }
+            }
+        }
+
+        let result: VariableReference<MiddleEarth> =
+            "$Mordor.mount_doom.cracks_of_doom".parse().unwrap();
+        assert_eq!(result.namespace.namespace, MiddleEarth::Mordor);
+        assert_eq!(result.path.len(), 2);
+        assert_eq!(result.path[0].part, "mount_doom");
+        assert_eq!(result.path[1].part, "cracks_of_doom");
+        assert_eq!(result.location, 0..33);
+        assert_eq!(result.namespace.location, 0..7);
+        assert_eq!(result.path[0].location, 8..18);
+        assert_eq!(result.path[1].location, 19..33);
+    }
+}


### PR DESCRIPTION
Reusable types and validation for variables in Apollo Connectors directives.

* Provides common parsing and validation for variable references, with location awareness for the variable reference itself as well as the parts within a reference so validation can provide specific problem locations
* Separates out the logic around what variables are available in a given context, and how those variables are resolved to types, from the expression language. For example, `$status` is only available in an HTTP response context.
* Designed to be generically useable outside of connectors if variable expressions or JSON Selection syntax becomes used more widely
* Updates both URL template and HTTP header expressions to use the common variable types and validation, so these will consistently use the same validations
* JSON Selection has *not* been updated to use the variable types directly, but a `TryFrom` implementation is added on `KnownVariable` to allow easily adapting types

<img width="1021" alt="Screenshot 2024-11-13 at 10 22 25 AM" src="https://github.com/user-attachments/assets/ff9480f6-7c4d-4b58-99ff-e459f44b4ab2">


<!-- CNN-510 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
