### PR TITLE
[JSONSelection] Support variadic `$(...)` function

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/apply_to.rs
+++ b/apollo-federation/src/sources/connect/json_selection/apply_to.rs
@@ -420,9 +420,39 @@ impl ApplyToInternal for WithRange<PathList> {
                     )
                 }
             }
-            PathList::Expr(expr, tail) => expr
-                .apply_to_path(data, vars, input_path)
-                .and_then_collecting_errors(|value| tail.apply_to_path(value, vars, input_path)),
+
+            PathList::Expr(expr_seq, tail) => {
+                // In case none of the expressions in expr_seq successfully
+                // evaluate to a JSON value, we'll want to see all the errors
+                // that could be responsible for that failure. If any expression
+                // succeeds, all_errors will be ignored.
+                let mut all_errors = Vec::new();
+
+                for expr in expr_seq.as_ref() {
+                    let (expr_value, expr_errors) = expr.apply_to_path(data, vars, input_path);
+                    if let Some(value) = expr_value {
+                        // If any expression evaluates to Some(JSON), apply the
+                        // tail to that value and return errors pertaining only
+                        // to this specific expression or its tail, ignoring any
+                        // errors previously added to all_errors.
+                        return tail
+                            .apply_to_path(&value, vars, input_path)
+                            .prepend_errors(expr_errors);
+                    }
+                    // As long as the expressions keep evaluating to None, keep
+                    // accumulating errors in all_errors.
+                    all_errors.extend(expr_errors);
+                }
+
+                all_errors.push(ApplyToError::new(
+                    "No $(...) expression evaluated successfully".to_string(),
+                    input_path.to_vec(),
+                    expr_seq.range(),
+                ));
+
+                (None, all_errors)
+            }
+
             PathList::Method(method_name, method_args, tail) => {
                 let method_path =
                     input_path.append(JSON::String(format!("->{}", method_name.as_ref()).into()));
@@ -1445,6 +1475,184 @@ mod tests {
                 })),
                 vec![],
             ),
+        );
+    }
+
+    #[test]
+    fn test_variadic_expression_selection() {
+        assert_eq!(
+            selection!("id nameOrTitle: $($.name, $.title)").apply_to(&json!({
+                "id": 123,
+                "name": "Ben",
+                "title": "Developer",
+            })),
+            (
+                Some(json!({
+                    "id": 123,
+                    "nameOrTitle": "Ben",
+                })),
+                vec![],
+            ),
+        );
+
+        assert_eq!(
+            selection!("id titleOrName: $(maybe.title, maybe.name)").apply_to(&json!({
+                "id": 123,
+                "maybe": {
+                    "name": "Ben",
+                    "title": "Developer",
+                },
+            })),
+            (
+                Some(json!({
+                    "id": 123,
+                    "titleOrName": "Developer",
+                })),
+                vec![],
+            ),
+        );
+
+        assert_eq!(
+            selection!(
+                r#"
+            nameOrTitle: product->echo($(@.name, @.title, null))
+            "#
+            )
+            .apply_to(&json!({
+                "product": {
+                    "isbn": "9780593734223",
+                    "author": "Yuval Noah Harari",
+                },
+            })),
+            (
+                Some(json!({
+                    "nameOrTitle": null,
+                })),
+                vec![],
+            ),
+        );
+
+        assert_eq!(
+            selection!(
+                r#"
+            nameOrTitle: product->echo($(@.name, @.title, null))
+            "#
+            )
+            .apply_to(&json!({
+                "product": {
+                    "isbn": "9780593734223",
+                    "author": "Yuval Noah Harari",
+                    "title": "Nexus",
+                },
+            })),
+            (
+                Some(json!({
+                    "nameOrTitle": "Nexus",
+                })),
+                vec![],
+            ),
+        );
+
+        assert_eq!(
+            selection!("$(people->first, 'nobody')").apply_to(&json!({
+                "people": [],
+            })),
+            (Some(json!("nobody")), vec![]),
+        );
+
+        assert_eq!(
+            selection!("$(people->first, 'nobody')").apply_to(&json!({
+                "people": [{ "name": "Ben" }],
+            })),
+            (Some(json!({ "name": "Ben" })), vec![]),
+        );
+
+        assert_eq!(
+            selection!("$($($.people, $.folks)->first, 'missing')").apply_to(&json!({
+                "folks": ["Alice", "Bob"],
+            })),
+            (Some(json!("Alice")), vec![]),
+        );
+
+        assert_eq!(
+            selection!("$($($.people, $.folks)->first, 'missing')").apply_to(&json!({
+                "dinosaurs": ["Allosaurus", "Brachiosaurus"],
+            })),
+            (Some(json!("missing")), vec![]),
+        );
+
+        assert_eq!(
+            selection!("$($.people, $.folks)->first").apply_to(&json!({
+                "dinosaurs": ["Allosaurus", "Brachiosaurus"],
+            })),
+            (
+                None,
+                vec![
+                    ApplyToError::new(
+                        "Property .people not found in object".to_string(),
+                        vec![json!("people")],
+                        Some(4..10),
+                    ),
+                    ApplyToError::new(
+                        "Property .folks not found in object".to_string(),
+                        vec![json!("folks")],
+                        Some(14..19),
+                    ),
+                    ApplyToError::new(
+                        "No $(...) expression evaluated successfully".to_string(),
+                        vec![],
+                        Some(0..20),
+                    ),
+                ],
+            ),
+        );
+
+        assert_eq!(
+            selection!("$($($.people, $.folks)->first)").apply_to(&json!({
+                "dinosaurs": ["Allosaurus", "Brachiosaurus"],
+            })),
+            (
+                None,
+                vec![
+                    ApplyToError::new(
+                        "Property .people not found in object".to_string(),
+                        vec![json!("people")],
+                        Some(6..12),
+                    ),
+                    ApplyToError::new(
+                        "Property .folks not found in object".to_string(),
+                        vec![json!("folks")],
+                        Some(16..21),
+                    ),
+                    ApplyToError::new(
+                        "No $(...) expression evaluated successfully".to_string(),
+                        vec![],
+                        Some(2..22),
+                    ),
+                    ApplyToError::new(
+                        "No $(...) expression evaluated successfully".to_string(),
+                        vec![],
+                        Some(0..30),
+                    ),
+                ],
+            ),
+        );
+
+        assert_eq!(
+            selection!(
+                r#"
+            $(
+                $("unexpected")->match(
+                    ["hi", "hello"],
+                    ["greetings", "salutations"],
+                    # No default [@, "whatever"] case
+                ),
+                "default",
+            )
+            "#
+            )
+            .apply_to(&json!(null)),
+            (Some(json!("default")), vec![],),
         );
     }
 

