### PR TITLE
docs: Remove experimental "Schema aware query hashing"

### DIFF
--- a/docs/source/routing/performance/caching/in-memory.mdx
+++ b/docs/source/routing/performance/caching/in-memory.mdx
@@ -40,7 +40,7 @@ supergraph:
 
 ### Cache warm-up
 
-When loading a new schema, a query plan might change for some queries, so cached query plans cannot be reused. 
+When loading a new schema, a query plan might change for some queries, so cached query plans cannot be reused.
 
 To prevent increased latency upon query plan cache invalidation, the router precomputes query plans for the most used queries from the cache when a new schema is loaded.
 
@@ -79,19 +79,6 @@ then look at `apollo_router_schema_loading_time` and `apollo.router.query_planni
 #### Cache warm-up with distributed caching
 
 If the router is using distributed caching for query plans, the warm-up phase will also store the new query plans in Redis. Since all Router instances might have the same distributions of queries in their in-memory cache, the list of queries is shuffled before warm-up, so each Router instance can plan queries in a different order and share their results through the cache.
-
-#### Schema aware query hashing
-
-The query plan cache key uses a hashing algorithm specifically designed for GraphQL queries, using the schema. If a schema update does not affect a query (example: a field was added), then the query hash will stay the same. The query plan cache can use that key during warm up to check if a cached entry can be reused instead of planning it again.
-
-It can be activated through this option:
-
-```yaml title="router.yaml"
-supergraph:
-  query_planning:
-    warmed_up_queries: 100
-    experimental_reuse_query_plans: true
-```
 
 ## Caching automatic persisted queries (APQ)
 


### PR DESCRIPTION
This feature is not something we want to continue to advertise in our documentation.  We don't recommend its use.
