### PR TITLE
Reimplement HTTP snapshot server on hyper 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "aws-types",
  "axum 0.7.9",
  "axum-extra",
+ "axum-server",
  "base64 0.22.1",
  "basic-toml",
  "bloomfilter",
@@ -1292,6 +1293,25 @@ dependencies = [
  "serde",
  "tower 0.5.1",
  "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56bac90848f6a9393ac03c63c640925c4b7c8ca21654de40d53f55964667c7d8"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower 0.4.13",
  "tower-service",
 ]
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -391,6 +391,11 @@ name = "samples"
 path = "tests/samples_tests.rs"
 harness = false
 
+[[bin]]
+name = "snapshot"
+path = "src/test_harness/http_snapshot_main.rs"
+test = false
+
 [[bench]]
 name = "huge_requests"
 harness = false

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -55,6 +55,9 @@ telemetry_next = []
 # is set when ci builds take place. It allows us to disable some tests when CI is running on certain platforms.
 ci = []
 
+# Enables the HTTP snapshot server for testing
+snapshot = ["axum-server"]
+
 [package.metadata.docs.rs]
 features = ["docs_rs"]
 
@@ -74,6 +77,7 @@ async-compression = { version = "0.4.6", features = [
 async-trait.workspace = true
 axum = { version = "0.7.9", features = ["http2"] }
 axum-extra = { version = "0.9.6", features = [ "typed-header" ] }
+axum-server = {  version = "0.7.1", optional = true }
 base64 = "0.22.0"
 bloomfilter = "1.0.13"
 buildstructor = "0.5.4"
@@ -306,6 +310,7 @@ tikv-jemallocator = "0.6.0"
 
 [dev-dependencies]
 axum = { version = "0.7.9", features = ["http2", "ws"] }
+axum-server = "0.7.1"
 ecdsa = { version = "0.16.9", features = ["signing", "pem", "pkcs8"] }
 fred = { version = "9.4.0", features = ["enable-rustls", "mocks", "i-cluster"] }
 futures-test = "0.3.30"
@@ -395,6 +400,7 @@ harness = false
 name = "snapshot"
 path = "src/test_harness/http_snapshot_main.rs"
 test = false
+required-features = ["snapshot"]
 
 [[bench]]
 name = "huge_requests"

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -102,7 +102,9 @@ pub use crate::router::RouterHttpServer;
 pub use crate::router::SchemaSource;
 pub use crate::router::ShutdownSource;
 pub use crate::router_factory::Endpoint;
+#[cfg(any(test, feature = "snapshot"))]
 pub use crate::test_harness::http_snapshot::standalone::main as snapshot_server;
+#[cfg(any(test, feature = "snapshot"))]
 pub use crate::test_harness::http_snapshot::SnapshotServer;
 pub use crate::test_harness::make_fake_batch;
 pub use crate::test_harness::MockedSubgraphs;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -102,6 +102,8 @@ pub use crate::router::RouterHttpServer;
 pub use crate::router::SchemaSource;
 pub use crate::router::ShutdownSource;
 pub use crate::router_factory::Endpoint;
+pub use crate::test_harness::http_snapshot::standalone::main as snapshot_server;
+pub use crate::test_harness::http_snapshot::SnapshotServer;
 pub use crate::test_harness::make_fake_batch;
 pub use crate::test_harness::MockedSubgraphs;
 pub use crate::test_harness::TestHarness;

--- a/apollo-router/src/plugins/connectors/testdata/quickstart_api_snapshots/query_1.json
+++ b/apollo-router/src/plugins/connectors/testdata/quickstart_api_snapshots/query_1.json
@@ -1,0 +1,31 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": [
+        {
+          "userId": 1,
+          "id": 1,
+          "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+          "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+        },
+        {
+          "userId": 1,
+          "id": 2,
+          "title": "qui est esse",
+          "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
+        }
+      ]
+    }
+  }
+]

--- a/apollo-router/src/plugins/connectors/testdata/quickstart_api_snapshots/query_2.json
+++ b/apollo-router/src/plugins/connectors/testdata/quickstart_api_snapshots/query_2.json
@@ -1,0 +1,23 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/1",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 1,
+        "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+        "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+      }
+    }
+  }
+]

--- a/apollo-router/src/plugins/connectors/testdata/quickstart_api_snapshots/query_3.json
+++ b/apollo-router/src/plugins/connectors/testdata/quickstart_api_snapshots/query_3.json
@@ -1,0 +1,61 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/1",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 1,
+        "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+        "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "users/1",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "id": 1,
+        "name": "Leanne Graham",
+        "username": "Bret",
+        "email": "Sincere@april.biz",
+        "address": {
+          "street": "Kulas Light",
+          "suite": "Apt. 556",
+          "city": "Gwenborough",
+          "zipcode": "92998-3874",
+          "geo": {
+            "lat": "-37.3159",
+            "lng": "81.1496"
+          }
+        },
+        "phone": "1-770-736-8031 x56442",
+        "website": "hildegard.org",
+        "company": {
+          "name": "Romaguera-Crona",
+          "catchPhrase": "Multi-layered client-server neural-net",
+          "bs": "harness real-time e-markets"
+        }
+      }
+    }
+  }
+]

