### PR TITLE
Make all header validations consistent

### DIFF
--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -26,6 +26,7 @@ pub use url_template::Variable;
 pub use self::models::Connector;
 pub use self::models::EntityResolver;
 pub use self::models::HTTPMethod;
+pub use self::models::Header;
 pub use self::models::HeaderSource;
 pub use self::models::HttpJsonTransport;
 use crate::schema::position::ObjectFieldDefinitionPosition;

--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use apollo_compiler::ast;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::Name;
+use apollo_compiler::Node;
+use http::header;
 use http::HeaderName;
 use serde_json::Value;
 use url::Url;
@@ -18,6 +21,10 @@ use crate::schema::ValidFederationSchema;
 use crate::sources::connect::header::HeaderValue;
 use crate::sources::connect::spec::extract_connect_directive_arguments;
 use crate::sources::connect::spec::extract_source_directive_arguments;
+use crate::sources::connect::spec::schema::HEADERS_ARGUMENT_NAME;
+use crate::sources::connect::spec::schema::HTTP_HEADER_MAPPING_FROM_ARGUMENT_NAME;
+use crate::sources::connect::spec::schema::HTTP_HEADER_MAPPING_NAME_ARGUMENT_NAME;
+use crate::sources::connect::spec::schema::HTTP_HEADER_MAPPING_VALUE_ARGUMENT_NAME;
 use crate::sources::connect::ConnectSpecDefinition;
 // --- Connector ---------------------------------------------------------------
 
