### PR TITLE
Move distributed cache key version from router-bridge to apollo-federation

### DIFF
--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -59,6 +59,19 @@ use crate::subgraph::ValidSubgraph;
 pub use crate::supergraph::ValidFederationSubgraph;
 pub use crate::supergraph::ValidFederationSubgraphs;
 
+/// Part of the key for distributed query plan cache.
+///
+/// Update this every time the cache key or the query plan format has to change,
+/// specifically if an old serialized query plan cannot always be deserialized and used correctly
+/// in the current Router version.
+///
+/// When changed it MUST BE CALLED OUT PROMINENTLY IN THE CHANGELOG.
+///
+/// Historically this was based in part on the federation version extracted from the build metadata
+/// in the router-bridge crate version number (e.g. `0.6.4+v2.9.3`) but any arbitrary string works.
+/// The next version can be "2", and this paragraph removed.
+pub const CACHE_KEY_VERSION: &str = "1:federation:v2.9.3";
+
 pub(crate) type SupergraphSpecs = (&'static LinkSpecDefinition, &'static JoinSpecDefinition);
 
 pub(crate) fn validate_supergraph_for_query_planning(

--- a/apollo-router/build/main.rs
+++ b/apollo-router/build/main.rs
@@ -1,37 +1,5 @@
-use std::fs;
-use std::path::PathBuf;
-
 mod studio;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cargo_manifest: serde_json::Value = basic_toml::from_str(
-        &fs::read_to_string(PathBuf::from(&env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
-            .expect("could not read Cargo.toml"),
-    )
-    .expect("could not parse Cargo.toml");
-
-    let router_bridge = cargo_manifest
-        .get("dependencies")
-        .expect("Cargo.toml does not contain dependencies")
-        .as_object()
-        .expect("Cargo.toml dependencies key is not an object")
-        .get("router-bridge")
-        .expect("Cargo.toml dependencies does not have an entry for router-bridge");
-    let router_bridge_version = router_bridge
-        .as_str()
-        .or_else(|| {
-            router_bridge
-                .as_object()
-                .and_then(|o| o.get("version"))
-                .and_then(|version| version.as_str())
-        })
-        .expect("router-bridge does not have a version");
-
-    let mut it = router_bridge_version.split('+');
-    let _ = it.next();
-    let fed_version = it.next().expect("invalid router-bridge version format");
-
-    println!("cargo:rustc-env=FEDERATION_VERSION={fed_version}");
-
     studio::main()
 }

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -1405,28 +1405,6 @@ mod tests {
             .await
     }
 
-    #[test]
-    fn router_bridge_dependency_is_pinned() {
-        let cargo_manifest: serde_json::Value = basic_toml::from_str(
-            &fs::read_to_string(PathBuf::from(&env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
-                .expect("could not read Cargo.toml"),
-        )
-        .expect("could not parse Cargo.toml");
-        let router_bridge_version = cargo_manifest
-            .get("dependencies")
-            .expect("Cargo.toml does not contain dependencies")
-            .as_object()
-            .expect("Cargo.toml dependencies key is not an object")
-            .get("router-bridge")
-            .expect("Cargo.toml dependencies does not have an entry for router-bridge")
-            .as_str()
-            .unwrap_or_default();
-        assert!(
-            router_bridge_version.contains('='),
-            "router-bridge in Cargo.toml is not pinned with a '=' prefix"
-        );
-    }
-
     #[tokio::test]
     async fn test_both_mode() {
         let mut harness = crate::TestHarness::builder()

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -859,9 +859,6 @@ pub(crate) fn metric_rust_qp_init(init_error_kind: Option<&'static str>) {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-    use std::path::PathBuf;
-
     use serde_json::json;
     use test_log::test;
     use tower::Service;

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -5,6 +5,9 @@ use std::sync::Arc;
 use std::task;
 
 use apollo_compiler::validation::Valid;
+/// Update this key every time the cache key or the query plan format has to change.
+/// When changed it MUST BE CALLED OUT PROMINENTLY IN THE CHANGELOG.
+use apollo_federation::CACHE_KEY_VERSION;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
 use query_planner::QueryPlannerPlugin;
@@ -632,11 +635,6 @@ pub(crate) struct CachingQueryKey {
     pub(crate) config_mode: Arc<QueryHash>,
 }
 
-// Update this key every time the cache key or the query plan format has to change.
-// When changed it MUST BE CALLED OUT PROMINENTLY IN THE CHANGELOG.
-const CACHE_KEY_VERSION: usize = 1;
-const FEDERATION_VERSION: &str = std::env!("FEDERATION_VERSION");
-
 impl std::fmt::Display for CachingQueryKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut hasher = Sha256::new();
@@ -654,8 +652,8 @@ impl std::fmt::Display for CachingQueryKey {
 
         write!(
             f,
-            "plan:cache:{}:federation:{}:{}:opname:{}:metadata:{}",
-            CACHE_KEY_VERSION, FEDERATION_VERSION, self.hash, operation, metadata,
+            "plan:cache:{}:{}:opname:{}:metadata:{}",
+            CACHE_KEY_VERSION, self.hash, operation, metadata,
         )
     }
 }


### PR DESCRIPTION
We plan to stop using the router-bridge crate entirely. The apollo-federation crate seems like a good place for this since most query plan changes would come from there.

This PR should *not* change current cache keys.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
