### PR TITLE
feat: make executable module public

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -59,7 +59,7 @@ mod compute_job;
 mod configuration;
 mod context;
 mod error;
-mod executable;
+pub mod executable;
 mod files;
 pub mod graphql;
 mod http_ext;


### PR DESCRIPTION
The ` apollo_router::Executable::builder()` allows passing [cli_args](https://github.com/apollographql/router/blob/dev/apollo-router/src/executable.rs#L399) but the module executable that contains the struct [Opt](https://github.com/apollographql/router/blob/dev/apollo-router/src/executable.rs#L153) is private
we have to do our own parsing before calling the executable bc we run some logic before starting the router, this causes a conflict when we run the router just to create the configuration json file
router config schema > configuration_schema.json

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
