### PR TITLE
fix for \n in json selection arguments

### DIFF
--- a/apollo-federation/src/sources/connect/validation/graphql/strings.rs
+++ b/apollo-federation/src/sources/connect/validation/graphql/strings.rs
@@ -61,6 +61,10 @@ impl<'schema> GraphQLString<'schema> {
         self.raw_string
     }
 
+    pub(crate) fn as_string(&self) -> String {
+        self.raw_string.replace("\\n", "\n")
+    }
+
     pub(crate) fn line_col_for_subslice(
         &self,
         substring_location: Range<usize>,

--- a/apollo-federation/src/sources/connect/validation/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/selection.rs
@@ -99,7 +99,7 @@ pub(super) fn validate_body_selection(
                 .collect(),
         })?;
 
-    let selection = JSONSelection::parse(selection_str.as_str()).map_err(|err| Message {
+    let selection = JSONSelection::parse(&selection_str.as_string()).map_err(|err| Message {
         code: Code::InvalidJsonSelection,
         message: format!("{coordinate} is not a valid JSONSelection: {err}"),
         locations: selection_node
@@ -202,7 +202,7 @@ fn get_json_selection<'a>(
                 .collect(),
         })?;
 
-    let selection = JSONSelection::parse(selection_str.as_str()).map_err(|err| Message {
+    let selection = JSONSelection::parse(&selection_str.as_string()).map_err(|err| Message {
         code: Code::InvalidJsonSelection,
         message: format!("{coordinate} is not a valid JSONSelection: {err}",),
         locations: selection_str

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_with_escapes.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_with_escapes.graphql.snap
@@ -1,0 +1,14 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/valid_selection_with_escapes.graphql
+---
+[
+    Message {
+        code: InvalidJsonSelection,
+        message: "`@connect(selection:)` on `Query.something` is not a valid JSONSelection: Path selection . must be followed by key (identifier or quoted string literal) at offset 7: .",
+        locations: [
+            20:26..20:27,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_selection_with_escapes.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_selection_with_escapes.graphql
@@ -1,0 +1,27 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
+
+type Query {
+  something: T
+    # bug fix
+    @connect(http: { GET: "http://127.0.0.1/something" }, selection: "foo\nbar")
+    # this always worked
+    @connect(
+      http: { GET: "http://127.0.0.1/something" }
+      selection: """
+      foo
+      bar
+      """
+    )
+    # results in an error. the location should be 20:27..20:28,
+    # but because we remove the escape for the newline, it's 20:26..20:27
+    @connect(
+      http: { GET: "http://127.0.0.1/something" }
+      selection: "foo\nbar."
+    )
+}
+
+type T {
+  foo: String
+  bar: String
+}


### PR DESCRIPTION
i dunno if this is the right fix

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
