### PR TITLE
fix(semantic-diff): fixed false mismatches with type conditioned fetching enabled

### DIFF
--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -37,13 +37,13 @@ fn extract_matched_conditions(caps: &Captures) -> TypeConditions {
         .unwrap_or_default()
 }
 
-fn split_key_and_type_conditions(s: &str) -> (String, Option<TypeConditions>) {
+fn split_path_element_and_type_conditions(s: &str) -> (String, Option<TypeConditions>) {
     let mut type_conditions = None;
-    let key = TYPE_CONDITIONS_REGEX.replace(s, |caps: &Captures| {
+    let path_element = TYPE_CONDITIONS_REGEX.replace(s, |caps: &Captures| {
         type_conditions = Some(extract_matched_conditions(caps));
         ""
     });
-    (key.to_string(), type_conditions)
+    (path_element.to_string(), type_conditions)
 }
 
 macro_rules! extract_key_value_from_object {
@@ -866,8 +866,8 @@ impl<'de> serde::de::Visitor<'de> for FlattenVisitor {
     where
         E: serde::de::Error,
     {
-        let (key, type_conditions) = split_key_and_type_conditions(s);
-        if key == "@" {
+        let (path_element, type_conditions) = split_path_element_and_type_conditions(s);
+        if path_element == "@" {
             Ok(type_conditions)
         } else {
             Err(serde::de::Error::invalid_value(
@@ -917,7 +917,7 @@ impl<'de> serde::de::Visitor<'de> for KeyVisitor {
     where
         E: serde::de::Error,
     {
-        Ok(split_key_and_type_conditions(s))
+        Ok(split_path_element_and_type_conditions(s))
     }
 }
 
@@ -972,15 +972,15 @@ where
 }
 
 fn flatten_from_str(s: &str) -> Result<PathElement, String> {
-    let (key, type_conditions) = split_key_and_type_conditions(s);
-    if key != "@" {
+    let (path_element, type_conditions) = split_path_element_and_type_conditions(s);
+    if path_element != "@" {
         return Err("invalid flatten".to_string());
     }
     Ok(PathElement::Flatten(type_conditions))
 }
 
 fn key_from_str(s: &str) -> Result<PathElement, String> {
-    let (key, type_conditions) = split_key_and_type_conditions(s);
+    let (key, type_conditions) = split_path_element_and_type_conditions(s);
     Ok(PathElement::Key(key, type_conditions))
 }
 

--- a/apollo-router/src/query_planner/plan_compare.rs
+++ b/apollo-router/src/query_planner/plan_compare.rs
@@ -1245,15 +1245,15 @@ mod path_comparison_tests {
     }
 
     #[test]
-    fn test_same_path_ignore_empty_conditions() {
-        // Create a legacy path with an empty type conditions.
+    fn test_same_path_distinguishes_empty_conditions_from_no_conditions() {
+        // Create paths that use no type conditions and empty type conditions
         let path_json_legacy = json!(["k|[]", "v"]);
         let path_json_native = json!(["k", "v"]);
 
         let legacy_path: Path = serde_json::from_value(path_json_legacy).unwrap();
         let native_path: Path = serde_json::from_value(path_json_native).unwrap();
 
-        // Tests that both formats are deserialized into the same Path.
-        assert!(same_path(&legacy_path, &native_path));
+        // Tests that both formats are deserialized into different Paths.
+        assert!(!same_path(&legacy_path, &native_path));
     }
 }


### PR DESCRIPTION
Two issues:

1. JS QP may have empty key roots in response path data, which is ignored by the router. On the other hand, Rust QP does not use such a placeholder. So, the semantic diff ignores the placeholder during comparison.
2. JS QP may have empty condition list, but it was deserialized incorrectly (for example, `k|[]` would be interpreted as a whole key name). This is now fixed in the router's deserializer.

<!-- ROUTER-920 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests
