### PR TITLE
`->jsonStringify` method

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/methods.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods.rs
@@ -34,6 +34,7 @@ pub(super) enum ArrowMethod {
     Slice,
     Size,
     Entries,
+    JsonStringify,
 
     // Future methods:
     TypeOf,
@@ -142,6 +143,7 @@ impl std::ops::Deref for ArrowMethod {
             Self::Slice => &public::SliceMethod,
             Self::Size => &public::SizeMethod,
             Self::Entries => &public::EntriesMethod,
+            Self::JsonStringify => &public::JsonStringifyMethod,
 
             // Future methods:
             Self::TypeOf => &future::TypeOfMethod,
@@ -195,6 +197,7 @@ impl ArrowMethod {
             "not" => Some(Self::Not),
             "or" => Some(Self::Or),
             "and" => Some(Self::And),
+            "jsonStringify" => Some(Self::JsonStringify),
             _ => None,
         };
 
@@ -218,6 +221,7 @@ impl ArrowMethod {
                 | Self::Slice
                 | Self::Size
                 | Self::Entries
+                | Self::JsonStringify
         )
     }
 }

--- a/apollo-federation/src/sources/connect/json_selection/methods/public.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public.rs
@@ -773,3 +773,56 @@ fn entries_shape(
         ),
     }
 }
+
+impl_arrow_method!(
+    JsonStringifyMethod,
+    json_stringify_method,
+    json_stringify_shape
+);
+fn json_stringify_method(
+    method_name: &WithRange<String>,
+    method_args: Option<&MethodArgs>,
+    data: &JSON,
+    _vars: &VarsWithPathsMap,
+    input_path: &InputPath<JSON>,
+    _tail: &WithRange<PathList>,
+) -> (Option<JSON>, Vec<ApplyToError>) {
+    if method_args.is_some() {
+        return (
+            None,
+            vec![ApplyToError::new(
+                format!(
+                    "Method ->{} does not take any arguments",
+                    method_name.as_ref()
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+            )],
+        );
+    }
+
+    match serde_json::to_string(data) {
+        Ok(val) => (Some(JSON::String(val.into())), vec![]),
+        Err(err) => (
+            None,
+            vec![ApplyToError::new(
+                format!(
+                    "Method ->{} failed to serialize JSON: {}",
+                    method_name.as_ref(),
+                    err
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+            )],
+        ),
+    }
+}
+fn json_stringify_shape(
+    _method_name: &WithRange<String>,
+    _method_args: Option<&MethodArgs>,
+    _input_shape: Shape,
+    _dollar_shape: Shape,
+    _named_var_shapes: &IndexMap<&str, Shape>,
+) -> Shape {
+    Shape::string()
+}

--- a/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
@@ -1138,3 +1138,39 @@ fn test_logical_methods() {
         (Some(json!(false)), vec![]),
     );
 }
+
+#[rstest::rstest]
+#[case(json!(null), json!("null"), vec![])]
+#[case(json!(true), json!("true"), vec![])]
+#[case(json!(false), json!("false"), vec![])]
+#[case(json!(42), json!("42"), vec![])]
+#[case(json!(10.8), json!("10.8"), vec![])]
+#[case(json!("hello world"), json!("\"hello world\""), vec![])]
+#[case(json!([1, 2, 3]), json!("[1,2,3]"), vec![])]
+#[case(json!({ "key": "value" }), json!("{\"key\":\"value\"}"), vec![])]
+#[case(json!([1, "two", true, null]), json!("[1,\"two\",true,null]"), vec![])]
+fn table_test_json_stringify_method(
+    #[case] input: JSON,
+    #[case] expected: JSON,
+    #[case] errors: Vec<ApplyToError>,
+) {
+    assert_eq!(
+        selection!("$->jsonStringify").apply_to(&input),
+        (Some(expected), errors),
+    );
+}
+
+#[test]
+fn test_json_stringify_method_error() {
+    assert_eq!(
+        selection!("$->jsonStringify(1)").apply_to(&json!(null)),
+        (
+            None,
+            vec![ApplyToError::new(
+                "Method ->jsonStringify does not take any arguments".to_string(),
+                vec![json!("->jsonStringify")],
+                Some(3..16)
+            )]
+        ),
+    );
+}


### PR DESCRIPTION
with this method, users can reimplement previous accidental behavior:

```graphql
type Query {
  f(foos: [Int]): T
    @connect(http: { GET: "/{$args.foos}" }, selection: "$")
}
```

Prior to preview.3, this would result in `"/[1,2,3]"`. We removed that behavior so we could implement repeated path/query params in a principled way. But now you can achieve the same result with:

```graphql
type Query {
  f(foos: [Int]): T
    @connect(http: { GET: "/{$args.foos->jsonStringify}" }, selection: "$")
}
```

<!-- https://apollographql.atlassian.net/browse/CNN-535 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
