### PR TITLE
ci: Upgrade build/test environments to macOS v14.3.1 and Xcode v15.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,18 +48,14 @@ executors:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
-      xcode: "14.2.0"
+      xcode: "15.4.0"
     resource_class: macos.m1.large.gen1
   macos_test: &macos_test_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
-      #
-      # TODO: remove workaround added in https://github.com/apollographql/router/pull/5462
-      # once we update to Xcode >= 15.1.0
-      # See: https://github.com/apollographql/router/pull/5462
-      xcode: "14.2.0"
+      xcode: "15.4.0"
     resource_class: macos.m1.large.gen1
   windows_build: &windows_build_executor
     machine:
@@ -512,10 +508,6 @@ commands:
           environment:
             # Use the settings from the "ci" profile in nextest configuration.
             NEXTEST_PROFILE: ci
-            # Temporary disable lib backtrace since it crashing on MacOS
-            # TODO: remove this workaround once we update to Xcode >= 15.1.0
-            # See: https://github.com/apollographql/router/pull/5462
-            RUST_LIB_BACKTRACE: 0
           command: xtask test --workspace --locked --features ci,hyper_header_limits
       - run:
           name: Delete large files from cache


### PR DESCRIPTION
In the same spirit as the `next` branch did in 21a05d752cc140a685a971f63158 and in the spirit of eliminating the occasionally recurring but decidedly problematic `libunwind` error, which is actively blocking the v1.58.0 release, but has previously caused corrutped builds in CI.

Previously, while we had updated the "next" branch (for v2.x of the Router), we had delayed this work on the v1 line (dev branch) eliminate because we hadn't time to validate that it wouldn't potentially drop support for macOS 12 users.

However, given some more time to validate, we confirmed that release binaries produced with these newer versions of macOS and Xcode are still able to execute on older macOS versions, therefore making the change not only acceptable, but desireable since we will want to have the most stable versions of the toolchain, prior to entering LTS for the v1 series.

The passing of tests on this PR will also have proven that this fixes the suspicously failing macOS build.  Of course, none of this is really supsicious when recognizing that libunwind is coupled in somewhat necessary but also necessarily dodgy ways to the Rust toolchain.

Ref: https://www.apollographql.com/docs/graphos/reference/router-release-lifecycle
Ref: https://circleci.com/docs/using-macos/#supported-xcode-versions
Ref: https://github.com/apollographql/router/pull/5462
Ref: https://github.com/apollographql/router/pull/6298
