### PR TITLE
extract context onto interface and union

### DIFF
--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -9,11 +9,13 @@ use std::sync::atomic;
 use std::sync::Arc;
 
 use apollo_compiler::ast::InputValueDefinition;
+use apollo_compiler::ast::NamedType;
 use apollo_compiler::ast::Type;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::Argument;
+use apollo_compiler::schema::ComponentName;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
@@ -1708,45 +1710,69 @@ where
                     if !was_unsatisfied && !context_map.contains_key(&ctx.named_parameter) {
                         if let Some(parent_type) = parent_type {
                             let parent_type = parent_type.parent();
-                            let subgraph_schema = self.graph.schema_by_source(&ctx.subgraph_name)?;
-                            let matches = ctx.types_with_context_set.iter().any(|pos| {
-                                if (pos.type_name() == parent_type.type_name()) {
-                                    return true;
+                            let subgraph_schema =
+                                self.graph.schema_by_source(&ctx.subgraph_name)?;
+                            let mut potential_matches: IndexSet<Name> = Default::default();
+                            ctx.types_with_context_set.iter().for_each(|pos| {
+                                if pos.type_name() == parent_type.type_name() {
+                                    potential_matches.insert(parent_type.type_name().clone());
+                                    ()
                                 }
                                 match &pos {
                                     CompositeTypeDefinitionPosition::Object(obj_pos) => {
                                         if let Ok(obj) = obj_pos.get(subgraph_schema.schema()) {
-                                            if let Some(_) =
-                                                obj.implements_interfaces.get(pos.type_name())
-                                            {
-                                                return true;
-                                            }
+                                            obj.implements_interfaces
+                                                .iter()
+                                                .filter(|item| {
+                                                    &item.name == parent_type.type_name()
+                                                })
+                                                .for_each(|item| {
+                                                    potential_matches.insert(item.name.clone());
+                                                });
                                         }
                                     }
                                     CompositeTypeDefinitionPosition::Interface(iface_pos) => {
                                         if let Ok(iface) = iface_pos.get(subgraph_schema.schema()) {
-                                            if iface.implements_interfaces.iter().any(|item| &item.name == parent_type.type_name()) {
-                                                return true;
-                                            }
+                                            iface
+                                                .implements_interfaces
+                                                .iter()
+                                                .filter(|item| {
+                                                    &item.name == parent_type.type_name()
+                                                })
+                                                .for_each(|item| {
+                                                    potential_matches.insert(iface.name.clone());
+                                                });
                                         }
                                     }
                                     CompositeTypeDefinitionPosition::Union(union_pos) => {
                                         if let Ok(un) = union_pos.get(subgraph_schema.schema()) {
-                                            if un.members.iter().any(|item| &item.name == parent_type.type_name()) {
-                                                return true;
-                                            }
+                                            un.members
+                                                .iter()
+                                                .filter(|item| {
+                                                    &item.name == parent_type.type_name()
+                                                })
+                                                .for_each(|item| {
+                                                    potential_matches.insert(un.name.clone());
+                                                });
                                         }
                                     }
                                 }
-                                false
+                                ()
                             });
-                            if matches {
-                                let selection_set = parse_field_set(
-                                    subgraph_schema,
-                                    parent_type.type_name().clone(),
-                                    &ctx.selection,
-                                )?
-                                .lazy_map(
+                            
+                            // get the selection set for the first match that parses
+                            let selection_set =
+                                potential_matches.iter().find_map(|parent_type_name| {
+                                    parse_field_set(
+                                        subgraph_schema,
+                                        parent_type_name.clone(),
+                                        &ctx.selection,
+                                    )
+                                    .ok()
+                                });
+
+                            if let Some(selection_set) = selection_set {
+                                selection_set.lazy_map(
                                     &NamedFragments::default(),
                                     |selection| {
                                         if let OpPathElement::InlineFragment(fragment) =
@@ -1805,6 +1831,8 @@ where
                                         was_unsatisfied = true
                                     }
                                 }
+                            } else {
+                                internal_error!("Could not parse selection {} over any types {:?}", &ctx.selection, potential_matches);
                             }
                         }
                     }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -1000,7 +1000,7 @@ fn extract_interface_type_content(
                 }
             }
         }
-                
+        
         let context = supergraph_schema
             .metadata()
             .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -47,6 +47,7 @@ pub use self::subgraph::ValidFederationSubgraphs;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
+use crate::internal_error;
 use crate::link::context_spec_definition::CONTEXT_VERSIONS;
 use crate::link::cost_spec_definition::CostSpecDefinition;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
@@ -302,6 +303,7 @@ fn extract_subgraphs_from_fed_2_supergraph(
         supergraph_schema,
         subgraphs,
         graph_enum_value_name_to_subgraph_name,
+        federation_spec_definitions,
         join_spec_definition,
         &union_types,
     )?;
@@ -762,61 +764,15 @@ fn extract_object_type_content(
         }
 
         if let Some((_context_spec_def, name_in_supergraph)) = &context {
-            for directive in type_.directives.get_all(name_in_supergraph.as_str()) {
-                FederationSpecDefinition::context_directive_arguments(directive).and_then(
-                    |context_name| {
-                        let mut arr = context_name.name.split("__");
-                        let subgraph_name = arr.next().ok_or_else(|| {
-                            SingleFederationError::InvalidFederationSupergraph {
-                                message: format!(
-                                    "Could not parse context name from supergraph '{}'",
-                                    name_in_supergraph
-                                )
-                                .to_owned(),
-                            }
-                        })?;
-                        let subgraph_name = Name::new(subgraph_name)?;
-                        let subgraph_index = get_index_from_subgraph_name(
-                            graph_enum_value_name_to_subgraph_name,
-                            &subgraph_name,
-                        )
-                        .ok_or_else(|| {
-                            SingleFederationError::InvalidSubgraph {
-                                message: format!(
-                                    "Could not look up subgraph by name '{}'",
-                                    subgraph_name
-                                )
-                                .to_owned(),
-                            }
-                        })?;
-                        let subgraph = get_subgraph(
-                            subgraphs,
-                            graph_enum_value_name_to_subgraph_name,
-                            subgraph_index,
-                        )?;
-
-                        let federation_spec_definition = federation_spec_definitions
-                            .get(subgraph_index)
-                            .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
-                                message: "Subgraph unexpectedly does not use federation spec"
-                                    .to_owned(),
-                            })?;
-                        let context_in_subgraph = arr.last().ok_or_else(|| {
-                            SingleFederationError::InvalidFederationSupergraph {
-                                message: format!(
-                                    "Could not parse context name from supergraph '{}'",
-                                    name_in_supergraph
-                                )
-                                .to_owned(),
-                            }
-                        })?;
-                        let context_directive = federation_spec_definition
-                            .context_directive(&subgraph.schema, context_in_subgraph.to_string())?;
-                        pos.insert_directive(&mut subgraph.schema, context_directive.into())?;
-                        Ok(())
-                    },
-                )?;
-            }
+            apply_context_to_type(
+                type_,
+                supergraph_schema,
+                subgraphs,
+                graph_enum_value_name_to_subgraph_name,
+                federation_spec_definitions,
+                name_in_supergraph,
+                &CompositeTypeDefinitionPosition::Object(pos.clone()),
+            );
         }
 
         for graph_enum_value in subgraph_info.keys() {
@@ -962,10 +918,10 @@ fn extract_interface_type_content(
         subgraph_info,
     } in info.iter()
     {
-        let type_ = InterfaceTypeDefinitionPosition {
+        let pos = InterfaceTypeDefinitionPosition {
             type_name: (*type_name).clone(),
-        }
-        .get(supergraph_schema.schema())?;
+        };
+        let type_ = pos.get(supergraph_schema.schema())?;
         fn get_pos(
             subgraph: &FederationSubgraph,
             subgraph_info: &IndexMap<Name, bool>,
@@ -1043,6 +999,28 @@ fn extract_interface_type_content(
                     )?;
                 }
             }
+        }
+                
+        let context = supergraph_schema
+            .metadata()
+            .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))
+            .and_then(|context_link| CONTEXT_VERSIONS.find(&context_link.url.version))
+            .and_then(|context_spec_def| {
+                context_spec_def
+                    .context_directive_name_in_schema(supergraph_schema)
+                    .ok()
+                    .map(|name_in_schema| (context_spec_def, name_in_schema))
+            });
+        if let Some((_context_spec_def, name_in_supergraph)) = &context {
+            apply_context_to_type(
+                type_,
+                supergraph_schema,
+                subgraphs,
+                graph_enum_value_name_to_subgraph_name,
+                federation_spec_definitions,
+                name_in_supergraph,
+                &CompositeTypeDefinitionPosition::Interface(pos.clone()),
+            );
         }
 
         for (field_name, field) in type_.fields.iter() {
@@ -1138,6 +1116,7 @@ fn extract_union_type_content(
     supergraph_schema: &FederationSchema,
     subgraphs: &mut FederationSubgraphs,
     graph_enum_value_name_to_subgraph_name: &IndexMap<Name, Arc<str>>,
+    federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
 ) -> Result<(), FederationError> {
@@ -1220,6 +1199,29 @@ fn extract_union_type_content(
                     ComponentName::from(Name::new(union_member_directive_application.member)?),
                 )?;
             }
+        }
+
+        let context = supergraph_schema
+            .metadata()
+            .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))
+            .and_then(|context_link| CONTEXT_VERSIONS.find(&context_link.url.version))
+            .and_then(|context_spec_def| {
+                context_spec_def
+                    .context_directive_name_in_schema(supergraph_schema)
+                    .ok()
+                    .map(|name_in_schema| (context_spec_def, name_in_schema))
+            });
+
+        if let Some((_context_spec_def, name_in_supergraph)) = &context {
+            apply_context_to_type(
+                type_,
+                supergraph_schema,
+                subgraphs,
+                graph_enum_value_name_to_subgraph_name,
+                federation_spec_definitions,
+                name_in_supergraph,
+                &CompositeTypeDefinitionPosition::Union(pos.clone()),
+            );
         }
     }
 
