### PR TITLE
add `Serialize` to apollo_federation::QueryPlannerConfig

### DIFF
--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -54,7 +54,7 @@ use crate::Supergraph;
 
 pub(crate) const CONTEXT_DIRECTIVE: &str = "context";
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Serialize)]
 pub struct QueryPlannerConfig {
     /// Whether the query planner should try to reuse the named fragments of the planned query in
     /// subgraph fetches.
@@ -117,7 +117,7 @@ impl Default for QueryPlannerConfig {
     }
 }
 
-#[derive(Debug, Clone, Default, Hash)]
+#[derive(Debug, Clone, Default, Hash, Serialize)]
 pub struct QueryPlanIncrementalDeliveryConfig {
     /// Enables `@defer` support in the query planner, breaking up the query plan with [DeferNode]s
     /// as appropriate.
@@ -128,10 +128,11 @@ pub struct QueryPlanIncrementalDeliveryConfig {
     /// Defaults to false.
     ///
     /// [DeferNode]: crate::query_plan::DeferNode
+    #[serde(default)]
     pub enable_defer: bool,
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, Serialize)]
 pub struct QueryPlannerDebugConfig {
     /// If used and the supergraph is built from a single subgraph, then user queries do not go
     /// through the normal query planning and instead a fetch to the one subgraph is built directly

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -56,8 +56,6 @@ pub(crate) const APOLLO_OPERATION_ID: &str = "apollo_operation_id";
 
 #[derive(Debug, Clone, Hash)]
 pub(crate) enum ConfigMode {
-    //FIXME: add the Rust planner structure once it is hashable and serializable,
-    // for now use the JS config as it expected to be identical to the Rust one
     Rust(Arc<apollo_federation::query_plan::query_planner::QueryPlannerConfig>),
     Both(Arc<QueryPlannerConfig>),
     BothBestEffort(Arc<QueryPlannerConfig>),


### PR DESCRIPTION
QueryPlannerConfig is currently missing Serialize implementation that will be eventually needed for the query planner cache once we use only one planner in the Router.

<!-- ROUTER-480-->
