### PR TITLE
wrap http client errors in an error type we control

### DIFF
--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -57,6 +57,11 @@ impl ConnectId {
         )
     }
 
+    pub fn subgraph_source(&self) -> String {
+        let source = format!(".{}", self.source_name.as_deref().unwrap_or(""));
+        format!("{}{}", self.subgraph_name, source)
+    }
+
     pub fn coordinate(&self) -> String {
         format!(
             "{}:{}.{}@connect[{}]",

--- a/apollo-router/src/plugins/connectors/error.rs
+++ b/apollo-router/src/plugins/connectors/error.rs
@@ -1,6 +1,7 @@
 //! Connectors error types.
 
 use apollo_federation::sources::connect::Connector;
+use tower::BoxError;
 
 use crate::graphql;
 use crate::graphql::ErrorExtension;
@@ -12,6 +13,9 @@ use crate::json_ext::Path;
 pub(crate) enum Error {
     /// Request limit exceeded
     RequestLimitExceeded,
+
+    /// {0}
+    HTTPClientError(#[from] BoxError),
 }
 
 impl Error {
@@ -47,6 +51,7 @@ impl ErrorExtension for Error {
     fn extension_code(&self) -> String {
         match self {
             Self::RequestLimitExceeded => "REQUEST_LIMIT_EXCEEDED",
+            Self::HTTPClientError(_) => "HTTP_CLIENT_ERROR",
         }
         .to_string()
     }

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -515,6 +515,40 @@ async fn basic_errors() {
 }
 
 #[tokio::test]
+async fn basic_connection_errors() {
+    let response = execute(
+        STEEL_THREAD_SCHEMA,
+        "http://localhost:9999",
+        "{ users { id } }",
+        Default::default(),
+        None,
+        |_| {},
+    )
+    .await;
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": null,
+      "errors": [
+        {
+          "message": "HTTP fetch failed from 'connectors.json': tcp connect error: Connection refused (os error 61)",
+          "path": [
+            "users"
+          ],
+          "extensions": {
+            "service": "connectors",
+            "connector": {
+              "coordinate": "connectors:Query.users@connect[0]"
+            },
+            "code": "HTTP_CLIENT_ERROR"
+          }
+        }
+      ]
+    }
+    "###);
+}
+
+#[tokio::test]
 async fn test_headers() {
     let mock_server = MockServer::start().await;
     mock_api::users().mount(&mock_server).await;


### PR DESCRIPTION
now a single connection error won't halt the processing of all requests for a fetch node

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
