### PR TITLE
ci: install cmake straight from github on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,8 @@ commands:
                 command: |
                   if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
                     curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
-                    unzip cmake.zip -d $HOME/.local
+                    unzip cmake.zip -d /tmp
+                    cp "/tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_x64/bin/*" "$HOME/.local/bin/"
                   fi
 
                   cmake --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,10 @@ parameters:
   protoc_version:
     type: string
     default: "21.8"
+  # note the cmake version is only used for manual installs, not for installs from a package manager like apt or homebrew
+  cmake_version:
+    type: string
+    default: "3.31.1"
   nightly:
     type: boolean
     default: false
@@ -249,15 +253,12 @@ commands:
             - run:
                 name: Install CMake
                 command: |
-                  choco install cmake -y
-                  echo 'export PATH="/c/Program Files/CMake/bin:$PATH"' >> "$BASH_ENV"
-                  SAVED_EXIT_CODE=$LASTEXITCODE
+                  if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
+                    curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
+                    unzip cmake.zip -d $HOME/.local
+                  fi
 
-                  source "$BASH_ENV"
-                  echo "Test CMake -- if this fails, play around with chocolatey, I guess."
                   cmake --version
-
-                  exit $SAVED_EXIT_CODE
       - when:
           condition:
             or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ commands:
                   if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
                     curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
                     unzip cmake.zip -d /tmp
-                    cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_x64/bin/* "$HOME/.local/bin/"
+                    cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_x64/bin/cmake.exe "$HOME/.local/bin/"
                   fi
 
                   cmake --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ commands:
                   if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
                     curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
                     unzip cmake.zip -d /tmp
-                    cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_x64/bin/cmake.exe "$HOME/.local/bin/"
+                    cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64/bin/* "$HOME/.local/bin/"
                   fi
 
                   cmake --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ commands:
                   if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
                     curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
                     unzip cmake.zip -d /tmp
-                    cp "/tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_x64/bin/*" "$HOME/.local/bin/"
+                    cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_x64/bin/* "$HOME/.local/bin/"
                   fi
 
                   cmake --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,10 +253,11 @@ commands:
             - run:
                 name: Install CMake
                 command: |
+                  mkdir -p "$HOME/.local"
                   if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
                     curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
                     # The zip file has a root directory, so we put it somewhere else first before placing the files in .local
-                    unzip cmake.zip -d /tmp
+                    unzip cmake.zip -d /tmp > /dev/null
                     cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64/* -R "$HOME/.local"
                   fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1038,30 +1038,31 @@ workflows:
           - << pipeline.parameters.quick_nightly >>
           - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
-      - lint:
-          matrix:
-            parameters:
-              platform: [ amd_linux_build ]
-      - check_helm:
-          matrix:
-            parameters:
-              platform: [ amd_linux_helm ]
-      - check_compliance:
-          matrix:
-            parameters:
-              platform: [ amd_linux_build ]
+      # - lint:
+      #     matrix:
+      #       parameters:
+      #         platform: [ amd_linux_build ]
+      # - check_helm:
+      #     matrix:
+      #       parameters:
+      #         platform: [ amd_linux_helm ]
+      # - check_compliance:
+      #     matrix:
+      #       parameters:
+      #         platform: [ amd_linux_build ]
 
       - test:
           # this should be changed back to true on dev after release
           fuzz: false
-          requires:
-            - lint
-            - check_helm
-            - check_compliance
+          # requires:
+          #   - lint
+          #   - check_helm
+          #   - check_compliance
           matrix:
             parameters:
               platform:
-                [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
+                [ windows_test ]
+                # [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
 
   quick-nightly:
     when: << pipeline.parameters.quick_nightly >>
@@ -1208,22 +1209,22 @@ workflows:
             tags:
               only: /v.*/
 
