### PR TITLE
docs: cmake and nodejs are no longer required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,6 @@ parameters:
   protoc_version:
     type: string
     default: "21.8"
-  # note the cmake version is only used for manual installs, not for installs from a package manager like apt or homebrew
-  cmake_version:
-    type: string
-    default: "3.31.1"
   nightly:
     type: boolean
     default: false
@@ -237,37 +233,9 @@ commands:
                 command: |
                   if [[ ! -d "$HOME/.deb" ]]; then
                     mkdir $HOME/.deb
-                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install libssl-dev libdw-dev cmake
+                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install libssl-dev libdw-dev
                   fi
                   sudo dpkg -i $HOME/.deb/*.deb
-      - when:
-          condition:
-            or:
-              - equal: [ *windows_build_executor, << parameters.platform >> ]
-              - equal: [ *windows_test_executor, << parameters.platform >> ]
-          steps:
-            - run:
-                name: Install CMake
-                command: |
-                  mkdir -p "$HOME/.local"
-                  if [[ ! -f "$HOME/.local/bin/cmake" ]]; then
-                    curl -L https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.cmake_version >>/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64.zip  --output cmake.zip
-                    # The zip file has a root directory, so we put it somewhere else first before placing the files in .local
-                    unzip cmake.zip -d /tmp > /dev/null
-                    cp /tmp/cmake-<< pipeline.parameters.cmake_version >>-windows-x86_64/* -R "$HOME/.local"
-                  fi
-
-                  cmake --version
-      - when:
-          condition:
-            or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
-              - equal: [ *macos_test_executor, << parameters.platform >> ]
-          steps:
-            - run:
-                name: Install CMake
-                command: |
-                  brew install cmake
   install_protoc:
     parameters:
       platform:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,16 +18,17 @@ The **Apollo Router Core** is a configurable, high-performance **graph router** 
 
 ## Development
 
-You will need a recent version of rust (`1.72` works well as of writing).
+You will need a recent version of rust (`1.83.0` works well as of writing).
 Installing rust [using rustup](https://www.rust-lang.org/tools/install) is
-the recommended way to do it as it will install rustup, rustfmt and other
-goodies that are not always included by default in other rust distribution channels:
+the recommended way to do it as it will automatically install the toolchain version
+specified in `rust-toolchain.toml`, including rustfmt and clippy
+that are not always included by default in other rust distribution channels:
 
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-In addition, you will need to [install protoc](https://grpc.io/docs/protoc-installation/) and [cmake](https://cmake.org/).
+In addition, you will need to [install protoc](https://grpc.io/docs/protoc-installation/).
 
 Set up your git hooks:
 

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -8,8 +8,7 @@ WORKDIR /usr/src/router
 # Update our build image and install required packages
 RUN apt-get update
 RUN apt-get -y install \
-    protobuf-compiler \
-    cmake
+    protobuf-compiler
 
 # Add rustfmt since build requires it
 RUN rustup component add rustfmt

--- a/docs/source/routing/customization/custom-binary.mdx
+++ b/docs/source/routing/customization/custom-binary.mdx
@@ -15,29 +15,24 @@ Learn how to compile a custom binary from Apollo Router Core source, which is re
 
 ## Prerequisites
 
-To compile the router, you need to have the following installed:
-
 <!-- renovate-automation: rustc version -->
-* [Rust 1.83.0 or later](https://www.rust-lang.org/tools/install)
-* [Node.js 16.9.1 or later](https://nodejs.org/en/download/)
-* [CMake 3.5.1 or later](https://cmake.org/download/)
+To compile the router, you need to have [Rust 1.83.0 or later](https://www.rust-lang.org/tools/install) installed.
 
-After you install the above, also install the `cargo-xtask` and `cargo-scaffold` crates:
+After you install the above, also install the `cargo-scaffold` tool:
 
 ```sh
-cargo install cargo-xtask
 cargo install cargo-scaffold
 ```
 
 ## 1. Create a new project
 
-1. Use the `cargo-scaffold` command to create a project for your custom router:
+1. Use the `cargo scaffold` command to create a project for your custom router:
 
    ```bash
-   cargo-scaffold scaffold https://github.com/apollographql/router.git -r apollo-router-scaffold/templates/base -t main
+   cargo scaffold https://github.com/apollographql/router.git -r apollo-router-scaffold/templates/base -t main
    ```
 
-2. The `cargo-scaffold` command prompts you for some configuration settings. For the purposes of this tutorial, set your project's name to `starstuff`.
+2. The `cargo scaffold` command prompts you for some configuration settings. For the purposes of this tutorial, set your project's name to `starstuff`.
 
 3. After your project is created, change to the `starstuff` directory:
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,6 +1,6 @@
 # xtask
 
-The Apollo Router project uses [xtask](https://github.com/matklad/cargo-xtask) to help with the automation of code quality. 
+The Apollo Router project uses the [xtask](https://github.com/matklad/cargo-xtask) pattern to help with the automation of code quality. 
 
 You can run `cargo xtask --help` to see the usage. Generally we recommend that you continue to use the default cargo commands like `cargo fmt`, `cargo clippy`, and `cargo test`, but if you are debugging something that is happening in CI it can be useful to run the xtask commands that we run [in CI](../.github/workflows).
 


### PR DESCRIPTION
* cmake is no longer required to build Router since https://github.com/apollographql/router/pull/6418
* nodejs hasen’t been required for much longer: router-bridge shipped with a pre-built V8 "bundle"
* xtask is a pattern not a singular tool: <https://crates.io/crates/cargo-xtask> is just a placeholder so `cargo install cargo-xtask` does nothing