@@ -1694,6 +1696,140 @@ lazy_static! {
         .into_iter()
         .collect()
     };
+}
+
+trait CompositeType {
+    fn directives(&self) -> &DirectiveList;
+    fn insert_directive(
+        &self,
+        schema: &mut FederationSchema,
+        pos: &CompositeTypeDefinitionPosition,
+        directive: Component<Directive>,
+    ) -> Result<(), FederationError>;
+}
+
+impl CompositeType for UnionType {
+    fn directives(&self) -> &DirectiveList {
+        &self.directives
+    }
+    fn insert_directive(
+        &self,
+        schema: &mut FederationSchema,
+        pos: &CompositeTypeDefinitionPosition,
+        directive: Component<Directive>,
+    ) -> Result<(), FederationError> {
+        match pos {
+            CompositeTypeDefinitionPosition::Union(pos) => {
+                pos.insert_directive(schema, directive.into())?;
+                return Ok(());
+            }
+            _ => Err(internal_error!("an error")),
+        }
+    }
+}
+
+impl CompositeType for ObjectType {
+    fn directives(&self) -> &DirectiveList {
+        &self.directives
+    }
+    fn insert_directive(
+        &self,
+        schema: &mut FederationSchema,
+        pos: &CompositeTypeDefinitionPosition,
+        directive: Component<Directive>,
+    ) -> Result<(), FederationError> {
+        match pos {
+            CompositeTypeDefinitionPosition::Object(pos) => {
+                pos.insert_directive(schema, directive.into())?;
+                Ok(())
+            }
+            _ => Err(internal_error!("an error")),
+        }
+    }
+}
+
+impl CompositeType for InterfaceType {
+    fn directives(&self) -> &DirectiveList {
+        &self.directives
+    }
+    fn insert_directive(
+        &self,
+        schema: &mut FederationSchema,
+        pos: &CompositeTypeDefinitionPosition,
+        directive: Component<Directive>,
+    ) -> Result<(), FederationError> {
+        match pos {
+            CompositeTypeDefinitionPosition::Interface(pos) => {
+                pos.insert_directive(schema, directive.into())?;
+                Ok(())
+            }
+            _ => Err(internal_error!("an error")),
+        }
+    }
+}
+
+fn apply_context_to_type<T>(
+    ty: &Node<T>,
+    supergraph_schema: &FederationSchema,
+    subgraphs: &mut FederationSubgraphs,
+    graph_enum_value_name_to_subgraph_name: &IndexMap<Name, Arc<str>>,
+    federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
+    context_name_in_supergraph: &Name,
+    pos: &CompositeTypeDefinitionPosition,
+) -> Result<(), FederationError>
+where
+    T: CompositeType,
+{
+    for directive in ty.directives().get_all(context_name_in_supergraph.as_str()) {
+        FederationSpecDefinition::context_directive_arguments(directive).and_then(
+            |context_name| {
+                let mut arr = context_name.name.split("__");
+                let subgraph_name = arr.next().ok_or_else(|| {
+                    SingleFederationError::InvalidFederationSupergraph {
+                        message: format!(
+                            "Could not parse context name from supergraph '{}'",
+                            context_name_in_supergraph
+                        )
+                        .to_owned(),
+                    }
+                })?;
+                let subgraph_name = Name::new(subgraph_name)?;
+                let subgraph_index = get_index_from_subgraph_name(
+                    graph_enum_value_name_to_subgraph_name,
+                    &subgraph_name,
+                )
+                .ok_or_else(|| SingleFederationError::InvalidSubgraph {
+                    message: format!("Could not look up subgraph by name '{}'", subgraph_name)
+                        .to_owned(),
+                })?;
+                let subgraph = get_subgraph(
+                    subgraphs,
+                    graph_enum_value_name_to_subgraph_name,
+                    subgraph_index,
+                )?;
+
+                let federation_spec_definition = federation_spec_definitions
+                    .get(subgraph_index)
+                    .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
+                        message: "Subgraph unexpectedly does not use federation spec".to_owned(),
+                    })?;
+                let context_in_subgraph = arr.last().ok_or_else(|| {
+                    SingleFederationError::InvalidFederationSupergraph {
+                        message: format!(
+                            "Could not parse context name from supergraph '{}'",
+                            context_name_in_supergraph
+                        )
+                        .to_owned(),
+                    }
+                })?;
+                let context_directive = federation_spec_definition
+                    .context_directive(&subgraph.schema, context_in_subgraph.to_string())?;
+                ty.insert_directive(&mut subgraph.schema, pos, context_directive.into())?;
+                Ok(())
+            },
+        )?;
+    }
+    Ok(())
 }
 
 fn remove_unused_types_from_subgraph(schema: &mut FederationSchema) -> Result<(), FederationError> {

--- a/apollo-federation/src/supergraph/schema.rs
+++ b/apollo-federation/src/supergraph/schema.rs
@@ -101,7 +101,7 @@ pub(crate) fn new_empty_fed_2_subgraph_schema() -> Result<FederationSchema, Fede
 
     directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
 
-    directive @federation__context(name: String) repeatable on INTERFACE | OBJECT
+    directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
     
     scalar federation__FieldSet
 

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
@@ -338,33 +338,33 @@ fn set_context_test_variable_is_already_in_a_different_fetch_group() {
         "###
     );
     match plan.node {
-      Some(TopLevelPlanNode::Sequence(node)) => match node.nodes.get(1) {
-          Some(PlanNode::Flatten(node)) => match &*node.node {
-              PlanNode::Fetch(node) => {
-                  assert_eq!(
-                      node.context_rewrites,
-                      vec![Arc::new(FetchDataRewrite::KeyRenamer(
-                          FetchDataKeyRenamer {
-                              rename_key_to: Name::new("contextualArgument__Subgraph2_0")
-                                  .unwrap(),
-                              path: vec![
-                                  FetchDataPathElement::Parent,
-                                  FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
-                                  FetchDataPathElement::Key(
-                                      Name::new("prop").unwrap(),
-                                      Default::default()
-                                  ),
-                              ],
-                          }
-                      )),]
-                  );
-              }
-              _ => assert!(false, "failed to get fetch node"),
-          },
-          _ => assert!(false, "failed to get flatten node"),
-      },
-      _ => assert!(false, "failed to get sequence node"),
-  }
+        Some(TopLevelPlanNode::Sequence(node)) => match node.nodes.get(1) {
+            Some(PlanNode::Flatten(node)) => match &*node.node {
+                PlanNode::Fetch(node) => {
+                    assert_eq!(
+                        node.context_rewrites,
+                        vec![Arc::new(FetchDataRewrite::KeyRenamer(
+                            FetchDataKeyRenamer {
+                                rename_key_to: Name::new("contextualArgument__Subgraph2_0")
+                                    .unwrap(),
+                                path: vec![
+                                    FetchDataPathElement::Parent,
+                                    FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
+                                    FetchDataPathElement::Key(
+                                        Name::new("prop").unwrap(),
+                                        Default::default()
+                                    ),
+                                ],
+                            }
+                        )),]
+                    );
+                }
+                _ => assert!(false, "failed to get fetch node"),
+            },
+            _ => assert!(false, "failed to get flatten node"),
+        },
+        _ => assert!(false, "failed to get sequence node"),
+    }
 }
 
 #[test]
