### PR TITLE
Removed TODOs in context snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "multimap 0.10.0",
  "nom",
  "petgraph",
+ "regex",
  "ron",
  "serde",
  "serde_json_bytes",
@@ -2934,8 +2935,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5306,14 +5307,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5327,13 +5328,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5350,9 +5351,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -38,6 +38,7 @@ url = "2"
 tracing = "0.1.40"
 ron = { version = "0.8.1", optional = true }
 either = "1.13.0"
+regex = "1.11.1"
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -50,7 +50,7 @@ macro_rules! internal_error {
 #[macro_export]
 macro_rules! bail {
     ( $( $arg:tt )+ ) => {
-        return Err($crate::internal_error!( $( $arg )+ ).into());
+        return Err($crate::internal_error!( $( $arg )+ ).into())
     }
 }
 

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -13,16 +13,18 @@
 //! See [Router documentation](https://www.apollographql.com/docs/router/federation-version-support/)
 //! for which Federation versions are supported by which Router versions.
 
+// TODO: Re-add the removed and remove the allowed lints when the context feature is finished.
+#![allow(unused, dead_code, clippy::all)]
 #![warn(
     rustdoc::broken_intra_doc_links,
     unreachable_pub,
     unreachable_patterns,
-    unused,
+    // unused,
     unused_qualifications,
-    dead_code,
+    // dead_code,
     while_true,
     unconditional_panic,
-    clippy::all
+    // clippy::all
 )]
 
 mod api_schema;

--- a/apollo-federation/src/link/argument.rs
+++ b/apollo-federation/src/link/argument.rs
@@ -7,6 +7,7 @@ use apollo_compiler::Node;
 
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
+use crate::internal_error;
 use crate::link::graphql_definition::BooleanOrVariable;
 
 pub(crate) fn directive_optional_enum_argument(
@@ -130,5 +131,22 @@ pub(crate) fn directive_optional_variable_boolean_argument(
             ))),
         },
         None => Ok(None),
+    }
+}
+
+pub(crate) fn directive_optional_list_argument<'a>(
+    application: &'a Node<Directive>,
+    name: &'_ Name,
+) -> Result<Option<&'a [Node<Value>]>, FederationError> {
+    match application.specified_argument_by_name(name) {
+        None => Ok(None),
+        Some(value) => match value.as_ref() {
+            Value::Null => Ok(None),
+            Value::List(values) => Ok(Some(values.as_slice())),
+            _ => internal_error!(
+                r#"Argument "{name}" of directive "@{}" must be a boolean."#,
+                application.name
+            ),
+        },
     }
 }

--- a/apollo-federation/src/link/argument.rs
+++ b/apollo-federation/src/link/argument.rs
@@ -5,6 +5,7 @@ use apollo_compiler::schema::Directive;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 
+use crate::bail;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::internal_error;
@@ -143,7 +144,7 @@ pub(crate) fn directive_optional_list_argument<'a>(
         Some(value) => match value.as_ref() {
             Value::Null => Ok(None),
             Value::List(values) => Ok(Some(values.as_slice())),
-            _ => internal_error!(
+            _ => bail!(
                 r#"Argument "{name}" of directive "@{}" must be a boolean."#,
                 application.name
             ),

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -1,0 +1,202 @@
+use apollo_compiler::ast::Argument;
+use apollo_compiler::ast::Directive;
+use apollo_compiler::collections::IndexMap;
+use apollo_compiler::name;
+use apollo_compiler::schema::Component;
+use apollo_compiler::schema::EnumType;
+use apollo_compiler::schema::ObjectType;
+use apollo_compiler::schema::ScalarType;
+use apollo_compiler::Name;
+use apollo_compiler::Node;
+use lazy_static::lazy_static;
+
+use crate::error::FederationError;
+use crate::link::spec::Identity;
+use crate::link::spec::Url;
+use crate::link::spec::Version;
+use crate::link::spec_definition::SpecDefinition;
+use crate::link::spec_definition::SpecDefinitions;
+use crate::schema::position::EnumTypeDefinitionPosition;
+use crate::schema::position::ObjectTypeDefinitionPosition;
+use crate::schema::position::ScalarTypeDefinitionPosition;
+use crate::schema::FederationSchema;
+
+pub(crate) const CONTEXT_DIRECTIVE_NAME_IN_SPEC: Name = name!("context");
+pub(crate) const CONTEXT_DIRECTIVE_NAME_DEFAULT: Name = name!("federation__context");
+
+pub(crate) const FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC: Name = name!("fromContext");
+pub(crate) const FROM_CONTEXT_DIRECTIVE_NAME_DEFAULT: Name = name!("federation__fromContext");
+
+#[derive(Clone)]
+pub(crate) struct ContextSpecDefinition {
+    url: Url,
+    minimum_federation_version: Option<Version>,
+}
+
+macro_rules! propagate_context_directives {
+    ($func_name:ident, $directives_ty:ty, $wrap_ty:expr) => {
+        pub(crate) fn $func_name(
+            &self,
+            subgraph_schema: &FederationSchema,
+            source: &$directives_ty,
+            dest: &mut $directives_ty,
+            original_directive_names: &IndexMap<Name, Name>,
+        ) -> Result<(), FederationError> {
+            let context_directive_name =
+                original_directive_names.get(&CONTEXT_DIRECTIVE_NAME_IN_SPEC);
+            let context_directive =
+                context_directive_name.and_then(|name| source.get(name.as_str()));
+            if let Some(context_directive) = context_directive {
+                dest.push($wrap_ty(self.context_directive(
+                    subgraph_schema,
+                    context_directive.arguments.clone(),
+                )?));
+            }
+
+            let from_context_directive_name =
+                original_directive_names.get(&FROM_CONTEXT_DIRECTIVE_NAME_DEFAULT);
+            let from_context_directive =
+                from_context_directive_name.and_then(|name| source.get(name.as_str()));
+            if let Some(from_context_directive) = from_context_directive {
+                dest.push($wrap_ty(self.from_context_directive(
+                    subgraph_schema,
+                    from_context_directive.arguments.clone(),
+                )?));
+            }
+
+            Ok(())
+        }
+    };
+}
+
+macro_rules! propagate_context_directives_to_position {
+    ($func_name:ident, $source_ty:ty, $dest_ty:ty) => {
+        pub(crate) fn $func_name(
+            &self,
+            subgraph_schema: &mut FederationSchema,
+            source: &Node<$source_ty>,
+            dest: &$dest_ty,
+            original_directive_names: &IndexMap<Name, Name>,
+        ) -> Result<(), FederationError> {
+            let context_directive_name =
+                original_directive_names.get(&CONTEXT_DIRECTIVE_NAME_IN_SPEC);
+            let context_directive =
+                context_directive_name.and_then(|name| source.directives.get(name.as_str()));
+            if let Some(context_directive) = context_directive {
+                dest.insert_directive(
+                    subgraph_schema,
+                    Component::from(
+                        self.context_directive(
+                            subgraph_schema,
+                            context_directive.arguments.clone(),
+                        )?,
+                    ),
+                )?;
+            }
+
+            let from_context_directive_name =
+                original_directive_names.get(&FROM_CONTEXT_DIRECTIVE_NAME_DEFAULT);
+            let from_context_directive =
+                from_context_directive_name.and_then(|name| source.directives.get(name.as_str()));
+            if let Some(from_context_directive) = from_context_directive {
+                dest.insert_directive(
+                    subgraph_schema,
+                    Component::from(self.from_context_directive(
+                        subgraph_schema,
+                        from_context_directive.arguments.clone(),
+                    )?),
+                )?;
+            }
+
+            Ok(())
+        }
+    };
+}
+
+impl ContextSpecDefinition {
+    pub(crate) fn new(version: Version, minimum_federation_version: Option<Version>) -> Self {
+        Self {
+            url: Url {
+                identity: Identity::context_identity(),
+                version,
+            },
+            minimum_federation_version,
+        }
+    }
+
+    pub(crate) fn context_directive_name_in_schema(
+        &self,
+        schema: &FederationSchema,
+    ) -> Result<Name, FederationError> {
+        Ok(self
+            .directive_name_in_schema(schema, &CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .unwrap_or(CONTEXT_DIRECTIVE_NAME_DEFAULT))
+    }
+
+    pub(crate) fn context_directive(
+        &self,
+        schema: &FederationSchema,
+        arguments: Vec<Node<Argument>>,
+    ) -> Result<Directive, FederationError> {
+        let name = self
+            .directive_name_in_schema(schema, &CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .unwrap_or(CONTEXT_DIRECTIVE_NAME_DEFAULT);
+
+        Ok(Directive { name, arguments })
+    }
+
+    pub(crate) fn from_context_directive(
+        &self,
+        schema: &FederationSchema,
+        arguments: Vec<Node<Argument>>,
+    ) -> Result<Directive, FederationError> {
+        let name = self
+            .directive_name_in_schema(schema, &FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .unwrap_or(FROM_CONTEXT_DIRECTIVE_NAME_DEFAULT);
+
+        Ok(Directive { name, arguments })
+    }
+
+    propagate_context_directives!(
+        propagate_context_directives,
+        apollo_compiler::ast::DirectiveList,
+        Node::new
+    );
+
+    propagate_context_directives_to_position!(
+        propagate_context_directives_for_enum,
+        EnumType,
+        EnumTypeDefinitionPosition
+    );
+    propagate_context_directives_to_position!(
+        propagate_context_directives_for_object,
+        ObjectType,
+        ObjectTypeDefinitionPosition
+    );
+    propagate_context_directives_to_position!(
+        propagate_context_directives_for_scalar,
+        ScalarType,
+        ScalarTypeDefinitionPosition
+    );
+}
+
+impl SpecDefinition for ContextSpecDefinition {
+    fn url(&self) -> &Url {
+        &self.url
+    }
+
+    fn minimum_federation_version(&self) -> Option<&Version> {
+        self.minimum_federation_version.as_ref()
+    }
+}
+
+lazy_static! {
+    pub(crate) static ref CONTEXT_VERSIONS: SpecDefinitions<ContextSpecDefinition> = {
+        let mut definitions = SpecDefinitions::new(Identity::context_identity());
+        definitions.add(ContextSpecDefinition::new(
+            Version { major: 0, minor: 1 },
+            Some(Version { major: 2, minor: 8 }),
+        ));
+        definitions
+    };
+}

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -145,6 +145,7 @@ impl ContextSpecDefinition {
         Ok(Directive { name, arguments })
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn from_context_directive(
         &self,
         schema: &FederationSchema,

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -425,7 +425,7 @@ impl FederationSpecDefinition {
             )?,
         })
     }
-    
+
     pub(crate) fn context_directive_definition<'schema>(
         &self,
         schema: &'schema FederationSchema,
@@ -495,7 +495,7 @@ impl FederationSpecDefinition {
             arguments,
         })
     }
-    
+
     pub(crate) fn get_cost_spec_definition(
         &self,
         schema: &FederationSchema,

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -58,17 +58,17 @@ pub(crate) struct ProvidesDirectiveArguments<'doc> {
     pub(crate) fields: &'doc str,
 }
 
-pub(crate) struct OverrideDirectiveArguments<'doc> {
-    pub(crate) from: &'doc str,
-    pub(crate) label: Option<&'doc str>,
-}
-
 pub(crate) struct ContextDirectiveArguments<'doc> {
     pub(crate) name: &'doc str,
 }
 
 pub(crate) struct FromContextDirectiveArguments<'doc> {
     pub(crate) field: &'doc str,
+}
+
+pub(crate) struct OverrideDirectiveArguments<'doc> {
+    pub(crate) from: &'doc str,
+    pub(crate) label: Option<&'doc str>,
 }
 
 #[derive(Debug)]
@@ -492,6 +492,18 @@ impl FederationSpecDefinition {
             })
     }
 
+    pub(crate) fn from_context_directive_arguments<'doc>(
+        &self,
+        application: &'doc Node<Directive>,
+    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
+        Ok(FromContextDirectiveArguments {
+            field: directive_required_string_argument(
+                application,
+                &FEDERATION_FIELD_ARGUMENT_NAME,
+            )?,
+        })
+    }
+
     pub(crate) fn from_context_directive(
         &self,
         schema: &FederationSchema,
@@ -511,18 +523,6 @@ impl FederationSpecDefinition {
         Ok(Directive {
             name: name_in_schema,
             arguments,
-        })
-    }
-
-    pub(crate) fn from_context_directive_arguments<'doc>(
-        &self,
-        application: &'doc Node<Directive>,
-    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
-        Ok(FromContextDirectiveArguments {
-            field: directive_required_string_argument(
-                application,
-                &FEDERATION_FIELD_ARGUMENT_NAME,
-            )?,
         })
     }
 

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -9,6 +9,8 @@ use apollo_compiler::Name;
 use apollo_compiler::Node;
 use lazy_static::lazy_static;
 
+use super::context_spec_definition::ContextSpecDefinition;
+use super::context_spec_definition::CONTEXT_VERSIONS;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::argument::directive_optional_boolean_argument;
@@ -59,6 +61,14 @@ pub(crate) struct ProvidesDirectiveArguments<'doc> {
 pub(crate) struct OverrideDirectiveArguments<'doc> {
     pub(crate) from: &'doc str,
     pub(crate) label: Option<&'doc str>,
+}
+
+pub(crate) struct ContextDirectiveArguments<'doc> {
+    pub(crate) name: &'doc str,
+}
+
+pub(crate) struct FromContextDirectiveArguments<'doc> {
+    pub(crate) field: &'doc str,
 }
 
 #[derive(Debug)]
@@ -461,6 +471,14 @@ impl FederationSpecDefinition {
         })
     }
 
+    pub(crate) fn context_directive_arguments<'doc>(
+        application: &'doc Node<Directive>,
+    ) -> Result<ContextDirectiveArguments<'doc>, FederationError> {
+        Ok(ContextDirectiveArguments {
+            name: directive_required_string_argument(application, &FEDERATION_NAME_ARGUMENT_NAME)?,
+        })
+    }
+
     pub(crate) fn from_context_directive_definition<'schema>(
         &self,
         schema: &'schema FederationSchema,
@@ -496,6 +514,18 @@ impl FederationSpecDefinition {
         })
     }
 
+    pub(crate) fn from_context_directive_arguments<'doc>(
+        &self,
+        application: &'doc Node<Directive>,
+    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
+        Ok(FromContextDirectiveArguments {
+            field: directive_required_string_argument(
+                application,
+                &FEDERATION_FIELD_ARGUMENT_NAME,
+            )?,
+        })
+    }
+
     pub(crate) fn get_cost_spec_definition(
         &self,
         schema: &FederationSchema,
@@ -505,6 +535,17 @@ impl FederationSpecDefinition {
             .and_then(|metadata| metadata.for_identity(&Identity::cost_identity()))
             .and_then(|link| COST_VERSIONS.find(&link.url.version))
             .or_else(|| COST_VERSIONS.find_for_federation_version(self.version()))
+    }
+
+    pub(crate) fn get_context_spec_definition(
+        &self,
+        schema: &FederationSchema,
+    ) -> Option<&'static ContextSpecDefinition> {
+        schema
+            .metadata()
+            .and_then(|metadata| metadata.for_identity(&&Identity::context_identity()))
+            .and_then(|link| CONTEXT_VERSIONS.find(&link.url.version))
+            .or_else(|| CONTEXT_VERSIONS.find_for_federation_version(self.version()))
     }
 }
 

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -478,8 +478,8 @@ impl FederationSpecDefinition {
             name: directive_required_string_argument(application, &FEDERATION_NAME_ARGUMENT_NAME)?,
         })
     }
-   
-    #[allow(clippy::wrong_self_convention)] 
+
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn from_context_directive_definition<'schema>(
         &self,
         schema: &'schema FederationSchema,

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -32,12 +32,16 @@ pub(crate) const FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC: Name = name!("requi
 pub(crate) const FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC: Name = name!("provides");
 pub(crate) const FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC: Name = name!("shareable");
 pub(crate) const FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC: Name = name!("override");
+pub(crate) const FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC: Name = name!("context");
+pub(crate) const FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC: Name = name!("fromContext");
 
 pub(crate) const FEDERATION_FIELDS_ARGUMENT_NAME: Name = name!("fields");
 pub(crate) const FEDERATION_RESOLVABLE_ARGUMENT_NAME: Name = name!("resolvable");
 pub(crate) const FEDERATION_REASON_ARGUMENT_NAME: Name = name!("reason");
 pub(crate) const FEDERATION_FROM_ARGUMENT_NAME: Name = name!("from");
 pub(crate) const FEDERATION_OVERRIDE_LABEL_ARGUMENT_NAME: Name = name!("label");
+pub(crate) const FEDERATION_NAME_ARGUMENT_NAME: Name = name!("name");
+pub(crate) const FEDERATION_FIELD_ARGUMENT_NAME: Name = name!("field");
 
 pub(crate) struct KeyDirectiveArguments<'doc> {
     pub(crate) fields: &'doc str,
@@ -421,7 +425,77 @@ impl FederationSpecDefinition {
             )?,
         })
     }
+    
+    pub(crate) fn context_directive_definition<'schema>(
+        &self,
+        schema: &'schema FederationSchema,
+    ) -> Result<&'schema Node<DirectiveDefinition>, FederationError> {
+        self.directive_definition(schema, &FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .ok_or_else(|| {
+                FederationError::internal(format!(
+                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
+                    FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC,
+                ))
+            })
+    }
 
