### PR TITLE
fix(federation): convert query graph node's type for fetch dependency graph path

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -26,6 +26,9 @@ struct QueryPlannerArgs {
     /// Generate fragments to compress subgraph queries.
     #[arg(long, default_value_t = false)]
     generate_fragments: bool,
+    /// Enable type conditioned fetching.
+    #[arg(long, default_value_t = false)]
+    type_conditioned_fetching: bool,
     /// Run GraphQL validation check on generated subgraph queries. (default: true)
     #[arg(long, default_missing_value = "true", require_equals = true, num_args = 0..=1)]
     subgraph_validation: Option<bool>,
@@ -103,6 +106,7 @@ impl QueryPlannerArgs {
     fn apply(&self, config: &mut QueryPlannerConfig) {
         config.incremental_delivery.enable_defer = self.enable_defer;
         config.generate_query_fragments = self.generate_fragments;
+        config.type_conditioned_fetching = self.type_conditioned_fetching;
         config.subgraph_graphql_validation = self.subgraph_validation.unwrap_or(true);
         if let Some(max_evaluated_plans) = self.max_evaluated_plans {
             config.debug.max_evaluated_plans = max_evaluated_plans;

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -32,6 +32,7 @@ use crate::query_plan::fetch_dependency_graph::FetchDependencyGraphNodePath;
 use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphProcessor;
 use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphToCostProcessor;
 use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphToQueryPlanProcessor;
+use crate::query_plan::query_planning_traversal::convert_type_from_subgraph;
 use crate::query_plan::query_planning_traversal::BestQueryPlanInfo;
 use crate::query_plan::query_planning_traversal::QueryPlanningParameters;
 use crate::query_plan::query_planning_traversal::QueryPlanningTraversal;
@@ -563,6 +564,7 @@ fn compute_root_serial_dependency_graph(
             );
             compute_root_fetch_groups(
                 operation.root_kind,
+                federated_query_graph,
                 &mut fetch_dependency_graph,
                 &prev_path,
                 parameters.config.type_conditioned_fetching,
@@ -600,6 +602,7 @@ fn only_root_subgraph(graph: &FetchDependencyGraph) -> Result<Arc<str>, Federati
 )]
 pub(crate) fn compute_root_fetch_groups(
     root_kind: SchemaRootDefinitionKind,
+    federated_query_graph: &QueryGraph,
     dependency_graph: &mut FetchDependencyGraph,
     path: &OpPathTree,
     type_conditioned_fetching_enabled: bool,
@@ -635,6 +638,12 @@ pub(crate) fn compute_root_fetch_groups(
             dependency_graph.to_dot(),
             "tree_with_root_node"
         );
+        let subgraph_schema = federated_query_graph.schema_by_source(subgraph_name)?;
+        let supergraph_root_type = convert_type_from_subgraph(
+            root_type,
+            subgraph_schema,
+            &dependency_graph.supergraph_schema,
+        )?;
         compute_nodes_for_tree(
             dependency_graph,
             &child.tree,
@@ -642,7 +651,7 @@ pub(crate) fn compute_root_fetch_groups(
             FetchDependencyGraphNodePath::new(
                 dependency_graph.supergraph_schema.clone(),
                 type_conditioned_fetching_enabled,
-                root_type,
+                supergraph_root_type,
             )?,
             Default::default(),
             &Default::default(),

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 
+use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
 use apollo_federation::query_plan::FetchDataPathElement;
 use apollo_federation::query_plan::FetchDataRewrite;
 
@@ -954,5 +955,105 @@ fn test_interface_object_advance_with_non_collecting_and_type_preserving_transit
       },
     }
     "###
+    );
+}
+
+#[test]
+fn test_type_conditioned_fetching_with_interface_object_does_not_crash() {
+    let planner = planner!(
+        config = QueryPlannerConfig {
+          type_conditioned_fetching: true,
+          ..Default::default()
+        },
+        S1: r#"
+          type I @interfaceObject @key(fields: "id") {
+            id: ID!
+            t: T
+          }
+
+          type T {
+            relatedIs: [I]
+          }
+        "#,
+        S2: r#"
+          type Query {
+            i: I
+          }
+
+          interface I @key(fields: "id") {
+            id: ID!
+            a: Int
+          }
+
+          type A implements I @key(fields: "id") {
+            id: ID!
+            a: Int
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          {
+            i {
+              t {
+                relatedIs {
+                  a
+                }
+              }
+            }
+          }
+        "#,
+
+        @r###"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "S2") {
+              {
+                i {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "i") {
+              Fetch(service: "S1") {
+                {
+                  ... on I {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on I {
+                    t {
+                      relatedIs {
+                        __typename
+                        id
+                      }
+                    }
+                  }
+                }
+              },
+            },
+            Flatten(path: "i.t.relatedIs.@") {
+              Fetch(service: "S2") {
+                {
+                  ... on I {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on I {
+                    __typename
+                    a
+                  }
+                }
+              },
+            },
+          },
+        }
+      "###
     );
 }

--- a/apollo-federation/tests/query_plan/supergraphs/test_type_conditioned_fetching_with_interface_object_does_not_crash.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_type_conditioned_fetching_with_interface_object_does_not_crash.graphql
@@ -1,0 +1,86 @@
+# Composed from subgraphs with hash: 161c48cab8f2c97bc5fef235b557994f82dc7e51
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A implements I
+  @join__implements(graph: S2, interface: "I")
+  @join__type(graph: S2, key: "id")
+{
+  id: ID!
+  a: Int
+  t: T @join__field
+}
+
+interface I
+  @join__type(graph: S1, key: "id", isInterfaceObject: true)
+  @join__type(graph: S2, key: "id")
+{
+  id: ID!
+  t: T @join__field(graph: S1)
+  a: Int @join__field(graph: S2)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  S1 @join__graph(name: "S1", url: "none")
+  S2 @join__graph(name: "S2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: S1)
+  @join__type(graph: S2)
+{
+  i: I @join__field(graph: S2)
+}
+
+type T
+  @join__type(graph: S1)
+{
+  relatedIs: [I]
+}


### PR DESCRIPTION
Fetch dependency graph expects supergraph types.
So, Interface object types from subgraphs need to be converted to interface type positions.

Also, added `--type-conditioned-fetching` option to the CLI tool.

<!-- ROUTER-924 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests