### PR TITLE
chore(federation): Improved serialization impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,6 @@ dependencies = [
  "time",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "time",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -7308,9 +7309,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -39,6 +39,7 @@ tracing = "0.1.40"
 ron = { version = "0.8.1", optional = true }
 either = "1.13.0"
 regex = "1.11.1"
+uuid = { version = "1.11.0", features = ["v4", "serde"] }
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -39,7 +39,6 @@ tracing = "0.1.40"
 ron = { version = "0.8.1", optional = true }
 either = "1.13.0"
 regex = "1.11.1"
-uuid = { version = "1.11.0", features = ["v4", "serde"] }
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/src/display_helpers.rs
+++ b/apollo-federation/src/display_helpers.rs
@@ -1,8 +1,5 @@
 use std::fmt;
-use std::fmt::Debug;
 use std::fmt::Display;
-
-use serde::Serializer;
 
 pub(crate) struct State<'fmt, 'fmt2> {
     indent_level: usize,
@@ -97,31 +94,4 @@ impl<T: Display> Display for DisplayOption<T> {
             None => write!(f, "None"),
         }
     }
-}
-
-pub(crate) fn serialize_as_debug_string<T, S>(data: &T, ser: S) -> Result<S::Ok, S::Error>
-where
-    T: Debug,
-    S: Serializer,
-{
-    ser.serialize_str(&format!("{data:?}"))
-}
-
-pub(crate) fn serialize_as_string<T, S>(data: &T, ser: S) -> Result<S::Ok, S::Error>
-where
-    T: ToString,
-    S: Serializer,
-{
-    ser.serialize_str(&data.to_string())
-}
-
-pub(crate) fn serialize_optional_vec_as_string<T, S>(
-    data: &Option<Vec<T>>,
-    ser: S,
-) -> Result<S::Ok, S::Error>
-where
-    T: Display,
-    S: Serializer,
-{
-    serialize_as_string(&DisplayOption(data.as_deref().map(DisplaySlice)), ser)
 }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -83,7 +83,9 @@ impl SelectionId {
 #[derive(Clone, PartialEq, Eq, Default, serde::Serialize)]
 pub(crate) struct ArgumentList {
     /// The inner list *must* be sorted with `sort_arguments`.
-    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_optional_slice_of_exe_argument_nodes")]
+    #[serde(
+        serialize_with = "crate::utils::serde_bridge::serialize_optional_slice_of_exe_argument_nodes"
+    )]
     inner: Option<Arc<[Node<executable::Argument>]>>,
 }
 

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -17,7 +17,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hash;
 use std::ops::Deref;
-use std::sync::atomic;
 use std::sync::Arc;
 
 use apollo_compiler::collections::IndexMap;
@@ -29,7 +28,7 @@ use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use itertools::Itertools;
-use serde::Serialize;
+use uuid::Uuid;
 
 use crate::compat::coerce_executable_values;
 use crate::error::FederationError;
@@ -66,23 +65,13 @@ pub(crate) use rebase::*;
 
 pub(crate) const TYPENAME_FIELD: Name = name!("__typename");
 
-// Global storage for the counter used to uniquely identify selections
-static NEXT_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(1);
-
 /// Opaque wrapper of the unique selection ID type.
-///
-/// Note that we shouldn't add `derive(Serialize, Deserialize)` to this without changing the types
-/// to be something like UUIDs.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-// NOTE(@TylerBloom): This feature gate can be removed once the condition in the comment above is
-// met. Note that there are `serde(skip)` statements that should be removed once this is removed.
-#[cfg_attr(feature = "snapshot_tracing", derive(Serialize))]
-pub(crate) struct SelectionId(usize);
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, serde::Serialize)]
+pub(crate) struct SelectionId(Uuid);
 
 impl SelectionId {
     pub(crate) fn new() -> Self {
-        // atomically increment global counter
-        Self(NEXT_ID.fetch_add(1, atomic::Ordering::AcqRel))
+        Self(Uuid::new_v4())
     }
 }
 
