### PR TITLE
Update Rust toolchain to 1.83.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,6 @@ dependencies = [
  "reqwest",
  "rhai",
  "rmp",
- "rowan",
  "rstack",
  "rust-embed",
  "rustls",

--- a/apollo-federation/src/display_helpers.rs
+++ b/apollo-federation/src/display_helpers.rs
@@ -67,7 +67,7 @@ pub(crate) fn write_indented_lines<T>(
 
 pub(crate) struct DisplaySlice<'a, T>(pub(crate) &'a [T]);
 
-impl<'a, T: Display> Display for DisplaySlice<'a, T> {
+impl<T: Display> Display for DisplaySlice<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[")?;
         let mut iter = self.0.iter();

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -25,17 +25,15 @@ pub(crate) struct ContextDirectiveArguments<'doc> {
 #[derive(Clone)]
 pub(crate) struct ContextSpecDefinition {
     url: Url,
-    minimum_federation_version: Option<Version>,
 }
 
 impl ContextSpecDefinition {
-    pub(crate) fn new(version: Version, minimum_federation_version: Option<Version>) -> Self {
+    pub(crate) fn new(version: Version) -> Self {
         Self {
             url: Url {
                 identity: Identity::context_identity(),
                 version,
             },
-            minimum_federation_version,
         }
     }
 
@@ -61,10 +59,6 @@ impl SpecDefinition for ContextSpecDefinition {
     fn url(&self) -> &Url {
         &self.url
     }
-
-    fn minimum_federation_version(&self) -> Option<&Version> {
-        self.minimum_federation_version.as_ref()
-    }
 }
 
 lazy_static! {
@@ -72,7 +66,7 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::context_identity());
         definitions.add(ContextSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            Some(Version { major: 2, minor: 8 }),
+            // minimum_federation_version = Some(Version { major: 2, minor: 8 }),
         ));
         definitions
     };

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -66,7 +66,6 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::context_identity());
         definitions.add(ContextSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            // minimum_federation_version = Some(Version { major: 2, minor: 8 }),
         ));
         definitions
     };

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -64,9 +64,7 @@ impl SpecDefinition for ContextSpecDefinition {
 lazy_static! {
     pub(crate) static ref CONTEXT_VERSIONS: SpecDefinitions<ContextSpecDefinition> = {
         let mut definitions = SpecDefinitions::new(Identity::context_identity());
-        definitions.add(ContextSpecDefinition::new(
-            Version { major: 0, minor: 1 },
-        ));
+        definitions.add(ContextSpecDefinition::new(Version { major: 0, minor: 1 }));
         definitions
     };
 }

--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -37,7 +37,6 @@ const LIST_SIZE_DIRECTIVE_REQUIRE_ONE_SLICING_ARGUMENT_ARGUMENT_NAME: Name =
 #[derive(Clone)]
 pub struct CostSpecDefinition {
     url: Url,
-    minimum_federation_version: Option<Version>,
 }
 
 macro_rules! propagate_demand_control_directives {
@@ -109,13 +108,12 @@ macro_rules! propagate_demand_control_directives_to_position {
 }
 
 impl CostSpecDefinition {
-    pub(crate) fn new(version: Version, minimum_federation_version: Option<Version>) -> Self {
+    pub(crate) fn new(version: Version) -> Self {
         Self {
             url: Url {
                 identity: Identity::cost_identity(),
                 version,
             },
-            minimum_federation_version,
         }
     }
 
@@ -242,10 +240,6 @@ impl SpecDefinition for CostSpecDefinition {
     fn url(&self) -> &Url {
         &self.url
     }
-
-    fn minimum_federation_version(&self) -> Option<&Version> {
-        self.minimum_federation_version.as_ref()
-    }
 }
 
 lazy_static! {
@@ -253,7 +247,7 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::cost_identity());
         definitions.add(CostSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            Some(Version { major: 2, minor: 9 }),
+            // minimum_federation_version = Some(Version { major: 2, minor: 9 }),
         ));
         definitions
     };

--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -247,7 +247,6 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::cost_identity());
         definitions.add(CostSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            // minimum_federation_version = Some(Version { major: 2, minor: 9 }),
         ));
         definitions
     };

--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -245,9 +245,7 @@ impl SpecDefinition for CostSpecDefinition {
 lazy_static! {
     pub(crate) static ref COST_VERSIONS: SpecDefinitions<CostSpecDefinition> = {
         let mut definitions = SpecDefinitions::new(Identity::cost_identity());
-        definitions.add(CostSpecDefinition::new(
-            Version { major: 0, minor: 1 },
-        ));
+        definitions.add(CostSpecDefinition::new(Version { major: 0, minor: 1 }));
         definitions
     };
 }

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -543,10 +543,6 @@ impl SpecDefinition for FederationSpecDefinition {
     fn url(&self) -> &Url {
         &self.url
     }
-
-    fn minimum_federation_version(&self) -> Option<&Version> {
-        None
-    }
 }
 
 lazy_static! {

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -100,12 +100,14 @@ impl SpecDefinition for InaccessibleSpecDefinition {
 lazy_static! {
     pub(crate) static ref INACCESSIBLE_VERSIONS: SpecDefinitions<InaccessibleSpecDefinition> = {
         let mut definitions = SpecDefinitions::new(Identity::inaccessible_identity());
-        definitions.add(InaccessibleSpecDefinition::new(
-            Version { major: 0, minor: 1 },
-        ));
-        definitions.add(InaccessibleSpecDefinition::new(
-            Version { major: 0, minor: 2 },
-        ));
+        definitions.add(InaccessibleSpecDefinition::new(Version {
+            major: 0,
+            minor: 1,
+        }));
+        definitions.add(InaccessibleSpecDefinition::new(Version {
+            major: 0,
+            minor: 2,
+        }));
         definitions
     };
 }

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -102,11 +102,9 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::inaccessible_identity());
         definitions.add(InaccessibleSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            // minimum_federation_version = None,
         ));
         definitions.add(InaccessibleSpecDefinition::new(
             Version { major: 0, minor: 2 },
-            // minimum_federation_version = Some(Version { major: 2, minor: 0 }),
         ));
         definitions
     };

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -39,17 +39,15 @@ pub(crate) const INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC: Name = name!("inaccessible
 
 pub(crate) struct InaccessibleSpecDefinition {
     url: Url,
-    minimum_federation_version: Option<Version>,
 }
 
 impl InaccessibleSpecDefinition {
-    pub(crate) fn new(version: Version, minimum_federation_version: Option<Version>) -> Self {
+    pub(crate) fn new(version: Version) -> Self {
         Self {
             url: Url {
                 identity: Identity::inaccessible_identity(),
                 version,
             },
-            minimum_federation_version,
         }
     }
 
@@ -97,10 +95,6 @@ impl SpecDefinition for InaccessibleSpecDefinition {
     fn url(&self) -> &Url {
         &self.url
     }
-
-    fn minimum_federation_version(&self) -> Option<&Version> {
-        self.minimum_federation_version.as_ref()
-    }
 }
 
 lazy_static! {
@@ -108,11 +102,11 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::inaccessible_identity());
         definitions.add(InaccessibleSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            None,
+            // minimum_federation_version = None,
         ));
         definitions.add(InaccessibleSpecDefinition::new(
             Version { major: 0, minor: 2 },
-            Some(Version { major: 2, minor: 0 }),
+            // minimum_federation_version = Some(Version { major: 2, minor: 0 }),
         ));
         definitions
     };

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -167,17 +167,15 @@ pub(crate) struct EnumValueDirectiveArguments {
 #[derive(Clone)]
 pub(crate) struct JoinSpecDefinition {
     url: Url,
-    minimum_federation_version: Option<Version>,
 }
 
 impl JoinSpecDefinition {
-    pub(crate) fn new(version: Version, minimum_federation_version: Option<Version>) -> Self {
+    pub(crate) fn new(version: Version) -> Self {
         Self {
             url: Url {
                 identity: Identity::join_identity(),
                 version,
             },
-            minimum_federation_version,
         }
     }
 
@@ -410,10 +408,6 @@ impl SpecDefinition for JoinSpecDefinition {
     fn url(&self) -> &Url {
         &self.url
     }
-
-    fn minimum_federation_version(&self) -> Option<&Version> {
-        self.minimum_federation_version.as_ref()
-    }
 }
 
 lazy_static! {
@@ -421,23 +415,23 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::join_identity());
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            None,
+            // minimum_federation_version = None,
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 2 },
-            None,
+            // minimum_federation_version = None,
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 3 },
-            Some(Version { major: 2, minor: 0 }),
+            // minimum_federation_version = Some(Version { major: 2, minor: 0 }),
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 4 },
-            Some(Version { major: 2, minor: 7 }),
+            // minimum_federation_version = Some(Version { major: 2, minor: 7 }),
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 5 },
-            Some(Version { major: 2, minor: 8 }),
+            // minimum_federation_version = Some(Version { major: 2, minor: 8 }),
         ));
         definitions
     };

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -413,21 +413,11 @@ impl SpecDefinition for JoinSpecDefinition {
 lazy_static! {
     pub(crate) static ref JOIN_VERSIONS: SpecDefinitions<JoinSpecDefinition> = {
         let mut definitions = SpecDefinitions::new(Identity::join_identity());
-        definitions.add(JoinSpecDefinition::new(
-            Version { major: 0, minor: 1 },
-        ));
-        definitions.add(JoinSpecDefinition::new(
-            Version { major: 0, minor: 2 },
-        ));
-        definitions.add(JoinSpecDefinition::new(
-            Version { major: 0, minor: 3 },
-        ));
-        definitions.add(JoinSpecDefinition::new(
-            Version { major: 0, minor: 4 },
-        ));
-        definitions.add(JoinSpecDefinition::new(
-            Version { major: 0, minor: 5 },
-        ));
+        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 1 }));
+        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 2 }));
+        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 3 }));
+        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 4 }));
+        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 5 }));
         definitions
     };
 }

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -415,23 +415,18 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::join_identity());
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            // minimum_federation_version = None,
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 2 },
-            // minimum_federation_version = None,
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 3 },
-            // minimum_federation_version = Some(Version { major: 2, minor: 0 }),
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 4 },
-            // minimum_federation_version = Some(Version { major: 2, minor: 7 }),
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 5 },
-            // minimum_federation_version = Some(Version { major: 2, minor: 8 }),
         ));
         definitions
     };

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -29,12 +29,10 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::core_identity());
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            // minimum_federation_version = None,
             Identity::core_identity(),
         ));
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 2 },
-            // minimum_federation_version = Some(Version { major: 2, minor: 0 }),
             Identity::core_identity(),
         ));
         definitions
@@ -43,7 +41,6 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::link_identity());
         definitions.add(LinkSpecDefinition::new(
             Version { major: 1, minor: 0 },
-            // minimum_federation_version = Some(Version { major: 2, minor: 0 }),
             Identity::link_identity(),
         ));
         definitions

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -8,18 +8,12 @@ use crate::link::spec_definition::SpecDefinitions;
 
 pub(crate) struct LinkSpecDefinition {
     url: Url,
-    minimum_federation_version: Option<Version>,
 }
 
 impl LinkSpecDefinition {
-    pub(crate) fn new(
-        version: Version,
-        minimum_federation_version: Option<Version>,
-        identity: Identity,
-    ) -> Self {
+    pub(crate) fn new(version: Version, identity: Identity) -> Self {
         Self {
             url: Url { identity, version },
-            minimum_federation_version,
         }
     }
 }
@@ -28,10 +22,6 @@ impl SpecDefinition for LinkSpecDefinition {
     fn url(&self) -> &Url {
         &self.url
     }
-
-    fn minimum_federation_version(&self) -> Option<&Version> {
-        self.minimum_federation_version.as_ref()
-    }
 }
 
 lazy_static! {
@@ -39,12 +29,12 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::core_identity());
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            None,
+            // minimum_federation_version = None,
             Identity::core_identity(),
         ));
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 2 },
-            Some(Version { major: 2, minor: 0 }),
+            // minimum_federation_version = Some(Version { major: 2, minor: 0 }),
             Identity::core_identity(),
         ));
         definitions
