### PR TITLE
Eagerly init subgraph operation for subscription primary nodes

### DIFF
--- a/.changesets/fix_tninesling_subscription_operation_init.md
+++ b/.changesets/fix_tninesling_subscription_operation_init.md
@@ -1,0 +1,5 @@
+### Eagerly init subgraph operation for subscription primary nodes ([PR #6509](https://github.com/apollographql/router/pull/6509))
+
+When subgraph operations are deserialized, typically from a query plan cache, they are not automatically parsed into a full document. Instead, each node needs to initialize its operation(s) prior to execution. With this change, the primary node inside SubscriptionNode is initialized in the same way as other nodes in the plan.
+
+By [@tninesling](https://github.com/tninesling) in https://github.com/apollographql/router/pull/6509

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/subscription_query.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/subscription_query.graphql
@@ -1,0 +1,6 @@
+subscription MessageSubscription {
+  messages {
+    subject
+    content
+  }
+}

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/subscription_schema.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/subscription_schema.graphql
@@ -1,0 +1,92 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION) {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+directive @join__directive(
+  graphs: [join__Graph!]
+  name: String!
+  args: join__DirectiveArguments
+) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH @join__graph(name: "subgraph", url: "http://localhost:4001")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Message @join__type(graph: SUBGRAPH) {
+  subject: String
+  content: String
+}
+
+type Mutation @join__type(graph: SUBGRAPH) {
+  addMessage(subject: String, content: String): Message
+}
+
+type Query @join__type(graph: SUBGRAPH) {
+  allMessages: [Message]
+}
+
+type Subscription @join__type(graph: SUBGRAPH) {
+  messages: Message
+}

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -1143,4 +1143,15 @@ mod tests {
 
         assert_eq!(estimated_cost(schema, query, variables), 1.0);
     }
+
+    #[test(tokio::test)]
+    async fn subscription_request() {
+        let schema = include_str!("./fixtures/subscription_schema.graphql");
+        let query = include_str!("./fixtures/subscription_query.graphql");
+        let variables = "{}";
+
+        assert_eq!(estimated_cost(schema, query, variables), 1.0);
+        assert_eq!(planned_cost_js(schema, query, variables).await, 1.0);
+        assert_eq!(planned_cost_rust(schema, query, variables), 1.0);
+    }
 }

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -354,7 +354,8 @@ impl PlanNode {
                     }
                 }
             }
-            PlanNode::Subscription { primary: _, rest } => {
+            PlanNode::Subscription { primary, rest } => {
+                primary.init_parsed_operation(subgraph_schemas)?;
                 if let Some(node) = rest.as_mut() {
                     node.init_parsed_operations(subgraph_schemas)?;
                 }

--- a/apollo-router/src/query_planner/subscription.rs
+++ b/apollo-router/src/query_planner/subscription.rs
@@ -12,10 +12,12 @@ use tower::ServiceExt;
 use tracing_futures::Instrument;
 
 use super::execution::ExecutionParameters;
+use super::fetch::SubgraphSchemas;
 use super::fetch::Variables;
 use super::rewrites;
 use super::OperationKind;
 use crate::error::FetchError;
+use crate::error::ValidationErrors;
 use crate::graphql::Error;
 use crate::graphql::Request;
 use crate::graphql::Response;
@@ -271,5 +273,14 @@ impl SubscriptionNode {
             .into_parts();
 
         Ok(response.errors)
+    }
+
+    pub(crate) fn init_parsed_operation(
+        &mut self,
+        subgraph_schemas: &SubgraphSchemas,
+    ) -> Result<(), ValidationErrors> {
+        let schema = &subgraph_schemas[self.service_name.as_ref()];
+        self.operation.init_parsed(schema)?;
+        Ok(())
     }
 }


### PR DESCRIPTION
When subgraph operations are deserialized, typically from a query plan cache, they are not automatically parsed into a full document. Each node needs to initialize its operation(s) prior to execution, and the primary node inside SubscriptionNode was missed in the first pass.

This PR also includes a test for demand control scoring. The new test does not reproduce this original issue, but it does provide some basic coverage to ensure scoring handles this operation type.

<!-- ROUTER-824 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