@@ -91,9 +80,10 @@ impl SelectionId {
 /// All arguments and input object values are sorted in a consistent order.
 ///
 /// This type is immutable and cheaply cloneable.
-#[derive(Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default, serde::Serialize)]
 pub(crate) struct ArgumentList {
     /// The inner list *must* be sorted with `sort_arguments`.
+    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_optional_slice_of_exe_argument_nodes")]
     inner: Option<Arc<[Node<executable::Argument>]>>,
 }
 
@@ -242,7 +232,7 @@ impl Operation {
 /// - For the type, stores the schema and the position in that schema instead of just the
 ///   `NamedType`.
 /// - Stores selections in a map so they can be normalized efficiently.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub(crate) struct SelectionSet {
     #[serde(skip)]
     pub(crate) schema: ValidFederationSchema,
@@ -270,7 +260,7 @@ pub(crate) use selection_map::SelectionValue;
 
 /// An analogue of the apollo-compiler type `Selection` that stores our other selection analogues
 /// instead of the apollo-compiler types.
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::IsVariant, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::IsVariant, serde::Serialize)]
 pub(crate) enum Selection {
     Field(Arc<FieldSelection>),
     FragmentSpread(Arc<FragmentSpreadSelection>),
@@ -658,9 +648,7 @@ mod field_selection {
         pub(crate) schema: ValidFederationSchema,
         pub(crate) field_position: FieldDefinitionPosition,
         pub(crate) alias: Option<Name>,
-        #[serde(serialize_with = "crate::display_helpers::serialize_as_debug_string")]
         pub(crate) arguments: ArgumentList,
-        #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         pub(crate) directives: DirectiveList,
         pub(crate) sibling_typename: Option<SiblingTypename>,
     }
@@ -868,16 +856,13 @@ mod fragment_spread_selection {
         pub(crate) fragment_name: Name,
         pub(crate) type_condition_position: CompositeTypeDefinitionPosition,
         // directives applied on the fragment spread selection
-        #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         pub(crate) directives: DirectiveList,
         // directives applied within the fragment definition
         //
         // PORT_NOTE: The JS codebase combined the fragment spread's directives with the fragment
         // definition's directives. This was invalid GraphQL as those directives may not be applicable
         // on different locations. While we now keep track of those references, they are currently ignored.
-        #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         pub(crate) fragment_directives: DirectiveList,
-        #[cfg_attr(not(feature = "snapshot_tracing"), serde(skip))]
         pub(crate) selection_id: SelectionId,
     }
 
@@ -1062,9 +1047,7 @@ mod inline_fragment_selection {
         pub(crate) schema: ValidFederationSchema,
         pub(crate) parent_type_position: CompositeTypeDefinitionPosition,
         pub(crate) type_condition_position: Option<CompositeTypeDefinitionPosition>,
-        #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         pub(crate) directives: DirectiveList,
-        #[cfg_attr(not(feature = "snapshot_tracing"), serde(skip))]
         pub(crate) selection_id: SelectionId,
     }
 

--- a/apollo-federation/src/operation/selection_map.rs
+++ b/apollo-federation/src/operation/selection_map.rs
@@ -34,26 +34,22 @@ pub(crate) enum SelectionKey<'a> {
         /// The field alias (if specified) or field name in the resulting selection set.
         response_name: &'a Name,
         /// directives applied on the field
-        #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         directives: &'a DirectiveList,
     },
     FragmentSpread {
         /// The name of the fragment.
         fragment_name: &'a Name,
         /// Directives applied on the fragment spread (does not contain @defer).
-        #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         directives: &'a DirectiveList,
     },
     InlineFragment {
         /// The optional type condition of the fragment.
         type_condition: Option<&'a Name>,
         /// Directives applied on the fragment spread (does not contain @defer).
-        #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         directives: &'a DirectiveList,
     },
     Defer {
         /// Unique selection ID used to distinguish deferred fragment spreads that cannot be merged.
-        #[cfg_attr(not(feature = "snapshot_tracing"), serde(skip))]
         deferred_id: SelectionId,
     },
 }

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -18,6 +18,16 @@ pub(crate) mod query_planning_traversal;
 
 pub type QueryPlanCost = f64;
 
