### PR TITLE
QP comparison mode: skip comparing PlanNode.authorization

### DIFF
--- a/apollo-router/src/plugins/authorization/tests.rs
+++ b/apollo-router/src/plugins/authorization/tests.rs
@@ -51,6 +51,7 @@ async fn authenticated_request() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "require_authentication": true
         }}))
@@ -123,6 +124,7 @@ async fn unauthenticated_request() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "require_authentication": true
         }}))
@@ -254,6 +256,7 @@ async fn authenticated_directive() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true
@@ -371,6 +374,7 @@ async fn authenticated_directive_reject_unauthorized() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -456,6 +460,7 @@ async fn authenticated_directive_dry_run() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -604,6 +609,7 @@ async fn scopes_directive() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true
@@ -775,6 +781,7 @@ async fn scopes_directive_reject_unauthorized() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -855,6 +862,7 @@ async fn scopes_directive_dry_run() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -935,6 +943,7 @@ async fn errors_in_extensions() {
         "include_subgraph_errors": {
             "all": true
         },
+        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -1054,6 +1063,7 @@ async fn cache_key_metadata() {
             "include_subgraph_errors": {
                 "all": true
             },
+            "experimental_query_planner_mode": "new",
             "authorization": {
                 "directives": {
                     "enabled": true

--- a/apollo-router/src/plugins/authorization/tests.rs
+++ b/apollo-router/src/plugins/authorization/tests.rs
@@ -51,7 +51,6 @@ async fn authenticated_request() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
         "authorization": {
             "require_authentication": true
         }}))
@@ -124,7 +123,6 @@ async fn unauthenticated_request() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
         "authorization": {
             "require_authentication": true
         }}))
@@ -256,7 +254,6 @@ async fn authenticated_directive() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "both_best_effort",
         "authorization": {
             "directives": {
                 "enabled": true
@@ -374,7 +371,6 @@ async fn authenticated_directive_reject_unauthorized() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -460,7 +456,6 @@ async fn authenticated_directive_dry_run() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -609,7 +604,6 @@ async fn scopes_directive() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "both_best_effort",
         "authorization": {
             "directives": {
                 "enabled": true
@@ -781,7 +775,6 @@ async fn scopes_directive_reject_unauthorized() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -862,7 +855,6 @@ async fn scopes_directive_dry_run() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -943,7 +935,6 @@ async fn errors_in_extensions() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
         "authorization": {
             "directives": {
                 "enabled": true,
@@ -1063,7 +1054,6 @@ async fn cache_key_metadata() {
             "include_subgraph_errors": {
                 "all": true
             },
-            "experimental_query_planner_mode": "both_best_effort",
             "authorization": {
                 "directives": {
                     "enabled": true

--- a/apollo-router/src/plugins/authorization/tests.rs
+++ b/apollo-router/src/plugins/authorization/tests.rs
@@ -256,7 +256,7 @@ async fn authenticated_directive() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
+        "experimental_query_planner_mode": "both_best_effort",
         "authorization": {
             "directives": {
                 "enabled": true
@@ -609,7 +609,7 @@ async fn scopes_directive() {
         "include_subgraph_errors": {
             "all": true
         },
-        "experimental_query_planner_mode": "new",
+        "experimental_query_planner_mode": "both_best_effort",
         "authorization": {
             "directives": {
                 "enabled": true
@@ -1063,7 +1063,7 @@ async fn cache_key_metadata() {
             "include_subgraph_errors": {
                 "all": true
             },
-            "experimental_query_planner_mode": "new",
+            "experimental_query_planner_mode": "both_best_effort",
             "authorization": {
                 "directives": {
                     "enabled": true

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -256,20 +256,26 @@ fn fetch_node_matches(this: &FetchNode, other: &FetchNode) -> Result<(), MatchFa
         requires,
         variable_usages,
         operation,
-        operation_name: _, // ignored (reordered parallel fetches may have different names)
+        // ignored:
+        // reordered parallel fetches may have different names
+        operation_name: _,
         operation_kind,
         id,
         input_rewrites,
         output_rewrites,
         context_rewrites,
-        schema_aware_hash: _, // ignored
-        authorization,
+        // ignored
+        schema_aware_hash: _,
+        // ignored:
+        // when running in comparison mode, the rust plan node does not have
+        // the attached cache key metadata for authorisation, since the rust plan is
+        // not going to be the one being executed.
+        authorization: _,
     } = this;
 
     check_match_eq!(*service_name, other.service_name);
     check_match_eq!(*operation_kind, other.operation_kind);
     check_match_eq!(*id, other.id);
-    check_match_eq!(*authorization, other.authorization);
     check_match!(same_requires(requires, &other.requires));
     check_match!(vec_matches_sorted(variable_usages, &other.variable_usages));
     check_match!(same_rewrites(input_rewrites, &other.input_rewrites));


### PR DESCRIPTION
We are getting mismatches when comparing PlanNodes between JS & Rust with ~authorisation~ authorization directives. This mismatch comes from `authorization` field in PlanNode. The executing query plan (and in comparison mode, it will be the JS QP) receives the appropriate `CacheKeyMetadata`,

```rust
CacheKeyMetadata { 
  is_authenticated: true,
  scopes: [],
  policies: []
}
```
but the Rust QP does not, since it will not be used to execute, authenticate, etc any of the requests and gets discarded in this comparison mode. 

Because we do not attach this metadata to the Rust PlanNode **in comparison mode**, we see a ton of false mismatches for everyone using auth directives. 

This PR skips comparing `authorization` field in PlanNode, as this field gets populated _after_ the query plan is already present. In addition, this data is not based on the query plan itself, so it's not necessary to establish equivalence between the two implementations.

When **just the Rust QP is used**, the cache key metadata is present and accounted for correctly, which is why none of the mocks fail when running with only the Rust planner.

It's incredibly difficult to write a test for this little nit in semantic equivalence, so this PR does not come with any, apologies.
<!-- ROUTER-861 -->
