### PR TITLE
Added ability to configure timeout on JWKS endpoints instead of always being 15 seconds

### DIFF
--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -156,6 +156,13 @@ struct JwksConf {
     )]
     #[schemars(with = "String", default = "default_poll_interval")]
     poll_interval: Duration,
+    /// Timeout for each JWKS endpoint in human-readable format; defaults to 15s
+    #[serde(
+        deserialize_with = "humantime_serde::deserialize",
+        default = "default_timeout"
+    )]
+    #[schemars(with = "String", default = "default_timeout")]
+    timeout: Duration,
     /// Expected issuer for tokens verified by that JWKS
     issuer: Option<String>,
     /// List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`
@@ -229,6 +236,10 @@ fn default_header_value_prefix() -> String {
 
 fn default_poll_interval() -> Duration {
     DEFAULT_AUTHENTICATION_DOWNLOAD_INTERVAL
+}
+
+fn default_timeout() -> Duration {
+    DEFAULT_AUTHENTICATION_NETWORK_TIMEOUT
 }
 
 #[derive(Debug, Default)]
@@ -475,6 +486,7 @@ impl Plugin for AuthenticationPlugin {
                         .as_ref()
                         .map(|algs| algs.iter().cloned().collect()),
                     poll_interval: jwks_conf.poll_interval,
+                    timeout: jwks_conf.timeout,
                     headers: jwks_conf.headers.clone(),
                 });
             }

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -828,6 +828,7 @@ async fn build_jwks_search_components() -> JwksManager {
             issuer: None,
             algorithms: None,
             poll_interval: Duration::from_secs(60),
+            timeout: Duration::from_secs(15),
             headers: Vec::new(),
         });
     }
@@ -939,6 +940,7 @@ fn make_manager(jwk: &Jwk, issuer: Option<String>) -> JwksManager {
         issuer,
         algorithms: None,
         poll_interval: Duration::from_secs(60),
+        timeout: Duration::from_secs(15),
         headers: Vec::new(),
     }];
     let map = HashMap::from([(url, jwks); 1]);
@@ -1129,6 +1131,7 @@ async fn it_rejects_key_with_restricted_algorithm() {
             issuer: None,
             algorithms: Some(HashSet::from([Algorithm::RS256])),
             poll_interval: Duration::from_secs(60),
+            timeout: Duration::from_secs(15),
             headers: Vec::new(),
         });
     }
@@ -1161,6 +1164,7 @@ async fn it_rejects_and_accepts_keys_with_restricted_algorithms_and_unknown_jwks
             issuer: None,
             algorithms: Some(HashSet::from([Algorithm::RS256])),
             poll_interval: Duration::from_secs(60),
+            timeout: Duration::from_secs(15),
             headers: Vec::new(),
         });
     }
@@ -1200,6 +1204,7 @@ async fn it_accepts_key_without_use_or_keyops() {
             issuer: None,
             algorithms: None,
             poll_interval: Duration::from_secs(60),
+            timeout: Duration::from_secs(15),
             headers: Vec::new(),
         });
     }
@@ -1231,6 +1236,7 @@ async fn it_accepts_elliptic_curve_key_without_alg() {
             issuer: None,
             algorithms: None,
             poll_interval: Duration::from_secs(60),
+            timeout: Duration::from_secs(15),
             headers: Vec::new(),
         });
     }
@@ -1262,6 +1268,7 @@ async fn it_accepts_rsa_key_without_alg() {
             issuer: None,
             algorithms: None,
             poll_interval: Duration::from_secs(60),
+            timeout: Duration::from_secs(15),
             headers: Vec::new(),
         });
     }
@@ -1332,6 +1339,7 @@ async fn jwks_send_headers() {
         issuer: None,
         algorithms: Some(HashSet::from([Algorithm::RS256])),
         poll_interval: Duration::from_secs(60),
+        timeout: Duration::from_secs(15),
         headers: vec![Header {
             name: HeaderName::from_static("jwks-authz"),
             value: HeaderValue::from_static("user1"),

--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -111,6 +111,7 @@ The following configuration options are supported:
 - `issuer`: **optional** name of the issuer, that will be compared to the `iss` claim in the JWT if present. If it does not match, the request will be rejected.
 - `algorithms`: **optional** list of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`
 - `poll_interval`: **optional** interval in human-readable format (e.g. `60s` or `1hour 30s`) at which the JWKS will be polled for changes. If not specified, the JWKS endpoint will be polled every 60 seconds.
+- `timeout`: **optional** interval in human-readable format (e.g. `60s` or `1hour 30s`) at which the call for the JWKS will timeout. If not specified, the JWKS call will timeout after 15 seconds.
 - `headers`: **optional** a list of headers sent when downloading from the JWKS URL
 
 </td>


### PR DESCRIPTION
Added ability to configure timeout on JWKS endpoints instead of always being 15 seconds

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
