### PR TITLE
Report a metric to Apollo if fragment reuse is enabled

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -502,7 +502,7 @@ impl InstrumentData {
             && !configuration.supergraph.generate_query_fragments
         {
             self.data.insert(
-                "apollo.router.config.experimental_reuse_query_fragments".to_string(),
+                "apollo.router.config.reuse_query_fragments".to_string(),
                 (1, HashMap::new()),
             );
         }

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -49,6 +49,8 @@ impl Metrics {
         data.populate_user_plugins_instrument(configuration);
         data.populate_query_planner_experimental_parallelism(configuration);
         data.populate_deno_or_rust_mode_instruments(configuration);
+        data.populate_legacy_fragment_usage(configuration);
+
         data.into()
     }
 }
@@ -492,6 +494,16 @@ impl InstrumentData {
                 [].into(),
             ),
         );
+    }
+
+    pub(crate) fn populate_legacy_fragment_usage(&mut self, configuration: &Configuration) {
+        // Fragment generation takes precedence over fragment reuse. Only report when fragment reuse is *actually active*.
+        if configuration.supergraph.reuse_query_fragments == Some(true) && !configuration.supergraph.generate_query_fragments {
+            self.data.insert(
+                "apollo.router.config.experimental_reuse_query_fragments".to_string(),
+                (1, HashMap::new()),
+            );
+        }
     }
 
     pub(crate) fn populate_query_planner_experimental_parallelism(

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -498,7 +498,9 @@ impl InstrumentData {
 
     pub(crate) fn populate_legacy_fragment_usage(&mut self, configuration: &Configuration) {
         // Fragment generation takes precedence over fragment reuse. Only report when fragment reuse is *actually active*.
-        if configuration.supergraph.reuse_query_fragments == Some(true) && !configuration.supergraph.generate_query_fragments {
+        if configuration.supergraph.reuse_query_fragments == Some(true)
+            && !configuration.supergraph.generate_query_fragments
+        {
             self.data.insert(
                 "apollo.router.config.experimental_reuse_query_fragments".to_string(),
                 (1, HashMap::new()),


### PR DESCRIPTION
Follow-up to #6013 

We'd like to know if anyone opts out of fragment generation, as we are intending to remove the experimental fragment reuse algorithm (due to being slow, and potentially buggy).

I did not add an automated test for this, I'm not sure how to approach a test for a private metric, and I did not find tests for the other configuration metrics. Perhaps I missed them?

I did manual testing by adding a `println!()` to the new code and running it with various configurations.

<!-- [ROUTER-843] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-843]: https://apollographql.atlassian.net/browse/ROUTER-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