### PR TITLE
Fix bug with `@context` state tracking in `GraphPath::add()`

### DIFF
--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -1069,6 +1069,8 @@ where
         let mut edges = self.edges.clone();
         let mut edge_triggers = self.edge_triggers.clone();
         let mut edge_conditions = self.edge_conditions.clone();
+        let mut context_to_selection = self.context_to_selection.clone();
+        let mut parameter_to_context = self.parameter_to_context.clone();
         let mut last_subgraph_entering_edge_info = if defer.is_none() {
             self.last_subgraph_entering_edge_info.clone()
         } else {
@@ -1079,6 +1081,8 @@ where
             edges.push(edge);
             edge_triggers.push(Arc::new(trigger));
             edge_conditions.push(condition_path_tree);
+            context_to_selection.push(None);
+            parameter_to_context.push(None);
             return Ok(GraphPath {
                 graph: self.graph.clone(),
                 head: self.head,
@@ -1098,8 +1102,8 @@ where
                 ),
                 runtime_types_before_tail_if_last_is_cast: None,
                 defer_on_tail: defer,
-                context_to_selection: self.context_to_selection.clone(),
-                parameter_to_context: self.parameter_to_context.clone(),
+                context_to_selection,
+                parameter_to_context,
             });
         };
 
@@ -1471,6 +1475,8 @@ where
     pub(crate) fn iter(&self) -> impl Iterator<Item = GraphPathItem<'_, TTrigger, TEdge>> {
         debug_assert_eq!(self.edges.len(), self.edge_triggers.len());
         debug_assert_eq!(self.edges.len(), self.edge_conditions.len());
+        debug_assert_eq!(self.edges.len(), self.context_to_selection.len());
+        debug_assert_eq!(self.edges.len(), self.parameter_to_context.len());
         self.edges
             .iter()
             .copied()

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -364,7 +364,11 @@ impl FederationSpecDefinitions {
             }
             .into()],
             repeatable: true,
-            locations: vec![DirectiveLocation::Interface, DirectiveLocation::Object, DirectiveLocation::Union],
+            locations: vec![
+                DirectiveLocation::Interface,
+                DirectiveLocation::Object,
+                DirectiveLocation::Union,
+            ],
         }
     }
 

--- a/apollo-router/tests/set_context.rs
+++ b/apollo-router/tests/set_context.rs
@@ -50,7 +50,7 @@ fn get_configuration(rust_qp: bool) -> serde_json::Value {
             }
         }};
     }
-    return json! {{
+    json! {{
         "experimental_type_conditioned_fetching": true,
         // will make debugging easier
         "plugins": {
@@ -63,7 +63,7 @@ fn get_configuration(rust_qp: bool) -> serde_json::Value {
             // TODO(@goto-bus-stop): need to update the mocks and remove this, #6013
             "generate_query_fragments": false,
         }
-    }};
+    }}
 }
 
 async fn run_single_request(
@@ -135,10 +135,7 @@ async fn test_set_context_rust_qp() {
         QUERY,
         true,
         &[
-            (
-                "Subgraph1",
-                include_str!("fixtures/set_context/one.json"),
-            ),
+            ("Subgraph1", include_str!("fixtures/set_context/one.json")),
             ("Subgraph2", include_str!("fixtures/set_context/two.json")),
         ],
     )
@@ -188,10 +185,7 @@ async fn test_set_context_no_typenames_rust_qp() {
         QUERY_NO_TYPENAMES,
         true,
         &[
-            (
-                "Subgraph1",
-                include_str!("fixtures/set_context/one.json"),
-            ),
+            ("Subgraph1", include_str!("fixtures/set_context/one.json")),
             ("Subgraph2", include_str!("fixtures/set_context/two.json")),
         ],
     )
@@ -241,10 +235,7 @@ async fn test_set_context_list_rust_qp() {
         QUERY_WITH_LIST,
         true,
         &[
-            (
-                "Subgraph1",
-                include_str!("fixtures/set_context/one.json"),
-            ),
+            ("Subgraph1", include_str!("fixtures/set_context/one.json")),
             ("Subgraph2", include_str!("fixtures/set_context/two.json")),
         ],
     )
@@ -294,10 +285,7 @@ async fn test_set_context_list_of_lists_rust_qp() {
         QUERY_WITH_LIST_OF_LISTS,
         true,
         &[
-            (
-                "Subgraph1",
-                include_str!("fixtures/set_context/one.json"),
-            ),
+            ("Subgraph1", include_str!("fixtures/set_context/one.json")),
             ("Subgraph2", include_str!("fixtures/set_context/two.json")),
         ],
     )
@@ -359,10 +347,7 @@ async fn test_set_context_union_rust_qp() {
         QUERY_WITH_UNION,
         true,
         &[
-            (
-                "Subgraph1",
-                include_str!("fixtures/set_context/one.json"),
-            ),
+            ("Subgraph1", include_str!("fixtures/set_context/one.json")),
             ("Subgraph2", include_str!("fixtures/set_context/two.json")),
         ],
     )
@@ -472,10 +457,7 @@ async fn test_set_context_type_mismatch_rust_qp() {
         QUERY,
         true,
         &[
-            (
-                "Subgraph1",
-                include_str!("fixtures/set_context/one.json"),
-            ),
+            ("Subgraph1", include_str!("fixtures/set_context/one.json")),
             ("Subgraph2", include_str!("fixtures/set_context/two.json")),
         ],
     )


### PR DESCRIPTION
This PR fixes a Rust-only bug in `GraphPath::add()` where it didn't properly push to `context_to_selection` and `parameter_to_context` in the case of a `None` edge, causing the `GraphPath` iterator to prematurely end due to `zip` semantics.