--- a/apollo-router/src/plugins/connectors/testdata/quickstart_api_snapshots/query_4.json
+++ b/apollo-router/src/plugins/connectors/testdata/quickstart_api_snapshots/query_4.json
@@ -1,0 +1,279 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/1",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 1,
+        "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+        "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/10",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 10,
+        "title": "optio molestias id quia eum",
+        "body": "quo et expedita modi cum officia vel magni\ndoloribus qui repudiandae\nvero nisi sit\nquos veniam quod sed accusamus veritatis error"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/2",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 2,
+        "title": "qui est esse",
+        "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/3",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 3,
+        "title": "ea molestias quasi exercitationem repellat qui ipsa sit aut",
+        "body": "et iusto sed quo iure\nvoluptatem occaecati omnis eligendi aut ad\nvoluptatem doloribus vel accusantium quis pariatur\nmolestiae porro eius odio et labore et velit aut"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/4",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 4,
+        "title": "eum et est occaecati",
+        "body": "ullam et saepe reiciendis voluptatem adipisci\nsit amet autem assumenda provident rerum culpa\nquis hic commodi nesciunt rem tenetur doloremque ipsam iure\nquis sunt voluptatem rerum illo velit"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/5",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 5,
+        "title": "nesciunt quas odio",
+        "body": "repudiandae veniam quaerat sunt sed\nalias aut fugiat sit autem sed est\nvoluptatem omnis possimus esse voluptatibus quis\nest aut tenetur dolor neque"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/6",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 6,
+        "title": "dolorem eum magni eos aperiam quia",
+        "body": "ut aspernatur corporis harum nihil quis provident sequi\nmollitia nobis aliquid molestiae\nperspiciatis et ea nemo ab reprehenderit accusantium quas\nvoluptate dolores velit et doloremque molestiae"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/7",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 7,
+        "title": "magnam facilis autem",
+        "body": "dolore placeat quibusdam ea quo vitae\nmagni quis enim qui quis quo nemo aut saepe\nquidem repellat excepturi ut quia\nsunt ut sequi eos ea sed quas"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/8",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 8,
+        "title": "dolorem dolore est ipsam",
+        "body": "dignissimos aperiam dolorem qui eum\nfacilis quibusdam animi sint suscipit qui sint possimus cum\nquaerat magni maiores excepturi\nipsam ut commodi dolor voluptatum modi aut vitae"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/9",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 9,
+        "title": "nesciunt iure omnis dolorem tempora et accusantium",
+        "body": "consectetur animi nesciunt iure dolore\nenim quia ad\nveniam autem ut quam aut nobis\net est aut quod aut provident voluptas autem voluptas"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "users/1",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "id": 1,
+        "name": "Leanne Graham",
+        "username": "Bret",
+        "email": "Sincere@april.biz",
+        "address": {
+          "street": "Kulas Light",
+          "suite": "Apt. 556",
+          "city": "Gwenborough",
+          "zipcode": "92998-3874",
+          "geo": {
+            "lat": "-37.3159",
+            "lng": "81.1496"
+          }
+        },
+        "phone": "1-770-736-8031 x56442",
+        "website": "hildegard.org",
+        "company": {
+          "name": "Romaguera-Crona",
+          "catchPhrase": "Multi-layered client-server neural-net",
+          "bs": "harness real-time e-markets"
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "users/1/posts",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": [
+        {
+          "userId": 1,
+          "id": 1,
+          "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+          "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+        },
+        {
+          "userId": 1,
+          "id": 2,
+          "title": "qui est esse",
+          "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
+        }
+      ]
+    }
+  }
+]

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -1488,6 +1488,194 @@ async fn test_variables() {
     );
 }
 