@@ -226,6 +233,123 @@ impl HTTPMethod {
 pub enum HeaderSource {
     From(String),
     Value(HeaderValue),
+}
+
+impl HeaderSource {
+    /// Get a list of headers from the `headers` argument in a `@connect` or `@source` directive.
+    pub fn from_headers_arg(value: &Node<ast::Value>) -> Result<Vec<(HeaderName, Self)>, String> {
+        if let Some(values) = value.as_list() {
+            values.iter().map(Self::from_single).collect()
+        } else if value.as_object().is_some() {
+            Ok(vec![
+                Self::from_single(value).map_err(|err| format!("Invalid header mapping: {err}"))?
+            ])
+        } else {
+            Err(format!(
+                "`{HEADERS_ARGUMENT_NAME}` must be an object or list of objects"
+            ))
+        }
+    }
+
+    /// Build a single [`Self`] from a single entry in the `headers` arg.
+    fn from_single(value: &Node<ast::Value>) -> Result<(HeaderName, Self), String> {
+        let mappings = value
+            .as_object()
+            .ok_or_else(|| "HTTP header mapping is not an object".to_string())?;
+        let name = mappings
+            .iter()
+            .find_map(|(name, value)| {
+                (*name == HTTP_HEADER_MAPPING_NAME_ARGUMENT_NAME).then_some(value)
+            })
+            .ok_or_else(|| "missing `name` field in HTTP header mapping".to_string())
+            .and_then(|value| {
+                value.as_str().ok_or_else(|| {
+                    "`name` field in HTTP header mapping is not a string".to_string()
+                })
+            })
+            .and_then(|name_str| {
+                HeaderName::try_from(name_str).map_err(|err| format!("Invalid header name: {err}"))
+            })?;
+
+        if Self::is_reserved(&name) {
+            return Err(format!(
+                "Header {name} is reserved and cannot be set by a connector"
+            ));
+        }
+
+        let from = mappings
+            .iter()
+            .find_map(|(name, value)| {
+                (*name == HTTP_HEADER_MAPPING_FROM_ARGUMENT_NAME).then_some(value)
+            })
+            .map(|value| {
+                value.as_str().ok_or_else(|| {
+                    "`from` field in HTTP header mapping is not a string".to_string()
+                })
+            })
+            .transpose()?;
+        if let Some(from) = from {
+            return if Self::is_static(&name) {
+                Err(format!(
+                    "Header {name} can't be set dynamically, only via {HTTP_HEADER_MAPPING_VALUE_ARGUMENT_NAME}."
+                ))
+            } else {
+                Ok((name, HeaderSource::From(from.to_string())))
+            };
+        }
+
+        let value = mappings
+            .iter()
+            .find_map(|(name, value)| {
+                (*name == HTTP_HEADER_MAPPING_VALUE_ARGUMENT_NAME).then_some(value)
+            })
+            .ok_or_else(|| "missing `from` or `value` field in HTTP header mapping".to_string())?;
+
+        if let Some(value) = value.as_str() {
+            Ok((
+                name,
+                HeaderSource::Value(
+                    value
+                        .parse::<HeaderValue>()
+                        .map_err(|err| format!("Invalid header value: {err}"))?,
+                ),
+            ))
+        } else {
+            Err("`value` field in HTTP header mapping is not a string".to_string())
+        }
+    }
+
+    /// These headers are not allowed to be defined by connect directives at all.
+    /// Copied from Router's plugins::headers
+    /// Headers from https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1
+    /// These are not propagated by default using a regex match as they will not make sense for the
+    /// second hop.
+    /// In addition, because our requests are not regular proxy requests content-type, content-length
+    /// and host are also in the exclude list.
+    fn is_reserved(header_name: &HeaderName) -> bool {
+        static KEEP_ALIVE: HeaderName = HeaderName::from_static("keep-alive");
+        matches!(
+            *header_name,
+            header::CONNECTION
+                | header::PROXY_AUTHENTICATE
+                | header::PROXY_AUTHORIZATION
+                | header::TE
+                | header::TRAILER
+                | header::TRANSFER_ENCODING
+                | header::UPGRADE
+                | header::CONTENT_LENGTH
+                | header::CONTENT_ENCODING
+                | header::HOST
+                | header::ACCEPT
+                | header::ACCEPT_ENCODING
+        ) || header_name == KEEP_ALIVE
+    }
+
+    /// These headers can be defined as static values in connect directives, but can't be
+    /// forwarded by the user.
+    fn is_static(header_name: &HeaderName) -> bool {
+        header::CONTENT_TYPE == *header_name
+    }
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/sources/connect/spec/directives.rs
+++ b/apollo-federation/src/sources/connect/spec/directives.rs
@@ -1,12 +1,8 @@
-use std::iter::once;
-
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::Value;
-use apollo_compiler::collections::IndexMap;
 use apollo_compiler::schema::Component;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
-use http::HeaderName;
 use itertools::Itertools;
 
 use super::schema::ConnectDirectiveArguments;
@@ -18,16 +14,12 @@ use super::schema::CONNECT_ENTITY_ARGUMENT_NAME;
 use super::schema::CONNECT_SELECTION_ARGUMENT_NAME;
 use super::schema::HEADERS_ARGUMENT_NAME;
 use super::schema::HTTP_ARGUMENT_NAME;
-use super::schema::HTTP_HEADER_MAPPING_FROM_ARGUMENT_NAME;
-use super::schema::HTTP_HEADER_MAPPING_NAME_ARGUMENT_NAME;
-use super::schema::HTTP_HEADER_MAPPING_VALUE_ARGUMENT_NAME;
 use super::schema::SOURCE_BASE_URL_ARGUMENT_NAME;
 use super::schema::SOURCE_NAME_ARGUMENT_NAME;
 use crate::error::FederationError;
 use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceFieldDirectivePosition;
 use crate::schema::FederationSchema;
-use crate::sources::connect::header::HeaderValue;
 use crate::sources::connect::json_selection::JSONSelection;
 use crate::sources::connect::spec::schema::CONNECT_SOURCE_ARGUMENT_NAME;
 use crate::sources::connect::HeaderSource;
@@ -164,15 +156,12 @@ impl TryFrom<&ObjectNode> for SourceHTTPArguments {
                         .map_err(|err| internal!(format!("Invalid base URL: {}", err)))?,
                 );
             } else if name == HEADERS_ARGUMENT_NAME.as_str() {
-                headers = if let Some(values) = value.as_list() {
-                    Some(nodes_to_headers(values)?)
-                } else if value.as_object().is_some() {
-                    Some(once(node_to_header(value)?).collect())
-                } else {
-                    return Err(internal!(
-                        "`headers` field in `@source` directive's `http` field is not an object or list of objects"
-                    ));
-                }
+                headers = Some(
+                    HeaderSource::from_headers_arg(value)
+                        .map_err(|err| internal!(err))?
+                        .into_iter()
+                        .collect(),
+                );
             } else {
                 return Err(internal!(format!(
                     "unknown argument in `@source` directive's `http` field: {name}"
@@ -186,73 +175,6 @@ impl TryFrom<&ObjectNode> for SourceHTTPArguments {
             ))?,
             headers: headers.unwrap_or_default(),
         })
-    }
-}
-
-/// Converts a list of (name, value) pairs into a list of HTTP headers.
-fn nodes_to_headers(
-    values: &[Node<Value>],
-) -> Result<IndexMap<HeaderName, HeaderSource>, FederationError> {
-    values.iter().map(node_to_header).try_collect()
-}
-
-fn node_to_header(value: &Node<Value>) -> Result<(HeaderName, HeaderSource), FederationError> {
-    let mappings = value
-        .as_object()
-        .ok_or(internal!("HTTP header mapping is not an object"))?;
-    let name = mappings
-        .iter()
-        .find_map(|(name, value)| {
-            (*name == HTTP_HEADER_MAPPING_NAME_ARGUMENT_NAME).then_some(value)
-        })
-        .ok_or(internal!("missing `name` field in HTTP header mapping"))
-        .and_then(|value| {
-            value.as_str().ok_or(internal!(
-                "`name` field in HTTP header mapping is not a string"
-            ))
-        })
-        .and_then(|name_str| {
-            HeaderName::try_from(name_str)
-                .map_err(|err| internal!(format!("Invalid header name: {}", err.to_string())))
-        })?;
-
-    let from = mappings
-        .iter()
-        .find_map(|(name, value)| {
-            (*name == HTTP_HEADER_MAPPING_FROM_ARGUMENT_NAME).then_some(value)
-        })
-        .map(|value| {
-            value.as_str().ok_or(internal!(
-                "`from` field in HTTP header mapping is not a string"
-            ))
-        })
-        .transpose()?;
-    if let Some(from) = from {
-        return Ok((name, HeaderSource::From(from.to_string())));
-    }
-
-    let value = mappings
-        .iter()
-        .find_map(|(name, value)| {
-            (*name == HTTP_HEADER_MAPPING_VALUE_ARGUMENT_NAME).then_some(value)
-        })
-        .ok_or(internal!(
-            "missing `from` or `value` field in HTTP header mapping"
-        ))?;
-
-    if let Some(value) = value.as_str() {
-        Ok((
-            name,
-            HeaderSource::Value(
-                value.parse::<HeaderValue>().map_err(|err| {
-                    internal!(format!("Invalid header value: {}", err.to_string()))
-                })?,
-            ),
-        ))
-    } else {
-        Err(internal!(
-            "`value` field in HTTP header mapping is not a string"
-        ))
     }
 }
 
