### PR TITLE
hyper upgrade - dd exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "hex",
  "hickory-resolver",
  "hmac",
+ "http 0.2.12",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -104,6 +104,7 @@ graphql_client = "0.14.0"
 hex.workspace = true
 # http.workspace = true
 http = { version = "1.1.0" }
+http-0_2 = { version = "0.2.12", package = "http" }
 # http-body = "0.4.6"
 http-body = "1.0.1"
 http-body-util = {version = "0.1.2" }

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/mod.rs
@@ -8,9 +8,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::BoxFuture;
-use http::Method;
-use http::Request;
-use http::Uri;
+use http_0_2 as http;
+
 pub use model::ApiVersion;
 pub use model::Error;
 pub use model::FieldMappingFn;
@@ -74,7 +73,7 @@ impl Mapping {
 /// Datadog span exporter
 pub struct DatadogExporter {
     client: Arc<dyn HttpClient>,
-    request_url: Uri,
+    request_url: http::Uri,
     model_config: ModelConfig,
     api_version: ApiVersion,
     mapping: Mapping,
@@ -84,7 +83,7 @@ pub struct DatadogExporter {
 impl DatadogExporter {
     fn new(
         model_config: ModelConfig,
-        request_url: Uri,
+        request_url: http::Uri,
         api_version: ApiVersion,
         client: Arc<dyn HttpClient>,
         mapping: Mapping,
@@ -112,8 +111,8 @@ impl DatadogExporter {
             &self.mapping,
             &self.unified_tags,
         )?;
-        let req = Request::builder()
-            .method(Method::POST)
+        let req = http::Request::builder()
+            .method(http::Method::POST)
             .uri(self.request_url.clone())
             .header(http::header::CONTENT_TYPE, self.api_version.content_type())
             .header(DATADOG_TRACE_COUNT_HEADER, trace_count)
@@ -255,7 +254,7 @@ impl DatadogPipelineBuilder {
 
     // parse the endpoint and append the path based on versions.
     // keep the query and host the same.
-    fn build_endpoint(agent_endpoint: &str, version: &str) -> Result<Uri, TraceError> {
+    fn build_endpoint(agent_endpoint: &str, version: &str) -> Result<http::Uri, TraceError> {
         // build agent endpoint based on version
         let mut endpoint = agent_endpoint
             .parse::<Url>()
@@ -528,7 +527,7 @@ mod tests {
     impl HttpClient for DummyClient {
         async fn send(
             &self,
-            _request: Request<Vec<u8>>,
+            _request: http::Request<Vec<u8>>,
         ) -> Result<http::Response<bytes::Bytes>, opentelemetry_http::HttpError> {
             Ok(http::Response::new("dummy response".into()))
         }


### PR DESCRIPTION
This PR adds a dependency of:

```http-0_2 = { version = "0.2.12", package = "http" }```

to allow the vendored dd exporter code to continue to use hyper 0.2 pending the otel upgrade.

<!-- start metadata -->
<!-- ROUTER-906 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
