### PR TITLE
Miscellaneous @context/@fromContext bugfixes

### DIFF
--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -48,6 +48,8 @@ use schema::FederationSchema;
 pub use crate::api_schema::ApiSchemaOptions;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
+use crate::link::context_spec_definition::ContextSpecDefinition;
+use crate::link::context_spec_definition::CONTEXT_VERSIONS;
 use crate::link::join_spec_definition::JoinSpecDefinition;
 use crate::link::link_spec_definition::LinkSpecDefinition;
 use crate::link::spec::Identity;
@@ -59,18 +61,23 @@ use crate::subgraph::ValidSubgraph;
 pub use crate::supergraph::ValidFederationSubgraph;
 pub use crate::supergraph::ValidFederationSubgraphs;
 
-pub(crate) type SupergraphSpecs = (&'static LinkSpecDefinition, &'static JoinSpecDefinition);
+pub(crate) type SupergraphSpecs = (
+    &'static LinkSpecDefinition,
+    &'static JoinSpecDefinition,
+    Option<&'static ContextSpecDefinition>,
+);
 
 pub(crate) fn validate_supergraph_for_query_planning(
     supergraph_schema: &FederationSchema,
 ) -> Result<SupergraphSpecs, FederationError> {
-    validate_supergraph(supergraph_schema, &JOIN_VERSIONS)
+    validate_supergraph(supergraph_schema, &JOIN_VERSIONS, &CONTEXT_VERSIONS)
 }
 
 /// Checks that required supergraph directives are in the schema, and returns which ones were used.
 pub(crate) fn validate_supergraph(
     supergraph_schema: &FederationSchema,
     join_versions: &'static SpecDefinitions<JoinSpecDefinition>,
+    context_versions: &'static SpecDefinitions<ContextSpecDefinition>,
 ) -> Result<SupergraphSpecs, FederationError> {
     let Some(metadata) = supergraph_schema.metadata() else {
         return Err(SingleFederationError::InvalidFederationSupergraph {
@@ -94,7 +101,22 @@ pub(crate) fn validate_supergraph(
             ),
         }.into());
     };
-    Ok((link_spec_definition, join_spec_definition))
+    let context_spec_definition = metadata.for_identity(&Identity::context_identity()).map(|context_link| {
+        context_versions.find(&context_link.url.version).map_or_else(|| {
+            Err(SingleFederationError::InvalidFederationSupergraph {
+                message: format!(
+                    "Invalid supergraph: uses unsupported context spec version {} (supported versions: {})",
+                    context_link.url.version,
+                    context_versions.versions().map(|v| v.to_string()).collect::<Vec<_>>().join(", "),
+                ),
+            })
+        }, Ok)
+    }).transpose()?;
+    Ok((
+        link_spec_definition,
+        join_spec_definition,
+        context_spec_definition,
+    ))
 }
 
 pub struct Supergraph {

--- a/apollo-federation/src/link/argument.rs
+++ b/apollo-federation/src/link/argument.rs
@@ -144,7 +144,7 @@ pub(crate) fn directive_optional_list_argument<'a>(
             Value::Null => Ok(None),
             Value::List(values) => Ok(Some(values.as_slice())),
             _ => bail!(
-                r#"Argument "{name}" of directive "@{}" must be a boolean."#,
+                r#"Argument "{name}" of directive "@{}" must be a list."#,
                 application.name
             ),
         },

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -6,7 +6,7 @@ use apollo_compiler::Node;
 use lazy_static::lazy_static;
 
 use crate::error::FederationError;
-use crate::error::SingleFederationError;
+use crate::internal_error;
 use crate::link::argument::directive_required_string_argument;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
@@ -44,12 +44,7 @@ impl ContextSpecDefinition {
         schema: &'schema FederationSchema,
     ) -> Result<&'schema Node<DirectiveDefinition>, FederationError> {
         self.directive_definition(schema, &CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
-            .ok_or_else(|| {
-                SingleFederationError::Internal {
-                    message: "Unexpectedly could not find context spec in schema".to_owned(),
-                }
-                .into()
-            })
+            .ok_or_else(|| internal_error!("Unexpectedly could not find context spec in schema"))
     }
 
     pub(crate) fn context_directive_arguments<'doc>(

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -469,15 +469,16 @@ impl FederationSpecDefinition {
         })
     }
 
-    pub(crate) fn context_directive_arguments(
-        application: &Node<Directive>,
-    ) -> Result<ContextDirectiveArguments, FederationError> {
+    pub(crate) fn context_directive_arguments<'doc>(
+        &self,
+        application: &'doc Node<Directive>,
+    ) -> Result<ContextDirectiveArguments<'doc>, FederationError> {
         Ok(ContextDirectiveArguments {
             name: directive_required_string_argument(application, &FEDERATION_NAME_ARGUMENT_NAME)?,
         })
     }
 
-    // The directive is named `@fromContex`. This is confusing for clippy, as
+    // The directive is named `@fromContext`. This is confusing for clippy, as
     // `from` is a conventional prefix used in conversion methods, which do not
     // take `self` as an argument. This function does **not** perform
     // conversion, but extracts `@fromContext` directive definition.
@@ -495,24 +496,7 @@ impl FederationSpecDefinition {
             })
     }
 
-    // The directive is named `@fromContex`. This is confusing for clippy, as
-    // `from` is a conventional prefix used in conversion methods, which do not
-    // take `self` as an argument. This function does **not** perform
-    // conversion, but extracts `@fromContext` directive arguments.
-    #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn from_context_directive_arguments<'doc>(
-        &self,
-        application: &'doc Node<Directive>,
-    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
-        Ok(FromContextDirectiveArguments {
-            field: directive_required_string_argument(
-                application,
-                &FEDERATION_FIELD_ARGUMENT_NAME,
-            )?,
-        })
-    }
-
-    // The directive is named `@fromContex`. This is confusing for clippy, as
+    // The directive is named `@fromContext`. This is confusing for clippy, as
     // `from` is a conventional prefix used in conversion methods, which do not
     // take `self` as an argument. This function does **not** perform
     // conversion, but extracts `@fromContext` directive.