--- a/apollo-federation/src/sources/connect/json_selection/grammar/ExprPath.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/ExprPath.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="363" height="71">
+<svg xmlns="http://www.w3.org/2000/svg" width="487" height="113">
    <defs>
       <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -29,40 +29,56 @@
     polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
   </style>
    </defs>
-   <polygon points="9 51 1 47 1 55"/>
-   <polygon points="17 51 9 47 9 55"/>
-   <rect x="31" y="37" width="36" height="32" rx="10"/>
+   <polygon points="9 61 1 57 1 65"/>
+   <polygon points="17 61 9 57 9 65"/>
+   <rect x="31" y="47" width="36" height="32" rx="10"/>
    <rect x="29"
-         y="35"
+         y="45"
          width="36"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="55">$(</text>
+   <text class="terminal" x="39" y="65">$(</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#LitExpr"
       xlink:title="LitExpr">
-      <rect x="87" y="37" width="64" height="32"/>
-      <rect x="85" y="35" width="64" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="95" y="55">LitExpr</text>
+      <rect x="107" y="47" width="64" height="32"/>
+      <rect x="105" y="45" width="64" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="115" y="65">LitExpr</text>
    </a>
-   <rect x="171" y="37" width="26" height="32" rx="10"/>
-   <rect x="169"
-         y="35"
+   <rect x="107" y="3" width="24" height="32" rx="10"/>
+   <rect x="105"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="115" y="21">,</text>
+   <rect x="231" y="79" width="24" height="32" rx="10"/>
+   <rect x="229"
+         y="77"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="239" y="97">,</text>
+   <rect x="295" y="47" width="26" height="32" rx="10"/>
+   <rect x="293"
+         y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="179" y="55">)</text>
+   <text class="terminal" x="303" y="65">)</text>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#PathStep"
       xlink:title="PathStep">
-      <rect x="237" y="3" width="78" height="32"/>
-      <rect x="235" y="1" width="78" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="245" y="21">PathStep</text>
+      <rect x="361" y="13" width="78" height="32"/>
+      <rect x="359" y="11" width="78" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="369" y="31">PathStep</text>
    </a>
    <path class="line"
