### PR TITLE
remove fix for experimental_retry

### DIFF
--- a/apollo-router/src/plugins/traffic_shaping/retry.rs
+++ b/apollo-router/src/plugins/traffic_shaping/retry.rs
@@ -43,7 +43,7 @@ impl<E> Policy<subgraph::Request, subgraph::Response, E> for RetryPolicy {
     ) -> Option<Self::Future> {
         let subgraph_name = req.subgraph_name.clone().unwrap_or_default();
         match result {
-            Ok(resp) => {
+            Ok(_resp) => {
                 // Treat all `Response`s as success,
                 // so deposit budget and don't retry...
                 self.budget.deposit();
@@ -89,9 +89,6 @@ impl<E> Policy<subgraph::Request, subgraph::Response, E> for RetryPolicy {
 
 #[cfg(test)]
 mod tests {
-    use http::StatusCode;
-    use tower::BoxError;
-
     use super::*;
     use crate::error::FetchError;
     use crate::graphql;

--- a/apollo-router/src/plugins/traffic_shaping/retry.rs
+++ b/apollo-router/src/plugins/traffic_shaping/retry.rs
@@ -44,44 +44,10 @@ impl<E> Policy<subgraph::Request, subgraph::Response, E> for RetryPolicy {
         let subgraph_name = req.subgraph_name.clone().unwrap_or_default();
         match result {
             Ok(resp) => {
-                if resp.response.status() >= http::StatusCode::BAD_REQUEST {
-                    if req.operation_kind == OperationKind::Mutation && !self.retry_mutations {
-                        return None;
-                    }
-
-                    let withdrew = self.budget.withdraw();
-                    if withdrew.is_err() {
-                        u64_counter!(
-                            "apollo_router_http_request_retry_total",
-                            "Number of retries for an http request to a subgraph",
-                            1u64,
-                            status = "aborted",
-                            subgraph = subgraph_name
-                        );
-
-                        return None;
-                    }
-
-                    let _ = req
-                        .context
-                        .upsert::<_, usize>(SubgraphRequestResendCountKey::new(&req.id), |val| {
-                            val + 1
-                        });
-
-                    u64_counter!(
-                        "apollo_router_http_request_retry_total",
-                        "Number of retries for an http request to a subgraph",
-                        1u64,
-                        subgraph = subgraph_name
-                    );
-
-                    Some(future::ready(self.clone()))
-                } else {
-                    // Treat all `Response`s as success,
-                    // so deposit budget and don't retry...
-                    self.budget.deposit();
-                    None
-                }
+                // Treat all `Response`s as success,
+                // so deposit budget and don't retry...
+                self.budget.deposit();
+                None
             }
             Err(_e) => {
                 if req.operation_kind == OperationKind::Mutation && !self.retry_mutations {
@@ -176,63 +142,6 @@ mod tests {
                         service: String::from("my_subgraph_name_error"),
                         reason: String::from("cannot contact the subgraph"),
                     }))
-                )
-                .is_some());
-
-            assert_counter!(
-                "apollo_router_http_request_retry_total",
-                2,
-                "subgraph" = "my_subgraph_name_error"
-            );
-        }
-        .with_metrics()
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_retry_with_http_status_code() {
-        async {
-            let retry = RetryPolicy::new(
-                Some(Duration::from_secs(10)),
-                Some(10),
-                Some(0.2),
-                Some(false),
-            );
-
-            let subgraph_req = subgraph::Request::fake_builder()
-                .subgraph_name("my_subgraph_name_error")
-                .subgraph_request(
-                    http_ext::Request::fake_builder()
-                        .header("test", "my_value_set")
-                        .body(
-                            graphql::Request::fake_builder()
-                                .query(String::from("query { test }"))
-                                .build(),
-                        )
-                        .build()
-                        .unwrap(),
-                )
-                .build();
-
-            assert!(retry
-                .retry(
-                    &subgraph_req,
-                    Ok::<&subgraph::Response, &BoxError>(
-                        &subgraph::Response::fake_builder()
-                            .status_code(StatusCode::BAD_REQUEST)
-                            .build()
-                    )
-                )
-                .is_some());
-
-            assert!(retry
-                .retry(
-                    &subgraph_req,
-                    Ok::<&subgraph::Response, &BoxError>(
-                        &subgraph::Response::fake_builder()
-                            .status_code(StatusCode::BAD_REQUEST)
-                            .build()
-                    )
                 )
                 .is_some());
 


### PR DESCRIPTION
A change to the experimental_retry has been introduced accidentally in this [PR](https://github.com/apollographql/router/pull/6351). This PR reverts that change because it needs further discussion.