### PR TITLE
ci: Remove "test_updated" from release workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,9 @@ parameters:
   quick_nightly:
     type: boolean
     default: false
+  test_updated_cargo_deps:
+    type: boolean
+    default: false
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'
@@ -599,6 +602,10 @@ jobs:
     parameters:
       platform:
         type: executor
+        default: amd_linux_test
+      from_test_updated_cargo_deps_workflow:
+        type: boolean
+        default: false
     executor: << parameters.platform >>
     steps:
       - checkout
@@ -611,6 +618,67 @@ jobs:
             cargo fetch
       - xtask_test:
           variant: "updated"
+
+      - when:
+          condition:
+            equal: [ true, << parameters.from_test_updated_cargo_deps_workflow >> ]
+          steps:
+            - slack/notify:
+                event: fail
+                custom: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ":x: The `test_updated_cargo_deps` workflow has **failed** for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`!"
+                        }
+                      },
+                      {
+                        "type": "actions",
+                        "elements": [
+                          {
+                            "type": "button",
+                            "action_id": "success_tagged_deploy_view",
+                            "text": {
+                              "type": "plain_text",
+                              "text": "View Job"
+                            },
+                            "url": "${CIRCLE_BUILD_URL}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+            - slack/notify:
+                event: pass
+                custom: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ":white_check_mark: The `test_updated_cargo_deps` workflow has passed for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`."
+                        }
+                      },
+                      {
+                        "type": "actions",
+                        "elements": [
+                          {
+                            "type": "button",
+                            "action_id": "success_tagged_deploy_view",
+                            "text": {
+                              "type": "plain_text",
+                              "text": "View Job"
+                            },
+                            "url": "${CIRCLE_BUILD_URL}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
   pre_verify_release:
     environment:
       <<: *common_job_environment
@@ -948,12 +1016,19 @@ jobs:
                   helm push ${CHART} oci://ghcr.io/apollographql/helm-charts
 
 workflows:
+  test_updated_cargo_deps:
+    when: << pipeline.parameters.test_updated_cargo_deps >>
+    jobs:
+      - test_updated:
+          platform: amd_linux_test
+          from_test_updated_cargo_deps_workflow: true
   ci_checks:
     when:
       not:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
+          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - lint:
           matrix:
@@ -967,16 +1042,6 @@ workflows:
           matrix:
             parameters:
               platform: [ amd_linux_build ]
-
-      - test_updated:
-          requires:
-            - lint
-            - check_helm
-            - check_compliance
-          matrix:
-            parameters:
-              platform:
-                [ amd_linux_test ]
       - test:
           # this should be changed back to true on dev after release
           fuzz: false
@@ -1016,16 +1081,6 @@ workflows:
           matrix:
             parameters:
               platform: [ amd_linux_build ]
-
-      - test_updated:
-          requires:
-            - lint
-            - check_helm
-            - check_compliance
-          matrix:
-            parameters:
-              platform:
-                [ amd_linux_test ]
       - test:
           requires:
             - lint
@@ -1038,7 +1093,6 @@ workflows:
       - build_release:
           requires:
             - test
-            - test_updated
           nightly: true
           context:
             - router
@@ -1073,6 +1127,7 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
+          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - pre_verify_release:
           matrix:
@@ -1153,6 +1208,7 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
+          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - secops/gitleaks:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,9 @@ executors:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
-      # 
+      #
       # TODO: remove workaround added in https://github.com/apollographql/router/pull/5462
-      # once we update to Xcode >= 15.1.0 
+      # once we update to Xcode >= 15.1.0
       # See: https://github.com/apollographql/router/pull/5462
       xcode: "14.2.0"
     resource_class: macos.m1.large.gen1
@@ -504,7 +504,7 @@ commands:
             # Use the settings from the "ci" profile in nextest configuration.
             NEXTEST_PROFILE: ci
             # Temporary disable lib backtrace since it crashing on MacOS
-            # TODO: remove this workaround once we update to Xcode >= 15.1.0 
+            # TODO: remove this workaround once we update to Xcode >= 15.1.0
             # See: https://github.com/apollographql/router/pull/5462
             RUST_LIB_BACKTRACE: 0
           command: xtask test --workspace --locked --features ci,hyper_header_limits
@@ -750,20 +750,20 @@ jobs:
                 command: |
                   # Source of the new image will be ser to the repo URL.
                   # This will have the effect of setting org.opencontainers.image.source and org.opencontainers.image.author to the originating pipeline
-                  # Therefore the docker image will have the same permissions as the originating project. 
+                  # Therefore the docker image will have the same permissions as the originating project.
                   # See: https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-a-container-image-using-the-command-line
-                  
+
                   BASE_VERSION=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[0].version')
                   ARTIFACT_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/artifacts/router-v${BASE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
                   VERSION="v$(echo "${BASE_VERSION}" | tr "+" "-")"
                   ROUTER_TAG=ghcr.io/apollographql/nightly/router
-                  
+
                   echo "REPO_URL: ${REPO_URL}"
                   echo "BASE_VERSION: ${BASE_VERSION}"
                   echo "ARTIFACT_URL: ${ARTIFACT_URL}"
                   echo "VERSION: ${VERSION}"
                   echo "ROUTER_TAG: ${ROUTER_TAG}"
-                  
+
                   # Create a multi-arch builder which works properly under qemu
                   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
                   docker context create buildx-build
@@ -1110,16 +1110,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /v.*/
-      - test_updated:
-          matrix:
-            parameters:
-              platform:
-                [ amd_linux_test ]
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v.*/
       - test:
           matrix:
             parameters:
@@ -1131,6 +1121,9 @@ workflows:
             tags:
               only: /v.*/
       - build_release:
+          requires:
+            - pre_verify_release
+            - test
           matrix:
             parameters:
               platform:
@@ -1148,7 +1141,6 @@ workflows:
             - check_compliance
             - pre_verify_release
             - test
-            - test_updated
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1084,8 +1084,6 @@ workflows:
       - test:
           requires:
             - lint
-            - check_helm
-            - check_compliance
           matrix:
             parameters:
               platform:
@@ -1093,6 +1091,8 @@ workflows:
       - build_release:
           requires:
             - test
+            - check_helm
+            - check_compliance
           nightly: true
           context:
             - router
@@ -1176,9 +1176,6 @@ workflows:
             tags:
               only: /v.*/
       - build_release:
-          requires:
-            - pre_verify_release
-            - test
           matrix:
             parameters:
               platform:


### PR DESCRIPTION
Presently, knowing about this condition as soon as possible is valuable in
ensuring that we are quickly aware and able to reconcile changes to
dependencies which may be difficult for library-consumers of the Router.
Today, we get that through a feedback loop on individual PRs and release
workflows, however those can be inconveniently timed and blocking.

By moving this to a scheduled workflow in CircleCI, we can run it at a
cadence that suits us and get notifications via Slack immediately.

This should conceivably supersede https://github.com/apollographql/router/pull/5935

<!-- [ROUTER-868] -->

[ROUTER-868]: https://apollographql.atlassian.net/browse/ROUTER-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