-         d="m17 51 h2 m0 0 h10 m36 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h88 m-118 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m98 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-98 0 h10 m78 0 h10 m23 34 h-3"/>
-   <polygon points="353 51 361 47 361 55"/>
-   <polygon points="353 51 345 47 345 55"/>
+         d="m17 61 h2 m0 0 h10 m36 0 h10 m20 0 h10 m64 0 h10 m-104 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m84 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-84 0 h10 m24 0 h10 m0 0 h40 m40 44 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m0 0 h88 m-118 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m98 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-98 0 h10 m78 0 h10 m23 34 h-3"/>
+   <polygon points="477 61 485 57 485 65"/>
+   <polygon points="477 61 469 57 469 65"/>
 </svg>

--- a/apollo-federation/src/sources/connect/json_selection/location.rs
+++ b/apollo-federation/src/sources/connect/json_selection/location.rs
@@ -205,8 +205,13 @@ pub(crate) mod strip_ranges {
                     PathList::Key(key, rest) => {
                         PathList::Key(key.strip_ranges(), rest.strip_ranges())
                     }
-                    PathList::Expr(expr, rest) => {
-                        PathList::Expr(expr.strip_ranges(), rest.strip_ranges())
+                    PathList::Expr(expr_seq, rest) => {
+                        let stripped_expr_seq = expr_seq
+                            .as_ref()
+                            .iter()
+                            .map(|expr| expr.strip_ranges())
+                            .collect();
+                        PathList::Expr(WithRange::new(stripped_expr_seq, None), rest.strip_ranges())
                     }
                     PathList::Method(method, opt_args, rest) => PathList::Method(
                         method.strip_ranges(),

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -123,13 +123,18 @@ impl PrettyPrintable for PathList {
                 result.push_str(key.dotted().as_str());
                 result.push_str(rest.as_str());
             }
-            Self::Expr(expr, tail) => {
+            Self::Expr(expr_seq, tail) => {
                 let rest = tail.pretty_print_with_indentation(true, indentation);
                 result.push_str("$(");
-                result.push_str(
-                    expr.pretty_print_with_indentation(true, indentation)
-                        .as_str(),
-                );
+                for (i, expr) in expr_seq.as_ref().iter().enumerate() {
+                    if i > 0 {
+                        result.push_str(", ");
+                    }
+                    result.push_str(
+                        expr.pretty_print_with_indentation(true, indentation)
+                            .as_str(),
+                    );
+                }
                 result.push(')');
                 result.push_str(rest.as_str());
             }
@@ -382,6 +387,8 @@ mod tests {
             "$(12345678987654321)->div(111111111)->eq(111111111)",
             "$(\"Product\")->slice(0, $(4)->mul(-1))->eq(\"Pro\")",
             "$($args.unnecessary.parens)->eq(42)",
+            "$(maybe.one, $(maybe.two, $(maybe.three, maybe.four)), null)",
+            "$(maybe.this, maybe.that, maybe.another)->eq(42)",
         ];
         for path in paths {
             let (unmatched, path_selection) = PathSelection::parse(new_span(path)).unwrap();

--- a/apollo-federation/src/sources/connect/json_selection/selection_set.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_set.rs
@@ -59,7 +59,7 @@ impl SubSelection {
 
         // When the operation contains __typename, it might be used to complete
         // an entity reference (e.g. `__typename id`) for a subsequent fetch.
-        // This encodes the typename selection as `__typename: $->echo("Product")`
+        // This encodes the typename selection as `__typename: $("Product")`.
         //
         // TODO: this must change before we support interfaces and unions
         // because it will emit the abstract type's name which is invalid.

--- a/apollo-federation/src/sources/connect/json_selection/selection_set.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_set.rs
@@ -23,11 +23,9 @@ use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Node;
 use multimap::MultiMap;
 
-use super::known_var::KnownVariable;
 use super::lit_expr::LitExpr;
 use super::location::Ranged;
 use super::location::WithRange;
-use super::parser::MethodArgs;
 use super::parser::PathList;
 use crate::sources::connect::json_selection::Alias;
 use crate::sources::connect::json_selection::NamedSelection;
@@ -70,22 +68,15 @@ impl SubSelection {
                 Some(Alias::new("__typename")),
                 PathSelection {
                     path: WithRange::new(
-                        PathList::Var(
-                            WithRange::new(KnownVariable::Dollar, None),
+                        PathList::Expr(
                             WithRange::new(
-                                PathList::Method(
-                                    WithRange::new("echo".to_string(), None),
-                                    Some(MethodArgs {
-                                        args: vec![WithRange::new(
-                                            LitExpr::String(selection_set.ty.to_string()),
-                                            None,
-                                        )],
-                                        ..Default::default()
-                                    }),
-                                    WithRange::new(PathList::Empty, None),
-                                ),
+                                vec![WithRange::new(
+                                    LitExpr::String(selection_set.ty.to_string()),
+                                    None,
+                                )],
                                 None,
                             ),
+                            WithRange::new(PathList::Empty, None),
                         ),
                         None,
                     ),
@@ -568,10 +559,10 @@ mod tests {
         assert_eq!(
             transformed.to_string(),
             r###"$.result {
-  __typename: $->echo("T")
+  __typename: $("T")
   id
   author: {
-    __typename: $->echo("A")
+    __typename: $("A")
     id: authorId
   }
 }"###
@@ -648,11 +639,11 @@ mod tests {
             r###"reviews: result {
   id
   product: {
-    __typename: $->echo("Product")
+    __typename: $("Product")
     upc: product_upc
   }
   author: {
-    __typename: $->echo("User")
+    __typename: $("User")
     id: author_id
   }
 }"###

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__expr_path_selections.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__expr_path_selections.snap
@@ -49,11 +49,18 @@ Named(
                                                             path: WithRange {
                                                                 node: Expr(
                                                                     WithRange {
-                                                                        node: Number(
-                                                                            Number(-1),
-                                                                        ),
+                                                                        node: [
+                                                                            WithRange {
+                                                                                node: Number(
+                                                                                    Number(-1),
+                                                                                ),
+                                                                                range: Some(
+                                                                                    32..35,
+                                                                                ),
+                                                                            },
+                                                                        ],
                                                                         range: Some(
-                                                                            32..35,
+                                                                            29..37,
                                                                         ),
                                                                     },
                                                                     WithRange {

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-7.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-7.snap
@@ -85,11 +85,18 @@ Ok(
                                                         path: WithRange {
                                                             node: Expr(
                                                                 WithRange {
-                                                                    node: String(
-                                                                        "Args",
-                                                                    ),
+                                                                    node: [
+                                                                        WithRange {
+                                                                            node: String(
+                                                                                "Args",
+                                                                            ),
+                                                                            range: Some(
+                                                                                118..124,
+                                                                            ),
+                                                                        },
+                                                                    ],
                                                                     range: Some(
-                                                                        118..124,
+                                                                        116..125,
                                                                     ),
                                                                 },
                                                                 WithRange {

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -1160,35 +1160,20 @@ mod tests {
                                 ),
                                 PathSelection {
                                     path: WithRange {
-                                        node: Var(
+                                        node: Expr(
                                             WithRange {
-                                                node: $,
+                                                node: [
+                                                    WithRange {
+                                                        node: String(
+                                                            "_Entity",
+                                                        ),
+                                                        range: None,
+                                                    },
+                                                ],
                                                 range: None,
                                             },
                                             WithRange {
-                                                node: Method(
-                                                    WithRange {
-                                                        node: "echo",
-                                                        range: None,
-                                                    },
-                                                    Some(
-                                                        MethodArgs {
-                                                            args: [
-                                                                WithRange {
-                                                                    node: String(
-                                                                        "_Entity",
-                                                                    ),
-                                                                    range: None,
-                                                                },
-                                                            ],
-                                                            range: None,
-                                                        },
-                                                    ),
-                                                    WithRange {
-                                                        node: Empty,
-                                                        range: None,
-                                                    },
-                                                ),
+                                                node: Empty,
                                                 range: None,
                                             },
                                         ),
@@ -1267,35 +1252,20 @@ mod tests {
                                 ),
                                 PathSelection {
                                     path: WithRange {
-                                        node: Var(
+                                        node: Expr(
                                             WithRange {
-                                                node: $,
+                                                node: [
+                                                    WithRange {
+                                                        node: String(
+                                                            "_Entity",
+                                                        ),
+                                                        range: None,
+                                                    },
+                                                ],
                                                 range: None,
                                             },
                                             WithRange {
-                                                node: Method(
-                                                    WithRange {
-                                                        node: "echo",
-                                                        range: None,
-                                                    },
-                                                    Some(
-                                                        MethodArgs {
-                                                            args: [
-                                                                WithRange {
-                                                                    node: String(
-                                                                        "_Entity",
-                                                                    ),
-                                                                    range: None,
-                                                                },
-                                                            ],
-                                                            range: None,
-                                                        },
-                                                    ),
-                                                    WithRange {
-                                                        node: Empty,
-                                                        range: None,
-                                                    },
-                                                ),
+                                                node: Empty,
                                                 range: None,
                                             },
                                         ),
@@ -1476,35 +1446,20 @@ mod tests {
                                 ),
                                 PathSelection {
                                     path: WithRange {
-                                        node: Var(
+                                        node: Expr(
                                             WithRange {
-                                                node: $,
+                                                node: [
+                                                    WithRange {
+                                                        node: String(
+                                                            "_Entity",
+                                                        ),
+                                                        range: None,
+                                                    },
+                                                ],
                                                 range: None,
                                             },
                                             WithRange {
-                                                node: Method(
-                                                    WithRange {
-                                                        node: "echo",
-                                                        range: None,
-                                                    },
-                                                    Some(
-                                                        MethodArgs {
-                                                            args: [
-                                                                WithRange {
-                                                                    node: String(
-                                                                        "_Entity",
-                                                                    ),
-                                                                    range: None,
-                                                                },
-                                                            ],
-                                                            range: None,
-                                                        },
-                                                    ),
-                                                    WithRange {
-                                                        node: Empty,
-                                                        range: None,
-                                                    },
-                                                ),
+                                                node: Empty,
                                                 range: None,
                                             },
                                         ),
@@ -1583,35 +1538,20 @@ mod tests {
                                 ),
                                 PathSelection {
                                     path: WithRange {
-                                        node: Var(
+                                        node: Expr(
                                             WithRange {
-                                                node: $,
+                                                node: [
+                                                    WithRange {
+                                                        node: String(
+                                                            "_Entity",
+                                                        ),
+                                                        range: None,
+                                                    },
+                                                ],
                                                 range: None,
                                             },
                                             WithRange {
-                                                node: Method(
-                                                    WithRange {
-                                                        node: "echo",
-                                                        range: None,
-                                                    },
-                                                    Some(
-                                                        MethodArgs {
-                                                            args: [
-                                                                WithRange {
-                                                                    node: String(
-                                                                        "_Entity",
-                                                                    ),
-                                                                    range: None,
-                                                                },
-                                                            ],
-                                                            range: None,
-                                                        },
-                                                    ),
-                                                    WithRange {
-                                                        node: Empty,
-                                                        range: None,
-                                                    },
-                                                ),
+                                                node: Empty,
                                                 range: None,
                                             },
                                         ),


### PR DESCRIPTION
When it takes a single argument, the `$(...)` function (aka [`ExprPath` syntax](https://github.com/apollographql/router/blob/909e897200c0f2ccf9187aa6c861b6a14fa42aa3/apollo-federation/src/sources/connect/json_selection/README.md#exprpath-), introduced in #5994), is useful for embedding literal values into selection syntax.

This PR generalizes the `$(...)` function to take one or more arguments, where the first argument that evaluates to `Some(JSON)` instead of `None` is returned, allowing default expressions like `$(possiblyEmptyList->first, {})` or `$($args.possibly.missing, null)`. A benefit of this syntax is that it's insensitive to whether the first expression failed because `$args.possibly` was missing or because `$args.possibly.missing` was missing. The whole expression evaluated (in the `apply_to_path` sense) to `None`, for whatever reason, so the `$(...)` function moves on to the next option.

Passing more than two arguments is also possible, as in `$(maybe.this, maybe.that, false)`.

Like many `->` functions, the `$(...)` syntax evaluates its arguments lazily, so any arguments passed _after_ the one returned will remain fully unevaluated. This makes it possible to use a (hypothetical) `->withError(message)` method to report errors only when an expression is evaluated:
```graphql
$(possiblyEmptyList->first, $(null)->withError("list was empty"))
```

It may also be worth noting that methods like `->match` can evaluate to `None` if they do not have an infallible `[@, ...]` catch-all case, or if the matched value expression evaluates to `None`. In principle, you could use the `$(...)` function to provide a catch-all default, like so:
```graphql
$(kind->match(
  ["book", "Book"],
  ["movie", "Film"],
), "Product")
```
The `->match` method will normally produce a runtime `ApplyToError` when it exhausts all its cases, but the `$(...)` function hides those errors as long as one of its options evaluates to `Some(JSON)`. If they all fail (i.e. evaluate to `None`), then all the original runtime `ApplyToError`s will be returned.