+mod quickstart_tests {
+    use http::Uri;
+
+    use super::*;
+    use crate::test_harness::http_snapshot::SnapshotServer;
+
+    const SNAPSHOT_DIR: &str = "./src/plugins/connectors/testdata/quickstart_api_snapshots/";
+
+    macro_rules! map {
+        ($($tt:tt)*) => {
+          serde_json_bytes::json!($($tt)*).as_object().unwrap().clone()
+        };
+    }
+
+    async fn execute(
+        query: &str,
+        variables: JsonMap,
+        snapshot_file_name: &str,
+    ) -> serde_json::Value {
+        let snapshot_path = [SNAPSHOT_DIR, snapshot_file_name, ".json"].concat();
+
+        let server = SnapshotServer::spawn(
+            snapshot_path,
+            Uri::from_str("https://jsonPlaceholder.typicode.com/").unwrap(),
+            true,
+            false,
+            Some(vec![CONTENT_TYPE.to_string()]),
+        )
+        .await;
+
+        super::execute(
+            &QUICKSTART_SCHEMA.replace("https://jsonplaceholder.typicode.com", &server.uri()),
+            &server.uri(),
+            query,
+            variables,
+            None,
+            |_| {},
+        )
+        .await
+    }
+    #[tokio::test]
+    async fn query_1() {
+        let query = r#"
+          query Posts {
+            posts {
+              id
+              body
+              title
+            }
+          }
+        "#;
+
+        let response = execute(query, Default::default(), "query_1").await;
+
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "posts": [
+              {
+                "id": 1,
+                "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto",
+                "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit"
+              },
+              {
+                "id": 2,
+                "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla",
+                "title": "qui est esse"
+              }
+            ]
+          }
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn query_2() {
+        let query = r#"
+          query Post($postId: ID!) {
+            post(id: $postId) {
+              id
+              title
+              body
+            }
+          }
+        "#;
+
+        let response = execute(query, map!({ "postId": "1" }), "query_2").await;
+
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "post": {
+              "id": 1,
+              "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+              "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+            }
+          }
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn query_3() {
+        let query = r#"
+          query PostWithAuthor($postId: ID!) {
+            post(id: $postId) {
+              id
+              title
+              body
+              author {
+                id
+                name
+              }
+            }
+          }
+      "#;
+
+        let response = execute(query, map!({ "postId": "1" }), "query_3").await;
+
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "post": {
+              "id": 1,
+              "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+              "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto",
+              "author": {
+                "id": 1,
+                "name": "Leanne Graham"
+              }
+            }
+          }
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn query_4() {
+        let query = r#"
+          query PostsForUser($userId: ID!) {
+            user(id: $userId) {
+              id
+              name
+              posts {
+                id
+                title
+                author {
+                  id
+                  name
+                }
+              }
+            }
+          }
+      "#;
+
+        let response = execute(query, map!({ "userId": "1" }), "query_4").await;
+
+        insta::assert_json_snapshot!(response, @r###"
+        {
+          "data": {
+            "user": {
+              "id": 1,
+              "name": "Leanne Graham",
+              "posts": [
+                {
+                  "id": 1,
+                  "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+                  "author": {
+                    "id": 1,
+                    "name": "Leanne Graham"
+                  }
+                },
+                {
+                  "id": 2,
+                  "title": "qui est esse",
+                  "author": {
+                    "id": 1,
+                    "name": "Leanne Graham"
+                  }
+                }
+              ]
+            }
+          }
+        }
+        "###);
+    }
+}
+
 async fn execute(
     schema: &str,
     uri: &str,

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -43,6 +43,8 @@ pub mod mocks;
 #[cfg(test)]
 pub(crate) mod http_client;
 
+pub(crate) mod http_snapshot;
+
 /// Builder for the part of an Apollo Router that handles GraphQL requests, as a [`tower::Service`].
 ///
 /// This allows tests, benchmarks, etc

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -43,6 +43,7 @@ pub mod mocks;
 #[cfg(test)]
 pub(crate) mod http_client;
 
+#[cfg(any(test, feature = "snapshot"))]
 pub(crate) mod http_snapshot;
 
 /// Builder for the part of an Apollo Router that handles GraphQL requests, as a [`tower::Service`].

--- a/apollo-router/src/test_harness/http_snapshot.rs
+++ b/apollo-router/src/test_harness/http_snapshot.rs
@@ -1,0 +1,564 @@
+//! Snapshot server to capture and replay HTTP responses. This is useful for:
+//!
+//! * Capturing HTTP responses from a real API or server, and replaying them in tests
+//! * Mocking responses from a non-existent HTTP API for testing
+//! * Working offline by capturing output from a server, and replaying it
+//!
+//! For example, this can be used with the router `override_subgraph_url` to replay recorded
+//! responses from GraphQL subgraphs. Or it can be used with `override_url` in Connectors, to
+//! record the HTTP responses from an external REST API. This allows the replayed responses to
+//! be used in tests, or even in Apollo Sandbox to work offline or avoid hitting the REST API
+//! too frequently.
+//!
+//! The snapshot server can be started from tests by calling the [`SnapshotServer::spawn`] method,
+//! or as a standalone application by invoking [`standalone::main`]. In the latter case, there
+//! is a binary wrapper in `http_snapshot_main` that can be run like this:
+//!
+//! `cargo run --bin snapshot -- --snapshot-path <file> --url <base URL to snapshot> [--offline] [--update] [--port <port number>]`
+//!
+//! Any requests made to the snapshot server will be proxied on to the given base URL, and the
+//! responses will be saved to the given file. The next time the snapshot server receives the
+//! same request (same relative path, HTTP method, and request body), it will respond with the
+//! response recorded in the file rather than sending the request to the upstream server.
+//!
+//! The snapshot file can be manually edited to manipulate responses for testing purposes, or to
+//! redact information that you don't want to include in source-controlled snapshot files.
+//!
+//! The offline mode will never call the upstream server, and will always return a saved snapshot
+//! response. If one is not available, a `500` error is returned. This is useful for tests, for
+//! example to ensure that CI builds never attempt to access the network.
+//!
+//! The update mode can be used to force an update of recorded snapshots, even if there is already
+//! a snapshot saved in the file. This overrides the offline mode, and is useful to update tests
+//! when a change is made to the upstream HTTP responses.
+//!
+//! The set of response headers returned can be filtered by supplying a list of headers to include.
+//! This is typically desirable, as headers may contain ephemeral information like dates or tokens.
+//!
+//! **IMPORTANT:** this module stores HTTP responses to the local file system in plain text. It
+//! should not be used with production APIs that return sensitive data.
+//!
+//! This module should also not be used in conjunction with performance testing, as returning
+//! snapshot data locally will be much faster than sending HTTP requests to an external server.
+
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::net::TcpListener;
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use axum::extract::Path as AxumPath;
+use axum::extract::State;
+use axum::routing::any;
+use axum::Router;
+use base64::Engine;
+use http::HeaderMap;
+use http::HeaderName;
+use http::HeaderValue;
+use http::Method;
+use http::Uri;
+use hyper::StatusCode;
+use hyper_rustls::ConfigBuilderExt;
+use indexmap::IndexMap;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json_bytes::json;
+use serde_json_bytes::Value;
+use tower::ServiceExt;
+use tracing::debug;
+use tracing::error;
+use tracing::info;
+use tracing::warn;
+
+use crate::configuration::shared::Client;
+use crate::services::http::HttpClientService;
+use crate::services::http::HttpRequest;
+use crate::services::router::body::RouterBody;
+
+/// An error from the snapshot server
+#[derive(Debug, thiserror::Error)]
+enum SnapshotError {
+    /// Unable to load snapshots
+    #[error("unable to load snapshots")]
+    IoError(#[from] std::io::Error),
+    /// Unable to parse snapshots
+    #[error("unable to parse snapshots")]
+    ParseError(#[from] serde_json::Error),
+}
+
+/// A server that mocks an API using snapshots recorded from actual HTTP responses.
+#[cfg_attr(test, allow(unreachable_pub))]
+pub struct SnapshotServer {
+    // The socket address the server is listening on
+    #[cfg_attr(not(test), allow(dead_code))]
+    socket_address: SocketAddr,
+}
+
+#[derive(Clone)]
+struct SnapshotServerState {
+    client: HttpClientService,
+    base_url: Uri,
+    snapshots: Arc<Mutex<BTreeMap<String, Snapshot>>>,
+    snapshot_file: Box<Path>,
+    offline: bool,
+    update: bool,
+    include_headers: Option<Vec<String>>,
+}
+
+async fn root_handler(
+    State(state): State<SnapshotServerState>,
+    req: http::Request<axum::body::Body>,
+) -> Result<http::Response<RouterBody>, StatusCode> {
+    handle(State(state), req, "/".to_string()).await
+}
+
+async fn handler(
+    State(state): State<SnapshotServerState>,
+    AxumPath(path): AxumPath<String>,
+    req: http::Request<axum::body::Body>,
+) -> Result<http::Response<RouterBody>, StatusCode> {
+    handle(State(state), req, path).await
+}
+
+async fn handle(
+    State(state): State<SnapshotServerState>,
+    req: http::Request<axum::body::Body>,
+    path: String,
+) -> Result<http::Response<RouterBody>, StatusCode> {
+    let uri = [state.base_url.to_string(), path.clone()].concat();
+    let method = req.method().clone();
+    let version = req.version();
+    let request_headers = req.headers().clone();
+    let hyper_body = hyper::body::to_bytes(req.into_body()).await.unwrap();
+    let request_json_body = serde_json::from_slice(&hyper_body).unwrap_or(Value::Null);
+
+    let key = snapshot_key(
+        Some(method.as_str()),
+        Some(path.as_str()),
+        &request_json_body,
+    );
+
+    if let Some(response) = response_from_snapshot(&state, &uri, &method, &key) {
+        Ok(response)
+    } else if state.offline && !state.update {
+        fail(
+            uri,
+            method,
+            "Offline mode enabled and no snapshot available",
+        )
+    } else {
+        debug!(
+            url = %uri,
+            method = %method,
+            "Taking snapshot"
+        );
+        let mut request = http::Request::builder()
+            .method(method.clone())
+            .version(version)
+            .uri(uri.clone())
+            .body(RouterBody::from(hyper_body))
+            .unwrap();
+        *request.headers_mut() = request_headers.clone();
+        let response = state
+            .client
+            .oneshot(HttpRequest {
+                http_request: request,
+                context: crate::context::Context::new(),
+            })
+            .await
+            .unwrap();
+        let (parts, body) = response.http_response.into_parts();
+
+        if let Ok(body_bytes) = body.to_bytes().await {
+            if let Ok(response_json_body) = serde_json::from_slice(&body_bytes) {
+                let snapshot = Snapshot {
+                    request: Request {
+                        method: Some(method.to_string()),
+                        path: Some(path),
+                        body: request_json_body,
+                    },
+                    response: Response {
+                        status: parts.status.as_u16(),
+                        headers: map_headers(parts.headers, |name| {
+                            state
+                                .include_headers
+                                .as_ref()
+                                .map(|headers| headers.contains(&name.to_string()))
+                                .unwrap_or(true)
+                        }),
+                        body: response_json_body,
+                    },
+                };
+                {
+                    let mut snapshots = state.snapshots.lock().unwrap();
+                    snapshots.insert(key, snapshot.clone());
+                    if let Err(e) = save(state.snapshot_file, &mut snapshots) {
+                        error!(
+                            url = %uri,
+                            method = %method,
+                            error = ?e,
+                            "Unable to save snapshot"
+                        );
+                    }
+                }
+                Ok(snapshot.try_into().unwrap())
+            } else {
+                fail(uri, method, "Unable to parse response body as JSON")
+            }
+        } else {
+            fail(uri, method, "Unable to read response body")
+        }
+    }
+}
+
+fn response_from_snapshot(
+    state: &SnapshotServerState,
+    uri: &String,
+    method: &Method,
+    key: &String,
+) -> Option<http::Response<RouterBody>> {
+    let mut snapshots = state.snapshots.lock().unwrap();
+    if state.update {
+        snapshots.remove(key);
+        None
+    } else {
+        snapshots.get(key).and_then(|snapshot| {
+            debug!(
+                url = %uri,
+                method = %method,
+                "Found existing snapshot"
+            );
+            snapshot
+                .clone()
+                .try_into()
+                .map_err(|e| error!("Unable to convert snapshot into HTTP response: {:?}", e))
+                .ok()
+        })
+    }
+}
+
+fn fail(
+    uri: String,
+    method: Method,
+    message: &str,
+) -> Result<http::Response<RouterBody>, StatusCode> {
+    error!(
+        url = %uri,
+        method = %method,
+        message
+    );
+    http::Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(json!({ "error": message}).to_string().into())
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn map_headers<F: Fn(&str) -> bool>(
+    headers: HeaderMap<HeaderValue>,
+    include: F,
+) -> IndexMap<String, Vec<String>> {
+    headers.iter().fold(
+        IndexMap::new(),
+        |mut map: IndexMap<String, Vec<String>>, (name, value)| {
+            let name = name.to_string();
+            if include(&name) {
+                let value = value.to_str().unwrap_or_default().to_string();
+                map.entry(name).or_default().push(value);
+            }
+            map
+        },
+    )
+}
+
+fn save<P: AsRef<Path>>(
+    path: P,
+    snapshots: &mut BTreeMap<String, Snapshot>,
+) -> Result<(), SnapshotError> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let snapshots = snapshots.values().cloned().collect::<Vec<_>>();
+    std::fs::write(path, serde_json::to_string_pretty(&snapshots)?).map_err(Into::into)
+}
+
+fn load<P: AsRef<Path>>(path: P) -> Result<BTreeMap<String, Snapshot>, SnapshotError> {
+    let str = std::fs::read_to_string(path)?;
+    let snapshots: Vec<Snapshot> = serde_json::from_str(&str)?;
+    info!("Loaded {} snapshots", snapshots.len());
+    Ok(snapshots
+        .into_iter()
+        .map(|snapshot| (snapshot.key(), snapshot))
+        .collect())
+}
+
+impl SnapshotServer {
+    /// Spawn the server in a new task and return. Used for tests.
+    #[cfg_attr(test, allow(unreachable_pub))]
+    pub async fn spawn<P: AsRef<Path>>(
+        snapshot_path: P,
+        base_url: Uri,
+        offline: bool,
+        update: bool,
+        include_headers: Option<Vec<String>>,
+    ) -> Self {
+        Self::inner_start(
+            snapshot_path,
+            base_url,
+            true,
+            offline,
+            update,
+            include_headers,
+            None,
+        )
+        .await
+    }
+
+    /// Start the server and block. Can be used to run the server as a standalone application.
+    pub(crate) async fn start<P: AsRef<Path>>(
+        snapshot_path: P,
+        base_url: Uri,
+        offline: bool,
+        update: bool,
+        include_headers: Option<Vec<String>>,
+        listener: Option<TcpListener>,
+    ) -> Self {
+        Self::inner_start(
+            snapshot_path,
+            base_url,
+            false,
+            offline,
+            update,
+            include_headers,
+            listener,
+        )
+        .await
+    }
+
+    /// Get the URI the server is listening at
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg_attr(test, allow(unreachable_pub))]
+    pub fn uri(&self) -> String {
+        format!("http://{}", self.socket_address)
+    }
+
+    async fn inner_start<P: AsRef<Path>>(
+        snapshot_path: P,
+        base_url: Uri,
+        spawn: bool,
+        offline: bool,
+        update: bool,
+        include_headers: Option<Vec<String>>,
+        listener: Option<TcpListener>,
+    ) -> Self {
+        if update {
+            info!("Running in update mode ⬆️");
+        } else if offline {
+            info!("Running in offline mode ⛔️");
+        }
+
+        let snapshot_file = snapshot_path.as_ref();
+
+        let snapshots = load(snapshot_file).unwrap_or_else(|_| {
+            if offline {
+                warn!("Unable to load snapshot file in offline mode - all requests will fail");
+            }
+            BTreeMap::default()
+        });
+
+        let http_service = HttpClientService::new(
+            "test",
+            rustls::ClientConfig::builder()
+                .with_safe_defaults()
+                .with_native_roots()
+                .with_no_client_auth(),
+            Client::builder().build(),
+        )
+        .expect("can create a HttpService");
+        let app = Router::new()
+            .route("/", any(root_handler))
+            .route("/*path", any(handler)) // won't match root, so we need the root handler above
+            .with_state(SnapshotServerState {
+                client: http_service,
+                base_url: base_url.clone(),
+                snapshots: Arc::new(Mutex::new(snapshots.clone())),
+                snapshot_file: Box::from(snapshot_file),
+                offline,
+                update,
+                include_headers,
+            });
+        let listener = listener.unwrap_or(
+            TcpListener::bind("127.0.0.1:0")
+                .expect("Failed to bind an OS port for snapshot server"),
+        );
+        let local_address = listener
+            .local_addr()
+            .expect("Failed to get snapshot server address.");
+        info!(
+            "Snapshot server listening on port {:?}",
+            local_address.port()
+        );
+        if spawn {
+            tokio::spawn(async move {
+                axum::Server::from_tcp(listener)
+                    .expect("Unable to start snapshot server")
+                    .serve(app.into_make_service())
+                    .await
+                    .unwrap();
+            });
+        } else {
+            axum::Server::from_tcp(listener)
+                .expect("Unable to start snapshot server")
+                .serve(app.into_make_service())
+                .await
+                .unwrap();
+        }
+        Self {
+            socket_address: local_address,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Snapshot {
+    request: Request,
+    response: Response,
+}
+
+impl TryFrom<Snapshot> for http::Response<RouterBody> {
+    type Error = ();
+
+    fn try_from(snapshot: Snapshot) -> Result<Self, Self::Error> {
+        let mut response = http::Response::builder().status(snapshot.response.status);
+        if let Some(headers) = response.headers_mut() {
+            for (name, values) in snapshot.response.headers.into_iter() {
+                if let Ok(name) = HeaderName::from_str(&name.clone()) {
+                    for value in values {
+                        if let Ok(value) = HeaderValue::from_str(&value.clone()) {
+                            headers.insert(name.clone(), value);
+                        }
+                    }
+                } else {
+                    warn!("Invalid header name `{}` in snapshot", name);
+                }
+            }
+        }
+        let body_string = snapshot.response.body.to_string();
+        if let Ok(response) = response.body(RouterBody::from(body_string)) {
+            return Ok(response);
+        }
+        Err(())
+    }
+}
+
+impl Snapshot {
+    fn key(&self) -> String {
+        snapshot_key(
+            self.request.method.as_deref(),
+            self.request.path.as_deref(),
+            &self.request.body,
+        )
+    }
+}
+
+fn snapshot_key(method: Option<&str>, path: Option<&str>, body: &Value) -> String {
+    if body.is_null() {
+        format!("{}-{}", method.unwrap_or("GET"), path.unwrap_or("/"))
+    } else {
+        let body = base64::engine::general_purpose::STANDARD.encode(body.to_string());
+        format!(
+            "{}-{}-{}",
+            method.unwrap_or("GET"),
+            path.unwrap_or("/"),
+            body,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Request {
+    method: Option<String>,
+    path: Option<String>,
+    body: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Response {
+    status: u16,
+    #[serde(default)]
+    headers: IndexMap<String, Vec<String>>,
+    body: Value,
+}
+
+/// Standalone snapshot server
+pub(crate) mod standalone {
+    use std::net::TcpListener;
+    use std::path::PathBuf;
+
+    use clap::Parser;
+    use http::Uri;
+    use tracing_core::Level;
+
+    use super::SnapshotServer;
+
+    #[derive(Parser, Debug)]
+    #[clap(name = "snapshot", about = "Apollo snapshot server")]
+    #[command(disable_version_flag(true))]
+    struct Args {
+        /// Snapshot location relative to the project directory.
+        #[arg(short, long, value_parser)]
+        snapshot_path: PathBuf,
+
+        /// Base URL for the server.
+        #[arg(short = 'l', long, value_parser)]
+        url: Uri,
+
+        /// Run in offline mode, without making any HTTP requests to the base URL.
+        #[arg(short, long)]
+        offline: bool,
+
+        /// Force snapshot updates (overrides `offline`).
+        #[arg(short, long)]
+        update: bool,
+
+        /// Optional port to listen on (defaults to an ephemeral port).
+        #[arg(short, long)]
+        port: Option<u16>,
+
+        /// Turn on verbose output
+        #[arg(short = 'v', long)]
+        verbose: bool,
+    }
+
+    /// Run the snapshot server as a standalone application
+    pub async fn main() {
+        let args = Args::parse();
+
+        let subscriber = tracing_subscriber::FmtSubscriber::builder()
+            .with_max_level(if args.verbose {
+                Level::DEBUG
+            } else {
+                Level::INFO
+            })
+            .finish();
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("setting default subscriber failed");
+
+        let listener = args.port.map(|port| {
+            TcpListener::bind(format!("127.0.0.1:{port}"))
+                .expect("Failed to bind an OS port for snapshot server")
+        });
+
+        SnapshotServer::start(
+            args.snapshot_path,
+            args.url,
+            args.offline,
+            args.update,
+            None,
+            listener,
+        )
+        .await;
+    }
+}

--- a/apollo-router/src/test_harness/http_snapshot_main.rs
+++ b/apollo-router/src/test_harness/http_snapshot_main.rs
@@ -1,0 +1,6 @@
+use apollo_router::snapshot_server;
+
+#[tokio::main]
+async fn main() {
+    snapshot_server().await
+}

--- a/apollo-router/tests/samples/enterprise/connectors/http_snapshots.json
+++ b/apollo-router/tests/samples/enterprise/connectors/http_snapshots.json
@@ -1,0 +1,61 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "posts/1",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "userId": 1,
+        "id": 1,
+        "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
+        "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "users/1",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "id": 1,
+        "name": "Leanne Graham",
+        "username": "Bret",
+        "email": "Sincere@april.biz",
+        "address": {
+          "street": "Kulas Light",
+          "suite": "Apt. 556",
+          "city": "Gwenborough",
+          "zipcode": "92998-3874",
+          "geo": {
+            "lat": "-37.3159",
+            "lng": "81.1496"
+          }
+        },
+        "phone": "1-770-736-8031 x56442",
+        "website": "hildegard.org",
+        "company": {
+          "name": "Romaguera-Crona",
+          "catchPhrase": "Multi-layered client-server neural-net",
+          "bs": "harness real-time e-markets"
+        }
+      }
+    }
+  }
+]

--- a/apollo-router/tests/samples/enterprise/connectors/plan.json
+++ b/apollo-router/tests/samples/enterprise/connectors/plan.json
@@ -8,52 +8,27 @@
             "configuration_path": "./configuration.yaml",
             "subgraphs": {
                 "jsonPlaceholder": {
-                    "requests": [
-                        {
-                            "request": {
-                                "method": "GET",
-                                "path": "/posts"
-                            },
-                            "response": {
-                                "body": [
-                                    {
-                                        "userId": 0,
-                                        "id": 1,
-                                        "title": "Test",
-                                        "body": "Hello World"
-                                    },
-                                    {
-                                        "userId": 1,
-                                        "id": 2,
-                                        "title": "Test2",
-                                        "body": "AAAA"
-                                    }
-                                ]
-                            }
-                        }
-                    ]
+                    "snapshot": {
+                        "path": "./http_snapshots.json",
+                        "base_url": "https://jsonplaceholder.typicode.com/"
+                    }
                 }
             }
         },
         {
             "type": "Request",
             "request": {
-                "query": "query Posts { posts { id body title }}"
+                "query": "query { post(id: 1) { id author { name } title } }"
             },
             "expected_response": {
                 "data": {
-                    "posts": [
-                        {
-                            "id": 1,
-                            "body": "Hello World",
-                            "title": "Test"
+                    "post": {
+                        "id": 1,
+                        "author": {
+                            "name": "Leanne Graham"
                         },
-                        {
-                            "id": 2,
-                            "body": "AAAA",
-                            "title": "Test2"
-                        }
-                    ]
+                        "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit"
+                    }
                 }
             }
         },

--- a/apollo-router/tests/samples/enterprise/connectors/plan.json
+++ b/apollo-router/tests/samples/enterprise/connectors/plan.json
@@ -1,6 +1,7 @@
 {
     "enterprise": true,
     "redis": true,
+    "snapshot": true,
     "actions": [
         {
             "type": "Start",

--- a/apollo-router/tests/samples_tests.rs
+++ b/apollo-router/tests/samples_tests.rs
@@ -10,7 +10,12 @@ use std::net::TcpListener;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::str::FromStr;
 
+use apollo_router::SnapshotServer;
+use http::header::CONTENT_LENGTH;
+use http::header::CONTENT_TYPE;
+use http::Uri;
 use libtest_mimic::Arguments;
 use libtest_mimic::Failed;
 use libtest_mimic::Trial;
@@ -197,7 +202,7 @@ impl TestExecution {
                 subgraphs,
                 update_url_overrides,
             } => {
-                self.reload_subgraphs(subgraphs, *update_url_overrides, out)
+                self.reload_subgraphs(subgraphs, *update_url_overrides, path, out)
                     .await
             }
             Action::Request {
@@ -238,8 +243,10 @@ impl TestExecution {
         self.subgraphs = subgraphs.clone();
         let (mut subgraphs_server, url) = self.start_subgraphs(out).await;
 
-        let subgraph_overrides = self.load_subgraph_mocks(&mut subgraphs_server, &url).await;
-        writeln!(out, "got subgraph mocks: {subgraph_overrides:?}").unwrap();
+        let subgraph_overrides = self
+            .load_subgraph_mocks(&mut subgraphs_server, &url, path, out)
+            .await;
+        writeln!(out, "got subgraph mocks: {subgraph_overrides:?}")?;
 
         let config = open_file(&path.join(configuration_path), out)?;
         let schema_path = path.join(schema_path);
@@ -291,7 +298,7 @@ impl TestExecution {
 
         let subgraph_url = Self::subgraph_url(&subgraphs_server);
         let subgraph_overrides = self
-            .load_subgraph_mocks(&mut subgraphs_server, &subgraph_url)
+            .load_subgraph_mocks(&mut subgraphs_server, &subgraph_url, path, out)
             .await;
 
         let config = open_file(&path.join(configuration_path), out)?;
@@ -340,36 +347,60 @@ impl TestExecution {
         &mut self,
         subgraphs_server: &mut MockServer,
         url: &str,
+        path: &Path,
+        out: &mut String,
     ) -> HashMap<String, String> {
         let mut subgraph_overrides = HashMap::new();
 
         for (name, subgraph) in &self.subgraphs {
-            for SubgraphRequestMock { request, response } in &subgraph.requests {
-                let mut builder = match &request.body {
-                    Some(body) => Mock::given(body_partial_json(body)),
-                    None => Mock::given(wiremock::matchers::AnyMatcher),
-                };
+            if let Some(snapshot) = subgraph.snapshot.as_ref() {
+                let snapshot_server = SnapshotServer::spawn(
+                    &path.join(&snapshot.path),
+                    Uri::from_str(&snapshot.base_url).unwrap(),
+                    true,
+                    snapshot.update.unwrap_or(false),
+                    Some(vec![CONTENT_TYPE.to_string(), CONTENT_LENGTH.to_string()]),
+                )
+                .await;
+                let snapshot_url = snapshot_server.uri();
+                writeln!(
+                    out,
+                    "snapshot server for {name} listening on {snapshot_url}"
+                )
+                .unwrap();
+                subgraph_overrides
+                    .entry(name.to_string())
+                    .or_insert(snapshot_url.clone());
+            } else {
+                for SubgraphRequestMock { request, response } in
+                    subgraph.requests.as_ref().unwrap_or(&vec![])
+                {
+                    let mut builder = match &request.body {
+                        Some(body) => Mock::given(body_partial_json(body)),
+                        None => Mock::given(wiremock::matchers::AnyMatcher),
+                    };
 
-                if let Some(s) = request.method.as_deref() {
-                    builder = builder.and(method(s));
-                }
+                    if let Some(s) = request.method.as_deref() {
+                        builder = builder.and(method(s));
+                    }
 
-                if let Some(s) = request.path.as_deref() {
-                    builder = builder.and(wiremock::matchers::path(s));
-                }
+                    if let Some(s) = request.path.as_deref() {
+                        builder = builder.and(wiremock::matchers::path(s));
+                    }
 
-                for (header_name, header_value) in &request.headers {
-                    builder = builder.and(header(header_name.as_str(), header_value.as_str()));
-                }
+                    for (header_name, header_value) in &request.headers {
+                        builder = builder.and(header(header_name.as_str(), header_value.as_str()));
+                    }
 
-                let mut res = ResponseTemplate::new(response.status.unwrap_or(200));
-                for (header_name, header_value) in &response.headers {
-                    res = res.append_header(header_name.as_str(), header_value.as_str());
+                    let mut res = ResponseTemplate::new(response.status.unwrap_or(200));
+                    for (header_name, header_value) in &response.headers {
+                        res = res.append_header(header_name.as_str(), header_value.as_str());
+                    }
+                    builder
+                        .respond_with(res.set_body_json(&response.body))
+                        .mount(subgraphs_server)
+                        .await;
                 }
-                builder
-                    .respond_with(res.set_body_json(&response.body))
-                    .mount(subgraphs_server)
-                    .await;
             }
 
             // Add a default override for products, if not specified
@@ -385,6 +416,7 @@ impl TestExecution {
         &mut self,
         subgraphs: &HashMap<String, Subgraph>,
         update_url_overrides: bool,
+        path: &Path,
         out: &mut String,
     ) -> Result<(), Failed> {
         writeln!(out, "reloading subgraphs with: {subgraphs:?}").unwrap();
@@ -399,7 +431,7 @@ impl TestExecution {
 
         let subgraph_url = Self::subgraph_url(&subgraphs_server);
         let subgraph_overrides = self
-            .load_subgraph_mocks(&mut subgraphs_server, &subgraph_url)
+            .load_subgraph_mocks(&mut subgraphs_server, &subgraph_url, path, out)
             .await;
         self.subgraphs_server = Some(subgraphs_server);
 
@@ -752,9 +784,17 @@ enum Action {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+struct Snapshot {
+    path: String,
+    base_url: String,
+    update: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Subgraph {
-    requests: Vec<SubgraphRequestMock>,
+    snapshot: Option<Snapshot>,
+    requests: Option<Vec<SubgraphRequestMock>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
This re-implements the HTTP snapshot server from #6032, but on top of `hyper` 1.x.

The snapshot server is behind the `snapshot` feature flag.

## Examples

To run the snapshot server standalone:

```sh
cargo run --bin snapshot --features snapshot -- --snapshot-path /tmp/snapshots.json --url https://jsonPlaceholder.typicode.com/ --port 5280 --offline -v
```

To install the snapshot server:

```sh
cargo install --locked --path apollo-router --features snapshot
```

To run the samples tests using the snapshot server:

```sh
cargo test --test samples --features snapshot
```

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
