### PR TITLE
Enable typename tests that now pass

### DIFF
--- a/apollo-router/tests/integration/typename.rs
+++ b/apollo-router/tests/integration/typename.rs
@@ -106,11 +106,7 @@ async fn aliased() {
     "###);
 }
 
-// FIXME: bellow test panic because of bug in query planner, failing with:
-// "value retrieval failed: empty query plan. This behavior is unexpected and we suggest opening an issue to apollographql/router with a reproduction."
-// See: https://github.com/apollographql/router/issues/6154
 #[tokio::test]
-#[should_panic]
 async fn inside_inline_fragment() {
     let request = Request::fake_builder()
         .query("{ ... { __typename } }")
@@ -120,14 +116,13 @@ async fn inside_inline_fragment() {
     insta::assert_json_snapshot!(response, @r###"
     {
       "data": {
-        "n": "MyQuery"
+        "__typename": "MyQuery"
       }
     }
     "###);
 }
 
 #[tokio::test]
-#[should_panic] // See above FIXME
 async fn inside_fragment() {
     let query = r#"
        { ...SomeFragment }
@@ -141,14 +136,13 @@ async fn inside_fragment() {
     insta::assert_json_snapshot!(response, @r###"
     {
       "data": {
-        "n": "MyQuery"
+        "__typename": "MyQuery"
       }
     }
     "###);
 }
 
 #[tokio::test]
-#[should_panic] // See above FIXME
 async fn deeply_nested_inside_fragments() {
     let query = r#"
        { ...SomeFragment }
@@ -168,7 +162,7 @@ async fn deeply_nested_inside_fragments() {
     insta::assert_json_snapshot!(response, @r###"
     {
       "data": {
-        "n": "MyQuery"
+        "__typename": "MyQuery"
       }
     }
     "###);
@@ -215,6 +209,9 @@ async fn two_named_operations() {
 async fn make_request(request: Request) -> apollo_router::graphql::Response {
     apollo_router::TestHarness::builder()
         .configuration_json(json!({
+            "supergraph": {
+                "introspection": true,
+            },
             "include_subgraph_errors": {
                 "all": true,
             },


### PR DESCRIPTION
Fixes https://github.com/apollographql/router/issues/6154

These tests were using `#[should_panic]` without an `expected` message. At some point the underlying bug was fixed but these tests still panicked for a different reason, so we didn’t notice at the time.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