@@ -536,6 +520,23 @@ impl FederationSpecDefinition {
         Ok(Directive {
             name: name_in_schema,
             arguments,
+        })
+    }
+
+    // The directive is named `@fromContext`. This is confusing for clippy, as
+    // `from` is a conventional prefix used in conversion methods, which do not
+    // take `self` as an argument. This function does **not** perform
+    // conversion, but extracts `@fromContext` directive arguments.
+    #[allow(clippy::wrong_self_convention)]
+    pub(crate) fn from_context_directive_arguments<'doc>(
+        &self,
+        application: &'doc Node<Directive>,
+    ) -> Result<FromContextDirectiveArguments<'doc>, FederationError> {
+        Ok(FromContextDirectiveArguments {
+            field: directive_required_string_argument(
+                application,
+                &FEDERATION_FIELD_ARGUMENT_NAME,
+            )?,
         })
     }
 

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -82,7 +82,7 @@ impl<'doc> TryFrom<&'doc Value> for ContextArgument<'doc> {
         ) -> Result<(), FederationError> {
             if let Some(first_value) = field {
                 bail!(
-                    r#"Input field "{name}" in contextArguments was repeated with value "{value}" (previous value was "{first_value}")"#
+                    r#"Input field "{name}" in contextArguments is repeated with value "{value}" (previous value was "{first_value}")"#
                 )
             }
             let _ = field.insert(value);
@@ -96,19 +96,19 @@ impl<'doc> TryFrom<&'doc Value> for ContextArgument<'doc> {
             field
                 .ok_or_else(|| {
                     FederationError::internal(format!(
-                        r#"Input field "{field_name}" was missing from contextArguments"#
+                        r#"Input field "{field_name}" is missing from contextArguments"#
                     ))
                 })?
                 .as_str()
                 .ok_or_else(|| {
                     FederationError::internal(format!(
-                        r#"Input field "{field_name}" in contextArguments was not a string"#
+                        r#"Input field "{field_name}" in contextArguments is not a string"#
                     ))
                 })
         }
 
         let Value::Object(input_object) = value else {
-            bail!(r#"Item "{value}" in contextArguments list was not an object"#)
+            bail!(r#"Item "{value}" in contextArguments list is not an object"#)
         };
         let mut name = None;
         let mut type_ = None;

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -18,6 +18,7 @@ use strum::IntoEnumIterator;
 use crate::bail;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
+use crate::internal_error;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::link::federation_spec_definition::KeyDirectiveArguments;
@@ -31,6 +32,7 @@ use crate::query_graph::QueryGraphEdge;
 use crate::query_graph::QueryGraphEdgeTransition;
 use crate::query_graph::QueryGraphNode;
 use crate::query_graph::QueryGraphNodeType;
+use crate::query_plan::fetch_dependency_graph::iter_into_single_item;
 use crate::schema::field_set::parse_field_set;
 use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::CompositeTypeDefinitionPosition;
@@ -70,11 +72,11 @@ pub fn build_federated_query_graph(
         graph: Default::default(),
         sources: Default::default(),
         subgraphs_by_name: Default::default(),
+        supergraph_schema: Default::default(),
         types_to_nodes_by_source: Default::default(),
         root_kinds_to_nodes_by_source: Default::default(),
         non_trivial_followup_edges: Default::default(),
-        subgraph_to_args: Default::default(),
-        subgraph_to_arg_indices: Default::default(),
+        arguments_to_context_ids_by_source: Default::default(),
     };
     let query_graph =
         extract_subgraphs_from_supergraph(&supergraph_schema, validate_extracted_subgraphs)?
@@ -105,11 +107,11 @@ pub fn build_query_graph(
         graph: Default::default(),
         sources: Default::default(),
         subgraphs_by_name: Default::default(),
+        supergraph_schema: Default::default(),
         types_to_nodes_by_source: Default::default(),
         root_kinds_to_nodes_by_source: Default::default(),
         non_trivial_followup_edges: Default::default(),
-        subgraph_to_args: Default::default(),
-        subgraph_to_arg_indices: Default::default(),
+        arguments_to_context_ids_by_source: Default::default(),
     };
     let builder = SchemaQueryGraphBuilder::new(query_graph, name, schema, None, false)?;
     query_graph = builder.build()?;
@@ -962,9 +964,10 @@ struct FederatedQueryGraphBuilder {
 
 impl FederatedQueryGraphBuilder {
     fn new(
-        query_graph: QueryGraph,
+        mut query_graph: QueryGraph,
         supergraph_schema: ValidFederationSchema,
     ) -> Result<Self, FederationError> {
+        query_graph.supergraph_schema = Some(supergraph_schema.clone());
         let base = BaseQueryGraphBuilder::new(
             query_graph,
             FEDERATED_GRAPH_ROOT_SOURCE.into(),
@@ -972,6 +975,7 @@ impl FederatedQueryGraphBuilder {
             // here (note that empty schemas have no Query type, making them invalid GraphQL).
             ValidFederationSchema::new(Valid::assume_valid(Schema::new()))?,
         );
+
         let subgraphs = FederatedQueryGraphBuilderSubgraphs::new(&base)?;
         Ok(FederatedQueryGraphBuilder {
             base,
@@ -1478,27 +1482,24 @@ impl FederatedQueryGraphBuilder {
 
     fn handle_context(&mut self) -> Result<(), FederationError> {
         let mut subgraph_to_args: IndexMap<Arc<str>, Vec<ObjectFieldArgumentDefinitionPosition>> =
-            IndexMap::default();
+            Default::default();
         let mut coordinate_map: IndexMap<
             Arc<str>,
             IndexMap<ObjectFieldDefinitionPosition, Vec<ContextCondition>>,
-        > = IndexMap::default();
+        > = Default::default();
         for (subgraph_name, subgraph) in self.base.query_graph.subgraphs() {
             let subgraph_data = self.subgraphs.get(subgraph_name)?;
-            let Some((_, context_refs)) = &subgraph
+            let Some(context_refs) = &subgraph
                 .referencers()
                 .directives
-                .iter()
-                .find(|(dir, _)| **dir == subgraph_data.context_directive_definition_name)
+                .get(&subgraph_data.context_directive_definition_name)
             else {
                 continue;
             };
-
-            let Some((_, from_context_refs)) = &subgraph
+            let Some(from_context_refs) = &subgraph
                 .referencers()
                 .directives
-                .iter()
-                .find(|(dir, _)| **dir == subgraph_data.from_context_directive_definition_name)
+                .get(&subgraph_data.from_context_directive_definition_name)
             else {
                 continue;
             };
@@ -1514,7 +1515,9 @@ impl FederatedQueryGraphBuilder {
                     .directives
                     .get_all(subgraph_data.context_directive_definition_name.as_str())
                 {
-                    let application = FederationSpecDefinition::context_directive_arguments(dir)?;
+                    let application = subgraph_data
+                        .federation_spec_definition
+                        .context_directive_arguments(dir)?;
                     context_name_to_types
                         .entry(application.name)
                         .or_default()
@@ -1527,7 +1530,9 @@ impl FederatedQueryGraphBuilder {
                     .directives
                     .get_all(subgraph_data.context_directive_definition_name.as_str())
                 {
-                    let application = FederationSpecDefinition::context_directive_arguments(dir)?;
+                    let application = subgraph_data
+                        .federation_spec_definition
+                        .context_directive_arguments(dir)?;
                     context_name_to_types
                         .entry(application.name)
                         .or_default()
@@ -1540,7 +1545,9 @@ impl FederatedQueryGraphBuilder {
                     .directives
                     .get_all(subgraph_data.context_directive_definition_name.as_str())
                 {
-                    let application = FederationSpecDefinition::context_directive_arguments(dir)?;
+                    let application = subgraph_data
+                        .federation_spec_definition
+                        .context_directive_arguments(dir)?;
                     context_name_to_types
                         .entry(application.name)
                         .or_default()
@@ -1557,36 +1564,41 @@ impl FederatedQueryGraphBuilder {
                     .or_default()
                     .push(object_field_arg.clone());
                 let field_coordinate = object_field_arg.parent();
-                if let Some(dir) = input_value.directives.get(
+                let Some(dir) = input_value.directives.get(
                     subgraph_data
                         .from_context_directive_definition_name
                         .as_str(),
-                ) {
-                    let application = subgraph_data
-                        .federation_spec_definition
-                        .from_context_directive_arguments(dir)?;
-                    let (context, selection) = parse_context(application.field)?;
-
-                    let types_with_context_set = context_name_to_types
-                        .get(context.as_str())
-                        .into_iter()
-                        .flatten()
-                        .cloned()
-                        .collect();
-                    let conditions = ContextCondition {
+                ) else {
+                    bail!(
+                        "Argument {} unexpectedly missing @fromContext directive",
+                        object_field_arg
+                    );
+                };
+                let application = subgraph_data
+                    .federation_spec_definition
+                    .from_context_directive_arguments(dir)?;
+                let (context, selection) = parse_context(application.field)?;
+                let Some(types_with_context_set) = context_name_to_types.get(context.as_str())
+                else {
+                    bail!(
+                        r#"Context ${} is never set in subgraph "{}""#,
                         context,
-                        selection,
-                        subgraph_name: subgraph_name.clone(),
-                        argument_coordinate: object_field_arg.clone(),
-                        types_with_context_set,
-                        named_parameter: object_field_arg.argument_name.to_owned(),
-                        arg_type: input_value.ty.clone(),
-                    };
-                    coordinate_map
-                        .entry(field_coordinate.clone())
-                        .or_default()
-                        .push(conditions);
-                }
+                        subgraph_name
+                    );
+                };
+                let conditions = ContextCondition {
+                    context,
+                    subgraph_name: subgraph_name.clone(),
+                    selection,
+                    types_with_context_set: types_with_context_set.clone(),
+                    argument_name: object_field_arg.argument_name.to_owned(),
+                    argument_coordinate: object_field_arg.clone(),
+                    argument_type: input_value.ty.clone(),
+                };
+                coordinate_map
+                    .entry(field_coordinate.clone())
+                    .or_default()
+                    .push(conditions);
             }
         }
 
@@ -1617,7 +1629,7 @@ impl FederatedQueryGraphBuilder {
         }
 
         // Add the context argument mapping
-        self.base.query_graph.subgraph_to_arg_indices = self
+        self.base.query_graph.arguments_to_context_ids_by_source = self
             .base
             .query_graph
             .subgraphs()
@@ -1638,7 +1650,6 @@ impl FederatedQueryGraphBuilder {
                 ))
             })
             .process_results(|r| r.collect())?;
-        self.base.query_graph.subgraph_to_args = subgraph_to_args;
 
         Ok(())
     }
@@ -2333,42 +2344,66 @@ fn resolvable_key_applications<'doc>(
 }
 
 fn parse_context(field: &str) -> Result<(String, String), FederationError> {
-    let pattern = Regex::new(
-        r#"^(?:[\n\r\t ,]|#[^\n\r]*)*\$(?:[\n\r\t ,]|#[^\n\r]*)*([A-Za-z_]\w*)([\s\S]*)$"#,
-    )
-    .unwrap();
+    // PORT_NOTE: The original JS regex, as shown below
+    //   /^(?:[\n\r\t ,]|#[^\n\r]*(?![^\n\r]))*\$(?:[\n\r\t ,]|#[^\n\r]*(?![^\n\r]))*([A-Za-z_]\w*(?!\w))([\s\S]*)$/
+    // makes use of negative lookaheads, which aren't supported natively by Rust's regex crate.
+    // There's a fancy_regex crate which does support this, but in the specific case above, the
+    // negative lookaheads are just used to ensure strict *-greediness for the preceding expression
+    // (i.e., it guarantees those *-expressions match greedily and won't backtrack).
+    //
+    // We can emulate that in this case by matching a series of regexes instead of a single regex,
+    // where for each regex, the relevant *-expression doesn't backtrack by virtue of the rest of
+    // the haystack guaranteeing a match. Also note that Rust has (?s:.) to match all characters
+    // including newlines, which we use in place of JS's common regex workaround of [\s\S].
+    fn strip_leading_ignored_tokens(input: &str) -> Result<&str, FederationError> {
+        let leading_pattern = Regex::new(r#"^(?:[\n\r\t ,]|#[^\n\r]*)*((?s:.)*)$"#).unwrap();
+        iter_into_single_item(leading_pattern.captures_iter(input))
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str())
+            .ok_or_else(|| {
+                internal_error!(r#"Failed to skip any leading ignored tokens in @fromContext substring "{input}""#)
+            })
+    }
 
-    let mut iter = pattern.captures_iter(field);
+    let dollar_start = strip_leading_ignored_tokens(field)?;
+    let mut dollar_iter = dollar_start.chars();
+    if dollar_iter.next() != Some('$') {
+        bail!(r#"Failed to find leading "$" in @fromContext substring "{dollar_start}""#);
+    }
+    let after_dollar = dollar_iter.as_str();
 
-    let Some(captures) = iter.next() else {
-        bail!("Expected to find the name of a context and a selection inside the field argument to `@fromContext`: {field:?}");
+    let context_start = strip_leading_ignored_tokens(after_dollar)?;
+    let context_pattern = Regex::new(r#"^([A-Za-z_](?-u:\w)*)((?s:.)*)$"#).unwrap();
+    let Some(context_captures) =
+        iter_into_single_item(context_pattern.captures_iter(context_start))
+    else {
+        bail!(
+            r#"Failed to find context name token and selection in @fromContext substring "{context_start}""#
+        );
     };
 
-    if iter.next().is_some() {
-        bail!("Expected only one context and selection pair inside the field argument to `@fromContext`: {field:?}");
-    }
+    let context = match context_captures.get(1).map(|m| m.as_str()) {
+        Some(context) if !context.is_empty() => context,
+        _ => {
+            bail!(
+                r#"Expected to find non-empty context name in @fromContext substring "{context_start}""#
+            );
+        }
+    };
 
-    let (context, selection) = captures
-        .iter()
-        // Ignore the first match because it is always the whole matching substring
-        .skip(1)
-        .flatten()
-        .fold(("", ""), |(_, b), group| (b, group.as_str()));
+    let selection = match context_captures.get(2).map(|m| m.as_str()) {
+        Some(selection) if !selection.is_empty() => selection,
+        _ => {
+            bail!(
+                r#"Expected to find non-empty selection in @fromContext substring "{context_start}""#
+            );
+        }
+    };
 
-    if context.is_empty() {
-        bail!("Expected to find the name of a context inside the field argument to `@fromContext`: {field:?}");
-    }
-
-    if selection.is_empty() {
-        bail!(
-            "Expected to find and a selection inside the field argument to `@fromContext`: {field:?}"
-        );
-    }
-
-    Ok((
-        context.trim_end().to_owned(),
-        selection.trim_start().to_owned(),
-    ))
+    // PORT_NOTE: apollo_compiler's parsing code for field sets requires ignored tokens to be
+    // pre-stripped if curly braces are missing, so we additionally do that here.
+    let selection = strip_leading_ignored_tokens(selection)?;
+    Ok((context.to_owned(), selection.to_owned()))
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -23,9 +23,13 @@ pub(crate) struct ContextMapEntry {
     pub(crate) levels_in_query_path: usize,
     pub(crate) path_tree: Option<Arc<OpPathTree>>,
     pub(crate) selection_set: SelectionSet,
-    pub(crate) param_name: Name,
-    pub(crate) arg_type: Node<Type>,
-    pub(crate) id: Name,
+    // PORT_NOTE: This field was renamed from the JS name (`paramName`) to better align with naming
+    // in ContextCondition.
+    pub(crate) argument_name: Name,
+    // PORT_NOTE: This field was renamed from the JS name (`argType`) to better align with naming in
+    // ContextCondition.
+    pub(crate) argument_type: Node<Type>,
+    pub(crate) context_id: Name,
 }
 
 /// Note that `ConditionResolver`s are guaranteed to be only called for edge with conditions.

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -4,16 +4,13 @@ use std::fmt::Formatter;
 use std::fmt::Write;
 use std::hash::Hash;
 use std::ops::Deref;
-use std::ops::DerefMut;
 use std::sync::atomic;
 use std::sync::Arc;
 
-use apollo_compiler::ast::InputValueDefinition;
 use apollo_compiler::ast::Type;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
-use apollo_compiler::executable::Argument;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use either::Either;
@@ -32,7 +29,6 @@ use crate::display_helpers::DisplayOption;
 use crate::display_helpers::DisplaySlice;
 use crate::display_helpers::State as IndentedFormatter;
 use crate::error::FederationError;
-use crate::internal_error;
 use crate::is_leaf_type;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::link::graphql_definition::BooleanOrVariable;
@@ -43,10 +39,8 @@ use crate::operation::DirectiveList;
 use crate::operation::Field;
 use crate::operation::HasSelectionKey;
 use crate::operation::InlineFragment;
-use crate::operation::NamedFragments;
 use crate::operation::SelectionId;
 use crate::operation::SelectionKey;
-use crate::operation::SelectionMapperReturn;
 use crate::operation::SelectionSet;
 use crate::operation::SiblingTypename;
 use crate::query_graph::condition_resolver::ConditionResolution;
@@ -59,24 +53,25 @@ use crate::query_graph::QueryGraphNodeType;
 use crate::query_plan::query_planner::EnabledOverrideConditions;
 use crate::query_plan::FetchDataPathElement;
 use crate::query_plan::QueryPlanCost;
-use crate::schema::field_set::parse_field_set;
+use crate::schema::field_set::parse_field_value_without_validation;
+use crate::schema::field_set::validate_field_value;
 use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::Captures;
 use crate::schema::position::CompositeTypeDefinitionPosition;
-use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::InterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::OutputTypeDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::ValidFederationSchema;
+use crate::utils::FallibleIterator;
 
 #[derive(Clone, serde::Serialize, Debug, Eq, PartialEq)]
-pub(crate) struct ContextAtUsageEntry {
+pub(crate) struct ContextUsageEntry {
     pub(crate) context_id: Name,
     pub(crate) relative_path: Vec<FetchDataPathElement>,
     pub(crate) selection_set: SelectionSet,
-    pub(crate) subgraph_arg_type: Node<Type>,
+    pub(crate) subgraph_argument_type: Node<Type>,
 }
 
 /// An immutable path in a query graph.
@@ -178,11 +173,15 @@ where
     // TODO(@TylerBloom): Add in once defer is supported.
     #[serde(skip)]
     defer_on_tail: Option<DeferDirectiveArguments>,
-    /// At the point where a `@context` is set, we will have fields to select
-    context_to_selection: Vec<Option<ContextToSelection>>,
-    /// Where a context is used (i.e. `@fromContext`) there will exist a ContextAtUsageEntry map
-    /// (1 for each parameter)
-    parameter_to_context: Vec<Option<ParameterToContext>>,
+    // PORT_NOTE: This field was renamed because the JS name (`contextToSelection`) implied it was
+    // a map to selections, which it isn't.
+    /// The IDs of contexts set at the head of an edge, for each edge in the path.
+    set_context_ids: Vec<Option<SetContextIds>>,
+    // PORT_NOTE: This field was renamed because the JS name (`parameterToContext`) left confusion
+    // to how a parameter was different from an argument.
+    /// Maps of @fromContext arguments to info about the contexts used in those arguments, for each
+    /// edge in the path.
+    arguments_to_context_usages: Vec<Option<ArgumentsToContextUsages>>,
 }
 
 impl<TTrigger, TEdge> std::fmt::Debug for GraphPath<TTrigger, TEdge>
@@ -209,8 +208,8 @@ where
             runtime_types_of_tail,
             runtime_types_before_tail_if_last_is_cast,
             defer_on_tail,
-            context_to_selection: _,
-            parameter_to_context: _,
+            set_context_ids: _,
+            arguments_to_context_usages: _,
         } = self;
 
         f.debug_struct("GraphPath")
@@ -270,16 +269,16 @@ impl OverrideId {
     }
 }
 
-pub(crate) type ContextToSelection = IndexSet<Name>;
-pub(crate) type ParameterToContext = IndexMap<Name, ContextAtUsageEntry>;
+pub(crate) type SetContextIds = IndexSet<Name>;
+pub(crate) type ArgumentsToContextUsages = IndexMap<Name, ContextUsageEntry>;
 
 /// The item type for [`GraphPath::iter`]
 pub(crate) type GraphPathItem<'path, TTrigger, TEdge> = (
     TEdge,
     &'path Arc<TTrigger>,
     &'path Option<Arc<OpPathTree>>,
-    Option<ContextToSelection>,
-    Option<ParameterToContext>,
+    Option<SetContextIds>,
+    Option<ArgumentsToContextUsages>,
 );
 
 /// A `GraphPath` whose triggers are operation elements (essentially meaning that the path has been
@@ -916,11 +915,13 @@ impl TryFrom<GraphPathTrigger> for Arc<QueryGraphEdgeTransition> {
     }
 }
 
+#[derive(derive_more::From)]
 pub(crate) enum GraphPathTriggerRef<'a> {
     Op(&'a OpGraphPathTrigger),
     Transition(&'a QueryGraphEdgeTransition),
 }
 
+#[derive(derive_more::From)]
 pub(crate) enum GraphPathTriggerRefMut<'a> {
     Op(&'a mut OpGraphPathTrigger),
     Transition(&'a mut QueryGraphEdgeTransition),
@@ -935,31 +936,7 @@ impl<'a> From<&'a GraphPathTrigger> for GraphPathTriggerRef<'a> {
     }
 }
 
-impl<'a> From<&'a OpGraphPathTrigger> for GraphPathTriggerRef<'a> {
-    fn from(value: &'a OpGraphPathTrigger) -> Self {
-        Self::Op(value)
-    }
-}
-
-impl<'a> From<&'a mut OpGraphPathTrigger> for GraphPathTriggerRefMut<'a> {
-    fn from(value: &'a mut OpGraphPathTrigger) -> Self {
-        Self::Op(value)
-    }
-}
-
-impl<'a> From<&'a QueryGraphEdgeTransition> for GraphPathTriggerRef<'a> {
-    fn from(value: &'a QueryGraphEdgeTransition) -> Self {
-        Self::Transition(value)
-    }
-}
-
-impl<'a> From<&'a mut QueryGraphEdgeTransition> for GraphPathTriggerRefMut<'a> {
-    fn from(value: &'a mut QueryGraphEdgeTransition) -> Self {
-        Self::Transition(value)
-    }
-}
-
-/// `GraphPath` is generic over two type, `TTrigger` and `TEdge`. This trait helps abstract over
+/// `GraphPath` is generic over two types, `TTrigger` and `TEdge`. This trait helps abstract over
 /// the `TTrigger` type bound. A `TTrigger` is one of the two types that make up the variants of
 /// the `GraphPathTrigger`. Rather than trying to cast into concrete types and cast back (and
 /// potentially raise errors), this trait provides ways to access the data needed within.
@@ -976,14 +953,14 @@ pub(crate) trait GraphPathTriggerVariant: Eq + Hash + std::fmt::Debug {
         }
     }
 
-    fn get_field_parent_type<'a>(&'a self) -> Option<FieldDefinitionPosition>
+    fn get_field_parent_type<'a>(&'a self) -> Option<CompositeTypeDefinitionPosition>
     where
         &'a Self: Into<GraphPathTriggerRef<'a>>,
     {
         match self.into() {
             GraphPathTriggerRef::Op(trigger) => match trigger {
                 OpGraphPathTrigger::OpPathElement(OpPathElement::Field(field)) => {
-                    Some(field.field_position.clone())
+                    Some(field.field_position.parent())
                 }
                 _ => None,
             },
@@ -991,7 +968,7 @@ pub(crate) trait GraphPathTriggerVariant: Eq + Hash + std::fmt::Debug {
                 QueryGraphEdgeTransition::FieldCollection {
                     field_definition_position,
                     ..
-                } => Some(field_definition_position.clone()),
+                } => Some(field_definition_position.parent()),
                 _ => None,
             },
         }
@@ -1025,8 +1002,8 @@ where
             runtime_types_of_tail: Arc::new(IndexSet::default()),
             runtime_types_before_tail_if_last_is_cast: None,
             defer_on_tail: None,
-            context_to_selection: Vec::default(),
-            parameter_to_context: Vec::default(),
+            set_context_ids: Vec::default(),
+            arguments_to_context_usages: Vec::default(),
         };
         path.runtime_types_of_tail = Arc::new(path.head_possible_runtime_types()?);
         Ok(path)
@@ -1069,8 +1046,8 @@ where
         let mut edges = self.edges.clone();
         let mut edge_triggers = self.edge_triggers.clone();
         let mut edge_conditions = self.edge_conditions.clone();
-        let mut context_to_selection = self.context_to_selection.clone();
-        let mut parameter_to_context = self.parameter_to_context.clone();
+        let mut set_context_ids = self.set_context_ids.clone();
+        let mut arguments_to_context_usages = self.arguments_to_context_usages.clone();
         let mut last_subgraph_entering_edge_info = if defer.is_none() {
             self.last_subgraph_entering_edge_info.clone()
         } else {
@@ -1081,8 +1058,8 @@ where
             edges.push(edge);
             edge_triggers.push(Arc::new(trigger));
             edge_conditions.push(condition_path_tree);
-            context_to_selection.push(None);
-            parameter_to_context.push(None);
+            set_context_ids.push(None);
+            arguments_to_context_usages.push(None);
             return Ok(GraphPath {
                 graph: self.graph.clone(),
                 head: self.head,
@@ -1102,8 +1079,8 @@ where
                 ),
                 runtime_types_before_tail_if_last_is_cast: None,
                 defer_on_tail: defer,
-                context_to_selection,
-                parameter_to_context,
+                set_context_ids,
+                arguments_to_context_usages,
             });
         };
 
@@ -1241,8 +1218,10 @@ where
                                         } else {
                                             self.defer_on_tail.clone()
                                         },
-                                        context_to_selection: self.context_to_selection.clone(),
-                                        parameter_to_context: self.parameter_to_context.clone(),
+                                        set_context_ids: self.set_context_ids.clone(),
+                                        arguments_to_context_usages: self
+                                            .arguments_to_context_usages
+                                            .clone(),
                                     });
                                 }
                             }
