### PR TITLE
Move result handling to initial async block

### DIFF
--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -150,7 +150,7 @@ impl RawResponse {
 
 // --- MAPPED RESPONSE ---------------------------------------------------------
 
-enum MappedResponse {
+pub(crate) enum MappedResponse {
     /// This is equivalent to RawResponse::Error, but it also represents errors
     /// when the request is semantically unsuccessful (e.g. 404, 500).
     Error {
@@ -244,73 +244,63 @@ impl MappedResponse {
 
 // --- handle_responses --------------------------------------------------------
 
-pub(crate) async fn handle_responses<T: HttpBody>(
-    responses: Vec<ConnectorResponse<T>>,
+pub(crate) async fn process_response<T: HttpBody>(
+    response: ConnectorResponse<T>,
     connector: &Connector,
     context: &Context,
     debug_context: &Option<Arc<Mutex<ConnectorContext>>>,
-) -> Result<Response, HandleResponseError> {
-    let futures_vec = responses
-        .into_iter()
-        .map(|response| async move {
-            let response_key = response.key;
-            let debug_request = response.debug_request;
+) -> MappedResponse {
+    let response_key = response.key;
+    let debug_request = response.debug_request;
 
-            match response.result {
-                // This occurs when we short-circuit the request when over the limit
-                ConnectorResult::Err(error) => RawResponse::Error {
-                    error: error.to_graphql_error(connector, None),
+    let raw = match response.result {
+        // This occurs when we short-circuit the request when over the limit
+        ConnectorResult::Err(error) => RawResponse::Error {
+            error: error.to_graphql_error(connector, None),
+            key: response_key,
+        },
+        ConnectorResult::HttpResponse(response) => {
+            let (parts, body) = response.into_parts();
+
+            // If this errors, it will write to the debug context because it
+            // has access to the raw bytes, so we can't write to it again
+            // in any RawResponse::Error branches.
+            match deserialize_response(body, &parts, connector, debug_context, &debug_request).await
+            {
+                Ok(data) => RawResponse::Data {
+                    parts,
+                    data,
+                    key: response_key,
+                    debug_request,
+                },
+                Err(error) => RawResponse::Error {
+                    error,
                     key: response_key,
                 },
-                ConnectorResult::HttpResponse(response) => {
-                    let (parts, body) = response.into_parts();
-
-                    // If this errors, it will write to the debug context because it
-                    // has access to the raw bytes, so we can't write to it again
-                    // in any RawResponse::Error branches.
-                    match deserialize_response(
-                        body,
-                        &parts,
-                        connector,
-                        debug_context,
-                        &debug_request,
-                    )
-                    .await
-                    {
-                        Ok(data) => RawResponse::Data {
-                            parts,
-                            data,
-                            key: response_key,
-                            debug_request,
-                        },
-                        Err(error) => RawResponse::Error {
-                            error,
-                            key: response_key,
-                        },
-                    }
-                }
             }
-        })
-        .collect::<Vec<_>>();
+        }
+    };
 
-    let responses = futures::future::join_all(futures_vec).await;
+    let is_success = match &raw {
+        RawResponse::Error { .. } => false,
+        RawResponse::Data { parts, .. } => parts.status.is_success(),
+    };
 
+    if is_success {
+        raw.map_response(connector, context, debug_context)
+    } else {
+        raw.map_error(connector, context, debug_context)
+    }
+}
+
+pub(crate) fn aggregate_responses(
+    responses: Vec<MappedResponse>,
+) -> Result<Response, HandleResponseError> {
     let mut data = serde_json_bytes::Map::new();
     let mut errors = Vec::new();
     let count = responses.len();
 
-    for raw in responses {
-        let is_success = match &raw {
-            RawResponse::Error { .. } => false,
-            RawResponse::Data { parts, .. } => parts.status.is_success(),
-        };
-
-        let mapped = if is_success {
-            raw.map_response(connector, context, debug_context)
-        } else {
-            raw.map_error(connector, context, debug_context)
-        };
-
+    for mapped in responses {
         mapped.add_to_data(&mut data, &mut errors, count)?;
     }
 
@@ -395,6 +385,7 @@ mod tests {
     use insta::assert_debug_snapshot;
     use url::Url;
 
+    use crate::plugins::connectors::handle_responses::process_response;
     use crate::plugins::connectors::http::Response as ConnectorResponse;
     use crate::plugins::connectors::make_requests::ResponseKey;
     use crate::services::router::body::RouterBody;
@@ -436,7 +427,7 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let response2 = http::Response::builder()
+        let response2: http::Response<RouterBody> = http::Response::builder()
             .body(hyper::Body::from(r#"{"data":"world"}"#).into())
             .unwrap();
         let response_key2 = ResponseKey::RootField {
@@ -445,24 +436,30 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let res = super::handle_responses(
-            vec![
+        let res = super::aggregate_responses(vec![
+            process_response(
                 ConnectorResponse {
                     result: response1.into(),
                     key: response_key1,
                     debug_request: None,
                 },
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+            process_response(
                 ConnectorResponse {
                     result: response2.into(),
                     key: response_key2,
                     debug_request: None,
                 },
-            ],
-            &connector,
-            &Context::default(),
-            &None,
-        )
-        .await
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+        ])
         .unwrap();
 
         assert_debug_snapshot!(res, @r###"
@@ -532,7 +529,7 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let response2 = http::Response::builder()
+        let response2: http::Response<RouterBody> = http::Response::builder()
             .body(hyper::Body::from(r#"{"data":{"id": "2"}}"#).into())
             .unwrap();
         let response_key2 = ResponseKey::Entity {
@@ -541,24 +538,30 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let res = super::handle_responses(
-            vec![
+        let res = super::aggregate_responses(vec![
+            process_response(
                 ConnectorResponse {
                     result: response1.into(),
                     key: response_key1,
                     debug_request: None,
                 },
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+            process_response(
                 ConnectorResponse {
                     result: response2.into(),
                     key: response_key2,
                     debug_request: None,
                 },
-            ],
-            &connector,
-            &Context::default(),
-            &None,
-        )
-        .await
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+        ])
         .unwrap();
 
         assert_debug_snapshot!(res, @r###"
@@ -636,7 +639,7 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let response2 = http::Response::builder()
+        let response2: http::Response<RouterBody> = http::Response::builder()
             .body(hyper::Body::from(r#"{"data":"value2"}"#).into())
             .unwrap();
         let response_key2 = ResponseKey::EntityField {
@@ -647,24 +650,30 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let res = super::handle_responses(
-            vec![
+        let res = super::aggregate_responses(vec![
+            process_response(
                 ConnectorResponse {
                     result: response1.into(),
                     key: response_key1,
                     debug_request: None,
                 },
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+            process_response(
                 ConnectorResponse {
                     result: response2.into(),
                     key: response_key2,
                     debug_request: None,
                 },
-            ],
-            &connector,
-            &Context::default(),
-            &None,
-        )
-        .await
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+        ])
         .unwrap();
 
         assert_debug_snapshot!(res, @r###"
@@ -756,7 +765,7 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let response2 = http::Response::builder()
+        let response2: http::Response<RouterBody> = http::Response::builder()
             .body(hyper::Body::from(r#"{"data":{"id":"2"}}"#).into())
             .unwrap();
         let response_key2 = ResponseKey::Entity {
@@ -765,7 +774,7 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let response3 = http::Response::builder()
+        let response3: http::Response<RouterBody> = http::Response::builder()
             .status(500)
             .body(hyper::Body::from(r#"{"error":"whoops"}"#).into())
             .unwrap();
@@ -775,34 +784,52 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
-        let res = super::handle_responses(
-            vec![
+        let res = super::aggregate_responses(vec![
+            process_response(
                 ConnectorResponse {
                     result: response_plaintext.into(),
                     key: response_key_plaintext,
                     debug_request: None,
                 },
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+            process_response(
                 ConnectorResponse {
                     result: response1.into(),
                     key: response_key1,
                     debug_request: None,
                 },
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+            process_response(
                 ConnectorResponse {
                     result: response2.into(),
                     key: response_key2,
                     debug_request: None,
                 },
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+            process_response(
                 ConnectorResponse {
                     result: response3.into(),
                     key: response_key3,
                     debug_request: None,
                 },
-            ],
-            &connector,
-            &Context::default(),
-            &None,
-        )
-        .await
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+        ])
         .unwrap();
 
         assert_debug_snapshot!(res, @r###"
@@ -945,17 +972,19 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$status").unwrap()),
         };
 
-        let res = super::handle_responses(
-            vec![ConnectorResponse {
-                result: response1.into(),
-                key: response_key1,
-                debug_request: None,
-            }],
-            &connector,
-            &Context::default(),
-            &None,
-        )
-        .await
+        let res = super::aggregate_responses(vec![
+            process_response(
+                ConnectorResponse {
+                    result: response1.into(),
+                    key: response_key1,
+                    debug_request: None,
+                },
+                &connector,
+                &Context::default(),
+                &None,
+            )
+            .await,
+        ])
         .unwrap();
 
         assert_debug_snapshot!(res, @r###"

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -25,7 +25,8 @@ use super::http::HttpRequest;
 use super::new_service::ServiceFactory;
 use crate::error::FetchError;
 use crate::plugins::connectors::error::Error as ConnectorError;
-use crate::plugins::connectors::handle_responses::handle_responses;
+use crate::plugins::connectors::handle_responses::aggregate_responses;
+use crate::plugins::connectors::handle_responses::process_response;
 use crate::plugins::connectors::http::Request;
 use crate::plugins::connectors::http::Response as ConnectorResponse;
 use crate::plugins::connectors::http::Result as ConnectorResult;
@@ -36,6 +37,7 @@ use crate::plugins::connectors::tracing::connect_spec_version_instrument;
 use crate::plugins::connectors::tracing::CONNECTOR_TYPE_HTTP;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::plugins::telemetry::consts::CONNECT_SPAN_NAME;
+use crate::services::router::body::RouterBody;
 use crate::services::ConnectRequest;
 use crate::services::ConnectResponse;
 use crate::spec::Schema;
@@ -205,10 +207,9 @@ async fn execute(
     connector: &Connector,
 ) -> Result<ConnectResponse, BoxError> {
     let context = request.context.clone();
-    let context2 = request.context.clone();
     let original_subgraph_name = connector.id.subgraph_name.to_string();
 
-    let (debug, request_limit) = context.extensions().with_lock(|lock| {
+    let (ref debug, request_limit) = context.extensions().with_lock(|lock| {
         let debug = lock.get::<Arc<Mutex<ConnectorContext>>>().cloned();
         let request_limit = lock
             .get::<Arc<RequestLimits>>()
@@ -217,7 +218,7 @@ async fn execute(
         (debug, request_limit)
     });
 
-    let requests = make_requests(request, connector, &debug).map_err(BoxError::from)?;
+    let requests = make_requests(request, connector, debug).map_err(BoxError::from)?;
 
     let tasks = requests.into_iter().map(
         move |Request {
@@ -239,63 +240,60 @@ async fn execute(
             let original_subgraph_name = original_subgraph_name.clone();
             let request_limit = request_limit.clone();
             async move {
-                if let Some(request_limit) = request_limit {
-                    if !request_limit.allow() {
-                        return Ok(ConnectorResponse {
-                            result: ConnectorResult::Err(ConnectorError::RequestLimitExceeded),
-                            key,
-                            debug_request,
-                        });
+                let res = if request_limit.is_some_and(|request_limit| !request_limit.allow()) {
+                    ConnectorResponse {
+                        result: ConnectorResult::<RouterBody>::Err(
+                            ConnectorError::RequestLimitExceeded,
+                        ),
+                        key,
+                        debug_request,
                     }
-                }
-                let client = http_client_factory.create(&original_subgraph_name);
-                let req = HttpRequest {
-                    http_request: req,
-                    context,
+                } else {
+                    let client = http_client_factory.create(&original_subgraph_name);
+                    let req = HttpRequest {
+                        http_request: req,
+                        context: context.clone(),
+                    };
+                    let res = client.oneshot(req).await.map_err(|e| {
+                        match e.downcast::<FetchError>() {
+                            // Replace the internal subgraph name with the connector label
+                            Ok(inner) => match *inner {
+                                FetchError::SubrequestHttpError {
+                                    status_code,
+                                    service: _,
+                                    reason,
+                                } => Box::new(FetchError::SubrequestHttpError {
+                                    status_code,
+                                    service: connector.id.label.clone(),
+                                    reason,
+                                }),
+                                _ => inner,
+                            },
+                            Err(e) => e,
+                        }
+                    });
+
+                    u64_counter!(
+                        "apollo.router.operations.connectors",
+                        "Total number of requests to connectors",
+                        1,
+                        "connector.type" = CONNECTOR_TYPE_HTTP,
+                        "subgraph.name" = original_subgraph_name
+                    );
+
+                    ConnectorResponse {
+                        result: ConnectorResult::HttpResponse(res?.http_response),
+                        key,
+                        debug_request,
+                    }
                 };
-                let res = client.oneshot(req).await.map_err(|e| {
-                    match e.downcast::<FetchError>() {
-                        // Replace the internal subgraph name with the connector label
-                        Ok(inner) => match *inner {
-                            FetchError::SubrequestHttpError {
-                                status_code,
-                                service: _,
-                                reason,
-                            } => Box::new(FetchError::SubrequestHttpError {
-                                status_code,
-                                service: connector.id.label.clone(),
-                                reason,
-                            }),
-                            _ => inner,
-                        },
-                        Err(e) => e,
-                    }
-                });
 
-                u64_counter!(
-                    "apollo.router.operations.connectors",
-                    "Total number of requests to connectors",
-                    1,
-                    "connector.type" = CONNECTOR_TYPE_HTTP,
-                    "subgraph.name" = original_subgraph_name
-                );
-
-                Ok::<_, BoxError>(ConnectorResponse {
-                    result: ConnectorResult::HttpResponse(res?.http_response),
-                    key,
-                    debug_request,
-                })
+                Ok::<_, BoxError>(process_response(res, connector, &context, debug).await)
             }
         },
     );
 
-    let responses = futures::future::try_join_all(tasks)
-        .await
-        .map_err(BoxError::from)?;
-
-    handle_responses(responses, connector, &context2, &debug)
-        .await
-        .map_err(BoxError::from)
+    aggregate_responses(futures::future::try_join_all(tasks).await?).map_err(BoxError::from)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
The Connectors service runs all the REST API requests for an operation as parallel async tasks. However, it was waiting for *all* of them to return a response before processing the results from *any* request.

These changes move the result processing into the same async block as the request, allowing each result to be processed as soon as it is available. These changes don't reduce the total amount of work to be done, but rather change when the work is done to reduce the total latency in some cases. For example, if one task is blocked due to long REST API request latency, we can spend that time processing the results of any requests that have already completed.

The only work that needs to happen after all of the requests complete is the aggregation of the results. The work is now split between two functions, `process_response` and `aggregate_responses`, to allow executing each bit of work at the appropriate time.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**


**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
