### PR TITLE
refactor: simplify __typename handling in connectors code

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/selection_set.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_set.rs
@@ -61,12 +61,10 @@ impl SubSelection {
 
         // When the operation contains __typename, it might be used to complete
         // an entity reference (e.g. `__typename id`) for a subsequent fetch.
-        // We don't have a way to inject static values into the mapping, so for
-        // now we'll hardcode a special "variable" prefix that returns values
-        // based on the key. ({ "Product": "Product" }).
+        // This encodes the typename selection as `__typename: $->echo("Product")`
         //
-        // TODO: when we support abstract types, we'll want to first check if
-        // the user defined a __typename mapping.
+        // TODO: this must change before we support interfaces and unions
+        // because it will emit the abstract type's name which is invalid.
         if field_map.contains_key("__typename") {
             new_selections.push(NamedSelection::Path(
                 Some(Alias::new("__typename")),

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -576,16 +576,10 @@ mod tests {
                                     "id": String(
                                         "1",
                                     ),
-                                    "__typename": String(
-                                        "User",
-                                    ),
                                 }),
                                 Object({
                                     "id": String(
                                         "2",
-                                    ),
-                                    "__typename": String(
-                                        "User",
                                     ),
                                 }),
                             ]),
@@ -827,9 +821,6 @@ mod tests {
                                 Object({
                                     "id": String(
                                         "2",
-                                    ),
-                                    "__typename": String(
-                                        "User",
                                     ),
                                 }),
                                 Null,

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -594,9 +594,6 @@ mod tests {
             [
                 RootField {
                     name: "a",
-                    typename: Concrete(
-                        "A",
-                    ),
                     selection: Named(
                         SubSelection {
                             selections: [
@@ -625,9 +622,6 @@ mod tests {
                 },
                 RootField {
                     name: "a2",
-                    typename: Concrete(
-                        "A",
-                    ),
                     selection: Named(
                         SubSelection {
                             selections: [
@@ -731,9 +725,6 @@ mod tests {
             [
                 RootField {
                     name: "b",
-                    typename: Concrete(
-                        "String",
-                    ),
                     selection: Path(
                         PathSelection {
                             path: WithRange {
@@ -768,9 +759,6 @@ mod tests {
                 },
                 RootField {
                     name: "b2",
-                    typename: Concrete(
-                        "String",
-                    ),
                     selection: Path(
                         PathSelection {
                             path: WithRange {
@@ -896,9 +884,6 @@ mod tests {
             [
                 RootField {
                     name: "c",
-                    typename: Concrete(
-                        "String",
-                    ),
                     selection: Path(
                         PathSelection {
                             path: WithRange {
@@ -962,9 +947,6 @@ mod tests {
                 },
                 RootField {
                     name: "c2",
-                    typename: Concrete(
-                        "String",
-                    ),
                     selection: Path(
                         PathSelection {
                             path: WithRange {
@@ -1130,9 +1112,6 @@ mod tests {
         [
             Entity {
                 index: 0,
-                typename: Concrete(
-                    "Entity",
-                ),
                 selection: Named(
                     SubSelection {
                         selections: [
@@ -1240,9 +1219,6 @@ mod tests {
             },
             Entity {
                 index: 1,
-                typename: Concrete(
-                    "Entity",
-                ),
                 selection: Named(
                     SubSelection {
                         selections: [
@@ -1452,9 +1428,6 @@ mod tests {
         [
             Entity {
                 index: 0,
-                typename: Concrete(
-                    "Entity",
-                ),
                 selection: Named(
                     SubSelection {
                         selections: [
@@ -1562,9 +1535,6 @@ mod tests {
             },
             Entity {
                 index: 1,
-                typename: Concrete(
-                    "Entity",
-                ),
                 selection: Named(
                     SubSelection {
                         selections: [
@@ -1755,9 +1725,6 @@ mod tests {
         [
             RootField {
                 name: "a",
-                typename: Concrete(
-                    "Entity",
-                ),
                 selection: Named(
                     SubSelection {
                         selections: [
@@ -1810,9 +1777,6 @@ mod tests {
             },
             RootField {
                 name: "b",
-                typename: Concrete(
-                    "Entity",
-                ),
                 selection: Named(
                     SubSelection {
                         selections: [
@@ -1981,7 +1945,7 @@ mod tests {
             EntityField {
                 index: 0,
                 field_name: "field",
-                typename: Concrete(
+                typename: Some(
                     "Entity",
                 ),
                 selection: Named(
@@ -2024,7 +1988,7 @@ mod tests {
             EntityField {
                 index: 1,
                 field_name: "field",
-                typename: Concrete(
+                typename: Some(
                     "Entity",
                 ),
                 selection: Named(
@@ -2067,7 +2031,7 @@ mod tests {
             EntityField {
                 index: 0,
                 field_name: "alias",
-                typename: Concrete(
+                typename: Some(
                     "Entity",
                 ),
                 selection: Named(
@@ -2110,7 +2074,7 @@ mod tests {
             EntityField {
                 index: 1,
                 field_name: "alias",
-                typename: Concrete(
+                typename: Some(
                     "Entity",
                 ),
                 selection: Named(
@@ -2259,7 +2223,7 @@ mod tests {
             EntityField {
                 index: 0,
                 field_name: "field",
-                typename: Concrete(
+                typename: Some(
                     "Entity",
                 ),
                 selection: Named(
@@ -2302,7 +2266,7 @@ mod tests {
             EntityField {
                 index: 1,
                 field_name: "field",
-                typename: Concrete(
+                typename: Some(
                     "Entity",
                 ),
                 selection: Named(
@@ -2345,7 +2309,7 @@ mod tests {
             EntityField {
                 index: 0,
                 field_name: "alias",
-                typename: Concrete(
+                typename: Some(
                     "Entity",
                 ),
                 selection: Named(
@@ -2388,7 +2352,7 @@ mod tests {
             EntityField {
                 index: 1,
                 field_name: "alias",
-                typename: Concrete(
+                typename: Some(
                     "Entity",
                 ),
                 selection: Named(
@@ -2534,7 +2498,7 @@ mod tests {
             EntityField {
                 index: 0,
                 field_name: "field",
-                typename: Omitted,
+                typename: None,
                 selection: Named(
                     SubSelection {
                         selections: [
@@ -2575,7 +2539,7 @@ mod tests {
             EntityField {
                 index: 1,
                 field_name: "field",
-                typename: Omitted,
+                typename: None,
                 selection: Named(
                     SubSelection {
                         selections: [
@@ -2685,9 +2649,6 @@ mod tests {
                 },
                 key: RootField {
                     name: "a",
-                    typename: Concrete(
-                        "String",
-                    ),
                     selection: Path(
                         PathSelection {
                             path: WithRange {

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::executable::Selection;
+use apollo_compiler::Name;
 use apollo_federation::sources::connect::Connector;
 use apollo_federation::sources::connect::CustomConfiguration;
 use apollo_federation::sources::connect::EntityResolver;
@@ -97,20 +98,21 @@ impl RequestInputs {
 pub(crate) enum ResponseKey {
     RootField {
         name: String,
-        typename: ResponseTypeName,
         selection: Arc<JSONSelection>,
         inputs: RequestInputs,
     },
     Entity {
         index: usize,
-        typename: ResponseTypeName,
         selection: Arc<JSONSelection>,
         inputs: RequestInputs,
     },
     EntityField {
         index: usize,
         field_name: String,
-        typename: ResponseTypeName,
+        /// Is Some only if the output type is a concrete object type. If it's
+        /// an interface, it's treated as an interface object and we can't emit
+        /// a __typename in the response.
+        typename: Option<Name>,
         selection: Arc<JSONSelection>,
         inputs: RequestInputs,
     },
@@ -132,14 +134,6 @@ impl ResponseKey {
             ResponseKey::EntityField { inputs, .. } => inputs,
         }
     }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) enum ResponseTypeName {
-    Concrete(String),
-    /// For interfaceObject support. We don't want to include __typename in the
-    /// response because this subgraph doesn't know the concrete type
-    Omitted,
 }
 
 pub(crate) fn make_requests(
@@ -262,9 +256,6 @@ fn root_fields(
 
                 let response_key = ResponseKey::RootField {
                     name: response_name,
-                    typename: ResponseTypeName::Concrete(
-                        field.definition.ty.inner_named_type().to_string(),
-                    ),
                     selection: Arc::new(
                         connector
                             .selection
@@ -322,8 +313,7 @@ fn entities_from_request(
         .get(None)
         .map_err(|_| InvalidOperation("no operation document".into()))?;
 
-    let (entities_field, typename_requested) =
-        graphql_utils::get_entity_fields(&request.operation, op)?;
+    let (entities_field, _) = graphql_utils::get_entity_fields(&request.operation, op)?;
 
     let selection = Arc::new(
         connector
@@ -337,27 +327,6 @@ fn entities_from_request(
         .iter()
         .enumerate()
         .map(|(i, rep)| {
-            // TODO abstract types?
-            let typename = rep
-                .as_object()
-                .ok_or_else(|| InvalidRepresentations("representation is not an object".into()))?
-                .get(TYPENAME)
-                .ok_or_else(|| {
-                    InvalidRepresentations("representation is missing __typename".into())
-                })?
-                .as_str()
-                .ok_or_else(|| InvalidRepresentations("__typename is not a string".into()))?
-                .to_string();
-
-            // if the fetch node operation doesn't include __typename, then
-            // we're assuming this is for an interface object and we don't want
-            // to include a __typename in the response.
-            let typename = if typename_requested {
-                ResponseTypeName::Concrete(typename)
-            } else {
-                ResponseTypeName::Omitted
-            };
-
             let request_inputs = RequestInputs {
                 args: rep
                     .as_object()
@@ -372,7 +341,6 @@ fn entities_from_request(
 
             Ok(ResponseKey::Entity {
                 index: i,
-                typename,
                 selection: selection.clone(),
                 inputs: request_inputs,
             })
@@ -448,7 +416,7 @@ fn entities_with_fields_from_request(
                                 )))
                             }
                         };
-                        field.map(|f| Ok((typename.to_string(), f)))
+                        field.map(|f| Ok((typename, f)))
                     })
                     .collect::<Result<Vec<_>, _>>()?)
             }
@@ -478,7 +446,7 @@ fn entities_with_fields_from_request(
                                 )));
                             }
                         };
-                        field.map(|f| Ok((typename.to_string(), f)))
+                        field.map(|f| Ok((typename, f)))
                     })
                     .collect::<Result<Vec<_>, _>>()?)
             }
@@ -514,15 +482,6 @@ fn entities_with_fields_from_request(
                         InvalidArguments("cannot build inputs from field arguments".into())
                     })?;
 
-                // if the fetch node operation doesn't include __typename, then
-                // we're assuming this is for an interface object and we don't want
-                // to include a __typename in the response.
-                let typename = if typename_requested {
-                    ResponseTypeName::Concrete(typename.to_string())
-                } else {
-                    ResponseTypeName::Omitted
-                };
-
                 let response_name = field
                     .alias
                     .as_ref()
@@ -541,7 +500,13 @@ fn entities_with_fields_from_request(
                 Ok::<_, MakeRequestError>(ResponseKey::EntityField {
                     index: *i,
                     field_name: response_name.to_string(),
-                    typename,
+                    // if the fetch node operation doesn't include __typename, then
+                    // we're assuming this is for an interface object and we don't want
+                    // to include a __typename in the response.
+                    //
+                    // TODO: is this fragile? should we just check the output
+                    // type of the field and omit the typename if it's abstract?
+                    typename: typename_requested.then_some(typename.clone()),
                     selection: selection.clone(),
                     inputs: request_inputs,
                 })

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -235,7 +235,7 @@ async fn test_root_field_plus_entity() {
     let response = execute(
         STEEL_THREAD_SCHEMA,
         &mock_server.uri(),
-        "query { users { id name username } }",
+        "query { users { __typename id name username } }",
         Default::default(),
         None,
         |_| {},
@@ -247,11 +247,13 @@ async fn test_root_field_plus_entity() {
       "data": {
         "users": [
           {
+            "__typename": "User",
             "id": 1,
             "name": "Leanne Graham",
             "username": "Bret"
           },
           {
+            "__typename": "User",
             "id": 2,
             "name": "Ervin Howell",
             "username": "Antonette"
@@ -302,7 +304,7 @@ async fn test_root_field_plus_entity_plus_requires() {
     let response = execute(
         STEEL_THREAD_SCHEMA,
         &mock_server.uri(),
-        "query { users { id name username d } }",
+        "query { users { __typename id name username d } }",
         Default::default(),
         None,
         |_| {},
@@ -314,12 +316,14 @@ async fn test_root_field_plus_entity_plus_requires() {
       "data": {
         "users": [
           {
+            "__typename": "User",
             "id": 1,
             "name": "Leanne Graham",
             "username": "Bret",
             "d": "1-770-736-8031 x56442"
           },
           {
+            "__typename": "User",
             "id": 2,
             "name": "Ervin Howell",
             "username": "Antonette",


### PR DESCRIPTION
three scenarios:

1. connector on a root field: the entire object is handled by json_selection, which does __typename injection. if the return type is abstract, json_selection logic will handle it.
2. explicit entity connector: the entire object is handled by json_selection, which does __typename injection. if the entity type is abstract, the planner decides if it needs __typename (it won't if it's an interfaceObject), and json_selection logic will handle it.
3. field on an entity: the __typename for the entity type is handled outside of json_selection. but there's only two scenarios: it's an object type so we know the __typename and can inject it, or its an interface object and we shouldn't supply the __typename.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
