### PR TITLE
Reduce stack usage when parsing JSON selection

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/lit_expr.rs
+++ b/apollo-federation/src/sources/connect/json_selection/lit_expr.rs
@@ -45,29 +45,32 @@ impl LitExpr {
     // LitExpr      ::= LitPrimitive | LitObject | LitArray | PathSelection
     // LitPrimitive ::= LitString | LitNumber | "true" | "false" | "null"
     pub(crate) fn parse(input: Span) -> ParseResult<WithRange<Self>> {
-        tuple((
-            spaces_or_comments,
-            alt((
-                map(parse_string_literal, |s| s.take_as(Self::String)),
-                Self::parse_number,
-                map(ranged_span("true"), |t| {
-                    WithRange::new(Self::Bool(true), t.range())
-                }),
-                map(ranged_span("false"), |f| {
-                    WithRange::new(Self::Bool(false), f.range())
-                }),
-                map(ranged_span("null"), |n| {
-                    WithRange::new(Self::Null, n.range())
-                }),
-                Self::parse_object,
-                Self::parse_array,
-                map(PathSelection::parse, |p| {
-                    let range = p.range();
-                    WithRange::new(Self::Path(p), range)
-                }),
-            )),
+        let (input, _) = spaces_or_comments(input)?;
+        alt((
+            Self::parse_primitive,
+            Self::parse_object,
+            Self::parse_array,
+            map(PathSelection::parse, |p| {
+                let range = p.range();
+                WithRange::new(Self::Path(p), range)
+            }),
         ))(input)
-        .map(|(input, (_, value))| (input, value))
+    }
+
+    fn parse_primitive(input: Span) -> ParseResult<WithRange<Self>> {
+        alt((
+            map(parse_string_literal, |s| s.take_as(Self::String)),
+            Self::parse_number,
+            map(ranged_span("true"), |t| {
+                WithRange::new(Self::Bool(true), t.range())
+            }),
+            map(ranged_span("false"), |f| {
+                WithRange::new(Self::Bool(false), f.range())
+            }),
+            map(ranged_span("null"), |n| {
+                WithRange::new(Self::Null, n.range())
+            }),
+        ))(input)
     }
 
     // LitNumber ::= "-"? ([0-9]+ ("." [0-9]*)? | "." [0-9]+)
@@ -160,37 +163,32 @@ impl LitExpr {
 
     // LitObject ::= "{" (LitProperty ("," LitProperty)* ","?)? "}"
     fn parse_object(input: Span) -> ParseResult<WithRange<Self>> {
-        tuple((
-            spaces_or_comments,
-            ranged_span("{"),
-            spaces_or_comments,
-            map(
-                opt(tuple((
-                    Self::parse_property,
-                    many0(preceded(
-                        tuple((spaces_or_comments, char(','))),
-                        Self::parse_property,
-                    )),
-                    opt(tuple((spaces_or_comments, char(',')))),
-                ))),
-                |properties| {
-                    let mut output = IndexMap::default();
-                    if let Some(((first_key, first_value), rest, _trailing_comma)) = properties {
-                        output.insert(first_key, first_value);
-                        for (key, value) in rest {
-                            output.insert(key, value);
-                        }
-                    }
-                    Self::Object(output)
-                },
-            ),
-            spaces_or_comments,
-            ranged_span("}"),
-        ))(input)
-        .map(|(input, (_, open_brace, _, output, _, close_brace))| {
-            let range = merge_ranges(open_brace.range(), close_brace.range());
-            (input, WithRange::new(output, range))
-        })
+        let (input, _) = spaces_or_comments(input)?;
+        let (input, open_brace) = ranged_span("{")(input)?;
+        let (mut input, _) = spaces_or_comments(input)?;
+
+        let mut output = IndexMap::default();
+
+        if let Ok((remainder, (key, value))) = Self::parse_property(input) {
+            output.insert(key, value);
+            input = remainder;
+
+            while let Ok((remainder, _)) = tuple((spaces_or_comments, char(',')))(input) {
+                input = remainder;
+                if let Ok((remainder, (key, value))) = Self::parse_property(input) {
+                    output.insert(key, value);
+                    input = remainder;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        let (input, _) = spaces_or_comments(input)?;
+        let (input, close_brace) = ranged_span("}")(input)?;
+
+        let range = merge_ranges(open_brace.range(), close_brace.range());
+        Ok((input, WithRange::new(Self::Object(output), range)))
     }
 
     // LitProperty ::= Key ":" LitExpr

--- a/apollo-federation/src/sources/connect/json_selection/lit_expr.rs
+++ b/apollo-federation/src/sources/connect/json_selection/lit_expr.rs
@@ -43,7 +43,6 @@ pub(crate) enum LitExpr {
 
 impl LitExpr {
     // LitExpr      ::= LitPrimitive | LitObject | LitArray | PathSelection
-    // LitPrimitive ::= LitString | LitNumber | "true" | "false" | "null"
     pub(crate) fn parse(input: Span) -> ParseResult<WithRange<Self>> {
         let (input, _) = spaces_or_comments(input)?;
         alt((
@@ -57,6 +56,7 @@ impl LitExpr {
         ))(input)
     }
 
+    // LitPrimitive ::= LitString | LitNumber | "true" | "false" | "null"
     fn parse_primitive(input: Span) -> ParseResult<WithRange<Self>> {
         alt((
             map(parse_string_literal, |s| s.take_as(Self::String)),


### PR DESCRIPTION
The `tuple` and `alt` methods in `nom` can result in high stack usage because they can take a number of parsers as parameters, which are all on the stack at once. Breaking up `alt` calls into smaller chunks of parsers and eliminating `tuple` in favor of incrementally calling parsers results in a large reduction in the amount of data that needs to be on the stack all at once.

This allows parsing a greater depth of nested JSON selection syntax in a given stack size (from a depth 33 to 46 on my local machine for the test case I was using, a 40% improvement).

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
