### PR TITLE
Regenerate the runtime test cases for connectors and provide some instructions.

### DIFF
--- a/apollo-router/src/plugins/connectors/testdata/README.md
+++ b/apollo-router/src/plugins/connectors/testdata/README.md
@@ -1,0 +1,22 @@
+# Connectors runtime tests
+
+Each schema in this directory is used to test the runtime behavior of connectors in the sibling `test` directory.
+
+The runtime test require an already composed "supergraph SDL", which is the ouput of `rover supergraph compose`. Each
+schema is defined using a supergraph config `.yaml` file in this directory.
+
+## Regenerating
+
+The `regenerate.sh` script will convert each of these `.yaml` files into a composed `.graphql` file which can be
+executed.
+
+### Options:
+
+- Pass a specific `.yaml` file as an argument to regenerate only that file.
+- Set the `FEDERATION_VERSION` environment variable to specify the federation version to use.
+
+> [!TIP]
+> If you need to compose with an unreleased version of composition, you can add any `supergraph` binary to
+> `~/.rover/bin` and use the suffix of that binary as a version. For example, if you have `supergraph-v2.10.0-blah` in
+> that
+> bin folder, you can set `FEDERATION_VERSION="2.10.0-blah"` to use that version.

--- a/apollo-router/src/plugins/connectors/testdata/connector-without-source.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/connector-without-source.graphql
@@ -1,6 +1,7 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
 {
   query: Query

--- a/apollo-router/src/plugins/connectors/testdata/connector-without-source.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/connector-without-source.yaml
@@ -1,12 +1,10 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/connector-without-source.yaml > apollo-router/src/plugins/connectors/testdata/connector-without-source.graphql
-federation_version: =2.9.0-connectors.10
 subgraphs:
   connectors:
     routing_url: none
     schema:
       sdl: |
         extend schema
-          @link(url: "https://specs.apollo.dev/federation/v2.8")
+          @link(url: "https://specs.apollo.dev/federation/v2.10")
           @link(
             url: "https://specs.apollo.dev/connect/v0.1"
             import: ["@connect", "@source"]
@@ -19,5 +17,5 @@ subgraphs:
 
         type Query {
           user(id: ID!): User
-            @connect(http: { GET: "http://127.0.0.1:37895/users/{$$args.id}" }, selection: "id name")
+            @connect(http: { GET: "http://localhost/users/{$$args.id}" }, selection: "id name")
         }

--- a/apollo-router/src/plugins/connectors/testdata/form-encoding.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/form-encoding.yaml
@@ -1,5 +1,3 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/form-encoding.yaml > apollo-router/src/plugins/connectors/testdata/form-encoding.graphql
-federation_version: =2.10.0-alpha.0
 subgraphs:
   connectors:
     routing_url: none

--- a/apollo-router/src/plugins/connectors/testdata/interface-object.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/interface-object.yaml
@@ -1,5 +1,3 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/interface-object.yaml > apollo-router/src/plugins/connectors/testdata/interface-object.graphql
-federation_version: =2.10.0-preview.3 # NOTE: unreleased at time of writing
 subgraphs:
   connectors:
     routing_url: none

--- a/apollo-router/src/plugins/connectors/testdata/mutation.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/mutation.graphql
@@ -1,6 +1,7 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
   @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/"}})
 {

--- a/apollo-router/src/plugins/connectors/testdata/mutation.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/mutation.yaml
@@ -1,5 +1,3 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/mutation.yaml > apollo-router/src/plugins/connectors/testdata/mutation.graphql
-federation_version: =2.9.0-connectors.8
 subgraphs:
   connectors:
     routing_url: none

--- a/apollo-router/src/plugins/connectors/testdata/nullability.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/nullability.yaml
@@ -1,5 +1,3 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/nullability.yaml > apollo-router/src/plugins/connectors/testdata/nullability.graphql
-federation_version: =2.10.0-alpha.0
 subgraphs:
   connectors:
     routing_url: none

--- a/apollo-router/src/plugins/connectors/testdata/quickstart.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/quickstart.graphql
@@ -1,6 +1,7 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
   @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "jsonPlaceholder", http: {baseURL: "https://jsonplaceholder.typicode.com/"}})
 {

--- a/apollo-router/src/plugins/connectors/testdata/quickstart.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/quickstart.yaml
@@ -1,5 +1,3 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/quickstart.yaml > apollo-router/src/plugins/connectors/testdata/quickstart.graphql
-federation_version: =2.9.0-connectors.12
 subgraphs:
   connectors:
     routing_url: none

--- a/apollo-router/src/plugins/connectors/testdata/regenerate.sh
+++ b/apollo-router/src/plugins/connectors/testdata/regenerate.sh
@@ -1,0 +1,23 @@
+set -euo pipefail
+
+if [ -z "${FEDERATION_VERSION:-}" ]; then
+  FEDERATION_VERSION="2.10.0-preview.2"
+fi
+
+regenerate_graphql() {
+  local supergraph_config=$1
+  local test_name
+  test_name=$(basename "$supergraph_config" .yaml)
+  local dir_name
+  dir_name=$(dirname "$supergraph_config")
+  echo "Regenerating $dir_name/$test_name.graphql"
+  rover supergraph compose --federation-version "=$FEDERATION_VERSION" --config "$supergraph_config" > "$dir_name/$test_name.graphql"
+}
+
+if [ -z "${1:-}" ]; then
+  for supergraph_config in **/*.yaml; do
+    regenerate_graphql "$supergraph_config"
+  done
+else
+  regenerate_graphql "$1"
+fi

--- a/apollo-router/src/plugins/connectors/testdata/selection.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/selection.graphql
@@ -1,6 +1,7 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
   @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/"}})
 {

--- a/apollo-router/src/plugins/connectors/testdata/selection.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/selection.yaml
@@ -1,5 +1,3 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/selection.yaml > apollo-router/src/plugins/connectors/testdata/selection.graphql
-federation_version: =2.9.0-connectors.8
 subgraphs:
   connectors:
     routing_url: none
@@ -26,13 +24,13 @@ subgraphs:
           name_from_path: String
           by: CommitAuthor
         }
-          
+        
         type CommitAuthor {
           name: String
           email: String
           owner: String
         }
-          
+        
         type Query {
           commits(owner: String!, repo: String!): [Commit]
             @connect(

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
@@ -84,7 +84,7 @@ type User
   id: ID!
   name: String @join__field(graph: CONNECTORS)
   username: String @join__field(graph: CONNECTORS)
-  nickname: String @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$this.id}/nicknames", headers: [{name: "x-from-this", value: "before {$this.id} after"}]}, selection: "nickname: $.first"})
+  nickname: String @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$this.id}/nicknames", headers: [{name: "x-from-this", value: "before {$this.id} after"}]}, selection: "$.first"})
   c: String @join__field(graph: CONNECTORS, external: true) @join__field(graph: GRAPHQL)
   d: String @join__field(graph: CONNECTORS, requires: "c") @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$this.c}"}, selection: "$.phone"})
 }

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.yaml
@@ -1,5 +1,3 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/steelthread.yaml > apollo-router/src/plugins/connectors/testdata/steelthread.graphql
-federation_version: =2.10.0-preview.0
 subgraphs:
   connectors:
     routing_url: none

--- a/apollo-router/src/plugins/connectors/testdata/variables.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/variables.yaml
@@ -1,5 +1,3 @@
-# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/variables.yaml > apollo-router/src/plugins/connectors/testdata/variables.graphql
-federation_version: =2.10.0-local.3
 subgraphs:
   connectors:
     routing_url: none


### PR DESCRIPTION
Same treatment I gave the expansion test cases. Removes references to old versions of composition and brings all the supergraph SDLs up to date. Also fixed one inconsistency between a YAML and its .graphql.