+    pub(crate) fn context_directive(
+        &self,
+        schema: &FederationSchema,
+        name: String,
+    ) -> Result<Directive, FederationError> {
+        let name_in_schema = self
+            .directive_name_in_schema(schema, &FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .ok_or_else(|| SingleFederationError::Internal {
+                message: "Unexpectedly could not find federation spec in schema".to_owned(),
+            })?;
+
+        let arguments = vec![Node::new(Argument {
+            name: FEDERATION_NAME_ARGUMENT_NAME,
+            value: Node::new(Value::String(name)),
+        })];
+
+        Ok(Directive {
+            name: name_in_schema,
+            arguments,
+        })
+    }
+
+    pub(crate) fn from_context_directive_definition<'schema>(
+        &self,
+        schema: &'schema FederationSchema,
+    ) -> Result<&'schema Node<DirectiveDefinition>, FederationError> {
+        self.directive_definition(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .ok_or_else(|| {
+                FederationError::internal(format!(
+                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
+                    FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC,
+                ))
+            })
+    }
+
+    pub(crate) fn from_context_directive(
+        &self,
+        schema: &FederationSchema,
+        name: String,
+    ) -> Result<Directive, FederationError> {
+        let name_in_schema = self
+            .directive_name_in_schema(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .ok_or_else(|| SingleFederationError::Internal {
+                message: "Unexpectedly could not find federation spec in schema".to_owned(),
+            })?;
+
+        let arguments = vec![Node::new(Argument {
+            name: FEDERATION_FIELD_ARGUMENT_NAME,
+            value: Node::new(Value::String(name)),
+        })];
+
+        Ok(Directive {
+            name: name_in_schema,
+            arguments,
+        })
+    }
+    
     pub(crate) fn get_cost_spec_definition(
         &self,
         schema: &FederationSchema,

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -471,14 +471,15 @@ impl FederationSpecDefinition {
         })
     }
 
-    pub(crate) fn context_directive_arguments<'doc>(
-        application: &'doc Node<Directive>,
-    ) -> Result<ContextDirectiveArguments<'doc>, FederationError> {
+    pub(crate) fn context_directive_arguments(
+        application: &Node<Directive>,
+    ) -> Result<ContextDirectiveArguments, FederationError> {
         Ok(ContextDirectiveArguments {
             name: directive_required_string_argument(application, &FEDERATION_NAME_ARGUMENT_NAME)?,
         })
     }
-
+   
+    #[allow(clippy::wrong_self_convention)] 
     pub(crate) fn from_context_directive_definition<'schema>(
         &self,
         schema: &'schema FederationSchema,
@@ -492,6 +493,7 @@ impl FederationSpecDefinition {
             })
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn from_context_directive_arguments<'doc>(
         &self,
         application: &'doc Node<Directive>,
@@ -504,6 +506,7 @@ impl FederationSpecDefinition {
         })
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn from_context_directive(
         &self,
         schema: &FederationSchema,
@@ -543,7 +546,7 @@ impl FederationSpecDefinition {
     ) -> Option<&'static ContextSpecDefinition> {
         schema
             .metadata()
-            .and_then(|metadata| metadata.for_identity(&&Identity::context_identity()))
+            .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))
             .and_then(|link| CONTEXT_VERSIONS.find(&link.url.version))
             .or_else(|| CONTEXT_VERSIONS.find_for_federation_version(self.version()))
     }

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -10,6 +10,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 
 use super::argument::directive_optional_list_argument;
+use crate::bail;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::internal_error;
@@ -81,9 +82,7 @@ impl<'doc> TryFrom<&'doc Value> for ContextArgument<'doc> {
             value: &'a Value,
         ) -> Result<(), FederationError> {
             if let Some(first_value) = field {
-                internal_error!(
-                    "Duplicate contextArgument for '{name}' field: {first_value} and {value}"
-                )
+                bail!("Duplicate contextArgument for '{name}' field: {first_value} and {value}")
             }
             field.insert(value);
             Ok(())
@@ -108,7 +107,7 @@ impl<'doc> TryFrom<&'doc Value> for ContextArgument<'doc> {
         }
 
         let Value::Object(names) = value else {
-            internal_error!("Item in contextArgument list is not an object {value}")
+            bail!("Item in contextArgument list is not an object {value}")
         };
         let mut name = None;
         let mut type_ = None;
@@ -120,7 +119,7 @@ impl<'doc> TryFrom<&'doc Value> for ContextArgument<'doc> {
                 "type" => insert_value(arg_name, &mut type_, value)?,
                 "context" => insert_value(arg_name, &mut context, value)?,
                 "selection" => insert_value(arg_name, &mut selection, value)?,
-                _ => internal_error!("Found unknown contextArgument {arg_name}"),
+                _ => bail!("Found unknown contextArgument {arg_name}"),
             }
         }
 

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -116,10 +116,10 @@ impl<'doc> TryFrom<&'doc Value> for ContextArgument<'doc> {
         let mut selection = None;
         for (arg_name, value) in names.as_slice() {
             match arg_name.as_str() {
-                "name" => insert_value(&arg_name, &mut name, value)?,
-                "type" => insert_value(&arg_name, &mut type_, value)?,
-                "context" => insert_value(&arg_name, &mut context, value)?,
-                "selection" => insert_value(&arg_name, &mut selection, value)?,
+                "name" => insert_value(arg_name, &mut name, value)?,
+                "type" => insert_value(arg_name, &mut type_, value)?,
+                "context" => insert_value(arg_name, &mut context, value)?,
+                "selection" => insert_value(arg_name, &mut selection, value)?,
                 _ => internal_error!("Found unknown contextArgument {arg_name}"),
             }
         }

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -1,3 +1,4 @@
+use apollo_compiler::ast::Value;
 use apollo_compiler::name;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::DirectiveDefinition;
@@ -5,10 +6,13 @@ use apollo_compiler::schema::EnumType;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
+use itertools::Itertools;
 use lazy_static::lazy_static;
 
+use super::argument::directive_optional_list_argument;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
+use crate::internal_error;
 use crate::link::argument::directive_optional_boolean_argument;
 use crate::link::argument::directive_optional_enum_argument;
 use crate::link::argument::directive_optional_string_argument;
@@ -45,6 +49,7 @@ pub(crate) const JOIN_OVERRIDE_LABEL_ARGUMENT_NAME: Name = name!("overrideLabel"
 pub(crate) const JOIN_USEROVERRIDDEN_ARGUMENT_NAME: Name = name!("usedOverridden");
 pub(crate) const JOIN_INTERFACE_ARGUMENT_NAME: Name = name!("interface");
 pub(crate) const JOIN_MEMBER_ARGUMENT_NAME: Name = name!("member");
+pub(crate) const JOIN_MEMBER_CONTEXT_ARGUMENTS: Name = name!("contextArguments");
 
 pub(crate) struct GraphDirectiveArguments<'doc> {
     pub(crate) name: &'doc str,
@@ -59,6 +64,80 @@ pub(crate) struct TypeDirectiveArguments<'doc> {
     pub(crate) is_interface_object: bool,
 }
 
+pub(crate) struct ContextArgument<'doc> {
+    pub(crate) name: &'doc str,
+    pub(crate) type_: &'doc str,
+    pub(crate) context: &'doc str,
+    pub(crate) selection: &'doc str,
+}
+
+impl<'doc> TryFrom<&'doc Value> for ContextArgument<'doc> {
+    type Error = FederationError;
+
+    fn try_from(value: &'doc Value) -> Result<Self, Self::Error> {
+        fn insert_value<'a>(
+            name: &str,
+            field: &mut Option<&'a Value>,
+            value: &'a Value,
+        ) -> Result<(), FederationError> {
+            if let Some(first_value) = field {
+                internal_error!(
+                    "Duplicate contextArgument for '{name}' field: {first_value} and {value}"
+                )
+            }
+            field.insert(value);
+            Ok(())
+        }
+
+        fn field_or_else<'a>(
+            field_name: &'static str,
+            field: Option<&'a Value>,
+        ) -> Result<&'a str, FederationError> {
+            field
+                .ok_or_else(|| {
+                    FederationError::internal(format!(
+                        "'{field_name}' field was missing from contextArgument"
+                    ))
+                })?
+                .as_str()
+                .ok_or_else(|| {
+                    FederationError::internal(format!(
+                        "'{field_name}' field of contextArgument was not a string"
+                    ))
+                })
+        }
+
+        let Value::Object(names) = value else {
+            internal_error!("Item in contextArgument list is not an object {value}")
+        };
+        let mut name = None;
+        let mut type_ = None;
+        let mut context = None;
+        let mut selection = None;
+        for (arg_name, value) in names.as_slice() {
+            match arg_name.as_str() {
+                "name" => insert_value(&arg_name, &mut name, value)?,
+                "type" => insert_value(&arg_name, &mut type_, value)?,
+                "context" => insert_value(&arg_name, &mut context, value)?,
+                "selection" => insert_value(&arg_name, &mut selection, value)?,
+                _ => internal_error!("Found unknown contextArgument {arg_name}"),
+            }
+        }
+
+        let name = field_or_else("name", name)?;
+        let type_ = field_or_else("type_", type_)?;
+        let context = field_or_else("context", context)?;
+        let selection = field_or_else("selection", selection)?;
+
+        Ok(Self {
+            name,
+            type_,
+            context,
+            selection,
+        })
+    }
+}
+
 pub(crate) struct FieldDirectiveArguments<'doc> {
     pub(crate) graph: Option<Name>,
     pub(crate) requires: Option<&'doc str>,
@@ -68,6 +147,7 @@ pub(crate) struct FieldDirectiveArguments<'doc> {
     pub(crate) override_: Option<&'doc str>,
     pub(crate) override_label: Option<&'doc str>,
     pub(crate) user_overridden: Option<bool>,
+    pub(crate) context_arguments: Option<Vec<ContextArgument<'doc>>>,
 }
 
 pub(crate) struct ImplementsDirectiveArguments<'doc> {
@@ -228,6 +308,17 @@ impl JoinSpecDefinition {
                 application,
                 &JOIN_USEROVERRIDDEN_ARGUMENT_NAME,
             )?,
+            context_arguments: directive_optional_list_argument(
+                application,
+                &JOIN_MEMBER_CONTEXT_ARGUMENTS,
+            )?
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|value| ContextArgument::try_from(value.as_ref()))
+                    .try_collect()
+            })
+            .transpose()?,
         })
     }
 

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -22,6 +22,7 @@ use crate::link::spec::Identity;
 use crate::link::spec::Url;
 
 pub(crate) mod argument;
+pub(crate) mod context_spec_definition;
 pub(crate) mod cost_spec_definition;
 pub mod database;
 pub(crate) mod federation_spec_definition;

--- a/apollo-federation/src/link/spec.rs
+++ b/apollo-federation/src/link/spec.rs
@@ -95,6 +95,13 @@ impl Identity {
             name: name!("cost"),
         }
     }
+
+    pub fn context_identity() -> Identity {
+        Identity {
+            domain: APOLLO_SPEC_DOMAIN.to_string(),
+            name: name!("context"),
+        }
+    }
 }
 
 /// The version of a `@link` specification, in the form of a major and minor version numbers.

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -35,9 +35,11 @@ use indexmap::map::Iter;
 use itertools::Itertools;
 
 use crate::error::FederationError;
+use crate::link::federation_spec_definition::FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_FIELDS_ARGUMENT_NAME;
 use crate::link::federation_spec_definition::FEDERATION_FROM_ARGUMENT_NAME;
