### PR TITLE
Update `ensure!` macro to return its error

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -82,7 +82,7 @@ macro_rules! ensure {
 
         #[cfg(not(debug_assertions))]
         if !$expr {
-            $crate::internal_error!( $( $arg )+ );
+            $crate::bail!( $( $arg )+ );
         }
     }
 }


### PR DESCRIPTION
In v1.58.0, the `internal_error!` macro was updated to no longer return its error for release builds, but the `ensure!` macro (which calls `internal_error!`) wasn't updated accordingly. This means that `ensure!` callsites in the current code are silently ignoring their errors if their check fails in release builds. This PR updates `ensure!` to use the `bail!` macro, which does return its error.

<!-- ROUTER-923 -->