@@ -491,33 +491,33 @@ fn set_context_test_fetched_as_a_list() {
         "###
     );
     match plan.node {
-      Some(TopLevelPlanNode::Sequence(node)) => match node.nodes.get(1) {
-          Some(PlanNode::Flatten(node)) => match &*node.node {
-              PlanNode::Fetch(node) => {
-                  assert_eq!(
-                      node.context_rewrites,
-                      vec![Arc::new(FetchDataRewrite::KeyRenamer(
-                          FetchDataKeyRenamer {
-                              rename_key_to: Name::new("contextualArgument__Subgraph1_0")
-                                  .unwrap(),
-                              path: vec![
-                                  FetchDataPathElement::Parent,
-                                  FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
-                                  FetchDataPathElement::Key(
-                                      Name::new("prop").unwrap(),
-                                      Default::default()
-                                  ),
-                              ],
-                          }
-                      )),]
-                  );
-              }
-              _ => assert!(false, "failed to get fetch node"),
-          },
-          _ => assert!(false, "failed to get flatten node"),
-      },
-      _ => assert!(false, "failed to get sequence node"),
-  }
+        Some(TopLevelPlanNode::Sequence(node)) => match node.nodes.get(1) {
+            Some(PlanNode::Flatten(node)) => match &*node.node {
+                PlanNode::Fetch(node) => {
+                    assert_eq!(
+                        node.context_rewrites,
+                        vec![Arc::new(FetchDataRewrite::KeyRenamer(
+                            FetchDataKeyRenamer {
+                                rename_key_to: Name::new("contextualArgument__Subgraph1_0")
+                                    .unwrap(),
+                                path: vec![
+                                    FetchDataPathElement::Parent,
+                                    FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
+                                    FetchDataPathElement::Key(
+                                        Name::new("prop").unwrap(),
+                                        Default::default()
+                                    ),
+                                ],
+                            }
+                        )),]
+                    );
+                }
+                _ => assert!(false, "failed to get fetch node"),
+            },
+            _ => assert!(false, "failed to get flatten node"),
+        },
+        _ => assert!(false, "failed to get sequence node"),
+    }
 }
 
 #[test]