@@ -1303,61 +1282,47 @@ where
                     // We know last edge is not a cast.
                     runtime_types_before_tail_if_last_is_cast: None,
                     defer_on_tail: defer,
-                    context_to_selection: self.context_to_selection.clone(),
-                    parameter_to_context: self.parameter_to_context.clone(),
+                    set_context_ids: self.set_context_ids.clone(),
+                    arguments_to_context_usages: self.arguments_to_context_usages.clone(),
                 });
             }
         }
 
-        let (new_edge_conditions, new_context_to_selection, new_parameter_to_context) =
+        let (new_edge_conditions, new_set_context_ids, new_arguments_to_context_usages) =
             self.merge_edge_conditions_with_resolution(&condition_path_tree, &context_map);
-        let last_parameter_to_context = new_parameter_to_context.last();
+        let last_arguments_to_context_usages = new_arguments_to_context_usages.last();
 
-        if let Some(Some(last_parameter_to_context)) = last_parameter_to_context {
+        if let Some(Some(last_arguments_to_context_usages)) = last_arguments_to_context_usages {
             // TODO: Perhaps it is better to explicitly cast this to `GraphPathTriggerRefMut` and
             // pull out the field from there.
             if let Some(field) = trigger.get_field_mut() {
-                let mut schema = field.schema.schema().clone().into_inner();
-                let type_name = field.field_position.type_name();
-                let field_name = field.field_position.field_name();
-                let Some(field_def) = schema.types.get_mut(type_name).and_then(|t| match t {
-                    apollo_compiler::schema::ExtendedType::Scalar(_) => None,
-                    apollo_compiler::schema::ExtendedType::Object(obj) => {
-                        obj.make_mut().fields.get_mut(field_name)
-                    }
-                    apollo_compiler::schema::ExtendedType::Interface(iface) => {
-                        iface.make_mut().fields.get_mut(field_name)
-                    }
-                    apollo_compiler::schema::ExtendedType::Union(_) => None,
-                    apollo_compiler::schema::ExtendedType::Enum(_) => None,
-                    apollo_compiler::schema::ExtendedType::InputObject(_) => None,
-                }) else {
-                    bail!("Unexpectedly failed to lookup field {type_name}.{field_name}")
+                // We need to add the extra @fromContext arguments to the trigger, but its likely
+                // pointing to a schema that doesn't have them, so we update the trigger to use the
+                // appropriate subgraph schema and position first.
+                let QueryGraphEdgeTransition::FieldCollection {
+                    source,
+                    field_definition_position,
+                    ..
+                } = &edge_weight.transition
+                else {
+                    bail!(
+                        "Unexpectedly found field trigger for non-field edge {}",
+                        edge_weight
+                    );
                 };
-                let field_def = field_def.deref_mut().make_mut();
-                let mut updated_field_arguments = vec![];
-                let mut updated_field_def_arguments = vec![];
-                for (param_name, usage_entry) in last_parameter_to_context {
-                    if !field_def
-                        .arguments
+                field.schema = self.graph.schema_by_source(source)?.clone();
+                field.field_position = field_definition_position.clone();
+
+                // Now we can append the extra @fromContext arguments.
+                let updated_field_arguments =
+                    last_arguments_to_context_usages
                         .iter()
-                        .any(|arg| arg.name.as_str() == param_name.as_str())
-                    {
-                        updated_field_def_arguments.push(Node::new(InputValueDefinition {
-                            name: usage_entry.context_id.clone(),
-                            ty: usage_entry.subgraph_arg_type.clone(),
-                            default_value: None,
-                            description: None,
-                            directives: Default::default(),
-                        }));
-                        updated_field_arguments.push(Node::new(Argument {
-                            name: param_name.clone(),
-                            value: Node::new(Value::Variable(usage_entry.context_id.clone())),
-                        }));
-                    }
-                }
-                field_def.arguments.extend(updated_field_def_arguments);
-                field.schema = ValidFederationSchema::new(schema.validate()?)?;
+                        .map(|(argument_name, usage_entry)| {
+                            Node::new(apollo_compiler::executable::Argument {
+                                name: argument_name.clone(),
+                                value: Node::new(Value::Variable(usage_entry.context_id.clone())),
+                            })
+                        });
                 field.arguments = field
                     .arguments
                     .iter()
@@ -1413,8 +1378,8 @@ where
             } else {
                 None
             },
-            context_to_selection: new_context_to_selection,
-            parameter_to_context: new_parameter_to_context,
+            set_context_ids: new_set_context_ids,
+            arguments_to_context_usages: new_arguments_to_context_usages,
         })
     }
 
