### PR TITLE
disable insecure ws semgrep signature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1228,3 +1228,4 @@ workflows:
             - secops-oidc
             - github-orb
           git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+          disabled-signatures: "rules.providers.semgrep.security.javascript.lang.security.detect-insecure-websocket"


### PR DESCRIPTION
Updated the configuration of the `semgrep` CI scan job to exclude a rule that is working to detect usage of insecure websockets. In general this is a good test, but Router runs a series of tests (like [here](https://github.com/apollographql/router/blob/31e73671f542ff987c1351c1748c91c4817349d1/apollo-router/src/protocols/websocket.rs#L958)) using `ws://` instead of `wss://` which is causing CI checks to fail unnecessarily. 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1] - N/A - not changing Router source
- [x] Documentation[^2] completed - N/A - not changing Router source
- [x] Performance impact assessed and acceptable - N/A - not changing Router source
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

N/A

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
