### PR TITLE
fix(cors): don't ignore invalid configuration

### DIFF
--- a/docs/source/reference/migration/from-router-v1.mdx
+++ b/docs/source/reference/migration/from-router-v1.mdx
@@ -58,6 +58,11 @@ telemetry:
     metrics_reference_mode: standard
 ```
 
+### Check CORS configuration
+
+If you already configured [CORS](../../routing/security/cors) on the router, the configuration won't change but with v1.x it accepted bad configuration and displayed an error log when some header names or regexes were invalid.
+With v2.x it will end up with an error and it won't start at all to avoid confusions and misconfigurations.
+
 ### Deploy your router
 
 Make sure that you are referencing the correct router release: **v2.0.0-preview.0**


### PR DESCRIPTION
Various invalid CORS configuration values were ignored, with an error logged. For example, providing an invalid regex to `match_origins`, or an unknown method to `allow_methods`. These are now hard errors and you can't start the router if you have invalid configuration.


<!-- [ROUTER-826] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-826]: https://apollographql.atlassian.net/browse/ROUTER-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