### PR TITLE
Update `rustls` usages

### DIFF
--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -160,7 +160,7 @@ impl RedisCacheStorage {
         if let Some(tls) = config.tls.as_ref() {
             let tls_cert_store = tls.create_certificate_store().transpose()?;
             let client_cert_config = tls.client_authentication.as_ref();
-            let tls_client_config = generate_tls_client_config(tls_cert_store, client_cert_config)?;
+            let tls_client_config = generate_tls_client_config(tls_cert_store, client_cert_config.map(|arc| arc.as_ref()))?;
             let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_client_config));
 
             client_config.tls = Some(TlsConfig {

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -1107,12 +1107,12 @@ pub(crate) struct Tls {
     /// TLS server configuration
     ///
     /// this will affect the GraphQL endpoint and any other endpoint targeting the same listen address
-    pub(crate) supergraph: Option<TlsSupergraph>,
+    pub(crate) supergraph: Option<Arc<TlsSupergraph>>,
     pub(crate) subgraph: SubgraphConfiguration<TlsClient>,
 }
 
 /// Configuration options pertaining to the supergraph server component.
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TlsSupergraph {
     /// server certificate in PEM format
@@ -1236,7 +1236,7 @@ pub(crate) struct TlsClient {
     /// list of certificate authorities in PEM format
     pub(crate) certificate_authorities: Option<String>,
     /// client certificate authentication
-    pub(crate) client_authentication: Option<TlsClientAuth>,
+    pub(crate) client_authentication: Option<Arc<TlsClientAuth>>,
 }
 
 #[buildstructor::buildstructor]
@@ -1244,7 +1244,7 @@ impl TlsClient {
     #[builder]
     pub(crate) fn new(
         certificate_authorities: Option<String>,
-        client_authentication: Option<TlsClientAuth>,
+        client_authentication: Option<Arc<TlsClientAuth>>,
     ) -> Self {
         Self {
             certificate_authorities,
@@ -1260,7 +1260,7 @@ impl Default for TlsClient {
 }
 
 /// TLS client authentication
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TlsClientAuth {
     /// list of certificates in PEM format

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -1135,7 +1135,6 @@ impl TlsSupergraph {
         certificates.extend(self.certificate_chain.iter().cloned());
 
         let mut config = ServerConfig::builder()
-            .with_safe_defaults()
             .with_no_client_auth()
             .with_single_cert(certificates, self.key.clone())
             .map_err(ApolloRouterError::Rustls)?;

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -94,8 +94,7 @@ impl Plugin for CoprocessorPlugin<HTTPClientService> {
         http_connector.enforce_http(false);
 
         let tls_config = rustls::ClientConfig::builder()
-            .with_safe_defaults()
-            .with_native_roots()
+            .with_native_roots()?
             .with_no_client_auth();
 
         let builder = hyper_rustls::HttpsConnectorBuilder::new()

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -183,11 +183,10 @@ impl HttpClientService {
 
         for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
         {
-            let cert = rustls::Certificate(cert.0);
             match roots.add(&cert) {
                 Ok(_) => valid_count += 1,
                 Err(err) => {
-                    tracing::trace!("invalid cert der {:?}", cert.0);
+                    tracing::trace!("invalid cert der {:?}", cert);
                     tracing::debug!("certificate parsing failed: {:?}", err);
                     invalid_count += 1
                 }

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -183,7 +183,7 @@ impl HttpClientService {
 
         for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
         {
-            match roots.add(&cert) {
+            match roots.add(cert) {
                 Ok(_) => valid_count += 1,
                 Err(err) => {
                     tracing::trace!("invalid cert der {:?}", cert);
@@ -206,7 +206,7 @@ pub(crate) fn generate_tls_client_config(
     tls_cert_store: RootCertStore,
     client_cert_config: Option<&TlsClientAuth>,
 ) -> Result<rustls::ClientConfig, BoxError> {
-    let tls_builder = rustls::ClientConfig::builder().with_safe_defaults();
+    let tls_builder = rustls::ClientConfig::builder();
     Ok(match client_cert_config {
         Some(client_auth_config) => tls_builder
             .with_root_certificates(tls_cert_store)

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -22,9 +22,9 @@ use hyper_rustls::TlsAcceptor;
 #[cfg(unix)]
 use hyperlocal::UnixServerExt;
 use mime::APPLICATION_JSON;
+use rustls::pki_types::CertificateDer;
+use rustls::pki_types::PrivateKeyDer;
 use rustls::server::AllowAnyAuthenticatedClient;
-use rustls::Certificate;
-use rustls::PrivateKey;
 use rustls::RootCertStore;
 use rustls::ServerConfig;
 use serde_json_bytes::ByteString;
@@ -52,8 +52,8 @@ use crate::TestHarness;
 
 async fn tls_server(
     listener: tokio::net::TcpListener,
-    certificates: Vec<Certificate>,
-    key: PrivateKey,
+    certificates: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
     body: &'static str,
 ) {
     let acceptor = TlsAcceptor::builder()
@@ -202,9 +202,9 @@ async fn tls_custom_root() {
 
 async fn tls_server_with_client_auth(
     listener: tokio::net::TcpListener,
-    certificates: Vec<Certificate>,
-    key: PrivateKey,
-    client_root: Certificate,
+    certificates: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+    client_root: CertificateDer<'static>,
     body: &'static str,
 ) {
     let mut client_auth_roots = RootCertStore::empty();

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -208,7 +208,7 @@ async fn tls_server_with_client_auth(
     body: &'static str,
 ) {
     let mut client_auth_roots = RootCertStore::empty();
-    client_auth_roots.add(&client_root).unwrap();
+    client_auth_roots.add(client_root).unwrap();
 
     let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots).boxed();
 
@@ -344,8 +344,7 @@ async fn test_subgraph_h2c() {
     let subgraph_service = HttpClientService::new(
         "test",
         rustls::ClientConfig::builder()
-            .with_safe_defaults()
-            .with_native_roots()
+            .with_native_roots()?
             .with_no_client_auth(),
         crate::configuration::shared::Client::builder()
             .experimental_http2(Http2Config::Http2Only)
@@ -422,8 +421,7 @@ async fn test_compressed_request_response_body() {
     let subgraph_service = HttpClientService::new(
         "test",
         rustls::ClientConfig::builder()
-            .with_safe_defaults()
-            .with_native_roots()
+            .with_native_roots()?
             .with_no_client_auth(),
         crate::configuration::shared::Client::builder()
             .experimental_http2(Http2Config::Http2Only)

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -190,13 +190,13 @@ pub(crate) fn generate_tls_client_config(
             .with_no_client_auth(),
         (None, Some(client_auth_config)) => tls_builder.with_native_roots()?.with_client_auth_cert(
             client_auth_config.certificate_chain.clone(),
-            client_auth_config.key.clone(),
+            client_auth_config.key.clone_key(),
         )?,
         (Some(store), Some(client_auth_config)) => tls_builder
             .with_root_certificates(store)
             .with_client_auth_cert(
                 client_auth_config.certificate_chain.clone(),
-                client_auth_config.key.clone(),
+                client_auth_config.key.clone_key(),
             )?,
     })
 }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -182,13 +182,13 @@ pub(crate) fn generate_tls_client_config(
     tls_cert_store: Option<RootCertStore>,
     client_cert_config: Option<&TlsClientAuth>,
 ) -> Result<rustls::ClientConfig, BoxError> {
-    let tls_builder = rustls::ClientConfig::builder().with_safe_defaults();
+    let tls_builder = rustls::ClientConfig::builder();
     Ok(match (tls_cert_store, client_cert_config) {
-        (None, None) => tls_builder.with_native_roots().with_no_client_auth(),
+        (None, None) => tls_builder.with_native_roots()?.with_no_client_auth(),
         (Some(store), None) => tls_builder
             .with_root_certificates(store)
             .with_no_client_auth(),
-        (None, Some(client_auth_config)) => tls_builder.with_native_roots().with_client_auth_cert(
+        (None, Some(client_auth_config)) => tls_builder.with_native_roots()?.with_client_auth_cert(
             client_auth_config.certificate_chain.clone(),
             client_auth_config.key.clone(),
         )?,


### PR DESCRIPTION
This contains 3 commits updating our usage of rustls to the new APIs. Please see the commit descriptions for details on all of the changes.

The trait solver started to kick in for a much larger amount of code, so this PR increases the compiler errors on the hyper upgrade branch to about 90. I've solved all the TLS-related errors I could find in the increased set of errors and left the rest alone.

<!-- [ROUTER-898] -->

[ROUTER-898]: https://apollographql.atlassian.net/browse/ROUTER-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