@@ -1426,21 +1391,23 @@ where
     ) -> (
         Vec<Option<Arc<OpPathTree>>>,
         Vec<Option<IndexSet<Name>>>,
-        Vec<Option<IndexMap<Name, ContextAtUsageEntry>>>,
+        Vec<Option<IndexMap<Name, ContextUsageEntry>>>,
     ) {
         let mut edge_conditions = self.edge_conditions.clone();
-        let mut context_to_selection = self.context_to_selection.clone();
-        let mut parameter_to_context = self.parameter_to_context.clone();
+        let mut set_context_ids = self.set_context_ids.clone();
+        let mut arguments_to_context_usages = self.arguments_to_context_usages.clone();
 
         edge_conditions.push(condition_path_tree.clone());
+        set_context_ids.push(None);
         if context_map.is_none() || context_map.as_ref().is_some_and(|m| m.is_empty()) {
-            context_to_selection.push(None);
-            parameter_to_context.push(None);
-            (edge_conditions, context_to_selection, parameter_to_context)
+            arguments_to_context_usages.push(None);
+            (
+                edge_conditions,
+                set_context_ids,
+                arguments_to_context_usages,
+            )
         } else {
-            // parameter_to_context.push(Some(Arc::new(IndexMap::default())));
-            context_to_selection.push(None);
-            let mut new_parameter_to_context = IndexMap::default();
+            let mut new_arguments_to_context_usages = IndexMap::default();
             for (_, entry) in context_map.iter().flat_map(|map| map.iter()) {
                 let idx = edge_conditions.len() - entry.levels_in_query_path - 1;
 
@@ -1450,48 +1417,52 @@ where
                         .map_or_else(|| path_tree.clone(), |condition| condition.merge(path_tree));
                     edge_conditions[idx] = Some(merged_conditions);
                 }
-                context_to_selection[idx]
+                set_context_ids[idx]
                     .get_or_insert_with(Default::default)
-                    .insert(entry.id.clone());
+                    .insert(entry.context_id.clone());
 
-                new_parameter_to_context.insert(
-                    entry.param_name.clone(),
-                    ContextAtUsageEntry {
-                        context_id: entry.id.clone(),
+                new_arguments_to_context_usages.insert(
+                    entry.argument_name.clone(),
+                    ContextUsageEntry {
+                        context_id: entry.context_id.clone(),
                         relative_path: vec![
                             FetchDataPathElement::Parent;
                             entry.levels_in_data_path
                         ],
                         selection_set: entry.selection_set.clone(),
-                        subgraph_arg_type: entry.arg_type.clone(),
+                        subgraph_argument_type: entry.argument_type.clone(),
                     },
                 );
             }
-            parameter_to_context.push(Some(new_parameter_to_context));
-            (edge_conditions, context_to_selection, parameter_to_context)
+            arguments_to_context_usages.push(Some(new_arguments_to_context_usages));
+            (
+                edge_conditions,
+                set_context_ids,
+                arguments_to_context_usages,
+            )
         }
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = GraphPathItem<'_, TTrigger, TEdge>> {
         debug_assert_eq!(self.edges.len(), self.edge_triggers.len());
         debug_assert_eq!(self.edges.len(), self.edge_conditions.len());
-        debug_assert_eq!(self.edges.len(), self.context_to_selection.len());
-        debug_assert_eq!(self.edges.len(), self.parameter_to_context.len());
+        debug_assert_eq!(self.edges.len(), self.set_context_ids.len());
+        debug_assert_eq!(self.edges.len(), self.arguments_to_context_usages.len());
         self.edges
             .iter()
             .copied()
             .zip(&self.edge_triggers)
             .zip(&self.edge_conditions)
-            .zip(&self.context_to_selection)
-            .zip(&self.parameter_to_context)
+            .zip(&self.set_context_ids)
+            .zip(&self.arguments_to_context_usages)
             .map(
-                |((((edge, trigger), condition), context_to_selection), parameter_to_context)| {
+                |((((edge, trigger), condition), set_context_ids), arguments_to_context_usages)| {
                     (
                         edge,
                         trigger,
                         condition,
-                        context_to_selection.clone(),
-                        parameter_to_context.clone(),
+                        set_context_ids.clone(),
+                        arguments_to_context_usages.clone(),
                     )
                 },
             )
@@ -1686,135 +1657,140 @@ where
                         levels_in_data_path += 1;
                     }
                     let Some(e) = (*e).into() else { continue };
-                    if !was_unsatisfied && !context_map.contains_key(&ctx.named_parameter) {
-                        if let Some(parent_type) = parent_type {
-                            let parent_type = parent_type.parent();
-                            let subgraph_schema =
-                                self.graph.schema_by_source(&ctx.subgraph_name)?;
-                            let mut potential_matches: IndexSet<Name> = Default::default();
-                            ctx.types_with_context_set.iter().for_each(|pos| {
-                                if pos.type_name() == parent_type.type_name() {
-                                    potential_matches.insert(parent_type.type_name().clone());
+                    if was_unsatisfied || context_map.contains_key(&ctx.argument_name) {
+                        continue;
+                    }
+                    // There's a context match if in the supergraph schema, the field's parent type
+                    // is equal to or a subtype of one of the @context types.
+                    let Some(parent_type) = parent_type else {
+                        continue;
+                    };
+                    let supergraph_schema = self.graph.supergraph_schema()?;
+                    let parent_type_in_supergraph: CompositeTypeDefinitionPosition =
+                        supergraph_schema
+                            .get_type(parent_type.type_name().clone())?
+                            .try_into()?;
+                    if !ctx.types_with_context_set.iter().fallible_any(|pos| {
+                        if pos.type_name() == parent_type_in_supergraph.type_name() {
+                            return Ok::<_, FederationError>(true);
+                        }
+                        match &parent_type_in_supergraph {
+                            CompositeTypeDefinitionPosition::Object(parent_type_in_supergraph) => {
+                                if parent_type_in_supergraph
+                                    .get(supergraph_schema.schema())?
+                                    .implements_interfaces
+                                    .iter()
+                                    .any(|item| &item.name == pos.type_name())
+                                {
+                                    return Ok(true);
                                 }
-                                match &pos {
-                                    CompositeTypeDefinitionPosition::Object(obj_pos) => {
-                                        if let Ok(obj) = obj_pos.get(subgraph_schema.schema()) {
-                                            obj.implements_interfaces
-                                                .iter()
-                                                .filter(|item| {
-                                                    &item.name == parent_type.type_name()
-                                                })
-                                                .for_each(|item| {
-                                                    potential_matches.insert(item.name.clone());
-                                                });
-                                        }
-                                    }
-                                    CompositeTypeDefinitionPosition::Interface(iface_pos) => {
-                                        if let Ok(iface) = iface_pos.get(subgraph_schema.schema()) {
-                                            iface
-                                                .implements_interfaces
-                                                .iter()
-                                                .filter(|item| {
-                                                    &item.name == parent_type.type_name()
-                                                })
-                                                .for_each(|_| {
-                                                    potential_matches.insert(iface.name.clone());
-                                                });
-                                        }
-                                    }
-                                    CompositeTypeDefinitionPosition::Union(union_pos) => {
-                                        if let Ok(un) = union_pos.get(subgraph_schema.schema()) {
-                                            un.members
-                                                .iter()
-                                                .filter(|item| {
-                                                    &item.name == parent_type.type_name()
-                                                })
-                                                .for_each(|_| {
-                                                    potential_matches.insert(un.name.clone());
-                                                });
-                                        }
-                                    }
+                            }
+                            CompositeTypeDefinitionPosition::Interface(
+                                parent_type_in_supergraph,
+                            ) => {
+                                if parent_type_in_supergraph
+                                    .get(supergraph_schema.schema())?
+                                    .implements_interfaces
+                                    .iter()
+                                    .any(|item| &item.name == pos.type_name())
+                                {
+                                    return Ok(true);
                                 }
-                            });
-
-                            // get the selection set for the first match that parses
-                            let selection_set =
-                                potential_matches.iter().find_map(|parent_type_name| {
-                                    parse_field_set(
-                                        subgraph_schema,
-                                        parent_type_name.clone(),
-                                        &ctx.selection,
-                                    )
-                                    .ok()
-                                });
-
-                            if let Some(selection_set) = selection_set {
-                                selection_set.lazy_map(
-                                    &NamedFragments::default(),
-                                    |selection| {
-                                        if let OpPathElement::InlineFragment(fragment) =
-                                            selection.element()?
-                                        {
-                                            if let Some(CompositeTypeDefinitionPosition::Object(
-                                                obj,
-                                            )) = &fragment.type_condition_position
-                                            {
-                                                if !subgraph_schema
-                                                    .possible_runtime_types(parent_type.clone())?
-                                                    .contains(obj)
-                                                {
-                                                    return Ok(SelectionMapperReturn::None);
-                                                }
-                                            }
-                                        }
-                                        Ok(SelectionMapperReturn::Selection(selection.clone()))
-                                    },
-                                )?;
-                                let resolution = condition_resolver.resolve(
-                                    e,
-                                    context,
-                                    excluded_destinations,
-                                    excluded_conditions,
-                                    Some(&selection_set),
-                                )?;
-                                let Some(arg_indices) =
-                                    self.graph.subgraph_to_arg_indices.get(&ctx.subgraph_name)
-                                else {
-                                    bail!("Unknown subgraph, {:?}, in QueryGraph::subgraph_to_arg_indices", ctx.subgraph_name)
-                                };
-                                let Some(id) = arg_indices.get(&ctx.argument_coordinate).cloned()
-                                else {
-                                    bail!("Unknown argument coordiate, {:?}, in QueryGraph::subgraph_to_arg_indices[{}]", ctx.argument_coordinate, ctx.subgraph_name)
-                                };
-
-                                match &resolution {
-                                    ConditionResolution::Satisfied {
-                                        cost, path_tree, ..
-                                    } => {
-                                        total_cost += cost;
-                                        let entry = ContextMapEntry {
-                                            levels_in_data_path,
-                                            levels_in_query_path,
-                                            path_tree: path_tree.clone(),
-                                            selection_set,
-                                            param_name: ctx.named_parameter.clone(),
-                                            arg_type: ctx.arg_type.clone(),
-                                            id,
-                                        };
-                                        context_map.insert(ctx.named_parameter.clone(), entry);
-                                    }
-                                    ConditionResolution::Unsatisfied { .. } => {
-                                        was_unsatisfied = true
-                                    }
-                                }
-                            } else {
-                                internal_error!(
-                                    "Could not parse selection {} over any types {:?}",
-                                    &ctx.selection,
-                                    potential_matches
-                                );
+                            }
+                            _ => {}
+                        }
+                        let pos_in_supergraph: CompositeTypeDefinitionPosition = supergraph_schema
+                            .get_type(pos.type_name().clone())?
+                            .try_into()?;
+                        if let CompositeTypeDefinitionPosition::Union(pos_in_supergraph) =
+                            &pos_in_supergraph
+                        {
+                            if pos_in_supergraph
+                                .get(supergraph_schema.schema())?
+                                .members
+                                .iter()
+                                .any(|item| &item.name == parent_type_in_supergraph.type_name())
+                            {
+                                return Ok(true);
                             }
                         }
+                        Ok(false)
+                    })? {
+                        continue;
+                    }
+
+                    // We have a match, so parse the selection set against the field's parent type
+                    // in the supergraph schema.
+                    let mut selection_set = parse_field_value_without_validation(
+                        &supergraph_schema,
+                        parent_type_in_supergraph.type_name().clone(),
+                        &ctx.selection,
+                    )?;
+
+                    // In the current version of @context (v0.1), type conditions (if they appear at
+                    // all) are only allowed at top-level, and are only allowed to reference object
+                    // types. Due to duck-typing semantics, there may be type conditions that have
+                    // an empty intersection in possible runtime types with their parent type, which
+                    // means we need to remove those type conditions for the selection set to be
+                    // considered valid GraphQL.
+                    let possible_runtime_types =
+                        supergraph_schema.possible_runtime_types(parent_type_in_supergraph)?;
+                    selection_set.selection_set.selections = selection_set
+                        .selection_set
+                        .selections
+                        .into_iter()
+                        .map(|selection| {
+                            let apollo_compiler::executable::Selection::InlineFragment(
+                                inline_fragment,
+                            ) = &selection
+                            else {
+                                return Ok::<_, FederationError>(Some(selection));
+                            };
+                            let Some(type_condition) = &inline_fragment.type_condition else {
+                                return Ok(Some(selection));
+                            };
+                            let type_condition_pos: ObjectTypeDefinitionPosition =
+                                supergraph_schema
+                                    .get_type(type_condition.clone())?
+                                    .try_into()?;
+                            if possible_runtime_types.contains(&type_condition_pos) {
+                                return Ok(Some(selection));
+                            }
+                            Ok(None)
+                        })
+                        .process_results(|r| r.flatten().collect())?;
+
+                    // The field set should be valid now, so we'll validate and convert to our
+                    // selection set representation.
+                    let selection_set = validate_field_value(&supergraph_schema, selection_set)?;
+                    let resolution = condition_resolver.resolve(
+                        e,
+                        context,
+                        excluded_destinations,
+                        excluded_conditions,
+                        Some(&selection_set),
+                    )?;
+                    let context_id = self.graph.context_id_by_source_and_argument(
+                        &ctx.subgraph_name,
+                        &ctx.argument_coordinate,
+                    )?;
+                    match &resolution {
+                        ConditionResolution::Satisfied {
+                            cost, path_tree, ..
+                        } => {
+                            total_cost += cost;
+                            let entry = ContextMapEntry {
+                                levels_in_data_path,
+                                levels_in_query_path,
+                                path_tree: path_tree.clone(),
+                                selection_set,
+                                argument_name: ctx.argument_name.clone(),
+                                argument_type: ctx.argument_type.clone(),
+                                context_id: context_id.clone(),
+                            };
+                            context_map.insert(ctx.argument_name.clone(), entry);
+                        }
+                        ConditionResolution::Unsatisfied { .. } => was_unsatisfied = true,
                     }
                 }
             }
@@ -1822,7 +1798,7 @@ where
             if edge_weight
                 .required_contexts
                 .iter()
-                .any(|ctx| !context_map.contains_key(&ctx.named_parameter))
+                .any(|ctx| !context_map.contains_key(&ctx.argument_name))
             {
                 debug!("@fromContext requires a context that is not set in graph path");
                 return Ok(ConditionResolution::Unsatisfied {
@@ -1865,6 +1841,9 @@ where
             excluded_conditions,
             None,
         )?;
+        if matches!(resolution, ConditionResolution::Unsatisfied { .. }) {
+            return Ok(ConditionResolution::Unsatisfied { reason: None });
+        }
         if let Some(Some(last_edge)) = self.edges.last().map(|e| (*e).into()) {
             if matches!(
                 edge_weight.transition,
@@ -1916,10 +1895,12 @@ where
             }
         }
         if let ConditionResolution::Satisfied {
+            cost,
             context_map: ctx_map,
             ..
         } = &mut resolution
         {
+            *cost += total_cost;
             *ctx_map = Some(context_map);
         }
         debug!("Condition resolution: {resolution:?}");
@@ -2350,6 +2331,12 @@ where
         ) -> Option<TEdge>,
         override_conditions: &EnabledOverrideConditions,
     ) -> Result<Option<NodeIndex>, FederationError> {
+        // TODO: Temporary fix to avoid optimization if context exists, a permanent fix is here:
+        //       https://github.com/apollographql/federation/pull/3017#pullrequestreview-2083949094
+        if self.graph.is_context_used() {
+            return Ok(None);
+        }
+
         let mut current_node = start_node;
         for index in start_index..self.edges.len() {
             let trigger = &self.edge_triggers[index];
@@ -2686,8 +2673,11 @@ impl OpGraphPath {
             runtime_types_before_tail_if_last_is_cast: None,
             // TODO: The JS codebase copied this from the current path, which seems like a bug.
             defer_on_tail: self.defer_on_tail.clone(),
-            context_to_selection: self.context_to_selection.clone(),
-            parameter_to_context: self.parameter_to_context.clone(),
+            // PORT_NOTE: The JS codebase doesn't properly truncate these fields, this is a bug
+            // which we fix here.
+            set_context_ids: self.set_context_ids[0..prefix_length].to_vec(),
+            arguments_to_context_usages: self.arguments_to_context_usages[0..prefix_length]
+                .to_vec(),
         })
     }
 

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -574,10 +574,7 @@ impl QueryGraph {
             .get(source)
             .and_then(|r| r.get(argument))
             .ok_or_else(|| {
-                SingleFederationError::Internal {
-                    message: "context ID unexpectedly missing for @fromContext argument".to_owned(),
-                }
-                .into()
+                internal_error!("context ID unexpectedly missing for @fromContext argument")
             })
     }
 

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -134,18 +134,24 @@ impl TryFrom<QueryGraphNodeType> for ObjectTypeDefinitionPosition {
     }
 }
 
-/// Contains all of the data necessary to connect the object field (`coordinate`) with the
-/// `@fromContext` to its (grand)parent types contain a matching selection.
+/// Contains all of the data necessary to connect the object field argument (`argument_coordinate`)
+/// with the `@fromContext` to its (grand)parent types contain a matching selection.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ContextCondition {
     context: String,
     subgraph_name: Arc<str>,
+    // This is purposely left unparsed in query graphs, due to @fromContext selection sets being
+    // duck-typed.
     selection: String,
     types_with_context_set: IndexSet<CompositeTypeDefinitionPosition>,
+    // PORT_NOTE: This field was renamed because the JS name (`namedParameter`) left confusion to
+    // how it was different from the argument name.
+    argument_name: Name,
     // PORT_NOTE: This field was renamed because the JS name (`coordinate`) was too vague.
     argument_coordinate: ObjectFieldArgumentDefinitionPosition,
-    named_parameter: Name,
-    arg_type: Node<Type>,
+    // PORT_NOTE: This field was renamed from the JS name (`argType`) for consistency with the rest
+    // of the naming in this struct.
+    argument_type: Node<Type>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -172,8 +178,8 @@ pub(crate) struct QueryGraphEdge {
     /// one of them has an @override with a label. If the override condition
     /// matches the query plan parameters, this edge can be taken.
     pub(crate) override_condition: Option<OverrideCondition>,
-    /// All fields with `@fromContext` that need access to parental type with corresponding
-    /// `@context`.
+    /// All arguments with `@fromContext` that need to be matched to an upstream graph path field
+    /// whose parent type has the corresponding `@context`.
     pub(crate) required_contexts: Vec<ContextCondition>,
 }
 
@@ -359,6 +365,8 @@ pub struct QueryGraph {
     /// same as `sources`, but is missing the dummy source FEDERATED_GRAPH_ROOT_SOURCE which isn't
     /// really a subgraph.
     subgraphs_by_name: IndexMap<Arc<str>, ValidFederationSchema>,
+    /// For federated query graphs, this is the supergraph schema; otherwise, this is `None`.
+    supergraph_schema: Option<ValidFederationSchema>,
     /// A map (keyed by source) that associates type names of the underlying schema on which this
     /// query graph was built to each of the nodes that points to a type of that name. Note that for
     /// a "federated" query graph source, each type name will only map to a single node.
@@ -389,10 +397,13 @@ pub struct QueryGraph {
     /// lowered composition validation on a big composition (100+ subgraphs) from ~4 minutes to
     /// ~10 seconds.
     non_trivial_followup_edges: IndexMap<EdgeIndex, Vec<EdgeIndex>>,
-    /// Maps each subgraph name to each field argument of `@fromContext`.
-    pub(crate) subgraph_to_args: IndexMap<Arc<str>, Vec<ObjectFieldArgumentDefinitionPosition>>,
-    /// Like `self.subgraph_to_args` but pairs each field argument with a unique identifier string.
-    pub(crate) subgraph_to_arg_indices:
+    // PORT_NOTE: This field was renamed from the JS name (`subgraphToArgIndices`) to better
+    // align with downstream code.
+    /// Maps subgraph names to another map, for any subgraph with usages of `@fromContext`. This
+    /// other map then maps subgraph argument positions/coordinates (for `@fromContext` arguments)
+    /// to a unique identifier string (specifically, unique across pairs of subgraph names and
+    /// argument coordinates). This identifier is called the "context ID".
+    arguments_to_context_ids_by_source:
         IndexMap<Arc<str>, IndexMap<ObjectFieldArgumentDefinitionPosition, Name>>,
 }
 
@@ -403,6 +414,12 @@ impl QueryGraph {
 
     pub(crate) fn graph(&self) -> &DiGraph<QueryGraphNode, QueryGraphEdge> {
         &self.graph
+    }
+
+    pub(crate) fn supergraph_schema(&self) -> Result<ValidFederationSchema, FederationError> {
+        self.supergraph_schema
+            .clone()
+            .ok_or_else(|| internal_error!("Supergraph schema unexpectedly missing"))
     }
 
     pub(crate) fn node_weight(&self, node: NodeIndex) -> Result<&QueryGraphNode, FederationError> {
@@ -546,6 +563,26 @@ impl QueryGraph {
                 }
                 .into()
             })
+    }
+
+    pub(crate) fn context_id_by_source_and_argument(
+        &self,
+        source: &str,
+        argument: &ObjectFieldArgumentDefinitionPosition,
+    ) -> Result<&Name, FederationError> {
+        self.arguments_to_context_ids_by_source
+            .get(source)
+            .and_then(|r| r.get(argument))
+            .ok_or_else(|| {
+                SingleFederationError::Internal {
+                    message: "context ID unexpectedly missing for @fromContext argument".to_owned(),
+                }
+                .into()
+            })
+    }
+
+    pub(crate) fn is_context_used(&self) -> bool {
+        !self.arguments_to_context_ids_by_source.is_empty()
     }
 
     /// All outward edges from the given node (including self-key and self-root-type-resolution

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -297,13 +297,13 @@ where
                         existing
                             .matching_context_ids
                             .get_or_insert_with(Default::default)
-                            .extend(other);
+                            .extend(other.iter().cloned());
                     }
                     if let Some(other) = arguments_to_context_usages {
                         existing
                             .arguments_to_context_usages
                             .get_or_insert_with(Default::default)
-                            .extend(other);
+                            .extend(other.iter().map(|(k, v)| (k.clone(), v.clone())));
                     }
                     existing
                         .sub_paths_and_selections
@@ -315,8 +315,8 @@ where
                         trigger,
                         conditions: conditions.clone(),
                         sub_paths_and_selections: vec![(graph_path_iter, selection)],
-                        matching_context_ids,
-                        arguments_to_context_usages,
+                        matching_context_ids: matching_context_ids.cloned(),
+                        arguments_to_context_usages: arguments_to_context_usages.cloned(),
                     });
                 }
             }

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -9,8 +9,8 @@ use petgraph::graph::EdgeIndex;
 use petgraph::graph::NodeIndex;
 use serde::Serialize;
 
