### PR TITLE
Fix bug where URL variable parsing was not all-consuming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "apollo-compiler",
  "derive_more",
  "either",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "hex",
  "http 0.2.12",
  "indexmap 2.2.6",
@@ -2978,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",

--- a/apollo-federation/src/sources/connect/variable/mod.rs
+++ b/apollo-federation/src/sources/connect/variable/mod.rs
@@ -11,6 +11,7 @@ use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ObjectType;
 use apollo_compiler::Node;
 use itertools::Itertools;
+use nom::combinator::all_consuming;
 use parser::Span;
 use parser::VariableParseError;
 
@@ -237,7 +238,7 @@ impl<'a, N: FromStr + ToString> VariableReference<'a, N> {
     }
 
     fn from_str(s: &'a str) -> Result<Self, VariableError> {
-        parser::variable_reference(Span::new(s))
+        all_consuming(parser::variable_reference)(Span::new(s))
             .map(|(_, reference)| reference)
             .map_err(|e| match e {
                 nom::Err::Error(e) => e.into(),


### PR DESCRIPTION

Extra text after a variable reference will now properly report an invalid variable reference in headers and URL paths.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
