### PR TITLE
Revert "Fix the query hashing algorithm (#6205)"

### DIFF
--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert-5.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:ab9056ba140750aa8fe58360172b450fa717e7ea177e4a3c9426fe1291a88da2:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:bfdf859dea9e38e1ea5530a470cd9d3331de3b3d3bacec71f67ada95160ae126:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   },
   {
-    "key": "version:1.0:subgraph:user:type:Query:hash:0d4d253b049bbea514a54a892902fa4b9b658aedc9b8f2a1308323cdeef3c0ca:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:user:type:Query:hash:15985941161a4bdd9f2b00b2e97ab33d8b2f375e2ab78afaffdb208231fe93bb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:ab9056ba140750aa8fe58360172b450fa717e7ea177e4a3c9426fe1291a88da2:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:bfdf859dea9e38e1ea5530a470cd9d3331de3b3d3bacec71f67ada95160ae126:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   },
   {
-    "key": "version:1.0:subgraph:user:type:Query:hash:0d4d253b049bbea514a54a892902fa4b9b658aedc9b8f2a1308323cdeef3c0ca:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:user:type:Query:hash:15985941161a4bdd9f2b00b2e97ab33d8b2f375e2ab78afaffdb208231fe93bb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-3.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:hash:4913f52405bb614177e7c718d43da695c2f0e7411707c2f77f1c62380153c8d8:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:hash:fc8c626beede25849752e711021eac9cf5e995c56a0a39e28f1916ecde4a0026:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "[REDACTED]"
   },
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:4913f52405bb614177e7c718d43da695c2f0e7411707c2f77f1c62380153c8d8:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:fc8c626beede25849752e711021eac9cf5e995c56a0a39e28f1916ecde4a0026:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "[REDACTED]"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:hash:4913f52405bb614177e7c718d43da695c2f0e7411707c2f77f1c62380153c8d8:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:hash:fc8c626beede25849752e711021eac9cf5e995c56a0a39e28f1916ecde4a0026:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "[REDACTED]"
   },
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:4913f52405bb614177e7c718d43da695c2f0e7411707c2f77f1c62380153c8d8:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:fc8c626beede25849752e711021eac9cf5e995c56a0a39e28f1916ecde4a0026:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "[REDACTED]"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-3.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:ab9056ba140750aa8fe58360172b450fa717e7ea177e4a3c9426fe1291a88da2:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:bfdf859dea9e38e1ea5530a470cd9d3331de3b3d3bacec71f67ada95160ae126:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   },
   {
-    "key": "version:1.0:subgraph:user:type:Query:hash:0d4d253b049bbea514a54a892902fa4b9b658aedc9b8f2a1308323cdeef3c0ca:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:user:type:Query:hash:15985941161a4bdd9f2b00b2e97ab33d8b2f375e2ab78afaffdb208231fe93bb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-5.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:ab9056ba140750aa8fe58360172b450fa717e7ea177e4a3c9426fe1291a88da2:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:bfdf859dea9e38e1ea5530a470cd9d3331de3b3d3bacec71f67ada95160ae126:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   },
   {
-    "key": "version:1.0:subgraph:user:type:Query:hash:0d4d253b049bbea514a54a892902fa4b9b658aedc9b8f2a1308323cdeef3c0ca:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:user:type:Query:hash:15985941161a4bdd9f2b00b2e97ab33d8b2f375e2ab78afaffdb208231fe93bb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:ab9056ba140750aa8fe58360172b450fa717e7ea177e4a3c9426fe1291a88da2:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:bfdf859dea9e38e1ea5530a470cd9d3331de3b3d3bacec71f67ada95160ae126:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "private"
   },
   {
-    "key": "version:1.0:subgraph:user:type:Query:hash:0d4d253b049bbea514a54a892902fa4b9b658aedc9b8f2a1308323cdeef3c0ca:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:user:type:Query:hash:15985941161a4bdd9f2b00b2e97ab33d8b2f375e2ab78afaffdb208231fe93bb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "new",
     "cache_control": "private"
   }

--- a/apollo-router/src/plugins/progressive_override/snapshots/apollo_router__plugins__progressive_override__tests__non_overridden_field_yields_expected_query_plan.snap
+++ b/apollo-router/src/plugins/progressive_override/snapshots/apollo_router__plugins__progressive_override__tests__non_overridden_field_yields_expected_query_plan.snap
@@ -19,7 +19,7 @@ expression: query_plan
           "inputRewrites": null,
           "outputRewrites": null,
           "contextRewrites": null,
-          "schemaAwareHash": "343157a7d5b7929ebdc0c17cbf0f23c8d3cf0c93a820856d3a189521cc2f24a2",
+          "schemaAwareHash": "8ffa028a5aed384f5ad1116ab5a94cd26d90d38e55bb8a95e3b847a7863a49a5",
           "authorization": {
             "is_authenticated": false,
             "scopes": [],

--- a/apollo-router/src/plugins/progressive_override/snapshots/apollo_router__plugins__progressive_override__tests__overridden_field_yields_expected_query_plan.snap
+++ b/apollo-router/src/plugins/progressive_override/snapshots/apollo_router__plugins__progressive_override__tests__overridden_field_yields_expected_query_plan.snap
@@ -24,7 +24,7 @@ expression: query_plan
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "df2a0633d70ab97805722bae920647da51b7eb821b06d8a2499683c5c7024316",
+              "schemaAwareHash": "30e3f34574b6a43bb731de8f76b113d845c12f7c07ed00eaf8762107325802b1",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -63,7 +63,7 @@ expression: query_plan
                 "inputRewrites": null,
                 "outputRewrites": null,
                 "contextRewrites": null,
-                "schemaAwareHash": "56ac7a7cc11b7f293acbdaf0327cb2b676415eab8343e9259322a1609c90455e",
+                "schemaAwareHash": "ea1b0945910928c41362204ca23e95924d70c4ff1ac66483645e94dff06e6c2c",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],

--- a/apollo-router/src/plugins/snapshots/apollo_router__plugins__expose_query_plan__tests__it_expose_query_plan-2.snap
+++ b/apollo-router/src/plugins/snapshots/apollo_router__plugins__expose_query_plan__tests__it_expose_query_plan-2.snap
@@ -69,7 +69,7 @@ expression: "serde_json::to_value(response).unwrap()"
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "45b4beebcbf1df72ab950db7bd278417712b1aa39119317f44ad5b425bdb6997",
+              "schemaAwareHash": "4d7744c8b45e9ab9ae0b4b739335904878872023793c7e269b7649ddac90a189",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -109,7 +109,7 @@ expression: "serde_json::to_value(response).unwrap()"
                 "inputRewrites": null,
                 "outputRewrites": null,
                 "contextRewrites": null,
-                "schemaAwareHash": "645f3f8763133d2376e33ab3d1145be7ded0ccc8e94e20aba1fbaa34a51633da",
+                "schemaAwareHash": "34900a19d589dbe2f15802a7ff36d198752af04d44ba6150fa226443871df07c",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],
@@ -156,7 +156,7 @@ expression: "serde_json::to_value(response).unwrap()"
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "a79f69245d777abc4afbd7d0a8fc434137fa4fd1079ef082edf4c7746b5a0fcd",
+                    "schemaAwareHash": "aafe1a73eaeec767664030cf6d0b9a385a4075ac74c992027c4293139afdb29c",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -200,7 +200,7 @@ expression: "serde_json::to_value(response).unwrap()"
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "5ad94764f288a41312e07745510bf5dade2b63fb82c3d896f7d00408dbbe5cce",
+                    "schemaAwareHash": "a76da96c78b57941fcedf7536d2f8b7b8a7241f0e90be0f802271ca0c788d3db",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/src/plugins/snapshots/apollo_router__plugins__expose_query_plan__tests__it_expose_query_plan.snap
+++ b/apollo-router/src/plugins/snapshots/apollo_router__plugins__expose_query_plan__tests__it_expose_query_plan.snap
@@ -69,7 +69,7 @@ expression: "serde_json::to_value(response).unwrap()"
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "45b4beebcbf1df72ab950db7bd278417712b1aa39119317f44ad5b425bdb6997",
+              "schemaAwareHash": "4d7744c8b45e9ab9ae0b4b739335904878872023793c7e269b7649ddac90a189",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -109,7 +109,7 @@ expression: "serde_json::to_value(response).unwrap()"
                 "inputRewrites": null,
                 "outputRewrites": null,
                 "contextRewrites": null,
