### PR TITLE
chore(router): add test for `Accept` with multiple MIME types & parameters

### DIFF
--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -293,5 +293,14 @@ mod tests {
         default_headers.append(ACCEPT, HeaderValue::from_static(MULTIPART_DEFER_ACCEPT));
         let accepts = parse_accept(&default_headers);
         assert!(accepts.multipart_defer);
+
+        // Multiple accepted types, including one with a parameter we are interested in
+        let mut default_headers = HeaderMap::new();
+        default_headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("multipart/mixed;subscriptionSpec=1.0, application/json"),
+        );
+        let accepts = parse_accept(&default_headers);
+        assert!(accepts.multipart_subscription);
     }
 }


### PR DESCRIPTION
Looking at https://github.com/apollographql/router/issues/6501, I didn't find a test that checks that multiple `Accept` mime types are parsed correctly. The existing tests either use a single mime type in the `Accept` header, or use multiple types that are all unsupported by the router.

The test passes already, so this does not solve #6501, but it covers a case we had not covered before.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

Compatibility, documentation, performance not relevant for an added test

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
