### PR TITLE
Context test rewriter assertion

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
@@ -77,33 +77,6 @@ macro_rules! node_assert {
             });
     };
 }
-/*
-vec![Arc::new(FetchDataRewrite::KeyRenamer(
-    FetchDataKeyRenamer {
-        rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
-        path: vec![
-            FetchDataPathElement::Parent,
-            FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
-            FetchDataPathElement::Key(
-                Name::new("a").unwrap(),
-                Default::default()
-            ),
-            FetchDataPathElement::Key(
-                Name::new("b").unwrap(),
-                Default::default()
-            ),
-            FetchDataPathElement::Key(
-                Name::new("c").unwrap(),
-                Default::default()
-            ),
-            FetchDataPathElement::Key(
-                Name::new("prop").unwrap(),
-                Default::default()
-            ),
-        ],
-    }
-)),]
-*/
 
 #[test]
 fn set_context_test_variable_is_from_same_subgraph() {


### PR DESCRIPTION
This PR refactors the `Rewriter` assertion in the `set_context` snapshot tests. This was an ergonomics issue, so I put it off until after the main feature branch was merged. The goal of the new macro is to mimic what the JS code did to assert equality for their `Rewriter` nodes.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