-                "schemaAwareHash": "645f3f8763133d2376e33ab3d1145be7ded0ccc8e94e20aba1fbaa34a51633da",
+                "schemaAwareHash": "34900a19d589dbe2f15802a7ff36d198752af04d44ba6150fa226443871df07c",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],
@@ -156,7 +156,7 @@ expression: "serde_json::to_value(response).unwrap()"
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "a79f69245d777abc4afbd7d0a8fc434137fa4fd1079ef082edf4c7746b5a0fcd",
+                    "schemaAwareHash": "aafe1a73eaeec767664030cf6d0b9a385a4075ac74c992027c4293139afdb29c",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -200,7 +200,7 @@ expression: "serde_json::to_value(response).unwrap()"
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "5ad94764f288a41312e07745510bf5dade2b63fb82c3d896f7d00408dbbe5cce",
+                    "schemaAwareHash": "a76da96c78b57941fcedf7536d2f8b7b8a7241f0e90be0f802271ca0c788d3db",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__bridge_query_planner__tests__plan_root.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__bridge_query_planner__tests__plan_root.snap
@@ -15,7 +15,7 @@ Fetch(
         output_rewrites: None,
         context_rewrites: None,
         schema_aware_hash: QueryHash(
-            "65e550250ef331b8dc49d9e2da8f4cd5add979720cbe83ba545a0f78ece8d329",
+            "5c5036eef33484e505dd5a8666fd0a802e60d830964a4dbbf662526398563ffd",
         ),
         authorization: CacheKeyMetadata {
             is_authenticated: false,

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -324,9 +324,7 @@ impl Query {
         let operation = Operation::from_hir(&operation, schema, &mut defer_stats, &fragments)?;
 
         let mut visitor =
-            QueryHashVisitor::new(schema.supergraph_schema(), &schema.raw_sdl, document).map_err(
-                |e| SpecError::QueryHashing(format!("could not calculate the query hash: {e}")),
-            )?;
+            QueryHashVisitor::new(schema.supergraph_schema(), &schema.raw_sdl, document);
         traverse::document(&mut visitor, document, operation_name).map_err(|e| {
             SpecError::QueryHashing(format!("could not calculate the query hash: {e}"))
         })?;

--- a/apollo-router/src/spec/query/change.rs
+++ b/apollo-router/src/spec/query/change.rs
@@ -1,57 +1,16 @@
-//! Schema aware query hashing algorithm
-//!
-//! This is a query visitor that calculates a hash of all fields, along with all
-//! the relevant types and directives in the schema. It is designed to generate
-//! the same hash for the same query across schema updates if the schema change
-//! would not affect that query. As an example, if a new type is added to the
-//! schema, we know that it will have no impact to an existing query that cannot
-//! be using it.
-//! This algorithm is used in 2 places:
-//! * in the query planner cache: generating query plans can be expensive, so the
-//! router has a warm up feature, where upon receving a new schema, it will take
-//! the most used queries and plan them, before switching traffic to the new
-//! schema. Generating all of those plans takes a lot of time. By using this
-//! hashing algorithm, we can detect that the schema change does not affect the
-//! query, which means that we can reuse the old query plan directly and avoid
-//! the expensive planning task
-//! * in entity caching: the responses returned by subgraphs can change depending
-//! on the schema (example: a field moving from String to Int), so we need to
-//! detect that. One way to do it was to add the schema hash to the cache key, but
-//! as a result it wipes the cache on every schema update, which will cause
-//! performance and reliability issues. With this hashing algorithm, cached entries
-//! can be kept across schema updates
-//!
-//! ## Technical details
-//!
-//! ### Query string hashing
-//! A full hash of the query string is added along with the schema level data. This
-//! is technically making the algorithm less useful, because the same query with
-//! different indentation would get a different hash, while there would be no difference
-//! in the query plan or the subgraph response. But this makes sure that if we forget
-//! something in the way we hash the query, we will avoid collisions.
-//!
-//! ### Prefixes and suffixes
-//! Across the entire visitor, we add prefixes and suffixes like this:
-//!
-//! ```rust
-//! "^SCHEMA".hash(self);
-//! ```
-//!
-//! This prevents possible collision while hashing multiple things in a sequence. The
-//! `^` character cannot be present in GraphQL names, so this is a good separator.
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::hash::Hasher;
 
 use apollo_compiler::ast;
+use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::executable;
 use apollo_compiler::parser::Parser;
 use apollo_compiler::schema;
 use apollo_compiler::schema::DirectiveList;
 use apollo_compiler::schema::ExtendedType;
-use apollo_compiler::schema::InterfaceType;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
@@ -66,8 +25,6 @@ use crate::plugins::progressive_override::JOIN_SPEC_BASE_URL;
 use crate::spec::Schema;
 
 pub(crate) const JOIN_TYPE_DIRECTIVE_NAME: &str = "join__type";
-pub(crate) const CONTEXT_SPEC_BASE_URL: &str = "https://specs.apollo.dev/context";
-pub(crate) const CONTEXT_DIRECTIVE_NAME: &str = "context";
 
 /// Calculates a hash of the query and the schema, but only looking at the parts of the
 /// schema which affect the query.
@@ -76,19 +33,17 @@ pub(crate) const CONTEXT_DIRECTIVE_NAME: &str = "context";
 pub(crate) struct QueryHashVisitor<'a> {
     schema: &'a schema::Schema,
     // TODO: remove once introspection has been moved out of query planning
-    // For now, introspection is still handled by the planner, so when an
+    // For now, introspection is stiull handled by the planner, so when an
     // introspection query is hashed, it should take the whole schema into account
     schema_str: &'a str,
     hasher: Sha256,
     fragments: HashMap<&'a Name, &'a Node<executable::Fragment>>,
     hashed_types: HashSet<String>,
-    hashed_field_definitions: HashSet<(String, String)>,
+    // name, field
+    hashed_fields: HashSet<(String, String)>,
     seen_introspection: bool,
     join_field_directive_name: Option<String>,
     join_type_directive_name: Option<String>,
-    context_directive_name: Option<String>,
-    // map from context string to list of type names
-    contexts: HashMap<String, Vec<String>>,
 }
 
 impl<'a> QueryHashVisitor<'a> {
@@ -96,14 +51,14 @@ impl<'a> QueryHashVisitor<'a> {
         schema: &'a schema::Schema,
         schema_str: &'a str,
         executable: &'a executable::ExecutableDocument,
-    ) -> Result<Self, BoxError> {
-        let mut visitor = Self {
+    ) -> Self {
+        Self {
             schema,
             schema_str,
             hasher: Sha256::new(),
             fragments: executable.fragments.iter().collect(),
             hashed_types: HashSet::new(),
-            hashed_field_definitions: HashSet::new(),
+            hashed_fields: HashSet::new(),
             seen_introspection: false,
             // should we just return an error if we do not find those directives?
             join_field_directive_name: Schema::directive_name(
@@ -118,30 +73,7 @@ impl<'a> QueryHashVisitor<'a> {
                 ">=0.1.0",
                 JOIN_TYPE_DIRECTIVE_NAME,
             ),
-            context_directive_name: Schema::directive_name(
-                schema,
-                CONTEXT_SPEC_BASE_URL,
-                ">=0.1.0",
-                CONTEXT_DIRECTIVE_NAME,
-            ),
-            contexts: HashMap::new(),
-        };
-
-        visitor.hash_schema()?;
-
-        Ok(visitor)
-    }
-
-    pub(crate) fn hash_schema(&mut self) -> Result<(), BoxError> {
-        "^SCHEMA".hash(self);
-        for directive_definition in self.schema.directive_definitions.values() {
-            self.hash_directive_definition(directive_definition)?;
         }
-
-        self.hash_directive_list_schema(&self.schema.schema_definition.directives);
-
-        "^SCHEMA-END".hash(self);
-        Ok(())
     }
 
     pub(crate) fn hash_query(
@@ -150,9 +82,8 @@ impl<'a> QueryHashVisitor<'a> {
         executable: &'a executable::ExecutableDocument,
         operation_name: Option<&str>,
     ) -> Result<Vec<u8>, BoxError> {
-        let mut visitor = QueryHashVisitor::new(schema, schema_str, executable)?;
+        let mut visitor = QueryHashVisitor::new(schema, schema_str, executable);
         traverse::document(&mut visitor, executable, operation_name)?;
-        // hash the entire query string to prevent collisions
         executable.to_string().hash(&mut visitor);
         Ok(visitor.finish())
     }
@@ -161,317 +92,180 @@ impl<'a> QueryHashVisitor<'a> {
         self.hasher.finalize().as_slice().into()
     }
 
-    fn hash_directive_definition(
-        &mut self,
-        directive_definition: &Node<ast::DirectiveDefinition>,
-    ) -> Result<(), BoxError> {
-        "^DIRECTIVE_DEFINITION".hash(self);
-        directive_definition.name.as_str().hash(self);
-        "^ARGUMENT_LIST".hash(self);
-        for argument in &directive_definition.arguments {
-            self.hash_input_value_definition(argument)?;
-        }
-        "^ARGUMENT_LIST_END".hash(self);
-
-        "^DIRECTIVE_DEFINITION-END".hash(self);
-
-        Ok(())
-    }
-
-    fn hash_directive_list_schema(&mut self, directive_list: &schema::DirectiveList) {
-        "^DIRECTIVE_LIST".hash(self);
-        for directive in directive_list {
-            self.hash_directive(directive);
-        }
-        "^DIRECTIVE_LIST_END".hash(self);
-    }
-
-    fn hash_directive_list_ast(&mut self, directive_list: &ast::DirectiveList) {
-        "^DIRECTIVE_LIST".hash(self);
-        for directive in directive_list {
-            self.hash_directive(directive);
-        }
-        "^DIRECTIVE_LIST_END".hash(self);
-    }
-
     fn hash_directive(&mut self, directive: &Node<ast::Directive>) {
-        "^DIRECTIVE".hash(self);
         directive.name.as_str().hash(self);
-        "^ARGUMENT_LIST".hash(self);
         for argument in &directive.arguments {
-            self.hash_argument(argument);
+            self.hash_argument(argument)
         }
-        "^ARGUMENT_END".hash(self);
-
-        "^DIRECTIVE-END".hash(self);
     }
 
     fn hash_argument(&mut self, argument: &Node<ast::Argument>) {
-        "^ARGUMENT".hash(self);
         argument.name.hash(self);
         self.hash_value(&argument.value);
-        "^ARGUMENT-END".hash(self);
     }
 
     fn hash_value(&mut self, value: &ast::Value) {
-        "^VALUE".hash(self);
-
         match value {
-            schema::Value::Null => "^null".hash(self),
+            schema::Value::Null => "null".hash(self),
             schema::Value::Enum(e) => {
-                "^enum".hash(self);
+                "enum".hash(self);
                 e.hash(self);
             }
             schema::Value::Variable(v) => {
-                "^variable".hash(self);
+                "variable".hash(self);
                 v.hash(self);
             }
             schema::Value::String(s) => {
-                "^string".hash(self);
+                "string".hash(self);
                 s.hash(self);
             }
             schema::Value::Float(f) => {
-                "^float".hash(self);
+                "float".hash(self);
                 f.hash(self);
             }
             schema::Value::Int(i) => {
-                "^int".hash(self);
+                "int".hash(self);
                 i.hash(self);
             }
             schema::Value::Boolean(b) => {
-                "^boolean".hash(self);
+                "boolean".hash(self);
                 b.hash(self);
             }
             schema::Value::List(l) => {
-                "^list[".hash(self);
+                "list[".hash(self);
                 for v in l.iter() {
                     self.hash_value(v);
                 }
-                "^]".hash(self);
+                "]".hash(self);
             }
             schema::Value::Object(o) => {
-                "^object{".hash(self);
+                "object{".hash(self);
                 for (k, v) in o.iter() {
-                    "^key".hash(self);
-
                     k.hash(self);
-                    "^value:".hash(self);
+                    ":".hash(self);
                     self.hash_value(v);
                 }
-                "^}".hash(self);
+                "}".hash(self);
             }
         }
-        "^VALUE-END".hash(self);
     }
 
-    fn hash_type_by_name(&mut self, name: &str) -> Result<(), BoxError> {
-        "^TYPE_BY_NAME".hash(self);
-
-        name.hash(self);
-
-        // we need this this to avoid an infinite loop when hashing types that refer to each other
-        if self.hashed_types.contains(name) {
+    fn hash_type_by_name(&mut self, t: &str) -> Result<(), BoxError> {
+        if self.hashed_types.contains(t) {
             return Ok(());
         }
 
-        self.hashed_types.insert(name.to_string());
+        self.hashed_types.insert(t.to_string());
 
-        if let Some(ty) = self.schema.types.get(name) {
+        if let Some(ty) = self.schema.types.get(t) {
             self.hash_extended_type(ty)?;
         }
-        "^TYPE_BY_NAME-END".hash(self);
-
         Ok(())
     }
 
     fn hash_extended_type(&mut self, t: &'a ExtendedType) -> Result<(), BoxError> {
-        "^EXTENDED_TYPE".hash(self);
-
         match t {
             ExtendedType::Scalar(s) => {
-                "^SCALAR".hash(self);
-                self.hash_directive_list_schema(&s.directives);
-                "^SCALAR_END".hash(self);
+                for directive in &s.directives {
+                    self.hash_directive(&directive.node);
+                }
             }
-            // this only hashes the type level info, not the fields, because those will be taken from the query
-            // we will still hash the fields using for the key
             ExtendedType::Object(o) => {
-                "^OBJECT".hash(self);
-
-                self.hash_directive_list_schema(&o.directives);
+                for directive in &o.directives {
+                    self.hash_directive(&directive.node);
+                }
 
                 self.hash_join_type(&o.name, &o.directives)?;
-
-                self.record_context(&o.name, &o.directives)?;
-
-                "^IMPLEMENTED_INTERFACES_LIST".hash(self);
-                for interface in &o.implements_interfaces {
-                    self.hash_type_by_name(&interface.name)?;
-                }
-                "^IMPLEMENTED_INTERFACES_LIST_END".hash(self);
-                "^OBJECT_END".hash(self);
             }
             ExtendedType::Interface(i) => {
-                "^INTERFACE".hash(self);
-
-                self.hash_directive_list_schema(&i.directives);
-
+                for directive in &i.directives {
+                    self.hash_directive(&directive.node);
+                }
                 self.hash_join_type(&i.name, &i.directives)?;
-
-                self.record_context(&i.name, &i.directives)?;
-
-                "^IMPLEMENTED_INTERFACES_LIST".hash(self);
-                for implementor in &i.implements_interfaces {
-                    self.hash_type_by_name(&implementor.name)?;
-                }
-                "^IMPLEMENTED_INTERFACES_LIST_END".hash(self);
-
-                if let Some(implementers) = self.schema().implementers_map().get(&i.name) {
-                    "^IMPLEMENTER_OBJECT_LIST".hash(self);
-
-                    for object in &implementers.objects {
-                        self.hash_type_by_name(object)?;
-                    }
-                    "^IMPLEMENTER_OBJECT_LIST_END".hash(self);
-
-                    "^IMPLEMENTER_INTERFACE_LIST".hash(self);
-                    for interface in &implementers.interfaces {
-                        self.hash_type_by_name(interface)?;
-                    }
-                    "^IMPLEMENTER_INTERFACE_LIST_END".hash(self);
-                }
-
-                "^INTERFACE_END".hash(self);
             }
             ExtendedType::Union(u) => {
-                "^UNION".hash(self);
+                for directive in &u.directives {
+                    self.hash_directive(&directive.node);
+                }
 
-                self.hash_directive_list_schema(&u.directives);
-
-                self.record_context(&u.name, &u.directives)?;
-
-                "^MEMBER_LIST".hash(self);
                 for member in &u.members {
                     self.hash_type_by_name(member.as_str())?;
                 }
-                "^MEMBER_LIST_END".hash(self);
-                "^UNION_END".hash(self);
             }
             ExtendedType::Enum(e) => {
-                "^ENUM".hash(self);
-
-                self.hash_directive_list_schema(&e.directives);
-
-                "^ENUM_VALUE_LIST".hash(self);
-                for (value, def) in &e.values {
-                    "^VALUE".hash(self);
-
-                    value.hash(self);
-                    self.hash_directive_list_ast(&def.directives);
-                    "^VALUE_END".hash(self);
+                for directive in &e.directives {
+                    self.hash_directive(&directive.node);
                 }
-                "^ENUM_VALUE_LIST_END".hash(self);
-                "^ENUM_END".hash(self);
+
+                for (value, def) in &e.values {
+                    value.hash(self);
+                    for directive in &def.directives {
+                        self.hash_directive(directive);
+                    }
+                }
             }
             ExtendedType::InputObject(o) => {
-                "^INPUT_OBJECT".hash(self);
-                self.hash_directive_list_schema(&o.directives);
-
-                "^FIELD_LIST".hash(self);
-                for (name, ty) in &o.fields {
-                    "^NAME".hash(self);
-                    name.hash(self);
-
-                    "^ARGUMENT".hash(self);
-                    self.hash_input_value_definition(&ty.node)?;
+                for directive in &o.directives {
+                    self.hash_directive(&directive.node);
                 }
-                "^FIELD_LIST_END".hash(self);
-                "^INPUT_OBJECT_END".hash(self);
+
+                for (name, ty) in &o.fields {
+                    if ty.default_value.is_some() {
+                        name.hash(self);
+                        self.hash_input_value_definition(&ty.node)?;
+                    }
+                }
             }
         }
-        "^EXTENDED_TYPE-END".hash(self);
-
         Ok(())
     }
 
     fn hash_type(&mut self, t: &ast::Type) -> Result<(), BoxError> {
-        "^TYPE".hash(self);
-
         match t {
-            schema::Type::Named(name) => self.hash_type_by_name(name.as_str())?,
+            schema::Type::Named(name) => self.hash_type_by_name(name.as_str()),
             schema::Type::NonNullNamed(name) => {
                 "!".hash(self);
-                self.hash_type_by_name(name.as_str())?;
+                self.hash_type_by_name(name.as_str())
             }
             schema::Type::List(t) => {
                 "[]".hash(self);
-                self.hash_type(t)?;
+                self.hash_type(t)
             }
             schema::Type::NonNullList(t) => {
                 "[]!".hash(self);
-                self.hash_type(t)?;
+                self.hash_type(t)
             }
         }
-        "^TYPE-END".hash(self);
-        Ok(())
     }
 
     fn hash_field(
         &mut self,
-        parent_type: &str,
+        parent_type: String,
+        type_name: String,
         field_def: &FieldDefinition,
-        node: &executable::Field,
+        arguments: &[Node<Argument>],
     ) -> Result<(), BoxError> {
-        "^FIELD".hash(self);
-        self.hash_field_definition(parent_type, field_def)?;
+        if self.hashed_fields.insert((parent_type.clone(), type_name)) {
+            self.hash_type_by_name(&parent_type)?;
 
-        "^ARGUMENT_LIST".hash(self);
-        for argument in &node.arguments {
-            self.hash_argument(argument);
+            field_def.name.hash(self);
+
+            for argument in &field_def.arguments {
+                self.hash_input_value_definition(argument)?;
+            }
+
+            for argument in arguments {
+                self.hash_argument(argument);
+            }
+
+            self.hash_type(&field_def.ty)?;
+
+            for directive in &field_def.directives {
+                self.hash_directive(directive);
+            }
+
+            self.hash_join_field(&parent_type, &field_def.directives)?;
         }
-        "^ARGUMENT_LIST_END".hash(self);
-
-        self.hash_directive_list_ast(&node.directives);
-
-        node.alias.hash(self);
-        "^FIELD-END".hash(self);
-
-        Ok(())
-    }
-
-    fn hash_field_definition(
-        &mut self,
-        parent_type: &str,
-        field_def: &FieldDefinition,
-    ) -> Result<(), BoxError> {
-        "^FIELD_DEFINITION".hash(self);
-
-        let field_index = (parent_type.to_string(), field_def.name.as_str().to_string());
-        if self.hashed_field_definitions.contains(&field_index) {
-            return Ok(());
-        }
-
-        self.hashed_field_definitions.insert(field_index);
-
-        self.hash_type_by_name(parent_type)?;
-
-        field_def.name.hash(self);
-        self.hash_type(&field_def.ty)?;
-
-        // for every field, we also need to look at fields defined in `@requires` because
-        // they will affect the query plan
-        self.hash_join_field(parent_type, &field_def.directives)?;
-
-        self.hash_directive_list_ast(&field_def.directives);
-
-        "^ARGUMENT_DEF_LIST".hash(self);
-        for argument in &field_def.arguments {
-            self.hash_input_value_definition(argument)?;
-        }
-        "^ARGUMENT_DEF_LIST_END".hash(self);
-
-        "^FIELD_DEFINITION_END".hash(self);
-
         Ok(())
     }
 
@@ -479,23 +273,17 @@ impl<'a> QueryHashVisitor<'a> {
         &mut self,
         t: &Node<ast::InputValueDefinition>,
     ) -> Result<(), BoxError> {
-        "^INPUT_VALUE".hash(self);
-
         self.hash_type(&t.ty)?;
-        self.hash_directive_list_ast(&t.directives);
-
+        for directive in &t.directives {
+            self.hash_directive(directive);
+        }
         if let Some(value) = t.default_value.as_ref() {
             self.hash_value(value);
-        } else {
-            "^INPUT_VALUE-NO_DEFAULT".hash(self);
         }
-        "^INPUT_VALUE-END".hash(self);
         Ok(())
     }
 
     fn hash_join_type(&mut self, name: &Name, directives: &DirectiveList) -> Result<(), BoxError> {
-        "^JOIN_TYPE".hash(self);
-
         if let Some(dir_name) = self.join_type_directive_name.as_deref() {
             if let Some(dir) = directives.get(dir_name) {
                 if let Some(key) = dir
@@ -518,7 +306,6 @@ impl<'a> QueryHashVisitor<'a> {
                 }
             }
         }
-        "^JOIN_TYPE-END".hash(self);
 
         Ok(())
     }
@@ -528,8 +315,6 @@ impl<'a> QueryHashVisitor<'a> {
         parent_type: &str,
         directives: &ast::DirectiveList,
     ) -> Result<(), BoxError> {
-        "^JOIN_FIELD".hash(self);
-
         if let Some(dir_name) = self.join_field_directive_name.as_deref() {
             if let Some(dir) = directives.get(dir_name) {
                 if let Some(requires) = dir
@@ -553,114 +338,9 @@ impl<'a> QueryHashVisitor<'a> {
                         }
                     }
                 }
-
-                if let Some(context_arguments) = dir
-                    .specified_argument_by_name("contextArguments")
-                    .and_then(|value| value.as_list())
-                {
-                    for argument in context_arguments {
-                        self.hash_context_argument(argument)?;
-                    }
-                }
             }
         }
-        "^JOIN_FIELD-END".hash(self);
 
-        Ok(())
-    }
-
-    fn record_context(
-        &mut self,
-        parent_type: &str,
-        directives: &DirectiveList,
-    ) -> Result<(), BoxError> {
-        if let Some(dir_name) = self.context_directive_name.as_deref() {
-            if let Some(dir) = directives.get(dir_name) {
-                if let Some(name) = dir
-                    .specified_argument_by_name("name")
-                    .and_then(|arg| arg.as_str())
-                {
-                    self.contexts
-                        .entry(name.to_string())
-                        .or_default()
-                        .push(parent_type.to_string());
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Hashes the context argument of a field
-    ///
-    /// contextArgument contains a selection that must be applied to a parent type in the
-    /// query that matches the context name. We store in advance which type names map to
-    /// which contexts, to reuse them here when we encounter the selection.
-    fn hash_context_argument(&mut self, argument: &ast::Value) -> Result<(), BoxError> {
-        if let Some(obj) = argument.as_object() {
-            let context_name = Name::new("context")?;
-            let selection_name = Name::new("selection")?;
-            // the contextArgument input type is defined as follows:
-            // input join__ContextArgument {
-            //     name: String!
-            //     type: String!
-            //     context: String!
-            //     selection: join__FieldValue!
-            //  }
-            // and that is checked by schema validation, so the `context` and `selection` fields
-            // are guaranteed to be present and to be strings.
-            if let (Some(context), Some(selection)) = (
-                obj.iter()
-                    .find(|(k, _)| k == &context_name)
-                    .and_then(|(_, v)| v.as_str()),
-                obj.iter()
-                    .find(|(k, _)| k == &selection_name)
-                    .and_then(|(_, v)| v.as_str()),
-            ) {
-                if let Some(types) = self.contexts.get(context).cloned() {
-                    for ty in types {
-                        if let Ok(parent_type) = Name::new(ty.as_str()) {
-                            let mut parser = Parser::new();
-
-                            // we assume that the selection was already checked by schema validation
-                            if let Ok(field_set) = parser.parse_field_set(
-                                Valid::assume_valid_ref(self.schema),
-                                parent_type.clone(),
-                                selection,
-                                std::path::Path::new("schema.graphql"),
-                            ) {
-                                traverse::selection_set(
-                                    self,
-                                    parent_type.as_str(),
-                                    &field_set.selection_set.selections[..],
-                                )?;
-                            }
-                        }
-                    }
-                }
-            }
-            Ok(())
-        } else {
-            Err("context argument value is not an object".into())
-        }
-    }
-
-    fn hash_interface_implementers(
-        &mut self,
-        intf: &InterfaceType,
-        node: &executable::Field,
-    ) -> Result<(), BoxError> {
-        "^INTERFACE_IMPL".hash(self);
-
-        if let Some(implementers) = self.schema.implementers_map().get(&intf.name) {
-            "^IMPLEMENTER_LIST".hash(self);
-            for object in &implementers.objects {
-                self.hash_type_by_name(object)?;
-                traverse::selection_set(self, object, &node.selection_set.selections)?;
-            }
-            "^IMPLEMENTER_LIST_END".hash(self);
-        }
-
-        "^INTERFACE_IMPL-END".hash(self);
         Ok(())
     }
 }
@@ -671,41 +351,16 @@ impl<'a> Hasher for QueryHashVisitor<'a> {
     }
 
     fn write(&mut self, bytes: &[u8]) {
-        // byte separator between each part that is hashed
-        self.hasher.update(&[0xFF][..]);
         self.hasher.update(bytes);
     }
 }
 
 impl<'a> Visitor for QueryHashVisitor<'a> {
     fn operation(&mut self, root_type: &str, node: &executable::Operation) -> Result<(), BoxError> {
-        "^VISIT_OPERATION".hash(self);
-
         root_type.hash(self);
         self.hash_type_by_name(root_type)?;
-        node.operation_type.hash(self);
-        node.name.hash(self);
 
-        "^VARIABLE_LIST".hash(self);
-        for variable in &node.variables {
-            variable.name.hash(self);
-            self.hash_type(&variable.ty)?;
-
-            if let Some(value) = variable.default_value.as_ref() {
-                self.hash_value(value);
-            } else {
-                "^VISIT_OPERATION-NO_DEFAULT".hash(self);
-            }
-
-            self.hash_directive_list_ast(&variable.directives);
-        }
-        "^VARIABLE_LIST_END".hash(self);
-
-        self.hash_directive_list_ast(&node.directives);
-
-        traverse::operation(self, root_type, node)?;
-        "^VISIT_OPERATION-END".hash(self);
-        Ok(())
+        traverse::operation(self, root_type, node)
     }
 
     fn field(
@@ -714,44 +369,30 @@ impl<'a> Visitor for QueryHashVisitor<'a> {
         field_def: &ast::FieldDefinition,
         node: &executable::Field,
     ) -> Result<(), BoxError> {
-        "^VISIT_FIELD".hash(self);
-
         if !self.seen_introspection && (field_def.name == "__schema" || field_def.name == "__type")
         {
             self.seen_introspection = true;
             self.schema_str.hash(self);
         }
 
-        self.hash_field(parent_type, field_def, node)?;
+        self.hash_field(
+            parent_type.to_string(),
+            field_def.name.as_str().to_string(),
+            field_def,
+            &node.arguments,
+        )?;
 
-        if let Some(ExtendedType::Interface(intf)) =
-            self.schema.types.get(field_def.ty.inner_named_type())
-        {
-            self.hash_interface_implementers(intf, node)?;
-        }
-
-        traverse::field(self, field_def, node)?;
-        "^VISIT_FIELD_END".hash(self);
-        Ok(())
+        traverse::field(self, field_def, node)
     }
 
     fn fragment(&mut self, node: &executable::Fragment) -> Result<(), BoxError> {
-        "^VISIT_FRAGMENT".hash(self);
-
         node.name.hash(self);
         self.hash_type_by_name(node.type_condition())?;
 
-        self.hash_directive_list_ast(&node.directives);
-
-        traverse::fragment(self, node)?;
-        "^VISIT_FRAGMENT-END".hash(self);
-
-        Ok(())
+        traverse::fragment(self, node)
     }
 
     fn fragment_spread(&mut self, node: &executable::FragmentSpread) -> Result<(), BoxError> {
-        "^VISIT_FRAGMENT_SPREAD".hash(self);
-
         node.fragment_name.hash(self);
         let type_condition = &self
             .fragments
@@ -760,12 +401,7 @@ impl<'a> Visitor for QueryHashVisitor<'a> {
             .type_condition();
         self.hash_type_by_name(type_condition)?;
 
-        self.hash_directive_list_ast(&node.directives);
-
-        traverse::fragment_spread(self, node)?;
-        "^VISIT_FRAGMENT_SPREAD-END".hash(self);
-
-        Ok(())
+        traverse::fragment_spread(self, node)
     }
 
     fn inline_fragment(
@@ -773,16 +409,10 @@ impl<'a> Visitor for QueryHashVisitor<'a> {
         parent_type: &str,
         node: &executable::InlineFragment,
     ) -> Result<(), BoxError> {
-        "^VISIT_INLINE_FRAGMENT".hash(self);
-
         if let Some(type_condition) = &node.type_condition {
             self.hash_type_by_name(type_condition)?;
         }
-        self.hash_directive_list_ast(&node.directives);
-
-        traverse::inline_fragment(self, parent_type, node)?;
-        "^VISIT_INLINE_FRAGMENT-END".hash(self);
-        Ok(())
+        traverse::inline_fragment(self, parent_type, node)
     }
 
     fn schema(&self) -> &apollo_compiler::Schema {
@@ -840,7 +470,7 @@ mod tests {
             .unwrap()
             .validate(&schema)
             .unwrap();
-        let mut visitor = QueryHashVisitor::new(&schema, schema_str, &exec).unwrap();
+        let mut visitor = QueryHashVisitor::new(&schema, schema_str, &exec);
         traverse::document(&mut visitor, &exec, None).unwrap();
 
         (
@@ -859,7 +489,7 @@ mod tests {
             .unwrap()
             .validate(&schema)
             .unwrap();
-        let mut visitor = QueryHashVisitor::new(&schema, schema_str, &exec).unwrap();
+        let mut visitor = QueryHashVisitor::new(&schema, schema_str, &exec);
         traverse::document(&mut visitor, &exec, None).unwrap();
 
         hex::encode(visitor.finish())
@@ -868,6 +498,10 @@ mod tests {
     #[test]
     fn me() {
         let schema1: &str = r#"
+        schema {
+          query: Query
+        }
+    
         type Query {
           me: User
           customer: User
@@ -880,6 +514,10 @@ mod tests {
         "#;
 
         let schema2: &str = r#"
+        schema {
+            query: Query
+        }
+    
         type Query {
           me: User
         }
@@ -908,83 +546,37 @@ mod tests {
     #[test]
     fn directive() {
         let schema1: &str = r#"
-        directive @test on OBJECT | FIELD_DEFINITION | INTERFACE | SCALAR | ENUM | UNION | INPUT_OBJECT
+        schema {
+          query: Query
+        }
+        directive @test on OBJECT | FIELD_DEFINITION | INTERFACE | SCALAR | ENUM
     
         type Query {
           me: User
           customer: User
-          s: S
-          u: U
-          e: E
-          inp(i: I): ID
         }
     
         type User {
           id: ID!
           name: String
         }
-
-        scalar S
-
-        type A {
-            a: ID
-        }
-
-        type B {
-            b: ID
-        }
-
-        union U = A | B
-
-        enum E {
-            A
-            B
-        }
-
-        input I {
-            a: Int = 0
-            b: Int
-        }
         "#;
 
         let schema2: &str = r#"
-        directive @test on OBJECT | FIELD_DEFINITION | INTERFACE | SCALAR | ENUM | UNION | INPUT_OBJECT
-
+        schema {
+            query: Query
+        }
+        directive @test on OBJECT | FIELD_DEFINITION | INTERFACE | SCALAR | ENUM
+    
         type Query {
           me: User
           customer: User @test
-          s: S
-          u: U
-          e: E
-          inp(i: I): ID
         }
+    
     
         type User {
           id: ID! @test
           name: String
-        }
-
-        scalar S @test
-
-        type A {
-            a: ID
-        }
-
-        type B {
-            b: ID
-        }
-
-        union U @test = A | B
-
-        enum E @test {
-            A
-            B
-        }
-
-
-        input I @test {
-            a: Int = 0
-            b: Int
         }
         "#;
         let query = "query { me { name } }";
@@ -995,23 +587,14 @@ mod tests {
 
         let query = "query { customer { id } }";
         assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { s }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { u { ...on A { a } ...on B { b } } }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { e }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { inp(i: { b: 0 }) }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
     }
 
     #[test]
     fn interface() {
         let schema1: &str = r#"
+        schema {
+          query: Query
+        }
         directive @test on OBJECT | FIELD_DEFINITION | INTERFACE | SCALAR | ENUM
     
         type Query {
@@ -1051,7 +634,7 @@ mod tests {
         "#;
 
         let query = "query { me { id name } }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
+        assert!(hash(schema1, query).equals(&hash(schema2, query)));
 
         let query = "query { customer { id } }";
         assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
@@ -1061,12 +644,12 @@ mod tests {
     }
 
     #[test]
-    fn arguments_int() {
+    fn arguments() {
         let schema1: &str = r#"
         type Query {
           a(i: Int): Int
           b(i: Int = 1): Int
-          c(i: Int = 1, j: Int = null): Int
+          c(i: Int = 1, j: Int): Int
         }
         "#;
 
@@ -1074,7 +657,7 @@ mod tests {
         type Query {
             a(i: Int!): Int
             b(i: Int = 2): Int
-            c(i: Int = 2, j: Int = null): Int
+            c(i: Int = 2, j: Int): Int
           }
         "#;
 
@@ -1091,141 +674,16 @@ mod tests {
         assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
 
         let query = "query { c(i:0, j: 0)}";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-    }
-
-    #[test]
-    fn arguments_float() {
-        let schema1: &str = r#"
-        type Query {
-          a(i: Float): Int
-          b(i: Float = 1.0): Int
-          c(i: Float = 1.0, j: Int): Int
-        }
-        "#;
-
-        let schema2: &str = r#"
-        type Query {
-            a(i: Float!): Int
-            b(i: Float = 2.0): Int
-            c(i: Float = 2.0, j: Int): Int
-          }
-        "#;
-
-        let query = "query { a(i: 0) }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { b }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { b(i: 0)}";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { c(j: 0)}";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { c(i:0, j: 0)}";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-    }
-
-    #[test]
-    fn arguments_list() {
-        let schema1: &str = r#"
-        type Query {
-          a(i: [Float]): Int
-          b(i: [Float] = [1.0]): Int
-          c(i: [Float] = [1.0], j: Int): Int
-        }
-        "#;
-
-        let schema2: &str = r#"
-        type Query {
-            a(i: [Float!]): Int
-            b(i: [Float] = [2.0]): Int
-            c(i: [Float] = [2.0], j: Int): Int
-          }
-        "#;
-
-        let query = "query { a(i: [0]) }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { b }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { b(i: [0])}";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { c(j: 0)}";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { c(i: [0], j: 0)}";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-    }
-
-    #[test]
-    fn arguments_object() {
-        let schema1: &str = r#"
-        input T {
-          d: Int
-          e: String
-        }
-        input U {
-          c: Int
-        }
-        input V {
-          d: Int = 0
-        }
-
-        type Query {
-          a(i: T): Int
-          b(i: T = { d: 1, e: "a" }): Int
-          c(c: U): Int
-          d(d: V): Int
-        }
-        "#;
-
-        let schema2: &str = r#"
-        input T {
-          d: Int
-          e: String
-        }
-        input U {
-          c: Int!
-        }
-        input V {
-          d: Int = 1
-        }
-        
-        type Query {
-            a(i: T!): Int
-            b(i: T = { d: 2, e: "b" }): Int
-            c(c: U): Int
-            d(d: V): Int
-          }
-        "#;
-
-        let query = "query { a(i: { d: 1, e: \"a\" }) }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { b }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { b(i: { d: 3, e: \"c\" })}";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { c(c: { c: 0 }) }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { d(d: { }) }";
-        assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
-
-        let query = "query { d(d: { d: 2 }) }";
         assert!(hash(schema1, query).doesnt_match(&hash(schema2, query)));
     }
 
     #[test]
     fn entities() {
         let schema1: &str = r#"
+        schema {
+          query: Query
+        }
+    
         scalar _Any
 
         union _Entity = User
@@ -1243,6 +701,10 @@ mod tests {
         "#;
 
         let schema2: &str = r#"
+        schema {
+            query: Query
+        }
+    
         scalar _Any
 
         union _Entity = User
@@ -1268,8 +730,14 @@ mod tests {
             }
         }"#;
 
+        println!("query1: {query1}");
+
         let hash1 = hash_subgraph_query(schema1, query1);
+        println!("hash1: {hash1}");
+
         let hash2 = hash_subgraph_query(schema2, query1);
+        println!("hash2: {hash2}");
+
         assert_ne!(hash1, hash2);
 
         let query2 = r#"query Query1($representations:[_Any!]!){
@@ -1280,8 +748,14 @@ mod tests {
             }
         }"#;
 
+        println!("query2: {query2}");
+
         let hash1 = hash_subgraph_query(schema1, query2);
+        println!("hash1: {hash1}");
+
         let hash2 = hash_subgraph_query(schema2, query2);
+        println!("hash2: {hash2}");
+
         assert_eq!(hash1, hash2);
     }
 
@@ -1567,6 +1041,10 @@ mod tests {
     #[test]
     fn fields_with_different_arguments_have_different_hashes() {
         let schema: &str = r#"
+        schema {
+          query: Query
+        }
+    
         type Query {
           test(arg: Int): String
         }
@@ -1585,35 +1063,19 @@ mod tests {
     }
 
     #[test]
-    fn fields_with_different_arguments_on_nest_field_different_hashes() {
-        let schema: &str = r#"
-        type Test {
-          test(arg: Int): String
-          recursiveLink: Test
-        }
-
-        type Query {
-          directLink: Test
-        }
-        "#;
-
-        let query_one = "{ directLink { test recursiveLink { test(arg: 1) } } }";
-        let query_two = "{ directLink { test recursiveLink { test(arg: 2) } } }";
-
-        assert!(hash(schema, query_one).from_hash_query != hash(schema, query_two).from_hash_query);
-        assert!(hash(schema, query_one).from_visitor != hash(schema, query_two).from_visitor);
-    }
-
-    #[test]
     fn fields_with_different_aliases_have_different_hashes() {
         let schema: &str = r#"
+        schema {
+          query: Query
+        }
+    
         type Query {
           test(arg: Int): String
         }
         "#;
 
-        let query_one = "{ a: test }";
-        let query_two = "{ b: test }";
+        let query_one = "query { a: test }";
+        let query_two = "query { b: test }";
 
         // This assertion tests an internal hash function that isn't directly
         // used for the query hash, and we'll need to make it pass to rely
@@ -1621,1036 +1083,5 @@ mod tests {
         //
         // assert!(hash(schema, query_one).doesnt_match(&hash(schema, query_two)));
         assert!(hash(schema, query_one).from_hash_query != hash(schema, query_two).from_hash_query);
-    }
-
-    #[test]
-    fn operations_with_different_names_have_different_hash() {
-        let schema: &str = r#"
-        type Query {
-          test: String
-        }
-        "#;
-
-        let query_one = "query Foo { test }";
-        let query_two = "query Bar { test }";
-
-        assert!(hash(schema, query_one).from_hash_query != hash(schema, query_two).from_hash_query);
-        assert!(hash(schema, query_one).from_visitor != hash(schema, query_two).from_visitor);
-    }
-
-    #[test]
-    fn adding_directive_on_operation_changes_hash() {
-        let schema: &str = r#"
-        directive @test on QUERY
-        type Query {
-          test: String
-        }
-        "#;
-
-        let query_one = "query { test }";
-        let query_two = "query @test { test }";
-
-        assert!(hash(schema, query_one).from_hash_query != hash(schema, query_two).from_hash_query);
-        assert!(hash(schema, query_one).from_visitor != hash(schema, query_two).from_visitor);
-    }
-
-    #[test]
-    fn order_of_variables_changes_hash() {
-        let schema: &str = r#"
-        type Query {
-          test1(arg: Int): String
-          test2(arg: Int): String
-        }
-        "#;
-
-        let query_one = "query ($foo: Int, $bar: Int) {  test1(arg: $foo) test2(arg: $bar) }";
-        let query_two = "query ($foo: Int, $bar: Int) { test1(arg: $bar) test2(arg: $foo) }";
-
-        assert!(hash(schema, query_one).doesnt_match(&hash(schema, query_two)));
-    }
-
-    #[test]
-    fn query_variables_with_different_types_have_different_hash() {
-        let schema: &str = r#"
-        type Query {
-          test(arg: Int): String
-        }
-        "#;
-
-        let query_one = "query ($var: Int) { test(arg: $var) }";
-        let query_two = "query ($var: Int!) { test(arg: $var) }";
-
-        assert!(hash(schema, query_one).from_hash_query != hash(schema, query_two).from_hash_query);
-        assert!(hash(schema, query_one).from_visitor != hash(schema, query_two).from_visitor);
-    }
-
-    #[test]
-    fn query_variables_with_different_default_values_have_different_hash() {
-        let schema: &str = r#"
-        type Query {
-          test(arg: Int): String
-        }
-        "#;
-
-        let query_one = "query ($var: Int = 1) { test(arg: $var) }";
-        let query_two = "query ($var: Int = 2) { test(arg: $var) }";
-
-        assert!(hash(schema, query_one).from_hash_query != hash(schema, query_two).from_hash_query);
-        assert!(hash(schema, query_one).from_visitor != hash(schema, query_two).from_visitor);
-    }
-
-    #[test]
-    fn adding_directive_to_query_variable_change_hash() {
-        let schema: &str = r#"
-        directive @test on VARIABLE_DEFINITION
-
-        type Query {
-          test(arg: Int): String
-        }
-        "#;
-
-        let query_one = "query ($var: Int) { test(arg: $var) }";
-        let query_two = "query ($var: Int @test) { test(arg: $var) }";
-
-        assert!(hash(schema, query_one).from_hash_query != hash(schema, query_two).from_hash_query);
-        assert!(hash(schema, query_one).from_visitor != hash(schema, query_two).from_visitor);
-    }
-
-    #[test]
-    fn order_of_directives_change_hash() {
-        let schema: &str = r#"
-        directive @foo on FIELD
-        directive @bar on FIELD
-
-        type Query {
-          test(arg: Int): String
-        }
-        "#;
-
-        let query_one = "{ test @foo @bar }";
-        let query_two = "{ test @bar @foo }";
-
-        assert!(hash(schema, query_one).from_hash_query != hash(schema, query_two).from_hash_query);
-        assert!(hash(schema, query_one).from_visitor != hash(schema, query_two).from_visitor);
-    }
-
-    #[test]
-    fn directive_argument_type_change_hash() {
-        let schema1: &str = r#"
-        directive @foo(a: Int) on FIELD
-        directive @bar on FIELD
-
-        type Query {
-          test(arg: Int): String
-        }
-        "#;
-
-        let schema2: &str = r#"
-        directive @foo(a: Int!) on FIELD
-        directive @bar on FIELD
-
-        type Query {
-          test(arg: Int): String
-        }
-        "#;
-
-        let query = "{ test @foo(a: 1) }";
-
-        assert!(hash(schema1, query).from_hash_query != hash(schema2, query).from_hash_query);
-        assert!(hash(schema1, query).from_visitor != hash(schema2, query).from_visitor);
-    }
-
-    #[test]
-    fn adding_directive_on_schema_changes_hash() {
-        let schema1: &str = r#"
-        schema {
-          query: Query
-        } 
-
-        type Query {
-          foo: String
-        }
-        "#;
-
-        let schema2: &str = r#"
-        directive @test on SCHEMA
-        schema @test {
-          query: Query
-        } 
-
-        type Query {
-          foo: String
-        }
-        "#;
-
-        let query = "{ foo }";
-
-        assert!(hash(schema1, query).from_hash_query != hash(schema2, query).from_hash_query);
-        assert!(hash(schema1, query).from_visitor != hash(schema2, query).from_visitor);
-    }
-
-    #[test]
-    fn changing_type_of_field_changes_hash() {
-        let schema1: &str = r#"
-        type Query {
-          test: Int
-        }
-        "#;
-
-        let schema2: &str = r#"
-        type Query {
-          test: Float
-        }
-        "#;
-
-        let query = "{ test }";
-
-        assert!(hash(schema1, query).from_hash_query != hash(schema2, query).from_hash_query);
-        assert!(hash(schema1, query).from_visitor != hash(schema2, query).from_visitor);
-    }
-
-    #[test]
-    fn changing_type_to_interface_changes_hash() {
-        let schema1: &str = r#"
-        type Query {
-          foo: Foo
-        }
-
-        interface Foo {
-          value: String
-        }
-        "#;
-
-        let schema2: &str = r#"
-        type Query {
-          foo: Foo
-        }
-
-        type Foo {
-          value: String
-        }
-        "#;
-
-        let query = "{ foo { value } }";
-
-        assert!(hash(schema1, query).from_hash_query != hash(schema2, query).from_hash_query);
-        assert!(hash(schema1, query).from_visitor != hash(schema2, query).from_visitor);
-    }
-
-    #[test]
-    fn changing_operation_kind_changes_hash() {
-        let schema: &str = r#"
-        schema {
-          query: Test
-          mutation: Test
-        }
-
-        type Test {
-          test: String
-        }
-        "#;
-
-        let query_one = "query { test }";
-        let query_two = "mutation { test }";
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn adding_directive_on_field_should_change_hash() {
-        let schema: &str = r#"
-        directive @test on FIELD
-
-        type Query {
-          test: String
-        }
-        "#;
-
-        let query_one = "{ test }";
-        let query_two = "{ test @test }";
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn adding_directive_on_fragment_spread_change_hash() {
-        let schema: &str = r#"
-        type Query {
-          test: String
-        }
-        "#;
-
-        let query_one = r#"
-        { ...Test }
-
-        fragment Test on Query {
-          test
-        }
-        "#;
-        let query_two = r#"
-        { ...Test @skip(if: false) }
-
-        fragment Test on Query {
-          test
-        }
-        "#;
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn adding_directive_on_fragment_change_hash() {
-        let schema: &str = r#"
-        directive @test on FRAGMENT_DEFINITION
-
-        type Query {
-          test: String
-        }
-        "#;
-
-        let query_one = r#"
-        { ...Test }
-
-        fragment Test on Query {
-          test
-        }
-        "#;
-        let query_two = r#"
-        { ...Test }
-
-        fragment Test on Query @test {
-          test
-        }
-        "#;
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn adding_directive_on_inline_fragment_change_hash() {
-        let schema: &str = r#"
-        type Query {
-          test: String
-        }
-        "#;
-
-        let query_one = "{ ... { test } }";
-        let query_two = "{ ... @skip(if: false) { test } }";
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn moving_field_changes_hash() {
-        let schema: &str = r#"
-        type Query {
-          me: User
-        }
-
-        type User {
-          id: ID
-          name: String
-          friend: User
-        }
-        "#;
-
-        let query_one = r#"
-        { 
-          me {
-            friend {
-              id
-              name
-            }
-          }
-        }
-        "#;
-        let query_two = r#"
-        { 
-          me {
-            friend {
-              id
-            }
-            name
-          }
-        }
-        "#;
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn changing_type_of_fragment_changes_hash() {
-        let schema: &str = r#"
-        type Query {
-          fooOrBar: FooOrBar
-        }
-
-        type Foo {
-          id: ID
-          value: String
-        }
-
-        type Bar {
-          id: ID
-          value: String
-        }
-
-        union FooOrBar = Foo | Bar
-        "#;
-
-        let query_one = r#"
-        { 
-          fooOrBar {
-            ... on Foo { id }
-            ... on Bar { id }
-            ... Test
-          }
-        }
-
-        fragment Test on Foo {
-          value
-        }
-        "#;
-        let query_two = r#"
-        { 
-          fooOrBar {
-            ... on Foo { id }
-            ... on Bar { id }
-            ... Test
-          }
-        }
-
-        fragment Test on Bar {
-          value
-        }
-        "#;
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn changing_interface_implementors_changes_hash() {
-        let schema1: &str = r#"
-        type Query {
-            data: I
-        }
-
-        interface I {
-            id: ID
-            value: String
-        }
-
-        type Foo implements I {
-          id: ID
-          value: String
-          foo: String
-        }
-
-        type Bar {
-          id: ID
-          value: String
-          bar: String
-        }
-        "#;
-
-        let schema2: &str = r#"
-        type Query {
-            data: I
-        }
-
-        interface I {
-            id: ID
-            value: String
-        }
-
-        type Foo implements I {
-          id: ID
-          value: String
-          foo2: String
-        }
-
-        type Bar {
-          id: ID
-          value: String
-          bar: String
-        }
-        "#;
-
-        let schema3: &str = r#"
-        type Query {
-            data: I
-        }
-
-        interface I {
-            id: ID
-            value: String
-        }
-
-        type Foo implements I {
-          id: ID
-          value: String
-          foo: String
-        }
-
-        type Bar implements I {
-          id: ID
-          value: String
-          bar: String
-        }
-        "#;
-
-        let query = r#"
-        {
-          data {
-            id
-            value
-          }
-        }
-        "#;
-
-        // changing an unrelated field in implementors does not change the hash
-        assert_eq!(
-            hash(schema1, query).from_hash_query,
-            hash(schema2, query).from_hash_query
-        );
-        assert_eq!(
-            hash(schema1, query).from_visitor,
-            hash(schema2, query).from_visitor
-        );
-
-        // adding a new implementor changes the hash
-        assert_ne!(
-            hash(schema1, query).from_hash_query,
-            hash(schema3, query).from_hash_query
-        );
-        assert_ne!(
-            hash(schema1, query).from_visitor,
-            hash(schema3, query).from_visitor
-        );
-    }
-
-    #[test]
-    fn changing_interface_directives_changes_hash() {
-        let schema1: &str = r#"
-        directive @a(name: String) on INTERFACE
-
-        type Query {
-            data: I
-        }
-
-        interface I @a {
-            id: ID
-            value: String
-        }
-
-        type Foo implements I {
-          id: ID
-          value: String
-          foo: String
-        }
-        "#;
-
-        let schema2: &str = r#"
-        directive @a(name: String) on INTERFACE
-
-        type Query {
-            data: I
-        }
-
-        interface I  @a(name: "abc") {
-            id: ID
-            value: String
-        }
-
-        type Foo implements I {
-          id: ID
-          value: String
-          foo2: String
-        }
-
-        "#;
-
-        let query = r#"
-        {
-          data {
-            id
-            value
-          }
-        }
-        "#;
-
-        // changing a directive applied on the interface definition changes the hash
-        assert_ne!(
-            hash(schema1, query).from_hash_query,
-            hash(schema2, query).from_hash_query
-        );
-        assert_ne!(
-            hash(schema1, query).from_visitor,
-            hash(schema2, query).from_visitor
-        );
-    }
-
-    #[test]
-    fn it_is_weird_so_i_dont_know_how_to_name_it_change_hash() {
-        let schema: &str = r#"
-        type Query {
-          id: ID
-          someField: SomeType
-          test: String
-        }
-
-        type SomeType {
-          id: ID
-          test: String
-        }
-        "#;
-
-        let query_one = r#"
-        {
-          test 
-          someField { id test }
-          id
-        }
-        "#;
-        let query_two = r#"
-        { 
-          ...test
-          someField { id }
-        }
-
-        fragment test on Query {
-          id
-        }
-        "#;
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn it_change_directive_location() {
-        let schema: &str = r#"
-        directive @foo on QUERY | VARIABLE_DEFINITION
-
-        type Query {
-          field(arg: String): String
-        }
-        "#;
-
-        let query_one = r#"
-        query Test ($arg: String @foo) {
-          field(arg: $arg)
-        }
-        "#;
-        let query_two = r#"
-        query Test ($arg: String) @foo {
-          field(arg: $arg)
-        }
-        "#;
-
-        assert_ne!(
-            hash(schema, query_one).from_hash_query,
-            hash(schema, query_two).from_hash_query
-        );
-        assert_ne!(
-            hash(schema, query_one).from_visitor,
-            hash(schema, query_two).from_visitor
-        );
-    }
-
-    #[test]
-    fn it_changes_on_implementors_list_changes() {
-        let schema_one: &str = r#"
-        interface SomeInterface {
-          value: String
-        }
-
-        type Foo implements SomeInterface {
-          value: String
-        }
-
-        type Bar implements SomeInterface {
-          value: String
-        }
-
-        union FooOrBar = Foo | Bar
-
-        type Query {
-          fooOrBar: FooOrBar
-        }
-        "#;
-        let schema_two: &str = r#"
-        interface SomeInterface {
-          value: String
-        }
-
-        type Foo {
-          value: String # <= This field shouldn't be a part of query plan anymore
-        }
-
-        type Bar implements SomeInterface {
-          value: String
-        }
-
-        union FooOrBar = Foo | Bar
-
-        type Query {
-          fooOrBar: FooOrBar
-        }
-        "#;
-
-        let query = r#"
-        {
-          fooOrBar {
-            ... on SomeInterface {
-              value
-            }
-          } 
-        }
-        "#;
-
-        assert_ne!(
-            hash(schema_one, query).from_hash_query,
-            hash(schema_two, query).from_hash_query
-        );
-        assert_ne!(
-            hash(schema_one, query).from_visitor,
-            hash(schema_two, query).from_visitor
-        );
-    }
-
-    #[test]
-    fn it_changes_on_context_changes() {
-        let schema_one: &str = r#"
-        schema
-  @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/context/v0.1", for: SECURITY) {
-  query: Query
-}
-
-directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
-
-directive @context__fromContext(field: String) on ARGUMENT_DEFINITION
-
-directive @join__directive(
-  graphs: [join__Graph!]
-  name: String!
-  args: join__DirectiveArguments
-) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
-
-directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
-
-directive @join__field(
-  graph: join__Graph
-  requires: join__FieldSet
-  provides: join__FieldSet
-  type: String
-  external: Boolean
-  override: String
-  usedOverridden: Boolean
-  overrideLabel: String
-  contextArguments: [join__ContextArgument!]
-) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-
-directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-
-directive @join__implements(
-  graph: join__Graph!
-  interface: String!
-) repeatable on OBJECT | INTERFACE
-
-directive @join__type(
-  graph: join__Graph!
-  key: join__FieldSet
-  extension: Boolean! = false
-  resolvable: Boolean! = true
-  isInterfaceObject: Boolean! = false
-) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-
-directive @join__unionMember(
-  graph: join__Graph!
-  member: String!
-) repeatable on UNION
-
-directive @link(
-  url: String
-  as: String
-  for: link__Purpose
-  import: [link__Import]
-) repeatable on SCHEMA
-
-scalar context__context
-
-input join__ContextArgument {
-  name: String!
-  type: String!
-  context: String!
-  selection: join__FieldValue!
-}
-
-scalar join__DirectiveArguments
-
-scalar join__FieldSet
-
-scalar join__FieldValue
-
-enum join__Graph {
-  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "https://Subgraph1")
-  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "https://Subgraph2")
-}
-
-scalar link__Import
-
-enum link__Purpose {
-  """
-  `SECURITY` features provide metadata necessary to securely resolve fields.
-  """
-  SECURITY
-
-  """
-  `EXECUTION` features provide metadata necessary for operation execution.
-  """
-  EXECUTION
-}
-
-type Query @join__type(graph: SUBGRAPH1) {
-  t: T! @join__field(graph: SUBGRAPH1)
-}
-
-
-type T
-  @join__type(graph: SUBGRAPH1, key: "id")
-  @context(name: "Subgraph1__context") {
-  id: ID!
-  u: U!
-  uList: [U]!
-  prop: String!
-}
-
-type U
-  @join__type(graph: SUBGRAPH1, key: "id")
-  @join__type(graph: SUBGRAPH2, key: "id") {
-  id: ID!
-  b: String! @join__field(graph: SUBGRAPH2)
-  field: Int!
-    @join__field(
-      graph: SUBGRAPH1
-      contextArguments: [
-        {
-          context: "Subgraph1__context"
-          name: "a"
-          type: "String"
-          selection: "{ prop }"
-        }
-      ]
-    )
-}
-        "#;
-
-        // changing T.prop from String! to String
-        let schema_two: &str = r#"
-        schema
-  @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/context/v0.1", for: SECURITY) {
-  query: Query
-}
-
-directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
-
-directive @context__fromContext(field: String) on ARGUMENT_DEFINITION
-
-directive @join__directive(
-  graphs: [join__Graph!]
-  name: String!
-  args: join__DirectiveArguments
-) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
-
-directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
-
-directive @join__field(
-  graph: join__Graph
-  requires: join__FieldSet
-  provides: join__FieldSet
-  type: String
-  external: Boolean
-  override: String
-  usedOverridden: Boolean
-  overrideLabel: String
-  contextArguments: [join__ContextArgument!]
-) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-
-directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-
-directive @join__implements(
-  graph: join__Graph!
-  interface: String!
-) repeatable on OBJECT | INTERFACE
-
-directive @join__type(
-  graph: join__Graph!
-  key: join__FieldSet
-  extension: Boolean! = false
-  resolvable: Boolean! = true
-  isInterfaceObject: Boolean! = false
-) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-
-directive @join__unionMember(
-  graph: join__Graph!
-  member: String!
-) repeatable on UNION
-
-directive @link(
-  url: String
-  as: String
-  for: link__Purpose
-  import: [link__Import]
-) repeatable on SCHEMA
-
-scalar context__context
-
-input join__ContextArgument {
-  name: String!
-  type: String!
-  context: String!
-  selection: join__FieldValue!
-}
-
-scalar join__DirectiveArguments
-
-scalar join__FieldSet
-
-scalar join__FieldValue
-
-enum join__Graph {
-  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "https://Subgraph1")
-  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "https://Subgraph2")
-}
-
-scalar link__Import
-
-enum link__Purpose {
-  """
-  `SECURITY` features provide metadata necessary to securely resolve fields.
-  """
-  SECURITY
-
-  """
-  `EXECUTION` features provide metadata necessary for operation execution.
-  """
-  EXECUTION
-}
-
-type Query @join__type(graph: SUBGRAPH1) {
-  t: T! @join__field(graph: SUBGRAPH1)
-}
-
-
-type T
-  @join__type(graph: SUBGRAPH1, key: "id")
-  @context(name: "Subgraph1__context") {
-  id: ID!
-  u: U!
-  uList: [U]!
-  prop: String
-}
-
-type U
-  @join__type(graph: SUBGRAPH1, key: "id")
-  @join__type(graph: SUBGRAPH2, key: "id") {
-  id: ID!
-  b: String! @join__field(graph: SUBGRAPH2)
-  field: Int!
-    @join__field(
-      graph: SUBGRAPH1
-      contextArguments: [
-        {
-          context: "Subgraph1__context"
-          name: "a"
-          type: "String"
-          selection: "{ prop }"
-        }
-      ]
-    )
-}
-        "#;
-
-        let query = r#"
-        query Query {
-            t {
-                __typename
-                id
-                u {
-                    __typename
-                    field
-                }
-            }
-        }
-        "#;
-
-        assert_ne!(
-            hash(schema_one, query).from_hash_query,
-            hash(schema_two, query).from_hash_query
-        );
-        assert_ne!(
-            hash(schema_one, query).from_visitor,
-            hash(schema_two, query).from_visitor
-        );
     }
 }

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -53,7 +53,7 @@ async fn query_planner_cache() -> Result<(), BoxError> {
     // If this test fails and the cache key format changed you'll need to update the key here.
     // Look at the top of the file for instructions on getting the new cache key.
     let known_cache_key = &format!(
-        "plan:router:{}:8c0b4bfb4630635c2b5748c260d686ddb301d164e5818c63d6d9d77e13631676:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:924b36a9ae6af4ff198220b1302b14b6329c4beb7c022fd31d6fef82eaad7ccb",
+        "plan:router:{}:70f115ebba5991355c17f4f56ba25bb093c519c4db49a30f3b10de279a4e3fa4:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:924b36a9ae6af4ff198220b1302b14b6329c4beb7c022fd31d6fef82eaad7ccb",
         env!("CARGO_PKG_VERSION")
     );
 
@@ -452,15 +452,14 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
         .unwrap();
     insta::assert_json_snapshot!(response);
 
-    // if this is failing due to a cache key change, hook up redis-cli with the MONITOR command to see the keys being set
     let s:String = client
-          .get("version:1.0:subgraph:products:type:Query:hash:5e8ac155fe1fb5b3b69292f89b7df818a39d88a3bf77031a6bd60c22eeb4b242:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+          .get("version:1.0:subgraph:products:type:Query:hash:238a7aea1ff14ec36fb59429c13e8b497377ad1d869e846f586a10770ca5a983:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
     insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
 
-    let s: String = client.get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:50354623eb0a347d47a62f002fae74c0f579ee693af1fdb9a1e4744b4723dd2c:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c").await.unwrap();
+    let s: String = client.get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:14b8df93cfec3abe70b6d5cad56d49308f9d569fe5dba6ab2aaf21c6302928bb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c").await.unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
     insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
 
@@ -572,7 +571,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
     insta::assert_json_snapshot!(response);
 
     let s:String = client
-        .get("version:1.0:subgraph:reviews:type:Product:entity:d9a4cd73308dd13ca136390c10340823f94c335b9da198d2339c886c738abf0d:hash:50354623eb0a347d47a62f002fae74c0f579ee693af1fdb9a1e4744b4723dd2c:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+        .get("version:1.0:subgraph:reviews:type:Product:entity:d9a4cd73308dd13ca136390c10340823f94c335b9da198d2339c886c738abf0d:hash:14b8df93cfec3abe70b6d5cad56d49308f9d569fe5dba6ab2aaf21c6302928bb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -801,7 +800,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
     insta::assert_json_snapshot!(response);
 
     let s:String = client
-          .get("version:1.0:subgraph:products:type:Query:hash:5e8ac155fe1fb5b3b69292f89b7df818a39d88a3bf77031a6bd60c22eeb4b242:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+          .get("version:1.0:subgraph:products:type:Query:hash:238a7aea1ff14ec36fb59429c13e8b497377ad1d869e846f586a10770ca5a983:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -822,7 +821,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
     );
 
     let s: String = client
-        .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:50354623eb0a347d47a62f002fae74c0f579ee693af1fdb9a1e4744b4723dd2c:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+        .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:14b8df93cfec3abe70b6d5cad56d49308f9d569fe5dba6ab2aaf21c6302928bb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -866,7 +865,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
     insta::assert_json_snapshot!(response);
 
     let s:String = client
-          .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:2253830e3b366dcfdfa4e1acf6afa9e05d3c80ff50171243768a3e416536c89b:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+          .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:b5cebfb48a2a7ed932f097ce6a11488f4ab6b0d9d1c47dae48572941101de3a8:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -993,7 +992,7 @@ async fn query_planner_redis_update_query_fragments() {
         // This configuration turns the fragment generation option *off*.
         include_str!("fixtures/query_planner_redis_config_update_query_fragments.router.yaml"),
         &format!(
-            "plan:router:{}:5938623f2155169070684a48be1e0b8468d0f2c662b5527a2247f683173f7d05:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:28acec2bebc3922cd261ed3c8a13b26d53b49e891797a199e3e1ce8089e813e6",
+            "plan:router:{}:e15b4f5cd51b8cc728e3f5171611073455601e81196cd3cbafc5610d9769a370:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:28acec2bebc3922cd261ed3c8a13b26d53b49e891797a199e3e1ce8089e813e6",
             env!("CARGO_PKG_VERSION")
         ),
     )
@@ -1026,7 +1025,7 @@ async fn query_planner_redis_update_defer() {
     test_redis_query_plan_config_update(
         include_str!("fixtures/query_planner_redis_config_update_defer.router.yaml"),
         &format!(
-            "plan:router:{}:5938623f2155169070684a48be1e0b8468d0f2c662b5527a2247f683173f7d05:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:af3139ddd647c755d2eab5e6a177dc443030a528db278c19ad7b45c5c0324378",
+            "plan:router:{}:e15b4f5cd51b8cc728e3f5171611073455601e81196cd3cbafc5610d9769a370:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:af3139ddd647c755d2eab5e6a177dc443030a528db278c19ad7b45c5c0324378",
             env!("CARGO_PKG_VERSION")
         ),
     )
@@ -1051,7 +1050,7 @@ async fn query_planner_redis_update_type_conditional_fetching() {
             "fixtures/query_planner_redis_config_update_type_conditional_fetching.router.yaml"
         ),
         &format!(
-            "plan:router:{}:5938623f2155169070684a48be1e0b8468d0f2c662b5527a2247f683173f7d05:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:8b87abe2e45d38df4712af966aa540f33dbab6fc2868a409f2dbb6a5a4fb2d08",
+            "plan:router:{}:e15b4f5cd51b8cc728e3f5171611073455601e81196cd3cbafc5610d9769a370:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:8b87abe2e45d38df4712af966aa540f33dbab6fc2868a409f2dbb6a5a4fb2d08",
             env!("CARGO_PKG_VERSION")
         ),
     )
@@ -1077,7 +1076,7 @@ async fn query_planner_redis_update_reuse_query_fragments() {
             "fixtures/query_planner_redis_config_update_reuse_query_fragments.router.yaml"
         ),
         &format!(
-            "plan:router:{}:5938623f2155169070684a48be1e0b8468d0f2c662b5527a2247f683173f7d05:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:9af18c8afd568c197050fc1a60c52a8c98656f1775016110516fabfbedc135fe",
+            "plan:router:{}:e15b4f5cd51b8cc728e3f5171611073455601e81196cd3cbafc5610d9769a370:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:9af18c8afd568c197050fc1a60c52a8c98656f1775016110516fabfbedc135fe",
             env!("CARGO_PKG_VERSION")
         ),
     )
@@ -1105,7 +1104,7 @@ async fn test_redis_query_plan_config_update(updated_config: &str, new_cache_key
 
     // If the tests above are failing, this is the key that needs to be changed first.
     let starting_key = &format!(
-        "plan:router:{}:5938623f2155169070684a48be1e0b8468d0f2c662b5527a2247f683173f7d05:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:924b36a9ae6af4ff198220b1302b14b6329c4beb7c022fd31d6fef82eaad7ccb",
+        "plan:router:{}:e15b4f5cd51b8cc728e3f5171611073455601e81196cd3cbafc5610d9769a370:opname:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:metadata:924b36a9ae6af4ff198220b1302b14b6329c4beb7c022fd31d6fef82eaad7ccb",
         env!("CARGO_PKG_VERSION")
     );
     assert_ne!(starting_key, new_cache_key, "starting_key (cache key for the initial config) and new_cache_key (cache key with the updated config) should not be equal. This either means that the cache key is not being generated correctly, or that the test is not actually checking the updated key.");

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__query_planner_cache.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__query_planner_cache.snap
@@ -13,7 +13,7 @@ expression: query_plan
   "inputRewrites": null,
   "outputRewrites": null,
   "contextRewrites": null,
-  "schemaAwareHash": "b86f4d9d705538498ec90551f9d90f9eee4386be36ad087638932dad3f44bf66",
+  "schemaAwareHash": "1e7884d6c9d01e70e960590b7b646139b416488ffcf6b0b2dd91b3e6940d5e4f",
   "authorization": {
     "is_authenticated": false,
     "scopes": [],

--- a/apollo-router/tests/snapshots/set_context__set_context.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context.snap
@@ -34,7 +34,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "b45f75d11c91f90d616e0786fe9a1a675f4f478a6688aa38b9809b3416b66507",
+              "schemaAwareHash": "0163c552923b61fbde6dbcd879ffc2bb887175dc41bbf75a272875524e664e8d",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -80,7 +80,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "02dbfc4ce65b1eb8ee39c37f09a88b56ee4671bbcdc935f3ec2a7e25e36c2931",
+                "schemaAwareHash": "e64d79913c52a4a8b95bfae44986487a1ac73118f27df3b602972a5cbb1f360a",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_dependent_fetch_failure.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_dependent_fetch_failure.snap
@@ -43,7 +43,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_fetch_dependent_failure__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "e8671657b38c13454f18f2bf8df9ebbeb80235c50592f72a2c4141803fe6db59",
+              "schemaAwareHash": "6bcaa7a2d52a416d5278eaef6be102427f328b6916075f193c87459516a7fb6d",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -89,7 +89,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "8499a69f5ac2e4ce2e0acc76b38b7839b89b6ccba9142494d1a82dd17dd0e5f2",
+                "schemaAwareHash": "0e56752501c8cbf53429c5aa2df95765ea2c7cba95db9213ce42918699232651",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_dependent_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_dependent_fetch_failure_rust_qp.snap
@@ -43,7 +43,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_fetch_dependent_failure__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "dfb0f7a17a089f11d0c95f8e9acb3a17fa4fb21216843913bc3a6c62ce2b7fbd",
+              "schemaAwareHash": "6b659295c8e5aff7b3d7146b878e848b43ad58fba3f4dfce2988530631c3448a",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -89,7 +89,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "f5ae7b50fe8d94eedfb385d91e561de06e3a3256fedca901c0b50ae689b5d630",
+                "schemaAwareHash": "3bc84712c95d01c4e9118cc1f8179e071662862a04cef56d39a0ac6a621daf36",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_list.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_list.snap
@@ -40,7 +40,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "50ba3d7291f38802f222251fe79055e06345e62252e74eba9e01bbec34510cea",
+              "schemaAwareHash": "805348468cefee0e3e745cb1bcec0ab4bd44ba55f6ddb91e52e0bc9b437c2dee",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -86,7 +86,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "02dbfc4ce65b1eb8ee39c37f09a88b56ee4671bbcdc935f3ec2a7e25e36c2931",
+                "schemaAwareHash": "e64d79913c52a4a8b95bfae44986487a1ac73118f27df3b602972a5cbb1f360a",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_list_of_lists.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_list_of_lists.snap
@@ -44,7 +44,7 @@ expression: response
               "operationKind": "query",
               "operationName": "QueryLL__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "589a7dec7f09fdedd06128f1e7396c727740ac1f84ad936ea9c61c3cf96d3ee4",
+              "schemaAwareHash": "53e85332dda78d566187c8886c207b81acfe3ab5ea0cafd3d71fb0b153026d80",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -90,7 +90,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "0c966292093d13acca6c8ebb257a146a46840e5a04c9cbaede12e08df98cd489",
+                "schemaAwareHash": "8ed6f85b6a77c293c97171b4a98f7dd563e98a737d4c3a9f5c54911248498ec7",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_list_of_lists_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_list_of_lists_rust_qp.snap
@@ -44,7 +44,7 @@ expression: response
               "operationKind": "query",
               "operationName": "QueryLL__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "560ba34c3cdda6c435aaab55e21528b252f44caabc6c082117e4e9fcc935af5f",
+              "schemaAwareHash": "0a6255094b34a44c5addf88a5a9bb37847f19ecf10370be675ba55a1330b4ac7",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -90,7 +90,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "b97924736c4f71e4b6e80e2a9e2661130363820bd3df5b2e38000be4a4fb47b5",
+                "schemaAwareHash": "71e6d73b679197d0e979c07446c670bad69897d77bd280dc9c39276fde6e8d99",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_list_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_list_rust_qp.snap
@@ -40,7 +40,7 @@ expression: response
               "operationKind": "query",
               "operationName": "set_context_list_rust_qp__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "f89e82a2730898d4c37766615534224fe8f569b4786a3946e652572a1b99117d",
+              "schemaAwareHash": "fd215e24828b3a7296abe901f843f68b525d8eaf35a019ac34a2198738c91230",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -86,7 +86,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "57d42b319499942de11c8eaf8bedb3618079a21fb01792b1a0a1ca8a1157d04c",
+                "schemaAwareHash": "96a8bf16a86cbddab93bb46364f8b0e63635a928924dcb681dc2371b810eee02",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_no_typenames.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_no_typenames.snap
@@ -32,7 +32,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "b45f75d11c91f90d616e0786fe9a1a675f4f478a6688aa38b9809b3416b66507",
+              "schemaAwareHash": "0163c552923b61fbde6dbcd879ffc2bb887175dc41bbf75a272875524e664e8d",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -78,7 +78,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "02dbfc4ce65b1eb8ee39c37f09a88b56ee4671bbcdc935f3ec2a7e25e36c2931",
+                "schemaAwareHash": "e64d79913c52a4a8b95bfae44986487a1ac73118f27df3b602972a5cbb1f360a",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_no_typenames_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_no_typenames_rust_qp.snap
@@ -32,7 +32,7 @@ expression: response
               "operationKind": "query",
               "operationName": "set_context_no_typenames_rust_qp__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "9b5e7d0de84a6e670d5235682e776eb0ebcd753c955403c7159adea338813a93",
+              "schemaAwareHash": "9c1d7c67821fc43d63e8a217417fbe600a9100e1a43ba50e2f961d4fd4974144",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -78,7 +78,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "0b5a9920448d114be6250a0b85f3092f5dfbce80dc89e26880fb28a5ea684d3b",
+                "schemaAwareHash": "5fdc56a38428bad98d0c5e46f096c0179886815509ffc1918f5c6e0a784e2547",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_rust_qp.snap
@@ -34,7 +34,7 @@ expression: response
               "operationKind": "query",
               "operationName": "set_context_rust_qp__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "d9094fb75802583731265ab088bd914c2c10ad3d2f7e835cbe13d58811ab797f",
+              "schemaAwareHash": "7fb5b477b89d2dcf76239dd30abcf6210462e144376a6b1b589ceb603edd55cd",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -80,7 +80,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "971f94cb09cb7a1a5564661ae4345da5e709f3ae16b81215db80ae61a740e8d2",
+                "schemaAwareHash": "fef499e9ca815057242c5a03e9f0960d5c50d6958b0ac7329fc23b5a6e714eab",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_type_mismatch.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_type_mismatch.snap
@@ -32,7 +32,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_type_mismatch__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "f47b7620f3ba24d2c15a2978451bd7b59f462e63dc3259a244efe1d971979bfa",
+              "schemaAwareHash": "34c8f7c0f16220c5d4b589c8da405f49510e092756fa98629c73dea06fd7c243",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -78,7 +78,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "a6ff3cddbf800b647fdb15f6da6d5e68a71979be93d51852bd289f047202d8ac",
+                "schemaAwareHash": "feb578fd1831280f376d8961644e670dd8c3508d0a18fcf69a6de651e25e9ca8",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_type_mismatch_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_type_mismatch_rust_qp.snap
@@ -32,7 +32,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_type_mismatch__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "0ca90df94a895d97f403b550a05e72808aee80cbfc6f2f3aea8d32ae0d73d2cd",
+              "schemaAwareHash": "29f5e6a254fac05382ddc3e4aac47368dc9847abe711ecf17dbfca7945097faf",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -78,7 +78,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "8ea1a4dce3d934c98814d56884f9e7dad9045562a072216ea903570e01c04680",
+                "schemaAwareHash": "864f2eecd06e2c450e48f2cb551d4e95946575eb7e537a17a04c9a1716c0a482",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_union.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_union.snap
@@ -31,7 +31,7 @@ expression: response
               "operationKind": "query",
               "operationName": "QueryUnion__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "b6ed60b7e69ed10f45f85aba713969cd99b0e1a832464ba3f225fdf055706424",
+              "schemaAwareHash": "3e768a1879f4ced427937721980688052b471dbfee0d653b212c85f2732591cc",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -80,7 +80,7 @@ expression: response
                         "typeCondition": "V"
                       }
                     ],
-                    "schemaAwareHash": "99faa73249f207ea11b1b5064d77f278367398cfee881b2fc3a8a9ebe53f44fe",
+                    "schemaAwareHash": "0c190d5db5b15f89fa45de844d2cec59725986e44fcb0dbdb9ab870a197cf026",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_1"
@@ -134,7 +134,7 @@ expression: response
                         "typeCondition": "V"
                       }
                     ],
-                    "schemaAwareHash": "e925299b31ea9338d10257fd150ec7ece230f55117105dd631181f4b2a33075a",
+                    "schemaAwareHash": "2d7376a8d1f7f2a929361e838bb0435ed4c4a6194fa8754af52d4b6dc7140508",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_1"

--- a/apollo-router/tests/snapshots/set_context__set_context_union_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_union_rust_qp.snap
@@ -31,7 +31,7 @@ expression: response
               "operationKind": "query",
               "operationName": "QueryUnion__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "967a248e156212f72f5abb27c01fe3d5e8bb4db154e0f7015db551ee0fe46877",
+              "schemaAwareHash": "eae4d791b0314c4e2509735ad3d0dd0ca5de8ee4c7f315513931df6e4cb5102d",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -80,7 +80,7 @@ expression: response
                         "typeCondition": "V"
                       }
                     ],
-                    "schemaAwareHash": "77647255b7cbdfcb4a47ab2492c0c5252c4f6d06dd4008b104d8770a584a1e32",
+                    "schemaAwareHash": "b1ba6dd8a0e2edc415efd084401bfa01ecbaaa76a0f7896c27c431bed8c20a08",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_1"
@@ -133,7 +133,7 @@ expression: response
                         "typeCondition": "V"
                       }
                     ],
-                    "schemaAwareHash": "4a608fbd27c2498c1f31bf737143990d8a2f31e72682542d3169fe2fac6d5834",
+                    "schemaAwareHash": "45785998d1610758abe68519f9bc100828afa2ba56c7e55b9d18ad69f3ad27eb",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_1"

--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure.snap
@@ -37,7 +37,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_fetch_failure__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "d321568b33e32986df6d30a82443ebb919949617ffc33affe8b413658af52b8a",
+              "schemaAwareHash": "84a7305d62d79b5bbca976c5522d6b32c5bbcbf76b495e4430f9cdcb51c80a57",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -76,7 +76,7 @@ expression: response
                         "typeCondition": "U"
                       }
                     ],
-                    "schemaAwareHash": "a9aa68bb30f2040298629fc2fe72dc8438ce16bcdfdbe1a16ff088cf61d38719",
+                    "schemaAwareHash": "acb960692b01a756fcc627cafef1c47ead8afa60fa70828e5011ba9f825218ab",
                     "serviceName": "Subgraph2",
                     "variableUsages": []
                   },
@@ -128,7 +128,7 @@ expression: response
                         "typeCondition": "U"
                       }
                     ],
-                    "schemaAwareHash": "da0e31f9990723a68dbd1e1bb164a068342da5561db1a28679693a406429d09a",
+                    "schemaAwareHash": "9fd65f6f213899810bce20180de6754354a25dc3c1bc97d0b7214a177cf8b0bb",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
@@ -37,7 +37,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_fetch_failure__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "03786f26d73a1ad1bfa3fed40f657316857018dc1105b2da578904373b7e1882",
+              "schemaAwareHash": "d3f1ad875170d008059583ca6074e732a178f74474ac31de3bb4397c5080020d",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -86,7 +86,7 @@ expression: response
                         "typeCondition": "U"
                       }
                     ],
-                    "schemaAwareHash": "f615a413abdf99efaf7e760e1246371aa5dd0f2330820cf295335ed48cc077ed",
+                    "schemaAwareHash": "05dc59a826cec26ad8263101508c298dd8d31d79d36f18194dd4cf8cd5f02dc3",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_0"
@@ -129,7 +129,7 @@ expression: response
                         "typeCondition": "U"
                       }
                     ],
-                    "schemaAwareHash": "0e71b293b5c0b6143252865b2c97338cd72a558897b0a478dd0cd8b027f9a5a3",
+                    "schemaAwareHash": "a3c7e6df6f9c93b228f16a937b7159ccf1294fec50a92f60ba004dbebbb64b50",
                     "serviceName": "Subgraph2",
                     "variableUsages": []
                   },

--- a/apollo-router/tests/snapshots/set_context__set_context_with_null.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_with_null.snap
@@ -29,7 +29,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "73819a48542fc2a3eb3a831b27ab5cc0b1286a73c2750279d8886fc529ba9e9e",
+              "schemaAwareHash": "4c0c9f83a57e9a50ff1f6dd601ec0a1588f1485d5cfb1015822af4017263e807",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -82,7 +82,7 @@ expression: response
                     "renameKeyTo": "contextualArgument_1_0"
                   }
                 ],
-                "schemaAwareHash": "042955e454618e67e75f3c86c9b8c71e2da866f1c40d0dc462d52053e1861803",
+                "schemaAwareHash": "8db802e78024d406645f1ddc8972255e917bc738bfbed281691a45e34c92debb",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],

--- a/apollo-router/tests/snapshots/set_context__set_context_with_null_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_with_null_rust_qp.snap
@@ -29,7 +29,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "5a33cc9574d930882310fe1f9ddae8f262a448a50ac9a899e71896a339fa0f85",
+              "schemaAwareHash": "4fc423a49bbddcc8869c014934dfd128dd61a1760c4eb619940ad46f614c843b",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -81,7 +81,7 @@ expression: response
                     "renameKeyTo": "contextualArgument_1_0"
                   }
                 ],
-                "schemaAwareHash": "4f6eeca0e601bbf183b759aa785df84eb0c435a266a36568238e8d721dc8fc3c",
+                "schemaAwareHash": "d863b0ef9ef616faaade4c73b2599395e074ec1521ec07634471894145e97f44",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_disabled-2.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_disabled-2.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "1d2d8b1ab80b4b1293e9753a915997835e6ff5bc54ba4c9b400abe7fa4661386",
+              "schemaAwareHash": "70ca85b28e861b24a7749862930a5f965c4c6e8074d60a87a3952d596fe7cc36",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -137,7 +137,7 @@ expression: response
                 "inputRewrites": null,
                 "outputRewrites": null,
                 "contextRewrites": null,
-                "schemaAwareHash": "66a2bd39c499f1edd8c3ec1bfbc170cb995c6f9e23427b5486b633decd2da08b",
+                "schemaAwareHash": "317a722a677563080aeac92f60ac2257d9288ca6851a0e8980fcf18f58b462a8",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_disabled.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_disabled.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "18631e67bb0c6b514cb51e8dff155a2900c8000ad319ea4784e5ca8b1275aca2",
+              "schemaAwareHash": "0e1644746fe4beab7def35ec8cc12bde39874c6bb8b9dfd928456196b814a111",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -137,7 +137,7 @@ expression: response
                 "inputRewrites": null,
                 "outputRewrites": null,
                 "contextRewrites": null,
-                "schemaAwareHash": "7f3ec4c2c644d43e54d95da83790166d87ab6bfcb31fe5692d8262199bff6d3f",
+                "schemaAwareHash": "6510f6b9672829bd9217618b78ef6f329fbddb125f88184d04e6faaa982ff8bb",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled-2.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled-2.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "1d2d8b1ab80b4b1293e9753a915997835e6ff5bc54ba4c9b400abe7fa4661386",
+              "schemaAwareHash": "70ca85b28e861b24a7749862930a5f965c4c6e8074d60a87a3952d596fe7cc36",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -140,7 +140,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "31465e7b7e358ea9407067188249b51fd7342088e6084360ed0df28199cef5cc",
+                    "schemaAwareHash": "1d21a65a3b5a31e17f7834750ef5b37fb49d99d0a1e2145f00a62d43c5f8423a",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -199,7 +199,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "550ad525da9bb9497fb0d51bf7a64b7d5d73ade5ee7d2e425573dc7e2e248e99",
+                    "schemaAwareHash": "df321f6532c2c9eda0d8c042e5f08073c24e558dd0cae01054886b79416a6c08",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "18631e67bb0c6b514cb51e8dff155a2900c8000ad319ea4784e5ca8b1275aca2",
+              "schemaAwareHash": "0e1644746fe4beab7def35ec8cc12bde39874c6bb8b9dfd928456196b814a111",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -141,7 +141,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "7f3ec4c2c644d43e54d95da83790166d87ab6bfcb31fe5692d8262199bff6d3f",
+                    "schemaAwareHash": "6510f6b9672829bd9217618b78ef6f329fbddb125f88184d04e6faaa982ff8bb",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -201,7 +201,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3874fd9db4a0302422701b93506f42a5de5604355be7093fa2abe23f440161f9",
+                    "schemaAwareHash": "6bc34c108f7cf81896971bffad76dc5275d46231b4dfe492ccc205dda9a4aa16",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_generate_query_fragments-2.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_generate_query_fragments-2.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "1d2d8b1ab80b4b1293e9753a915997835e6ff5bc54ba4c9b400abe7fa4661386",
+              "schemaAwareHash": "70ca85b28e861b24a7749862930a5f965c4c6e8074d60a87a3952d596fe7cc36",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -140,7 +140,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "31465e7b7e358ea9407067188249b51fd7342088e6084360ed0df28199cef5cc",
+                    "schemaAwareHash": "1d21a65a3b5a31e17f7834750ef5b37fb49d99d0a1e2145f00a62d43c5f8423a",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -199,7 +199,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "550ad525da9bb9497fb0d51bf7a64b7d5d73ade5ee7d2e425573dc7e2e248e99",
+                    "schemaAwareHash": "df321f6532c2c9eda0d8c042e5f08073c24e558dd0cae01054886b79416a6c08",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_generate_query_fragments.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_generate_query_fragments.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "18631e67bb0c6b514cb51e8dff155a2900c8000ad319ea4784e5ca8b1275aca2",
+              "schemaAwareHash": "0e1644746fe4beab7def35ec8cc12bde39874c6bb8b9dfd928456196b814a111",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -141,7 +141,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "7f3ec4c2c644d43e54d95da83790166d87ab6bfcb31fe5692d8262199bff6d3f",
+                    "schemaAwareHash": "6510f6b9672829bd9217618b78ef6f329fbddb125f88184d04e6faaa982ff8bb",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -201,7 +201,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3874fd9db4a0302422701b93506f42a5de5604355be7093fa2abe23f440161f9",
+                    "schemaAwareHash": "6bc34c108f7cf81896971bffad76dc5275d46231b4dfe492ccc205dda9a4aa16",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list-2.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list-2.snap
@@ -141,7 +141,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "b74616ae898acf3abefb83e24bde5faf0de0f9475d703b105b60c18c7372ab13",
+              "schemaAwareHash": "ff18ff586aee784ec507117854cb4b64f9693d528df1ee69c922b5d75ae637fb",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -203,7 +203,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "31465e7b7e358ea9407067188249b51fd7342088e6084360ed0df28199cef5cc",
+                    "schemaAwareHash": "1d21a65a3b5a31e17f7834750ef5b37fb49d99d0a1e2145f00a62d43c5f8423a",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -263,7 +263,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "550ad525da9bb9497fb0d51bf7a64b7d5d73ade5ee7d2e425573dc7e2e248e99",
+                    "schemaAwareHash": "df321f6532c2c9eda0d8c042e5f08073c24e558dd0cae01054886b79416a6c08",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list.snap
@@ -141,7 +141,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "65c1648beef44b81ac988224191b18ff469c641fd33032ef0c84165245018b62",
+              "schemaAwareHash": "70b62e564b3924984694d90de2b10947a2f5c14ceb76d154f43bb3c638c4830b",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -204,7 +204,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "7f3ec4c2c644d43e54d95da83790166d87ab6bfcb31fe5692d8262199bff6d3f",
+                    "schemaAwareHash": "6510f6b9672829bd9217618b78ef6f329fbddb125f88184d04e6faaa982ff8bb",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -265,7 +265,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3874fd9db4a0302422701b93506f42a5de5604355be7093fa2abe23f440161f9",
+                    "schemaAwareHash": "6bc34c108f7cf81896971bffad76dc5275d46231b4dfe492ccc205dda9a4aa16",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list_of_list-2.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list_of_list-2.snap
@@ -145,7 +145,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "dc1df8e8d701876c6ea7d25bbeab92a5629a82e55660ccc48fc37e12d5157efa",
+              "schemaAwareHash": "cb374f6eaa19cb529eeae258f2b136dbc751e3784fdc279954e59622cfb1edde",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -208,7 +208,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "31465e7b7e358ea9407067188249b51fd7342088e6084360ed0df28199cef5cc",
+                    "schemaAwareHash": "1d21a65a3b5a31e17f7834750ef5b37fb49d99d0a1e2145f00a62d43c5f8423a",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -269,7 +269,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "550ad525da9bb9497fb0d51bf7a64b7d5d73ade5ee7d2e425573dc7e2e248e99",
+                    "schemaAwareHash": "df321f6532c2c9eda0d8c042e5f08073c24e558dd0cae01054886b79416a6c08",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list_of_list.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list_of_list.snap
@@ -145,7 +145,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "f2466229a91f69cadfa844a20343b03668b7f85fd1310a4b20ba9382ffa2f5e7",
+              "schemaAwareHash": "26ae1da614855e4edee344061c0fc95ec4613a99e012de1f33207cb5318487b8",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -209,7 +209,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "7f3ec4c2c644d43e54d95da83790166d87ab6bfcb31fe5692d8262199bff6d3f",
+                    "schemaAwareHash": "6510f6b9672829bd9217618b78ef6f329fbddb125f88184d04e6faaa982ff8bb",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -271,7 +271,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3874fd9db4a0302422701b93506f42a5de5604355be7093fa2abe23f440161f9",
+                    "schemaAwareHash": "6bc34c108f7cf81896971bffad76dc5275d46231b4dfe492ccc205dda9a4aa16",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_shouldnt_make_article_fetch-2.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_shouldnt_make_article_fetch-2.snap
@@ -54,7 +54,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "446c1a72168f736a89e4f56799333e05b26092d36fc55e22c2e92828061c787b",
+              "schemaAwareHash": "587c887350ef75eaf4b647be94fd682616bcd33909e15fb797cee226e95fa36a",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -115,7 +115,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "f9052a9ce97a084006a1f2054b7e0fba8734f24bb53cf0f7e0ba573c7e709b98",
+                    "schemaAwareHash": "a0bf36d3a611df53c3a60b9b124a2887f2d266858221c606ace0985d101d64bd",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -174,7 +174,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "027cac0584184439636aea68757da18f3e0e18142948e3b8625724f93e8720fc",
+                    "schemaAwareHash": "3e84a53f967bf40d4c08254a94f3fa32a828ab3ad8184a22bb3439c596ecaaf4",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_shouldnt_make_article_fetch.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_shouldnt_make_article_fetch.snap
@@ -54,7 +54,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "cc52bb826d3c06b3ccbc421340fe3f49a81dc2b71dcb6a931a9a769745038e3f",
+              "schemaAwareHash": "5201830580c9c5fadd9c59aea072878f84465c1ae9d905207fa281aa7c1d5340",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -116,7 +116,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "6e83e0a67b509381f1a0c2dfe84db92d0dd6bf4bb23fe4c97ccd3d871364c9f4",
+                    "schemaAwareHash": "62ff891f6971184d3e42b98f8166be72027b5479f9ec098af460a48ea6f6cbf4",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -176,7 +176,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "67834874c123139d942b140fb9ff00ed4e22df25228c3e758eeb44b28d3847eb",
+                    "schemaAwareHash": "7e6f6850777335eb1421a30a45f6888bb9e5d0acf8f55d576d55d1c4b7d23ec7",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],


### PR DESCRIPTION
This branch is based on v1.59.1 but reverts commit c5e12464d52f8ffcfa66669c9f066bf03a8ba0e5 from https://github.com/apollographql/router/pull/6205. This preserves the rest of the work done in the v1.59.x series, including the Datadog priority sampling fix which was a critical bug fix for some users.

The justification for this reversal is currently only hunch-based, but we are trying to investigate an increased cache hit miss rate observed on v1.59.0.  Reverting this commit is the easiest way to eliminate https://github.com/apollographql/router/pull/6205 as the cause.