-use super::graph_path::ContextToSelection;
-use super::graph_path::ParameterToContext;
+use super::graph_path::ArgumentsToContextUsages;
+use super::graph_path::SetContextIds;
 use crate::error::FederationError;
 use crate::operation::SelectionSet;
 use crate::query_graph::graph_path::GraphPathItem;
@@ -94,10 +94,14 @@ where
     pub(crate) conditions: Option<Arc<OpPathTree>>,
     /// The child `PathTree` reached by taking the edge.
     pub(crate) tree: Arc<PathTree<TTrigger, TEdge>>,
-    // a list of contexts set at this point in the path tree
-    pub(crate) context_to_selection: Option<ContextToSelection>,
-    // a list of contexts used at this point in the path tree
-    pub(crate) parameter_to_context: Option<ParameterToContext>,
+    // PORT_NOTE: This field was renamed because the JS name (`contextToSelection`) implied it was
+    // a map to selections, which it isn't.
+    /// The IDs of contexts set at the head of the edge.
+    pub(crate) set_context_ids: Option<SetContextIds>,
+    // PORT_NOTE: This field was renamed because the JS name (`parameterToContext`) left confusion
+    // to how a parameter was different from an argument.
+    /// A map of @fromContext arguments to info about the contexts used in those arguments.
+    pub(crate) arguments_to_context_usages: Option<ArgumentsToContextUsages>,
 }
 
 impl<TTrigger, TEdge> PartialEq for PathTreeChild<TTrigger, TEdge>
@@ -248,8 +252,8 @@ where
             trigger: &'inputs Arc<TTrigger>,
             conditions: Option<Arc<OpPathTree>>,
             sub_paths_and_selections: Vec<(GraphPathIter, Option<&'inputs Arc<SelectionSet>>)>,
-            context_to_selection: Option<ContextToSelection>,
-            parameter_to_context: Option<ParameterToContext>,
+            set_context_ids: Option<SetContextIds>,
+            arguments_to_context_usages: Option<ArgumentsToContextUsages>,
         }
 
         let mut local_selection_sets = Vec::new();
@@ -259,8 +263,8 @@ where
                 generic_edge,
                 trigger,
                 conditions,
-                context_to_selection,
-                parameter_to_context,
+                set_context_ids,
+                arguments_to_context_usages,
             )) = graph_path_iter.next()
             else {
                 // End of an input `GraphPath`
@@ -289,16 +293,16 @@ where
                     let existing = entry.into_mut();
                     existing.trigger = trigger;
                     existing.conditions = merge_conditions(&existing.conditions, conditions);
-                    if let Some(other) = context_to_selection {
+                    if let Some(other) = set_context_ids {
                         existing
-                            .context_to_selection
+                            .set_context_ids
                             .get_or_insert_with(Default::default)
                             .extend(other);
                     }
-                    if let Some(other) = parameter_to_context {
+                    if let Some(other) = arguments_to_context_usages {
                         existing
-                            .parameter_to_context
-                            .get_or_insert_with(IndexMap::default)
+                            .arguments_to_context_usages
+                            .get_or_insert_with(Default::default)
                             .extend(other);
                     }
                     existing
@@ -311,8 +315,8 @@ where
                         trigger,
                         conditions: conditions.clone(),
                         sub_paths_and_selections: vec![(graph_path_iter, selection)],
-                        context_to_selection,
-                        parameter_to_context,
+                        set_context_ids,
+                        arguments_to_context_usages,
                     });
                 }
             }
@@ -330,8 +334,8 @@ where
                         by_unique_edge.target_node,
                         child.sub_paths_and_selections,
                     )?),
-                    context_to_selection: child.context_to_selection.clone(),
-                    parameter_to_context: child.parameter_to_context.clone(),
+                    set_context_ids: child.set_context_ids.clone(),
+                    arguments_to_context_usages: child.arguments_to_context_usages.clone(),
                 }))
             }
         }
@@ -365,8 +369,18 @@ where
                         (Some(cond_a), Some(cond_b)) => cond_a.equals_same_root(cond_b),
                         _ => false,
                     }
-                    && a.context_to_selection == b.context_to_selection
-                    && a.parameter_to_context == b.parameter_to_context
+                    && match (&a.set_context_ids, &b.set_context_ids) {
+                        (Some(_), Some(_)) => a.set_context_ids == b.set_context_ids,
+                        (_, _) =>
+                            a.set_context_ids.as_ref().map(|c| c.is_empty()).unwrap_or(true) &&
+                                b.set_context_ids.as_ref().map(|c| c.is_empty()).unwrap_or(true)
+                    }
+                    && match (&a.arguments_to_context_usages, &b.arguments_to_context_usages) {
+                        (Some(_), Some(_)) => a.arguments_to_context_usages == b.arguments_to_context_usages,
+                        (_, _) =>
+                            a.arguments_to_context_usages.as_ref().map(|c| c.is_empty()).unwrap_or(true) &&
+                                b.arguments_to_context_usages.as_ref().map(|c| c.is_empty()).unwrap_or(true)
+                    }
                     && a.tree.equals_same_root(&b.tree)
             })
     }
@@ -448,13 +462,13 @@ where
                     trigger: child.trigger.clone(),
                     conditions: merge_conditions(&child.conditions, &other_child.conditions),
                     tree: child.tree.merge(&other_child.tree),
