### PR TITLE
Added 2 mermaid diagrams to demonstrate entity caching and entity cache invalidation

### DIFF
--- a/docs/source/routing/performance/caching/entity.mdx
+++ b/docs/source/routing/performance/caching/entity.mdx
@@ -61,6 +61,86 @@ With entity caching enabled for this example, the router can:
 - Cache the cart per user, with a small amount of data.
 - Cache inventory data with a short TTL or not cache it at all.
 
+```mermaid
+---
+title: Entity Caching using the "Price" entity
+---
+flowchart RL
+	subgraph QueryResponse["JSON Response"]
+		n1["{
+			&emsp;&emsp;&quot;products&quot;: [
+			&emsp;&emsp;&emsp;&emsp;{
+			&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&quot;name&quot;: &quot;DraftSnowboard&quot;,
+			&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&quot;pastPurchases&quot;: ...,
+			&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&quot;price&quot;: {
+			&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&quot;amount&quot;: &quot;1500&quot;,
+			&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&quot;currency_code&quot;: &quot;USD&quot;
+			&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;},
+			&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&quot;quantity&quot;: &quot;250&quot;
+			&emsp;&emsp;&emsp;&emsp;},
+			&emsp;&emsp;&emsp;&emsp;...
+			&emsp;&emsp;]		
+		}"]
+    end
+
+
+
+	subgraph Subgraphs["Subgraphs"]
+		Purchases["Purchases"]
+		Inventory["Inventory"]
+		Price["Price"]
+	end
+
+	subgraph PriceQueryFragment["Price Query Fragment (e.g. TTL 2200)"]
+		n2["{
+    	&emsp;&emsp;&quot;price&quot;: {
+        &emsp;&emsp;&emsp;&emsp;&quot;id&quot;: 101,
+        &emsp;&emsp;&emsp;&emsp;&quot;product_id&quot;: 12,
+        &emsp;&emsp;&emsp;&emsp;&quot;amount&quot;: 1500,
+        &emsp;&emsp;&emsp;&emsp;&quot;currency_code&quot;: &quot;USD&quot;
+    	&emsp;&emsp;}
+		}"]
+	end
+
+	subgraph PurchaseHistoryQueryFragment["Purchase History Query Fragment"]
+		n3["{
+			&emsp;&emsp;&quot;purchases&quot;: {
+			&emsp;&emsp;&emsp;&emsp;&quot;product_id&quot;: 12,
+			&emsp;&emsp;&emsp;&emsp;&quot;user_id&quot;: 2932,
+			&emsp;&emsp;&emsp;&emsp;...
+			&emsp;&emsp;}
+		}"]
+	end
+
+	subgraph InventoryQueryFragment["Inventory Query Fragment"]
+		n4["{
+			&emsp;&emsp;&quot;inventory&quot;: {
+			&emsp;&emsp;&emsp;&emsp;&quot;id&quot;: 19,
+			&emsp;&emsp;&emsp;&emsp;&quot;product_id&quot;: 12,
+			&emsp;&emsp;&emsp;&emsp;&quot;quantity&quot;: 250
+			&emsp;&emsp;}
+		}"]
+	end
+
+	Router
+	Database[("&emsp;&emsp;&emsp;")]
+
+  Router --> QueryResponse
+	Purchases --> Router
+	Inventory --> Router
+	Price --- Router
+	PriceQueryFragment --> Database
+	PurchaseHistoryQueryFragment --> Purchases
+	InventoryQueryFragment --> Inventory
+	Database --> Router
+
+	style n1 text-align:left
+	style n2 text-align:left
+	style n3 text-align:left
+	style n4 text-align:left
+	style Price border:none,stroke-width:1px,stroke-dasharray:5 5,stroke:#A6A6A6
+```
+
 ## Use entity caching
 
 Follow this guide to enable and configure entity caching in the GraphOS Router.
@@ -134,6 +214,54 @@ This entry contains an object with the `all` field to affect all subgraph reques
 ```
 
 ### Entity cache invalidation
+
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false}} }%%
+flowchart RL
+	subgraph QueryResponse["Cache invalidation POST"]
+		n1["{
+			&emsp;&emsp;&quot;kind&quot;: &quot;subgraph&quot;,
+			&emsp;&emsp;&quot;subgraph&quot;: &quot;price&quot;,
+			&emsp;&emsp;&quot;type&quot;: &quot;Price&quot;,
+			&emsp;&emsp;&quot;key&quot;: {
+			&emsp;&emsp;&emsp;&emsp;&quot;id&quot;: &quot;101&quot;
+			&emsp;&emsp;}
+		}"]
+    end
+
+	subgraph Subgraphs["Subgraphs"]
+		Purchases["Purchases"]
+		Inventory["Inventory"]
+		Price["Price"]
+	end
+
+	subgraph PriceQueryFragment["Price Query Fragment (e.g. TTL 2200)"]
+		n2["` ̶{̶
+    	&emsp;&emsp;&quot; ̶p̶r̶i̶c̶e̶&quot;:  ̶{̶
+        &emsp;&emsp;&emsp;&emsp;&quot; ̶i̶d̶&quot;:  ̶1̶0̶1̶,
+        &emsp;&emsp;&emsp;&emsp;&quot; ̶p̶r̶o̶d̶u̶c̶t̶_̶i̶d̶&quot;:  ̶1̶2̶,
+        &emsp;&emsp;&emsp;&emsp;&quot; ̶a̶m̶o̶u̶n̶t̶&quot;:  ̶1̶5̶0̶0̶,
+        &emsp;&emsp;&emsp;&emsp;&quot;̶c̶u̶r̶r̶e̶n̶c̶y̶_̶c̶o̶d̶e̶&quot;: &quot; ̶U̶S̶D̶&quot;
+    	&emsp;&emsp; ̶}̶
+		 ̶}̶`"]
+	end
+
+	Router
+	Database[("&emsp;&emsp;&emsp;")]
+
+    Router --> QueryResponse
+	Purchases --> Router
+	Inventory --> Router
+	Price --- Router
+	PriceQueryFragment --> Database
+	Database --> Router
+
+	style n1 text-align:left
+	style Price border:none,stroke-width:1px,stroke-dasharray:5 5,stroke:#A6A6A6
+	style Purchases border:none,stroke-width:1px,stroke-dasharray:5 5,stroke:#A6A6A6
+	style Inventory border:none,stroke-width:1px,stroke-dasharray:5 5,stroke:#A6A6A6
+	style n2 text-align:left
+```
 
 When existing cache entries need to be replaced, the router supports a couple of ways for you to invalidate entity cache entries:
 - [**Invalidation endpoint**](#invalidation-http-endpoint) - the router exposes an invalidation endpoint that can receive invalidation requests from any authorized service. This is primarily intended as an alternative to the extensions mechanism described below. For example a subgraph could use it to trigger invalidation events "out of band" from any requests received by the router or a platform operator could use it to invalidate cache entries in response to events which aren't directly related to a router.


### PR DESCRIPTION
This PR adds two Mermaid diagrams demonstrating Entity Caching using a Price entity, and then a cache invalidation workflow. These are similar to the diagrams we used in the GraphQL Summit 2024 keynote, but I had to make some styling concessions to fit within the constraints of Mermaid (comments inline in the file below)