### PR TITLE
Make `->` method registration more flexible and type-safe

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/apply_to.rs
+++ b/apollo-federation/src/sources/connect/json_selection/apply_to.rs
@@ -15,7 +15,7 @@ use super::lit_expr::LitExpr;
 use super::location::OffsetRange;
 use super::location::Ranged;
 use super::location::WithRange;
-use super::methods::lookup_arrow_method;
+use super::methods::ArrowMethod;
 use super::parser::*;
 
 pub(super) type VarsWithPathsMap<'a> = IndexMap<KnownVariable, (&'a JSON, InputPath<JSON>)>;
@@ -427,8 +427,8 @@ impl ApplyToInternal for WithRange<PathList> {
                 let method_path =
                     input_path.append(JSON::String(format!("->{}", method_name.as_ref()).into()));
 
-                if let Some(method) = lookup_arrow_method(method_name) {
-                    method(
+                if let Some(method) = ArrowMethod::lookup(method_name) {
+                    method.apply(
                         method_name,
                         method_args.as_ref(),
                         data,

--- a/apollo-federation/src/sources/connect/json_selection/methods.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods.rs
@@ -53,10 +53,10 @@ pub(super) enum ArrowMethod {
 
 #[macro_export]
 macro_rules! impl_arrow_method {
-    ($struct_name:ident, $trait_name:ident, $impl_fn_name:ident) => {
+    ($struct_name:ident, $impl_fn_name:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub(super) struct $struct_name;
-        impl $trait_name for $struct_name {
+        impl $crate::sources::connect::json_selection::methods::ArrowMethodImpl for $struct_name {
             fn apply(
                 &self,
                 method_name: &WithRange<String>,

--- a/apollo-federation/src/sources/connect/json_selection/methods/future.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future.rs
@@ -5,6 +5,7 @@
 use serde_json::Number;
 use serde_json_bytes::Value as JSON;
 
+use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::helpers::json_type_name;
 use crate::sources::connect::json_selection::helpers::vec_push;
@@ -13,13 +14,15 @@ use crate::sources::connect::json_selection::lit_expr::LitExpr;
 use crate::sources::connect::json_selection::location::merge_ranges;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
+use crate::sources::connect::json_selection::methods::ArrowMethodImpl;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
 use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 
-pub(super) fn typeof_method(
+impl_arrow_method!(TypeOfMethod, ArrowMethodImpl, typeof_method);
+fn typeof_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -45,7 +48,8 @@ pub(super) fn typeof_method(
     }
 }
 
-pub(super) fn eq_method(
+impl_arrow_method!(EqMethod, ArrowMethodImpl, eq_method);
+fn eq_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -79,12 +83,12 @@ pub(super) fn eq_method(
     )
 }
 
-// Like ->match, but expects the first element of each pair
-// to evaluate to a boolean, returning the second element of
-// the first pair whose first element is true. This makes
-// providing a final catch-all case easy, since the last
+// Like ->match, but expects the first element of each pair to evaluate to a
+// boolean, returning the second element of the first pair whose first element
+// is true. This makes providing a final catch-all case easy, since the last
 // pair can be [true, <default>].
-pub(super) fn match_if_method(
+impl_arrow_method!(MatchIfMethod, ArrowMethodImpl, match_if_method);
+fn match_if_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -234,8 +238,9 @@ infix_math_op!(div_op, /);
 infix_math_op!(rem_op, %);
 
 macro_rules! infix_math_method {
-    ($name:ident, $op:ident) => {
-        pub(super) fn $name(
+    ($struct_name:ident, $fn_name:ident, $op:ident) => {
+        impl_arrow_method!($struct_name, ArrowMethodImpl, $fn_name);
+        fn $fn_name(
             method_name: &WithRange<String>,
             method_args: Option<&MethodArgs>,
             data: &JSON,
@@ -248,13 +253,14 @@ macro_rules! infix_math_method {
         }
     };
 }
-infix_math_method!(add_method, add_op);
-infix_math_method!(sub_method, sub_op);
-infix_math_method!(mul_method, mul_op);
-infix_math_method!(div_method, div_op);
-infix_math_method!(mod_method, rem_op);
+infix_math_method!(AddMethod, add_method, add_op);
+infix_math_method!(SubMethod, sub_method, sub_op);
+infix_math_method!(MulMethod, mul_method, mul_op);
+infix_math_method!(DivMethod, div_method, div_op);
+infix_math_method!(ModMethod, mod_method, rem_op);
 
-pub(super) fn has_method(
+impl_arrow_method!(HasMethod, ArrowMethodImpl, has_method);
+fn has_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -348,9 +354,8 @@ pub(super) fn has_method(
     }
 }
 
-// Returns the array or string element at the given index, as Option<JSON>. If
-// the index is out of bounds, returns None and reports an error.
-pub(super) fn get_method(
+impl_arrow_method!(GetMethod, ArrowMethodImpl, get_method);
+fn get_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -547,7 +552,8 @@ pub(super) fn get_method(
     }
 }
 
-pub(super) fn keys_method(
+impl_arrow_method!(KeysMethod, ArrowMethodImpl, keys_method);
+fn keys_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -589,7 +595,8 @@ pub(super) fn keys_method(
     }
 }
 
-pub(super) fn values_method(
+impl_arrow_method!(ValuesMethod, ArrowMethodImpl, values_method);
+fn values_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -631,7 +638,8 @@ pub(super) fn values_method(
     }
 }
 
-pub(super) fn not_method(
+impl_arrow_method!(NotMethod, ArrowMethodImpl, not_method);
+fn not_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -666,7 +674,8 @@ fn is_truthy(data: &JSON) -> bool {
     }
 }
 
-pub(super) fn or_method(
+impl_arrow_method!(OrMethod, ArrowMethodImpl, or_method);
+fn or_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -701,7 +710,8 @@ pub(super) fn or_method(
     }
 }
 
-pub(super) fn and_method(
+impl_arrow_method!(AndMethod, ArrowMethodImpl, and_method);
+fn and_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,

--- a/apollo-federation/src/sources/connect/json_selection/methods/future.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future.rs
@@ -14,14 +14,13 @@ use crate::sources::connect::json_selection::lit_expr::LitExpr;
 use crate::sources::connect::json_selection::location::merge_ranges;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
-use crate::sources::connect::json_selection::methods::ArrowMethodImpl;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
 use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 
-impl_arrow_method!(TypeOfMethod, ArrowMethodImpl, typeof_method);
+impl_arrow_method!(TypeOfMethod, typeof_method);
 fn typeof_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -48,7 +47,7 @@ fn typeof_method(
     }
 }
 
-impl_arrow_method!(EqMethod, ArrowMethodImpl, eq_method);
+impl_arrow_method!(EqMethod, eq_method);
 fn eq_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -87,7 +86,7 @@ fn eq_method(
 // boolean, returning the second element of the first pair whose first element
 // is true. This makes providing a final catch-all case easy, since the last
 // pair can be [true, <default>].
-impl_arrow_method!(MatchIfMethod, ArrowMethodImpl, match_if_method);
+impl_arrow_method!(MatchIfMethod, match_if_method);
 fn match_if_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -239,7 +238,7 @@ infix_math_op!(rem_op, %);
 
 macro_rules! infix_math_method {
     ($struct_name:ident, $fn_name:ident, $op:ident) => {
-        impl_arrow_method!($struct_name, ArrowMethodImpl, $fn_name);
+        impl_arrow_method!($struct_name, $fn_name);
         fn $fn_name(
             method_name: &WithRange<String>,
             method_args: Option<&MethodArgs>,
@@ -259,7 +258,7 @@ infix_math_method!(MulMethod, mul_method, mul_op);
 infix_math_method!(DivMethod, div_method, div_op);
 infix_math_method!(ModMethod, mod_method, rem_op);
 
-impl_arrow_method!(HasMethod, ArrowMethodImpl, has_method);
+impl_arrow_method!(HasMethod, has_method);
 fn has_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -354,7 +353,7 @@ fn has_method(
     }
 }
 
-impl_arrow_method!(GetMethod, ArrowMethodImpl, get_method);
+impl_arrow_method!(GetMethod, get_method);
 fn get_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -552,7 +551,7 @@ fn get_method(
     }
 }
 
-impl_arrow_method!(KeysMethod, ArrowMethodImpl, keys_method);
+impl_arrow_method!(KeysMethod, keys_method);
 fn keys_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -595,7 +594,7 @@ fn keys_method(
     }
 }
 
-impl_arrow_method!(ValuesMethod, ArrowMethodImpl, values_method);
+impl_arrow_method!(ValuesMethod, values_method);
 fn values_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -638,7 +637,7 @@ fn values_method(
     }
 }
 
-impl_arrow_method!(NotMethod, ArrowMethodImpl, not_method);
+impl_arrow_method!(NotMethod, not_method);
 fn not_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -674,7 +673,7 @@ fn is_truthy(data: &JSON) -> bool {
     }
 }
 
-impl_arrow_method!(OrMethod, ArrowMethodImpl, or_method);
+impl_arrow_method!(OrMethod, or_method);
 fn or_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -710,7 +709,7 @@ fn or_method(
     }
 }
 
-impl_arrow_method!(AndMethod, ArrowMethodImpl, and_method);
+impl_arrow_method!(AndMethod, and_method);
 fn and_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,

--- a/apollo-federation/src/sources/connect/json_selection/methods/public.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public.rs
@@ -11,14 +11,13 @@ use crate::sources::connect::json_selection::lit_expr::LitExpr;
 use crate::sources::connect::json_selection::location::merge_ranges;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
-use crate::sources::connect::json_selection::methods::ArrowMethodImpl;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
 use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 
-impl_arrow_method!(EchoMethod, ArrowMethodImpl, echo_method);
+impl_arrow_method!(EchoMethod, echo_method);
 fn echo_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -44,7 +43,7 @@ fn echo_method(
     )
 }
 
-impl_arrow_method!(MapMethod, ArrowMethodImpl, map_method);
+impl_arrow_method!(MapMethod, map_method);
 fn map_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -101,7 +100,7 @@ fn map_method(
     )
 }
 
-impl_arrow_method!(MatchMethod, ArrowMethodImpl, match_method);
+impl_arrow_method!(MatchMethod, match_method);
 fn match_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -158,7 +157,7 @@ fn match_method(
     )
 }
 
-impl_arrow_method!(FirstMethod, ArrowMethodImpl, first_method);
+impl_arrow_method!(FirstMethod, first_method);
 fn first_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -202,7 +201,7 @@ fn first_method(
     }
 }
 
-impl_arrow_method!(LastMethod, ArrowMethodImpl, last_method);
+impl_arrow_method!(LastMethod, last_method);
 fn last_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -246,7 +245,7 @@ fn last_method(
     }
 }
 
-impl_arrow_method!(SliceMethod, ArrowMethodImpl, slice_method);
+impl_arrow_method!(SliceMethod, slice_method);
 fn slice_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -337,7 +336,7 @@ fn slice_method(
     }
 }
 
-impl_arrow_method!(SizeMethod, ArrowMethodImpl, size_method);
+impl_arrow_method!(SizeMethod, size_method);
 fn size_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
@@ -390,7 +389,7 @@ fn size_method(
     }
 }
 
-impl_arrow_method!(EntriesMethod, ArrowMethodImpl, entries_method);
+impl_arrow_method!(EntriesMethod, entries_method);
 fn entries_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,

--- a/apollo-federation/src/sources/connect/json_selection/methods/public.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public.rs
@@ -2,6 +2,7 @@ use serde_json_bytes::ByteString;
 use serde_json_bytes::Map as JSONMap;
 use serde_json_bytes::Value as JSON;
 
+use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::helpers::json_type_name;
 use crate::sources::connect::json_selection::helpers::vec_push;
@@ -10,13 +11,15 @@ use crate::sources::connect::json_selection::lit_expr::LitExpr;
 use crate::sources::connect::json_selection::location::merge_ranges;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
+use crate::sources::connect::json_selection::methods::ArrowMethodImpl;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
 use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 
-pub(super) fn echo_method(
+impl_arrow_method!(EchoMethod, ArrowMethodImpl, echo_method);
+fn echo_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -41,7 +44,8 @@ pub(super) fn echo_method(
     )
 }
 
-pub(super) fn map_method(
+impl_arrow_method!(MapMethod, ArrowMethodImpl, map_method);
+fn map_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -72,33 +76,33 @@ pub(super) fn map_method(
                     output.push(JSON::Null);
                 }
 
-                (Some(JSON::Array(output)), errors)
+                return (Some(JSON::Array(output)), errors);
             } else {
-                first_arg.apply_to_path(data, vars, input_path)
+                return first_arg.apply_to_path(data, vars, input_path);
             }
         } else {
-            (
+            return (
                 None,
                 vec![ApplyToError::new(
                     format!("Method ->{} requires one argument", method_name.as_ref()),
                     input_path.to_vec(),
                     method_name.range(),
                 )],
-            )
+            );
         }
-    } else {
-        (
-            None,
-            vec![ApplyToError::new(
-                format!("Method ->{} requires one argument", method_name.as_ref()),
-                input_path.to_vec(),
-                method_name.range(),
-            )],
-        )
     }
+    (
+        None,
+        vec![ApplyToError::new(
+            format!("Method ->{} requires one argument", method_name.as_ref()),
+            input_path.to_vec(),
+            method_name.range(),
+        )],
+    )
 }
 
-pub(super) fn match_method(
+impl_arrow_method!(MatchMethod, ArrowMethodImpl, match_method);
+fn match_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -154,7 +158,8 @@ pub(super) fn match_method(
     )
 }
 
-pub(super) fn first_method(
+impl_arrow_method!(FirstMethod, ArrowMethodImpl, first_method);
+fn first_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -197,7 +202,8 @@ pub(super) fn first_method(
     }
 }
 
-pub(super) fn last_method(
+impl_arrow_method!(LastMethod, ArrowMethodImpl, last_method);
+fn last_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -240,7 +246,8 @@ pub(super) fn last_method(
     }
 }
 
-pub(super) fn slice_method(
+impl_arrow_method!(SliceMethod, ArrowMethodImpl, slice_method);
+fn slice_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -330,7 +337,8 @@ pub(super) fn slice_method(
     }
 }
 
-pub(super) fn size_method(
+impl_arrow_method!(SizeMethod, ArrowMethodImpl, size_method);
+fn size_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
@@ -382,11 +390,8 @@ pub(super) fn size_method(
     }
 }
 
-// Returns a list of [{ key, value }, ...] objects for each key-value pair in
-// the object. Returning a list of [[ key, value ], ...] pairs might also seem
-// like an option, but GraphQL doesn't handle heterogeneous lists (or tuples) as
-// well as it handles objects with named properties like { key, value }.
-pub(super) fn entries_method(
+impl_arrow_method!(EntriesMethod, ArrowMethodImpl, entries_method);
+fn entries_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,


### PR DESCRIPTION
Previously, `->` methods (#5762) were implemented as functions and registered in a `lazy_static!` map for dynamic lookup at runtime.

This PR refactors the system for registering methods, so there is now an `ArrowMethod` enum with a variant for each known method, and each method is now represented by a struct type that has an `::apply` method, whose signature resembles the previous function implementations.

In the future, we can add other methods to these structs, so `->` methods can programmatically define their interactions with the output shape of the JSONSelection, for example.