### PR TITLE
fix(federation): remove special-casing of adding reserved or built-in items to a schema

### DIFF
--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -5143,10 +5143,9 @@ lazy_static! {
             name!("defer"),
         ])
     };
-    // This is static so that UnionTypenameFieldDefinitionPosition.field_name() can return `&Name`,
-    // like the other field_name() methods in this file.
-    pub(crate) static ref INTROSPECTION_TYPENAME_FIELD_NAME: Name = name!("__typename");
 }
+
+pub(crate) static INTROSPECTION_TYPENAME_FIELD_NAME: Name = name!("__typename");
 
 fn validate_component_directives(
     directives: &[Component<Directive>],

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -29,6 +29,7 @@ use lazy_static::lazy_static;
 use serde::Serialize;
 use strum::IntoEnumIterator;
 
+use crate::bail;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::database::links_metadata;
@@ -1056,10 +1057,7 @@ impl ScalarTypeDefinitionPosition {
             {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has already been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has already been pre-inserted"#);
         }
         schema
             .referencers
@@ -1087,10 +1085,7 @@ impl ScalarTypeDefinitionPosition {
             .scalar_types
             .contains_key(&self.type_name)
         {
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has not been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
             // TODO: Allow built-in shadowing instead of ignoring them
@@ -1099,10 +1094,7 @@ impl ScalarTypeDefinitionPosition {
             {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" already exists in schema"#);
         }
         schema
             .schema
@@ -1358,10 +1350,7 @@ impl ObjectTypeDefinitionPosition {
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has already been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has already been pre-inserted"#);
         }
         schema
             .referencers
@@ -1389,20 +1378,14 @@ impl ObjectTypeDefinitionPosition {
             .object_types
             .contains_key(&self.type_name)
         {
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has not been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
             // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" already exists in schema"#);
         }
         schema
             .schema
@@ -1824,10 +1807,7 @@ impl ObjectFieldDefinitionPosition {
             .into());
         }
         if self.try_get(&schema.schema).is_some() {
-            return Err(SingleFederationError::Internal {
-                message: format!("Object field \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Object field "{self}" already exists in schema"#);
         }
         self.parent()
             .make_mut(&mut schema.schema)?
@@ -2427,10 +2407,7 @@ impl InterfaceTypeDefinitionPosition {
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has already been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has already been pre-inserted"#);
         }
         schema
             .referencers
@@ -2458,20 +2435,14 @@ impl InterfaceTypeDefinitionPosition {
             .interface_types
             .contains_key(&self.type_name)
         {
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has not been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
             // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" already exists in schema"#);
         }
         schema
             .schema
@@ -2823,10 +2794,7 @@ impl InterfaceFieldDefinitionPosition {
             .into());
         }
         if self.try_get(&schema.schema).is_some() {
-            return Err(SingleFederationError::Internal {
-                message: format!("Interface field \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Interface field "{self}" already exists in schema"#);
         }
         self.parent()
             .make_mut(&mut schema.schema)?
@@ -3405,10 +3373,7 @@ impl UnionTypeDefinitionPosition {
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has already been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has already been pre-inserted"#);
         }
         schema
             .referencers
@@ -3432,20 +3397,14 @@ impl UnionTypeDefinitionPosition {
             .into());
         }
         if !schema.referencers.union_types.contains_key(&self.type_name) {
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has not been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
             // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" already exists in schema"#);
         }
         schema
             .schema
@@ -3819,10 +3778,7 @@ impl EnumTypeDefinitionPosition {
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has already been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has already been pre-inserted"#);
         }
         schema
             .referencers
@@ -3843,20 +3799,14 @@ impl EnumTypeDefinitionPosition {
             .into());
         }
         if !schema.referencers.enum_types.contains_key(&self.type_name) {
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has not been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
             // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" already exists in schema"#);
         }
         schema
             .schema
@@ -4088,10 +4038,7 @@ impl EnumValueDefinitionPosition {
             .into());
         }
         if self.try_get(&schema.schema).is_some() {
-            return Err(SingleFederationError::Internal {
-                message: format!("Enum value \"{}\" already exists in schema", self,),
-            }
-            .into());
+            bail!(r#"Enum value "{self}" already exists in schema"#);
         }
         self.parent()
             .make_mut(&mut schema.schema)?
@@ -4275,10 +4222,7 @@ impl InputObjectTypeDefinitionPosition {
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has already been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has already been pre-inserted"#);
         }
         schema
             .referencers
@@ -4306,20 +4250,14 @@ impl InputObjectTypeDefinitionPosition {
             .input_object_types
             .contains_key(&self.type_name)
         {
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" has not been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
             // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Type \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Type "{self}" already exists in schema"#);
         }
         schema
             .schema
@@ -4578,10 +4516,7 @@ impl InputObjectFieldDefinitionPosition {
             .into());
         }
         if self.try_get(&schema.schema).is_some() {
-            return Err(SingleFederationError::Internal {
-                message: format!("Input object field \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Input object field "{self}" already exists in schema"#);
         }
         self.parent()
             .make_mut(&mut schema.schema)?
@@ -4820,10 +4755,7 @@ impl DirectiveDefinitionPosition {
             {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Directive \"{}\" has already been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Directive "{self}" has already been pre-inserted"#);
         }
         schema
             .referencers
@@ -4842,10 +4774,7 @@ impl DirectiveDefinitionPosition {
             .directives
             .contains_key(&self.directive_name)
         {
-            return Err(SingleFederationError::Internal {
-                message: format!("Directive \"{}\" has not been pre-inserted", self),
-            }
-            .into());
+            bail!(r#"Directive "{self}" has not been pre-inserted"#);
         }
         if schema
             .schema
@@ -4858,10 +4787,7 @@ impl DirectiveDefinitionPosition {
             {
                 return Ok(());
             }
-            return Err(SingleFederationError::Internal {
-                message: format!("Directive \"{}\" already exists in schema", self),
-            }
-            .into());
+            bail!(r#"Directive "{self}" already exists in schema"#);
         }
         schema
             .schema

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -1051,7 +1051,6 @@ impl ScalarTypeDefinitionPosition {
 
     pub(crate) fn pre_insert(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
         if schema.referencers.contains_type_name(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name)
                 || GRAPHQL_BUILTIN_SCALAR_NAMES.contains(&self.type_name)
             {
@@ -1088,7 +1087,6 @@ impl ScalarTypeDefinitionPosition {
             bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name)
                 || GRAPHQL_BUILTIN_SCALAR_NAMES.contains(&self.type_name)
             {
@@ -1346,7 +1344,6 @@ impl ObjectTypeDefinitionPosition {
 
     pub(crate) fn pre_insert(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
         if schema.referencers.contains_type_name(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -1381,7 +1378,6 @@ impl ObjectTypeDefinitionPosition {
             bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -2403,7 +2399,6 @@ impl InterfaceTypeDefinitionPosition {
 
     pub(crate) fn pre_insert(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
         if schema.referencers.contains_type_name(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -2438,7 +2433,6 @@ impl InterfaceTypeDefinitionPosition {
             bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -3369,7 +3363,6 @@ impl UnionTypeDefinitionPosition {
 
     pub(crate) fn pre_insert(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
         if schema.referencers.contains_type_name(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -3400,7 +3393,6 @@ impl UnionTypeDefinitionPosition {
             bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -3774,7 +3766,6 @@ impl EnumTypeDefinitionPosition {
 
     pub(crate) fn pre_insert(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
         if schema.referencers.contains_type_name(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -3802,7 +3793,6 @@ impl EnumTypeDefinitionPosition {
             bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -4218,7 +4208,6 @@ impl InputObjectTypeDefinitionPosition {
 
     pub(crate) fn pre_insert(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
         if schema.referencers.contains_type_name(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -4253,7 +4242,6 @@ impl InputObjectTypeDefinitionPosition {
             bail!(r#"Type "{self}" has not been pre-inserted"#);
         }
         if schema.schema.types.contains_key(&self.type_name) {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.type_name) {
                 return Ok(());
             }
@@ -4749,7 +4737,6 @@ impl DirectiveDefinitionPosition {
             .directives
             .contains_key(&self.directive_name)
         {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.directive_name)
                 || GRAPHQL_BUILTIN_DIRECTIVE_NAMES.contains(&self.directive_name)
             {
@@ -4781,7 +4768,6 @@ impl DirectiveDefinitionPosition {
             .directive_definitions
             .contains_key(&self.directive_name)
         {
-            // TODO: Allow built-in shadowing instead of ignoring them
             if is_graphql_reserved_name(&self.directive_name)
                 || GRAPHQL_BUILTIN_DIRECTIVE_NAMES.contains(&self.directive_name)
             {

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -339,6 +339,7 @@ fn extract_subgraphs_from_fed_2_supergraph(
         .schema()
         .directive_definitions
         .values()
+        .filter(|directive| !directive.is_built_in())
         .filter_map(|directive_definition| {
             let executable_locations = directive_definition
                 .locations


### PR DESCRIPTION
This is my proposed "solution" for handling the shadowing of builtin types and directives in federated schemas.

That is, what happens if a subgraph (*or supergraph*) SDL contains a scalar declaration like:
```graphql
scalar Boolean
```
where the type name collides with a name provided by the GraphQL spec.

The PR contains some cleanup commits. The first two commits are cleanup, the rest is implementing the below.

## Background

graphql-js completely ignores SDL definitions of built-in scalars, instead only using the built-in ones:

https://github.com/graphql/graphql-js/blob/c079ae3cf8bf5bc0f255bde1ce2fbd424436cffb/src/utilities/extendSchema.ts#L185-L188 

For directives, graphql-js uses the built-in definitions if no custom definition was provided:

https://github.com/graphql/graphql-js/blob/c079ae3cf8bf5bc0f255bde1ce2fbd424436cffb/src/utilities/buildASTSchema.ts#L81-L89

As for federation, JS composition does not propagate a shadowed builtin scalar definition *or* a redefined builtin directive in a subgraph to the supergraph. If you write `scalar Boolean` in your subgraph, the supergraph does not have it. The same goes for a directive like `@skip`. I was surprised by this, but if I declare a subgraph with:
```graphql
directive @skip(if: Boolean!) on FIELD
directive @myskip(if: Boolean!) on FIELD
```
then only `@myskip` is propagated to the supergraph.

In Rust, apollo-rs validation rejects shadowing of built-in types and directives. This could be seen as a bug, but I don’t think it is relevant to us today, as supergraphs do not contain shadowed builtin declarations. It may be a problem for the composition work, as subgraphs that write `scalar Boolean` will be rejected by apollo-rs schema validation. It may be appropriate for apollo-rs to accept shadowed builtin types, like graphql-js does.

I conclude that there are no supergraphs today that shadow builtin scalars or builtin directives. The router will not start up with a supergraph like that.

## Solution

As supergraphs produced by JS composition do not contain shadowing declarations, I suggest we should not treat them specially in the position.rs code. I think the caller of `.pre_insert()` and `.insert()` should ensure that they do not insert a preexisting builtin scalar or directive. Since the query planner and the router both make many assumptions about the meaning of `@skip` and `@include`, and of builtin types, I think we should explicitly not support customising them.

This PR implements that by removing the handling of shadowed types in position.rs.

<!-- [ROUTER-488] -->

[ROUTER-488]: https://apollographql.atlassian.net/browse/ROUTER-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