+// NOTE: This type implements `Serialize` for debugging purposes; however, it should not implement
+// `Deserialize` until two requires are met.
+// 1) `SelectionId`s and `OverrideId`s are only unique per lifetime of the application. To avoid
+//    problems when caching, this needs to be changes.
+// 2) There are several types transatively used in the query plan that are from `apollo-compiler`.
+//    They are serialized as strings and use the `serialize` methods provided by that crate. In
+//    order to implement `Deserialize`, care needs to be taken to deserialize these correctly.
+//    Moreover, how we serialize these types should also be revisited to make sure we can and want
+//    to support how they are serialized long term (e.g. how `DirectiveList` is serialized can be
+//    optimized).
 #[derive(Debug, Default, PartialEq, Serialize)]
 pub struct QueryPlan {
     pub node: Option<TopLevelPlanNode>,

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -68,15 +68,15 @@ pub struct FetchNode {
     /// `FragmentSpread`.
     // PORT_NOTE: This was its own type in the JS codebase, but it's likely simpler to just have the
     // constraint be implicit for router instead of creating a new type.
-    #[serde(serialize_with = "crate::display_helpers::serialize_optional_vec_as_string")]
+    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_optional_vec_of_exe_selection")]
     pub requires: Option<Vec<executable::Selection>>,
     // PORT_NOTE: We don't serialize the "operation" string in this struct, as these query plan
     // nodes are meant for direct consumption by router (without any serdes), so we leave the
     // question of whether it needs to be serialized to router.
-    #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
+    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_valid_executable_document")]
     pub operation_document: Valid<ExecutableDocument>,
     pub operation_name: Option<Name>,
-    #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
+    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_exe_operation_type")]
     pub operation_kind: executable::OperationType,
     /// Optionally describe a number of "rewrites" that query plan executors should apply to the
     /// data that is sent as the input of this fetch. Note that such rewrites should only impact the
@@ -166,7 +166,7 @@ pub struct DeferredDeferBlock {
     pub query_path: Vec<QueryPathElement>,
     /// The part of the original query that "selects" the data to send in the deferred response
     /// (once the plan in `node` completes). Will be set _unless_ `node` is a `DeferNode` itself.
-    #[serde(serialize_with = "crate::display_helpers::serialize_as_debug_string")]
+    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_optional_exe_selection_set")]
     pub sub_selection: Option<executable::SelectionSet>,
     /// The plan to get all the data for this deferred block. Usually set, but can be `None` for a
     /// `@defer` application where everything has been fetched in the "primary block" (i.e. when
@@ -249,9 +249,9 @@ pub type Conditions = Vec<Name>;
 /// an inline fragment in a query.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum QueryPathElement {
-    #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
+    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_exe_field")]
     Field(executable::Field),
-    #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
+    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_exe_inline_fragment")]
     InlineFragment(executable::InlineFragment),
 }
 

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -68,7 +68,9 @@ pub struct FetchNode {
     /// `FragmentSpread`.
     // PORT_NOTE: This was its own type in the JS codebase, but it's likely simpler to just have the
     // constraint be implicit for router instead of creating a new type.
-    #[serde(serialize_with = "crate::utils::serde_bridge::serialize_optional_vec_of_exe_selection")]
+    #[serde(
+        serialize_with = "crate::utils::serde_bridge::serialize_optional_vec_of_exe_selection"
+    )]
     pub requires: Option<Vec<executable::Selection>>,
     // PORT_NOTE: We don't serialize the "operation" string in this struct, as these query plan
     // nodes are meant for direct consumption by router (without any serdes), so we leave the

--- a/apollo-federation/src/utils/mod.rs
+++ b/apollo-federation/src/utils/mod.rs
@@ -2,5 +2,6 @@
 
 mod fallible_iterator;
 pub(crate) mod logging;
+pub(crate) mod serde_bridge;
 
 pub(crate) use fallible_iterator::*;

--- a/apollo-federation/src/utils/serde_bridge.rs
+++ b/apollo-federation/src/utils/serde_bridge.rs
@@ -1,0 +1,82 @@
+use apollo_compiler::{executable, validation::Valid, ExecutableDocument, Node};
+use serde::{ser::SerializeSeq, Serializer};
+
+/// This module contains functions used to bridge the apollo compiler serialization methods with
+/// serialization with serde.
+
+pub(crate) fn serialize_exe_field<S: Serializer>(
+    field: &executable::Field,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    ser.serialize_str(&field.serialize().no_indent().to_string())
+}
+
+pub(crate) fn serialize_exe_inline_fragment<S: Serializer>(
+    fragment: &executable::InlineFragment,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    ser.serialize_str(&fragment.serialize().no_indent().to_string())
+}
+
+pub(crate) fn serialize_optional_exe_selection_set<S: Serializer>(
+    set: &Option<executable::SelectionSet>,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    match set {
+        Some(set) => ser.serialize_str(&set.serialize().no_indent().to_string()),
+        None => ser.serialize_none(),
+    }
+}
+
+pub(crate) fn serialize_optional_slice_of_exe_argument_nodes<
+    S: Serializer,
+    Args: AsRef<[Node<executable::Argument>]>,
+>(
+    args: &Option<Args>,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    let Some(args) = args else {
+        return ser.serialize_none();
+    };
+    let args = args.as_ref();
+    let _ser = ser.serialize_seq(Some(args.len()))?;
+    // FIXME: Arg doesn't have the serialize method like the other types:
+    // args.iter().try_for_each(|arg| ser.serialize_element(&arg.))?;
+    // ser.end()
+    todo!();
+}
+
+pub(crate) fn serialize_exe_directive_list<S: Serializer>(
+    list: &executable::DirectiveList,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    ser.serialize_str(&list.serialize().no_indent().to_string())
+}
+
+pub(crate) fn serialize_optional_vec_of_exe_selection<S: Serializer>(
+    selection: &Option<Vec<executable::Selection>>,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    let Some(selections) = selection else {
+        return ser.serialize_none();
+    };
+    let mut ser = ser.serialize_seq(Some(selections.len()))?;
+    selections.iter().try_for_each(|selection| {
+        ser.serialize_element(&selection.serialize().no_indent().to_string())
+    })?;
+    ser.end()
+}
+
+pub(crate) fn serialize_valid_executable_document<S: Serializer>(
+    doc: &Valid<ExecutableDocument>,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    ser.serialize_str(&doc.serialize().no_indent().to_string())
+}
+
+pub(crate) fn serialize_exe_operation_type<S: Serializer>(
+    ty: &executable::OperationType,
+    ser: S,
+) -> Result<S::Ok, S::Error> {
+    ser.serialize_str(&ty.to_string())
+}

--- a/apollo-federation/src/utils/serde_bridge.rs
+++ b/apollo-federation/src/utils/serde_bridge.rs
@@ -1,5 +1,9 @@
-use apollo_compiler::{executable, validation::Valid, ExecutableDocument, Node};
-use serde::{ser::SerializeSeq, Serializer};
+use apollo_compiler::executable;
+use apollo_compiler::validation::Valid;
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Node;
+use serde::ser::SerializeSeq;
+use serde::Serializer;
 
 /// This module contains functions used to bridge the apollo compiler serialization methods with
 /// serialization with serde.

--- a/apollo-federation/src/utils/serde_bridge.rs
+++ b/apollo-federation/src/utils/serde_bridge.rs
@@ -1,12 +1,11 @@
+/// This module contains functions used to bridge the apollo compiler serialization methods with
+/// serialization with serde.
 use apollo_compiler::executable;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Node;
 use serde::ser::SerializeSeq;
 use serde::Serializer;
-
-/// This module contains functions used to bridge the apollo compiler serialization methods with
-/// serialization with serde.
 
 pub(crate) fn serialize_exe_field<S: Serializer>(
     field: &executable::Field,
@@ -43,11 +42,15 @@ pub(crate) fn serialize_optional_slice_of_exe_argument_nodes<
         return ser.serialize_none();
     };
     let args = args.as_ref();
-    let _ser = ser.serialize_seq(Some(args.len()))?;
-    // FIXME: Arg doesn't have the serialize method like the other types:
-    // args.iter().try_for_each(|arg| ser.serialize_element(&arg.))?;
-    // ser.end()
-    todo!();
+    let mut ser = ser.serialize_seq(Some(args.len()))?;
+    args.iter().try_for_each(|arg| {
+        ser.serialize_element(&format!(
+            "{}: {}",
+            arg.name,
+            arg.value.serialize().no_indent()
+        ))
+    })?;
+    ser.end()
 }
 
 pub(crate) fn serialize_exe_directive_list<S: Serializer>(


### PR DESCRIPTION
This PR changes how several types are serialized in `apollo-federation`. Namely, there are several types from `apollo-compiler` that do not implement `serde::Serialize`. Before, these types were serialized as strings or simply skipped. This has been changes to use the provided `serialize` method on those `apollo-compiler` types. Additionally, this changes the inner type of `SelectionId` and `OverrideId` from a `usize` to a `Uuid`. This adds `uuid` as a dependency to `apollo-federation`, but `uuid` was already a (transitive) dependency of `apollo-router`.

<!-- start metadata [ROUTER-841](https://apollographql.atlassian.net/browse/ROUTER-841)-->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-841]: https://apollographql.atlassian.net/browse/ROUTER-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