@@ -668,7 +668,7 @@ fn set_context_test_with_type_conditions_for_union() {
         "#,
     );
 
-    assert_plan!(planner,
+    let plan = assert_plan!(planner,
         r#"
         {
           t {
@@ -734,21 +734,48 @@ fn set_context_test_with_type_conditions_for_union() {
       }
         "###
     );
-    /* TODO: Port
-    expect((plan as any).node.nodes[1].node.contextRewrites).toEqual([
-      {
-        kind: 'KeyRenamer',
-        path: ['..', '... on A', 'prop'],
-        renameKeyTo: 'contextualArgument_1_0',
+    match plan.node {
+      Some(TopLevelPlanNode::Sequence(node)) => match node.nodes.get(1) {
+          Some(PlanNode::Flatten(node)) => match &*node.node {
+              PlanNode::Fetch(node) => {
+                  assert_eq!(
+                      node.context_rewrites,
+                      vec![Arc::new(FetchDataRewrite::KeyRenamer(
+                          FetchDataKeyRenamer {
+                              rename_key_to: Name::new("contextualArgument__Subgraph1_0")
+                                  .unwrap(),
+                              path: vec![
+                                  FetchDataPathElement::Parent,
+                                  FetchDataPathElement::TypenameEquals(Name::new("A").unwrap()),
+                                  FetchDataPathElement::Key(
+                                      Name::new("prop").unwrap(),
+                                      Default::default()
+                                  ),
+                              ],
+                          }
+                      )),
+                      Arc::new(FetchDataRewrite::KeyRenamer(
+                        FetchDataKeyRenamer {
+                            rename_key_to: Name::new("contextualArgument__Subgraph1_0")
+                                .unwrap(),
+                            path: vec![
+                                FetchDataPathElement::Parent,
+                                FetchDataPathElement::TypenameEquals(Name::new("B").unwrap()),
+                                FetchDataPathElement::Key(
+                                    Name::new("prop").unwrap(),
+                                    Default::default()
+                                ),
+                            ],
+                        }
+                    )),]
+                  );
+              }
+              _ => assert!(false, "failed to get fetch node"),
+          },
+          _ => assert!(false, "failed to get flatten node"),
       },
-      {
-        kind: 'KeyRenamer',
-        path: ['..', '... on B', 'prop'],
-        renameKeyTo: 'contextualArgument_1_0',
-      },
-    ]);
-    */
-    todo!("See the comment above")
+      _ => assert!(false, "failed to get sequence node"),
+  }
 }
 
 #[test]


### PR DESCRIPTION
Refactoring to avoid copypasta as much as possible, though there's still room to improve. Also some changes in can_satisfy_conditions to accomodate union.