### PR TITLE
[docs] update configuration redirect

### DIFF
--- a/docs/source/reference/router/configuration.mdx
+++ b/docs/source/reference/router/configuration.mdx
@@ -2,6 +2,8 @@
 title: Router Configuration
 subtitle: Configure a router via environment variables, command-line options, and YAML
 description: Learn how to configure the Apollo GraphOS Router or Apollo Router Core with environment variables, command-line options and commands, and YAML configuration files.
+redirectFrom:
+  - /router/configuration/overview/
 ---
 
 Learn how to customize the behavior of your GraphOS Router or Apollo Router Core with environment variables, command-line commands and options, and YAML file configuration.

--- a/docs/source/routing/configure-your-router.mdx
+++ b/docs/source/routing/configure-your-router.mdx
@@ -2,8 +2,6 @@
 title: Configuring a Router
 subtitle: Learn to configure cloud-hosted and self-hosted routers
 description: Learn how to configure the Apollo GraphOS Router with environment variables, command-line options and commands, and YAML configuration files.
-redirectFrom:
-  - /router/configuration/overview/
 ---
 
 You can configure a router in multiple ways. Because cloud-hosted and self-hosted routers share the common foundation of Apollo Router Core, all routers support declarative configuration with a YAML file, usually named `router.yaml`. Differences between configuring cloud-hosted and self-hosted routers:


### PR DESCRIPTION
Many links to the configuration page include anchors to specific configurations, for example, [this link](https://github.com/apollographql/rover/blob/552069115e7253238da63be9007b429a76baa193/src/utils/expansion.rs#L16) in Rover. So that the anchors can be successfully applied, it makes more sense to link to the reference rather than overview page.