### PR TITLE
fix(fleet_detector): use SizeHint for subgraph request when possible

### DIFF
--- a/.changesets/fix_junior_granddad_salami_dye.md
+++ b/.changesets/fix_junior_granddad_salami_dye.md
@@ -1,0 +1,7 @@
+### Fix missing Content-Length header in subgraph requests ([Issue #6503](https://github.com/apollographql/router/issues/6503))
+
+A new telemetry feature introduced in the Router version 1.59.0 would convert all request bodies to subgraphs into stream to infer the total body sizes. This would cause requests to subgraphs to no longer have a `Content-Length` header, which could cause issues with some GraphQL servers.
+
+This solves this issue by using `SizeHint` when possible to infer the body size instead.
+
+By [@nmoutschen](https://github.com/nmoutschen) in https://github.com/apollographql/router/pull/6538

--- a/.changesets/fix_junior_granddad_salami_dye.md
+++ b/.changesets/fix_junior_granddad_salami_dye.md
@@ -1,7 +1,7 @@
 ### Fix missing Content-Length header in subgraph requests ([Issue #6503](https://github.com/apollographql/router/issues/6503))
 
-A new telemetry feature introduced in the Router version 1.59.0 would convert all request bodies to subgraphs into stream to infer the total body sizes. This would cause requests to subgraphs to no longer have a `Content-Length` header, which could cause issues with some GraphQL servers.
+A change in `1.59.0` caused the Router to send requests to subgraphs without a `Content-Length` header, which would cause issues with some GraphQL servers that depend on that header.
 
-This solves this issue by using `SizeHint` when possible to infer the body size instead.
+This solves the underlying bug and reintroduces the `Content-Length` header.
 
 By [@nmoutschen](https://github.com/nmoutschen) in https://github.com/apollographql/router/pull/6538

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use futures::StreamExt;
+use http_body::Body;
 use opentelemetry::metrics::MeterProvider;
 use opentelemetry_api::metrics::ObservableGauge;
 use opentelemetry_api::metrics::Unit;
@@ -299,6 +300,27 @@ impl PluginPrivate for FleetDetector {
                 HttpRequest {
                     http_request: req.http_request.map(move |body| {
                         let sn = sn.clone();
+                        let size_hint = body.size_hint();
+
+                        // Short-circuit for complete bodies
+                        //
+                        // If the `SizeHint` gives us an exact value, where the upper and lower
+                        // bounds are equal, we can use this for the metric and return without
+                        // wrapping the request Body.
+                        if let Some(upper) = size_hint.upper() {
+                            if upper == size_hint.lower() {
+                                let sn = sn.clone();
+                                u64_counter!(
+                                    "apollo.router.operations.fetch.request_size",
+                                    "Total number of request bytes for subgraph fetches",
+                                    upper as u64,
+                                    subgraph.name = sn.to_string()
+                                );
+                                return body;
+                            }
+                        }
+
+                        // For streaming bodies, we need to wrap the stream and count bytes as we go
                         RouterBody::wrap_stream(body.inspect(move |res| {
                             if let Ok(bytes) = res {
                                 let sn = sn.clone();
@@ -473,6 +495,8 @@ register_private_plugin!("apollo", "fleet_detector", FleetDetector);
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
     use http::StatusCode;
     use tower::Service as _;
 
@@ -660,7 +684,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_enabled_http_client_service() {
+    async fn test_enabled_http_client_service_full() {
         async {
             // WHEN the plugin is enabled
             let plugin = FleetDetector {
@@ -668,7 +692,7 @@ mod tests {
                 ..Default::default()
             };
 
-            // GIVEN an http client service request
+            // GIVEN an http client service request with a complete body
             let mut mock_bad_request_service = MockHttpClientService::new();
             mock_bad_request_service.expect_call().times(1).returning(
                 |req: http::Request<Body>| {
@@ -696,6 +720,86 @@ mod tests {
             let http_client_req = HttpRequest {
                 http_request: http::Request::builder()
                     .body(RouterBody::from("request"))
+                    .unwrap(),
+                context: Default::default(),
+            };
+            let http_client_response = bad_request_http_client_service
+                .ready()
+                .await
+                .unwrap()
+                .call(http_client_req)
+                .await
+                .unwrap();
+
+            // making sure the response body is consumed
+            let _data = hyper::body::to_bytes(http_client_response.http_response.into_body())
+                .await
+                .unwrap();
+
+            // THEN fetch metrics should exist
+            assert_counter!(
+                "apollo.router.operations.fetch",
+                1,
+                &[
+                    KeyValue::new("subgraph.name", "subgraph"),
+                    KeyValue::new("http.response.status_code", 400),
+                    KeyValue::new("client_error", false)
+                ]
+            );
+            assert_counter!(
+                "apollo.router.operations.fetch.request_size",
+                7,
+                &[KeyValue::new("subgraph.name", "subgraph"),]
+            );
+            assert_counter!(
+                "apollo.router.operations.fetch.response_size",
+                7,
+                &[KeyValue::new("subgraph.name", "subgraph"),]
+            );
+        }
+        .with_metrics()
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_enabled_http_client_service_stream() {
+        async {
+            // WHEN the plugin is enabled
+            let plugin = FleetDetector {
+                enabled: true,
+                ..Default::default()
+            };
+
+            // GIVEN an http client service request with a streaming body
+            let mut mock_bad_request_service = MockHttpClientService::new();
+            mock_bad_request_service.expect_call().times(1).returning(
+                |req: http::Request<Body>| {
+                    Box::pin(async {
+                        let data = hyper::body::to_bytes(req.into_body()).await?;
+                        Ok(http::Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .header("content-type", "application/json")
+                            // making sure the request body is consumed
+                            .body(Body::from(data))
+                            .unwrap())
+                    })
+                },
+            );
+            let mut bad_request_http_client_service = plugin.http_client_service(
+                "subgraph",
+                mock_bad_request_service
+                    .map_request(|req: HttpRequest| req.http_request.map(|body| body.into_inner()))
+                    .map_response(|res: http::Response<Body>| HttpResponse {
+                        http_response: res.map(RouterBody::from),
+                        context: Default::default(),
+                    })
+                    .boxed(),
+            );
+            let http_client_req = HttpRequest {
+                http_request: http::Request::builder()
+                    .body(RouterBody::wrap_stream(futures::stream::once(async {
+                        Ok::<_, Infallible>("request")
+                    })))
                     .unwrap(),
                 context: Default::default(),
             };

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -313,7 +313,7 @@ impl PluginPrivate for FleetDetector {
                                 u64_counter!(
                                     "apollo.router.operations.fetch.request_size",
                                     "Total number of request bytes for subgraph fetches",
-                                    upper as u64,
+                                    upper,
                                     subgraph.name = sn.to_string()
                                 );
                                 return body;

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -304,20 +304,17 @@ impl PluginPrivate for FleetDetector {
 
                         // Short-circuit for complete bodies
                         //
-                        // If the `SizeHint` gives us an exact value, where the upper and lower
-                        // bounds are equal, we can use this for the metric and return without
-                        // wrapping the request Body.
-                        if let Some(upper) = size_hint.upper() {
-                            if upper == size_hint.lower() {
-                                let sn = sn.clone();
-                                u64_counter!(
-                                    "apollo.router.operations.fetch.request_size",
-                                    "Total number of request bytes for subgraph fetches",
-                                    upper,
-                                    subgraph.name = sn.to_string()
-                                );
-                                return body;
-                            }
+                        // If the `SizeHint` gives us an exact value, we can use this for the
+                        // metric and return without wrapping the request Body into a stream.
+                        if let Some(size) = size_hint.exact() {
+                            let sn = sn.clone();
+                            u64_counter!(
+                                "apollo.router.operations.fetch.request_size",
+                                "Total number of request bytes for subgraph fetches",
+                                size,
+                                subgraph.name = sn.to_string()
+                            );
+                            return body;
                         }
 
                         // For streaming bodies, we need to wrap the stream and count bytes as we go


### PR DESCRIPTION
This uses hyper's `SizeHint` for infering the request body size when we have a priori knowledge of the request body.

Fixes #6503 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

None

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
