### PR TITLE
fix: ignore @external types when validating resolvablility

### DIFF
--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -263,19 +263,31 @@ fn check_seen_fields(
                 return None;
             }
             let coord = |(name, _): (&Name, _)| (extended_type.name().clone(), name.clone());
+
+            // ignore all fields on objects marked @external
+            if extended_type
+                .directives()
+                .iter()
+                .any(|dir| &dir.name == external_directive_name)
+            {
+                return None;
+            }
+
             match extended_type {
-                ExtendedType::Object(object) => Some(
-                    // ignore @external fields
-                    object
-                        .fields
-                        .iter()
-                        .filter(|(_, def)| {
-                            !def.directives
-                                .iter()
-                                .any(|dir| &dir.name == external_directive_name)
-                        })
-                        .map(coord),
-                ),
+                ExtendedType::Object(object) => {
+                    // ignore fields marked @external
+                    Some(
+                        object
+                            .fields
+                            .iter()
+                            .filter(|(_, def)| {
+                                !def.directives
+                                    .iter()
+                                    .any(|dir| &dir.name == external_directive_name)
+                            })
+                            .map(coord),
+                    )
+                }
                 ExtendedType::Interface(_) => None, // TODO: when interfaces are supported (probably should include fields from implementing/member types as well)
                 _ => None,
             }

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@all_fields_selected.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@all_fields_selected.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/sources/connect/validation/mod.rs
-expression: "format!(\"{:#?}\", errors)"
+expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/sources/connect/validation/test_data/all_fields_selected.graphql
 ---
 [
@@ -15,28 +15,28 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/all_field
         code: ConnectorsUnresolvedField,
         message: "No connector resolves field `T.secondUnused`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
-            48:3..48:23,
+            49:3..49:23,
         ],
     },
     Message {
         code: ConnectorsUnresolvedField,
         message: "No connector resolves field `C.unselected`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
-            54:3..54:21,
+            55:3..55:21,
         ],
     },
     Message {
         code: ConnectorsUnresolvedField,
         message: "No connector resolves field `D.unselected`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
-            59:3..59:21,
+            60:3..60:21,
         ],
     },
     Message {
         code: ConnectorsUnresolvedField,
         message: "No connector resolves field `Unused.unselected`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
-            63:3..63:18,
+            64:3..64:18,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/test_data/all_fields_selected.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/all_fields_selected.graphql
@@ -36,11 +36,12 @@ type T @key(fields: "id") {
   wrapped: D
   unwrapped: String!
   external: External @external
+  external2: External2 @external
   computed: String!
     @requires(fields: "external")
     @connect(
       http: {
-        GET: "http://test/computed?id={$this.id}&external={$this.external.id}"
+        GET: "http://test/computed?id={$this.id}&external={$this.external.id}&external2={$this.external2.id}"
       }
       selection: "$"
     )
@@ -65,4 +66,8 @@ type Unused {
 
 type External {
   id: ID! @external
+}
+
+type External2 @external {
+  id: ID!
 }


### PR DESCRIPTION
the external directive can be applied to fields, or to an object which effectively applies it to all fields

<!-- https://apollographql.atlassian.net/browse/CNN-541 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