-                    context_to_selection: merge_context_to_selection(
-                        &child.context_to_selection,
-                        &other_child.context_to_selection,
+                    set_context_ids: merge_set_context_ids(
+                        &child.set_context_ids,
+                        &other_child.set_context_ids,
                     ),
-                    parameter_to_context: merge_parameter_to_context(
-                        &child.parameter_to_context,
-                        &other_child.parameter_to_context,
+                    arguments_to_context_usages: merge_arguments_to_context_usages(
+                        &child.arguments_to_context_usages,
+                        &other_child.arguments_to_context_usages,
                     ),
                 })
             } else {
@@ -477,13 +491,13 @@ where
     }
 }
 
-fn merge_context_to_selection(
-    a: &Option<ContextToSelection>,
-    b: &Option<ContextToSelection>,
-) -> Option<ContextToSelection> {
+fn merge_set_context_ids(
+    a: &Option<SetContextIds>,
+    b: &Option<SetContextIds>,
+) -> Option<SetContextIds> {
     match (a, b) {
         (Some(a), Some(b)) => {
-            let mut merged: ContextToSelection = Default::default();
+            let mut merged: SetContextIds = Default::default();
             merged.extend(a.iter().cloned());
             merged.extend(b.iter().cloned());
             Some(merged)
@@ -494,13 +508,13 @@ fn merge_context_to_selection(
     }
 }
 
-fn merge_parameter_to_context(
-    a: &Option<ParameterToContext>,
-    b: &Option<ParameterToContext>,
-) -> Option<ParameterToContext> {
+fn merge_arguments_to_context_usages(
+    a: &Option<ArgumentsToContextUsages>,
+    b: &Option<ArgumentsToContextUsages>,
+) -> Option<ArgumentsToContextUsages> {
     match (a, b) {
         (Some(a), Some(b)) => {
-            let mut merged: ParameterToContext = Default::default();
+            let mut merged: ArgumentsToContextUsages = Default::default();
             merged.extend(a.iter().map(|(k, v)| (k.clone(), v.clone())));
             merged.extend(b.iter().map(|(k, v)| (k.clone(), v.clone())));
             Some(merged)

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -77,6 +77,7 @@ use crate::subgraph::spec::ANY_SCALAR_NAME;
 use crate::subgraph::spec::ENTITIES_QUERY;
 use crate::supergraph::FEDERATION_REPRESENTATIONS_ARGUMENTS_NAME;
 use crate::supergraph::FEDERATION_REPRESENTATIONS_VAR_NAME;
+use crate::utils::iter_into_single_item;
 use crate::utils::logging::snapshot;
 
 /// Represents the value of a `@defer(label:)` argument.
@@ -681,16 +682,6 @@ impl FetchDependencyGraphNodePath {
                 Ok(new_path)
             }
         }
-    }
-}
-
-/// If the `iter` yields a single element, return it. Else return `None`.
-pub(crate) fn iter_into_single_item<T>(mut iter: impl Iterator<Item = T>) -> Option<T> {
-    let item = iter.next()?;
-    if iter.next().is_none() {
-        Some(item)
-    } else {
-        None
     }
 }
 

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -685,7 +685,7 @@ impl FetchDependencyGraphNodePath {
 }
 
 /// If the `iter` yields a single element, return it. Else return `None`.
-fn iter_into_single_item<T>(mut iter: impl Iterator<Item = T>) -> Option<T> {
+pub(crate) fn iter_into_single_item<T>(mut iter: impl Iterator<Item = T>) -> Option<T> {
     let item = iter.next()?;
     if iter.next().is_none() {
         Some(item)
@@ -3948,7 +3948,7 @@ fn compute_nodes_for_op_path_element<'a>(
             (stack_item.node_id, &stack_item.node_path),
             // If setting a context, add __typename to the site where we are retrieving context from
             // since the context rewrites path will start with a type condition.
-            if child.context_to_selection.is_some() {
+            if child.set_context_ids.is_some() {
                 Some(edge_id)
             } else {
                 None
@@ -3957,12 +3957,12 @@ fn compute_nodes_for_op_path_element<'a>(
             created_nodes,
         )?;
 
-        if let Some(context_to_selection) = &child.context_to_selection {
+        if let Some(set_context_ids) = &child.set_context_ids {
             let mut condition_nodes = vec![conditions_node_data.conditions_merge_node_id];
             condition_nodes.extend(&conditions_node_data.created_node_ids);
             let mut context_to_condition_nodes =
                 stack_item.context_to_condition_nodes.deref().clone();
-            for context in context_to_selection {
+            for context in set_context_ids {
                 context_to_condition_nodes.insert(context.clone(), condition_nodes.clone());
             }
             updated.context_to_condition_nodes = Arc::new(context_to_condition_nodes);
@@ -3987,17 +3987,17 @@ fn compute_nodes_for_op_path_element<'a>(
 
     // If the edge uses context variables, every context used must be set in a different parent
     // node or else we need to create a new one.
-    if let Some(parameter_to_context) = &child.parameter_to_context {
+    if let Some(arguments_to_context_usages) = &child.arguments_to_context_usages {
         let mut conditions_nodes: IndexSet<NodeIndex> = Default::default();
         let mut is_subgraph_jump_needed = false;
-        for context_entry in parameter_to_context.values() {
+        for context_usage in arguments_to_context_usages.values() {
             let Some(context_nodes) = updated
                 .context_to_condition_nodes
-                .get(&context_entry.context_id)
+                .get(&context_usage.context_id)
             else {
                 bail!(
                     "Could not find condition nodes for context {}",
-                    context_entry.context_id
+                    context_usage.context_id
                 );
             };
             conditions_nodes.extend(context_nodes);
@@ -4106,14 +4106,14 @@ fn compute_nodes_for_op_path_element<'a>(
             }
 
             // Add context renamers.
-            for context_entry in parameter_to_context.values() {
+            for context_entry in arguments_to_context_usages.values() {
                 let updated_node = FetchDependencyGraph::node_weight_mut(
                     &mut dependency_graph.graph,
                     updated.node_id,
                 )?;
                 updated_node.add_input_context(
                     context_entry.context_id.clone(),
-                    context_entry.subgraph_arg_type.clone(),
+                    context_entry.subgraph_argument_type.clone(),
                 )?;
                 updated_node.add_context_renamers_for_selection_set(
                     Some(&context_entry.selection_set),
@@ -4139,7 +4139,7 @@ fn compute_nodes_for_op_path_element<'a>(
                 .iter()
                 .filter(|e| matches!((**e).deref(), OpPathElement::Field(_)))
                 .count();
-            for context_entry in parameter_to_context.values() {
+            for context_entry in arguments_to_context_usages.values() {
                 let new_relative_path = &context_entry.relative_path
                     [..(context_entry.relative_path.len() - num_fields)];
                 let updated_node = FetchDependencyGraph::node_weight_mut(
@@ -4148,7 +4148,7 @@ fn compute_nodes_for_op_path_element<'a>(
                 )?;
                 updated_node.add_input_context(
                     context_entry.context_id.clone(),
-                    context_entry.subgraph_arg_type.clone(),
+                    context_entry.subgraph_argument_type.clone(),
                 )?;
                 updated_node.add_context_renamers_for_selection_set(
                     Some(&context_entry.selection_set),

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3948,7 +3948,7 @@ fn compute_nodes_for_op_path_element<'a>(
             (stack_item.node_id, &stack_item.node_path),
             // If setting a context, add __typename to the site where we are retrieving context from
             // since the context rewrites path will start with a type condition.
-            if child.set_context_ids.is_some() {
+            if child.matching_context_ids.is_some() {
                 Some(edge_id)
             } else {
                 None
@@ -3957,12 +3957,12 @@ fn compute_nodes_for_op_path_element<'a>(
             created_nodes,
         )?;
 
-        if let Some(set_context_ids) = &child.set_context_ids {
+        if let Some(matching_context_ids) = &child.matching_context_ids {
             let mut condition_nodes = vec![conditions_node_data.conditions_merge_node_id];
             condition_nodes.extend(&conditions_node_data.created_node_ids);
             let mut context_to_condition_nodes =
                 stack_item.context_to_condition_nodes.deref().clone();
-            for context in set_context_ids {
+            for context in matching_context_ids {
                 context_to_condition_nodes.insert(context.clone(), condition_nodes.clone());
             }
             updated.context_to_condition_nodes = Arc::new(context_to_condition_nodes);

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -181,6 +181,9 @@ pub(crate) fn parse_field_value_without_validation(
     )?)
 }
 
+// Similar to parse_field_set(), we explicitly forbid aliases for field values. In this case though,
+// it's because field value evaluation semantics means aliases would be stripped out and have no
+// effect.
 pub(crate) fn validate_field_value(
     schema: &ValidFederationSchema,
     field_value: FieldSet,

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -63,23 +63,23 @@ fn check_absence_of_aliases(selection_set: &SelectionSet) -> Result<(), Federati
 pub(crate) fn parse_field_set(
     schema: &ValidFederationSchema,
     parent_type_name: NamedType,
-    value: &str,
+    field_set: &str,
 ) -> Result<SelectionSet, FederationError> {
     // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
     // string.
     let field_set = FieldSet::parse_and_validate(
         schema.schema(),
         parent_type_name,
-        value,
+        field_set,
         "field_set.graphql",
     )?;
 
-    // field set should not contain any named fragments
+    // A field set should not contain any named fragments.
     let named_fragments = NamedFragments::new(&IndexMap::default(), schema);
     let selection_set =
         SelectionSet::from_selection_set(&field_set.selection_set, &named_fragments, schema)?;
 
-    // Validate the field set has no aliases.
+    // Validate that the field set has no aliases.
     check_absence_of_aliases(&selection_set)?;
 
     Ok(selection_set)
@@ -93,12 +93,12 @@ pub(crate) fn parse_field_set(
 pub(crate) fn parse_field_set_without_normalization(
     schema: &Valid<Schema>,
     parent_type_name: NamedType,
-    value: &str,
+    field_set: &str,
 ) -> Result<executable::SelectionSet, FederationError> {
     // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
     // string.
     let field_set =
-        FieldSet::parse_and_validate(schema, parent_type_name, value, "field_set.graphql")?;
+        FieldSet::parse_and_validate(schema, parent_type_name, field_set, "field_set.graphql")?;
     Ok(field_set.into_inner().selection_set)
 }
 
@@ -109,12 +109,12 @@ pub(crate) fn parse_field_set_without_normalization(
 pub(crate) fn collect_target_fields_from_field_set(
     schema: &Valid<Schema>,
     parent_type_name: NamedType,
-    value: &str,
+    field_set: &str,
 ) -> Result<Vec<FieldDefinitionPosition>, FederationError> {
     // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
     // string.
     let field_set =
-        FieldSet::parse_and_validate(schema, parent_type_name, value, "field_set.graphql")?;
+        FieldSet::parse_and_validate(schema, parent_type_name, field_set, "field_set.graphql")?;
     let mut stack = vec![&field_set.selection_set];
     let mut fields = vec![];
     while let Some(selection_set) = stack.pop() {
@@ -164,6 +164,38 @@ pub(crate) fn collect_target_fields_from_field_set(
         }
     }
     Ok(fields)
+}
+
+pub(crate) fn parse_field_value_without_validation(
+    schema: &ValidFederationSchema,
+    parent_type_name: NamedType,
+    field_value: &str,
+) -> Result<FieldSet, FederationError> {
+    // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
+    // string.
+    Ok(FieldSet::parse(
+        schema.schema(),
+        parent_type_name,
+        field_value,
+        "field_set.graphql",
+    )?)
+}
+
+pub(crate) fn validate_field_value(
+    schema: &ValidFederationSchema,
+    field_value: FieldSet,
+) -> Result<SelectionSet, FederationError> {
+    field_value.validate(schema.schema())?;
+
+    // A field value should not contain any named fragments.
+    let named_fragments = NamedFragments::new(&IndexMap::default(), schema);
+    let selection_set =
+        SelectionSet::from_selection_set(&field_value.selection_set, &named_fragments, schema)?;
+
+    // Validate that the field value has no aliases.
+    check_absence_of_aliases(&selection_set)?;
+
+    Ok(selection_set)
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -232,6 +232,21 @@ impl TypeDefinitionPosition {
             )),
         }
     }
+
+    pub(crate) fn insert_directive(
+        &self,
+        schema: &mut FederationSchema,
+        directive: Component<Directive>,
+    ) -> Result<(), FederationError> {
+        match self {
+            TypeDefinitionPosition::Scalar(type_) => type_.insert_directive(schema, directive),
+            TypeDefinitionPosition::Object(type_) => type_.insert_directive(schema, directive),
+            TypeDefinitionPosition::Interface(type_) => type_.insert_directive(schema, directive),
+            TypeDefinitionPosition::Union(type_) => type_.insert_directive(schema, directive),
+            TypeDefinitionPosition::Enum(type_) => type_.insert_directive(schema, directive),
+            TypeDefinitionPosition::InputObject(type_) => type_.insert_directive(schema, directive),
+        }
+    }
 }
 
 fallible_conversions!(TypeDefinitionPosition::Scalar -> ScalarTypeDefinitionPosition);
@@ -399,6 +414,24 @@ impl CompositeTypeDefinitionPosition {
                 name.clone(),
                 self.describe(),
             )),
+        }
+    }
+
+    pub(crate) fn insert_directive(
+        &self,
+        schema: &mut FederationSchema,
+        directive: Component<Directive>,
+    ) -> Result<(), FederationError> {
+        match self {
+            CompositeTypeDefinitionPosition::Object(type_) => {
+                type_.insert_directive(schema, directive)
+            }
+            CompositeTypeDefinitionPosition::Interface(type_) => {
+                type_.insert_directive(schema, directive)
+            }
+            CompositeTypeDefinitionPosition::Union(type_) => {
+                type_.insert_directive(schema, directive)
+            }
         }
     }
 }

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -22,6 +22,7 @@ use crate::subgraph::spec::AppliedFederationLink;
 use crate::subgraph::spec::FederationSpecDefinitions;
 use crate::subgraph::spec::LinkSpecDefinitions;
 use crate::subgraph::spec::ANY_SCALAR_NAME;
+use crate::subgraph::spec::CONTEXTFIELDVALUE_SCALAR_NAME;
 use crate::subgraph::spec::ENTITIES_QUERY;
 use crate::subgraph::spec::ENTITY_UNION_NAME;
 use crate::subgraph::spec::FEDERATION_V2_DIRECTIVE_NAMES;
@@ -175,6 +176,7 @@ impl Subgraph {
         schema: &mut Schema,
         fed_definitions: &FederationSpecDefinitions,
     ) -> Result<(), FederationError> {
+        // scalar FieldSet
         let fieldset_scalar_name = &fed_definitions.fieldset_scalar_name;
         schema
             .types
@@ -184,6 +186,19 @@ impl Subgraph {
                     .fieldset_scalar_definition(fieldset_scalar_name.clone())
                     .into()
             });
+
+        // scalar ContextFieldValue
+        let namespaced_contextfieldvalue_scalar_name =
+            fed_definitions.namespaced_type_name(&CONTEXTFIELDVALUE_SCALAR_NAME, false);
+        if let Entry::Vacant(entry) = schema
+            .types
+            .entry(namespaced_contextfieldvalue_scalar_name.clone())
+        {
+            let type_definition = fed_definitions.contextfieldvalue_scalar_definition(&Some(
+                namespaced_contextfieldvalue_scalar_name,
+            ));
+            entry.insert(type_definition.into());
+        }
 
         for directive_name in &FEDERATION_V2_DIRECTIVE_NAMES {
             let namespaced_directive_name =

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -51,6 +51,7 @@ pub const REQUIRES_DIRECTIVE_NAME: Name = name!("requires");
 pub const SHAREABLE_DIRECTIVE_NAME: Name = name!("shareable");
 pub const TAG_DIRECTIVE_NAME: Name = name!("tag");
 pub const FIELDSET_SCALAR_NAME: Name = name!("FieldSet");
+pub const CONTEXTFIELDVALUE_SCALAR_NAME: Name = name!("ContextFieldValue");
 
 // federated types
 pub const ANY_SCALAR_NAME: Name = name!("_Any");
@@ -320,6 +321,15 @@ impl FederationSpecDefinitions {
         }
     }
 
+    /// scalar ContextFieldValue
+    pub fn contextfieldvalue_scalar_definition(&self, alias: &Option<Name>) -> ScalarType {
+        ScalarType {
+            description: None,
+            name: alias.clone().unwrap_or(CONTEXTFIELDVALUE_SCALAR_NAME),
+            directives: Default::default(),
+        }
+    }
+
     fn fields_argument_definition(&self) -> Result<InputValueDefinition, FederationSpecError> {
         Ok(InputValueDefinition {
             description: None,
@@ -425,7 +435,7 @@ impl FederationSpecDefinitions {
     // `from` is a conventional prefix used in conversion methods, which do not
     // take `self` as an argument. This function does **not** perform
     // conversion, but extracts `@fromContext` directive definition.
-    /// directive @fromContext(field: String!) on ARGUMENT_DEFINITION
+    /// directive @fromContext(field: ContextFieldValue) on ARGUMENT_DEFINITION
     #[allow(clippy::wrong_self_convention)]
     fn from_context_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
@@ -434,7 +444,8 @@ impl FederationSpecDefinitions {
             arguments: vec![InputValueDefinition {
                 description: None,
                 name: name!("field"),
-                ty: ty!(String!).into(),
+                ty: Type::Named(self.namespaced_type_name(&CONTEXTFIELDVALUE_SCALAR_NAME, false))
+                    .into(),
                 default_value: None,
                 directives: Default::default(),
             }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -47,7 +47,7 @@ pub use self::subgraph::ValidFederationSubgraphs;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
-use crate::link::context_spec_definition::CONTEXT_VERSIONS;
+use crate::link::context_spec_definition::ContextSpecDefinition;
 use crate::link::cost_spec_definition::CostSpecDefinition;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::link::federation_spec_definition::FederationSpecDefinition;
@@ -94,7 +94,7 @@ pub(crate) fn extract_subgraphs_from_supergraph(
     validate_extracted_subgraphs: Option<bool>,
 ) -> Result<ValidFederationSubgraphs, FederationError> {
     let validate_extracted_subgraphs = validate_extracted_subgraphs.unwrap_or(true);
-    let (link_spec_definition, join_spec_definition) =
+    let (link_spec_definition, join_spec_definition, context_spec_definition) =
         crate::validate_supergraph_for_query_planning(supergraph_schema)?;
     let is_fed_1 = *join_spec_definition.version() == Version { major: 0, minor: 1 };
     let (mut subgraphs, federation_spec_definitions, graph_enum_value_name_to_subgraph_name) =
@@ -126,6 +126,7 @@ pub(crate) fn extract_subgraphs_from_supergraph(
             &graph_enum_value_name_to_subgraph_name,
             &federation_spec_definitions,
             join_spec_definition,
+            context_spec_definition,
             &filtered_types,
         )?;
     }
@@ -213,6 +214,7 @@ fn collect_empty_subgraphs(
             name: graph_arguments.name.to_owned(),
             url: graph_arguments.url.to_owned(),
             schema: new_empty_fed_2_subgraph_schema()?,
+            graph_enum_value: enum_value_name.clone(),
         };
         let federation_link = &subgraph
             .schema
@@ -260,6 +262,7 @@ fn extract_subgraphs_from_fed_2_supergraph(
     graph_enum_value_name_to_subgraph_name: &IndexMap<Name, Arc<str>>,
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &'static JoinSpecDefinition,
+    context_spec_definition: Option<&'static ContextSpecDefinition>,
     filtered_types: &Vec<TypeDefinitionPosition>,
 ) -> Result<(), FederationError> {
     let original_directive_names = get_apollo_directive_names(supergraph_schema)?;
@@ -276,6 +279,7 @@ fn extract_subgraphs_from_fed_2_supergraph(
         graph_enum_value_name_to_subgraph_name,
         federation_spec_definitions,
         join_spec_definition,
+        context_spec_definition,
         filtered_types,
         &original_directive_names,
     )?;
@@ -302,7 +306,6 @@ fn extract_subgraphs_from_fed_2_supergraph(
         supergraph_schema,
         subgraphs,
         graph_enum_value_name_to_subgraph_name,
-        federation_spec_definitions,
         join_spec_definition,
         &union_types,
     )?;
@@ -392,12 +395,14 @@ fn extract_subgraphs_from_fed_2_supergraph(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn add_all_empty_subgraph_types(
     supergraph_schema: &FederationSchema,
     subgraphs: &mut FederationSubgraphs,
     graph_enum_value_name_to_subgraph_name: &IndexMap<Name, Arc<str>>,
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &'static JoinSpecDefinition,
+    context_spec_definition: Option<&'static ContextSpecDefinition>,
     filtered_types: &Vec<TypeDefinitionPosition>,
     original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<TypeInfos, FederationError> {
@@ -469,9 +474,12 @@ fn add_all_empty_subgraph_types(
             types_mut.push(add_empty_type(
                 type_definition_position.clone(),
                 &type_directive_applications,
+                type_.directives(),
+                supergraph_schema,
                 subgraphs,
                 graph_enum_value_name_to_subgraph_name,
                 federation_spec_definitions,
+                context_spec_definition,
             )?);
         }
     }
@@ -485,12 +493,16 @@ fn add_all_empty_subgraph_types(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn add_empty_type(
     type_definition_position: TypeDefinitionPosition,
     type_directive_applications: &Vec<TypeDirectiveArguments>,
+    directives: &DirectiveList,
+    supergraph_schema: &FederationSchema,
     subgraphs: &mut FederationSubgraphs,
     graph_enum_value_name_to_subgraph_name: &IndexMap<Name, Arc<str>>,
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
+    context_spec_definition: Option<&'static ContextSpecDefinition>,
 ) -> Result<TypeInfo, FederationError> {
     // In fed2, we always mark all types with `@join__type` but making sure.
     if type_directive_applications.is_empty() {
@@ -672,22 +684,49 @@ fn add_empty_type(
                     }
                     .into());
                 }
-                TypeDefinitionPosition::Object(pos) => {
-                    pos.insert_directive(&mut subgraph.schema, key_directive)?;
-                }
-                TypeDefinitionPosition::Interface(pos) => {
-                    pos.insert_directive(&mut subgraph.schema, key_directive)?;
-                }
-                TypeDefinitionPosition::Union(pos) => {
-                    pos.insert_directive(&mut subgraph.schema, key_directive)?;
-                }
-                TypeDefinitionPosition::Enum(pos) => {
-                    pos.insert_directive(&mut subgraph.schema, key_directive)?;
-                }
-                TypeDefinitionPosition::InputObject(pos) => {
-                    pos.insert_directive(&mut subgraph.schema, key_directive)?;
+                _ => {
+                    subgraph_type_definition_position
+                        .insert_directive(&mut subgraph.schema, key_directive)?;
                 }
             };
+        }
+    }
+
+    if let Some(context_spec_definition) = context_spec_definition {
+        let context_directive_definition =
+            context_spec_definition.context_directive_definition(supergraph_schema)?;
+        for directive in directives.get_all(&context_directive_definition.name) {
+            let context_directive_application =
+                context_spec_definition.context_directive_arguments(directive)?;
+            let (subgraph_name, context_name) = context_directive_application
+                .name
+                .rsplit_once("__")
+                .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
+                    message: format!(
+                        "Invalid context \"{}\" in supergraph schema",
+                        context_directive_application.name
+                    ),
+                })?;
+            let subgraph = subgraphs.get_mut(subgraph_name).ok_or_else(|| {
+                SingleFederationError::Internal {
+                    message:
+                        "All subgraphs should have been created by \"collect_empty_subgraphs()\""
+                            .to_owned(),
+                }
+            })?;
+            let federation_spec_definition = federation_spec_definitions
+                .get(&subgraph.graph_enum_value)
+                .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
+                    message: "Subgraph unexpectedly does not use federation spec".to_owned(),
+                })?;
+            let context_directive = federation_spec_definition
+                .context_directive(&subgraph.schema, context_name.to_owned())?;
+            let subgraph_type_definition_position: CompositeTypeDefinitionPosition = subgraph
+                .schema
+                .get_type(type_definition_position.type_name().clone())?
+                .try_into()?;
+            subgraph_type_definition_position
+                .insert_directive(&mut subgraph.schema, Component::new(context_directive))?;
         }
     }
 
@@ -713,16 +752,6 @@ fn extract_object_type_content(
             message: "@join__implements should exist for a fed2 supergraph".to_owned(),
         })?;
 
-    let context = supergraph_schema
-        .metadata()
-        .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))
-        .and_then(|context_link| CONTEXT_VERSIONS.find(&context_link.url.version))
-        .and_then(|context_spec_def| {
-            context_spec_def
-                .context_directive_name_in_schema(supergraph_schema)
-                .ok()
-                .map(|name_in_schema| (context_spec_def, name_in_schema))
-        });
     for TypeInfo {
         name: type_name,
         subgraph_info,
@@ -758,17 +787,6 @@ fn extract_object_type_content(
             pos.insert_implements_interface(
                 &mut subgraph.schema,
                 ComponentName::from(Name::new(implements_directive_application.interface)?),
-            )?;
-        }
-
-        if let Some((_context_spec_def, name_in_supergraph)) = &context {
-            apply_context_to_type(
-                type_,
-                subgraphs,
-                graph_enum_value_name_to_subgraph_name,
-                federation_spec_definitions,
-                name_in_supergraph,
-                &CompositeTypeDefinitionPosition::Object(pos.clone()),
             )?;
         }
 
@@ -998,27 +1016,6 @@ fn extract_interface_type_content(
             }
         }
 
-        let context = supergraph_schema
-            .metadata()
-            .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))
-            .and_then(|context_link| CONTEXT_VERSIONS.find(&context_link.url.version))
-            .and_then(|context_spec_def| {
-                context_spec_def
-                    .context_directive_name_in_schema(supergraph_schema)
-                    .ok()
-                    .map(|name_in_schema| (context_spec_def, name_in_schema))
-            });
-        if let Some((_context_spec_def, name_in_supergraph)) = &context {
-            apply_context_to_type(
-                type_,
-                subgraphs,
-                graph_enum_value_name_to_subgraph_name,
-                federation_spec_definitions,
-                name_in_supergraph,
-                &CompositeTypeDefinitionPosition::Interface(pos.clone()),
-            )?;
-        }
-
         for (field_name, field) in type_.fields.iter() {
             let mut field_directive_applications = Vec::new();
             for directive in field.directives.get_all(&field_directive_definition.name) {
@@ -1112,7 +1109,6 @@ fn extract_union_type_content(
     supergraph_schema: &FederationSchema,
     subgraphs: &mut FederationSubgraphs,
     graph_enum_value_name_to_subgraph_name: &IndexMap<Name, Arc<str>>,
-    federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
 ) -> Result<(), FederationError> {
@@ -1195,28 +1191,6 @@ fn extract_union_type_content(
                     ComponentName::from(Name::new(union_member_directive_application.member)?),
                 )?;
             }
-        }
-
-        let context = supergraph_schema
-            .metadata()
-            .and_then(|metadata| metadata.for_identity(&Identity::context_identity()))
-            .and_then(|context_link| CONTEXT_VERSIONS.find(&context_link.url.version))
-            .and_then(|context_spec_def| {
-                context_spec_def
-                    .context_directive_name_in_schema(supergraph_schema)
-                    .ok()
-                    .map(|name_in_schema| (context_spec_def, name_in_schema))
-            });
-
-        if let Some((_context_spec_def, name_in_supergraph)) = &context {
-            apply_context_to_type(
-                type_,
-                subgraphs,
-                graph_enum_value_name_to_subgraph_name,
-                federation_spec_definitions,
-                name_in_supergraph,
-                &CompositeTypeDefinitionPosition::Union(pos.clone()),
-            )?;
         }
     }
 
@@ -1554,11 +1528,7 @@ fn add_subgraph_field(
             } = args;
             let (_, context_name_in_subgraph) = context.rsplit_once("__").ok_or_else(|| {
                 SingleFederationError::InvalidFederationSupergraph {
-                    message: format!(
-                        "Could not parse context field from supergraph '{}'",
-                        context
-                    )
-                    .to_owned(),
+                    message: format!(r#"Invalid context "{}" in supergraph schema"#, context),
                 }
             })?;
 
@@ -1666,16 +1636,6 @@ fn get_subgraph<'subgraph>(
     })
 }
 
-fn get_index_from_subgraph_name<'a>(
-    graph_enum_value_name_to_subgraph_name: &'a IndexMap<Name, Arc<str>>,
-    subgraph_name: &'a Name,
-) -> Option<&'a Name> {
-    graph_enum_value_name_to_subgraph_name
-        .iter()
-        .find(|(_, v)| v.as_ref() == subgraph_name.as_str())
-        .map(|(k, _)| k)
-}
-
 lazy_static! {
     static ref EXECUTABLE_DIRECTIVE_LOCATIONS: IndexSet<DirectiveLocation> = {
         [
@@ -1691,103 +1651,6 @@ lazy_static! {
         .into_iter()
         .collect()
     };
-}
-
-fn insert_directive(
-    schema: &mut FederationSchema,
-    pos: &CompositeTypeDefinitionPosition,
-    directive: Component<Directive>,
-) -> Result<(), FederationError> {
-    match pos {
-        CompositeTypeDefinitionPosition::Union(pos) => pos.insert_directive(schema, directive),
-        CompositeTypeDefinitionPosition::Object(pos) => pos.insert_directive(schema, directive),
-        CompositeTypeDefinitionPosition::Interface(pos) => pos.insert_directive(schema, directive),
-    }
-}
-
-trait CompositeType {
-    fn directives(&self) -> &DirectiveList;
-}
-
-impl CompositeType for UnionType {
-    fn directives(&self) -> &DirectiveList {
-        &self.directives
-    }
-}
-
-impl CompositeType for ObjectType {
-    fn directives(&self) -> &DirectiveList {
-        &self.directives
-    }
-}
-
-impl CompositeType for InterfaceType {
-    fn directives(&self) -> &DirectiveList {
-        &self.directives
-    }
-}
-
-fn apply_context_to_type<T>(
-    ty: &Node<T>,
-    subgraphs: &mut FederationSubgraphs,
-    graph_enum_value_name_to_subgraph_name: &IndexMap<Name, Arc<str>>,
-    federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
-    context_name_in_supergraph: &Name,
-    pos: &CompositeTypeDefinitionPosition,
-) -> Result<(), FederationError>
-where
-    T: CompositeType,
-{
-    for directive in ty.directives().get_all(context_name_in_supergraph.as_str()) {
-        FederationSpecDefinition::context_directive_arguments(directive).and_then(
-            |context_name| {
-                let mut arr = context_name.name.split("__");
-                let subgraph_name = arr.next().ok_or_else(|| {
-                    SingleFederationError::InvalidFederationSupergraph {
-                        message: format!(
-                            "Could not parse context name from supergraph '{}'",
-                            context_name_in_supergraph
-                        )
-                        .to_owned(),
-                    }
-                })?;
-                let subgraph_name = Name::new_unchecked(subgraph_name);
-                let subgraph_index = get_index_from_subgraph_name(
-                    graph_enum_value_name_to_subgraph_name,
-                    &subgraph_name,
-                )
-                .ok_or_else(|| SingleFederationError::InvalidSubgraph {
-                    message: format!("Could not look up subgraph by name '{}'", subgraph_name)
-                        .to_owned(),
-                })?;
-                let subgraph = get_subgraph(
-                    subgraphs,
-                    graph_enum_value_name_to_subgraph_name,
-                    subgraph_index,
-                )?;
-
-                let federation_spec_definition = federation_spec_definitions
-                    .get(subgraph_index)
-                    .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
-                        message: "Subgraph unexpectedly does not use federation spec".to_owned(),
-                    })?;
-                let context_in_subgraph = arr.last().ok_or_else(|| {
-                    SingleFederationError::InvalidFederationSupergraph {
-                        message: format!(
-                            "Could not parse context name from supergraph '{}'",
-                            context_name_in_supergraph
-                        )
-                        .to_owned(),
-                    }
-                })?;
-                let context_directive = federation_spec_definition
-                    .context_directive(&subgraph.schema, context_in_subgraph.to_string())?;
-                insert_directive(&mut subgraph.schema, pos, context_directive.into())?;
-                Ok(())
-            },
-        )?;
-    }
-    Ok(())
 }
 
 fn remove_unused_types_from_subgraph(schema: &mut FederationSchema) -> Result<(), FederationError> {

--- a/apollo-federation/src/supergraph/schema.rs
+++ b/apollo-federation/src/supergraph/schema.rs
@@ -99,10 +99,12 @@ pub(crate) fn new_empty_fed_2_subgraph_schema() -> Result<FederationSchema, Fede
 
     directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-    directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+    directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-    directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
-    
+    directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+    scalar federation__ContextFieldValue
+
     scalar federation__FieldSet
 
     scalar federation__Scope

--- a/apollo-federation/src/supergraph/subgraph.rs
+++ b/apollo-federation/src/supergraph/subgraph.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
 
+use apollo_compiler::Name;
+
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::schema::FederationSchema;
@@ -11,6 +13,7 @@ pub(super) struct FederationSubgraph {
     pub(super) name: String,
     pub(super) url: String,
     pub(super) schema: FederationSchema,
+    pub(super) graph_enum_value: Name,
 }
 
 pub(super) struct FederationSubgraphs {

--- a/apollo-federation/src/utils/mod.rs
+++ b/apollo-federation/src/utils/mod.rs
@@ -4,3 +4,13 @@ mod fallible_iterator;
 pub(crate) mod logging;
 
 pub(crate) use fallible_iterator::*;
+
+/// If the `iter` yields a single element, return it. Else return `None`.
+pub(crate) fn iter_into_single_item<T>(mut iter: impl Iterator<Item = T>) -> Option<T> {
+    let item = iter.next()?;
+    if iter.next().is_none() {
+        Some(item)
+    } else {
+        None
+    }
+}

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
@@ -328,7 +328,7 @@ fn set_context_test_variable_is_already_in_a_different_fetch_group() {
                        } =>
                        {
                          ... on U {
-                           field(a: $contextualArgument_1_0)
+                           field(a: $contextualArgument_2_0)
                          }
                        }
                      },
@@ -345,7 +345,7 @@ fn set_context_test_variable_is_already_in_a_different_fetch_group() {
                         node.context_rewrites,
                         vec![Arc::new(FetchDataRewrite::KeyRenamer(
                             FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
+                                rename_key_to: Name::new("contextualArgument_2_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Parent,
                                     FetchDataPathElement::TypenameEquals(Name::new("T").unwrap()),
@@ -1308,7 +1308,7 @@ fn set_context_test_before_key_resolution_transition() {
             } =>
             {
               ... on Child {
-                prop(legacyUserId: $contextualArgument_1_0)
+                prop(legacyUserId: $contextualArgument_2_0)
               }
             }
           },
@@ -1440,7 +1440,7 @@ fn set_context_test_efficiently_merge_fetch_groups() {
             {
               ... on Customer {
                 accounts {
-                  foo(ctx_id5: $contextualArgument_1_0, ctx_mid: $contextualArgument_1_1) {
+                  foo(ctx_id5: $contextualArgument_3_0, ctx_mid: $contextualArgument_3_1) {
                     id
                   }
                 }
@@ -1460,7 +1460,7 @@ fn set_context_test_efficiently_merge_fetch_groups() {
                         node.context_rewrites,
                         vec![
                             Arc::new(FetchDataRewrite::KeyRenamer(FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_0").unwrap(),
+                                rename_key_to: Name::new("contextualArgument_3_0").unwrap(),
                                 path: vec![
                                     FetchDataPathElement::Key(
                                         Name::new_unchecked("identifiers"),
@@ -1473,7 +1473,7 @@ fn set_context_test_efficiently_merge_fetch_groups() {
                                 ],
                             })),
                             Arc::new(FetchDataRewrite::KeyRenamer(FetchDataKeyRenamer {
-                                rename_key_to: Name::new("contextualArgument_1_1").unwrap(),
+                                rename_key_to: Name::new("contextualArgument_3_1").unwrap(),
                                 path: vec![FetchDataPathElement::Key(
                                     Name::new_unchecked("mid"),
                                     Default::default()

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__can_extract_subgraph.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__can_extract_subgraph.snap
@@ -42,9 +42,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -58,6 +58,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 
@@ -127,9 +129,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -143,6 +145,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_demand_control_directive_name_conflicts.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_demand_control_directive_name_conflicts.snap
@@ -42,9 +42,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -58,6 +58,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 
@@ -116,9 +118,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -132,6 +134,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_renamed_demand_control_directive_name_conflicts.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_renamed_demand_control_directive_name_conflicts.snap
@@ -42,9 +42,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -58,6 +58,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 
@@ -116,9 +118,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -132,6 +134,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_demand_control_directives.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_demand_control_directives.snap
@@ -42,9 +42,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -58,6 +58,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 
@@ -136,9 +138,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -152,6 +154,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_renamed_demand_control_directives.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_renamed_demand_control_directives.snap
@@ -42,9 +42,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -58,6 +58,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 
@@ -136,9 +138,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -152,6 +154,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_set_context_directives.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_set_context_directives.snap
@@ -42,9 +42,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -58,6 +58,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 
@@ -130,9 +132,9 @@ directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_
 
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @federation__fromContext(field: String) on ARGUMENT_DEFINITION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @federation__context(name: String) repeatable on INTERFACE | OBJECT | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
 scalar link__Import
 
@@ -146,6 +148,8 @@ enum link__Purpose {
   """
   EXECUTION
 }
+
+scalar federation__ContextFieldValue
 
 scalar federation__FieldSet
 

--- a/apollo-router/tests/snapshots/set_context__set_context_union_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_union_rust_qp.snap
@@ -51,15 +51,6 @@ expression: response
                         "kind": "KeyRenamer",
                         "path": [
                           "..",
-                          "... on A",
-                          "prop"
-                        ],
-                        "renameKeyTo": "contextualArgument_1_1"
-                      },
-                      {
-                        "kind": "KeyRenamer",
-                        "path": [
-                          "..",
                           "... on B",
                           "prop"
                         ],
@@ -114,15 +105,6 @@ expression: response
                         "path": [
                           "..",
                           "... on A",
-                          "prop"
-                        ],
-                        "renameKeyTo": "contextualArgument_1_1"
-                      },
-                      {
-                        "kind": "KeyRenamer",
-                        "path": [
-                          "..",
-                          "... on B",
                           "prop"
                         ],
                         "renameKeyTo": "contextualArgument_1_1"


### PR DESCRIPTION
In summary, this PR makes changes to the Rust QP port of `@context`/`@fromContext` for the sake of:
- Bugfixes.
- Renames/Refactors to simplify and reduce confusion.
- Adherence to existing conventions.
  - This isn't necessarily an endorsement of those conventions, but primarily for consistency sake.

There's a lot of these, so I'm going to leave comments on the code with relevant information (mainly bugfix notes, but with some occasional notes about refactors). 

<!-- ROUTER-894 -->
