### PR TITLE
docs: fix table wrapping

### DIFF
--- a/docs/source/reference/router/telemetry/instrumentation/instruments.mdx
+++ b/docs/source/reference/router/telemetry/instrumentation/instruments.mdx
@@ -476,9 +476,9 @@ telemetry:
 | `<instrument-name>`         |                                                                                |            | The name of the custom instrument.            |
 | `attributes`                | [standard attributes](/router/configuration/telemetry/instrumentation/standard-attributes) or [selectors](/router/configuration/telemetry/instrumentation/selectors)       |            | The attributes of the custom instrument.      |
 | `condition`                 | [conditions](/router/configuration/telemetry/instrumentation/conditions)                                                     |            | The condition for mutating the instrument.    |
-| `default_requirement_level` | `required`\|`recommended`                                                      | `required` | The default attribute requirement level.      |
-| `type`                      | `counter`\|`histogram`                                                         |            | The name of the custom instrument.            |
+| `default_requirement_level` | `required` \| `recommended`                                                      | `required` | The default attribute requirement level.      |
+| `type`                      | `counter` \| `histogram`                                                         |            | The name of the custom instrument.            |
 | `unit`                      |                                                                                |            | A unit name, for example `By` or `{request}`. |
 | `description`               |                                                                                |            | The description of the custom instrument.     |
-| `value`                     | `unit`\|`duration`\|`<custom>`\|`event_unit`\|`event_duration`\|`event_custom` |            | The value of the instrument.                  |
+| `value`                     | `unit` \| `duration` \| `<custom>` \| `event_unit` \| `event_duration` \| `event_custom` |            | The value of the instrument.                  |
 


### PR DESCRIPTION
Fix table being too wide by adding spaces and making it wrappable