### PR TITLE
connectors: keep schema in validation

### DIFF
--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -73,18 +73,40 @@ use crate::subgraph::spec::CONTEXT_DIRECTIVE_NAME;
 use crate::subgraph::spec::EXTERNAL_DIRECTIVE_NAME;
 use crate::subgraph::spec::FROM_CONTEXT_DIRECTIVE_NAME;
 
+// The result of a validation pass on a subgraph
+#[derive(Debug)]
+pub struct ValidationResult {
+    /// All validation errors encountered.
+    pub errors: Vec<Message>,
+
+    /// Whether or not the validated subgraph contained connector directives
+    pub has_connectors: bool,
+
+    /// The original subgraph name
+    pub subgraph_name: String,
+
+    /// The parsed (and potentially invalid) schema of the subgraph
+    pub schema: Schema,
+}
+
 /// Validate the connectors-related directives `@source` and `@connect`.
 ///
 /// This function attempts to collect as many validation errors as possible, so it does not bail
 /// out as soon as it encounters one.
-pub fn validate(source_text: &str, file_name: &str) -> Vec<Message> {
+pub fn validate(source_text: &str, file_name: &str) -> ValidationResult {
     // TODO: Use parse_and_validate (adding in directives as needed)
     // TODO: Handle schema errors rather than relying on JavaScript to catch it later
     let schema = Schema::parse(source_text, file_name)
         .unwrap_or_else(|schema_with_errors| schema_with_errors.partial);
     let connect_identity = ConnectSpec::identity();
     let Some((link, link_directive)) = Link::for_identity(&schema, &connect_identity) else {
-        return Vec::new(); // There are no connectors-related directives to validate
+        // There are no connectors-related directives to validate
+        return ValidationResult {
+            errors: Vec::new(),
+            has_connectors: false,
+            subgraph_name: file_name.to_string(),
+            schema,
+        };
     };
 
     let federation = Link::for_identity(&schema, &Identity::federation_identity());
@@ -181,7 +203,12 @@ pub fn validate(source_text: &str, file_name: &str) -> Vec<Message> {
         };
     }
 
-    messages
+    ValidationResult {
+        errors: messages,
+        has_connectors: true,
+        subgraph_name: file_name.to_string(),
+        schema,
+    }
 }
 
 fn advanced_validations(
@@ -470,7 +497,7 @@ fn find_all_resolvable_keys(schema: &Schema) -> Vec<(FieldSet, &Component<Direct
 
 type DirectiveName = Name;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Message {
     /// A unique, per-error code to allow consuming tools to take specific actions. These codes
     /// should not change once stabilized.
@@ -602,8 +629,8 @@ mod test_validate_source {
         insta::with_settings!({prepend_module_to_snapshot => false}, {
             glob!("test_data", "**/*.graphql", |path| {
                 let schema = read_to_string(path).unwrap();
-                let errors = validate(&schema, path.to_str().unwrap());
-                assert_snapshot!(format!("{:#?}", errors));
+                let result = validate(&schema, path.to_str().unwrap());
+                assert_snapshot!(format!("{:#?}", result.errors));
             });
         });
     }

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -82,9 +82,6 @@ pub struct ValidationResult {
     /// Whether or not the validated subgraph contained connector directives
     pub has_connectors: bool,
 
-    /// The original subgraph name
-    pub subgraph_name: String,
-
     /// The parsed (and potentially invalid) schema of the subgraph
     pub schema: Schema,
 }
@@ -104,7 +101,6 @@ pub fn validate(source_text: &str, file_name: &str) -> ValidationResult {
         return ValidationResult {
             errors: Vec::new(),
             has_connectors: false,
-            subgraph_name: file_name.to_string(),
             schema,
         };
     };
@@ -206,7 +202,6 @@ pub fn validate(source_text: &str, file_name: &str) -> ValidationResult {
     ValidationResult {
         errors: messages,
         has_connectors: true,
-        subgraph_name: file_name.to_string(),
         schema,
     }
 }


### PR DESCRIPTION
This commit modifies the result of connector-related validation to add some metadata around connector-enabled subgraphs and to keep the parsed schema so that downstream consumers can leverage the schema if needed when performing additional validation.

A follow-up PR to those downstream consumers to use this new format is pending.

<!-- [CNN-321] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-321]: https://apollographql.atlassian.net/browse/CNN-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