-  security-scans:
-    when:
-      not:
-        or:
-          - << pipeline.parameters.nightly >>
-          - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
-    jobs:
-      - secops/gitleaks:
-          context:
-            - secops-oidc
-            - github-orb
-          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
-          git-revision: << pipeline.git.revision >>
-      - secops/semgrep:
-          context:
-            - secops-oidc
-            - github-orb
-          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+  # security-scans:
+  #   when:
+  #     not:
+  #       or:
+  #         - << pipeline.parameters.nightly >>
+  #         - << pipeline.parameters.quick_nightly >>
+  #         - << pipeline.parameters.test_updated_cargo_deps >>
+  #   jobs:
+  #     - secops/gitleaks:
+  #         context:
+  #           - secops-oidc
+  #           - github-orb
+  #         git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+  #         git-revision: << pipeline.git.revision >>
+  #     - secops/semgrep:
+  #         context:
+  #           - secops-oidc
+  #           - github-orb
+  #         git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,8 @@ commands:
             - run:
                 name: Install CMake
                 command: |
+                  mkdir -p "$HOME/.local/bin"
+
                   if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
                     curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
                     unzip cmake.zip -d /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,12 +253,11 @@ commands:
             - run:
                 name: Install CMake
                 command: |
-                  mkdir -p "$HOME/.local/bin"
-
                   if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
                     curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
+                    # The zip file has a root directory, so we put it somewhere else first before placing the files in .local
                     unzip cmake.zip -d /tmp
-                    cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64/bin/* "$HOME/.local/bin/"
+                    cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64/* -R "$HOME/.local"
                   fi
 
                   cmake --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1040,31 +1040,30 @@ workflows:
           - << pipeline.parameters.quick_nightly >>
           - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
-      # - lint:
-      #     matrix:
-      #       parameters:
-      #         platform: [ amd_linux_build ]
-      # - check_helm:
-      #     matrix:
-      #       parameters:
-      #         platform: [ amd_linux_helm ]
-      # - check_compliance:
-      #     matrix:
-      #       parameters:
-      #         platform: [ amd_linux_build ]
+      - lint:
+          matrix:
+            parameters:
+              platform: [ amd_linux_build ]
+      - check_helm:
+          matrix:
+            parameters:
+              platform: [ amd_linux_helm ]
+      - check_compliance:
+          matrix:
+            parameters:
+              platform: [ amd_linux_build ]
 
       - test:
           # this should be changed back to true on dev after release
           fuzz: false
-          # requires:
-          #   - lint
-          #   - check_helm
-          #   - check_compliance
+          requires:
+            - lint
+            - check_helm
+            - check_compliance
           matrix:
             parameters:
               platform:
-                [ windows_test ]
-                # [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
+                [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
 
   quick-nightly:
     when: << pipeline.parameters.quick_nightly >>
@@ -1211,22 +1210,22 @@ workflows:
             tags:
               only: /v.*/
 
-  # security-scans:
-  #   when:
-  #     not:
-  #       or:
-  #         - << pipeline.parameters.nightly >>
-  #         - << pipeline.parameters.quick_nightly >>
-  #         - << pipeline.parameters.test_updated_cargo_deps >>
-  #   jobs:
-  #     - secops/gitleaks:
-  #         context:
-  #           - secops-oidc
-  #           - github-orb
-  #         git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
-  #         git-revision: << pipeline.git.revision >>
-  #     - secops/semgrep:
-  #         context:
-  #           - secops-oidc
-  #           - github-orb
-  #         git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+  security-scans:
+    when:
+      not:
+        or:
+          - << pipeline.parameters.nightly >>
+          - << pipeline.parameters.quick_nightly >>
+          - << pipeline.parameters.test_updated_cargo_deps >>
+    jobs:
+      - secops/gitleaks:
+          context:
+            - secops-oidc
+            - github-orb
+          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+          git-revision: << pipeline.git.revision >>
+      - secops/semgrep:
+          context:
+            - secops-oidc
+            - github-orb
+          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>


### PR DESCRIPTION
Alternative title: "Fix the f* chocolatey cant work!!!" (lovingly)

We get weird spurious failures from chocolatey installing CMake, on some branches and not others. If we just grab cmake.exe from the CMake release on GitHub, and put it in `~/.local/bin`, what can go wrong? Let's find out!