### PR TITLE
Handle escape sequences in GraphQL strings

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -116,11 +116,7 @@ impl std::error::Error for JSONSelectionParseError {}
 
 impl Display for JSONSelectionParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}: {}",
-            self.message, self.fragment
-        )
+        write!(f, "{}: {}", self.message, self.fragment)
     }
 }
 

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -118,8 +118,8 @@ impl Display for JSONSelectionParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} at offset {}: {}",
-            self.message, self.offset, self.fragment
+            "{}: {}",
+            self.message, self.fragment
         )
     }
 }

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_connect_http_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_connect_http_headers.graphql.snap
@@ -52,7 +52,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_c
         code: InvalidHeader,
         message: "In `@connect(http.headers:)` on `Query.resources` invalid HTTP header value `  Value with 😊 emoji and newline  \n `",
         locations: [
-            21:21..21:60,
+            21:21..21:58,
         ],
     },
     Message {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_syntax.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_syntax.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
 [
     Message {
         code: InvalidJsonSelection,
-        message: "`@connect(selection:)` on `Query.something` is not a valid JSONSelection: nom::error::ErrorKind::Eof at offset 0: &how",
+        message: "`@connect(selection:)` on `Query.something` is not a valid JSONSelection: nom::error::ErrorKind::Eof: &how",
         locations: [
             8:87..8:88,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_source_http_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_source_http_headers.graphql.snap
@@ -52,7 +52,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
         code: InvalidHeader,
         message: "In `@source(http.headers:)` invalid HTTP header value `  Value with 😊 emoji and newline  \n `",
         locations: [
-            22:19..22:58,
+            22:19..22:56,
         ],
     },
     Message {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_with_escapes.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_with_escapes.graphql.snap
@@ -8,14 +8,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/valid_sel
         code: InvalidJsonSelection,
         message: "`@connect(selection:)` on `Query.block` is not a valid JSONSelection: Path selection . must be followed by key (identifier or quoted string literal): .",
         locations: [
-            16:27..16:28,
+            16:30..16:31,
         ],
     },
     Message {
         code: InvalidJsonSelection,
         message: "`@connect(selection:)` on `Query.standard` is not a valid JSONSelection: Path selection . must be followed by key (identifier or quoted string literal): .",
         locations: [
-            22:77..22:78,
+            22:95..22:96,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_with_escapes.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_with_escapes.graphql.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/valid_selection_with_escapes.graphql
+---
+[
+    Message {
+        code: InvalidJsonSelection,
+        message: "`@connect(selection:)` on `Query.block` is not a valid JSONSelection: Path selection . must be followed by key (identifier or quoted string literal): .",
+        locations: [
+            16:27..16:28,
+        ],
+    },
+    Message {
+        code: InvalidJsonSelection,
+        message: "`@connect(selection:)` on `Query.standard` is not a valid JSONSelection: Path selection . must be followed by key (identifier or quoted string literal): .",
+        locations: [
+            22:77..22:78,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_selection_with_escapes.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_selection_with_escapes.graphql
@@ -8,23 +8,23 @@ type Query {
         selection: """
 
 
-        foo
-        bar
+        one
+        two
 
 
 
-        			unicode:$('﷽é').
+        			unicode:$('﷽é€中π').
         """
     )
     standard: T
     @connect(
         http: { GET: "http://127.0.0.1/something" }
-        selection: "\n\n\nfoo bar\t\t\t\n\n\nunicode:$('\uFDFD\u0065\u0301')."
+        selection: "\n\n\none two\t\t\t\n\n\nunicode:$('\uFDFD\u0065\u0301\u20AC\u4E2D\u03C0')."
     )
 }
 
 type T {
-    foo: String
-    bar: String
+    one: String
+    two: String
     unicode: String
 }

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_selection_with_escapes.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_selection_with_escapes.graphql
@@ -1,0 +1,30 @@
+extend schema
+@link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
+
+type Query {
+    block: T
+    @connect(
+        http: { GET: "http://127.0.0.1/something" }
+        selection: """
+
+
+        foo
+        bar
+
+
+
+        			unicode:$('﷽é').
+        """
+    )
+    standard: T
+    @connect(
+        http: { GET: "http://127.0.0.1/something" }
+        selection: "\n\n\nfoo bar\t\t\t\n\n\nunicode:$('\uFDFD\u0065\u0301')."
+    )
+}
+
+type T {
+    foo: String
+    bar: String
+    unicode: String
+}


### PR DESCRIPTION

As defined in the [GraphQL spec](https://spec.graphql.org/October2021/#sec-String-Value), standard strings may contain escape sequences, and block strings have their whitespace modified to remove any common indent or leading whitespace lines.

The Apollo Connectors feature parses various GraphQL strings in the `@connect` and `@source` directives, and provides messages with location information when there are problems within the content of those strings. To prevent each parser from having to handle escape sequences, the parsers should execute on the strings returned by `apollo-compiler`, which processes the escape sequences and block string whitespace. This requires mapping the locations returned by the parsers back to the corresponding locations in the original file by reversing the rules for handling escape sequences and whitespace. These changes provide that mapping.

## Limitations

The following known limitations still exist:

* The GraphQL spec allows line endings to be `\n`, `\r\n`, or just  a single `\r` character. The location mapping does not function properly with the last case. The `line-col` dependency used to convert offsets to line/column values only handles `\n` newlines, and as such, this code does not attempt to handle that case either.
* Unicode surrogate pairs cannot be used in escape sequences, due to an [open issue in the `apollo-rs` dependency](https://github.com/apollographql/apollo-rs/issues/657). Strings containing these sequences will not be recognized as GraphQL strings by the compiler. An example is the codepoint pair `\uD83E\uDD80`, which corresponds to the 🦀 character.
* Some of the parsers, such as the JSON Selection parser, do not appear to handle `\b` (backspace) and `\f`(form feed) escape sequences allowed by the GraphQL spec. Strings containing those characters will result in parse errors.

<!-- [CNN-528] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-528]: https://apollographql.atlassian.net/browse/CNN-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