### PR TITLE
plugins/fleet_detector: detect if the Router was deployed using the official Apollo Helm chart

### DIFF
--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -90,7 +90,7 @@ impl GaugeStore {
                     attributes.push(KeyValue::new("cloud.provider", cloud_provider.code()));
                 }
             }
-            // Official helm chart
+            // Deployment type
             attributes.push(KeyValue::new("deployment.type", get_deployment_type()));
             gauges.push(
                 meter
@@ -299,6 +299,7 @@ fn get_otel_os() -> &'static str {
 }
 
 fn get_deployment_type() -> &'static str {
+    // Official Apollo helm chart
     if std::env::var_os(OFFICIAL_HELM_CHART_VAR).is_some() {
         return "official_helm_chart";
     }


### PR DESCRIPTION
This adds a new attribute to the `apollo.router.instance` metric to track if the Router instance was deployed using the official Apollo helm chart vended in this repository.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
