### PR TITLE
Migrate `apollo_router_session_count_total` metric to an OTel gauge

### DIFF
--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -88,16 +88,16 @@ fn session_count_instrument() -> ObservableGauge<u64> {
         .init()
 }
 
-struct SessionCountGuard;
+struct ActiveSessionCountGuard;
 
-impl SessionCountGuard {
+impl ActiveSessionCountGuard {
     fn start() -> Self {
         ACTIVE_SESSION_COUNT.fetch_add(1, Ordering::Acquire);
         Self
     }
 }
 
-impl Drop for SessionCountGuard {
+impl Drop for ActiveSessionCountGuard {
     fn drop(&mut self) {
         ACTIVE_SESSION_COUNT.fetch_sub(1, Ordering::Acquire);
     }
@@ -655,7 +655,7 @@ async fn handle_graphql(
     experimental_log_on_broken_pipe: bool,
     http_request: Request<DecompressionBody<Body>>,
 ) -> impl IntoResponse {
-    let _guard = SessionCountGuard::start();
+    let _guard = ActiveSessionCountGuard::start();
 
     let (parts, body) = http_request.into_parts();
 


### PR DESCRIPTION
Somehow missed this in #6476

No changeset because it's in #6476 : )

<!-- [ROUTER-911] -->


[ROUTER-911]: https://apollographql.atlassian.net/browse/ROUTER-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