### PR TITLE
Improve error messaging when QP encounters unmergeable fields

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -125,6 +125,9 @@ pub enum SingleFederationError {
     #[error("An internal error has occurred, please report this bug to Apollo. Details: {0}")]
     #[allow(private_interfaces)] // users should not inspect this.
     InternalRebaseError(#[from] crate::operation::RebaseError),
+    // This is a known bug that will take time to fix, and does not require reporting.
+    #[error("{message}")]
+    InternalUnmergeableFields { message: String },
     #[error("{diagnostics}")]
     InvalidGraphQL { diagnostics: DiagnosticList },
     #[error(transparent)]
@@ -301,6 +304,7 @@ impl SingleFederationError {
         match self {
             SingleFederationError::Internal { .. } => ErrorCode::Internal,
             SingleFederationError::InternalRebaseError { .. } => ErrorCode::Internal,
+            SingleFederationError::InternalUnmergeableFields { .. } => ErrorCode::Internal,
             SingleFederationError::InvalidGraphQL { .. }
             | SingleFederationError::InvalidGraphQLName(_) => ErrorCode::InvalidGraphQL,
             SingleFederationError::InvalidSubgraph { .. } => ErrorCode::InvalidGraphQL,

--- a/apollo-federation/src/operation/merging.rs
+++ b/apollo-federation/src/operation/merging.rs
@@ -47,14 +47,14 @@ impl<'a> FieldSelectionValue<'a> {
                 return Err(SingleFederationError::InternalUnmergeableFields {
                     message: format!(
                         "Cannot merge field selection for field \"{}\" into a field selection for \
-                        field \"{}\". This is a known query planning bug that was silently ignored \
-                        in the old  Javascript query planner. The new Rust-native query planner \
-                        does not fix this bug at this time, but in some cases does catch when this \
-                        bug occurs. If you're seeing this message, this bug was likely triggered \
-                        by one of the field selections mentioned previously having an alias that \
-                        was the same name as the field in the other field selection. The \
-                        recommended workaround is to change this alias to a different one in your \
-                        operation.",
+                        field \"{}\". This is a known query planning bug in the old Javascript \
+                        query planner that was silently ignored. The Rust-native query planner \
+                        does not address this bug at this time, but in some cases does catch when \
+                        this bug occurs. If you're seeing this message, this bug was likely \
+                        triggered by one of the field selections mentioned previously having an \
+                        alias that was the same name as the field in the other field selection. \
+                        The recommended workaround is to change this alias to a different one in \
+                        your operation.",
                         other_field.field_position, self_field.field_position,
                     ),
                 }

--- a/apollo-federation/src/operation/merging.rs
+++ b/apollo-federation/src/operation/merging.rs
@@ -18,6 +18,7 @@ use super::SelectionValue;
 use crate::bail;
 use crate::ensure;
 use crate::error::FederationError;
+use crate::error::SingleFederationError;
 
 impl<'a> FieldSelectionValue<'a> {
     /// Merges the given field selections into this one.
@@ -42,12 +43,23 @@ impl<'a> FieldSelectionValue<'a> {
                 other_field.schema == self_field.schema,
                 "Cannot merge field selections from different schemas",
             );
-            ensure!(
-                other_field.field_position == self_field.field_position,
-                "Cannot merge field selection for field \"{}\" into a field selection for field \"{}\"",
-                other_field.field_position,
-                self_field.field_position,
-            );
+            if other_field.field_position != self_field.field_position {
+                return Err(SingleFederationError::InternalUnmergeableFields {
+                    message: format!(
+                        "Cannot merge field selection for field \"{}\" into a field selection for \
+                        field \"{}\". This is a known query planning bug that was silently ignored \
+                        in the old  Javascript query planner. The new Rust-native query planner \
+                        does not fix this bug at this time, but in some cases does catch when this \
+                        bug occurs. If you're seeing this message, this bug was likely triggered \
+                        by one of the field selections mentioned previously having an alias that \
+                        was the same name as the field in the other field selection. The \
+                        recommended workaround is to change this alias to a different one in your \
+                        operation.",
+                        other_field.field_position, self_field.field_position,
+                    ),
+                }
+                .into());
+            }
             if self.get().selection_set.is_some() {
                 let Some(other_selection_set) = &other.selection_set else {
                     bail!(


### PR DESCRIPTION
This PR updates the error messaging when query planner encounters unmergeable fields (indicating a known bug in query planner), and increments an internal metric when this error kind is encountered. Note that query planner does not check all such cases of this, as doing so is computationally expensive. The bug itself is not fixed in this PR, as it requires substantial effort to fix.

<!-- ROUTER-919 -->