@@ -332,8 +254,12 @@ impl TryFrom<&ObjectNode> for ConnectHTTPArguments {
                 ))?;
                 body = Some(JSONSelection::parse(body_value).map_err(|e| internal!(e.message))?);
             } else if name == HEADERS_ARGUMENT_NAME.as_str() {
-                // TODO: handle a single object since the language spec allows it
-                headers = value.as_list().map(nodes_to_headers).transpose()?;
+                headers = Some(
+                    HeaderSource::from_headers_arg(value)
+                        .map_err(|err| internal!(err))?
+                        .into_iter()
+                        .collect(),
+                );
             } else if name == "GET" {
                 get = Some(value.as_str().ok_or(internal!(
                     "supplied HTTP template URL in `@connect` directive's `http` field is not a string"

--- a/apollo-federation/src/sources/connect/validation/extended_type.rs
+++ b/apollo-federation/src/sources/connect/validation/extended_type.rs
@@ -297,19 +297,15 @@ fn validate_field(
             }
         }
 
-        errors.extend(
-            headers::validate_arg(
-                http_arg,
-                source_map,
-                HttpHeadersCoordinate::Connect {
-                    directive_name: schema.connect_directive_name,
-                    object: &object.name,
-                    field: &field.name,
-                },
-            )
-            .into_iter()
-            .flatten(),
-        );
+        errors.extend(headers::validate_arg(
+            http_arg,
+            source_map,
+            HttpHeadersCoordinate::Connect {
+                directive_name: schema.connect_directive_name,
+                object: &object.name,
+                field: &field.name,
+            },
+        ));
     }
     errors
 }

--- a/apollo-federation/src/sources/connect/validation/http/headers.rs
+++ b/apollo-federation/src/sources/connect/validation/http/headers.rs
@@ -4,14 +4,10 @@ use apollo_compiler::ast::Value;
 use apollo_compiler::parser::SourceMap;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
-use http::HeaderName;
 
+use crate::sources::connect::models::Header;
 use crate::sources::connect::spec::schema::HEADERS_ARGUMENT_NAME;
-use crate::sources::connect::spec::schema::HTTP_HEADER_MAPPING_FROM_ARGUMENT_NAME as FROM_ARG;
-use crate::sources::connect::spec::schema::HTTP_HEADER_MAPPING_NAME_ARGUMENT_NAME as NAME_ARG;
-use crate::sources::connect::spec::schema::HTTP_HEADER_MAPPING_VALUE_ARGUMENT_NAME as VALUE_ARG;
 use crate::sources::connect::validation::coordinates::HttpHeadersCoordinate;
-use crate::sources::connect::validation::require_value_is_str;
 use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
 
@@ -19,135 +15,45 @@ pub(crate) fn validate_arg<'a>(
     http_arg: &'a [(Name, Node<Value>)],
     source_map: &'a SourceMap,
     coordinate: HttpHeadersCoordinate<'a>,
-) -> Option<impl Iterator<Item = Message> + 'a> {
-    let headers = get_arg(http_arg)?;
+) -> Vec<Message> {
+    let mut messages = Vec::new();
+    let Some(headers_arg) = get_arg(http_arg) else {
+        return messages;
+    };
     #[allow(clippy::mutable_key_type)]
     let mut names = HashMap::new();
-    let messages = headers
-        .as_list()
-        .into_iter()
-        .flat_map(|l| l.iter().filter_map(|o| o.as_object()))
-        .chain(headers.as_object())
-        .flat_map(move |arg_pairs| {
-            let mut messages = Vec::new();
-
-            let name_arg = arg_pairs.iter().find_map(|(key, value)| (key == &NAME_ARG).then_some(value));
-            let value_arg = arg_pairs.iter().find_map(|(key, value)| (key == &VALUE_ARG).then_some(value));
-            let from_arg = arg_pairs.iter().find_map(|(key, value)| (key == &FROM_ARG).then_some(value));
-
-            // validate `name`
-            let Some(name_value) = name_arg else {
-                // `name` must be provided
+    for header in Header::from_headers_arg(headers_arg) {
+        let Header {
+            name,
+            source: _,
+            node,
+        } = match header {
+            Ok(header) => header,
+            Err((message, node)) => {
                 messages.push(Message {
-                    code: Code::GraphQLError,
-                    message: format!("{coordinate} must include a `name` value."),
-                    // TODO: get this closer to the pair
-                    locations: headers.line_column_range(source_map)
-                        .into_iter()
-                        .collect(),
+                    code: Code::InvalidHeader,
+                    message: format!("In {coordinate} {message}"),
+                    locations: node.line_column_range(source_map).into_iter().collect(),
                 });
-                return messages;
-            };
-
-            let header_name = match validate_name(&NAME_ARG, name_value, coordinate, source_map) {
-                Err(err) => {
-                    messages.push(err);
-                    None
-                },
-                Ok(value) => Some(value),
-            };
-
-            if let Some(header_name) = header_name {
-                if let Some(duplicate) = names.insert(header_name.clone(), name_value.location()) {
-                    messages.push(Message {
-                        code: Code::HttpHeaderNameCollision,
-                        message: format!(
-                            "Duplicate header names are not allowed. The header name '{header_name}' at {coordinate} is already defined.",
-                        ),
-                        locations: name_value.line_column_range(source_map)
-                            .into_iter()
-                            .chain(
-                                duplicate.and_then(|span| span.line_column_range(source_map))
-                            )
-                            .collect(),
-                    });
-                }
+                continue;
             }
-
-            messages.extend(match (from_arg, value_arg)  {
-                (Some(from_value), None) => {
-                    validate_name(&FROM_ARG, from_value, coordinate, source_map).err()
-                },
-                (None, Some(value_arg)) => {
-                    validate_value(value_arg, coordinate, source_map)
-                },
-                (Some(from_arg), Some(value_arg)) => Some(
-                    Message {
-                        code: Code::InvalidHttpHeaderMapping,
-                        message: format!("{coordinate} uses both `from` and `value` keys together. Please choose only one."),
-                        locations: from_arg.line_column_range(source_map)
-                            .into_iter()
-                            .chain(
-                                value_arg.line_column_range(source_map)
-                            )
-                            .collect(),
-                    }
+        };
+        if let Some(duplicate) = names.insert(name.clone(), node.location()) {
+            messages.push(Message {
+                code: Code::HttpHeaderNameCollision,
+                message: format!(
+                    "Duplicate header names are not allowed. The header name '{name}' at {coordinate} is already defined.",
                 ),
-                (None, None) => Some(
-                    Message {
-                        code: Code::MissingHeaderSource,
-                        message: format!("{coordinate} must include either a `from` or `value` argument."),
-                        locations: headers.line_column_range(source_map)
-                            .into_iter()
-                            .collect(),
-                    }
-                )
+                locations: node.line_column_range(source_map)
+                    .into_iter()
+                    .chain(
+                        duplicate.and_then(|span| span.line_column_range(source_map))
+                    )
+                    .collect(),
             });
-
-            messages
-        });
-    Some(messages)
-}
-
-fn validate_value(
-    value: &Node<Value>,
-    coordinate: HttpHeadersCoordinate,
-    source_map: &SourceMap,
-) -> Option<Message> {
-    let str_value = match require_value_is_str(value, coordinate, source_map) {
-        Ok(str_value) => str_value,
-        Err(err) => return Some(err),
-    };
-
-    http::HeaderValue::try_from(str_value)
-        .map_err(|_| Message {
-            code: Code::InvalidHttpHeaderValue,
-            message: format!("The value `{value}` at {coordinate} is an invalid HTTP header"),
-            locations: value.line_column_range(source_map).into_iter().collect(),
-        })
-        .err()
-}
-
-fn validate_name(
-    key: &Name,
-    value: &Node<Value>,
-    coordinate: HttpHeadersCoordinate,
-    source_map: &SourceMap,
-) -> Result<HeaderName, Message> {
-    let s = value.as_str().ok_or_else(|| Message {
-        code: Code::GraphQLError,
-        message: format!("{coordinate} contains an invalid header name type."),
-        locations: value.line_column_range(source_map).into_iter().collect(),
-    })?;
-
-    HeaderName::try_from(s).map_err(|_| Message {
-        code: Code::InvalidHttpHeaderName,
-        message: format!(
-            "The value `{}` for `{}` at {} must be a valid HTTP header name.",
-            s, key, coordinate
-        ),
-        locations: value.line_column_range(source_map).into_iter().collect(),
-    })
+        }
+    }
+    messages
 }
 
 fn get_arg(http_arg: &[(Name, Node<Value>)]) -> Option<&Node<Value>> {

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -329,17 +329,13 @@ fn validate_source(directive: &Component<Directive>, schema: &SchemaInfo) -> Sou
             }
         }
 
-        errors.extend(
-            headers::validate_arg(
-                http_arg,
-                &schema.sources,
-                HttpHeadersCoordinate::Source {
-                    directive_name: &directive.name,
-                },
-            )
-            .into_iter()
-            .flatten(),
-        );
+        errors.extend(headers::validate_arg(
+            http_arg,
+            &schema.sources,
+            HttpHeadersCoordinate::Source {
+                directive_name: &directive.name,
+            },
+        ));
     } else {
         errors.push(Message {
             code: Code::GraphQLError,
@@ -514,21 +510,16 @@ pub enum Code {
     SelectedFieldNotFound,
     /// A group selection (`a { b }`) was used, but the field is not an object
     GroupSelectionIsNotObject,
-    /// Invalid header name
-    /// The `name` and `as` mappings should be valid, HTTP header names.
-    InvalidHttpHeaderName,
     /// The `value` mapping should be either a valid HTTP header value or list of valid HTTP header values.
     InvalidHttpHeaderValue,
     /// The `name` mapping must be unique for all headers.
     HttpHeaderNameCollision,
-    /// Header mappings cannot include both `as` and `value` properties.
-    InvalidHttpHeaderMapping,
     /// Certain directives are not allowed when using connectors
     UnsupportedFederationDirective,
     /// Abstract types are not allowed when using connectors
     UnsupportedAbstractType,
-    /// Header does not define `from` or `value`
-    MissingHeaderSource,
+    /// A value in `headers` was not a valid header source
+    InvalidHeader,
     /// Fields that return an object type must use a group JSONSelection `{}`
     GroupSelectionRequiredForObject,
     /// Fields in the schema that aren't resolved by a connector

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_connect_http_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_connect_http_headers.graphql.snap
@@ -5,52 +5,51 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_c
 ---
 [
     Message {
-        code: MissingHeaderSource,
-        message: "`@connect(http.headers:)` on `Query.resources` must include either a `from` or `value` argument.",
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.resources` either `from` or `value` must be set",
         locations: [
-            9:18..23:10,
+            12:11..12:39,
         ],
     },
     Message {
-        code: GraphQLError,
-        message: "`@connect(http.headers:)` on `Query.resources` must include a `name` value.",
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.resources` missing `name` field",
         locations: [
-            9:18..23:10,
+            13:11..13:37,
         ],
     },
     Message {
-        code: InvalidHttpHeaderMapping,
-        message: "`@connect(http.headers:)` on `Query.resources` uses both `from` and `value` keys together. Please choose only one.",
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.resources` `from` and `value` can't be set at the same time",
         locations: [
-            14:43..14:59,
-            14:68..14:79,
+            14:11..14:81,
         ],
     },
     Message {
         code: HttpHeaderNameCollision,
         message: "Duplicate header names are not allowed. The header name 'x-name-collision' at `@connect(http.headers:)` on `Query.resources` is already defined.",
         locations: [
-            16:19..16:37,
-            15:19..15:37,
+            16:11..16:65,
+            15:11..15:59,
         ],
     },
     Message {
-        code: InvalidHttpHeaderName,
-        message: "The value `<Invalid-Header>` for `name` at `@connect(http.headers:)` on `Query.resources` must be a valid HTTP header name.",
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.resources` the value `<Invalid-Header>` is an invalid HTTP header name",
         locations: [
             17:19..17:37,
         ],
     },
     Message {
-        code: InvalidHttpHeaderName,
-        message: "The value `<Invalid-Header>` for `from` at `@connect(http.headers:)` on `Query.resources` must be a valid HTTP header name.",
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.resources` the value `<Invalid-Header>` is an invalid HTTP header name",
         locations: [
             18:43..18:61,
         ],
     },
     Message {
-        code: InvalidHttpHeaderValue,
-        message: "The value `\"  Value with 😊 emoji and newline  \\n \"` at `@connect(http.headers:)` on `Query.resources` is an invalid HTTP header",
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.resources` the value `  Value with 😊 emoji and newline  \n ` is an invalid HTTP header",
         locations: [
             21:20..21:62,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_connect_http_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_connect_http_headers.graphql.snap
@@ -54,4 +54,18 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_c
             21:20..21:62,
         ],
     },
+    Message {
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.resources` header 'content-length' is reserved and cannot be set by a connector",
+        locations: [
+            23:19..23:35,
+        ],
+    },
+    Message {
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.resources` header 'content-type' can't be set dynamically, only via `value`",
+        locations: [
+            24:19..24:33,
+        ],
+    },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_source_http_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_source_http_headers.graphql.snap
@@ -54,4 +54,18 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
             22:18..22:60,
         ],
     },
+    Message {
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)` header 'content-length' is reserved and cannot be set by a connector",
+        locations: [
+            24:17..24:33,
+        ],
+    },
+    Message {
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)` header 'content-type' can't be set dynamically, only via `value`",
+        locations: [
+            25:17..25:31,
+        ],
+    },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_source_http_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_source_http_headers.graphql.snap
@@ -5,52 +5,51 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
 ---
 [
     Message {
-        code: MissingHeaderSource,
-        message: "`@source(http.headers:)` must include either a `from` or `value` argument.",
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)` either `from` or `value` must be set",
         locations: [
-            10:16..24:8,
+            13:9..13:37,
         ],
     },
     Message {
-        code: GraphQLError,
-        message: "`@source(http.headers:)` must include a `name` value.",
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)` missing `name` field",
         locations: [
-            10:16..24:8,
+            14:9..14:35,
         ],
     },
     Message {
-        code: InvalidHttpHeaderMapping,
-        message: "`@source(http.headers:)` uses both `from` and `value` keys together. Please choose only one.",
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)` `from` and `value` can't be set at the same time",
         locations: [
-            15:41..15:57,
-            15:66..15:77,
+            15:9..15:79,
         ],
     },
     Message {
         code: HttpHeaderNameCollision,
         message: "Duplicate header names are not allowed. The header name 'x-name-collision' at `@source(http.headers:)` is already defined.",
         locations: [
-            17:17..17:35,
-            16:17..16:35,
+            17:9..17:63,
+            16:9..16:57,
         ],
     },
     Message {
-        code: InvalidHttpHeaderName,
-        message: "The value `<Invalid-Header>` for `name` at `@source(http.headers:)` must be a valid HTTP header name.",
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)` the value `<Invalid-Header>` is an invalid HTTP header name",
         locations: [
             18:17..18:35,
         ],
     },
     Message {
-        code: InvalidHttpHeaderName,
-        message: "The value `<Invalid-Header>` for `from` at `@source(http.headers:)` must be a valid HTTP header name.",
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)` the value `<Invalid-Header>` is an invalid HTTP header name",
         locations: [
             19:41..19:59,
         ],
     },
     Message {
-        code: InvalidHttpHeaderValue,
-        message: "The value `\"  Value with 😊 emoji and newline  \\n \"` at `@source(http.headers:)` is an invalid HTTP header",
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)` the value `  Value with 😊 emoji and newline  \n ` is an invalid HTTP header",
         locations: [
             22:18..22:60,
         ],

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_connect_http_headers.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_connect_http_headers.graphql
@@ -20,6 +20,8 @@ type Query {
             name: "x-invalid-value"
             value: "  Value with 😊 emoji and newline  \n "
           }
+          { name: "Content-Length", value: "Is a reserved header" }
+          { name: "Content-Type", from: "Cant-Be-Dynamic" }
         ]
       }
       selection: "$"

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_source_http_headers.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_source_http_headers.graphql
@@ -21,6 +21,8 @@ extend schema
           name: "x-invalid-value"
           value: "  Value with 😊 emoji and newline  \n "
         }
+        { name: "Content-Length", value: "Is a reserved header" }
+        { name: "Content-Type", from: "Cant-Be-Dynamic" }
       ]
     }
   )

--- a/apollo-router/src/plugins/connectors/http_json_transport.rs
+++ b/apollo-router/src/plugins/connectors/http_json_transport.rs
@@ -202,18 +202,13 @@ fn add_headers(
                 }
             }
             HeaderSource::Value(value) => match value.interpolate(inputs) {
-                Ok(value) => match HeaderValue::from_str(value.as_str()) {
-                    Ok(value) => {
-                        request = request.header(header_name, value.clone());
+                Ok(value) => {
+                    request = request.header(header_name, value.clone());
 
-                        if header_name == CONTENT_TYPE {
-                            content_type = Some(value.clone());
-                        }
+                    if header_name == CONTENT_TYPE {
+                        content_type = Some(value.clone());
                     }
-                    Err(err) => {
-                        tracing::error!("Invalid header value '{:?}': {:?}", value, err);
-                    }
-                },
+                }
                 Err(err) => {
                     tracing::error!("Unable to interpolate header value: {:?}", err);
                 }


### PR DESCRIPTION
WIP

Before this PR, there were four separate validations for headers:

1. At composition, header names and values are parsed to check for validity. This also checks whether `to` and `from` are both set or just one of them, and disallows duplicate headers.
2. When the router loads a schema, it has a separate, less thorough check for argument validity on `@source`
3. When the router loads a schema, it also checks `@connect` headers in a similar code path, but one that didn't allow single header objects yet.
4. At runtime, certain header names are disallowed in some contexts

This PR unifies the base definition of what's considered a valid `headers` argument, catching disallowed header names at composition time and at router schema load (so there's no need to validate again at runtime).

Improves the locations of a number of validations, pointing at the specific header that errored rather than the whole `headers` block. Also makes the locations of a couple pieces worse, when there are multiple locations within a single header value (i.e., pointing at the whole header instead of the `name` and `value` arguments separately).

TODO: 

- [ ] Check for variables after #6258 merges. None allowed in `@source` (I think?) and only valid types allowed in `@connect`

<!-- CNN-413 -->