+use crate::link::federation_spec_definition::FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC;
@@ -725,6 +727,8 @@ struct DirectiveNames {
     interface_object: Name,
     r#override: Name,
     inaccessible: Name,
+    context: Name,
+    from_context: Name,
 }
 
 impl DirectiveNames {
@@ -747,7 +751,7 @@ impl DirectiveNames {
         let external = federation_identity
             .map(|link| link.directive_name_in_schema(&FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC))
             .unwrap_or(FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC);
-
+        
         let interface_object = federation_identity
             .map(|link| {
                 link.directive_name_in_schema(&FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC)
@@ -762,11 +766,21 @@ impl DirectiveNames {
             .map(|link| link.directive_name_in_schema(&INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC))
             .unwrap_or(INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC);
 
+        let context = federation_identity
+            .map(|link| link.directive_name_in_schema(&FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC))
+            .unwrap_or(FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC);
+
+        let from_context = federation_identity
+            .map(|link| link.directive_name_in_schema(&FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC))
+            .unwrap_or(FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC);
+
         Self {
             key,
             requires,
             provides,
             external,
+            context,
+            from_context,
             interface_object,
             r#override,
             inaccessible,

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -751,7 +751,7 @@ impl DirectiveNames {
         let external = federation_identity
             .map(|link| link.directive_name_in_schema(&FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC))
             .unwrap_or(FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC);
-        
+
         let interface_object = federation_identity
             .map(|link| {
                 link.directive_name_in_schema(&FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC)
@@ -771,7 +771,9 @@ impl DirectiveNames {
             .unwrap_or(FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC);
 
         let from_context = federation_identity
-            .map(|link| link.directive_name_in_schema(&FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC))
+            .map(|link| {
+                link.directive_name_in_schema(&FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
+            })
             .unwrap_or(FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC);
 
         Self {

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -20,7 +20,6 @@ use std::ops::Deref;
 use std::sync::atomic;
 use std::sync::Arc;
 
-use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable;
@@ -2982,7 +2981,7 @@ pub(crate) struct NormalizedDefer {
 }
 
 struct DeferNormalizer {
-    used_labels: HashSet<String>,
+    used_labels: IndexSet<String>,
     assigned_labels: IndexSet<String>,
     conditions: IndexMap<Name, IndexSet<String>>,
     label_offset: usize,
@@ -2991,7 +2990,7 @@ struct DeferNormalizer {
 impl DeferNormalizer {
     fn new(selection_set: &SelectionSet) -> Result<Self, FederationError> {
         let mut digest = Self {
-            used_labels: HashSet::default(),
+            used_labels: IndexSet::default(),
             label_offset: 0,
             assigned_labels: IndexSet::default(),
             conditions: IndexMap::default(),

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -18,6 +18,7 @@ use petgraph::Direction;
 use regex::Regex;
 use strum::IntoEnumIterator;
 
+use crate::bail;
 use crate::display_helpers::DisplaySlice;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
@@ -2327,11 +2328,11 @@ fn parse_context(field: &str) -> Result<(String, String), FederationError> {
     let mut iter = pattern.captures_iter(field);
 
     let Some(captures) = iter.next() else {
-        internal_error!("Expected to find the name of a context and a selection inside the field argument to `@fromContext`: {field:?}");
+        bail!("Expected to find the name of a context and a selection inside the field argument to `@fromContext`: {field:?}");
     };
 
     if iter.next().is_some() {
-        internal_error!("Expected only one context and selection pair inside the field argument to `@fromContext`: {field:?}");
+        bail!("Expected only one context and selection pair inside the field argument to `@fromContext`: {field:?}");
     }
 
     let (context, selection) = captures
@@ -2342,11 +2343,11 @@ fn parse_context(field: &str) -> Result<(String, String), FederationError> {
         .fold(("", ""), |(a, b), group| (b, group.as_str()));
 
     if context.is_empty() {
-        internal_error!("Expected to find the name of a context inside the field argument to `@fromContext`: {field:?}");
+        bail!("Expected to find the name of a context inside the field argument to `@fromContext`: {field:?}");
     }
 
     if selection.is_empty() {
-        internal_error!(
+        bail!(
             "Expected to find and a selection inside the field argument to `@fromContext`: {field:?}"
         );
     }

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1602,7 +1602,7 @@ impl FederatedQueryGraphBuilder {
                 .query_graph
                 .edge_weight_mut(edge)?
                 .required_contexts
-                .extend_from_slice(&required_contexts);
+                .extend_from_slice(required_contexts);
         }
 
         // Add the context argument mapping

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1515,7 +1515,10 @@ impl FederatedQueryGraphBuilder {
             > = Default::default();
             for object_def_pos in &context_refs.object_types {
                 let object = object_def_pos.get(subgraph.schema())?;
-                for dir in object.directives.get_all(&CONTEXT_DIRECTIVE_NAME) {
+                for dir in object
+                    .directives
+                    .get_all(subgraph_data.context_directive_definition_name.as_str())
+                {
                     let application = FederationSpecDefinition::context_directive_arguments(dir)?;
                     context_name_to_types
                         .entry(application.name)
@@ -1525,7 +1528,10 @@ impl FederatedQueryGraphBuilder {
             }
             for interface_def_pos in &context_refs.interface_types {
                 let interface = interface_def_pos.get(subgraph.schema())?;
-                for dir in interface.directives.get_all(&CONTEXT_DIRECTIVE_NAME) {
+                for dir in interface
+                    .directives
+                    .get_all(subgraph_data.context_directive_definition_name.as_str())
+                {
                     let application = FederationSpecDefinition::context_directive_arguments(dir)?;
                     context_name_to_types
                         .entry(application.name)
@@ -1535,7 +1541,10 @@ impl FederatedQueryGraphBuilder {
             }
             for union_def_pos in &context_refs.union_types {
                 let union = union_def_pos.get(subgraph.schema())?;
-                for dir in union.directives.get_all(&CONTEXT_DIRECTIVE_NAME) {
+                for dir in union
+                    .directives
+                    .get_all(subgraph_data.context_directive_definition_name.as_str())
+                {
                     let application = FederationSpecDefinition::context_directive_arguments(dir)?;
                     context_name_to_types
                         .entry(application.name)
@@ -1553,7 +1562,11 @@ impl FederatedQueryGraphBuilder {
                     .or_default()
                     .push(object_field_arg.clone());
                 let field_coordinate = object_field_arg.parent();
-                for dir in input_value.directives.get_all(&FROM_CONTEXT_DIRECTIVE_NAME) {
+                if let Some(dir) = input_value.directives.get(
+                    subgraph_data
+                        .from_context_directive_definition_name
+                        .as_str(),
+                ) {
                     let application = subgraph_data
                         .federation_spec_definition
                         .from_context_directive_arguments(dir)?;

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use apollo_compiler::ast::Type;
 use apollo_compiler::collections::IndexMap;
+use apollo_compiler::Name;
 use apollo_compiler::Node;
 use petgraph::graph::EdgeIndex;
 
@@ -23,9 +24,9 @@ pub(crate) struct ContextMapEntry {
     pub(crate) path_tree: Option<Arc<OpPathTree>>,
     pub(crate) selection_set: SelectionSet,
     pub(crate) inbound_edge: EdgeIndex,
-    pub(crate) param_name: String,
+    pub(crate) param_name: Name,
     pub(crate) arg_type: Node<Type>,
-    pub(crate) id: String,
+    pub(crate) id: Name,
 }
 
 /// Note that `ConditionResolver`s are guaranteed to be only called for edge with conditions.
@@ -44,7 +45,7 @@ pub(crate) enum ConditionResolution {
     Satisfied {
         cost: QueryPlanCost,
         path_tree: Option<Arc<OpPathTree>>,
-        context_map: Option<IndexMap<String, ContextMapEntry>>,
+        context_map: Option<IndexMap<Name, ContextMapEntry>>,
     },
     Unsatisfied {
         // NOTE: This seems to be a false positive...

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -7,11 +7,25 @@ use apollo_compiler::collections::IndexMap;
 use petgraph::graph::EdgeIndex;
 
 use crate::error::FederationError;
+use crate::operation::SelectionSet;
 use crate::query_graph::graph_path::ExcludedConditions;
 use crate::query_graph::graph_path::ExcludedDestinations;
 use crate::query_graph::graph_path::OpGraphPathContext;
 use crate::query_graph::path_tree::OpPathTree;
 use crate::query_plan::QueryPlanCost;
+use apollo_compiler::ast::Type;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ContextMapEntry {
+    pub(crate) levels_in_data_path: usize,
+    pub(crate) levels_in_query_path: usize,
+    pub(crate) path_tree: Option<OpPathTree>,
+    pub(crate) selection_set: SelectionSet,
+    pub(crate) inbound_edge: EdgeIndex,
+    pub(crate) param_name: String,
+    pub(crate) arg_type: Type,
+    pub(crate) id: String,
+}
 
 /// Note that `ConditionResolver`s are guaranteed to be only called for edge with conditions.
 pub(crate) trait ConditionResolver {
@@ -29,6 +43,7 @@ pub(crate) enum ConditionResolution {
     Satisfied {
         cost: QueryPlanCost,
         path_tree: Option<Arc<OpPathTree>>,
+        context_map: Option<IndexMap<String, ContextMapEntry>>,
     },
     Unsatisfied {
         // NOTE: This seems to be a false positive...
@@ -48,6 +63,7 @@ impl ConditionResolution {
         Self::Satisfied {
             cost: 0.0,
             path_tree: None,
+            context_map: None,
         }
     }
 

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use apollo_compiler::ast::Type;
 use apollo_compiler::collections::IndexMap;
+use apollo_compiler::Node;
 use petgraph::graph::EdgeIndex;
 
 use crate::error::FederationError;
@@ -19,11 +20,11 @@ use crate::query_plan::QueryPlanCost;
 pub(crate) struct ContextMapEntry {
     pub(crate) levels_in_data_path: usize,
     pub(crate) levels_in_query_path: usize,
-    pub(crate) path_tree: Option<OpPathTree>,
+    pub(crate) path_tree: Option<Arc<OpPathTree>>,
     pub(crate) selection_set: SelectionSet,
     pub(crate) inbound_edge: EdgeIndex,
     pub(crate) param_name: String,
-    pub(crate) arg_type: Type,
+    pub(crate) arg_type: Node<Type>,
     pub(crate) id: String,
 }
 

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -37,6 +37,7 @@ pub(crate) trait ConditionResolver {
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
         excluded_conditions: &ExcludedConditions,
+        extra_conditions: Option<&SelectionSet>,
     ) -> Result<ConditionResolution, FederationError>;
 }
 
@@ -110,6 +111,7 @@ impl ConditionResolverCache {
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
         excluded_conditions: &ExcludedConditions,
+        // extra_conditions: Option<&SelectionSet>,
     ) -> ConditionResolutionCacheResult {
         // We don't cache if there is a context or excluded conditions because those would impact the resolution and
         // we don't want to cache a value per-context and per-excluded-conditions (we also don't cache per-excluded-edges though

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -3,6 +3,7 @@
 //            trait directly using `ConditionResolverCache`.
 use std::sync::Arc;
 
+use apollo_compiler::ast::Type;
 use apollo_compiler::collections::IndexMap;
 use petgraph::graph::EdgeIndex;
 
@@ -13,7 +14,6 @@ use crate::query_graph::graph_path::ExcludedDestinations;
 use crate::query_graph::graph_path::OpGraphPathContext;
 use crate::query_graph::path_tree::OpPathTree;
 use crate::query_plan::QueryPlanCost;
-use apollo_compiler::ast::Type;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ContextMapEntry {

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -40,6 +40,7 @@ pub(crate) enum ConditionResolution {
 #[derive(Debug, Clone)]
 pub(crate) enum UnsatisfiedConditionReason {
     NoPostRequireKey,
+    NoSetContext,
 }
 
 impl ConditionResolution {

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -3,8 +3,6 @@ use std::fmt::Formatter;
 use std::hash::Hash;
 use std::sync::Arc;
 
-use apollo_compiler::collections::HashMap;
-use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::FieldSet;
@@ -146,10 +144,10 @@ pub struct ContextCondition {
     context: String,
     subgraph_name: Arc<str>,
     selection: String,
-    types_with_context_set: HashSet<CompositeTypeDefinitionPosition>,
+    types_with_context_set: IndexSet<CompositeTypeDefinitionPosition>,
     // PORT_NOTE: This field was renamed because the JS name (`coordinate`) was too vague.
     argument_coordinate: ObjectFieldArgumentDefinitionPosition,
-    named_parameter: String,
+    named_parameter: Name,
     arg_type: Node<Type>,
 }
 
@@ -411,7 +409,7 @@ pub struct QueryGraph {
     pub(crate) subgraph_to_args: IndexMap<Arc<str>, Vec<ObjectFieldArgumentDefinitionPosition>>,
     /// Like `self.subgraph_to_args` but pairs each field argument with a unique identifier string.
     pub(crate) subgraph_to_arg_indices:
-        IndexMap<Arc<str>, IndexMap<ObjectFieldArgumentDefinitionPosition, String>>,
+        IndexMap<Arc<str>, IndexMap<ObjectFieldArgumentDefinitionPosition, Name>>,
 }
 
 impl QueryGraph {

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -652,6 +652,7 @@ impl QueryGraph {
                 &OpGraphPathContext::default(),
                 &ExcludedDestinations::default(),
                 &ExcludedConditions::default(),
+                None,
             )?;
             let ConditionResolution::Satisfied { cost, .. } = condition_resolution else {
                 continue;

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -3,6 +3,8 @@ use std::fmt::Formatter;
 use std::hash::Hash;
 use std::sync::Arc;
 
+use apollo_compiler::collections::HashMap;
+use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::schema::NamedType;
@@ -24,6 +26,8 @@ use crate::schema::field_set::parse_field_set;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::InterfaceFieldDefinitionPosition;
+use crate::schema::position::ObjectFieldArgumentDefinitionPosition;
+use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::OutputTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
@@ -131,6 +135,17 @@ impl TryFrom<QueryGraphNodeType> for ObjectTypeDefinitionPosition {
     }
 }
 
+/// Contains all of the data necessary to connect the object field (`coordinate`) with the
+/// `@fromContext` to its (grand)parent types contain a matching selection.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ContextCondition {
+    context: String,
+    subgraph_name: Arc<str>,
+    selection: String,
+    types_with_context_set: HashSet<CompositeTypeDefinitionPosition>,
+    coordinate: ObjectFieldDefinitionPosition,
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct QueryGraphEdge {
     /// Indicates what kind of edge this is and what the edge does/represents. For instance, if the
@@ -155,9 +170,37 @@ pub(crate) struct QueryGraphEdge {
     /// one of them has an @override with a label. If the override condition
     /// matches the query plan parameters, this edge can be taken.
     pub(crate) override_condition: Option<OverrideCondition>,
+    /// All fields with `@fromContext` that need access to parental type with corresponding
+    /// `@context`.
+    pub(crate) required_contexts: Vec<ContextCondition>,
 }
 
 impl QueryGraphEdge {
+    pub(crate) fn new(
+        transition: QueryGraphEdgeTransition,
+        conditions: Option<Arc<SelectionSet>>,
+    ) -> Self {
+        Self {
+            transition,
+            conditions,
+            override_condition: None,
+            required_contexts: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_override_condition(mut self, override_condition: OverrideCondition) -> Self {
+        self.override_condition = Some(override_condition);
+        self
+    }
+
+    pub(crate) fn with_required_contexts(
+        mut self,
+        contexts: impl IntoIterator<Item = ContextCondition>,
+    ) -> Self {
+        self.required_contexts.extend(contexts);
+        self
+    }
+
     fn satisfies_override_conditions(
         &self,
         conditions_to_check: &EnabledOverrideConditions,
@@ -357,6 +400,11 @@ pub struct QueryGraph {
     /// lowered composition validation on a big composition (100+ subgraphs) from ~4 minutes to
     /// ~10 seconds.
     non_trivial_followup_edges: IndexMap<EdgeIndex, Vec<EdgeIndex>>,
+    /// Maps each subgraph name to each field argument of `@fromContext`.
+    subgraph_to_args: IndexMap<Arc<str>, Vec<ObjectFieldArgumentDefinitionPosition>>,
+    /// Like `self.subgraph_to_args` but pairs each field argument with a unique identifier string.
+    subgraph_to_arg_indices:
+        IndexMap<Arc<str>, IndexMap<ObjectFieldArgumentDefinitionPosition, String>>,
 }
 
 impl QueryGraph {

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -7,8 +7,12 @@ use apollo_compiler::collections::HashMap;
 use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
+use apollo_compiler::executable::FieldSet;
+use apollo_compiler::schema::FieldDefinition;
 use apollo_compiler::schema::NamedType;
+use apollo_compiler::schema::Type;
 use apollo_compiler::Name;
+use apollo_compiler::Node;
 use petgraph::graph::DiGraph;
 use petgraph::graph::EdgeIndex;
 use petgraph::graph::EdgeReference;
@@ -143,7 +147,10 @@ pub struct ContextCondition {
     subgraph_name: Arc<str>,
     selection: String,
     types_with_context_set: HashSet<CompositeTypeDefinitionPosition>,
-    coordinate: ObjectFieldDefinitionPosition,
+    // PORT_NOTE: This field was renamed because the JS name (`coordinate`) was too vague.
+    argument_coordinate: ObjectFieldArgumentDefinitionPosition,
+    named_parameter: String,
+    arg_type: Node<Type>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -401,9 +408,9 @@ pub struct QueryGraph {
     /// ~10 seconds.
     non_trivial_followup_edges: IndexMap<EdgeIndex, Vec<EdgeIndex>>,
     /// Maps each subgraph name to each field argument of `@fromContext`.
-    subgraph_to_args: IndexMap<Arc<str>, Vec<ObjectFieldArgumentDefinitionPosition>>,
+    pub(crate) subgraph_to_args: IndexMap<Arc<str>, Vec<ObjectFieldArgumentDefinitionPosition>>,
     /// Like `self.subgraph_to_args` but pairs each field argument with a unique identifier string.
-    subgraph_to_arg_indices:
+    pub(crate) subgraph_to_arg_indices:
         IndexMap<Arc<str>, IndexMap<ObjectFieldArgumentDefinitionPosition, String>>,
 }
 

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -3,12 +3,16 @@ use std::fmt::Formatter;
 use std::hash::Hash;
 use std::sync::Arc;
 
+use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use indexmap::map::Entry;
 use petgraph::graph::EdgeIndex;
 use petgraph::graph::NodeIndex;
 use serde::Serialize;
 
+use super::graph_path::ContextAtUsageEntry;
+use super::graph_path::ContextToSelection;
+use super::graph_path::ParameterToContext;
 use crate::error::FederationError;
 use crate::operation::SelectionSet;
 use crate::query_graph::graph_path::GraphPathItem;
@@ -92,6 +96,10 @@ where
     pub(crate) conditions: Option<Arc<OpPathTree>>,
     /// The child `PathTree` reached by taking the edge.
     pub(crate) tree: Arc<PathTree<TTrigger, TEdge>>,
+    // a list of contexts set at this point in the path tree
+    pub(crate) context_to_selection: Option<ContextToSelection>,
+    // a list of contexts used at this point in the path tree
+    pub(crate) parameter_to_context: Option<ParameterToContext>,
 }
 
 impl<TTrigger, TEdge> PartialEq for PathTreeChild<TTrigger, TEdge>
@@ -242,12 +250,21 @@ where
             trigger: &'inputs Arc<TTrigger>,
             conditions: Option<Arc<OpPathTree>>,
             sub_paths_and_selections: Vec<(GraphPathIter, Option<&'inputs Arc<SelectionSet>>)>,
+            context_to_selection: Option<ContextToSelection>,
+            parameter_to_context: Option<ParameterToContext>,
         }
 
         let mut local_selection_sets = Vec::new();
 
         for (mut graph_path_iter, selection) in graph_paths_and_selections {
-            let Some((generic_edge, trigger, conditions)) = graph_path_iter.next() else {
+            let Some((
+                generic_edge,
+                trigger,
+                conditions,
+                context_to_selection,
+                parameter_to_context,
+            )) = graph_path_iter.next()
+            else {
                 // End of an input `GraphPath`
                 if let Some(selection) = selection {
                     local_selection_sets.push(selection.clone());
@@ -274,6 +291,18 @@ where
                     let existing = entry.into_mut();
                     existing.trigger = trigger;
                     existing.conditions = merge_conditions(&existing.conditions, conditions);
+                    if let Some(other) = context_to_selection {
+                        existing
+                            .context_to_selection
+                            .get_or_insert_with(HashSet::default)
+                            .extend(other);
+                    }
+                    if let Some(other) = parameter_to_context {
+                        existing
+                            .parameter_to_context
+                            .get_or_insert_with(IndexMap::default)
+                            .extend(other);
+                    }
                     existing
                         .sub_paths_and_selections
                         .push((graph_path_iter, selection))
@@ -284,6 +313,8 @@ where
                         trigger,
                         conditions: conditions.clone(),
                         sub_paths_and_selections: vec![(graph_path_iter, selection)],
+                        context_to_selection,
+                        parameter_to_context,
                     });
                 }
             }
@@ -301,6 +332,8 @@ where
                         by_unique_edge.target_node,
                         child.sub_paths_and_selections,
                     )?),
+                    context_to_selection: child.context_to_selection.clone(),
+                    parameter_to_context: child.parameter_to_context.clone(),
                 }))
             }
         }
@@ -334,6 +367,8 @@ where
                         (Some(cond_a), Some(cond_b)) => cond_a.equals_same_root(cond_b),
                         _ => false,
                     }
+                    && a.context_to_selection == b.context_to_selection
+                    && a.parameter_to_context == b.parameter_to_context
                     && a.tree.equals_same_root(&b.tree)
             })
     }
@@ -415,6 +450,14 @@ where
                     trigger: child.trigger.clone(),
                     conditions: merge_conditions(&child.conditions, &other_child.conditions),
                     tree: child.tree.merge(&other_child.tree),
+                    context_to_selection: merge_context_to_selection(
+                        &child.context_to_selection,
+                        &other_child.context_to_selection,
+                    ),
+                    parameter_to_context: merge_parameter_to_context(
+                        &child.parameter_to_context,
+                        &other_child.parameter_to_context,
+                    ),
                 })
             } else {
                 childs.push(other_child.clone())
@@ -433,6 +476,40 @@ where
                 .collect(),
             childs,
         })
+    }
+}
+
+fn merge_context_to_selection(
+    a: &Option<ContextToSelection>,
+    b: &Option<ContextToSelection>,
+) -> Option<ContextToSelection> {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            let mut merged: ContextToSelection = Default::default();
+            merged.extend(a.iter().cloned());
+            merged.extend(b.iter().cloned());
+            Some(merged)
+        }
+        (Some(a), None) => Some(a.clone()),
+        (None, Some(b)) => Some(b.clone()),
+        (None, None) => None,
+    }
+}
+
+fn merge_parameter_to_context(
+    a: &Option<ParameterToContext>,
+    b: &Option<ParameterToContext>,
+) -> Option<ParameterToContext> {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            let mut merged: ParameterToContext = Default::default();
+            merged.extend(a.iter().map(|(k, v)| (k.clone(), v.clone())));
+            merged.extend(b.iter().map(|(k, v)| (k.clone(), v.clone())));
+            Some(merged)
+        }
+        (Some(a), None) => Some(a.clone()),
+        (None, Some(b)) => Some(b.clone()),
+        (None, None) => None,
     }
 }
 

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -507,6 +507,7 @@ mod tests {
         ConditionResolution::Satisfied {
             cost: 0.0,
             path_tree: None,
+            context_map: None,
         }
     }
 

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -3,7 +3,6 @@ use std::fmt::Formatter;
 use std::hash::Hash;
 use std::sync::Arc;
 
-use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use indexmap::map::Entry;
 use petgraph::graph::EdgeIndex;
@@ -294,7 +293,7 @@ where
                     if let Some(other) = context_to_selection {
                         existing
                             .context_to_selection
-                            .get_or_insert_with(HashSet::default)
+                            .get_or_insert_with(Default::default)
                             .extend(other);
                     }
                     if let Some(other) = parameter_to_context {

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -377,6 +377,7 @@ impl fmt::Display for FetchDataPathElement {
                 write_conditions(conditions, f)
             }
             Self::TypenameEquals(name) => write!(f, "... on {name}"),
+            Self::Parent => write!(f, ".."),
         }
     }
 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3967,7 +3967,7 @@ fn compute_nodes_for_op_path_element<'a>(
             let mut context_to_condition_nodes =
                 stack_item.context_to_condition_nodes.deref().clone();
             for context in context_to_selection {
-                context_to_condition_nodes[context] = condition_nodes.clone();
+                context_to_condition_nodes.insert(context.clone(), condition_nodes.clone());
             }
             updated.context_to_condition_nodes = Arc::new(context_to_condition_nodes);
         }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -170,7 +170,7 @@ pub(crate) struct FetchDependencyGraphNode {
     /// Input rewrites for query plan execution to perform prior to executing the fetch.
     input_rewrites: Arc<Vec<Arc<FetchDataRewrite>>>,
     /// Rewrites that will need to occur to store contextual data for future use
-    context_inputs: Option<Vec<FetchDataKeyRenamer>>,
+    context_inputs: Vec<FetchDataRewrite>,
     /// As query plan execution runs, it accumulates fetch data into a response object. This is the
     /// path at which to merge in the data for this particular fetch.
     merge_at: Option<Vec<FetchDataPathElement>>,
@@ -797,7 +797,7 @@ impl FetchDependencyGraph {
             cached_cost: None,
             must_preserve_selection_set: false,
             is_known_useful: false,
-            context_inputs: None,
+            context_inputs: Vec::new(),
         })))
     }
 
@@ -2530,11 +2530,8 @@ impl FetchDependencyGraphNode {
                 input_rewrites.push(rewrite.clone());
             }
 
-            if let Some(other_context_inputs) = &other.context_inputs {
-                self.context_inputs
-                    .get_or_insert_with(Vec::new)
-                    .extend(other_context_inputs.iter().cloned());
-            }
+            self.context_inputs
+                .extend(other.context_inputs.iter().cloned());
         }
         Ok(())
     }
@@ -2707,7 +2704,7 @@ impl FetchDependencyGraphNode {
             operation_kind: self.root_kind.into(),
             input_rewrites: self.input_rewrites.clone(),
             output_rewrites,
-            context_rewrites: todo!(),
+            context_rewrites: self.context_inputs.clone(),
         }));
 
         Ok(Some(if let Some(path) = self.merge_at.clone() {
@@ -2924,19 +2921,15 @@ impl FetchDependencyGraphNode {
     }
 
     fn add_context_renamer(&mut self, renamer: FetchDataKeyRenamer) {
-        let context_inputs = self.context_inputs.get_or_insert_with(Default::default);
-        if !context_inputs.iter().any(|c| same_key_renamer(c, &renamer)) {
-            context_inputs.push(renamer);
+        let rewrite = FetchDataRewrite::KeyRenamer(renamer);
+        if !self
+            .context_inputs
+            .iter()
+            .any(|c| *c == rewrite)
+        {
+            self.context_inputs.push(rewrite);
         }
     }
-}
-
-fn same_key_renamer(k1: &FetchDataKeyRenamer, k2: &FetchDataKeyRenamer) -> bool {
-    if k1.rename_key_to != k2.rename_key_to || k1.path.len() != k2.path.len() {
-        return false;
-    }
-
-    k1.path.iter().zip(k2.path.iter()).all(|(p1, p2)| p1 == p2)
 }
 
 fn operation_for_entities_fetch(

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -28,6 +28,7 @@ use petgraph::visit::IntoNodeReferences;
 use serde::Serialize;
 
 use super::query_planner::SubgraphOperationCompression;
+use super::FetchDataKeyRenamer;
 use crate::display_helpers::DisplayOption;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
@@ -167,6 +168,8 @@ pub(crate) struct FetchDependencyGraphNode {
     inputs: Option<Arc<FetchInputs>>,
     /// Input rewrites for query plan execution to perform prior to executing the fetch.
     input_rewrites: Arc<Vec<Arc<FetchDataRewrite>>>,
+    /// Rewrites that will need to occur to store contextual data for future use
+    context_inputs: Option<Vec<FetchDataKeyRenamer>>,
     /// As query plan execution runs, it accumulates fetch data into a response object. This is the
     /// path at which to merge in the data for this particular fetch.
     merge_at: Option<Vec<FetchDataPathElement>>,
@@ -225,6 +228,8 @@ pub(crate) struct FetchInputs {
     /// The supergraph schema (primarily used for validation of added selection sets).
     #[serde(skip)]
     supergraph_schema: ValidFederationSchema,
+    /// Contexts used as inputs
+    used_contexts: IndexMap<String, CompositeTypeDefinitionPosition>,
 }
 
 /// Represents a dependency between two subgraph fetches, namely that the tail/child depends on the
@@ -791,6 +796,7 @@ impl FetchDependencyGraph {
             cached_cost: None,
             must_preserve_selection_set: false,
             is_known_useful: false,
+            context_inputs: None,
         })))
     }
 
@@ -2522,6 +2528,12 @@ impl FetchDependencyGraphNode {
             for rewrite in other.input_rewrites.iter() {
                 input_rewrites.push(rewrite.clone());
             }
+
+            if let Some(other_context_inputs) = &other.context_inputs {
+                self.context_inputs
+                    .get_or_insert_with(Vec::new)
+                    .extend(other_context_inputs.iter().cloned());
+            }
         }
         Ok(())
     }
@@ -2694,7 +2706,7 @@ impl FetchDependencyGraphNode {
             operation_kind: self.root_kind.into(),
             input_rewrites: self.input_rewrites.clone(),
             output_rewrites,
-            context_rewrites: Default::default(),
+            context_rewrites: todo!(),
         }));
 
         Ok(Some(if let Some(path) = self.merge_at.clone() {
@@ -2909,6 +2921,21 @@ impl FetchDependencyGraphNode {
         };
         Some(format!("{subgraph_name}-{merge_at_str}"))
     }
+
+    fn add_context_renamer(&mut self, renamer: FetchDataKeyRenamer) {
+        let context_inputs = self.context_inputs.get_or_insert_with(Default::default);
+        if !context_inputs.iter().any(|c| same_key_renamer(c, &renamer)) {
+            context_inputs.push(renamer);
+        }
+    }
+}
+
+fn same_key_renamer(k1: &FetchDataKeyRenamer, k2: &FetchDataKeyRenamer) -> bool {
+    if k1.rename_key_to != k2.rename_key_to || k1.path.len() != k2.path.len() {
+        return false;
+    }
+
+    k1.path.iter().zip(k2.path.iter()).all(|(p1, p2)| p1 == p2)
 }
 
 fn operation_for_entities_fetch(
@@ -3093,6 +3120,7 @@ impl FetchInputs {
         Self {
             selection_sets_per_parent_type: Default::default(),
             supergraph_schema,
+            used_contexts: Default::default(),
         }
     }
 
@@ -3118,7 +3146,12 @@ impl FetchInputs {
         other
             .selection_sets_per_parent_type
             .values()
-            .try_for_each(|selections| self.add(selections))
+            .try_for_each(|selections| self.add(selections))?;
+        other
+            .used_contexts
+            .iter()
+            .for_each(|(context, ty)| self.add_context(context.clone(), ty.clone()));
+        Ok(())
     }
 
     fn contains(&self, other: &Self) -> bool {
@@ -3130,7 +3163,13 @@ impl FetchInputs {
                 return false;
             }
         }
-        true
+        if self.used_contexts.len() != other.used_contexts.len() {
+            return false;
+        }
+        other
+            .used_contexts
+            .keys()
+            .all(|context| self.used_contexts.contains_key(context))
     }
 
     fn equals(&self, other: &Self) -> bool {
@@ -3153,8 +3192,13 @@ impl FetchInputs {
             }
             // so far so good
         }
-        // all clear
-        true
+        if self.used_contexts.len() != other.used_contexts.len() {
+            return false;
+        }
+        other
+            .used_contexts
+            .keys()
+            .all(|context| self.used_contexts.contains_key(context))
     }
 
     fn to_selection_set_nodes(
@@ -3176,6 +3220,10 @@ impl FetchInputs {
             type_position: type_position.clone(),
             selections: Arc::new(selections),
         })
+    }
+
+    fn add_context(&mut self, context: String, ty: CompositeTypeDefinitionPosition) {
+        self.used_contexts.insert(context, ty);
     }
 }
 

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -29,6 +29,7 @@ use serde::Serialize;
 
 use super::query_planner::SubgraphOperationCompression;
 use super::FetchDataKeyRenamer;
+use crate::bail;
 use crate::display_helpers::DisplayOption;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
@@ -2349,11 +2350,11 @@ impl FetchDependencyGraph {
             &parent.selection_set.selection_set.schema,
             parent_op_path,
         )?;
-        let new_node_is_unneeded = node
+        let node_is_unneeded = node
             .selection_set
             .selection_set
             .can_rebase_on(&type_at_path, &parent.selection_set.selection_set.schema)?;
-        Ok(new_node_is_unneeded)
+        Ok(node_is_unneeded)
     }
 
     fn type_at_path(
@@ -3844,13 +3845,20 @@ fn compute_nodes_for_op_path_element<'a>(
     };
     if let Some(conditions) = &child.conditions {
         // We have @requires or some other dependency to create nodes for.
-        let (required_node_id, require_path) = handle_requires(
+        let conditions_node_data = handle_conditions_tree(
             dependency_graph,
-            edge_id,
             conditions,
             (stack_item.node_id, &stack_item.node_path),
-            stack_item.context,
+            None,
             &updated.defer_context,
+            created_nodes,
+        )?;
+        let (required_node_id, require_path) = create_post_requires_node(
+            dependency_graph,
+            edge_id,
+            (stack_item.node_id, &stack_item.node_path),
+            stack_item.context,
+            conditions_node_data,
             created_nodes,
         )?;
         updated.node_id = required_node_id;
@@ -4112,134 +4120,183 @@ fn extract_defer_from_operation(
     Ok((updated_operation_element, updated_context))
 }
 
-fn handle_requires(
+struct ConditionsNodeData {
+    conditions_merge_node_id: NodeIndex,
+    path_in_conditions_merge_node_id: Option<Arc<OpPath>>,
+    created_node_ids: Vec<NodeIndex>,
+    is_fully_local_requires: bool,
+}
+
+/// Computes nodes for conditions imposed by @requires, @fromContext, and @interfaceObject, merging
+/// them into ancestors as an optimization if possible. This does not modify the current node to
+/// use the condition data as input, nor does it create parent-child relationships with created
+/// nodes and the current node.
+fn handle_conditions_tree(
     dependency_graph: &mut FetchDependencyGraph,
-    query_graph_edge_id: EdgeIndex,
-    requires_conditions: &OpPathTree,
+    conditions: &OpPathTree,
     (fetch_node_id, fetch_node_path): (NodeIndex, &FetchDependencyGraphNodePath),
-    context: &OpGraphPathContext,
+    query_graph_edge_id_if_typename_needed: Option<EdgeIndex>,
     defer_context: &DeferContext,
     created_nodes: &mut IndexSet<NodeIndex>,
-) -> Result<(NodeIndex, FetchDependencyGraphNodePath), FederationError> {
-    // @requires should be on an entity type, and we only support object types right now
-    let head = dependency_graph
-        .federated_query_graph
-        .edge_head_weight(query_graph_edge_id)?;
-    let entity_type_schema = dependency_graph
-        .federated_query_graph
-        .schema_by_source(&head.source)?
-        .clone();
-    let QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(entity_type_position)) =
-        head.type_.clone()
-    else {
-        return Err(FederationError::internal(
-            "@requires applied on non-entity object type",
-        ));
-    };
-
-    // In many cases, we can optimize @requires by merging the requirement to previously existing nodes. However,
-    // we only do this when the current node has only a single parent (it's hard to reason about it otherwise).
-    // But the current node could have multiple parents due to the graph lacking minimality, and we don't want that
-    // to needlessly prevent us from this optimization. So we do a graph reduction first (which effectively
-    // just eliminate unnecessary edges). To illustrate, we could be in a case like:
+) -> Result<ConditionsNodeData, FederationError> {
+    // In many cases, we can optimize conditions by merging the fields into previously existing
+    // nodes. However, we only do this when the current node has only a single parent (it's hard to
+    // reason about it otherwise). But the current node could have multiple parents due to the graph
+    // lacking minimality, and we don't want that to needlessly prevent us from this optimization.
+    // So we do a graph reduction first (which effectively just eliminates unnecessary edges). To
+    // illustrate, we could be in a case like:
     //    1
     //  /  \
     // 0 --- 2
-    // with current node 2. And while the node currently has 2 parents, the `reduce` step will ensure
-    // the edge `0 --- 2` is removed (since the dependency of 2 on 0 is already provide transitively through 1).
+    // with current node 2. And while the node currently has 2 parents, the `reduce` step will
+    // ensure the edge `0 --- 2` is removed (since the dependency of 2 on 0 is already provided
+    // transitively through 1).
     dependency_graph.reduce();
 
-    let single_parent = iter_into_single_item(dependency_graph.parents_relations_of(fetch_node_id));
-    // In general, we should do like for an edge, and create a new node _for the current subgraph_
-    // that depends on the created_nodes and have the created nodes depend on the current one.
-    // However, we can be more efficient in general (and this is expected by the user) because
-    // required fields will usually come just after a key edge (at the top of a fetch node).
-    // In that case (when the path is only type_casts), we can put the created nodes directly
-    // as dependency of the current node, avoiding creation of a new one. Additionally, if the
+    // In general, we should do like for a key edge, and create a new node _for the current
+    // subgraph_ that depends on the created nodes and have the created nodes depend on the current
+    // one. However, we can be more efficient in general (and this is expected by the user) because
+    // condition fields will usually come just after a key edge (at the top of a fetch node).
+    // In that case (when the path is only type conditions), we can put the created nodes directly
+    // as dependencies of the current node, avoiding creation of a new one. Additionally, if the
     // node we're coming from is our "direct parent", we can merge it to said direct parent (which
-    // effectively means that the parent node will collect the provides before taking the edge
-    // to our current node).
-    if single_parent.is_some() && fetch_node_path.path_in_node.has_only_fragments() {
-        // Should do `if let` but it requires extra indentation.
-        let parent = single_parent.unwrap();
-
-        // We start by computing the nodes for the conditions. We do this using a copy of the current
-        // node (with only the inputs) as that allows to modify this copy without modifying `node`.
-        let fetch_node = dependency_graph.node_weight(fetch_node_id)?;
-        let subgraph_name = fetch_node.subgraph_name.clone();
-        let Some(merge_at) = fetch_node.merge_at.clone() else {
-            return Err(FederationError::internal(format!(
-                "Fetch node {} merge_at_path is required but was missing",
-                fetch_node_id.index()
-            )));
-        };
-        let defer_ref = fetch_node.defer_ref.clone();
-        let new_node_id =
-            dependency_graph.new_key_node(&subgraph_name, merge_at, defer_ref.clone())?;
-        dependency_graph.add_parent(new_node_id, parent.clone());
-        dependency_graph.copy_inputs(new_node_id, fetch_node_id)?;
-
-        let newly_created_node_ids = compute_nodes_for_tree(
-            dependency_graph,
-            requires_conditions,
-            new_node_id,
-            fetch_node_path.clone(),
-            defer_context.for_conditions(),
-            &OpGraphPathContext::default(),
-        )?;
-        if newly_created_node_ids.is_empty() {
-            // All conditions were local. Just merge the newly created node back into the current node (we didn't need it)
-            // and continue.
-            if !dependency_graph.can_merge_sibling_in(fetch_node_id, new_node_id)? {
-                return Err(FederationError::internal(format!(
-                    "We should be able to merge {} into {} by construction",
-                    new_node_id.index(),
-                    fetch_node_id.index()
-                )));
+    // effectively means that the parent node will collect subgraph-local condition fields before
+    // taking the edge to our current node).
+    let copied_node_id_and_parent =
+        match iter_into_single_item(dependency_graph.parents_relations_of(fetch_node_id)) {
+            Some(parent) if fetch_node_path.path_in_node.has_only_fragments() => {
+                // Since we may want the condition fields in this case to be added into an earlier
+                // node, we create a copy of the current node (with only the inputs), and the
+                // condition fields will be added to this node instead of the current one.
+                let fetch_node = dependency_graph.node_weight(fetch_node_id)?;
+                let subgraph_name = fetch_node.subgraph_name.clone();
+                let Some(merge_at) = fetch_node.merge_at.clone() else {
+                    bail!(
+                        "Fetch node {} merge_at_path is required but was missing",
+                        fetch_node_id.index()
+                    );
+                };
+                let defer_ref = fetch_node.defer_ref.clone();
+                let copied_node_id =
+                    dependency_graph.new_key_node(&subgraph_name, merge_at, defer_ref.clone())?;
+                dependency_graph.add_parent(copied_node_id, parent.clone());
+                dependency_graph.copy_inputs(copied_node_id, fetch_node_id)?;
+                Some((copied_node_id, parent))
             }
-            dependency_graph.merge_sibling_in(fetch_node_id, new_node_id)?;
-            return Ok((fetch_node_id, fetch_node_path.clone()));
-        }
+            _ => None,
+        };
 
-        // We know the @requires needs `newly_created_node_ids`. We do want to know however if any of the conditions was
-        // fetched from our `new_node`. If not, then this means that the `newly_created_node_ids` don't really depend on
-        // the current `node` and can be dependencies of the parent (or even merged into this parent).
+    let condition_node_id = match &copied_node_id_and_parent {
+        Some((copied_node_id, _)) => *copied_node_id,
+        None => fetch_node_id,
+    };
+    if let Some(query_graph_edge_id) = query_graph_edge_id_if_typename_needed {
+        let head = dependency_graph
+            .federated_query_graph
+            .edge_head_weight(query_graph_edge_id)?;
+        let head_type: CompositeTypeDefinitionPosition = head.type_.clone().try_into()?;
+        let head_schema = dependency_graph
+            .federated_query_graph
+            .schema_by_source(&head.source)?
+            .clone();
+        let typename_field = Arc::new(OpPathElement::Field(Field::new_introspection_typename(
+            &head_schema,
+            &head_type,
+            None,
+        )));
+        let typename_path = fetch_node_path.path_in_node.with_pushed(typename_field);
+        let condition_node =
+            FetchDependencyGraph::node_weight_mut(&mut dependency_graph.graph, condition_node_id)?;
+        condition_node
+            .selection_set_mut()
+            .add_at_path(&typename_path, None)?;
+    }
+
+    // Compute the node changes/additions introduced by the conditions path tree, using either the
+    // current node or the copy of the current node if we expect to optimize.
+    let newly_created_node_ids = compute_nodes_for_tree(
+        dependency_graph,
+        conditions,
+        condition_node_id,
+        fetch_node_path.clone(),
+        defer_context.for_conditions(),
+        &OpGraphPathContext::default(),
+    )?;
+
+    if newly_created_node_ids.is_empty() {
+        // All conditions were local. If we copied the node expecting to optimize, just merge it
+        // back into the current node (we didn't need it) and continue.
         //
-        // So we want to know if anything in `new_node` selection cannot be fetched directly from the parent.
-        // For that, we first remove any of `new_node` inputs from its selection: in most case, `new_node`
-        // will just contain the key needed to jump back to its parent, and those would usually be the same
-        // as the inputs. And since by definition we know `new_node`'s inputs are already fetched, we
-        // know they are not things that we need. Then, we check if what remains (often empty) can be
-        // directly fetched from the parent. If it can, then we can just merge `new_node` into that parent.
-        // Otherwise, we will have to "keep it".
-        // Note: it is to be sure this test is not polluted by other things in `node` that we created `new_node`.
-        dependency_graph.remove_inputs_from_selection(new_node_id)?;
+        // NOTE: This behavior is largely to maintain backwards compatibility with @requires. For
+        // @fromContext, it still may be useful to merge the conditions into the parent if possible.
+        // but we leave this optimization for later.
+        if let Some((copied_node_id, _)) = copied_node_id_and_parent {
+            if !dependency_graph.can_merge_sibling_in(fetch_node_id, copied_node_id)? {
+                bail!(
+                    "We should be able to merge {} into {} by construction",
+                    copied_node_id.index(),
+                    fetch_node_id.index()
+                );
+            }
+            dependency_graph.merge_sibling_in(fetch_node_id, copied_node_id)?;
+        }
+        return Ok(ConditionsNodeData {
+            conditions_merge_node_id: fetch_node_id,
+            path_in_conditions_merge_node_id: Some(Arc::new(Default::default())),
+            created_node_ids: vec![],
+            is_fully_local_requires: true,
+        });
+    }
 
-        let new_node_is_not_needed = dependency_graph.is_node_unneeded(new_node_id, &parent)?;
+    if let Some((copied_node_id, parent)) = copied_node_id_and_parent {
+        // We know the conditions depend on at least one created node. We do want to know, however,
+        // if any of the condition fields was fetched from our copied node. If not, then this means
+        // that the created nodes don't really depend on the current node and can be dependencies
+        // of the parent (or even merged into the parent).
+        //
+        // So we want to know if anything in the copied node's selections cannot be fetched directly
+        // from the parent. For that, we first remove any of the copied node's inputs from its
+        // selections: in most cases, the copied node will just contain the key needed to jump back
+        // to its parent, and those would usually be the same as its inputs. And since by definition
+        // we know copied node's inputs are already fetched, we know they are not things that we
+        // need. Then, we check if what remains (often empty) can be directly fetched from the
+        // parent. If it can, then we can just merge the copied node into that parent. Otherwise, we
+        // will have to "keep it".
+        //
+        // NOTE: We have explicitly copied the current node without its selections, so the current
+        // node's fields should not pollute this check on the copied node.
+        dependency_graph.remove_inputs_from_selection(copied_node_id)?;
+        let copied_node_is_unneeded = dependency_graph.is_node_unneeded(copied_node_id, &parent)?;
         let mut unmerged_node_ids: Vec<NodeIndex> = Vec::new();
-        if new_node_is_not_needed {
-            // Up to this point, `new_node` had no parent, so let's first merge `new_node` to the parent, thus "rooting"
-            // its children to it. Note that we just checked that `new_node` selection was just its inputs, so
-            // we know that merging it to the parent is mostly a no-op from that POV, except maybe for requesting
-            // a few additional `__typename` we didn't before (due to the exclusion of `__typename` in the `new_node_is_unneeded` check)
-            dependency_graph.merge_child_in(parent.parent_node_id, new_node_id)?;
+        if copied_node_is_unneeded {
+            // We've removed the copied node's inputs from its own selections, and confirmed the
+            // remaining fields can be fetched from the parent. As an optimization, we now merge it
+            // into the parent, thus "rooting" the copied node's children to that parent. Note that
+            // the copied node's selections are often empty after removing inputs, so merging it
+            // into the parent is usually a no-op from that POV, except maybe for requesting
+            // a few additional `__typename`s we didn't before.
+            dependency_graph.merge_child_in(parent.parent_node_id, copied_node_id)?;
 
-            // Now, all created groups are going to be descendant of `parentGroup`. But some of them may actually be
-            // mergeable into it.
+            // Now, all created nodes are going to be descendants of the parent node. But some of
+            // them may actually be mergeable into it.
             for created_node_id in newly_created_node_ids {
-                // Note that `created_node_id` may not be a direct child of `parent_node_id`, but `can_merge_child_in` just return `false` in
-                // that case, yielding the behaviour we want (not trying to merge it in).
+                // Note that `created_node_id` may not be a direct child of `parent_node_id`, but
+                // `can_merge_child_in()` just returns `false` in that case, yielding the behavior
+                // we want (not trying to merge it in).
                 if dependency_graph.can_merge_child_in(parent.parent_node_id, created_node_id)? {
                     dependency_graph.merge_child_in(parent.parent_node_id, created_node_id)?;
                 } else {
                     unmerged_node_ids.push(created_node_id);
 
-                    // `created_node_id` cannot be merged into `parent_node_id`, which may typically be because they are not to the same
-                    // subgraph. However, while `created_node_id` currently depend on `parent_node_id` (directly or indirectly), that
-                    // dependency just come from the fact that `parent_node_id` is the parent of the node whose @requires we're
-                    // dealing with. And in practice, it could well be that some of the fetches needed for that require don't
-                    // really depend on anything that parent fetches and could be done in parallel with it. If we detect that
-                    // this is the case for `created_node_id`, we can move it "up the chain of dependency".
+                    // `created_node_id` cannot be merged into `parent_node_id`, which may typically
+                    // be because they aren't to the same subgraph. However, while `created_node_id`
+                    // currently depends on `parent_node_id` (directly or indirectly), that
+                    // dependency just comes from the fact that `parent_node_id` is the parent of
+                    // the node whose conditions we're dealing with. And in practice, it could well
+                    // be that some of the fetches needed for those conditions don't really depend
+                    // on anything that the parent fetches and could be done in parallel with it. If
+                    // we detect that this is the case for `created_node_id`, we can move it "up the
+                    // chain of dependencies".
                     let mut current_parent = parent.clone();
                     while dependency_graph.is_child_of_with_artificial_dependency(
                         created_node_id,
@@ -4252,10 +4309,10 @@ fn handle_requires(
                             .parents_relations_of(current_parent.parent_node_id)
                             .collect();
                         if grand_parents.is_empty() {
-                            return Err(FederationError::internal(format!(
+                            bail!(
                                 "Fetch node {} is not top-level, so it should have parents",
                                 current_parent.parent_node_id.index()
-                            )));
+                            );
                         }
                         for grand_parent_relation in &grand_parents {
                             dependency_graph.add_parent(
@@ -4281,26 +4338,26 @@ fn handle_requires(
                 }
             }
         } else {
-            // We cannot merge `new_node_id` to the parent, either because there it fetches some things necessary to the
-            // @requires, or because we had more than one parent and don't know how to handle this (unsure if the later
-            // can actually happen at this point tbh (?)). But there is no reason not to merge `new_node_id` back to `fetch_node_id`
-            // so we do that first.
-            if !dependency_graph.can_merge_sibling_in(fetch_node_id, new_node_id)? {
-                return Err(FederationError::internal(format!(
+            // We cannot merge the copied node into the parent because it fetches some conditions
+            // fields that can't be fetched from the parent. We bail on this specific optimization,
+            // and accordingly merge the copied node back to the original current node.
+            if !dependency_graph.can_merge_sibling_in(fetch_node_id, copied_node_id)? {
+                bail!(
                     "We should be able to merge {} into {} by construction",
-                    new_node_id.index(),
+                    copied_node_id.index(),
                     fetch_node_id.index()
-                )));
+                );
             };
-            dependency_graph.merge_sibling_in(fetch_node_id, new_node_id)?;
+            dependency_graph.merge_sibling_in(fetch_node_id, copied_node_id)?;
 
-            // The created node depend on `fetch_node` and the dependency cannot be moved to the parent in
-            // this case. However, we might still be able to merge some created nodes directly in the
-            // parent. But for this to be true, we should essentially make sure that the dependency
-            // on `node` is not a "true" dependency. That is, if the created node inputs are the same
-            // as `node` inputs (and said created node is the same subgraph as the parent of
-            // `node`, then it means we depend only on values that are already in the parent and
-            // can merge the node).
+            // The created nodes depend on the current node, and the dependency cannot be moved to
+            // the parent in this case. However, we might still be able to merge some created nodes
+            // directly into the parent. But for this to be true, we should essentially make sure
+            // that the dependency on the current node is not a "true" dependency. That is, if a
+            // created node's inputs are the same as the current node's inputs (and said created
+            // node is the same subgraph as the parent of the current node), then it means we depend
+            // only on values that are already fetched by the parent and/or its ancestors, and
+            // can merge that created node into the parent.
             if parent.path_in_parent.is_some() {
                 for created_node_id in newly_created_node_ids {
                     if dependency_graph.can_merge_grand_child_in(
@@ -4317,11 +4374,84 @@ fn handle_requires(
             }
         }
 
-        // If we've merged all the created nodes, then all the "requires" are handled _before_ we get to the
-        // current node, so we can "continue" with the current node.
-        if unmerged_node_ids.is_empty() {
-            // We still need to add the stuffs we require though (but `node` already has a key in its inputs,
-            // we don't need one).
+        created_nodes.extend(unmerged_node_ids.clone());
+        Ok(ConditionsNodeData {
+            conditions_merge_node_id: if copied_node_is_unneeded {
+                parent.parent_node_id
+            } else {
+                fetch_node_id
+            },
+            path_in_conditions_merge_node_id: if copied_node_is_unneeded {
+                parent.path_in_parent
+            } else {
+                Some(Arc::new(Default::default()))
+            },
+            created_node_ids: unmerged_node_ids,
+            is_fully_local_requires: false,
+        })
+    } else {
+        // We're in the somewhat simpler case where the conditions are queried somewhere in the
+        // middle of a subgraph fetch (so, not just after having jumped to that subgraph), or
+        // there's more than one parent. In that case, there isn't much optimisation we can easily
+        // do, so we leave the nodes as-is.
+        created_nodes.extend(newly_created_node_ids.clone());
+        Ok(ConditionsNodeData {
+            conditions_merge_node_id: fetch_node_id,
+            path_in_conditions_merge_node_id: Some(Arc::new(Default::default())),
+            created_node_ids: newly_created_node_ids.into_iter().collect(),
+            is_fully_local_requires: false,
+        })
+    }
+}
+
+/// Adds a @requires edge into the node at the given path, instead making a new node if optimization
+/// cannot place that edge in the given node. This function assumes handle_conditions_tree() has
+/// already been called, and accordingly takes its outputs.
+fn create_post_requires_node(
+    dependency_graph: &mut FetchDependencyGraph,
+    query_graph_edge_id: EdgeIndex,
+    (fetch_node_id, fetch_node_path): (NodeIndex, &FetchDependencyGraphNodePath),
+    context: &OpGraphPathContext,
+    conditions_node_data: ConditionsNodeData,
+    created_nodes: &mut IndexSet<NodeIndex>,
+) -> Result<(NodeIndex, FetchDependencyGraphNodePath), FederationError> {
+    // @requires should be on an entity type, and we only support object types right now.
+    let head = dependency_graph
+        .federated_query_graph
+        .edge_head_weight(query_graph_edge_id)?;
+    let entity_type_schema = dependency_graph
+        .federated_query_graph
+        .schema_by_source(&head.source)?
+        .clone();
+    let QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(entity_type_position)) =
+        head.type_.clone()
+    else {
+        bail!("@requires applied on non-entity object type");
+    };
+
+    // If all required fields could be fetched locally, we "continue" with the current node.
+    if conditions_node_data.is_fully_local_requires {
+        return Ok((fetch_node_id, fetch_node_path.clone()));
+    }
+
+    // NOTE: The code paths diverge below similar to handle_conditions_tree(), checking whether we
+    // tried optimizing based on whether there's a single parent and whether the path in the node is
+    // only type conditions. This is largely meant to just keep behavior the same as before and be
+    // aligned with the JS query planner. This could change in the future though, to permit simpler
+    // handling and further optimization. (There's also some arguably buggy behavior in this
+    // function we ought to resolve in the future.)
+    let parent_if_tried_optimizing =
+        match iter_into_single_item(dependency_graph.parents_relations_of(fetch_node_id)) {
+            Some(parent) if fetch_node_path.path_in_node.has_only_fragments() => Some(parent),
+            _ => None,
+        };
+
+    if let Some(parent) = parent_if_tried_optimizing {
+        // If all created nodes were merged into ancestors, then those nodes' data are fetched
+        // _before_ we get to the current node, so we "continue" with the current node.
+        if conditions_node_data.created_node_ids.is_empty() {
+            // We still need to add the required fields as inputs to the current node (but the node
+            // should already have a key in its inputs, so we don't need to add that).
             let inputs = inputs_for_require(
                 dependency_graph,
                 entity_type_position.clone(),
@@ -4337,51 +4467,51 @@ fn handle_requires(
             return Ok((fetch_node_id, fetch_node_path.clone()));
         }
 
-        // If we get here, it means that @require needs the information from `unmerged_nodes` (plus whatever has
-        // been merged before) _and_ those rely on some information from the current `fetch_node` (if they hadn't, we
-        // would have been able to merge `new_node` to `fetch_node`'s parent). So the group we should return, which
-        // is the node where the "post-@require" fields will be added, needs to be a new node that depends
-        // on all those `unmerged_nodes`.
-        let post_require_node_id = dependency_graph.new_key_node(
-            &subgraph_name,
+        // If we get here, it means that @requires needs the fields from the created nodes (plus
+        // potentially whatever has been merged before). So the node we should return, which is the
+        // node where the "post-@requires" fields will be given as input, needs to a be a new node
+        // that depends on all those created nodes.
+        let fetch_node = dependency_graph.node_weight(fetch_node_id)?;
+        let target_subgraph = fetch_node.subgraph_name.clone();
+        let defer_ref = fetch_node.defer_ref.clone();
+        let post_requires_node_id = dependency_graph.new_key_node(
+            &target_subgraph,
             fetch_node_path.response_path.clone(),
             defer_ref,
         )?;
-        // Note that `post_require_node` cannot generally be merged in any of the `unmerged_nodes` and we don't provide a `path`.
-        for unmerged_node_id in &unmerged_node_ids {
+        // Note that the post-requires node cannot generally be merged into any of the created
+        // nodes, and we accordingly don't provide a path in those created nodes.
+        for created_node_id in &conditions_node_data.created_node_ids {
             dependency_graph.add_parent(
-                post_require_node_id,
+                post_requires_node_id,
                 ParentRelation {
-                    parent_node_id: *unmerged_node_id,
+                    parent_node_id: *created_node_id,
                     path_in_parent: None,
                 },
             );
         }
-        // That node also need, in general, to depend on the current `fetch_node`. That said, if we detected that the @require
-        // didn't need anything of said `node` (if `new_node_is_unneeded`), then we can depend on the parent instead.
-        if new_node_is_not_needed {
-            dependency_graph.add_parent(post_require_node_id, parent.clone());
-        } else {
-            dependency_graph.add_parent(
-                post_require_node_id,
-                ParentRelation {
-                    parent_node_id: fetch_node_id,
-                    path_in_parent: Some(Arc::new(OpPath::default())),
-                },
-            )
-        }
+        // The post-requires node also needs to, in general, depend on the node that the @requires
+        // conditions were merged into (either the current node or its parent).
+        dependency_graph.add_parent(
+            post_requires_node_id,
+            ParentRelation {
+                parent_node_id: conditions_node_data.conditions_merge_node_id,
+                path_in_parent: conditions_node_data.path_in_conditions_merge_node_id,
+            },
+        );
 
-        // Note(Sylvain): I'm not 100% sure about this assert in the sense that while I cannot think of a case where `parent.path_in_parent` wouldn't
-        // exist, the code paths are complex enough that I'm not able to prove this easily and could easily be missing something. That said,
-        // we need the path here, so this will have to do for now, and if this ever breaks in practice, we'll at least have an example to
-        // guide us toward improving/fixing.
+        // NOTE(Sylvain): I'm not 100% sure about this assert in the sense that while I cannot think
+        // of a case where `parent.path_in_parent` wouldn't exist, the code paths are complex enough
+        // that I'm not able to prove this easily and could easily be missing something. That said,
+        // we need the path here, so this will have to do for now, and if this ever breaks in
+        // practice, we'll at least have an example to guide us toward improving/fixing the code.
         let Some(parent_path) = &parent.path_in_parent else {
-            return Err(FederationError::internal(format!(
+            bail!(
                 "Missing path_in_parent for @require on {} with group {} and parent {}",
                 query_graph_edge_id.index(),
                 fetch_node_id.index(),
                 parent.parent_node_id.index()
-            )));
+            );
         };
         let path_for_parent = path_for_parent(
             dependency_graph,
@@ -4397,61 +4527,43 @@ fn handle_requires(
             query_graph_edge_id,
             context,
             parent.parent_node_id,
-            post_require_node_id,
+            post_requires_node_id,
         )?;
-        created_nodes.extend(unmerged_node_ids);
-        created_nodes.insert(post_require_node_id);
+        created_nodes.insert(post_requires_node_id);
         let initial_fetch_path = create_fetch_initial_path(
             &dependency_graph.supergraph_schema,
             &entity_type_position.clone().into(),
             context,
         )?;
         let new_path = fetch_node_path.for_new_key_fetch(initial_fetch_path);
-        Ok((post_require_node_id, new_path))
+        Ok((post_requires_node_id, new_path))
     } else {
-        // We're in the somewhat simpler case where a @require happens somewhere in the middle of a subgraph query (so, not
-        // just after having jumped to that subgraph). In that case, there isn't tons of optimisation we can do: we have to
-        // see what satisfying the @require necessitate, and if it needs anything from another subgraph, we have to stop the
-        // current subgraph fetch there, get the requirements from other subgraphs, and then resume the query of that particular subgraph.
-        let new_created_nodes = compute_nodes_for_tree(
-            dependency_graph,
-            requires_conditions,
-            fetch_node_id,
-            fetch_node_path.clone(),
-            defer_context.for_conditions(),
-            &OpGraphPathContext::default(),
-        )?;
-        // If we didn't create any node, that means the whole condition was fetched from the current node
-        // and we're good.
-        if new_created_nodes.is_empty() {
-            return Ok((fetch_node_id, fetch_node_path.clone()));
-        }
-
-        // We need to create a new name, on the same subgraph `group`, where we resume fetching the field for
-        // which we handle the @requires _after_ we've dealt with the `requires_conditions_nodes`.
-        // Note that we know the conditions will include a key for our node so we can resume properly.
+        // We need to create a new node on the same subgraph as the current node, where we resume
+        // fetching the field for which we handle the @requires _after_ we've dealt with any created
+        // nodes. Note that during option generation, we already ensured a key exists, so the node
+        // can resume properly.
         let fetch_node = dependency_graph.node_weight(fetch_node_id)?;
         let target_subgraph = fetch_node.subgraph_name.clone();
         let defer_ref = fetch_node.defer_ref.clone();
-        let new_node_id = dependency_graph.new_key_node(
+        let post_requires_node_id = dependency_graph.new_key_node(
             &target_subgraph,
             fetch_node_path.response_path.clone(),
             defer_ref,
         )?;
-        let new_node = dependency_graph.node_weight(new_node_id)?;
-        let merge_at = new_node.merge_at.clone();
-        let parent_type = new_node.parent_type.clone();
-        for created_node_id in &new_created_nodes {
+        let post_requires_node = dependency_graph.node_weight(post_requires_node_id)?;
+        let merge_at = post_requires_node.merge_at.clone();
+        let parent_type = post_requires_node.parent_type.clone();
+        for created_node_id in &conditions_node_data.created_node_ids {
             let created_node = dependency_graph.node_weight(*created_node_id)?;
-            // Usually, computing the path of our new group into the created groups
-            // is not entirely trivial, but there is at least the relatively common
-            // case where the 2 groups we look at have:
-            // 1) the same `mergeAt`, and
-            // 2) the same parentType; in that case, we can basically infer those 2
-            //    groups apply at the same "place" and so the "path in parent" is
-            //    empty. TODO: it should probably be possible to generalize this by
-            //    checking the `mergeAt` plus analyzing the selection but that
-            //    warrants some reflection...
+            // Usually, computing the path of the post-requires node in the created nodes is not
+            // entirely trivial, but there is at least one relatively common case where the 2 nodes
+            // we look at have (1) the same merge-at, and (2) the same parent type.
+            //
+            // In that case, we can basically infer those 2 nodes apply at the same "place" and so
+            // the "path in parent" is empty.
+            //
+            // TODO(Sylvain): it should probably be possible to generalize this by checking the
+            //     `merge_at` plus analyzing the selection, but that warrants some reflection...
             let new_path =
                 if merge_at == created_node.merge_at && parent_type == created_node.parent_type {
                     Some(Arc::new(OpPath::default()))
@@ -4462,7 +4574,7 @@ fn handle_requires(
                 parent_node_id: *created_node_id,
                 path_in_parent: new_path,
             };
-            dependency_graph.add_parent(new_node_id, new_parent_relation);
+            dependency_graph.add_parent(post_requires_node_id, new_parent_relation);
         }
 
         add_post_require_inputs(
@@ -4473,17 +4585,16 @@ fn handle_requires(
             query_graph_edge_id,
             context,
             fetch_node_id,
-            new_node_id,
+            post_requires_node_id,
         )?;
-        created_nodes.extend(new_created_nodes);
-        created_nodes.insert(new_node_id);
+        created_nodes.insert(post_requires_node_id);
         let initial_fetch_path = create_fetch_initial_path(
             &dependency_graph.supergraph_schema,
             &entity_type_position.clone().into(),
             context,
         )?;
         let new_path = fetch_node_path.for_new_key_fetch(initial_fetch_path);
-        Ok((new_node_id, new_path))
+        Ok((post_requires_node_id, new_path))
     }
 }
 

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -89,7 +89,7 @@ pub struct FetchNode {
     pub output_rewrites: Vec<Arc<FetchDataRewrite>>,
     /// Similar to the other kinds of rewrites. This is a mechanism to convert a contextual path into
     /// an argument to a resolver
-    pub context_rewrites: Vec<Arc<FetchDataRewrite>>,
+    pub context_rewrites: Vec<FetchDataRewrite>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -583,19 +583,6 @@ impl QueryPlanner {
             .types
             .values()
             .any(|extended_type| extended_type.directives().has(CONTEXT_DIRECTIVE));
-        if has_set_context {
-            let message = "\
-                `experimental_query_planner_mode: new` or `both` cannot yet \
-                be used with `@context`. \
-                Remove uses of `@context` to try the experimental query planner, \
-                otherwise switch back to `legacy` or `both_best_effort`.\
-            ";
-            return Err(SingleFederationError::UnsupportedFeature {
-                message: message.to_owned(),
-                kind: crate::error::UnsupportedFeatureKind::Context,
-            }
-            .into());
-        }
         Ok(())
     }
 }

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -3,7 +3,6 @@ use std::num::NonZeroU32;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::validation::Valid;
@@ -209,10 +208,10 @@ pub struct QueryPlanOptions {
 }
 
 #[derive(Debug, Default, Clone)]
-pub(crate) struct EnabledOverrideConditions(HashSet<String>);
+pub(crate) struct EnabledOverrideConditions(IndexSet<String>);
 
 impl Deref for EnabledOverrideConditions {
-    type Target = HashSet<String>;
+    type Target = IndexSet<String>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -488,7 +487,7 @@ impl QueryPlanner {
                 .clone()
                 .into(),
             config: self.config.clone(),
-            override_conditions: EnabledOverrideConditions(HashSet::from_iter(
+            override_conditions: EnabledOverrideConditions(IndexSet::from_iter(
                 options.override_conditions,
             )),
             fetch_id_generator: Arc::new(FetchIdGenerator::new()),

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -1104,6 +1104,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             Some(best_plan) => Ok(ConditionResolution::Satisfied {
                 cost: best_plan.cost,
                 path_tree: Some(best_plan.path_tree),
+                context_map: todo!(),
             }),
             None => Ok(ConditionResolution::unsatisfied_conditions()),
         }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -1104,7 +1104,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             Some(best_plan) => Ok(ConditionResolution::Satisfied {
                 cost: best_plan.cost,
                 path_tree: Some(best_plan.path_tree),
-                context_map: todo!(),
+                context_map: None,
             }),
             None => Ok(ConditionResolution::unsatisfied_conditions()),
         }

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -2086,7 +2086,7 @@ impl Debug for ObjectFieldDefinitionPosition {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct ObjectFieldArgumentDefinitionPosition {
     pub(crate) type_name: Name,
     pub(crate) field_name: Name,

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -418,6 +418,7 @@ impl FederationSpecDefinitions {
     }
 
     /// directive @fromContext(field: String!) on ARGUMENT_DEFINITION
+    #[allow(clippy::wrong_self_convention)]
     fn from_context_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -38,9 +38,11 @@ use crate::subgraph::spec::FederationSpecError::UnsupportedFederationDirective;
 use crate::subgraph::spec::FederationSpecError::UnsupportedVersionError;
 
 pub const COMPOSE_DIRECTIVE_NAME: Name = name!("composeDirective");
+pub const CONTEXT_DIRECTIVE_NAME: Name = name!("context");
 pub const KEY_DIRECTIVE_NAME: Name = name!("key");
 pub const EXTENDS_DIRECTIVE_NAME: Name = name!("extends");
 pub const EXTERNAL_DIRECTIVE_NAME: Name = name!("external");
+pub const FROM_CONTEXT_DIRECTIVE_NAME: Name = name!("fromContext");
 pub const INACCESSIBLE_DIRECTIVE_NAME: Name = name!("inaccessible");
 pub const INTF_OBJECT_DIRECTIVE_NAME: Name = name!("interfaceObject");
 pub const OVERRIDE_DIRECTIVE_NAME: Name = name!("override");
@@ -48,8 +50,6 @@ pub const PROVIDES_DIRECTIVE_NAME: Name = name!("provides");
 pub const REQUIRES_DIRECTIVE_NAME: Name = name!("requires");
 pub const SHAREABLE_DIRECTIVE_NAME: Name = name!("shareable");
 pub const TAG_DIRECTIVE_NAME: Name = name!("tag");
-pub const CONTEXT_DIRECTIVE_NAME: Name = name!("context");
-pub const FROM_CONTEXT_DIRECTIVE_NAME: Name = name!("fromContext");
 pub const FIELDSET_SCALAR_NAME: Name = name!("FieldSet");
 
 // federated types
@@ -68,11 +68,13 @@ pub const FEDERATION_V1_DIRECTIVE_NAMES: [Name; 5] = [
     REQUIRES_DIRECTIVE_NAME,
 ];
 
-pub const FEDERATION_V2_DIRECTIVE_NAMES: [Name; 11] = [
+pub const FEDERATION_V2_DIRECTIVE_NAMES: [Name; 13] = [
     COMPOSE_DIRECTIVE_NAME,
+    CONTEXT_DIRECTIVE_NAME,
     KEY_DIRECTIVE_NAME,
     EXTENDS_DIRECTIVE_NAME,
     EXTERNAL_DIRECTIVE_NAME,
+    FROM_CONTEXT_DIRECTIVE_NAME,
     INACCESSIBLE_DIRECTIVE_NAME,
     INTF_OBJECT_DIRECTIVE_NAME,
     OVERRIDE_DIRECTIVE_NAME,
@@ -86,9 +88,11 @@ pub const FEDERATION_V2_DIRECTIVE_NAMES: [Name; 11] = [
 // in FederationSpecDefinitions.directive_definition() for more information.
 enum FederationDirectiveName {
     Compose,
+    Context,
     Key,
     Extends,
     External,
+    FromContext,
     Inaccessible,
     IntfObject,
     Override,
@@ -102,9 +106,11 @@ lazy_static! {
     static ref FEDERATION_DIRECTIVE_NAMES_TO_ENUM: IndexMap<Name, FederationDirectiveName> = {
         IndexMap::from_iter([
             (COMPOSE_DIRECTIVE_NAME, FederationDirectiveName::Compose),
+            (CONTEXT_DIRECTIVE_NAME, FederationDirectiveName::Context),
             (KEY_DIRECTIVE_NAME, FederationDirectiveName::Key),
             (EXTENDS_DIRECTIVE_NAME, FederationDirectiveName::Extends),
             (EXTERNAL_DIRECTIVE_NAME, FederationDirectiveName::External),
+            (FROM_CONTEXT_DIRECTIVE_NAME, FederationDirectiveName::FromContext),
             (
                 INACCESSIBLE_DIRECTIVE_NAME,
                 FederationDirectiveName::Inaccessible,
@@ -285,9 +291,11 @@ impl FederationSpecDefinitions {
         };
         Ok(match enum_name {
             FederationDirectiveName::Compose => self.compose_directive_definition(alias),
+            FederationDirectiveName::Context => self.context_directive_definition(alias),
             FederationDirectiveName::Key => self.key_directive_definition(alias)?,
             FederationDirectiveName::Extends => self.extends_directive_definition(alias),
             FederationDirectiveName::External => self.external_directive_definition(alias),
+            FederationDirectiveName::FromContext => self.from_context_directive_definition(alias),
             FederationDirectiveName::Inaccessible => self.inaccessible_directive_definition(alias),
             FederationDirectiveName::IntfObject => {
                 self.interface_object_directive_definition(alias)
@@ -338,6 +346,24 @@ impl FederationSpecDefinitions {
             locations: vec![DirectiveLocation::Schema],
         }
     }
+    
+    /// directive @context(name: String!) repeatable on INTERFACE | OBJECT
+    fn context_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
+        DirectiveDefinition {
+            description: None,
+            name: alias.clone().unwrap_or(CONTEXT_DIRECTIVE_NAME),
+            arguments: vec![InputValueDefinition {
+                description: None,
+                name: name!("name"),
+                ty: ty!(String!).into(),
+                default_value: None,
+                directives: Default::default(),
+            }
+            .into()],
+            repeatable: true,
+            locations: vec![DirectiveLocation::Interface, DirectiveLocation::Object],
+        }
+    }
 
     /// directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
     fn key_directive_definition(
@@ -385,6 +411,24 @@ impl FederationSpecDefinitions {
                 DirectiveLocation::Object,
                 DirectiveLocation::FieldDefinition,
             ],
+        }
+    }
+    
+    /// directive @fromContext(field: String!) on ARGUMENT_DEFINITION
+    fn from_context_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
+        DirectiveDefinition {
+            description: None,
+            name: alias.clone().unwrap_or(FROM_CONTEXT_DIRECTIVE_NAME),
+            arguments: vec![InputValueDefinition {
+                description: None,
+                name: name!("field"),
+                ty: ty!(String!).into(),
+                default_value: None,
+                directives: Default::default(),
+            }
+            .into()],
+            repeatable: false,
+            locations: vec![DirectiveLocation::ArgumentDefinition],
         }
     }
 

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -110,7 +110,10 @@ lazy_static! {
             (KEY_DIRECTIVE_NAME, FederationDirectiveName::Key),
             (EXTENDS_DIRECTIVE_NAME, FederationDirectiveName::Extends),
             (EXTERNAL_DIRECTIVE_NAME, FederationDirectiveName::External),
-            (FROM_CONTEXT_DIRECTIVE_NAME, FederationDirectiveName::FromContext),
+            (
+                FROM_CONTEXT_DIRECTIVE_NAME,
+                FederationDirectiveName::FromContext,
+            ),
             (
                 INACCESSIBLE_DIRECTIVE_NAME,
                 FederationDirectiveName::Inaccessible,
@@ -346,7 +349,7 @@ impl FederationSpecDefinitions {
             locations: vec![DirectiveLocation::Schema],
         }
     }
-    
+
     /// directive @context(name: String!) repeatable on INTERFACE | OBJECT
     fn context_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
@@ -413,7 +416,7 @@ impl FederationSpecDefinitions {
             ],
         }
     }
-    
+
     /// directive @fromContext(field: String!) on ARGUMENT_DEFINITION
     fn from_context_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -47,10 +47,12 @@ pub use self::subgraph::ValidFederationSubgraphs;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
+use crate::link::context_spec_definition::CONTEXT_VERSIONS;
 use crate::link::cost_spec_definition::CostSpecDefinition;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
+use crate::link::join_spec_definition::ContextArgument;
 use crate::link::join_spec_definition::FieldDirectiveArguments;
 use crate::link::join_spec_definition::JoinSpecDefinition;
 use crate::link::join_spec_definition::TypeDirectiveArguments;
@@ -709,6 +711,18 @@ fn extract_object_type_content(
             message: "@join__implements should exist for a fed2 supergraph".to_owned(),
         })?;
 
+    let context = supergraph_schema
+        .metadata()
+        .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))
+        .and_then(|context_link| CONTEXT_VERSIONS.find(&context_link.url.version))
+        .and_then(|context_spec_def| {
+            context_spec_def
+                .context_directive_name_in_schema(supergraph_schema)
+                .ok()
+                .map(|name_in_schema| (context_spec_def, name_in_schema))
+        });
+    // let context_name_in_schema = context_spec_def
+    //     .and_then(|def| def.context_directive_name_in_schema(supergraph_schema).ok());
     for TypeInfo {
         name: type_name,
         subgraph_info,
@@ -745,6 +759,64 @@ fn extract_object_type_content(
                 &mut subgraph.schema,
                 ComponentName::from(Name::new(implements_directive_application.interface)?),
             )?;
+        }
+
+        if let Some((_context_spec_def, name_in_supergraph)) = &context {
+            for directive in type_.directives.get_all(name_in_supergraph.as_str()) {
+                FederationSpecDefinition::context_directive_arguments(directive).and_then(
+                    |context_name| {
+                        let mut arr = context_name.name.split("__");
+                        let subgraph_name = arr.next().ok_or_else(|| {
+                            SingleFederationError::InvalidFederationSupergraph {
+                                message: format!(
+                                    "Could not parse context name from supergraph '{}'",
+                                    name_in_supergraph
+                                )
+                                .to_owned(),
+                            }
+                        })?;
+                        let subgraph_name = Name::new(subgraph_name)?;
+                        let subgraph_index = get_index_from_subgraph_name(
+                            graph_enum_value_name_to_subgraph_name,
+                            &subgraph_name,
+                        )
+                        .ok_or_else(|| {
+                            SingleFederationError::InvalidSubgraph {
+                                message: format!(
+                                    "Could not look up subgraph by name '{}'",
+                                    subgraph_name
+                                )
+                                .to_owned(),
+                            }
+                        })?;
+                        let subgraph = get_subgraph(
+                            subgraphs,
+                            graph_enum_value_name_to_subgraph_name,
+                            subgraph_index,
+                        )?;
+
+                        let federation_spec_definition = federation_spec_definitions
+                            .get(subgraph_index)
+                            .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
+                                message: "Subgraph unexpectedly does not use federation spec"
+                                    .to_owned(),
+                            })?;
+                        let context_in_subgraph = arr.last().ok_or_else(|| {
+                            SingleFederationError::InvalidFederationSupergraph {
+                                message: format!(
+                                    "Could not parse context name from supergraph '{}'",
+                                    name_in_supergraph
+                                )
+                                .to_owned(),
+                            }
+                        })?;
+                        let context_directive = federation_spec_definition
+                            .context_directive(&subgraph.schema, context_in_subgraph.to_string())?;
+                        pos.insert_directive(&mut subgraph.schema, context_directive.into())?;
+                        Ok(())
+                    },
+                )?;
+            }
         }
 
         for graph_enum_value in subgraph_info.keys() {
@@ -1389,6 +1461,7 @@ fn add_subgraph_field(
             override_: None,
             override_label: None,
             user_overridden: None,
+            context_arguments: None,
         });
     let subgraph_field_type = match &field_directive_application.type_ {
         Some(t) => decode_type(t)?,
@@ -1474,6 +1547,40 @@ fn add_subgraph_field(
         )?;
     }
 
+    if let Some(context_arguments) = &field_directive_application.context_arguments {
+        for args in context_arguments {
+            let ContextArgument {
+                name,
+                type_,
+                context,
+                selection,
+            } = args;
+            let (_, context_name_in_subgraph) = context.rsplit_once("__").ok_or_else(|| {
+                SingleFederationError::InvalidFederationSupergraph {
+                    message: format!(
+                        "Could not parse context field from supergraph '{}'",
+                        context
+                    )
+                    .to_owned(),
+                }
+            })?;
+
+            let arg = format!("${} {}", context_name_in_subgraph, selection);
+            let from_context_directive =
+                federation_spec_definition.from_context_directive(&subgraph.schema, arg)?;
+            let directives = std::iter::once(from_context_directive).collect();
+            let ty = decode_type(type_)?;
+            let node = Node::new(InputValueDefinition {
+                name: Name::new(name)?,
+                ty: ty.into(),
+                directives,
+                default_value: None,
+                description: None,
+            });
+            subgraph_field.arguments.push(node);
+        }
+    }
+
     match object_or_interface_field_definition_position {
         ObjectOrInterfaceFieldDefinitionPosition::Object(pos) => {
             pos.insert(&mut subgraph.schema, Component::from(subgraph_field))?;
@@ -1504,6 +1611,7 @@ fn add_subgraph_input_field(
             override_: None,
             override_label: None,
             user_overridden: None,
+            context_arguments: None,
         });
     let subgraph_input_field_type = match &field_directive_application.type_ {
         Some(t) => Node::new(decode_type(t)?),
@@ -1559,6 +1667,16 @@ fn get_subgraph<'subgraph>(
         }
         .into()
     })
+}
+
+fn get_index_from_subgraph_name<'a>(
+    graph_enum_value_name_to_subgraph_name: &'a IndexMap<Name, Arc<str>>,
+    subgraph_name: &'a Name,
+) -> Option<&'a Name> {
+    graph_enum_value_name_to_subgraph_name
+        .iter()
+        .find(|(_, v)| v.as_ref() == subgraph_name.as_str())
+        .map(|(k, _)| k)
 }
 
 lazy_static! {

--- a/apollo-federation/src/supergraph/schema.rs
+++ b/apollo-federation/src/supergraph/schema.rs
@@ -99,6 +99,10 @@ pub(crate) fn new_empty_fed_2_subgraph_schema() -> Result<FederationSchema, Fede
 
     directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
+    directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+    directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
+    
     scalar federation__FieldSet
 
     scalar federation__Scope

--- a/apollo-federation/src/utils/fallible_iterator.rs
+++ b/apollo-federation/src/utils/fallible_iterator.rs
@@ -405,6 +405,28 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     {
         self.process_results(|mut results| results.find(predicate))
     }
+
+    fn fallible_fold<F, O, T, E>(&mut self, mut init: O, mut mapper: F) -> Result<O, E>
+    where
+        Self: Iterator<Item = T>,
+        F: FnMut(O, T) -> Result<O, E>,
+    {
+        for item in self {
+            init = mapper(init, item)?;
+        }
+        Ok(init)
+    }
+
+    fn and_then_fold<F, O, T, E>(&mut self, mut init: O, mut mapper: F) -> Result<O, E>
+    where
+        Self: Iterator<Item = Result<T, E>>,
+        F: FnMut(O, T) -> Result<O, E>,
+    {
+        for item in self {
+            init = mapper(init, item?)?
+        }
+        Ok(init)
+    }
 }
 
 impl<I: Itertools> FallibleIterator for I {}

--- a/apollo-federation/tests/extract_subgraphs.rs
+++ b/apollo-federation/tests/extract_subgraphs.rs
@@ -697,3 +697,111 @@ fn does_not_extract_renamed_demand_control_directive_name_conflicts() {
     }
     insta::assert_snapshot!(snapshot);
 }
+
+#[test]
+fn extracts_set_context_directives() {
+    let subgraphs = Supergraph::new(r#"
+      schema
+        @link(url: "https://specs.apollo.dev/link/v1.0")
+        @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+        @link(url: "https://specs.apollo.dev/context/v0.1")
+      {
+        query: Query
+      }
+
+      directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+      directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+      directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+      directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+      directive @context(name: String!) repeatable on INTERFACE | OBJECT
+
+      directive @context__fromContext(field: String) on ARGUMENT_DEFINITION
+
+      enum link__Purpose {
+        """
+        \`SECURITY\` features provide metadata necessary to securely resolve fields.
+        """
+        SECURITY
+
+        """
+        \`EXECUTION\` features provide metadata necessary for operation execution.
+        """
+        EXECUTION
+      }
+
+      scalar link__Import
+
+      enum join__Graph {
+        SUBGRAPH1 @join__graph(name: "Subgraph1", url: "")
+        SUBGRAPH2 @join__graph(name: "Subgraph2", url: "")
+      }
+
+      scalar join__FieldSet
+
+      scalar join__DirectiveArguments
+
+      scalar join__FieldValue
+
+      input join__ContextArgument {
+        name: String!
+        type: String!
+        context: String!
+        selection: join__FieldValue!
+      }
+
+      scalar context__context
+
+      type Query
+        @join__type(graph: SUBGRAPH1)
+        @join__type(graph: SUBGRAPH2)
+      {
+        t: T! @join__field(graph: SUBGRAPH1)
+        a: Int! @join__field(graph: SUBGRAPH2)
+      }
+
+      type T
+        @join__type(graph: SUBGRAPH1, key: "id")
+        @context(name: "Subgraph1__context")
+      {
+        id: ID!
+        u: U!
+        prop: String!
+      }
+
+      type U
+        @join__type(graph: SUBGRAPH1, key: "id")
+        @join__type(graph: SUBGRAPH2, key: "id")
+      {
+        id: ID!
+        field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: "{ prop }"}])
+      }
+    "#)
+    .expect("is supergraph")
+    .extract_subgraphs()
+    .expect("extracts subgraphs");
+
+    let mut snapshot = String::new();
+    for (_name, subgraph) in subgraphs {
+        use std::fmt::Write;
+
+        _ = writeln!(
+            &mut snapshot,
+            "{}\n---\n{}",
+            subgraph.name,
+            subgraph.schema.schema()
+        );
+    }
+    insta::assert_snapshot!(snapshot);
+}

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -31,9 +31,9 @@ fn some_name() {
 }
 */
 
+mod context;
 mod debug_max_evaluated_plans_configuration;
 mod defer;
-mod context;
 mod fetch_operation_names;
 mod field_merging_with_skip_and_include;
 mod fragment_autogeneration;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -33,6 +33,7 @@ fn some_name() {
 
 mod debug_max_evaluated_plans_configuration;
 mod defer;
+mod context;
 mod fetch_operation_names;
 mod field_merging_with_skip_and_include;
 mod fragment_autogeneration;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
@@ -1,0 +1,1231 @@
+// PORT_NOTE: The context tests in the JS code had more involved setup compared to the other tests.
+// Here is a snippet from the JS context test leading up to the creation of the planner:
+// ```js
+//   const asFed2Service = (service: ServiceDefinition) => {
+//     return {
+//       ...service,
+//       typeDefs: asFed2SubgraphDocument(service.typeDefs, {
+//         includeAllImports: true,
+//       }),
+//     };
+//   };
+//
+//   const composeAsFed2Subgraphs = (services: ServiceDefinition[]) => {
+//     return composeServices(services.map((s) => asFed2Service(s)));
+//   };
+//
+//   const result = composeAsFed2Subgraphs([subgraph1, subgraph2]);
+//   const [api, queryPlanner] = [
+//     result.schema!.toAPISchema(),
+//     new QueryPlanner(Supergraph.buildForTests(result.supergraphSdl!)),
+//   ];
+// ```
+// For all other tests, the set up was a single line:
+// ```js
+//  const [api, queryPlanner] = composeAndCreatePlanner(subgraph1, subgraph2);
+// ```
+//
+// How this needs to be ported remains to be seen...
+
+#[test]
+fn set_context_test_variable_is_from_same_subgraph() {
+    let planner = planner!(
+      Subgraph1: r#"
+        type Query {
+          t: T!
+        }
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          b: String!
+          field(a: String @fromContext(field: "$context { prop }")): Int!
+        }
+      "#,
+      Subgraph2: r#"
+        type Query {
+          a: Int!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+        }
+      "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        {
+          t {
+            u {
+              b
+              field
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                prop
+                u {
+                  __typename
+                  id
+                  b
+                }
+              }
+            }
+          },
+          Flatten(path: "t.u") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+    /* TODO: How should these be ported??
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on T', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+    */
+    todo!("See the comment above");
+}
+
+#[test]
+fn set_context_test_variable_is_from_different_subgraph() {
+    let planner = planner!(
+    Subgraph1: r#"
+        type Query {
+          t: T!
+        }
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          u: U!
+          prop: String! @external
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          field(a: String @fromContext(field: "$context { prop }")): Int!
+        }
+      "#,
+    Subgraph2: r#"
+        type Query {
+          a: Int!
+        }
+        type T @key(fields: "id") {
+          id: ID!
+          prop: String!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+        }
+      "#,
+      );
+    assert_plan!(
+            planner,
+            r#"
+        {
+          t {
+            u {
+              id
+              field
+            }
+          }
+        }
+            "#,
+            @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                id
+                u {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "t") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on T {
+                  prop
+                }
+              }
+            },
+          },
+          Flatten(path: "t.u") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+    "###);
+
+    /* TODO: Port
+    expect((plan as any).node.nodes[2].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on T', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+    */
+    todo!("See the comment above");
+}
+
+#[test]
+fn set_context_test_variable_is_already_in_a_different_fetch_group() {
+    let planner = planner!(
+      Subgraph1: r#"
+        type Query {
+          t: T!
+        }
+        type T @key(fields: "id") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+        }
+      '#,
+      Subgraph2: r#"
+        type Query {
+          a: Int!
+        }
+
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          prop: String! @external
+        }
+
+        type U @key(fields: "id") {
+          id: ID!
+          field(a: String @fromContext(field: "$context { prop }")): Int!
+        }
+      "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        {
+          t {
+            u {
+              id
+              field
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                prop
+                u {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "t.u") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_2_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+
+    /* TODO: Port
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on T', 'prop'],
+        renameKeyTo: 'contextualArgument_2_0',
+      },
+    ]);
+    */
+    todo!("See the comment above");
+}
+
+#[test]
+fn set_context_test_variable_is_a_list() {
+    let (api_schema, planner) = planner!(
+      Subgraph1: r#"
+        type Query {
+          t: T!
+        }
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          u: U!
+          prop: [String]!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          field(a: [String]! @fromContext(field: "$context { prop }")): Int!
+        }
+        "#,
+      Subgraph2: r#"
+        type Query {
+          a: Int!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+        }
+        "#
+    );
+
+    let document = apollo_compiler::ExecutableDocument::parse_and_validate(
+        api_schema.schema(),
+        r#"
+        {
+          t {
+            u {
+              field
+            }
+          }
+        }
+        "#,
+        "operation.graphql",
+    )
+    .unwrap();
+
+    // TODO: We expect this to return an error. We should assert that the error message is what we
+    // expect.
+    planner
+        .build_query_plan(&document, None, Default::default())
+        .unwrap();
+}
+
+#[test]
+fn set_context_test_fetched_as_a_list() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Query {
+          t: [T]!
+        }
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          b: String!
+          field(a: String @fromContext(field: "$context { prop }")): Int!
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          a: Int!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        {
+          t {
+            u {
+              b
+              field
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                prop
+                u {
+                  __typename
+                  id
+                  b
+                }
+              }
+            }
+          },
+          Flatten(path: "t.@.u") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+    /* TODO: Port
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on T', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+    */
+    todo!("See the comment above")
+}
+
+#[test]
+fn set_context_test_impacts_on_query_planning() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Query {
+          t: I!
+        }
+
+        interface I @context(name: "context") @key(fields: "id") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+
+        type A implements I @key(fields: "id") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+
+        type B implements I @key(fields: "id") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+
+        type U @key(fields: "id") {
+          id: ID!
+          b: String!
+          field(a: String @fromContext(field: "$context { prop }")): Int!
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          a: Int!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        {
+          t {
+            u {
+              b
+              field
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                prop
+                u {
+                  __typename
+                  id
+                  b
+                }
+              }
+            }
+          },
+          Flatten(path: "t.u") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+    /* TODO: Port
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on A', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on B', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+    */
+    todo!("See the comment above")
+}
+
+#[test]
+fn set_context_test_with_type_conditions_for_union() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Query {
+          t: T!
+        }
+
+        union T @context(name: "context") = A | B
+
+        type A @key(fields: "id") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+
+        type B @key(fields: "id") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+
+        type U @key(fields: "id") {
+          id: ID!
+          b: String!
+          field(
+            a: String
+              @fromContext(
+                field: "$context ... on A { prop } ... on B { prop }"
+              )
+          ): Int!
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          a: Int!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        {
+          t {
+            ... on A {
+              u {
+                b
+                field
+              }
+            }
+            ... on B {
+              u {
+                b
+                field
+              }
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                ... on A {
+                  __typename
+                  prop
+                  u {
+                    __typename
+                    id
+                    b
+                  }
+                }
+                ... on B {
+                  __typename
+                  prop
+                  u {
+                    __typename
+                    id
+                    b
+                  }
+                }
+              }
+            }
+          },
+          Flatten(path: "t.u") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+    /* TODO: Port
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on A', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on B', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+    */
+    todo!("See the comment above")
+}
+
+#[test]
+fn set_context_test_accesses_a_different_top_level_query() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Query @context(name: "topLevelQuery") {
+          me: User!
+          product: Product
+        }
+
+        type User @key(fields: "id") {
+          id: ID!
+          locale: String!
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          price(
+            locale: String
+              @fromContext(field: "$topLevelQuery { me { locale } }")
+          ): Int!
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          randomId: ID!
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        {
+          product {
+            price
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              __typename
+              me {
+                locale
+              }
+              product {
+                __typename
+                id
+              }
+            }
+          },
+          Flatten(path: "product") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on Product {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Product {
+                  price(locale: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+    /* TODO: Port
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', 'me', 'locale'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+    */
+    todo!("See the comment above")
+}
+
+#[test]
+fn set_context_variable_is_a_list() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Query {
+          t: T!
+        }
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          b: String!
+          field(a: String @fromContext(field: "$context { prop }")): Int!
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          randomId: ID!
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        {
+          t {
+            u {
+              field
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                prop
+                u {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "t.u") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+    /* TODO: Port
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on T', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+    */
+    todo!("See the comment above")
+}
+
+#[test]
+fn set_context_required_field_is_several_levels_deep_going_back_and_forth_between_subgraphs() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Query {
+          t: T!
+        }
+
+        type A @key(fields: "id") {
+          id: ID!
+          b: B! @external
+        }
+
+        type B @key(fields: "id") {
+          id: ID!
+          c: C!
+        }
+
+        type C @key(fields: "id") {
+          id: ID!
+          prop: String!
+        }
+
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          u: U!
+          a: A!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          b: String!
+          field(
+            a: String @fromContext(field: "$context { a { b { c { prop }}} }")
+          ): Int!
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          randomId: ID!
+        }
+
+        type A @key(fields: "id") {
+          id: ID!
+          b: B!
+        }
+
+        type B @key(fields: "id") {
+          id: ID!
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        {
+          t {
+            u {
+              field
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                __typename
+                a {
+                  __typename
+                  id
+                }
+                u {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "t.a") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on A {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on A {
+                  b {
+                    __typename
+                    id
+                  }
+                }
+              }
+            },
+          },
+          Flatten(path: "t.a.b") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on B {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on B {
+                  c {
+                    prop
+                  }
+                }
+              }
+            },
+          },
+          Flatten(path: "t.u") {
+            Fetch(service: "Subgraph1") {
+              {
+                ... on U {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on U {
+                  field(a: $contextualArgument_1_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+    /* TODO: Port
+    expect((plan as any).node.nodes[3].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['..', '... on T', 'a', 'b', 'c', 'prop'],
+        renameKeyTo: 'contextualArgument_1_0',
+      },
+    ]);
+    */
+    todo!("See the comment above")
+}
+
+#[test]
+fn set_context_test_before_key_resolution_transition() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Query {
+          customer: Customer!
+        }
+
+        type Identifiers @key(fields: "id") {
+          id: ID!
+          legacyUserId: ID!
+        }
+
+        type Customer @key(fields: "id") {
+          id: ID!
+          child: Child!
+          identifiers: Identifiers!
+        }
+
+        type Child @key(fields: "id") {
+          id: ID!
+        }
+        "#,
+        Subgraph2: r#"
+        type Customer @key(fields: "id") @context(name: "ctx") {
+          id: ID!
+          identifiers: Identifiers! @external
+        }
+
+        type Identifiers @key(fields: "id") {
+          id: ID!
+          legacyUserId: ID! @external
+        }
+
+        type Child @key(fields: "id") {
+          id: ID!
+          prop(
+            legacyUserId: ID
+              @fromContext(field: "$ctx { identifiers { legacyUserId } }")
+          ): String
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        query {
+          customer {
+            child {
+              id
+              prop
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "subgraph1") {
+            {
+              customer {
+                __typename
+                identifiers {
+                  legacyUserId
+                }
+                child {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Flatten(path: "customer.child") {
+            Fetch(service: "subgraph2") {
+              {
+                ... on Child {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Child {
+                  prop(legacyUserId: $contextualArgument_2_0)
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+}
+
+#[test]
+fn set_context_test_efficiently_merge_fetch_groups() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Identifiers @key(fields: "id") {
+          id: ID!
+          id2: ID @external
+          id3: ID @external
+          wid: ID @requires(fields: "id2 id3")
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          customer: Customer
+        }
+
+        type Customer @key(fields: "id") {
+          id: ID!
+          identifiers: Identifiers
+          mid: ID
+        }
+
+        type Identifiers @key(fields: "id") {
+          id: ID!
+          id2: ID
+          id3: ID
+          id5: ID
+        }
+        "#,
+        Subgraph3: r#"
+        type Customer @key(fields: "id") @context(name: "retailCtx") {
+          accounts: Accounts @shareable
+          id: ID!
+          mid: ID @external
+          identifiers: Identifiers @external
+        }
+
+        type Identifiers @key(fields: "id") {
+          id: ID!
+          id5: ID @external
+        }
+        type Accounts @key(fields: "id") {
+          foo(
+            randomInput: String
+            ctx_id5: ID
+              @fromContext(field: "$retailCtx { identifiers { id5 } }")
+            ctx_mid: ID @fromContext(field: "$retailCtx { mid }")
+          ): Foo
+          id: ID!
+        }
+
+        type Foo {
+          id: ID
+        }
+        "#,
+        Subgraph4: r#"
+        type Customer
+          @key(fields: "id", resolvable: false)
+          @context(name: "widCtx") {
+          accounts: Accounts @shareable
+          id: ID!
+          identifiers: Identifiers @external
+        }
+
+        type Identifiers @key(fields: "id", resolvable: false) {
+          id: ID!
+          wid: ID @external # @requires(fields: "id2 id3")
+        }
+
+        type Accounts @key(fields: "id") {
+          bar(
+            ctx_wid: ID @fromContext(field: "$widCtx { identifiers { wid } }")
+          ): Bar
+
+          id: ID!
+        }
+
+        type Bar {
+          id: ID
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+        query {
+          customer {
+            accounts {
+              foo {
+                id
+              }
+            }
+          }
+        }
+        "#,
+        @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "sg2") {
+            {
+              customer {
+                __typename
+                id
+                identifiers {
+                  id5
+                }
+                mid
+              }
+            }
+          },
+          Flatten(path: "customer") {
+            Fetch(service: "sg3") {
+              {
+                ... on Customer {
+                  __typename
+                  id
+                }
+              } =>
+              {
+                ... on Customer {
+                  accounts {
+                    foo(ctx_id5: $contextualArgument_3_0, ctx_mid: $contextualArgument_3_1) {
+                      id
+                    }
+                  }
+                }
+              }
+            },
+          },
+        },
+      }
+        "###
+    );
+    /* TODO: Port
+    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
+      {
+        kind: 'KeyRenamer',
+        path: ['identifiers', 'id5'],
+        renameKeyTo: 'contextualArgument_3_0',
+      },
+      {
+        kind: 'KeyRenamer',
+        path: ['mid'],
+        renameKeyTo: 'contextualArgument_3_1',
+      },
+    ]);
+    */
+    todo!("See the comment above")
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_required_field_is_several_levels_deep_going_back_and_forth_between_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_required_field_is_several_levels_deep_going_back_and_forth_between_subgraphs.graphql
@@ -1,0 +1,110 @@
+# Composed from subgraphs with hash: f1dd07e720398727750d4546a6c36b1ee83e38d0
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  b: B! @join__field(graph: SUBGRAPH1, external: true) @join__field(graph: SUBGRAPH2)
+}
+
+type B
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  c: C! @join__field(graph: SUBGRAPH1)
+}
+
+type C
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  prop: String!
+}
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  randomId: ID! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  a: A!
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  b: String!
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " { a { b { c { prop }}} }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_accesses_a_different_top_level_query.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_accesses_a_different_top_level_query.graphql
@@ -1,0 +1,87 @@
+# Composed from subgraphs with hash: ccebd26247c9c39723f64c9ed99609619a002604
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Product
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  price: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__topLevelQuery", name: "locale", type: "String", selection: " { me { locale } }"}])
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @context(name: "Subgraph1__topLevelQuery")
+{
+  me: User! @join__field(graph: SUBGRAPH1)
+  product: Product @join__field(graph: SUBGRAPH1)
+  randomId: ID! @join__field(graph: SUBGRAPH2)
+}
+
+type User
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  locale: String!
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_before_key_resolution_transition.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_before_key_resolution_transition.graphql
@@ -1,0 +1,95 @@
+# Composed from subgraphs with hash: 70f79d57f189ed5847e652ef9fa7c60603f2d639
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Child
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  prop: String @join__field(graph: SUBGRAPH2, contextArguments: [{context: "Subgraph2__ctx", name: "legacyUserId", type: "ID", selection: " { identifiers { legacyUserId } }"}])
+}
+
+scalar context__ContextFieldValue
+
+type Customer
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @context(name: "Subgraph2__ctx")
+{
+  id: ID!
+  child: Child! @join__field(graph: SUBGRAPH1)
+  identifiers: Identifiers! @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
+}
+
+type Identifiers
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  legacyUserId: ID! @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  customer: Customer! @join__field(graph: SUBGRAPH1)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_efficiently_merge_fetch_groups.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_efficiently_merge_fetch_groups.graphql
@@ -1,0 +1,120 @@
+# Composed from subgraphs with hash: 753d6866862484ee27a265b4f2f2f9d4e0c97b03
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Accounts
+  @join__type(graph: SUBGRAPH3, key: "id")
+  @join__type(graph: SUBGRAPH4, key: "id")
+{
+  foo(randomInput: String): Foo @join__field(graph: SUBGRAPH3, contextArguments: [{context: "Subgraph3__retailCtx", name: "ctx_id5", type: "ID", selection: " { identifiers { id5 } }"}, {context: "Subgraph3__retailCtx", name: "ctx_mid", type: "ID", selection: " { mid }"}])
+  id: ID!
+  bar: Bar @join__field(graph: SUBGRAPH4, contextArguments: [{context: "Subgraph4__widCtx", name: "ctx_wid", type: "ID", selection: " { identifiers { wid } }"}])
+}
+
+type Bar
+  @join__type(graph: SUBGRAPH4)
+{
+  id: ID
+}
+
+scalar context__ContextFieldValue
+
+type Customer
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+  @join__type(graph: SUBGRAPH4, key: "id", resolvable: false)
+  @context(name: "Subgraph3__retailCtx")
+  @context(name: "Subgraph4__widCtx")
+{
+  id: ID!
+  identifiers: Identifiers @join__field(graph: SUBGRAPH2) @join__field(graph: SUBGRAPH3, external: true) @join__field(graph: SUBGRAPH4, external: true)
+  mid: ID @join__field(graph: SUBGRAPH2) @join__field(graph: SUBGRAPH3, external: true)
+  accounts: Accounts @join__field(graph: SUBGRAPH3) @join__field(graph: SUBGRAPH4)
+}
+
+type Foo
+  @join__type(graph: SUBGRAPH3)
+{
+  id: ID
+}
+
+type Identifiers
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+  @join__type(graph: SUBGRAPH4, key: "id", resolvable: false)
+{
+  id: ID!
+  id2: ID @join__field(graph: SUBGRAPH1, external: true) @join__field(graph: SUBGRAPH2)
+  id3: ID @join__field(graph: SUBGRAPH1, external: true) @join__field(graph: SUBGRAPH2)
+  wid: ID @join__field(graph: SUBGRAPH1, requires: "id2 id3") @join__field(graph: SUBGRAPH4, external: true)
+  id5: ID @join__field(graph: SUBGRAPH2) @join__field(graph: SUBGRAPH3, external: true)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+  SUBGRAPH4 @join__graph(name: "Subgraph4", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+  @join__type(graph: SUBGRAPH4)
+{
+  customer: Customer @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_fetched_as_a_list.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_fetched_as_a_list.graphql
@@ -1,0 +1,88 @@
+# Composed from subgraphs with hash: 8b81d5086b71ff9fb618f2d250eec4b47f7a1d04
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: [T]! @join__field(graph: SUBGRAPH1)
+  a: Int! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  b: String! @join__field(graph: SUBGRAPH1)
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " { prop }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_impacts_on_query_planning.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_impacts_on_query_planning.graphql
@@ -1,0 +1,106 @@
+# Composed from subgraphs with hash: 173623d59b042e5f8dcf81f5c08880ad2d2d3ccb
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type B implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+scalar context__ContextFieldValue
+
+interface I
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: I! @join__field(graph: SUBGRAPH1)
+  a: Int! @join__field(graph: SUBGRAPH2)
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  b: String! @join__field(graph: SUBGRAPH1)
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " { prop }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_variable_is_a_list.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_variable_is_a_list.graphql
@@ -1,0 +1,87 @@
+# Composed from subgraphs with hash: 1a8895fe791cc7cd69ace02dc95527034d7d864f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  a: Int! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  prop: [String]!
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "[String]", selection: " { prop }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_variable_is_already_in_a_different_fetch_group.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_variable_is_already_in_a_different_fetch_group.graphql
@@ -1,0 +1,88 @@
+# Composed from subgraphs with hash: 295947c45a4fbf129c3112e24611d04c40619c86
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  a: Int! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @context(name: "Subgraph2__context")
+{
+  id: ID!
+  u: U! @join__field(graph: SUBGRAPH1)
+  prop: String! @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  field: Int! @join__field(graph: SUBGRAPH2, contextArguments: [{context: "Subgraph2__context", name: "a", type: "String", selection: " { prop }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_variable_is_from_different_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_variable_is_from_different_subgraph.graphql
@@ -1,0 +1,88 @@
+# Composed from subgraphs with hash: a1eeaafd2a79733109742acf5e08df586d1358b0
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  a: Int! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U! @join__field(graph: SUBGRAPH1)
+  prop: String! @join__field(graph: SUBGRAPH1, external: true) @join__field(graph: SUBGRAPH2)
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " { prop }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_variable_is_from_same_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_variable_is_from_same_subgraph.graphql
@@ -1,0 +1,88 @@
+# Composed from subgraphs with hash: 2de3c6cc9b36392a362af0d19e03688085e2119b
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  a: Int! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  b: String! @join__field(graph: SUBGRAPH1)
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " { prop }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_test_with_type_conditions_for_union.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_test_with_type_conditions_for_union.graphql
@@ -1,0 +1,102 @@
+# Composed from subgraphs with hash: 0981934ba0944ccff6a8c554bef807ca905ad13a
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type B
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  a: Int! @join__field(graph: SUBGRAPH2)
+}
+
+union T
+  @join__type(graph: SUBGRAPH1)
+  @join__unionMember(graph: SUBGRAPH1, member: "A")
+  @join__unionMember(graph: SUBGRAPH1, member: "B")
+  @context(name: "Subgraph1__context")
+ = A | B
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  b: String! @join__field(graph: SUBGRAPH1)
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " ... on A { prop } ... on B { prop }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/set_context_variable_is_a_list.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/set_context_variable_is_a_list.graphql
@@ -1,0 +1,87 @@
+# Composed from subgraphs with hash: 493d78ea411e0726dbfcd63da1534851ed24438d
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  randomId: ID! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  b: String!
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " { prop }"}])
+}

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_demand_control_directive_name_conflicts.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_demand_control_directive_name_conflicts.snap
@@ -42,6 +42,10 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
+directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
+
 scalar link__Import
 
 enum link__Purpose {
@@ -111,6 +115,10 @@ directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD
 directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
 
 scalar link__Import
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_renamed_demand_control_directive_name_conflicts.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_renamed_demand_control_directive_name_conflicts.snap
@@ -42,6 +42,10 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
+directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
+
 scalar link__Import
 
 enum link__Purpose {
@@ -111,6 +115,10 @@ directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD
 directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
 
 scalar link__Import
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_demand_control_directives.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_demand_control_directives.snap
@@ -42,6 +42,10 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
+directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
+
 scalar link__Import
 
 enum link__Purpose {
@@ -131,6 +135,10 @@ directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD
 directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
 
 scalar link__Import
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_renamed_demand_control_directives.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_renamed_demand_control_directives.snap
@@ -42,6 +42,10 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
+directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
+
 scalar link__Import
 
 enum link__Purpose {
@@ -131,6 +135,10 @@ directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD
 directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
 
 scalar link__Import
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_set_context_directives.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_set_context_directives.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/extract_subgraphs.rs
 expression: snapshot
 ---
-Subgraph1: https://Subgraph1
+Subgraph1
 ---
 schema {
   query: Query
@@ -64,20 +64,23 @@ scalar federation__FieldSet
 scalar federation__Scope
 
 type Query {
-  t: T
+  t: T!
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service!
 }
 
-type S {
-  x: Int
+type T @federation__key(fields: "id", resolvable: true) @federation__context(name: "context") {
+  id: ID!
+  u: U!
+  prop: String!
 }
 
-type T @federation__key(fields: "k", resolvable: true) {
-  k: ID @federation__shareable
+type U @federation__key(fields: "id", resolvable: true) {
+  id: ID! @federation__shareable
+  field(
+    a: String @federation__fromContext(field: "$context { prop }"),
+  ): Int!
 }
-
-union U = S | T
 
 scalar _Any
 
@@ -85,9 +88,9 @@ type _Service {
   sdl: String
 }
 
-union _Entity = T
+union _Entity = T | U
 
-Subgraph2: https://Subgraph2
+Subgraph2
 ---
 schema {
   query: Query
@@ -148,15 +151,14 @@ scalar federation__FieldSet
 
 scalar federation__Scope
 
-enum E {
-  V1
-  V2
+type Query {
+  a: Int!
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
 }
 
-type T @federation__key(fields: "k", resolvable: true) {
-  k: ID @federation__shareable
-  a: Int
-  b: String
+type U @federation__key(fields: "id", resolvable: true) {
+  id: ID! @federation__shareable
 }
 
 scalar _Any
@@ -165,9 +167,4 @@ type _Service {
   sdl: String
 }
 
-union _Entity = T
-
-type Query {
-  _entities(representations: [_Any!]!): [_Entity]!
-  _service: _Service!
-}
+union _Entity = U

--- a/apollo-router/src/query_planner/convert.rs
+++ b/apollo-router/src/query_planner/convert.rs
@@ -324,6 +324,7 @@ impl From<&'_ next::FetchDataPathElement> for crate::json_ext::PathElement {
                 })
             }
             next::FetchDataPathElement::TypenameEquals(value) => Self::Fragment(value.to_string()),
+            next::FetchDataPathElement::Parent => Self::Key("..".to_owned(), None),
         }
     }
 }


### PR DESCRIPTION
This PR adds a macro to perform the assertions necessary for checking the `FetchDataRewrite::Rename` nodes in the `@context` snapshot tests.