### PR TITLE
Context test correction: `set_context_test_efficiently_merge_fetch_groups`

### DIFF
--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -111,8 +111,11 @@ impl ConditionResolverCache {
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
         excluded_conditions: &ExcludedConditions,
-        // extra_conditions: Option<&SelectionSet>,
+        extra_conditions: Option<&SelectionSet>,
     ) -> ConditionResolutionCacheResult {
+        if extra_conditions.is_some() {
+            return ConditionResolutionCacheResult::NotApplicable
+        }
         // We don't cache if there is a context or excluded conditions because those would impact the resolution and
         // we don't want to cache a value per-context and per-excluded-conditions (we also don't cache per-excluded-edges though
         // instead we cache a value only for the first-see excluded edges; see above why that work in practice).
@@ -171,7 +174,8 @@ mod tests {
                 edge1,
                 &empty_context,
                 &empty_destinations,
-                &empty_conditions
+                &empty_conditions,
+                None
             )
             .is_miss());
 
@@ -186,7 +190,8 @@ mod tests {
                 edge1,
                 &empty_context,
                 &empty_destinations,
-                &empty_conditions
+                &empty_conditions,
+                None
             )
             .is_hit(),);
 
@@ -197,7 +202,8 @@ mod tests {
                 edge2,
                 &empty_context,
                 &empty_destinations,
-                &empty_conditions
+                &empty_conditions,
+                None
             )
             .is_miss());
     }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -1191,7 +1191,7 @@ impl<'a> ConditionResolver for QueryPlanningTraversal<'a, '_> {
             context,
             excluded_destinations,
             excluded_conditions,
-            // extra_conditions,
+            extra_conditions,
         );
 
         if let ConditionResolutionCacheResult::Hit(cached_resolution) = cache_result {


### PR DESCRIPTION
Added `extra_conditions` argument to to `ConditionResolverCache` which was causing error in a snapshot test.