### PR TITLE
fix(federation): API schema should always include defer definition

### DIFF
--- a/apollo-federation/examples/api_schema.rs
+++ b/apollo-federation/examples/api_schema.rs
@@ -14,7 +14,7 @@ fn main() -> ExitCode {
     let schema = Schema::parse_and_validate(source, name).unwrap();
     let supergraph = Supergraph::from_schema(schema).unwrap();
 
-    match supergraph.to_api_schema(Default::default()) {
+    match supergraph.to_api_schema() {
         Ok(result) => println!("{}", result.schema()),
         Err(error) => {
             eprintln!("{error}");

--- a/apollo-federation/src/api_schema.rs
+++ b/apollo-federation/src/api_schema.rs
@@ -104,15 +104,8 @@ fn remove_core_feature_elements(schema: &mut FederationSchema) -> Result<(), Fed
     Ok(())
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct ApiSchemaOptions {
-    pub include_defer: bool,
-    pub include_stream: bool,
-}
-
 pub(crate) fn to_api_schema(
     schema: ValidFederationSchema,
-    options: ApiSchemaOptions,
 ) -> Result<ValidFederationSchema, FederationError> {
     // Create a whole new federation schema that we can mutate.
     let mut api_schema = FederationSchema::new(schema.schema().clone().into_inner())?;
@@ -136,17 +129,16 @@ pub(crate) fn to_api_schema(
 
     let mut schema = api_schema.into_inner();
 
-    if options.include_defer {
-        schema
-            .directive_definitions
-            .insert(name!("defer"), defer_definition());
-    }
+    // api schema should contain all built-in directive definitions
+    // QP will normalize applications of @defer based on whether
+    // incremental delivery is enabled/disabled
+    schema
+        .directive_definitions
+        .insert(name!("defer"), defer_definition());
 
-    if options.include_stream {
-        schema
-            .directive_definitions
-            .insert(name!("stream"), stream_definition());
-    }
+    schema
+        .directive_definitions
+        .insert(name!("stream"), stream_definition());
 
     crate::compat::make_print_schema_compatible(&mut schema);
 

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -45,7 +45,6 @@ use apollo_compiler::Schema;
 use link::join_spec_definition::JOIN_VERSIONS;
 use schema::FederationSchema;
 
-pub use crate::api_schema::ApiSchemaOptions;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::join_spec_definition::JoinSpecDefinition;
@@ -128,11 +127,8 @@ impl Supergraph {
 
     /// Generates an API Schema from this supergraph schema. The API Schema represents the combined
     /// API of the supergraph that's visible to end users.
-    pub fn to_api_schema(
-        &self,
-        options: ApiSchemaOptions,
-    ) -> Result<ValidFederationSchema, FederationError> {
-        api_schema::to_api_schema(self.schema.clone(), options)
+    pub fn to_api_schema(&self) -> Result<ValidFederationSchema, FederationError> {
+        api_schema::to_api_schema(self.schema.clone())
     }
 
     pub fn extract_subgraphs(&self) -> Result<ValidFederationSubgraphs, FederationError> {

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -49,7 +49,6 @@ use crate::schema::position::SchemaRootDefinitionKind;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::ValidFederationSchema;
 use crate::utils::logging::snapshot;
-use crate::ApiSchemaOptions;
 use crate::Supergraph;
 
 pub(crate) const CONTEXT_DIRECTIVE: &str = "context";
@@ -248,10 +247,7 @@ impl QueryPlanner {
         Self::check_unsupported_features(supergraph)?;
 
         let supergraph_schema = supergraph.schema.clone();
-        let api_schema = supergraph.to_api_schema(ApiSchemaOptions {
-            include_defer: config.incremental_delivery.enable_defer,
-            ..Default::default()
-        })?;
+        let api_schema = supergraph.to_api_schema()?;
         let query_graph = build_federated_query_graph(
             supergraph_schema.clone(),
             api_schema.clone(),
@@ -1317,7 +1313,7 @@ type User
         .unwrap();
         let subgraphs = vec![&a];
         let supergraph = Supergraph::compose(subgraphs).unwrap();
-        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
+        let api_schema = supergraph.to_api_schema().unwrap();
 
         let document = ExecutableDocument::parse_and_validate(
             api_schema.schema(),
@@ -1360,7 +1356,7 @@ type User
     #[test]
     fn test_optimize_basic() {
         let supergraph = Supergraph::new(TEST_SUPERGRAPH).unwrap();
-        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
+        let api_schema = supergraph.to_api_schema().unwrap();
         let document = ExecutableDocument::parse_and_validate(
             api_schema.schema(),
             r#"
@@ -1416,7 +1412,7 @@ type User
     #[test]
     fn test_optimize_inline_fragment() {
         let supergraph = Supergraph::new(TEST_SUPERGRAPH).unwrap();
-        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
+        let api_schema = supergraph.to_api_schema().unwrap();
         let document = ExecutableDocument::parse_and_validate(
             api_schema.schema(),
             r#"
@@ -1485,7 +1481,7 @@ type User
     #[test]
     fn test_optimize_fragment_definition() {
         let supergraph = Supergraph::new(TEST_SUPERGRAPH).unwrap();
-        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
+        let api_schema = supergraph.to_api_schema().unwrap();
         let document = ExecutableDocument::parse_and_validate(
             api_schema.schema(),
             r#"

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -210,7 +210,7 @@ mod tests {
 
         let subgraph = Subgraph::parse_and_expand("S1", "http://S1", sdl).unwrap();
         let supergraph = Supergraph::compose([&subgraph].to_vec()).unwrap();
-        let api_schema = supergraph.to_api_schema(Default::default())?;
+        let api_schema = supergraph.to_api_schema()?;
         // Testing via `build_federated_query_graph` function, which validates the @requires directive.
         let err = build_federated_query_graph(supergraph.schema, api_schema, None, None)
             .map(|_| "Unexpected success") // ignore the Ok value

--- a/apollo-federation/tests/composition_tests.rs
+++ b/apollo-federation/tests/composition_tests.rs
@@ -51,12 +51,7 @@ fn can_compose_supergraph() {
 
     let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
     insta::assert_snapshot!(print_sdl(supergraph.schema.schema()));
-    insta::assert_snapshot!(print_sdl(
-        supergraph
-            .to_api_schema(Default::default())
-            .unwrap()
-            .schema()
-    ));
+    insta::assert_snapshot!(print_sdl(supergraph.to_api_schema().unwrap().schema()));
 }
 
 #[test]
@@ -108,12 +103,7 @@ fn can_compose_with_descriptions() {
 
     let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
     insta::assert_snapshot!(print_sdl(supergraph.schema.schema()));
-    insta::assert_snapshot!(print_sdl(
-        supergraph
-            .to_api_schema(Default::default())
-            .unwrap()
-            .schema()
-    ));
+    insta::assert_snapshot!(print_sdl(supergraph.to_api_schema().unwrap().schema()));
 }
 
 #[test]
@@ -147,12 +137,7 @@ fn can_compose_types_from_different_subgraphs() {
     .unwrap();
     let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
     insta::assert_snapshot!(print_sdl(supergraph.schema.schema()));
-    insta::assert_snapshot!(print_sdl(
-        supergraph
-            .to_api_schema(Default::default())
-            .unwrap()
-            .schema()
-    ));
+    insta::assert_snapshot!(print_sdl(supergraph.to_api_schema().unwrap().schema()));
 }
 
 #[test]
@@ -191,10 +176,5 @@ fn compose_removes_federation_directives() {
 
     let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
     insta::assert_snapshot!(print_sdl(supergraph.schema.schema()));
-    insta::assert_snapshot!(print_sdl(
-        supergraph
-            .to_api_schema(Default::default())
-            .unwrap()
-            .schema()
-    ));
+    insta::assert_snapshot!(print_sdl(supergraph.to_api_schema().unwrap().schema()));
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -94,11 +94,7 @@ pub(crate) fn api_schema_and_planner(
     let supergraph = compose(function_path, subgraph_names_and_schemas);
     let supergraph = apollo_federation::Supergraph::new(&supergraph).unwrap();
     let planner = QueryPlanner::new(&supergraph, config).unwrap();
-    let api_schema_config = apollo_federation::ApiSchemaOptions {
-        include_defer: true,
-        include_stream: false,
-    };
-    let api_schema = supergraph.to_api_schema(api_schema_config).unwrap();
+    let api_schema = supergraph.to_api_schema().unwrap();
     (api_schema, planner)
 }
 

--- a/apollo-federation/tests/snapshots/main__composition_tests__can_compose_supergraph-2.snap
+++ b/apollo-federation/tests/snapshots/main__composition_tests__can_compose_supergraph-2.snap
@@ -1,7 +1,11 @@
 ---
 source: apollo-federation/tests/composition_tests.rs
-expression: "print_sdl(supergraph.to_api_schema(Default::default()).unwrap().schema())"
+expression: print_sdl(supergraph.to_api_schema().unwrap().schema())
 ---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @stream(label: String, if: Boolean! = true, initialCount: Int = 0) on FIELD
+
 enum E {
   V1
   V2

--- a/apollo-federation/tests/snapshots/main__composition_tests__can_compose_types_from_different_subgraphs-2.snap
+++ b/apollo-federation/tests/snapshots/main__composition_tests__can_compose_types_from_different_subgraphs-2.snap
@@ -1,7 +1,11 @@
 ---
 source: apollo-federation/tests/composition_tests.rs
-expression: "print_sdl(supergraph.to_api_schema(Default::default()).unwrap().schema())"
+expression: print_sdl(supergraph.to_api_schema().unwrap().schema())
 ---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @stream(label: String, if: Boolean! = true, initialCount: Int = 0) on FIELD
+
 scalar Import
 
 type Product {

--- a/apollo-federation/tests/snapshots/main__composition_tests__can_compose_with_descriptions-2.snap
+++ b/apollo-federation/tests/snapshots/main__composition_tests__can_compose_with_descriptions-2.snap
@@ -1,14 +1,18 @@
 ---
 source: apollo-federation/tests/composition_tests.rs
-expression: "print_sdl(supergraph.to_api_schema(Default::default()).unwrap().schema())"
+expression: print_sdl(supergraph.to_api_schema().unwrap().schema())
 ---
 """A cool schema"""
 schema {
   query: Query
 }
 
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 """The foo directive description"""
 directive @foo(url: String) on FIELD
+
+directive @stream(label: String, if: Boolean! = true, initialCount: Int = 0) on FIELD
 
 """An enum"""
 enum E {

--- a/apollo-federation/tests/snapshots/main__composition_tests__compose_removes_federation_directives-2.snap
+++ b/apollo-federation/tests/snapshots/main__composition_tests__compose_removes_federation_directives-2.snap
@@ -1,7 +1,11 @@
 ---
 source: apollo-federation/tests/composition_tests.rs
-expression: "print_sdl(supergraph.to_api_schema(Default::default()).unwrap().schema())"
+expression: print_sdl(supergraph.to_api_schema().unwrap().schema())
 ---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @stream(label: String, if: Boolean! = true, initialCount: Int = 0) on FIELD
+
 scalar Import
 
 type Product {

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -9,7 +9,6 @@ use apollo_compiler::schema::Implementers;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_federation::schema::ValidFederationSchema;
-use apollo_federation::ApiSchemaOptions;
 use apollo_federation::Supergraph;
 use http::Uri;
 use semver::Version;
@@ -112,16 +111,11 @@ impl Schema {
 
         let schema_id = Arc::new(Schema::schema_id(&raw_sdl));
 
-        let api_schema = supergraph
-            .to_api_schema(ApiSchemaOptions {
-                include_defer: config.supergraph.defer_support,
-                ..Default::default()
-            })
-            .map_err(|e| {
-                SchemaError::Api(format!(
-                    "The supergraph schema failed to produce a valid API schema: {e}"
-                ))
-            })?;
+        let api_schema = supergraph.to_api_schema().map_err(|e| {
+            SchemaError::Api(format!(
+                "The supergraph schema failed to produce a valid API schema: {e}"
+            ))
+        })?;
 
         Ok(Schema {
             raw_sdl,


### PR DESCRIPTION
Update `to_api_schema()` logic to always add `@defer/@stream` definitions. This addresses the problem that we would error out when user opts-out of `incremental_delivery` feature but pass an operation with `@defer` in it. While the passed in document is valid, during the conversion from `apollo-rs` selections to the federation representations, we explicitly revalidate whether fragment spread directives are valid and present in the API schema. Since API schema may not contain `@defer` definition, this conversion will error out.

Existence of `@defer/@stream` directives in the API schema was driven by the user configuration We expose a configuration that allows users to enable(default)/disable incremental delivery (`@defer`) support. If incremental delivery is disabled, we normalize the passed in query by removing any and all `@defer` applications. In RS implementation we first convert

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
