### PR TITLE
Allow compute jobs to use all available CPUs

### DIFF
--- a/apollo-router/src/compute_job.rs
+++ b/apollo-router/src/compute_job.rs
@@ -14,31 +14,13 @@ use crate::metrics::meter_provider;
 /// reaches `QUEUE_SOFT_CAPACITY_PER_THREAD * thread_pool_size()`
 const QUEUE_SOFT_CAPACITY_PER_THREAD: usize = 20;
 
-/// Leave a fraction of CPU cores free to run Tokio threads even if this thread pool is very busy:
-///
-/// available: 1     pool size: 1
-/// available: 2     pool size: 1
-/// available: 3     pool size: 2
-/// available: 4     pool size: 3
-/// available: 5     pool size: 4
-/// ...
-/// available: 8     pool size: 7
-/// available: 9     pool size: 7
-/// ...
-/// available: 16    pool size: 14
-/// available: 17    pool size: 14
-/// ...
-/// available: 32    pool size: 28
+/// Let this thread pool use all available resources if it can.
+/// In the worst case, we’ll have moderate context switching cost
+/// as the kernel’s scheduler distributes time to it or Tokio or other threads.
 fn thread_pool_size() -> usize {
-    let available = std::thread::available_parallelism()
+    std::thread::available_parallelism()
         .expect("available_parallelism() failed")
-        .get();
-    thread_poll_size_for_available_parallelism(available)
-}
-
-fn thread_poll_size_for_available_parallelism(available: usize) -> usize {
-    let reserved = available.div_ceil(8);
-    (available - reserved).max(1)
+        .get()
 }
 
 type Job = Box<dyn FnOnce() + Send + 'static>;
@@ -134,15 +116,5 @@ mod tests {
         assert_eq!(two.await.unwrap(), 2);
         // Evidence of fearless parallel sleep:
         assert!(start.elapsed() < Duration::from_millis(1_400));
-    }
-
-    #[test]
-    fn pool_size() {
-        assert_eq!(thread_poll_size_for_available_parallelism(1), 1);
-        assert_eq!(thread_poll_size_for_available_parallelism(2), 1);
-        assert_eq!(thread_poll_size_for_available_parallelism(3), 2);
-        assert_eq!(thread_poll_size_for_available_parallelism(4), 3);
-        assert_eq!(thread_poll_size_for_available_parallelism(31), 27);
-        assert_eq!(thread_poll_size_for_available_parallelism(32), 28);
     }
 }


### PR DESCRIPTION
With the previous thread pool size we saw benchmark regressions in 1.58.0-rc compared to 1.57.0