### PR TITLE
fix(router, only 1.x): fix the `apollo_router_session_count_total` metric

### DIFF
--- a/.changesets/maint_renee_migrate_metrics_histograms.md
+++ b/.changesets/maint_renee_migrate_metrics_histograms.md
@@ -1,5 +1,0 @@
-### Migrate histogram metrics to `{f,u}64_histogram!` ([PR #6356](https://github.com/apollographql/router/pull/6356))
-
-Updates histogram metrics using the legacy `tracing::info!(histogram.*)` syntax to the new metrics macros.
-
-By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/6356

--- a/.changesets/maint_renee_migrate_metrics_values.md
+++ b/.changesets/maint_renee_migrate_metrics_values.md
@@ -1,5 +1,5 @@
-### Migrate gauge metrics to OTel instruments ([PR #6476](https://github.com/apollographql/router/pull/6476))
+### Migrate various metrics to OTel instruments ([PR #6476](https://github.com/apollographql/router/pull/6476), [PR #6356](https://github.com/apollographql/router/pull/6356), [PR #6539](https://github.com/apollographql/router/pull/6539))
 
-Updates gauge metrics using the legacy `tracing::info!(value.*)` syntax to OTel instruments. 
+Various metrics using our legacy mechanism based on the `tracing` crate are migrated to OTel instruments.
 
-By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/6476
+By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/6476, https://github.com/apollographql/router/pull/6356, https://github.com/apollographql/router/pull/6539


### PR DESCRIPTION
In #6495 I migrated this metric to an otel ObservableGauge. However the lifetime of the count guard was too short, so the value of the metric would almost always just be 0; and the lifetime of the instrument was too short, so even the wrong value of 0 would not actually be reported. This change was not part of a release so there is no user impact as long as we land this :)

Now the lifetime of the instrument is captured by all requests, so the instrument is kept even post-reload if a request is still being completed from the old schema.

Also, a test verifies that the count increments and decrements as expected.

This does **not need to be ported to Router 2.0**.

<!-- [ROUTER-911] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-911]: https://apollographql.atlassian.net/browse/ROUTER-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