### PR TITLE
fix cargo about (#6423)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,9 +376,12 @@ commands:
       - run:
           name: Install cargo deny, about, edit
           command: |
+            # Until we are able to update rustc to at least 1.81.0,
+            # we need special handling of the cargo-about command.
+            rustup install 1.83.0
+            cargo +1.83.0 install --locked --version 0.6.6 cargo-about
             if [[ ! -f "$HOME/.cargo/bin/cargo-deny$EXECUTABLE_SUFFIX" ]]; then
               cargo install --locked --version 0.14.21 cargo-deny
-              cargo install --locked --version 0.6.1 cargo-about
               cargo install --locked --version 0.12.2 cargo-edit
               cargo install --locked --version 0.12.0 cargo-fuzz
             fi

--- a/about.toml
+++ b/about.toml
@@ -9,6 +9,7 @@ accepted = [
     "LicenseRef-ring",
     "MIT",
     "MPL-2.0",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib"
 ]


### PR DESCRIPTION
cargo about and cargo deny have separate configuration files: about.toml and deny.toml.

deny.toml was updated to allow Unicode-3.0 license in #6417 , but about.toml was not updated. This is causing `cargo xtask licenses` to fail.

This PR fixes about.toml.