@@ -53,7 +43,7 @@ lazy_static! {
         let mut definitions = SpecDefinitions::new(Identity::link_identity());
         definitions.add(LinkSpecDefinition::new(
             Version { major: 1, minor: 0 },
-            Some(Version { major: 2, minor: 0 }),
+            // minimum_federation_version = Some(Version { major: 2, minor: 0 }),
             Identity::link_identity(),
         ));
         definitions

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -231,7 +231,7 @@ struct DisplayName<'s> {
     is_directive: bool,
 }
 
-impl<'s> fmt::Display for DisplayName<'s> {
+impl fmt::Display for DisplayName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_directive {
             f.write_str("@")?;
@@ -440,11 +440,11 @@ impl LinksMetadata {
     }
 
     pub fn all_links(&self) -> &[Arc<Link>] {
-        return self.links.as_ref();
+        self.links.as_ref()
     }
 
     pub fn for_identity(&self, identity: &Identity) -> Option<Arc<Link>> {
-        return self.by_identity.get(identity).cloned();
+        self.by_identity.get(identity).cloned()
     }
 
     pub fn source_link_of_type(&self, type_name: &Name) -> Option<LinkedElement> {

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -17,7 +17,6 @@ use crate::schema::FederationSchema;
 
 pub(crate) trait SpecDefinition {
     fn url(&self) -> &Url;
-    fn minimum_federation_version(&self) -> Option<&Version>;
 
     fn identity(&self) -> &Identity {
         &self.url().identity

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -27,23 +27,6 @@ pub(crate) trait SpecDefinition {
         &self.url().version
     }
 
-    fn is_spec_directive_name(
-        &self,
-        schema: &FederationSchema,
-        name_in_schema: &Name,
-    ) -> Result<bool, FederationError> {
-        let Some(metadata) = schema.metadata() else {
-            return Err(SingleFederationError::Internal {
-                message: "Schema is not a core schema (add @link first)".to_owned(),
-            }
-            .into());
-        };
-        Ok(metadata
-            .source_link_of_directive(name_in_schema)
-            .map(|e| e.link.url.identity == *self.identity())
-            .unwrap_or(false))
-    }
-
     fn is_spec_type_name(
         &self,
         schema: &FederationSchema,

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -1535,7 +1535,10 @@ fn join_graph_enum_type(
 
 fn add_core_feature_inaccessible(supergraph: &mut Schema) {
     // @link(url: "https://specs.apollo.dev/inaccessible/v0.2")
-    let spec = InaccessibleSpecDefinition::new(Version { major: 0, minor: 2 }, None);
+    let spec = InaccessibleSpecDefinition::new(
+        Version { major: 0, minor: 2 },
+        // minimum_federation_version = None
+    );
 
     supergraph
         .schema_definition

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -85,7 +85,7 @@ impl From<FederationError> for MergeFailure {
 }
 
 pub struct MergeFailure {
-    pub schema: Option<Schema>,
+    pub schema: Option<Box<Schema>>,
     pub errors: Vec<MergeError>,
     pub composition_hints: Vec<MergeWarning>,
 }
@@ -252,7 +252,7 @@ impl Merger {
             })
         } else {
             Err(MergeFailure {
-                schema: Some(supergraph),
+                schema: Some(Box::new(supergraph)),
                 composition_hints: self.composition_hints.to_owned(),
                 errors: self.errors.to_owned(),
             })

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -1535,10 +1535,7 @@ fn join_graph_enum_type(
 
 fn add_core_feature_inaccessible(supergraph: &mut Schema) {
     // @link(url: "https://specs.apollo.dev/inaccessible/v0.2")
-    let spec = InaccessibleSpecDefinition::new(
-        Version { major: 0, minor: 2 },
-        // minimum_federation_version = None
-    );
+    let spec = InaccessibleSpecDefinition::new(Version { major: 0, minor: 2 });
 
     supergraph
         .schema_definition

--- a/apollo-federation/src/operation/directive_list.rs
+++ b/apollo-federation/src/operation/directive_list.rs
@@ -304,9 +304,7 @@ impl DirectiveList {
             // Nothing to do on an empty list
             return None;
         };
-        let Some(index) = inner.directives.iter().position(|dir| dir.name == name) else {
-            return None;
-        };
+        let index = inner.directives.iter().position(|dir| dir.name == name)?;
 
         // The directive exists and is the only directive: switch to the empty representation
         if inner.len() == 1 {

--- a/apollo-federation/src/operation/merging.rs
+++ b/apollo-federation/src/operation/merging.rs
@@ -20,7 +20,7 @@ use crate::ensure;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 
-impl<'a> FieldSelectionValue<'a> {
+impl FieldSelectionValue<'_> {
     /// Merges the given field selections into this one.
     ///
     /// # Preconditions
@@ -82,7 +82,7 @@ impl<'a> FieldSelectionValue<'a> {
     }
 }
 
-impl<'a> InlineFragmentSelectionValue<'a> {
+impl InlineFragmentSelectionValue<'_> {
     /// Merges the given normalized inline fragment selections into this one.
     ///
     /// # Preconditions
@@ -117,7 +117,7 @@ impl<'a> InlineFragmentSelectionValue<'a> {
     }
 }
 
-impl<'a> FragmentSpreadSelectionValue<'a> {
+impl FragmentSpreadSelectionValue<'_> {
     /// Merges the given normalized fragment spread selections into this one.
     ///
     /// # Preconditions

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1656,7 +1656,7 @@ impl SelectionSet {
     /// This tries to be smart about including or excluding the whole selection set.
     /// - If all selections have the same condition, returns that condition.
     /// - If selections in the set have different conditions, the selection set must always be
-    /// included, so the individual selections can be evaluated.
+    ///   included, so the individual selections can be evaluated.
     ///
     /// # Errors
     /// Returns an error if the selection set contains a fragment spread, or if any of the
@@ -1859,9 +1859,9 @@ impl SelectionSet {
     ///
     /// __typename is added to the sub selection set of a given selection in following conditions
     /// * if a given selection is a field, we add a __typename sub selection if its selection set type
-    /// position is an abstract type
+    ///   position is an abstract type
     /// * if a given selection is a fragment, we only add __typename sub selection if fragment specifies
-    /// type condition and that type condition is an abstract type.
+    ///   type condition and that type condition is an abstract type.
     pub(crate) fn add_typename_field_for_abstract_types(
         &self,
         parent_type_if_abstract: Option<AbstractTypeDefinitionPosition>,

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -40,7 +40,6 @@ use std::sync::Arc;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::executable;
 use apollo_compiler::Name;
-use apollo_compiler::Node;
 
 use super::Fragment;
 use super::FragmentSpreadSelection;
@@ -106,16 +105,6 @@ impl SelectionSet {
             iter,
         ))
     }
-}
-
-//=============================================================================
-// Matching fragments with selection set (`try_optimize_with_fragments`)
-
-/// The return type for `SelectionSet::try_optimize_with_fragments`.
-#[derive(derive_more::From)]
-enum SelectionSetOrFragment {
-    SelectionSet(SelectionSet),
-    Fragment(Node<Fragment>),
 }
 
 // Note: `retain_fragments` methods may return a selection or a selection set.
@@ -392,7 +381,6 @@ mod tests {
     ///
     /// empty branches removal
     ///
-
     mod test_empty_branch_removal {
         use apollo_compiler::name;
 

--- a/apollo-federation/src/operation/selection_map.rs
+++ b/apollo-federation/src/operation/selection_map.rs
@@ -138,12 +138,12 @@ impl OwnedSelectionKey {
     }
 }
 
+#[cfg(test)]
 impl<'a> SelectionKey<'a> {
     /// Create a selection key for a specific field name.
     ///
     /// This is available for tests only as selection keys should not normally be created outside of
     /// `HasSelectionKey::key`.
-    #[cfg(test)]
     pub(crate) fn field_name(name: &'a Name) -> Self {
         static EMPTY_LIST: DirectiveList = DirectiveList::new();
         SelectionKey::Field {

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -551,8 +551,7 @@ type Query {
 
         // Use apollo-compiler's selection set printer directly instead of the minimized
         // apollo-federation printer
-        let compiler_set =
-            apollo_compiler::executable::SelectionSet::try_from(&expanded_and_flattened).unwrap();
+        let compiler_set = executable::SelectionSet::try_from(&expanded_and_flattened).unwrap();
 
         insta::assert_snapshot!(compiler_set, @r#"
             {

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -51,11 +51,7 @@ pub(super) fn parse_and_expand(
     schema: &ValidFederationSchema,
     query: &str,
 ) -> Result<Operation, FederationError> {
-    let doc = apollo_compiler::ExecutableDocument::parse_and_validate(
-        schema.schema(),
-        query,
-        "query.graphql",
-    )?;
+    let doc = ExecutableDocument::parse_and_validate(schema.schema(), query, "query.graphql")?;
 
     let operation = doc
         .operations
@@ -1055,7 +1051,7 @@ scalar FieldSet
 /// https://github.com/apollographql/federation-next/pull/290#discussion_r1587200664
 #[test]
 fn converting_operation_types() {
-    let schema = apollo_compiler::Schema::parse_and_validate(
+    let schema = Schema::parse_and_validate(
         r#"
         interface Intf {
             intfField: Int
@@ -1389,9 +1385,7 @@ const ADD_AT_PATH_TEST_SCHEMA: &str = r#"
 
 #[test]
 fn add_at_path_merge_scalar_fields() {
-    let schema =
-        apollo_compiler::Schema::parse_and_validate(ADD_AT_PATH_TEST_SCHEMA, "schema.graphql")
-            .unwrap();
+    let schema = Schema::parse_and_validate(ADD_AT_PATH_TEST_SCHEMA, "schema.graphql").unwrap();
     let schema = ValidFederationSchema::new(schema).unwrap();
 
     let mut selection_set = SelectionSet::empty(
@@ -1418,9 +1412,7 @@ fn add_at_path_merge_scalar_fields() {
 
 #[test]
 fn add_at_path_merge_subselections() {
-    let schema =
-        apollo_compiler::Schema::parse_and_validate(ADD_AT_PATH_TEST_SCHEMA, "schema.graphql")
-            .unwrap();
+    let schema = Schema::parse_and_validate(ADD_AT_PATH_TEST_SCHEMA, "schema.graphql").unwrap();
     let schema = ValidFederationSchema::new(schema).unwrap();
 
     let mut selection_set = SelectionSet::empty(
@@ -1468,9 +1460,7 @@ fn add_at_path_merge_subselections() {
 
 #[test]
 fn add_at_path_collapses_unnecessary_fragments() {
-    let schema =
-        apollo_compiler::Schema::parse_and_validate(ADD_AT_PATH_TEST_SCHEMA, "schema.graphql")
-            .unwrap();
+    let schema = Schema::parse_and_validate(ADD_AT_PATH_TEST_SCHEMA, "schema.graphql").unwrap();
     let schema = ValidFederationSchema::new(schema).unwrap();
 
     let mut selection_set = SelectionSet::empty(

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -881,10 +881,7 @@ where
         //            multiple maximum items.
         // Note: `position_max` returns the last of the equally maximum items. Thus, we use
         //       `position_min_by` by reversing the ordering.
-        let pos = self.items.iter().position_min_by(|a, b| b.cmp(a));
-        let Some(pos) = pos else {
-            return None;
-        };
+        let pos = self.items.iter().position_min_by(|a, b| b.cmp(a))?;
         Some(self.items.remove(pos))
     }
 }
@@ -924,7 +921,8 @@ pub(crate) enum GraphPathTriggerRef<'a> {
 #[derive(derive_more::From)]
 pub(crate) enum GraphPathTriggerRefMut<'a> {
     Op(&'a mut OpGraphPathTrigger),
-    Transition(&'a mut QueryGraphEdgeTransition),
+    // Unused:
+    // Transition(&'a mut QueryGraphEdgeTransition),
 }
 
 impl<'a> From<&'a GraphPathTrigger> for GraphPathTriggerRef<'a> {
@@ -941,7 +939,7 @@ impl<'a> From<&'a GraphPathTrigger> for GraphPathTriggerRef<'a> {
 /// the `GraphPathTrigger`. Rather than trying to cast into concrete types and cast back (and
 /// potentially raise errors), this trait provides ways to access the data needed within.
 pub(crate) trait GraphPathTriggerVariant: Eq + Hash + std::fmt::Debug {
-    fn get_field_mut<'a>(&'a mut self) -> Option<&mut Field>
+    fn get_field_mut<'a>(&'a mut self) -> Option<&'a mut Field>
     where
         &'a mut Self: Into<GraphPathTriggerRefMut<'a>>,
     {
@@ -2760,10 +2758,10 @@ impl OpGraphPath {
         // So far, so good. Check that the rest of the paths are equal. Note that starts with
         // `diff_pos + 1` for `self`, but `diff_pos + 2` for `other` since we looked at two edges
         // there instead of one.
-        return Ok(self.edges[(diff_pos + 1)..]
+        Ok(self.edges[(diff_pos + 1)..]
             .iter()
             .zip(other.edges[(diff_pos + 2)..].iter())
-            .all(|(self_edge, other_edge)| self_edge == other_edge));
+            .all(|(self_edge, other_edge)| self_edge == other_edge))
     }
 
     /// This method is used to detect when using an interface field "directly" could fail (i.e. lead
@@ -4353,7 +4351,7 @@ fn is_useless_followup_element(
 
     // The followup is useless if it's a fragment (with no directives we would want to preserve) whose type
     // is already that of the first element (or a supertype).
-    return match followup {
+    match followup {
         OpPathElement::Field(_) => Ok(false),
         OpPathElement::InlineFragment(fragment) => {
             let Some(type_of_second) = fragment.type_condition_position.clone() else {
@@ -4369,7 +4367,7 @@ fn is_useless_followup_element(
                 .is_subtype(type_of_second.type_name(), type_of_first.type_name());
             Ok(are_useless_directives && (is_same_type || is_subtype))
         }
-    };
+    }
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -855,7 +855,7 @@ impl QueryGraph {
                 "Unexpectedly encountered federation root node as tail node.",
             ));
         };
-        return match &edge_weight.transition {
+        match &edge_weight.transition {
             QueryGraphEdgeTransition::FieldCollection {
                 source,
                 field_definition_position,
@@ -920,7 +920,7 @@ impl QueryGraph {
             QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { .. } => {
                 Ok(possible_runtime_types.clone())
             }
-        };
+        }
     }
 
     /// Returns a selection set that can be used as a key for the given type, and that can be

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -246,6 +246,7 @@ where
             /// trigger: the final trigger value
             ///   - Two equivalent triggers can have minor differences in the sibling_typename.
             ///     This field holds the final trigger value that will be used.
+            ///
             /// PORT_NOTE: The JS QP used the last trigger value. So, we are following that
             ///            to avoid mismatches. But, it can be revisited.
             ///            We may want to keep or merge the sibling_typename values.

--- a/apollo-federation/src/query_plan/generate.rs
+++ b/apollo-federation/src/query_plan/generate.rs
@@ -251,7 +251,7 @@ mod tests {
         target_len: usize,
     }
 
-    impl<'a> PlanBuilder<Plan, Element> for TestPlanBuilder<'a> {
+    impl PlanBuilder<Plan, Element> for TestPlanBuilder<'_> {
         fn add_to_plan(
             &mut self,
             partial_plan: &Plan,

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -371,7 +371,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             }
         }
         self.compute_best_plan_from_closed_branches()?;
-        return Ok(self.best_plan.as_ref());
+        Ok(self.best_plan.as_ref())
     }
 
     /// Returns whether to terminate planning immediately, and any new open branches to push onto
@@ -1201,7 +1201,7 @@ impl<'a: 'b, 'b> PlanBuilder<PlanInfo, Arc<OpPathTree>> for QueryPlanningTravers
 //            The same would be infeasible to implement in Rust due to the cyclic references.
 //            Thus, instead of `condition_resolver` field, QueryPlanningTraversal was made to
 //            implement `ConditionResolver` trait along with `resolver_cache` field.
-impl<'a> ConditionResolver for QueryPlanningTraversal<'a, '_> {
+impl ConditionResolver for QueryPlanningTraversal<'_, '_> {
     /// A query plan resolver for edge conditions that caches the outcome per edge.
     #[track_caller]
     fn resolve(

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -165,6 +165,7 @@ impl FederationSchema {
 
     /// Similar to `Self::validate` but returns `self` as part of the error should it be needed by
     /// the caller
+    #[allow(clippy::result_large_err)] // lint is accurate but this is not in a hot path
     pub(crate) fn validate_or_return_self(
         mut self,
     ) -> Result<ValidFederationSchema, (Self, FederationError)> {
@@ -229,6 +230,7 @@ impl ValidFederationSchema {
     }
 
     /// Construct a ValidFederationSchema by assuming the given FederationSchema is valid.
+    #[allow(clippy::result_large_err)] // lint is accurate but this is not in a hot path
     fn new_assume_valid(
         mut schema: FederationSchema,
     ) -> Result<ValidFederationSchema, (FederationSchema, FederationError)> {

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -810,7 +810,6 @@ mod tests {
         fn link_spec(_version: Version) -> Box<dyn SpecDefinition> {
             Box::new(LinkSpecDefinition::new(
                 Version { major: 1, minor: 0 },
-                // minimum_federation_version = None,
                 Identity {
                     domain: String::from("https://specs.apollo.dev/link/v1.0"),
                     name: name!("link"),
@@ -859,7 +858,6 @@ mod tests {
         fn link_spec(_version: Version) -> Box<dyn SpecDefinition> {
             Box::new(LinkSpecDefinition::new(
                 Version { major: 1, minor: 0 },
-                // minimum_federation_version = None,
                 Identity {
                     domain: String::from("https://specs.apollo.dev/link/v1.0"),
                     name: name!("link"),

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -810,7 +810,7 @@ mod tests {
         fn link_spec(_version: Version) -> Box<dyn SpecDefinition> {
             Box::new(LinkSpecDefinition::new(
                 Version { major: 1, minor: 0 },
-                None,
+                // minimum_federation_version = None,
                 Identity {
                     domain: String::from("https://specs.apollo.dev/link/v1.0"),
                     name: name!("link"),
@@ -859,7 +859,7 @@ mod tests {
         fn link_spec(_version: Version) -> Box<dyn SpecDefinition> {
             Box::new(LinkSpecDefinition::new(
                 Version { major: 1, minor: 0 },
-                None,
+                // minimum_federation_version = None,
                 Identity {
                     domain: String::from("https://specs.apollo.dev/link/v1.0"),
                     name: name!("link"),

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -2112,7 +2112,6 @@ fn maybe_dump_subgraph_schema(subgraph: FederationSubgraph, message: &mut String
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @join__directive extraction
-
 static JOIN_DIRECTIVE: &str = "join__directive";
 
 /// Converts `@join__directive(graphs: [A], name: "foo")` to `@foo` in the A subgraph.

--- a/apollo-federation/src/utils/fallible_iterator.rs
+++ b/apollo-federation/src/utils/fallible_iterator.rs
@@ -2,25 +2,6 @@
 
 use itertools::Itertools;
 
-/// A common use for iteator is to collect into a container and grow that container. This trait
-/// extends the standard library's `Extend` trait to work for containers that can be extended with
-/// `T`s to also be extendable with `Result<T, E>`. If an `Err` is encountered, that `Err` is
-/// returned. Notably, this means the container will contain all prior `Ok` values.
-pub(crate) trait FallibleExtend<A>: Extend<A> {
-    fn fallible_extend<I, E>(&mut self, iter: I) -> Result<(), E>
-    where
-        I: IntoIterator<Item = Result<A, E>>,
-    {
-        iter.into_iter()
-            .process_results(|results| self.extend(results))
-    }
-
-    // NOTE: The standard extend trait provides `extend_one` and `extend_reserve` methods. These
-    // have not been added and can be if a use arises.
-}
-
-impl<T, A> FallibleExtend<A> for T where T: Extend<A> {}
-
 /// An extension trait for `Iterator`, similar to `Itertools`, that seeks to improve the ergonomics
 /// around fallible operations.
 ///
@@ -29,11 +10,11 @@ impl<T, A> FallibleExtend<A> for T where T: Extend<A> {}
 /// also refer to the stream of items that you're iterating over (or both!). As much as possible, I
 /// will use the following naming scheme in order to keep these ideas consistent:
 ///  - If the iterator yeilds an arbitary `T` and the operation that you wish to apply is of the
-/// form `T -> Result`, then it will named `fallible_*`.
+///    form `T -> Result`, then it will named `fallible_*`.
 ///  - If the iterator yields `Result<T>` and the operation is of the form `T -> U` (for arbitary
-///  `U`), then it will named `*_ok`.
+///    `U`), then it will named `*_ok`.
 ///  - If both iterator and operation yield `Result`, then it will named `and_then_*` (more on that
-///  fewer down).
+///    fewer down).
 ///
 /// The first category mostly describes combinators that take closures that need specific types,
 /// such as `filter` and things in the `any`/`all`/`find`/`fold` family. There are several
@@ -173,82 +154,6 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
         Ok(digest)
     }
 
-    /// This method functions similarly to `FallibleIterator::fallible_all` but inverted. The
-    /// existing iterator yields `Result`s but the predicate is not fallible.
-    ///
-    /// Like `FallibleIterator::fallible_all`, this function short-curcuits but will short-curcuit
-    /// if it encounters an `Err` or `false`. If the existing iterator yields an `Err`, this
-    /// function short-curcuits, does not call the predicate, and returns that `Err`. If the value
-    /// is `Ok`, it is given to the predicate. If the predicate returns `false`, this method
-    /// returns `Ok(false)`.
-    ///
-    /// ```ignore
-    /// let first_values = vec![];
-    /// let second_values = vec![Ok(1), Err(())];
-    /// let third_values = vec![Ok(0), Ok(1), Ok(2)];
-    /// let fourth_values = vec![Err(()), Ok(0)];
-    ///
-    /// assert_eq!(Ok(true), first_values.into_iter().ok_and_all(is_even));
-    /// assert_eq!(Ok(false), second_values.into_iter().ok_and_all(is_even));
-    /// assert_eq!(Ok(false), third_values.into_iter().ok_and_all(is_even));
-    /// assert_eq!(Err(()), fourth_values.into_iter().ok_and_all(is_even));
-    /// ```
-    fn ok_and_all<T, E, F>(&mut self, predicate: F) -> Result<bool, E>
-    where
-        Self: Iterator<Item = Result<T, E>>,
-        F: FnMut(T) -> bool,
-    {
-        self.process_results(|mut results| results.all(predicate))
-    }
-
-    /// This method functions similarly to `FallibleIterator::fallible_all` but both the
-    /// existing iterator and predicate yield `Result`s.
-    ///
-    /// Like `FallibleIterator::fallible_all`, this function short-curcuits but will short-curcuit
-    /// if it encounters an `Err` or `Ok(false)`. If the existing iterator yields an `Err`, this
-    /// function returns that `Err`. If the value is `Ok`, it is given to the predicate. If the
-    /// predicate returns `Err`, that `Err` is returned. If the predicate returns `Ok(false)`,
-    /// `Ok(false)` is returned. By default, this function returned `Ok(true)`.
-    ///
-    /// ```ignore
-    /// // A totally accurate prime checker
-    /// fn is_prime(i: usize) -> Result<bool, ()> {
-    ///   match i {
-    ///     0 | 1 => Err(()), // 0 and 1 are neither prime or composite
-    ///     2 | 3 => Ok(true),
-    ///     _ => Ok(false), // Every other number is composite, I guess
-    ///   }
-    /// }
-    ///
-    /// let first_values = vec![];
-    /// let second_values = vec![Ok(0), Err(())];
-    /// let third_values = vec![Ok(2), Ok(3)];
-    /// let fourth_values = vec![Err(()), Ok(2)];
-    /// let fifth_values = vec![Ok(2), Err(())];
-    /// let sixth_values = vec![Ok(4), Ok(3)];
-    ///
-    /// assert_eq!(Ok(true), first_values.into_iter().and_then_all(is_prime));
-    /// assert_eq!(Err(()), second_values.into_iter().and_then_all(is_prime));
-    /// assert_eq!(Ok(true), third_values.into_iter().and_then_all(is_prime));
-    /// assert_eq!(Err(()), fourth_values.into_iter().and_then_all(is_prime));
-    /// assert_eq!(Err(()), fifth_values.into_iter().and_then_all(is_prime));
-    /// assert_eq!(Ok(false), sixth_values.into_iter().and_then_all(is_prime));
-    /// ```
-    fn and_then_all<T, E, F>(&mut self, mut predicate: F) -> Result<bool, E>
-    where
-        Self: Iterator<Item = Result<T, E>>,
-        F: FnMut(T) -> Result<bool, E>,
-    {
-        let mut digest = true;
-        for val in self.by_ref() {
-            digest &= val.and_then(&mut predicate)?;
-            if !digest {
-                break;
-            }
-        }
-        Ok(digest)
-    }
-
     /// This method functions similarly to `Iterator::any` but where the given predicate returns
     /// `Result`s.
     ///
@@ -315,54 +220,6 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
         self.process_results(|mut results| results.any(predicate))
     }
 
-    /// This method functions similarly to `FallibleIterator::fallible_any` but both the
-    /// existing iterator and predicate yield `Result`s.
-    ///
-    /// Like `FallibleIterator::fallible_any`, this function short-curcuits but will short-curcuit
-    /// if it encounters an `Err` or `Ok(true)`. If the existing iterator yields an `Err`, this
-    /// function returns that `Err`. If the value is `Ok`, it is given to the predicate. If the
-    /// predicate returns `Err`, that `Err` is returned. If the predicate returns `Ok(true)`,
-    /// `Ok(true)` is returned. By default, this function returned `Ok(false)`.
-    ///
-    /// ```ignore
-    /// // A totally accurate prime checker
-    /// fn is_prime(i: usize) -> Result<bool, ()> {
-    ///   match i {
-    ///     0 | 1 => Err(()), // 0 and 1 are neither prime or composite
-    ///     2 | 3 => Ok(true),
-    ///     _ => Ok(false), // Every other number is composite, I guess
-    ///   }
-    /// }
-    ///
-    /// let first_values = vec![];
-    /// let second_values = vec![Ok(0), Err(())];
-    /// let third_values = vec![Ok(3), Ok(4)];
-    /// let fourth_values = vec![Err(()), Ok(2)];
-    /// let fifth_values = vec![Ok(2), Err(())];
-    /// let sixth_values = vec![Ok(4), Ok(5)];
-    ///
-    /// assert_eq!(Ok(false), first_values.into_iter().and_then_any(is_prime));
-    /// assert_eq!(Err(()), second_values.into_iter().and_then_any(is_prime));
-    /// assert_eq!(Ok(true), third_values.into_iter().and_then_any(is_prime));
-    /// assert_eq!(Err(()), fourth_values.into_iter().and_then_any(is_prime));
-    /// assert_eq!(Ok(true), fifth_values.into_iter().and_then_any(is_prime));
-    /// assert_eq!(Ok(false), sixth_values.into_iter().and_then_any(is_prime));
-    /// ```
-    fn and_then_any<T, E, F>(&mut self, mut predicate: F) -> Result<bool, E>
-    where
-        Self: Iterator<Item = Result<T, E>>,
-        F: FnMut(T) -> Result<bool, E>,
-    {
-        let mut digest = false;
-        for val in self {
-            digest |= val.and_then(&mut predicate)?;
-            if digest {
-                break;
-            }
-        }
-        Ok(digest)
-    }
-
     /// A convenience method that is equivalent to calling `.map(|result|
     /// result.and_then(fallible_fn))`.
     fn and_then<T, E, U, F>(self, map: F) -> AndThen<Self, F>
@@ -371,26 +228,6 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
         F: FnMut(T) -> Result<U, E>,
     {
         AndThen { iter: self, map }
-    }
-
-    /// A convenience method that is equivalent to calling `.map(|result|
-    /// result.or_else(fallible_fn))`.
-    fn or_else<T, E, EE, F>(self, map: F) -> OrElse<Self, F>
-    where
-        Self: Iterator<Item = Result<T, E>>,
-        F: FnMut(E) -> Result<T, EE>,
-    {
-        OrElse { iter: self, map }
-    }
-
-    /// A convenience method for applying a fallible operation to an iterator of `Result`s and
-    /// returning the first `Err` if one occurs.
-    fn and_then_for_each<F, T, E>(self, inner: F) -> Result<(), E>
-    where
-        Self: Iterator<Item = Result<T, E>>,
-        F: FnMut(T) -> Result<(), E>,
-    {
-        self.and_then(inner).collect()
     }
 
     /// Tries to find the first `Ok` value that matches the predicate. If an `Err` is found before
@@ -413,17 +250,6 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     {
         for item in self {
             init = mapper(init, item)?;
-        }
-        Ok(init)
-    }
-
-    fn and_then_fold<F, O, T, E>(&mut self, mut init: O, mut mapper: F) -> Result<O, E>
-    where
-        Self: Iterator<Item = Result<T, E>>,
-        F: FnMut(O, T) -> Result<O, E>,
-    {
-        for item in self {
-            init = mapper(init, item?)?
         }
         Ok(init)
     }
@@ -501,23 +327,6 @@ where
     }
 }
 
-pub(crate) struct OrElse<I, F> {
-    iter: I,
-    map: F,
-}
-
-impl<I, T, E, EE, F> Iterator for OrElse<I, F>
-where
-    I: Iterator<Item = Result<T, E>>,
-    F: FnMut(E) -> Result<T, EE>,
-{
-    type Item = Result<T, EE>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|res| res.or_else(&mut self.map))
-    }
-}
-
 // Ideally, these would be doc tests, but gating access to the `utils` module is messy.
 #[cfg(test)]
 mod tests {
@@ -561,36 +370,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ok_and_all() {
-        let first_values: Vec<Item> = vec![];
-        let second_values: Vec<Item> = vec![Ok(1), Err(())];
-        let third_values: Vec<Item> = vec![Ok(0), Ok(1), Ok(2)];
-        let fourth_values: Vec<Item> = vec![Err(()), Ok(0)];
-
-        assert_eq!(Ok(true), first_values.into_iter().ok_and_all(is_even));
-        assert_eq!(Ok(false), second_values.into_iter().ok_and_all(is_even));
-        assert_eq!(Ok(false), third_values.into_iter().ok_and_all(is_even));
-        assert_eq!(Err(()), fourth_values.into_iter().ok_and_all(is_even));
-    }
-
-    #[test]
-    fn test_and_then_all() {
-        let first_values: Vec<Item> = vec![];
-        let second_values: Vec<Item> = vec![Ok(0), Err(())];
-        let third_values: Vec<Item> = vec![Ok(2), Ok(3)];
-        let fourth_values: Vec<Item> = vec![Err(()), Ok(2)];
-        let fifth_values: Vec<Item> = vec![Ok(2), Err(())];
-        let sixth_values: Vec<Item> = vec![Ok(4), Ok(3)];
-
-        assert_eq!(Ok(true), first_values.into_iter().and_then_all(is_prime));
-        assert_eq!(Err(()), second_values.into_iter().and_then_all(is_prime));
-        assert_eq!(Ok(true), third_values.into_iter().and_then_all(is_prime));
-        assert_eq!(Err(()), fourth_values.into_iter().and_then_all(is_prime));
-        assert_eq!(Err(()), fifth_values.into_iter().and_then_all(is_prime));
-        assert_eq!(Ok(false), sixth_values.into_iter().and_then_all(is_prime));
-    }
-
-    #[test]
     fn test_fallible_any() {
         assert_eq!(Ok(false), [].into_iter().fallible_any(is_prime));
         assert_eq!(Ok(true), (2..5).fallible_any(is_prime));
@@ -610,22 +389,5 @@ mod tests {
         assert_eq!(Ok(true), second_values.into_iter().ok_and_any(is_even));
         assert_eq!(Ok(false), third_values.into_iter().ok_and_any(is_even));
         assert_eq!(Err(()), fourth_values.into_iter().ok_and_any(is_even));
-    }
-
-    #[test]
-    fn test_and_then_any() {
-        let first_values: Vec<Item> = vec![];
-        let second_values: Vec<Item> = vec![Ok(0), Err(())];
-        let third_values: Vec<Item> = vec![Ok(3), Ok(4)];
-        let fourth_values: Vec<Item> = vec![Err(()), Ok(2)];
-        let fifth_values: Vec<Item> = vec![Ok(2), Err(())];
-        let sixth_values: Vec<Item> = vec![Ok(4), Ok(5)];
-
-        assert_eq!(Ok(false), first_values.into_iter().and_then_any(is_prime));
-        assert_eq!(Err(()), second_values.into_iter().and_then_any(is_prime));
-        assert_eq!(Ok(true), third_values.into_iter().and_then_any(is_prime));
-        assert_eq!(Err(()), fourth_values.into_iter().and_then_any(is_prime));
-        assert_eq!(Ok(true), fifth_values.into_iter().and_then_any(is_prime));
-        assert_eq!(Ok(false), sixth_values.into_iter().and_then_any(is_prime));
     }
 }

--- a/apollo-federation/src/utils/logging.rs
+++ b/apollo-federation/src/utils/logging.rs
@@ -57,7 +57,7 @@ pub(crate) fn make_string<T: ?Sized>(
         writer: fn(&mut std::fmt::Formatter<'_>, &T) -> std::fmt::Result,
     }
 
-    impl<'a, T: ?Sized> std::fmt::Display for Stringify<'a, T> {
+    impl<T: ?Sized> std::fmt::Display for Stringify<'_, T> {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             (self.writer)(f, self.data)
         }

--- a/apollo-router-scaffold/scaffold-test/Dockerfile
+++ b/apollo-router-scaffold/scaffold-test/Dockerfile
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.76.0 as build
+FROM rust:1.83.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router

--- a/apollo-router-scaffold/templates/base/Dockerfile
+++ b/apollo-router-scaffold/templates/base/Dockerfile
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.76.0 as build
+FROM rust:1.83.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router

--- a/apollo-router-scaffold/templates/base/rust-toolchain.toml
+++ b/apollo-router-scaffold/templates/base/rust-toolchain.toml
@@ -3,4 +3,4 @@
 [toolchain]
 # renovate-automation: rustc version
 channel = "1.76.0"
-components = [ "rustfmt", "clippy" ]
+components = ["rustfmt", "clippy"]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -150,8 +150,6 @@ opentelemetry-aws = "0.8.0"
 # opentelemetry-datadog = { version = "0.8.0", features = ["reqwest-client"] }
 rmp = "0.8"
 # END TEMP DATADOG
-# Pin rowan until update to rust 1.77
-rowan = "=0.15.15"
 opentelemetry-http = "0.9.0"
 opentelemetry-jaeger = { version = "0.19.0", features = [
     "collector_client",

--- a/apollo-router/README.md
+++ b/apollo-router/README.md
@@ -27,4 +27,4 @@ Most Apollo Router Core features can be defined using our [YAML configuration](h
 If you prefer to write customizations in Rust or need more advanced customizations, see our section on [native customizations](https://www.apollographql.com/docs/router/customizations/native) for information on how to use `apollo-router` as a Rust library.  We also publish Rust-specific documentation on our [`apollo-router` crate docs](https://docs.rs/crate/apollo-router).
 
 <!-- renovate-automation: rustc version -->
-The minimum supported Rust version (MSRV) for this version of `apollo-router` is **1.76.0**.
+The minimum supported Rust version (MSRV) for this version of `apollo-router` is **1.83.0**.

--- a/apollo-router/src/ageing_priority_queue.rs
+++ b/apollo-router/src/ageing_priority_queue.rs
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<'a, T> Receiver<'a, T>
+impl<T> Receiver<'_, T>
 where
     T: Send + 'static,
 {

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -763,7 +763,7 @@ struct SignatureFormatterWithAlgorithm<'a> {
     normalization_algorithm: &'a ApolloSignatureNormalizationAlgorithm,
 }
 
-impl<'a> fmt::Display for SignatureFormatterWithAlgorithm<'a> {
+impl fmt::Display for SignatureFormatterWithAlgorithm<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self.formatter {
             ApolloReportingSignatureFormatter::Operation(operation) => {

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -746,7 +746,7 @@ impl<'a> CancelHandler<'a> {
     }
 }
 
-impl<'a> Drop for CancelHandler<'a> {
+impl Drop for CancelHandler<'_> {
     fn drop(&mut self) {
         if !self.got_first_response {
             if self.experimental_log_on_broken_pipe {

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -273,6 +273,7 @@ fn test_listen() -> ListenAddr {
 #[buildstructor::buildstructor]
 impl Configuration {
     #[builder]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn new(
         supergraph: Option<Supergraph>,
         health_check: Option<HealthCheck>,
@@ -395,6 +396,7 @@ impl Default for Configuration {
 #[buildstructor::buildstructor]
 impl Configuration {
     #[builder]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn fake_new(
         supergraph: Option<Supergraph>,
         health_check: Option<HealthCheck>,
@@ -673,6 +675,7 @@ fn default_defer_support() -> bool {
 #[buildstructor::buildstructor]
 impl Supergraph {
     #[builder]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn new(
         listen: Option<ListenAddr>,
         path: Option<String>,
@@ -701,6 +704,7 @@ impl Supergraph {
 #[buildstructor::buildstructor]
 impl Supergraph {
     #[builder]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn fake_new(
         listen: Option<ListenAddr>,
         path: Option<String>,

--- a/apollo-router/src/configuration/subgraph.rs
+++ b/apollo-router/src/configuration/subgraph.rs
@@ -225,7 +225,7 @@ impl<'de> Deserialize<'de> for Field {
 
 struct FieldVisitor;
 
-impl<'de> Visitor<'de> for FieldVisitor {
+impl Visitor<'_> for FieldVisitor {
     type Value = Field;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/apollo-router/src/context/extensions/sync.rs
+++ b/apollo-router/src/context/extensions/sync.rs
@@ -58,7 +58,7 @@ impl<'a> ExtensionsGuard<'a> {
     }
 }
 
-impl<'a> Deref for ExtensionsGuard<'a> {
+impl Deref for ExtensionsGuard<'_> {
     type Target = super::Extensions;
 
     fn deref(&self) -> &super::Extensions {

--- a/apollo-router/src/graphql/request.rs
+++ b/apollo-router/src/graphql/request.rs
@@ -307,7 +307,7 @@ fn get_from_urlencoded_value<'a, T: Deserialize<'a>>(
 
 struct RequestFromBytesSeed<'data>(&'data Bytes);
 
-impl<'data, 'de> DeserializeSeed<'de> for RequestFromBytesSeed<'data> {
+impl<'de> DeserializeSeed<'de> for RequestFromBytesSeed<'_> {
     type Value = Request;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -329,7 +329,7 @@ impl<'data, 'de> DeserializeSeed<'de> for RequestFromBytesSeed<'data> {
 
         struct RequestVisitor<'data>(&'data Bytes);
 
-        impl<'data, 'de> serde::de::Visitor<'de> for RequestVisitor<'data> {
+        impl<'de> serde::de::Visitor<'de> for RequestVisitor<'_> {
             type Value = Request;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/apollo-router/src/http_ext.rs
+++ b/apollo-router/src/http_ext.rs
@@ -194,9 +194,8 @@ impl PartialEq for TryIntoHeaderName {
 
 impl Hash for TryIntoHeaderName {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        match &self.result {
-            Ok(value) => value.hash(state),
-            Err(_) => {}
+        if let Ok(value) = &self.result {
+            value.hash(state)
         }
     }
 }

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -168,9 +168,6 @@ pub(crate) trait ValueExt {
     #[track_caller]
     fn is_object_of_type(&self, schema: &Schema, maybe_type: &str) -> bool;
 
-    /// value type
-    fn json_type_name(&self) -> &'static str;
-
     fn as_i32(&self) -> Option<i32>;
 }
 
@@ -544,17 +541,6 @@ impl ValueExt for Value {
                 })
     }
 
-    fn json_type_name(&self) -> &'static str {
-        match self {
-            Value::Array(_) => "array",
-            Value::Null => "null",
-            Value::Bool(_) => "boolean",
-            Value::Number(_) => "number",
-            Value::String(_) => "string",
-            Value::Object(_) => "object",
-        }
-    }
-
     fn as_i32(&self) -> Option<i32> {
         self.as_i64()?.to_i32()
     }
@@ -852,7 +838,7 @@ where
 
 struct FlattenVisitor;
 
-impl<'de> serde::de::Visitor<'de> for FlattenVisitor {
+impl serde::de::Visitor<'_> for FlattenVisitor {
     type Value = Option<TypeConditions>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -903,7 +889,7 @@ where
 
 struct KeyVisitor;
 
-impl<'de> serde::de::Visitor<'de> for KeyVisitor {
+impl serde::de::Visitor<'_> for KeyVisitor {
     type Value = (String, Option<TypeConditions>);
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -947,7 +933,7 @@ where
 
 struct FragmentVisitor;
 
-impl<'de> serde::de::Visitor<'de> for FragmentVisitor {
+impl serde::de::Visitor<'_> for FragmentVisitor {
     type Value = String;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -19,8 +19,6 @@
 #![cfg_attr(feature = "failfast", allow(unreachable_code))]
 #![warn(unreachable_pub)]
 #![warn(missing_docs)]
-// TODO: silence false positives (apollo_compiler::Name) and investigate the rest
-#![allow(clippy::mutable_key_type)]
 
 macro_rules! failfast_debug {
     ($($tokens:tt)+) => {{

--- a/apollo-router/src/metrics/layer.rs
+++ b/apollo-router/src/metrics/layer.rs
@@ -169,7 +169,7 @@ pub(crate) struct MetricVisitor<'a> {
     attributes_ignored: bool,
 }
 
-impl<'a> MetricVisitor<'a> {
+impl MetricVisitor<'_> {
     fn set_metric(&mut self, name: &'static str, instrument_type: InstrumentType) {
         self.metric = Some((name, instrument_type));
         if self.attributes_ignored {
@@ -181,7 +181,7 @@ impl<'a> MetricVisitor<'a> {
     }
 }
 
-impl<'a> Visit for MetricVisitor<'a> {
+impl Visit for MetricVisitor<'_> {
     fn record_f64(&mut self, field: &Field, value: f64) {
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_MONOTONIC_COUNTER) {
             self.set_metric(metric_name, InstrumentType::CounterF64(value));
@@ -416,7 +416,7 @@ impl<'a> Visit for MetricVisitor<'a> {
     }
 }
 
-impl<'a> MetricVisitor<'a> {
+impl MetricVisitor<'_> {
     fn finish(self) {
         if let Some((metric_name, instrument_type)) = self.metric {
             self.instruments.update_metric(

--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -617,7 +617,6 @@ macro_rules! f64_counter {
 /// * Imperfect mapping to metrics API that can only be checked at runtime.
 ///
 /// New metrics should be added using these macros.
-
 #[allow(unused_macros)]
 macro_rules! i64_up_down_counter {
     ($($name:ident).+, $description:literal, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {

--- a/apollo-router/src/plugin/serde.rs
+++ b/apollo-router/src/plugin/serde.rs
@@ -112,7 +112,7 @@ where
 #[derive(Default)]
 struct HeaderNameVisitor;
 
-impl<'de> Visitor<'de> for HeaderNameVisitor {
+impl Visitor<'_> for HeaderNameVisitor {
     type Value = HeaderName;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
@@ -137,7 +137,7 @@ where
 
 struct JSONQueryVisitor;
 
-impl<'de> Visitor<'de> for JSONQueryVisitor {
+impl Visitor<'_> for JSONQueryVisitor {
     type Value = JSONQuery;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
@@ -163,7 +163,7 @@ where
 
 struct HeaderValueVisitor;
 
-impl<'de> Visitor<'de> for HeaderValueVisitor {
+impl Visitor<'_> for HeaderValueVisitor {
     type Value = HeaderValue;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
@@ -193,7 +193,7 @@ where
 {
     struct RegexVisitor;
 
-    impl<'de> Visitor<'de> for RegexVisitor {
+    impl Visitor<'_> for RegexVisitor {
         type Value = Regex;
 
         fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
@@ -221,7 +221,7 @@ where
 
 struct JSONPathVisitor;
 
-impl<'de> serde::de::Visitor<'de> for JSONPathVisitor {
+impl serde::de::Visitor<'_> for JSONPathVisitor {
     type Value = serde_json_bytes::path::JsonPathInst;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -237,7 +237,7 @@ pub(super) struct Iter<'a> {
     list: Vec<JwksConfig>,
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = JwkSetInfo;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -96,7 +96,7 @@ impl<'a> AuthenticatedCheckVisitor<'a> {
     }
 }
 
-impl<'a> traverse::Visitor for AuthenticatedCheckVisitor<'a> {
+impl traverse::Visitor for AuthenticatedCheckVisitor<'_> {
     fn operation(&mut self, root_type: &str, node: &executable::Operation) -> Result<(), BoxError> {
         if !self.entity_query {
             traverse::operation(self, root_type, node)
@@ -319,7 +319,7 @@ impl<'a> AuthenticatedVisitor<'a> {
     }
 }
 
-impl<'a> transform::Visitor for AuthenticatedVisitor<'a> {
+impl transform::Visitor for AuthenticatedVisitor<'_> {
     fn operation(
         &mut self,
         root_type: &str,
@@ -627,7 +627,7 @@ mod tests {
         paths: Vec<Path>,
     }
 
-    impl<'a> std::fmt::Display for TestResult<'a> {
+    impl std::fmt::Display for TestResult<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(
                 f,

--- a/apollo-router/src/plugins/authorization/policy.rs
+++ b/apollo-router/src/plugins/authorization/policy.rs
@@ -122,7 +122,7 @@ fn policy_argument(
         .filter_map(|v| v.as_str().map(str::to_owned))
 }
 
-impl<'a> traverse::Visitor for PolicyExtractionVisitor<'a> {
+impl traverse::Visitor for PolicyExtractionVisitor<'_> {
     fn operation(&mut self, root_type: &str, node: &executable::Operation) -> Result<(), BoxError> {
         if let Some(ty) = self.schema.types.get(root_type) {
             self.extracted_policies.extend(policy_argument(
@@ -417,7 +417,7 @@ impl<'a> PolicyFilteringVisitor<'a> {
     }
 }
 
-impl<'a> transform::Visitor for PolicyFilteringVisitor<'a> {
+impl transform::Visitor for PolicyFilteringVisitor<'_> {
     fn operation(
         &mut self,
         root_type: &str,
@@ -763,7 +763,7 @@ mod tests {
         paths: Vec<Path>,
     }
 
-    impl<'a> std::fmt::Display for TestResult<'a> {
+    impl std::fmt::Display for TestResult<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(
                 f,

--- a/apollo-router/src/plugins/authorization/scopes.rs
+++ b/apollo-router/src/plugins/authorization/scopes.rs
@@ -122,7 +122,7 @@ fn scopes_argument(
         .filter_map(|value| value.as_str().map(str::to_owned))
 }
 
-impl<'a> traverse::Visitor for ScopeExtractionVisitor<'a> {
+impl traverse::Visitor for ScopeExtractionVisitor<'_> {
     fn operation(&mut self, root_type: &str, node: &executable::Operation) -> Result<(), BoxError> {
         if let Some(ty) = self.schema.types.get(root_type) {
             self.extracted_scopes.extend(scopes_argument(
@@ -418,7 +418,7 @@ impl<'a> ScopeFilteringVisitor<'a> {
     }
 }
 
-impl<'a> transform::Visitor for ScopeFilteringVisitor<'a> {
+impl transform::Visitor for ScopeFilteringVisitor<'_> {
     fn operation(
         &mut self,
         root_type: &str,
@@ -767,7 +767,7 @@ mod tests {
         paths: Vec<Path>,
     }
 
-    impl<'a> std::fmt::Display for TestResult<'a> {
+    impl std::fmt::Display for TestResult<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(
                 f,

--- a/apollo-router/src/plugins/cache/cache_control.rs
+++ b/apollo-router/src/plugins/cache/cache_control.rs
@@ -258,11 +258,7 @@ impl CacheControl {
 
     fn update_ttl(&self, ttl: u32, now: u64) -> u32 {
         let elapsed = self.elapsed_inner(now);
-        if elapsed >= ttl {
-            0
-        } else {
-            ttl - elapsed
-        }
+        ttl.saturating_sub(elapsed)
     }
 
     pub(crate) fn merge(&self, other: &CacheControl) -> CacheControl {
@@ -376,11 +372,7 @@ impl CacheControl {
     pub(crate) fn remaining_time(&self, now: u64) -> Option<u32> {
         self.ttl().map(|ttl| {
             let elapsed = self.elapsed_inner(now);
-            if ttl > elapsed {
-                ttl - elapsed
-            } else {
-                0
-            }
+            ttl.saturating_sub(elapsed)
         })
     }
 }

--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -50,9 +50,6 @@ impl std::fmt::Display for InvalidationErrors {
 
 impl std::error::Error for InvalidationErrors {}
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub(crate) struct InvalidationTopic;
-
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum InvalidationOrigin {
     Endpoint,

--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -39,7 +39,7 @@ pub(in crate::plugins::demand_control) struct ListSizeDirective<'schema> {
     pub(in crate::plugins::demand_control) sized_fields: Option<HashSet<&'schema str>>,
 }
 
-impl<'schema> ListSizeDirective<'schema> {
+impl ListSizeDirective<'_> {
     pub(in crate::plugins::demand_control) fn new(
         parsed: &'schema ParsedListSizeDirective,
         field: &Field,

--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -39,7 +39,7 @@ pub(in crate::plugins::demand_control) struct ListSizeDirective<'schema> {
     pub(in crate::plugins::demand_control) sized_fields: Option<HashSet<&'schema str>>,
 }
 
-impl ListSizeDirective<'_> {
+impl<'schema> ListSizeDirective<'schema> {
     pub(in crate::plugins::demand_control) fn new(
         parsed: &'schema ParsedListSizeDirective,
         field: &Field,

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -561,7 +561,7 @@ impl<'schema> ResponseCostCalculator<'schema> {
     }
 }
 
-impl<'schema> ResponseVisitor for ResponseCostCalculator<'schema> {
+impl ResponseVisitor for ResponseCostCalculator<'_> {
     fn visit_field(
         &mut self,
         request: &ExecutableDocument,

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -193,7 +193,7 @@ impl<T> From<WithErrors<T>> for DemandControlError {
     }
 }
 
-impl<'a> From<FieldLookupError<'a>> for DemandControlError {
+impl From<FieldLookupError<'_>> for DemandControlError {
     fn from(value: FieldLookupError) -> Self {
         match value {
             FieldLookupError::NoSuchType => DemandControlError::QueryParseFailure(

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -66,7 +66,8 @@ enum GaugeStore {
     #[default]
     Disabled,
     Pending,
-    Active(Vec<ObservableGauge<u64>>),
+    // This `Vec` is not used explicitly but is to be kept alive until the enum is dropped
+    Active(#[allow(unused)] Vec<ObservableGauge<u64>>),
 }
 
 impl GaugeStore {

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -1051,7 +1051,7 @@ mod test {
     }
 
     impl SubgraphRequest {
-        pub fn assert_headers(&self, headers: Vec<(&'static str, &'static str)>) -> bool {
+        fn assert_headers(&self, headers: Vec<(&'static str, &'static str)>) -> bool {
             let mut headers = headers.clone();
             headers.push((HOST.as_str(), "rhost"));
             headers.push((CONTENT_LENGTH.as_str(), "22"));

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -47,7 +47,7 @@ impl Plugin for IncludeSubgraphErrors {
 
         let sub_name_response = name.to_string();
         let sub_name_error = name.to_string();
-        return service
+        service
             .map_response(move |mut response: SubgraphResponse| {
                 let errors = &mut response.response.body_mut().errors;
                 if !errors.is_empty() {
@@ -82,7 +82,7 @@ impl Plugin for IncludeSubgraphErrors {
                     })
                 }
             })
-            .boxed();
+            .boxed()
     }
 }
 

--- a/apollo-router/src/plugins/progressive_override/visitor.rs
+++ b/apollo-router/src/plugins/progressive_override/visitor.rs
@@ -29,7 +29,7 @@ impl<'a> OverrideLabelVisitor<'a> {
     }
 }
 
-impl<'a> traverse::Visitor for OverrideLabelVisitor<'a> {
+impl traverse::Visitor for OverrideLabelVisitor<'_> {
     fn schema(&self) -> &apollo_compiler::Schema {
         self.schema
     }

--- a/apollo-router/src/plugins/telemetry/config_new/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/attributes.rs
@@ -1149,7 +1149,7 @@ impl<'a> SubgraphRequestResendCountKey<'a> {
     }
 }
 
-impl<'a> From<SubgraphRequestResendCountKey<'a>> for String {
+impl From<SubgraphRequestResendCountKey<'_>> for String {
     fn from(value: SubgraphRequestResendCountKey) -> Self {
         format!(
             "apollo::telemetry::http_request_resend_count_{}",

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
@@ -167,7 +167,7 @@ struct GraphQLInstrumentsVisitor<'a> {
     instruments: &'a GraphQLInstruments,
 }
 
-impl<'a> ResponseVisitor for GraphQLInstrumentsVisitor<'a> {
+impl ResponseVisitor for GraphQLInstrumentsVisitor<'_> {
     fn visit_field(
         &mut self,
         request: &ExecutableDocument,

--- a/apollo-router/src/plugins/telemetry/endpoint.rs
+++ b/apollo-router/src/plugins/telemetry/endpoint.rs
@@ -72,7 +72,7 @@ impl<'de> Deserialize<'de> for UriEndpoint {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct EndpointVisitor;
 
-        impl<'de> Visitor<'de> for EndpointVisitor {
+        impl Visitor<'_> for EndpointVisitor {
             type Value = UriEndpoint;
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
@@ -134,7 +134,7 @@ impl<'de> Deserialize<'de> for SocketEndpoint {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct EndpointVisitor;
 
-        impl<'de> Visitor<'de> for EndpointVisitor {
+        impl Visitor<'_> for EndpointVisitor {
             type Value = SocketEndpoint;
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -196,7 +196,7 @@ pub(crate) struct FieldsVisitor<'a, 'b> {
     excluded_attributes: &'b HashSet<&'static str>,
 }
 
-impl<'a, 'b> FieldsVisitor<'a, 'b> {
+impl<'b> FieldsVisitor<'_, 'b> {
     fn new(excluded_attributes: &'b HashSet<&'static str>) -> Self {
         Self {
             values: HashMap::with_capacity(0),
@@ -205,7 +205,7 @@ impl<'a, 'b> FieldsVisitor<'a, 'b> {
     }
 }
 
-impl<'a, 'b> field::Visit for FieldsVisitor<'a, 'b> {
+impl field::Visit for FieldsVisitor<'_, '_> {
     /// Visit a double precision floating point value.
     fn record_f64(&mut self, field: &Field, value: f64) {
         self.values
@@ -375,7 +375,7 @@ subgraph:
     }
 
     struct Guard<'a>(MutexGuard<'a, Vec<u8>>);
-    impl<'a> std::io::Write for Guard<'a> {
+    impl std::io::Write for Guard<'_> {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
             self.0.write(buf)
         }

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -60,7 +60,7 @@ impl Default for Json {
 
 struct SerializableResources<'a>(&'a Vec<(String, serde_json::Value)>);
 
-impl<'a> serde::ser::Serialize for SerializableResources<'a> {
+impl serde::ser::Serialize for SerializableResources<'_> {
     fn serialize<Ser>(&self, serializer_o: Ser) -> Result<Ser::Ok, Ser::Error>
     where
         Ser: serde::ser::Serializer,
@@ -79,7 +79,7 @@ struct SerializableContext<'a, 'b, Span>(Option<SpanRef<'a, Span>>, &'b HashSet<
 where
     Span: Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>;
 
-impl<'a, 'b, Span> serde::ser::Serialize for SerializableContext<'a, 'b, Span>
+impl<Span> serde::ser::Serialize for SerializableContext<'_, '_, Span>
 where
     Span: Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
 {
@@ -108,7 +108,7 @@ struct SerializableSpan<'a, 'b, Span>(
 where
     Span: for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>;
 
-impl<'a, 'b, Span> serde::ser::Serialize for SerializableSpan<'a, 'b, Span>
+impl<Span> serde::ser::Serialize for SerializableSpan<'_, '_, Span>
 where
     Span: for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
 {
@@ -449,7 +449,7 @@ impl<'a> WriteAdaptor<'a> {
     }
 }
 
-impl<'a> io::Write for WriteAdaptor<'a> {
+impl io::Write for WriteAdaptor<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let s =
             std::str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -466,7 +466,7 @@ impl<'a> io::Write for WriteAdaptor<'a> {
     }
 }
 
-impl<'a> fmt::Debug for WriteAdaptor<'a> {
+impl fmt::Debug for WriteAdaptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("WriteAdaptor { .. }")
     }

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -422,7 +422,7 @@ impl<'a> FmtThreadName<'a> {
     }
 }
 
-impl<'a> fmt::Display for FmtThreadName<'a> {
+impl fmt::Display for FmtThreadName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use std::sync::atomic::AtomicUsize;
         use std::sync::atomic::Ordering::AcqRel;
@@ -572,7 +572,7 @@ impl<'a> DefaultVisitor<'a> {
     }
 }
 
-impl<'a> field::Visit for DefaultVisitor<'a> {
+impl field::Visit for DefaultVisitor<'_> {
     fn record_str(&mut self, field: &Field, value: &str) {
         if self.result.is_err() {
             return;
@@ -609,13 +609,13 @@ impl<'a> field::Visit for DefaultVisitor<'a> {
     }
 }
 
-impl<'a> VisitOutput<fmt::Result> for DefaultVisitor<'a> {
+impl VisitOutput<fmt::Result> for DefaultVisitor<'_> {
     fn finish(self) -> fmt::Result {
         self.result
     }
 }
 
-impl<'a> VisitFmt for DefaultVisitor<'a> {
+impl VisitFmt for DefaultVisitor<'_> {
     fn writer(&mut self) -> &mut dyn fmt::Write {
         &mut self.writer
     }
@@ -624,7 +624,7 @@ impl<'a> VisitFmt for DefaultVisitor<'a> {
 /// Renders an error into a list of sources, *including* the error
 struct ErrorSourceList<'a>(&'a (dyn std::error::Error + 'static));
 
-impl<'a> std::fmt::Display for ErrorSourceList<'a> {
+impl std::fmt::Display for ErrorSourceList<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut list = f.debug_list();
         let mut curr = Some(self.0);

--- a/apollo-router/src/plugins/telemetry/metrics/span_metrics_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/span_metrics_exporter.rs
@@ -155,7 +155,7 @@ struct ValueVisitor<'a> {
     timings: &'a mut Timings,
 }
 
-impl<'a> Visit for ValueVisitor<'a> {
+impl Visit for ValueVisitor<'_> {
     fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
 
     fn record_str(&mut self, field: &Field, value: &str) {

--- a/apollo-router/src/plugins/telemetry/otel/layer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/layer.rs
@@ -157,7 +157,7 @@ struct SpanEventVisitor<'a, 'b> {
     custom_event: bool,
 }
 
-impl<'a, 'b> field::Visit for SpanEventVisitor<'a, 'b> {
+impl field::Visit for SpanEventVisitor<'_, '_> {
     /// Record events on the underlying OpenTelemetry [`Span`] from `bool` values.
     ///
     /// [`Span`]: opentelemetry::trace::Span
@@ -318,7 +318,7 @@ struct SpanAttributeVisitor<'a> {
     exception_config: ExceptionFieldConfig,
 }
 
-impl<'a> SpanAttributeVisitor<'a> {
+impl SpanAttributeVisitor<'_> {
     fn record(&mut self, attribute: KeyValue) {
         debug_assert!(self.span_builder.attributes.is_some());
         if let Some(v) = self.span_builder.attributes.as_mut() {
@@ -327,7 +327,7 @@ impl<'a> SpanAttributeVisitor<'a> {
     }
 }
 
-impl<'a> field::Visit for SpanAttributeVisitor<'a> {
+impl field::Visit for SpanAttributeVisitor<'_> {
     /// Set attributes on the underlying OpenTelemetry [`Span`] from `bool` values.
     ///
     /// [`Span`]: opentelemetry::trace::Span

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -293,6 +293,7 @@ enum TreeData {
 #[buildstructor::buildstructor]
 impl Exporter {
     #[builder]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn new<'a>(
         endpoint: &'a Url,
         otlp_endpoint: &'a Url,

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -158,7 +158,7 @@ impl TracingConfigurator for Config {
                             return value.as_str();
                         }
                     }
-                    return span.name.as_ref();
+                    span.name.as_ref()
                 })
             })
             .with_name_mapping(move |span, _model_config| {

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/intern.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/intern.rs
@@ -16,7 +16,7 @@ pub(crate) enum InternValue<'a> {
     OpenTelemetryValue(&'a Value),
 }
 
-impl<'a> Hash for InternValue<'a> {
+impl Hash for InternValue<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match &self {
             InternValue::RegularString(s) => s.hash(state),
@@ -40,7 +40,7 @@ impl<'a> Hash for InternValue<'a> {
     }
 }
 
-impl<'a> Eq for InternValue<'a> {}
+impl Eq for InternValue<'_> {}
 
 const BOOLEAN_TRUE: &str = "true";
 const BOOLEAN_FALSE: &str = "false";
@@ -80,7 +80,7 @@ impl WriteAsLiteral for StringValue {
     }
 }
 
-impl<'a> InternValue<'a> {
+impl InternValue<'_> {
     pub(crate) fn write_as_str<W: RmpWrite>(
         &self,
         payload: &mut W,

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/mod.rs
@@ -169,26 +169,7 @@ impl Default for DatadogPipelineBuilder {
             mapping: Mapping::empty(),
             api_version: ApiVersion::Version05,
             unified_tags: UnifiedTags::new(),
-            #[cfg(all(
-                not(feature = "reqwest-client"),
-                not(feature = "reqwest-blocking-client"),
-                not(feature = "surf-client"),
-            ))]
             client: None,
-            #[cfg(all(
-                not(feature = "reqwest-client"),
-                not(feature = "reqwest-blocking-client"),
-                feature = "surf-client"
-            ))]
-            client: Some(Arc::new(surf::Client::new())),
-            #[cfg(all(
-                not(feature = "surf-client"),
-                not(feature = "reqwest-blocking-client"),
-                feature = "reqwest-client"
-            ))]
-            client: Some(Arc::new(reqwest::Client::new())),
-            #[cfg(feature = "reqwest-blocking-client")]
-            client: Some(Arc::new(reqwest::blocking::Client::new())),
         }
     }
 }

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/model/unified_tags.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/model/unified_tags.rs
@@ -1,4 +1,4 @@
-/// Unified tags - See: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging
+//! Unified tags - See: <https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging>
 
 pub struct UnifiedTags {
     pub service: UnifiedTagField,

--- a/apollo-router/src/plugins/telemetry/utils.rs
+++ b/apollo-router/src/plugins/telemetry/utils.rs
@@ -1,22 +1,6 @@
 use std::time::Duration;
 use std::time::Instant;
 
-use tracing_core::field::Value;
-
-pub(crate) trait TracingUtils {
-    fn or_empty(&self) -> &dyn Value;
-}
-
-impl TracingUtils for bool {
-    fn or_empty(&self) -> &dyn Value {
-        if *self {
-            self as &dyn Value
-        } else {
-            &::tracing::field::Empty
-        }
-    }
-}
-
 /// Timer implementing Drop to automatically compute the duration between the moment it has been created until it's dropped
 ///```ignore
 /// Timer::new(|duration| {

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -122,7 +122,7 @@ impl PlanNode {
         current_dir: &'a Path,
         parent_value: &'a Value,
         sender: mpsc::Sender<Response>,
-    ) -> future::BoxFuture<(Value, Vec<Error>)> {
+    ) -> future::BoxFuture<'a, (Value, Vec<Error>)> {
         Box::pin(async move {
             tracing::trace!("executing plan:\n{:#?}", self);
             let mut value;

--- a/apollo-router/src/query_planner/subgraph_context.rs
+++ b/apollo-router/src/query_planner/subgraph_context.rs
@@ -229,7 +229,7 @@ pub(crate) fn build_operation_with_aliasing(
 
         return ed
             .validate(subgraph_schema)
-            .map_err(ContextBatchingError::InvalidDocumentGenerated);
+            .map_err(|e| ContextBatchingError::InvalidDocumentGenerated(Box::new(e)));
     }
     Err(ContextBatchingError::NoSelectionSet)
 }
@@ -348,7 +348,7 @@ fn transform_field_arguments(
 pub(crate) enum ContextBatchingError {
     NoSelectionSet,
     // The only use of the field is in `Debug`, on purpose.
-    InvalidDocumentGenerated(#[allow(unused)] WithErrors<ExecutableDocument>),
+    InvalidDocumentGenerated(#[allow(unused)] Box<WithErrors<ExecutableDocument>>),
     InvalidRelativePath,
     UnexpectedSelection,
 }

--- a/apollo-router/src/query_planner/subscription.rs
+++ b/apollo-router/src/query_planner/subscription.rs
@@ -85,7 +85,7 @@ impl SubscriptionNode {
         current_dir: &'a Path,
         parent_value: &'a Value,
         sender: tokio::sync::mpsc::Sender<Response>,
-    ) -> future::BoxFuture<Vec<Error>> {
+    ) -> future::BoxFuture<'a, Vec<Error>> {
         if parameters.subscription_handle.is_none() {
             tracing::error!("No subscription handle provided for a subscription");
             return Box::pin(async {

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -117,6 +117,7 @@ where
     /// This is the constructor (or builder) to use when constructing a Router
     /// `Externalizable`.
     ///
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn router_new(
         stage: PipelineStep,
         control: Option<Control>,
@@ -157,6 +158,7 @@ where
     /// This is the constructor (or builder) to use when constructing a Supergraph
     /// `Externalizable`.
     ///
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn supergraph_new(
         stage: PipelineStep,
         control: Option<Control>,
@@ -197,6 +199,7 @@ where
     /// This is the constructor (or builder) to use when constructing an Execution
     /// `Externalizable`.
     ///
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn execution_new(
         stage: PipelineStep,
         control: Option<Control>,
@@ -238,6 +241,7 @@ where
     /// This is the constructor (or builder) to use when constructing a Subgraph
     /// `Externalizable`.
     ///
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn subgraph_new(
         stage: PipelineStep,
         control: Option<Control>,

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -266,9 +266,6 @@ pub(crate) struct ParsedDocumentInner {
     pub(crate) has_explicit_root_fields: bool,
 }
 
-#[derive(Debug)]
-pub(crate) struct RootFieldKinds {}
-
 impl ParsedDocumentInner {
     pub(crate) fn new(
         ast: ast::Document,

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -238,6 +238,7 @@ impl Response {
     /// The parameters are not optional, because in a live situation all of these properties must be
     /// set and be correct to create a Response.
     #[builder(visibility = "pub")]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn new(
         label: Option<String>,
         data: Option<Value>,
@@ -286,6 +287,7 @@ impl Response {
     /// Response. It's usually enough for testing, when a fully constructed Response is
     /// difficult to construct and not required for the purposes of the test.
     #[builder(visibility = "pub")]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn fake_new(
         label: Option<String>,
         data: Option<Value>,
@@ -320,6 +322,7 @@ impl Response {
     /// Response. It's usually enough for testing, when a fully constructed Response is
     /// difficult to construct and not required for the purposes of the test.
     #[builder(visibility = "pub")]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn fake2_new(
         label: Option<String>,
         data: Option<Value>,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1939,7 +1939,7 @@ mod tests {
                             .unwrap());
                     }
 
-                    return Ok(http::Response::builder()
+                    Ok(http::Response::builder()
                         .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                         .status(StatusCode::OK)
                         .body(
@@ -1950,7 +1950,7 @@ mod tests {
                             .expect("always valid")
                             .into(),
                         )
-                        .unwrap());
+                        .unwrap())
                 }
                 Err(_) => {
                     panic!("invalid graphql request recieved")
@@ -1996,7 +1996,7 @@ mod tests {
                             .unwrap());
                     }
 
-                    return Ok(http::Response::builder()
+                    Ok(http::Response::builder()
                         .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                         .status(StatusCode::OK)
                         .body(
@@ -2007,7 +2007,7 @@ mod tests {
                             .expect("always valid")
                             .into(),
                         )
-                        .unwrap());
+                        .unwrap())
                 }
                 Err(_) => {
                     panic!("invalid graphql request recieved")
@@ -2038,7 +2038,7 @@ mod tests {
                     }
 
                     if request.query.is_none() {
-                        return Ok(http::Response::builder()
+                        Ok(http::Response::builder()
                             .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                             .status(StatusCode::OK)
                             .body(
@@ -2053,9 +2053,9 @@ mod tests {
                                 .expect("always valid")
                                 .into(),
                             )
-                            .unwrap());
+                            .unwrap())
                     } else {
-                        return Ok(http::Response::builder()
+                        Ok(http::Response::builder()
                             .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                             .status(StatusCode::OK)
                             .body(
@@ -2066,7 +2066,7 @@ mod tests {
                                 .expect("always valid")
                                 .into(),
                             )
-                            .unwrap());
+                            .unwrap())
                     }
                 }
                 Err(_) => {
@@ -2098,7 +2098,7 @@ mod tests {
                     }
 
                     if request.query.is_none() {
-                        return Ok(http::Response::builder()
+                        Ok(http::Response::builder()
                             .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                             .status(StatusCode::OK)
                             .body(
@@ -2113,9 +2113,9 @@ mod tests {
                                 .expect("always valid")
                                 .into(),
                             )
-                            .unwrap());
+                            .unwrap())
                     } else {
-                        return Ok(http::Response::builder()
+                        Ok(http::Response::builder()
                             .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                             .status(StatusCode::OK)
                             .body(
@@ -2126,7 +2126,7 @@ mod tests {
                                 .expect("always valid")
                                 .into(),
                             )
-                            .unwrap());
+                            .unwrap())
                     }
                 }
                 Err(_) => {
@@ -2157,7 +2157,7 @@ mod tests {
                         panic!("persistedQuery expected when configuration has apq_enabled=true")
                     }
 
-                    return Ok(http::Response::builder()
+                    Ok(http::Response::builder()
                         .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                         .status(StatusCode::OK)
                         .body(
@@ -2168,7 +2168,7 @@ mod tests {
                             .expect("always valid")
                             .into(),
                         )
-                        .unwrap());
+                        .unwrap())
                 }
                 Err(_) => {
                     panic!("invalid graphql request recieved")
@@ -2200,7 +2200,7 @@ mod tests {
                         )
                     }
 
-                    return Ok(http::Response::builder()
+                    Ok(http::Response::builder()
                         .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                         .status(StatusCode::OK)
                         .body(
@@ -2211,7 +2211,7 @@ mod tests {
                             .expect("always valid")
                             .into(),
                         )
-                        .unwrap());
+                        .unwrap())
                 }
                 Err(_) => {
                     panic!("invalid graphql request recieved")

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -26,7 +26,7 @@ impl Serialize for FieldType {
     {
         struct BorrowedFieldType<'a>(&'a schema::Type);
 
-        impl<'a> Serialize for BorrowedFieldType<'a> {
+        impl Serialize for BorrowedFieldType<'_> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,

--- a/apollo-router/src/spec/query/change.rs
+++ b/apollo-router/src/spec/query/change.rs
@@ -8,18 +8,18 @@
 //! be using it.
 //! This algorithm is used in 2 places:
 //! * in the query planner cache: generating query plans can be expensive, so the
-//! router has a warm up feature, where upon receving a new schema, it will take
-//! the most used queries and plan them, before switching traffic to the new
-//! schema. Generating all of those plans takes a lot of time. By using this
-//! hashing algorithm, we can detect that the schema change does not affect the
-//! query, which means that we can reuse the old query plan directly and avoid
-//! the expensive planning task
+//!   router has a warm up feature, where upon receving a new schema, it will take
+//!   the most used queries and plan them, before switching traffic to the new
+//!   schema. Generating all of those plans takes a lot of time. By using this
+//!   hashing algorithm, we can detect that the schema change does not affect the
+//!   query, which means that we can reuse the old query plan directly and avoid
+//!   the expensive planning task
 //! * in entity caching: the responses returned by subgraphs can change depending
-//! on the schema (example: a field moving from String to Int), so we need to
-//! detect that. One way to do it was to add the schema hash to the cache key, but
-//! as a result it wipes the cache on every schema update, which will cause
-//! performance and reliability issues. With this hashing algorithm, cached entries
-//! can be kept across schema updates
+//!   on the schema (example: a field moving from String to Int), so we need to
+//!   detect that. One way to do it was to add the schema hash to the cache key, but
+//!   as a result it wipes the cache on every schema update, which will cause
+//!   performance and reliability issues. With this hashing algorithm, cached entries
+//!   can be kept across schema updates
 //!
 //! ## Technical details
 //!
@@ -665,7 +665,7 @@ impl<'a> QueryHashVisitor<'a> {
     }
 }
 
-impl<'a> Hasher for QueryHashVisitor<'a> {
+impl Hasher for QueryHashVisitor<'_> {
     fn finish(&self) -> u64 {
         unreachable!()
     }
@@ -677,7 +677,7 @@ impl<'a> Hasher for QueryHashVisitor<'a> {
     }
 }
 
-impl<'a> Visitor for QueryHashVisitor<'a> {
+impl Visitor for QueryHashVisitor<'_> {
     fn operation(&mut self, root_type: &str, node: &executable::Operation) -> Result<(), BoxError> {
         "^VISIT_OPERATION".hash(self);
 

--- a/apollo-router/src/spec/query/subselections.rs
+++ b/apollo-router/src/spec/query/subselections.rs
@@ -47,7 +47,7 @@ impl<'de> Deserialize<'de> for SubSelectionKey {
 }
 
 struct SubSelectionKeyVisitor;
-impl<'de> Visitor<'de> for SubSelectionKeyVisitor {
+impl Visitor<'_> for SubSelectionKeyVisitor {
     type Value = SubSelectionKey;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/apollo-router/src/spec/query/transform.rs
+++ b/apollo-router/src/spec/query/transform.rs
@@ -707,7 +707,7 @@ fragment F on Query {
         result: ast::Document,
     }
 
-    impl<'a> std::fmt::Display for TestResult<'a> {
+    impl std::fmt::Display for TestResult<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "query:\n{}\nfiltered:\n{}", self.query, self.result,)
         }

--- a/apollo-router/src/uplink/persisted_queries_manifest_stream.rs
+++ b/apollo-router/src/uplink/persisted_queries_manifest_stream.rs
@@ -19,7 +19,6 @@ use crate::uplink::UplinkResponse;
     response_derives = "PartialEq, Debug, Deserialize",
     deprecated = "warn"
 )]
-
 pub(crate) struct PersistedQueriesManifestQuery;
 
 impl From<UplinkRequest> for persisted_queries_manifest_query::Variables {

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -19,7 +19,6 @@ use crate::uplink::UplinkResponse;
     response_derives = "PartialEq, Debug, Deserialize",
     deprecated = "warn"
 )]
-
 pub(crate) struct SupergraphSdlQuery;
 
 impl From<UplinkRequest> for supergraph_sdl_query::Variables {

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -276,6 +276,7 @@ impl Telemetry {
 #[buildstructor]
 impl IntegrationTest {
     #[builder]
+    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub async fn new(
         config: String,
         telemetry: Option<Telemetry>,

--- a/apollo-router/tests/integration/telemetry/jaeger.rs
+++ b/apollo-router/tests/integration/telemetry/jaeger.rs
@@ -486,8 +486,7 @@ fn verify_root_span_fields(trace: &Value, operation_name: Option<&str>) -> Resul
     } else {
         assert!(request_span
             .select_path("$.tags[?(@.key == 'graphql.operation.name')].value")?
-            .first()
-            .is_none(),);
+            .is_empty(),);
     }
 
     assert_eq!(
@@ -519,8 +518,7 @@ fn verify_supergraph_span_fields(
     } else {
         assert!(supergraph_span
             .select_path("$.tags[?(@.key == 'graphql.operation.name')].value")?
-            .first()
-            .is_none(),);
+            .is_empty(),);
     }
     if custom_span_instrumentation {
         assert_eq!(

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.76.0 as build
+FROM rust:1.83.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router

--- a/docs/source/routing/customization/custom-binary.mdx
+++ b/docs/source/routing/customization/custom-binary.mdx
@@ -18,7 +18,7 @@ Learn how to compile a custom binary from Apollo Router Core source, which is re
 To compile the router, you need to have the following installed:
 
 <!-- renovate-automation: rustc version -->
-* [Rust 1.76.0 or later](https://www.rust-lang.org/tools/install)
+* [Rust 1.83.0 or later](https://www.rust-lang.org/tools/install)
 * [Node.js 16.9.1 or later](https://nodejs.org/en/download/)
 * [CMake 3.5.1 or later](https://cmake.org/download/)
 

--- a/examples/async-auth/rust/src/main.rs
+++ b/examples/async-auth/rust/src/main.rs
@@ -1,3 +1,4 @@
+//! ```text
 //! curl -v \
 //!     --header 'content-type: application/json' \
 //!     --header 'x-client-id: unknown' \
@@ -22,6 +23,7 @@
 //! <
 //! * Connection #0 to host 127.0.0.1 left intact
 //! {"data":{"me":{"name":"Ada Lovelace"}}}
+//! ```
 //! The only thing you need to add to your main.rs file is
 
 // adding the module to your main.rs file

--- a/examples/forbid-anonymous-operations/rust/src/main.rs
+++ b/examples/forbid-anonymous-operations/rust/src/main.rs
@@ -1,3 +1,4 @@
+//! ```text
 //! curl -v \
 //!     --header 'content-type: application/json' \
 //!     --url 'http://127.0.0.1:4000' \
@@ -9,6 +10,7 @@
 //! <
 //! * Connection #0 to host 127.0.0.1 left intact
 //! {"errors":[{"message":"Anonymous operations are not allowed","locations":[],"path":null}]}
+//! ```
 
 use anyhow::Result;
 

--- a/examples/status-code-propagation/rust/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/rust/src/propagate_status_code.rs
@@ -44,7 +44,7 @@ impl Plugin for PropagateStatusCode {
                     // - check for the presence of a value for `status_codes` (first parameter)
                     // update the value if present (second parameter)
                     res.context
-                        .upsert(&"status_code".to_string(), |status_code: u16| {
+                        .upsert("status_code", |status_code: u16| {
                             // return the status code with the highest priority
                             for &code in all_status_codes.iter() {
                                 if code == response_status_code || code == status_code {
@@ -210,7 +210,7 @@ mod tests {
                 let context = router_request.context;
                 // Insert several status codes which shall override the router response status
                 context
-                    .insert(&"status_code".to_string(), json!(500u16))
+                    .insert("status_code", json!(500u16))
                     .expect("couldn't insert status_code");
 
                 Ok(supergraph::Response::fake_builder()

--- a/fuzz/subgraph/src/model.rs
+++ b/fuzz/subgraph/src/model.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use std::sync::Once;
+use std::sync::LazyLock;
 
 use async_graphql::Context;
 use async_graphql::Object;
@@ -128,25 +128,21 @@ impl User {
 }
 
 fn users() -> &'static [User] {
-    static mut USERS: Vec<User> = vec![];
-    static INIT: Once = Once::new();
-    unsafe {
-        INIT.call_once(|| {
-            USERS = vec![
-                User {
-                    id: "1".to_string(),
-                    name: "Ada Lovelace".to_string(),
-                    username: "@ada".to_string(),
-                },
-                User {
-                    id: "2".to_string(),
-                    name: "Alan Turing".to_string(),
-                    username: "@complete".to_string(),
-                },
-            ];
-        });
-        &USERS
-    }
+    static USERS: LazyLock<Vec<User>> = LazyLock::new(|| {
+        vec![
+            User {
+                id: "1".to_string(),
+                name: "Ada Lovelace".to_string(),
+                username: "@ada".to_string(),
+            },
+            User {
+                id: "2".to_string(),
+                name: "Alan Turing".to_string(),
+                username: "@complete".to_string(),
+            },
+        ]
+    });
+    &USERS
 }
 
 /*
@@ -223,43 +219,39 @@ impl Product {
 }
 
 fn products() -> &'static [Product] {
-    static mut PRODUCTS: Vec<Product> = vec![];
-    static INIT: Once = Once::new();
-    unsafe {
-        INIT.call_once(|| {
-            PRODUCTS = vec![
-                Product {
-                    upc: "1".to_string(),
-                    name: Some("Table".to_string()),
-                    price: 899,
-                    weight: 100,
-                    inStock: true,
-                },
-                Product {
-                    upc: "2".to_string(),
-                    name: Some("Couch".to_string()),
-                    price: 1299,
-                    weight: 1000,
-                    inStock: false,
-                },
-                Product {
-                    upc: "3".to_string(),
-                    name: Some("Chair".to_string()),
-                    price: 54,
-                    weight: 50,
-                    inStock: true,
-                },
-                Product {
-                    upc: "4".to_string(),
-                    name: Some("Bed".to_string()),
-                    price: 1000,
-                    weight: 1200,
-                    inStock: false,
-                },
-            ];
-        });
-        &PRODUCTS
-    }
+    static PRODUCTS: LazyLock<Vec<Product>> = LazyLock::new(|| {
+        vec![
+            Product {
+                upc: "1".to_string(),
+                name: Some("Table".to_string()),
+                price: 899,
+                weight: 100,
+                inStock: true,
+            },
+            Product {
+                upc: "2".to_string(),
+                name: Some("Couch".to_string()),
+                price: 1299,
+                weight: 1000,
+                inStock: false,
+            },
+            Product {
+                upc: "3".to_string(),
+                name: Some("Chair".to_string()),
+                price: 54,
+                weight: 50,
+                inStock: true,
+            },
+            Product {
+                upc: "4".to_string(),
+                name: Some("Bed".to_string()),
+                price: 1000,
+                weight: 1200,
+                inStock: false,
+            },
+        ]
+    });
+    &PRODUCTS
 }
 
 /*
@@ -303,37 +295,33 @@ impl Review {
 }
 
 fn reviews() -> &'static [Review] {
-    static mut REVIEWS: Vec<Review> = vec![];
-    static INIT: Once = Once::new();
-    unsafe {
-        INIT.call_once(|| {
-            REVIEWS = vec![
-                Review {
-                    id: "1".to_string(),
-                    authorId: "1".to_string(),
-                    productUpc: "1".to_string(),
-                    body: Some("Love it!".to_string()),
-                },
-                Review {
-                    id: "2".to_string(),
-                    authorId: "1".to_string(),
-                    productUpc: "2".to_string(),
-                    body: Some("Too expensive.".to_string()),
-                },
-                Review {
-                    id: "3".to_string(),
-                    authorId: "2".to_string(),
-                    productUpc: "3".to_string(),
-                    body: Some("Could be better.".to_string()),
-                },
-                Review {
-                    id: "4".to_string(),
-                    authorId: "2".to_string(),
-                    productUpc: "1".to_string(),
-                    body: Some("Prefer something else.".to_string()),
-                },
-            ];
-        });
-        &REVIEWS
-    }
+    static REVIEWS: LazyLock<Vec<Review>> = LazyLock::new(|| {
+        vec![
+            Review {
+                id: "1".to_string(),
+                authorId: "1".to_string(),
+                productUpc: "1".to_string(),
+                body: Some("Love it!".to_string()),
+            },
+            Review {
+                id: "2".to_string(),
+                authorId: "1".to_string(),
+                productUpc: "2".to_string(),
+                body: Some("Too expensive.".to_string()),
+            },
+            Review {
+                id: "3".to_string(),
+                authorId: "2".to_string(),
+                productUpc: "3".to_string(),
+                body: Some("Could be better.".to_string()),
+            },
+            Review {
+                id: "4".to_string(),
+                authorId: "2".to_string(),
+                productUpc: "1".to_string(),
+                body: Some("Prefer something else.".to_string()),
+            },
+        ]
+    });
+    &REVIEWS
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # renovate-automation: rustc version
-channel = "1.76.0" # If updated, remove `rowan` dependency from apollo-router/Cargo.toml
-components = [ "rustfmt", "clippy" ]
+channel = "1.83.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
We had been stuck on 1.76.0 for a long time because of an unexplained panic in `rusty_v8` that only happened in release mode, but that is no longer relevant since https://github.com/apollographql/router/pull/6418!

The project compiles and passes test with no change in the new toolchain, but but rustc and clippy emit new warnings. Fixing those is most of the PR. Part of it was done by `cargo clippy --fix` to automatically apply the compiler’s suggested changes.

I have removed dead/unused code on the basis that if we want it later we can recover it from git history. This includes:

* Half of `apollo-federation/src/utils/fallible_iterator.rs`
* `SpecDefinition::minimum_federation_version`

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
