### PR TITLE
Move `Code::to_string` to `apollo-federation` from `apollo-composition`.

### DIFF
--- a/apollo-federation/src/sources/connect/validation/extended_type.rs
+++ b/apollo-federation/src/sources/connect/validation/extended_type.rs
@@ -321,7 +321,7 @@ fn validate_abstract_type(
     keyword: &str,
 ) -> Message {
     Message {
-        code: Code::UnsupportedAbstractType,
+        code: Code::ConnectorsUnsupportedAbstractType,
         message: format!("Abstract schema types, such as `{keyword}`, are not supported when using connectors. You can check out our documentation at https://go.apollo.dev/connectors/best-practices#abstract-schema-types-are-unsupported."),
         locations: node.and_then(|location| location.line_column_range(source_map))
             .into_iter()

--- a/apollo-federation/src/sources/connect/validation/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/selection.rs
@@ -436,7 +436,7 @@ impl<'schema> FieldVisitor<Field<'schema>> for SelectionValidator<'schema, '_> {
 
         if !field.definition.arguments.is_empty() {
             return Err(Message {
-                code: Code::FieldWithArguments,
+                code: Code::ConnectorsFieldWithArguments,
                 message: format!(
                     "{coordinate} selects field `{parent_type}.{field_name}`, which has arguments. Only fields with a connector can have arguments.",
                     parent_type = self.last_field().ty().name,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@all_fields_selected.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@all_fields_selected.graphql.snap
@@ -5,35 +5,35 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/all_field
 ---
 [
     Message {
-        code: UnresolvedField,
+        code: ConnectorsUnresolvedField,
         message: "No connector resolves field `T.unselected`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
             34:3..34:22,
         ],
     },
     Message {
-        code: UnresolvedField,
+        code: ConnectorsUnresolvedField,
         message: "No connector resolves field `T.secondUnused`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
             48:3..48:23,
         ],
     },
     Message {
-        code: UnresolvedField,
+        code: ConnectorsUnresolvedField,
         message: "No connector resolves field `C.unselected`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
             54:3..54:21,
         ],
     },
     Message {
-        code: UnresolvedField,
+        code: ConnectorsUnresolvedField,
         message: "No connector resolves field `D.unselected`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
             59:3..59:21,
         ],
     },
     Message {
-        code: UnresolvedField,
+        code: ConnectorsUnresolvedField,
         message: "No connector resolves field `Unused.unselected`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
             63:3..63:18,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@disallowed_abstract_types.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@disallowed_abstract_types.graphql.snap
@@ -5,14 +5,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/disallowe
 ---
 [
     Message {
-        code: UnsupportedAbstractType,
+        code: ConnectorsUnsupportedAbstractType,
         message: "Abstract schema types, such as `interface`, are not supported when using connectors. You can check out our documentation at https://go.apollo.dev/connectors/best-practices#abstract-schema-types-are-unsupported.",
         locations: [
             21:1..21:18,
         ],
     },
     Message {
-        code: UnsupportedAbstractType,
+        code: ConnectorsUnsupportedAbstractType,
         message: "Abstract schema types, such as `union`, are not supported when using connectors. You can check out our documentation at https://go.apollo.dev/connectors/best-practices#abstract-schema-types-are-unsupported.",
         locations: [
             25:1..25:12,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@disallowed_federation_imports.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@disallowed_federation_imports.graphql.snap
@@ -5,14 +5,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/disallowe
 ---
 [
     Message {
-        code: UnsupportedFederationDirective,
+        code: ConnectorsUnsupportedFederationDirective,
         message: "The directive `@context` is not supported when using connectors.",
         locations: [
             6:7..6:17,
         ],
     },
     Message {
-        code: UnsupportedFederationDirective,
+        code: ConnectorsUnsupportedFederationDirective,
         message: "The directive `@fromContext` is not supported when using connectors.",
         locations: [
             7:7..7:21,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@fields_with_arguments.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@fields_with_arguments.graphql.snap
@@ -5,7 +5,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/fields_wi
 ---
 [
     Message {
-        code: FieldWithArguments,
+        code: ConnectorsFieldWithArguments,
         message: "`@connect(selection:)` on `Query.ts` selects field `T.field`, which has arguments. Only fields with a connector can have arguments.",
         locations: [
             11:7..11:12,


### PR DESCRIPTION
Should give us less busy work in `federation-rs` when testing/releasing. Preserves naming of previous codes.