### PR TITLE
Rename metric to apollo.router.connectors.schema

### DIFF
--- a/apollo-router/src/metrics/filter.rs
+++ b/apollo-router/src/metrics/filter.rs
@@ -94,7 +94,7 @@ impl FilterMeterProvider {
             .delegate(delegate)
             .allow(
                 Regex::new(
-                    r"apollo\.(graphos\.cloud|router\.(operations?|lifecycle|config|schema|query|query_planning|telemetry))(\..*|$)|apollo_router_uplink_fetch_count_total|apollo_router_uplink_fetch_duration_seconds",
+                    r"apollo\.(graphos\.cloud|router\.(operations?|lifecycle|config|schema|query|query_planning|telemetry|connectors))(\..*|$)|apollo_router_uplink_fetch_count_total|apollo_router_uplink_fetch_duration_seconds",
                 )
                 .expect("regex should have been valid"),
             )
@@ -105,8 +105,10 @@ impl FilterMeterProvider {
         FilterMeterProvider::builder()
             .delegate(delegate)
             .deny(
-                Regex::new(r"apollo\.router\.(config|entities|operations.connectors|schema.connectors)(\..*|$)")
-                    .expect("regex should have been valid"),
+                Regex::new(
+                    r"apollo\.router\.(config|entities|operations.connectors|connectors)(\..*|$)",
+                )
+                .expect("regex should have been valid"),
             )
             .build()
     }
@@ -295,7 +297,7 @@ mod test {
             .init()
             .add(1, &[]);
         filtered
-            .u64_observable_gauge("apollo.router.schema.connectors")
+            .u64_observable_gauge("apollo.router.connectors.schema")
             .with_callback(move |observer| observer.observe(1, &[]))
             .init();
         meter_provider.force_flush(&cx).unwrap();
@@ -330,7 +332,7 @@ mod test {
             .any(|m| m.name == "apollo.router.operations.connectors"));
         assert!(metrics
             .iter()
-            .any(|m| m.name == "apollo.router.schema.connectors"));
+            .any(|m| m.name == "apollo.router.connectors.schema"));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -417,7 +419,7 @@ mod test {
             .init()
             .add(1, &[]);
         filtered
-            .u64_observable_gauge("apollo.router.schema.connectors")
+            .u64_observable_gauge("apollo.router.connectors.schema")
             .with_callback(move |observer| observer.observe(1, &[]))
             .init();
         meter_provider.force_flush(&cx).unwrap();
@@ -443,6 +445,6 @@ mod test {
             .any(|m| m.name == "apollo.router.operations.connectors"));
         assert!(!metrics
             .iter()
-            .any(|m| m.name == "apollo.router.schema.connectors"));
+            .any(|m| m.name == "apollo.router.connectors.schema"));
     }
 }

--- a/apollo-router/src/plugins/connectors/tracing.rs
+++ b/apollo-router/src/plugins/connectors/tracing.rs
@@ -17,7 +17,7 @@ pub(crate) fn connect_spec_version_instrument(
         let spec_counts = connect_spec_counts(connectors);
         meter_provider()
             .meter("apollo/router")
-            .u64_observable_gauge("apollo.router.schema.connectors")
+            .u64_observable_gauge("apollo.router.connectors.schema")
             .with_description("Number connect directives in the supergraph")
             .with_callback(move |observer| {
                 spec_counts.iter().for_each(|(spec, &count)| {
@@ -123,7 +123,7 @@ mod tests {
             );
 
             assert_gauge!(
-                "apollo.router.schema.connectors",
+                "apollo.router.connectors.schema",
                 6,
                 connect.spec.version = "0.1"
             );


### PR DESCRIPTION
Renames `apollo.router.schema.connectors` metric to `apollo.router.connectors.schema`. The `apollo.router.connectors` prefix is already enabled for gauge metrics.

Draft pending discussion.

<!-- [CNN-526] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-516]: https://apollographql.atlassian.net/browse/CNN-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CNN-526]: https://apollographql.atlassian.net/browse/CNN-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