### PR TITLE
update hashbrown dep for compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
  "apollo-compiler",
  "derive_more",
  "either",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "hex",
  "indexmap 2.2.6",
  "insta",
@@ -3136,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -22,7 +22,7 @@ time = { version = "0.3.34", default-features = false, features = [
     "local-offset",
 ] }
 derive_more = "0.99.17"
-hashbrown = "0.15.0"
+hashbrown = "0.15.1"
 indexmap = { version = "2.2.6", features = ["serde"] }
 itertools = "0.13.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION
We are getting errors with an outdated version of hashbrown that needs to updated due to a bug in borsch serialisation 🍲 . This updates us to a version of hashbrown that fixes this vulnerability.

```
error[vulnerability]: Borsh serialization of HashMap is non-canonical
    ┌─ /Users/ira/Code/apollographql/router/Cargo.lock:261:1
    │
261 │ hashbrown 0.15.0 registry+https://github.com/rust-lang/crates.io-index
    │ ---------------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2024-0402
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0402
    = The borsh serialization of the HashMap did not follow the borsh specification.
      It potentially produced non-canonical encodings dependent on insertion order.
      It also did not perform canonicty checks on decoding.
```