### PR TITLE
Context code clean up

### DIFF
--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -13,18 +13,17 @@
 //! See [Router documentation](https://www.apollographql.com/docs/router/federation-version-support/)
 //! for which Federation versions are supported by which Router versions.
 
-// TODO: Re-add the removed and remove the allowed lints when the context feature is finished.
-#![allow(unused, dead_code, clippy::all)]
-#![warn(
+#![allow(dead_code, clippy::all)]
+#![deny(
     rustdoc::broken_intra_doc_links,
     unreachable_pub,
     unreachable_patterns,
-    // unused,
+    unused,
     unused_qualifications,
-    // dead_code,
+    dead_code,
     while_true,
     unconditional_panic,
-    // clippy::all
+    clippy::all
 )]
 
 mod api_schema;

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -13,8 +13,7 @@
 //! See [Router documentation](https://www.apollographql.com/docs/router/federation-version-support/)
 //! for which Federation versions are supported by which Router versions.
 
-#![allow(dead_code, clippy::all)]
-#![deny(
+#![warn(
     rustdoc::broken_intra_doc_links,
     unreachable_pub,
     unreachable_patterns,

--- a/apollo-federation/src/link/argument.rs
+++ b/apollo-federation/src/link/argument.rs
@@ -8,7 +8,6 @@ use apollo_compiler::Node;
 use crate::bail;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
-use crate::internal_error;
 use crate::link::graphql_definition::BooleanOrVariable;
 
 pub(crate) fn directive_optional_enum_argument(

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -1,13 +1,5 @@
-use apollo_compiler::ast::Argument;
-use apollo_compiler::ast::Directive;
-use apollo_compiler::collections::IndexMap;
 use apollo_compiler::name;
-use apollo_compiler::schema::Component;
-use apollo_compiler::schema::EnumType;
-use apollo_compiler::schema::ObjectType;
-use apollo_compiler::schema::ScalarType;
 use apollo_compiler::Name;
-use apollo_compiler::Node;
 use lazy_static::lazy_static;
 
 use crate::error::FederationError;
@@ -16,101 +8,15 @@ use crate::link::spec::Url;
 use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::link::spec_definition::SpecDefinitions;
-use crate::schema::position::EnumTypeDefinitionPosition;
-use crate::schema::position::ObjectTypeDefinitionPosition;
-use crate::schema::position::ScalarTypeDefinitionPosition;
 use crate::schema::FederationSchema;
 
 pub(crate) const CONTEXT_DIRECTIVE_NAME_IN_SPEC: Name = name!("context");
 pub(crate) const CONTEXT_DIRECTIVE_NAME_DEFAULT: Name = name!("federation__context");
 
-pub(crate) const FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC: Name = name!("fromContext");
-pub(crate) const FROM_CONTEXT_DIRECTIVE_NAME_DEFAULT: Name = name!("federation__fromContext");
-
 #[derive(Clone)]
 pub(crate) struct ContextSpecDefinition {
     url: Url,
     minimum_federation_version: Option<Version>,
-}
-
-macro_rules! propagate_context_directives {
-    ($func_name:ident, $directives_ty:ty, $wrap_ty:expr) => {
-        pub(crate) fn $func_name(
-            &self,
-            subgraph_schema: &FederationSchema,
-            source: &$directives_ty,
-            dest: &mut $directives_ty,
-            original_directive_names: &IndexMap<Name, Name>,
-        ) -> Result<(), FederationError> {
-            let context_directive_name =
-                original_directive_names.get(&CONTEXT_DIRECTIVE_NAME_IN_SPEC);
-            let context_directive =
-                context_directive_name.and_then(|name| source.get(name.as_str()));
-            if let Some(context_directive) = context_directive {
-                dest.push($wrap_ty(self.context_directive(
-                    subgraph_schema,
-                    context_directive.arguments.clone(),
-                )?));
-            }
-
-            let from_context_directive_name =
-                original_directive_names.get(&FROM_CONTEXT_DIRECTIVE_NAME_DEFAULT);
-            let from_context_directive =
-                from_context_directive_name.and_then(|name| source.get(name.as_str()));
-            if let Some(from_context_directive) = from_context_directive {
-                dest.push($wrap_ty(self.from_context_directive(
-                    subgraph_schema,
-                    from_context_directive.arguments.clone(),
-                )?));
-            }
-
-            Ok(())
-        }
-    };
-}
-
-macro_rules! propagate_context_directives_to_position {
-    ($func_name:ident, $source_ty:ty, $dest_ty:ty) => {
-        pub(crate) fn $func_name(
-            &self,
-            subgraph_schema: &mut FederationSchema,
-            source: &Node<$source_ty>,
-            dest: &$dest_ty,
-            original_directive_names: &IndexMap<Name, Name>,
-        ) -> Result<(), FederationError> {
-            let context_directive_name =
-                original_directive_names.get(&CONTEXT_DIRECTIVE_NAME_IN_SPEC);
-            let context_directive =
-                context_directive_name.and_then(|name| source.directives.get(name.as_str()));
-            if let Some(context_directive) = context_directive {
-                dest.insert_directive(
-                    subgraph_schema,
-                    Component::from(
-                        self.context_directive(
-                            subgraph_schema,
-                            context_directive.arguments.clone(),
-                        )?,
-                    ),
-                )?;
-            }
-
-            let from_context_directive_name =
-                original_directive_names.get(&FROM_CONTEXT_DIRECTIVE_NAME_DEFAULT);
-            let from_context_directive =
-                from_context_directive_name.and_then(|name| source.directives.get(name.as_str()));
-            if let Some(from_context_directive) = from_context_directive {
-                dest.insert_directive(
-                    subgraph_schema,
-                    Component::from(self.from_context_directive(
-                        subgraph_schema,
-                        from_context_directive.arguments.clone(),
-                    )?),
-                )?;
-            }
-
-            Ok(())
-        }
-    };
 }
 
 impl ContextSpecDefinition {
@@ -132,53 +38,6 @@ impl ContextSpecDefinition {
             .directive_name_in_schema(schema, &CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
             .unwrap_or(CONTEXT_DIRECTIVE_NAME_DEFAULT))
     }
-
-    pub(crate) fn context_directive(
-        &self,
-        schema: &FederationSchema,
-        arguments: Vec<Node<Argument>>,
-    ) -> Result<Directive, FederationError> {
-        let name = self
-            .directive_name_in_schema(schema, &CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
-            .unwrap_or(CONTEXT_DIRECTIVE_NAME_DEFAULT);
-
-        Ok(Directive { name, arguments })
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn from_context_directive(
-        &self,
-        schema: &FederationSchema,
-        arguments: Vec<Node<Argument>>,
-    ) -> Result<Directive, FederationError> {
-        let name = self
-            .directive_name_in_schema(schema, &FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
-            .unwrap_or(FROM_CONTEXT_DIRECTIVE_NAME_DEFAULT);
-
-        Ok(Directive { name, arguments })
-    }
-
-    propagate_context_directives!(
-        propagate_context_directives,
-        apollo_compiler::ast::DirectiveList,
-        Node::new
-    );
-
-    propagate_context_directives_to_position!(
-        propagate_context_directives_for_enum,
-        EnumType,
-        EnumTypeDefinitionPosition
-    );
-    propagate_context_directives_to_position!(
-        propagate_context_directives_for_object,
-        ObjectType,
-        ObjectTypeDefinitionPosition
-    );
-    propagate_context_directives_to_position!(
-        propagate_context_directives_for_scalar,
-        ScalarType,
-        ScalarTypeDefinitionPosition
-    );
 }
 
 impl SpecDefinition for ContextSpecDefinition {

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -9,8 +9,6 @@ use apollo_compiler::Name;
 use apollo_compiler::Node;
 use lazy_static::lazy_static;
 
-use super::context_spec_definition::ContextSpecDefinition;
-use super::context_spec_definition::CONTEXT_VERSIONS;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::argument::directive_optional_boolean_argument;
@@ -538,17 +536,6 @@ impl FederationSpecDefinition {
             .and_then(|metadata| metadata.for_identity(&Identity::cost_identity()))
             .and_then(|link| COST_VERSIONS.find(&link.url.version))
             .or_else(|| COST_VERSIONS.find_for_federation_version(self.version()))
-    }
-
-    pub(crate) fn get_context_spec_definition(
-        &self,
-        schema: &FederationSchema,
-    ) -> Option<&'static ContextSpecDefinition> {
-        schema
-            .metadata()
-            .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))
-            .and_then(|link| CONTEXT_VERSIONS.find(&link.url.version))
-            .or_else(|| CONTEXT_VERSIONS.find_for_federation_version(self.version()))
     }
 }
 

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -13,7 +13,6 @@ use super::argument::directive_optional_list_argument;
 use crate::bail;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
-use crate::internal_error;
 use crate::link::argument::directive_optional_boolean_argument;
 use crate::link::argument::directive_optional_enum_argument;
 use crate::link::argument::directive_optional_string_argument;
@@ -84,7 +83,7 @@ impl<'doc> TryFrom<&'doc Value> for ContextArgument<'doc> {
             if let Some(first_value) = field {
                 bail!("Duplicate contextArgument for '{name}' field: {first_value} and {value}")
             }
-            field.insert(value);
+            let _ = field.insert(value);
             Ok(())
         }
 

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -35,11 +35,9 @@ use indexmap::map::Iter;
 use itertools::Itertools;
 
 use crate::error::FederationError;
-use crate::link::federation_spec_definition::FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_FIELDS_ARGUMENT_NAME;
 use crate::link::federation_spec_definition::FEDERATION_FROM_ARGUMENT_NAME;
-use crate::link::federation_spec_definition::FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC;
@@ -727,8 +725,6 @@ struct DirectiveNames {
     interface_object: Name,
     r#override: Name,
     inaccessible: Name,
-    context: Name,
-    from_context: Name,
 }
 
 impl DirectiveNames {
@@ -766,23 +762,11 @@ impl DirectiveNames {
             .map(|link| link.directive_name_in_schema(&INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC))
             .unwrap_or(INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC);
 
-        let context = federation_identity
-            .map(|link| link.directive_name_in_schema(&FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC))
-            .unwrap_or(FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC);
-
-        let from_context = federation_identity
-            .map(|link| {
-                link.directive_name_in_schema(&FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
-            })
-            .unwrap_or(FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC);
-
         Self {
             key,
             requires,
             provides,
             external,
-            context,
-            from_context,
             interface_object,
             r#override,
             inaccessible,

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -276,8 +276,7 @@ impl Field {
         else {
             return Ok(None);
         };
-        if let Some(federation_spec_definition) =
-            get_federation_spec_definition_from_subgraph(schema).ok()
+        if let Ok(federation_spec_definition) = get_federation_spec_definition_from_subgraph(schema)
         {
             let from_context_directive_definition_name = &federation_spec_definition
                 .from_context_directive_definition(schema)?

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -8,7 +8,6 @@ use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_compiler::Schema;
 use itertools::Itertools;
-use multimap::MultiMap;
 use petgraph::graph::EdgeIndex;
 use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
@@ -17,10 +16,8 @@ use regex::Regex;
 use strum::IntoEnumIterator;
 
 use crate::bail;
-use crate::display_helpers::DisplaySlice;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
-use crate::internal_error;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::link::federation_spec_definition::KeyDirectiveArguments;
@@ -49,8 +46,6 @@ use crate::schema::position::SchemaRootDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::position::UnionTypeDefinitionPosition;
 use crate::schema::ValidFederationSchema;
-use crate::subgraph::spec::CONTEXT_DIRECTIVE_NAME;
-use crate::subgraph::spec::FROM_CONTEXT_DIRECTIVE_NAME;
 use crate::supergraph::extract_subgraphs_from_supergraph;
 use crate::utils::FallibleIterator;
 
@@ -2358,7 +2353,7 @@ fn parse_context(field: &str) -> Result<(String, String), FederationError> {
         // Ignore the first match because it is always the whole matching substring
         .skip(1)
         .flatten()
-        .fold(("", ""), |(a, b), group| (b, group.as_str()));
+        .fold(("", ""), |(_, b), group| (b, group.as_str()));
 
     if context.is_empty() {
         bail!("Expected to find the name of a context inside the field argument to `@fromContext`: {field:?}");

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -113,7 +113,7 @@ impl ConditionResolverCache {
         extra_conditions: Option<&SelectionSet>,
     ) -> ConditionResolutionCacheResult {
         if extra_conditions.is_some() {
-            return ConditionResolutionCacheResult::NotApplicable
+            return ConditionResolutionCacheResult::NotApplicable;
         }
         // We don't cache if there is a context or excluded conditions because those would impact the resolution and
         // we don't want to cache a value per-context and per-excluded-conditions (we also don't cache per-excluded-edges though

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -23,7 +23,6 @@ pub(crate) struct ContextMapEntry {
     pub(crate) levels_in_query_path: usize,
     pub(crate) path_tree: Option<Arc<OpPathTree>>,
     pub(crate) selection_set: SelectionSet,
-    pub(crate) inbound_edge: EdgeIndex,
     pub(crate) param_name: Name,
     pub(crate) arg_type: Node<Type>,
     pub(crate) id: Name,

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -1802,7 +1802,11 @@ where
                                     }
                                 }
                             } else {
-                                internal_error!("Could not parse selection {} over any types {:?}", &ctx.selection, potential_matches);
+                                internal_error!(
+                                    "Could not parse selection {} over any types {:?}",
+                                    &ctx.selection,
+                                    potential_matches
+                                );
                             }
                         }
                     }

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -9,24 +9,19 @@ use std::sync::atomic;
 use std::sync::Arc;
 
 use apollo_compiler::ast::InputValueDefinition;
-use apollo_compiler::ast::NamedType;
 use apollo_compiler::ast::Type;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::Argument;
-use apollo_compiler::schema::ComponentName;
-use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
-use apollo_compiler::Schema;
 use either::Either;
 use itertools::Itertools;
 use petgraph::graph::EdgeIndex;
 use petgraph::graph::EdgeReference;
 use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
-use strum_macros::EnumTryAs;
 use tracing::debug;
 use tracing::debug_span;
 
@@ -37,7 +32,6 @@ use crate::display_helpers::DisplayOption;
 use crate::display_helpers::DisplaySlice;
 use crate::display_helpers::State as IndentedFormatter;
 use crate::error::FederationError;
-use crate::error::SingleFederationError;
 use crate::internal_error;
 use crate::is_leaf_type;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
@@ -215,8 +209,8 @@ where
             runtime_types_of_tail,
             runtime_types_before_tail_if_last_is_cast,
             defer_on_tail,
-            context_to_selection,
-            parameter_to_context,
+            context_to_selection: _,
+            parameter_to_context: _,
         } = self;
 
         f.debug_struct("GraphPath")
@@ -902,7 +896,7 @@ impl TryFrom<GraphPathTrigger> for Arc<OpGraphPathTrigger> {
     fn try_from(value: GraphPathTrigger) -> Result<Self, Self::Error> {
         match value {
             GraphPathTrigger::Op(op) => Ok(op),
-            GraphPathTrigger::Transition(transition) => {
+            GraphPathTrigger::Transition(_) => {
                 bail!("Failed to convert to GraphPathTrigger")
             }
         }
@@ -915,7 +909,7 @@ impl TryFrom<GraphPathTrigger> for Arc<QueryGraphEdgeTransition> {
     fn try_from(value: GraphPathTrigger) -> Result<Self, Self::Error> {
         match value {
             GraphPathTrigger::Transition(transition) => Ok(transition),
-            GraphPathTrigger::Op(op) => Err(FederationError::internal(
+            GraphPathTrigger::Op(_) => Err(FederationError::internal(
                 "Failed to convert to GraphPathTrigger",
             )),
         }
@@ -1345,26 +1339,6 @@ where
                         .iter()
                         .any(|arg| arg.name.as_str() == param_name.as_str())
                     {
-                        let mut schema = field.schema.schema().clone().into_inner();
-                        let type_name = field.field_position.type_name();
-                        let field_name = field.field_position.field_name();
-                        let Some(field_def) =
-                            schema.types.get_mut(type_name).and_then(|t| match t {
-                                apollo_compiler::schema::ExtendedType::Scalar(_) => None,
-                                apollo_compiler::schema::ExtendedType::Object(obj) => {
-                                    obj.make_mut().fields.get_mut(field_name)
-                                }
-                                apollo_compiler::schema::ExtendedType::Interface(iface) => {
-                                    iface.make_mut().fields.get_mut(field_name)
-                                }
-                                apollo_compiler::schema::ExtendedType::Union(_) => None,
-                                apollo_compiler::schema::ExtendedType::Enum(_) => None,
-                                apollo_compiler::schema::ExtendedType::InputObject(_) => None,
-                            })
-                        else {
-                            bail!("Unexpectedly failed to lookup field {type_name}.{field_name}")
-                        };
-
                         updated_field_def_arguments.push(Node::new(InputValueDefinition {
                             name: usage_entry.context_id.clone(),
                             ty: usage_entry.subgraph_arg_type.clone(),
@@ -1372,7 +1346,7 @@ where
                             description: None,
                             directives: Default::default(),
                         }));
-                        let push = updated_field_arguments.push(Node::new(Argument {
+                        updated_field_arguments.push(Node::new(Argument {
                             name: param_name.clone(),
                             value: Node::new(Value::Variable(usage_entry.context_id.clone())),
                         }));
@@ -1440,6 +1414,7 @@ where
         })
     }
 
+    #[allow(clippy::type_complexity)]
     fn merge_edge_conditions_with_resolution(
         &self,
         condition_path_tree: &Option<Arc<OpPathTree>>,
@@ -1454,7 +1429,7 @@ where
         let mut parameter_to_context = self.parameter_to_context.clone();
 
         edge_conditions.push(condition_path_tree.clone());
-        if (context_map.is_none() || context_map.as_ref().is_some_and(|m| m.is_empty())) {
+        if context_map.is_none() || context_map.as_ref().is_some_and(|m| m.is_empty()) {
             context_to_selection.push(None);
             parameter_to_context.push(None);
             (edge_conditions, context_to_selection, parameter_to_context)
@@ -1689,12 +1664,10 @@ where
         let mut context_map: IndexMap<Name, ContextMapEntry> = IndexMap::default();
 
         if !edge_weight.required_contexts.is_empty() {
-            let schema = self.graph.schema()?;
             let mut was_unsatisfied = false;
             for ctx in &edge_weight.required_contexts {
-                let mut levels_in_query_path = 0;
                 let mut levels_in_data_path = 0;
-                for (levels_in_query_graph, (e, trigger)) in self
+                for (mut levels_in_query_path, (e, trigger)) in self
                     .edges
                     .iter()
                     .zip(self.edge_triggers.iter())
@@ -1716,7 +1689,6 @@ where
                             ctx.types_with_context_set.iter().for_each(|pos| {
                                 if pos.type_name() == parent_type.type_name() {
                                     potential_matches.insert(parent_type.type_name().clone());
-                                    ()
                                 }
                                 match &pos {
                                     CompositeTypeDefinitionPosition::Object(obj_pos) => {
@@ -1739,7 +1711,7 @@ where
                                                 .filter(|item| {
                                                     &item.name == parent_type.type_name()
                                                 })
-                                                .for_each(|item| {
+                                                .for_each(|_| {
                                                     potential_matches.insert(iface.name.clone());
                                                 });
                                         }
@@ -1751,15 +1723,14 @@ where
                                                 .filter(|item| {
                                                     &item.name == parent_type.type_name()
                                                 })
-                                                .for_each(|item| {
+                                                .for_each(|_| {
                                                     potential_matches.insert(un.name.clone());
                                                 });
                                         }
                                     }
                                 }
-                                ()
                             });
-                            
+
                             // get the selection set for the first match that parses
                             let selection_set =
                                 potential_matches.iter().find_map(|parent_type_name| {
@@ -1820,7 +1791,6 @@ where
                                             levels_in_query_path,
                                             path_tree: path_tree.clone(),
                                             selection_set,
-                                            inbound_edge: e,
                                             param_name: ctx.named_parameter.clone(),
                                             arg_type: ctx.arg_type.clone(),
                                             id,

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
-use apollo_compiler::executable::FieldSet;
-use apollo_compiler::schema::FieldDefinition;
 use apollo_compiler::schema::NamedType;
 use apollo_compiler::schema::Type;
 use apollo_compiler::Name;
@@ -29,7 +27,6 @@ use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::InterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectFieldArgumentDefinitionPosition;
-use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::OutputTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
@@ -191,19 +188,6 @@ impl QueryGraphEdge {
             override_condition: None,
             required_contexts: Vec::new(),
         }
-    }
-
-    pub(crate) fn with_override_condition(mut self, override_condition: OverrideCondition) -> Self {
-        self.override_condition = Some(override_condition);
-        self
-    }
-
-    pub(crate) fn with_required_contexts(
-        mut self,
-        contexts: impl IntoIterator<Item = ContextCondition>,
-    ) -> Self {
-        self.required_contexts.extend(contexts);
-        self
     }
 
     fn satisfies_override_conditions(

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -9,7 +9,6 @@ use petgraph::graph::EdgeIndex;
 use petgraph::graph::NodeIndex;
 use serde::Serialize;
 
-use super::graph_path::ContextAtUsageEntry;
 use super::graph_path::ContextToSelection;
 use super::graph_path::ParameterToContext;
 use crate::error::FederationError;

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2599,19 +2599,16 @@ impl FetchDependencyGraphNode {
         if self.selection_set.selection_set.selections.is_empty() {
             return Ok(None);
         }
-        let context_variable_definitions = self
-            .inputs
-            .iter()
-            .flat_map(|inputs| {
-                inputs.used_contexts.iter().map(|(context, ty)| {
-                    Node::new(VariableDefinition {
-                        name: context.clone(),
-                        ty: ty.clone(),
-                        default_value: None,
-                        directives: Default::default(),
-                    })
+        let context_variable_definitions = self.inputs.iter().flat_map(|inputs| {
+            inputs.used_contexts.iter().map(|(context, ty)| {
+                Node::new(VariableDefinition {
+                    name: context.clone(),
+                    ty: ty.clone(),
+                    default_value: None,
+                    directives: Default::default(),
                 })
-            });
+            })
+        });
         let variable_definitions = variable_definitions
             .iter()
             .cloned()

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2599,10 +2599,10 @@ impl FetchDependencyGraphNode {
         if self.selection_set.selection_set.selections.is_empty() {
             return Ok(None);
         }
-        let mut context_variable_definitions = self
+        let context_variable_definitions = self
             .inputs
             .iter()
-            .map(|inputs| {
+            .flat_map(|inputs| {
                 inputs.used_contexts.iter().map(|(context, ty)| {
                     Node::new(VariableDefinition {
                         name: context.clone(),
@@ -2611,8 +2611,7 @@ impl FetchDependencyGraphNode {
                         directives: Default::default(),
                     })
                 })
-            })
-            .flatten();
+            });
         let variable_definitions = variable_definitions
             .iter()
             .cloned()
@@ -4023,7 +4022,6 @@ fn compute_nodes_for_op_path_element<'a>(
                 .schema_by_source(&source.source)?
                 .clone();
             let path_in_parent = &stack_item.node_path.path_in_node;
-            let updated_defer_context = updated.defer_context.after_subgraph_jump();
             // NOTE: We should re-examine defer-handling for path elements in this function in the
             // future to ensure they're working as intended.
             let new_node_id = dependency_graph.get_or_create_key_node(
@@ -4044,7 +4042,7 @@ fn compute_nodes_for_op_path_element<'a>(
                 .for_new_key_fetch(create_fetch_initial_path(
                     &dependency_graph.supergraph_schema,
                     &source_type,
-                    &stack_item.context,
+                    stack_item.context,
                 )?);
 
             let Some(key_condition) = stack_item
@@ -4065,7 +4063,7 @@ fn compute_nodes_for_op_path_element<'a>(
                 stack_item.node_id,
             )?;
             node.selection_set
-                .add_at_path(&path_in_parent, Some(&Arc::new(key_inputs)))?;
+                .add_at_path(path_in_parent, Some(&Arc::new(key_inputs)))?;
 
             let Ok(input_type): Result<CompositeTypeDefinitionPosition, _> = dependency_graph
                 .supergraph_schema
@@ -4086,14 +4084,10 @@ fn compute_nodes_for_op_path_element<'a>(
                 &dependency_graph.supergraph_schema,
                 &input_type,
                 input_selection_set,
-                &stack_item.context,
+                stack_item.context,
             );
-            let updated_node = FetchDependencyGraph::node_weight_mut(
-                &mut dependency_graph.graph,
-                updated.node_id,
-            )?;
             let input_rewrites = compute_input_rewrites_on_key_fetch(
-                &source_type.type_name(),
+                source_type.type_name(),
                 &source_type,
                 &source_schema,
             )?;
@@ -4123,7 +4117,7 @@ fn compute_nodes_for_op_path_element<'a>(
                 updated_node.add_input_context(
                     context_entry.context_id.clone(),
                     context_entry.subgraph_arg_type.clone(),
-                );
+                )?;
                 updated_node.add_context_renamers_for_selection_set(
                     Some(&context_entry.selection_set),
                     context_entry.relative_path.clone(),
@@ -4158,7 +4152,7 @@ fn compute_nodes_for_op_path_element<'a>(
                 updated_node.add_input_context(
                     context_entry.context_id.clone(),
                     context_entry.subgraph_arg_type.clone(),
-                );
+                )?;
                 updated_node.add_context_renamers_for_selection_set(
                     Some(&context_entry.selection_set),
                     new_relative_path.to_vec(),

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -51,8 +51,6 @@ use crate::utils::logging::snapshot;
 use crate::ApiSchemaOptions;
 use crate::Supergraph;
 
-pub(crate) const CONTEXT_DIRECTIVE: &str = "context";
-
 #[derive(Debug, Clone, Hash, Serialize)]
 pub struct QueryPlannerConfig {
     /// Whether the query planner should try to reuse the named fragments of the planned query in
@@ -244,7 +242,6 @@ impl QueryPlanner {
         config: QueryPlannerConfig,
     ) -> Result<Self, FederationError> {
         config.assert_valid();
-        Self::check_unsupported_features(supergraph)?;
 
         let supergraph_schema = supergraph.schema.clone();
         let api_schema = supergraph.to_api_schema(ApiSchemaOptions {
@@ -567,23 +564,6 @@ impl QueryPlanner {
     /// Get Query Planner's API Schema.
     pub fn api_schema(&self) -> &ValidFederationSchema {
         &self.api_schema
-    }
-
-    fn check_unsupported_features(supergraph: &Supergraph) -> Result<(), FederationError> {
-        // We will only check for `@context` direcive, since
-        // `@fromContext` can only be used if `@context` is already
-        // applied, and we assume a correctly composed supergraph.
-        //
-        // `@context` can only be applied on Object Types, Interface
-        // Types and Unions. For simplicity of this function, we just
-        // check all 'extended_type` directives.
-        let has_set_context = supergraph
-            .schema
-            .schema()
-            .types
-            .values()
-            .any(|extended_type| extended_type.directives().has(CONTEXT_DIRECTIVE));
-        Ok(())
     }
 }
 

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
@@ -118,8 +118,7 @@ fn set_context_test_variable_is_from_same_subgraph() {
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
@@ -239,8 +238,7 @@ fn set_context_test_variable_is_from_different_subgraph() {
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
@@ -347,8 +345,7 @@ fn set_context_test_variable_is_already_in_a_different_fetch_group() {
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
@@ -448,8 +445,7 @@ fn set_context_test_variable_is_a_list() {
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
@@ -552,8 +548,7 @@ fn set_context_test_fetched_as_a_list() {
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
@@ -670,8 +665,7 @@ fn set_context_test_impacts_on_query_planning() {
                         node.context_rewrites,
                         vec![
                             Arc::new(FetchDataRewrite::KeyRenamer(FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("A").unwrap()),
@@ -682,8 +676,7 @@ fn set_context_test_impacts_on_query_planning() {
                                 ],
                             })),
                             Arc::new(FetchDataRewrite::KeyRenamer(FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("B").unwrap()),
@@ -814,47 +807,43 @@ fn set_context_test_with_type_conditions_for_union() {
                "###
     );
     match plan.node {
-      Some(TopLevelPlanNode::Sequence(node)) => match node.nodes.get(1) {
-          Some(PlanNode::Flatten(node)) => match &*node.node {
-              PlanNode::Fetch(node) => {
-                  assert_eq!(
-                      node.context_rewrites,
-                      vec![Arc::new(FetchDataRewrite::KeyRenamer(
-                          FetchDataKeyRenamer {
-                              rename_key_to: Name::new("contextualArgument_1_0")
-                                  .unwrap(),
-                              path: vec![
-                                  FetchDataPathElement::Parent,
-                                  FetchDataPathElement::TypenameEquals(Name::new("A").unwrap()),
-                                  FetchDataPathElement::Key(
-                                      Name::new("prop").unwrap(),
-                                      Default::default()
-                                  ),
-                              ],
-                          }
-                      )),
-                      Arc::new(FetchDataRewrite::KeyRenamer(
-                        FetchDataKeyRenamer {
-                            rename_key_to: Name::new("contextualArgument_1_0")
-                                .unwrap(),
-                            path: vec![
-                                FetchDataPathElement::Parent,
-                                FetchDataPathElement::TypenameEquals(Name::new("B").unwrap()),
-                                FetchDataPathElement::Key(
-                                    Name::new("prop").unwrap(),
-                                    Default::default()
-                                ),
-                            ],
-                        }
-                    )),]
-                  );
-              }
-              _ => panic!("failed to get fetch node"),
-          },
-          _ => panic!("failed to get flatten node"),
-      },
-      _ => panic!("failed to get sequence node"),
-  }
+        Some(TopLevelPlanNode::Sequence(node)) => match node.nodes.get(1) {
+            Some(PlanNode::Flatten(node)) => match &*node.node {
+                PlanNode::Fetch(node) => {
+                    assert_eq!(
+                        node.context_rewrites,
+                        vec![
+                            Arc::new(FetchDataRewrite::KeyRenamer(FetchDataKeyRenamer {
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
+                                path: vec![
+                                    FetchDataPathElement::Parent,
+                                    FetchDataPathElement::TypenameEquals(Name::new("A").unwrap()),
+                                    FetchDataPathElement::Key(
+                                        Name::new("prop").unwrap(),
+                                        Default::default()
+                                    ),
+                                ],
+                            })),
+                            Arc::new(FetchDataRewrite::KeyRenamer(FetchDataKeyRenamer {
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
+                                path: vec![
+                                    FetchDataPathElement::Parent,
+                                    FetchDataPathElement::TypenameEquals(Name::new("B").unwrap()),
+                                    FetchDataPathElement::Key(
+                                        Name::new("prop").unwrap(),
+                                        Default::default()
+                                    ),
+                                ],
+                            })),
+                        ]
+                    );
+                }
+                _ => panic!("failed to get fetch node"),
+            },
+            _ => panic!("failed to get flatten node"),
+        },
+        _ => panic!("failed to get sequence node"),
+    }
 }
 
 #[test]
@@ -940,8 +929,7 @@ fn set_context_test_accesses_a_different_top_level_query() {
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::Key(
@@ -1042,8 +1030,7 @@ fn set_context_one_subgraph() {
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
@@ -1206,8 +1193,7 @@ fn set_context_required_field_is_several_levels_deep_going_back_and_forth_betwee
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0")
-                                    .unwrap(),
+                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
@@ -30,9 +30,11 @@
 use std::sync::Arc;
 
 use apollo_compiler::Name;
-use apollo_federation::query_plan::{
-    FetchDataKeyRenamer, FetchDataPathElement, FetchDataRewrite, PlanNode, TopLevelPlanNode,
-};
+use apollo_federation::query_plan::FetchDataKeyRenamer;
+use apollo_federation::query_plan::FetchDataPathElement;
+use apollo_federation::query_plan::FetchDataRewrite;
+use apollo_federation::query_plan::PlanNode;
+use apollo_federation::query_plan::TopLevelPlanNode;
 
 #[test]
 fn set_context_test_variable_is_from_same_subgraph() {
@@ -130,11 +132,11 @@ fn set_context_test_variable_is_from_same_subgraph() {
                         )),]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 
@@ -251,11 +253,11 @@ fn set_context_test_variable_is_from_different_subgraph() {
                         )),]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 
@@ -359,11 +361,11 @@ fn set_context_test_variable_is_already_in_a_different_fetch_group() {
                         )),]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 
@@ -460,11 +462,11 @@ fn set_context_test_variable_is_a_list() {
                         )),]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 
@@ -564,11 +566,11 @@ fn set_context_test_fetched_as_a_list() {
                         )),]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 
@@ -694,11 +696,11 @@ fn set_context_test_impacts_on_query_planning() {
                         ]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 
@@ -847,11 +849,11 @@ fn set_context_test_with_type_conditions_for_union() {
                     )),]
                   );
               }
-              _ => assert!(false, "failed to get fetch node"),
+              _ => panic!("failed to get fetch node"),
           },
-          _ => assert!(false, "failed to get flatten node"),
+          _ => panic!("failed to get flatten node"),
       },
-      _ => assert!(false, "failed to get sequence node"),
+      _ => panic!("failed to get sequence node"),
   }
 }
 
@@ -955,11 +957,11 @@ fn set_context_test_accesses_a_different_top_level_query() {
                         )),]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 
@@ -1054,11 +1056,11 @@ fn set_context_one_subgraph() {
                         )),]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 
@@ -1230,11 +1232,11 @@ fn set_context_required_field_is_several_levels_deep_going_back_and_forth_betwee
                         )),]
                     );
                 }
-                _ => assert!(false, "failed to get fetch node"),
+                _ => panic!("failed to get fetch node"),
             },
-            _ => assert!(false, "failed to get flatten node"),
+            _ => panic!("failed to get flatten node"),
         },
-        _ => assert!(false, "failed to get sequence node"),
+        _ => panic!("failed to get sequence node"),
     }
 }
 


### PR DESCRIPTION
This PR removes the allow directive for dead code, unused items, and clippy's lints and moves it back to be in a warning.