### PR TITLE
Document tower layers in router and supergraph services

### DIFF
--- a/apollo-router/src/plugins/limits/layer.rs
+++ b/apollo-router/src/plugins/limits/layer.rs
@@ -34,6 +34,9 @@ impl Clone for BodyLimitControlInner {
 
 /// This structure allows the body limit to be updated dynamically.
 /// It also allows the error message to be updated
+///
+// XXX(@goto-bus-stop): The dynamic updating seems to be used only in one place, and I'm not sure
+// why it is. But I doubt that it would be the only way to solve whatever it's doing.
 #[derive(Clone)]
 pub(crate) struct BodyLimitControl {
     inner: BodyLimitControlInner,

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -1,7 +1,7 @@
-//!  (A)utomatic (P)ersisted (Q)ueries cache.
+//! (A)utomatic (P)ersisted (Q)ueries cache.
 //!
-//!  For more information on APQ see:
-//!  <https://www.apollographql.com/docs/apollo-server/performance/apq/>
+//! For more information on APQ see:
+//! <https://www.apollographql.com/docs/apollo-server/performance/apq/>
 
 use http::header::CACHE_CONTROL;
 use http::HeaderValue;
@@ -71,6 +71,11 @@ impl APQLayer {
         Self { cache: None }
     }
 
+    /// Supergraph service implementation for Automatic Persisted Queries.
+    ///
+    /// This functions similarly to a checkpoint service, short-circuiting the pipeline on error
+    /// (using an `Err()` return value).
+    /// The user of this function is responsible for propagating short-circuiting.
     pub(crate) async fn supergraph_request(
         &self,
         request: SupergraphRequest,

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -1,3 +1,7 @@
+//! Layers that do HTTP content negotiation using the Accept and Content-Type headers.
+//!
+//! Content negotiation uses a pair of layers that work together at the router and supergraph stages.
+
 use std::ops::ControlFlow;
 
 use http::header::ACCEPT;
@@ -35,7 +39,15 @@ use crate::services::MULTIPART_SUBSCRIPTION_SPEC_PARAMETER;
 use crate::services::MULTIPART_SUBSCRIPTION_SPEC_VALUE;
 
 pub(crate) const GRAPHQL_JSON_RESPONSE_HEADER_VALUE: &str = "application/graphql-response+json";
-/// [`Layer`] for Content-Type checks implementation.
+
+/// A layer for the router service that rejects requests that do not have an expected Content-Type,
+/// or that have an Accept header that is not supported by the router.
+///
+/// In particular, the Content-Type must be JSON, and the Accept header must include */*, or one of
+/// the JSON/GraphQL MIME types.
+///
+/// # Context
+/// If the request is valid, this layer adds a [`ClientRequestAccepts`] value to the context.
 #[derive(Clone, Default)]
 pub(crate) struct RouterLayer {}
 
@@ -52,7 +64,7 @@ where
                 if req.router_request.method() != Method::GET
                     && !content_type_is_json(req.router_request.headers())
                 {
-                    let response: http::Response<crate::services::router::Body> = http::Response::builder()
+                    let response = http::Response::builder()
                         .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
                         .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                         .body(router::body::from_bytes(
@@ -88,8 +100,10 @@ where
 
                     Ok(ControlFlow::Continue(req))
                 } else {
-                    let response: http::Response<crate::services::router::Body> = http::Response::builder().status(StatusCode::NOT_ACCEPTABLE).header(CONTENT_TYPE, APPLICATION_JSON.essence_str()).body(
-                        router::body::from_bytes(
+                    let response = http::Response::builder()
+                        .status(StatusCode::NOT_ACCEPTABLE)
+                        .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                        .body(router::body::from_bytes(
                             serde_json::json!({
                                 "errors": [
                                     graphql::Error::builder()
@@ -103,7 +117,9 @@ where
                                         .extension_code("INVALID_ACCEPT_HEADER")
                                         .build()
                                 ]
-                            }).to_string())).expect("cannot fail");
+                            })
+                            .to_string()
+                        )).expect("cannot fail");
 
                     Ok(ControlFlow::Break(response.into()))
                 }
@@ -113,7 +129,12 @@ where
     }
 }
 
-/// [`Layer`] for Content-Type checks implementation.
+/// A layer for the supergraph service that populates the Content-Type response header.
+///
+/// The content type is decided based on the [`ClientRequestAccepts`] context value, which is
+/// populated by the content negotiation [`RouterLayer`].
+// XXX(@goto-bus-stop): this feels a bit odd. It probably works fine because we can only ever respond
+// with JSON, but maybe this should be done as close as possible to where we populate the response body..?
 #[derive(Clone, Default)]
 pub(crate) struct SupergraphLayer {}
 

--- a/apollo-router/src/services/layers/persisted_queries/mod.rs
+++ b/apollo-router/src/services/layers/persisted_queries/mod.rs
@@ -1,3 +1,5 @@
+//! Implements support for persisted queries and safelisting at the supergraph service stage.
+
 mod id_extractor;
 mod manifest_poller;
 
@@ -25,8 +27,21 @@ const PERSISTED_QUERIES_CLIENT_NAME_CONTEXT_KEY: &str = "apollo_persisted_querie
 const PERSISTED_QUERIES_SAFELIST_SKIP_ENFORCEMENT_CONTEXT_KEY: &str =
     "apollo_persisted_queries::safelist::skip_enforcement";
 
+/// Marker type for request context to identify requests that were expanded from a persisted query
+/// ID.
 struct UsedQueryIdFromManifest;
 
+/// Implements persisted query support, namely expanding requests using persisted query IDs and
+/// filtering free-form GraphQL requests based on router configuration.
+///
+/// Despite the name, this is not really in any way a layer today.
+///
+/// This type actually consists of two conceptual layers that must both be applied at the supergraph
+/// service stage, at different points:
+/// - [PersistedQueryLayer::supergraph_request] must be done *before* the GraphQL request is parsed
+///    and validated.
+/// - [PersistedQueryLayer::supergraph_request_with_analyzed_query] must be done *after* the
+///    GraphQL request is parsed and validated.
 #[derive(Debug)]
 pub(crate) struct PersistedQueryLayer {
     /// Manages polling uplink for persisted queries and caches the current
@@ -62,11 +77,17 @@ impl PersistedQueryLayer {
         }
     }
 
-    /// Run a request through the layer.
+    /// Handles pre-parsing work for requests using persisted queries.
+    ///
     /// Takes care of:
     /// 1) resolving a persisted query ID to a query body
-    /// 2) matching a freeform GraphQL request against persisted queries, optionally rejecting it based on configuration
-    /// 3) continuing to the next stage of the router
+    /// 2) rejecting free-form GraphQL requests if they are never allowed by configuration.
+    ///    Matching against safelists is done later in
+    ///    [`PersistedQueryLayer::supergraph_request_with_analyzed_query`].
+    ///
+    /// This functions similarly to a checkpoint service, short-circuiting the pipeline on error
+    /// (using an `Err()` return value).
+    /// The user of this function is responsible for propagating short-circuiting.
     pub(crate) fn supergraph_request(
         &self,
         request: SupergraphRequest,
@@ -178,6 +199,16 @@ impl PersistedQueryLayer {
         }
     }
 
+    /// Handles post-GraphQL-parsing work for requests using the persisted queries feature,
+    /// in particular safelisting.
+    ///
+    /// Any request that was expanded by the [`PersistedQueryLayer::supergraph_request`] call is
+    /// passed through immediately. Free-form GraphQL is matched against safelists and rejected or
+    /// passed through based on router configuration.
+    ///
+    /// This functions similarly to a checkpoint service, short-circuiting the pipeline on error
+    /// (using an `Err()` return value).
+    /// The user of this function is responsible for propagating short-circuiting.
     pub(crate) async fn supergraph_request_with_analyzed_query(
         &self,
         request: SupergraphRequest,

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -1,3 +1,6 @@
+//! Implements GraphQL parsing/validation/usage counting of requests at the supergraph service
+//! stage.
+
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -36,7 +39,9 @@ use crate::spec::SpecError;
 use crate::Configuration;
 use crate::Context;
 
-/// [`Layer`] for QueryAnalysis implementation.
+/// A layer-like type that handles several aspects of query parsing and analysis.
+///
+/// The supergraph layer implementation is in [QueryAnalysisLayer::supergraph_request].
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
 pub(crate) struct QueryAnalysisLayer {
@@ -75,6 +80,8 @@ impl QueryAnalysisLayer {
         }
     }
 
+    // XXX(@goto-bus-stop): This is public because query warmup uses it. I think the reason that
+    // warmup uses this instead of `Query::parse_document` directly is to use the worker pool.
     pub(crate) async fn parse_document(
         &self,
         query: &str,
@@ -107,6 +114,20 @@ impl QueryAnalysisLayer {
             .expect("Query::parse_document panicked")
     }
 
+    /// Parses the GraphQL in the supergraph request and computes Apollo usage references.
+    ///
+    /// This functions similarly to a checkpoint service, short-circuiting the pipeline on error
+    /// (using an `Err()` return value).
+    /// The user of this function is responsible for propagating short-circuiting.
+    ///
+    /// # Context
+    /// This stores values in the request context:
+    /// - [`ParsedDocument`]
+    /// - [`ExtendedReferenceStats`]
+    /// - "operation_name" and "operation_kind"
+    /// - authorization details (required scopes, policies), if any
+    /// - [`Arc`]`<`[`UsageReporting`]`>` if there was an error; normally, this would be populated
+    /// by the caching query planner, but we do not reach that code if we fail early here.
     pub(crate) async fn supergraph_request(
         &self,
         request: SupergraphRequest,

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -127,7 +127,7 @@ impl QueryAnalysisLayer {
     /// - "operation_name" and "operation_kind"
     /// - authorization details (required scopes, policies), if any
     /// - [`Arc`]`<`[`UsageReporting`]`>` if there was an error; normally, this would be populated
-    /// by the caching query planner, but we do not reach that code if we fail early here.
+    ///   by the caching query planner, but we do not reach that code if we fail early here.
     pub(crate) async fn supergraph_request(
         &self,
         request: SupergraphRequest,

--- a/apollo-router/src/services/layers/static_page.rs
+++ b/apollo-router/src/services/layers/static_page.rs
@@ -1,7 +1,4 @@
-//!  (A)utomatic (P)ersisted (Q)ueries cache.
-//!
-//!  For more information on APQ see:
-//!  <https://www.apollographql.com/docs/apollo-server/performance/apq/>
+//! Provides the home page and sandbox page implementations.
 
 use std::ops::ControlFlow;
 
@@ -23,13 +20,16 @@ use crate::layers::sync_checkpoint::CheckpointService;
 use crate::services::router;
 use crate::Configuration;
 
-/// [`Layer`] That serves Static pages such as Homepage and Sandbox.
+/// A layer that serves a static page for all requests that accept a `text/html` response
+/// (typically a user navigating to a page in the browser).
 #[derive(Clone)]
 pub(crate) struct StaticPageLayer {
     static_page: Option<Bytes>,
 }
 
 impl StaticPageLayer {
+    /// Create a static page based on configuration: either an Apollo Sandbox, or a simple home
+    /// page.
     pub(crate) fn new(configuration: &Configuration) -> Self {
         let static_page = if configuration.sandbox.enabled {
             Some(Bytes::from(sandbox_page_content()))
@@ -57,7 +57,7 @@ where
             CheckpointService::new(
                 move |req| {
                     let res = if req.router_request.method() == Method::GET
-                        && prefers_html(req.router_request.headers())
+                        && accepts_html(req.router_request.headers())
                     {
                         let response = http::Response::builder()
                             .header(
@@ -84,7 +84,11 @@ where
     }
 }
 
-fn prefers_html(headers: &HeaderMap) -> bool {
+/// Returns true if the given header map contains an `Accept` header which contains the "text/html"
+/// MIME type.
+///
+/// `Accept` priorities or preferences are not considered.
+fn accepts_html(headers: &HeaderMap) -> bool {
     let text_html = MediaType::new(TEXT, HTML);
 
     headers.get_all(&http::header::ACCEPT).iter().any(|value| {

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -245,6 +245,9 @@ impl RouterService {
         &self,
         supergraph_request: SupergraphRequest,
     ) -> Result<router::Response, BoxError> {
+        // XXX(@goto-bus-stop): This code looks confusing. we are manually calling several
+        // layers with various ifs and matches, but *really*, we are calling each layer in order
+        // and handling short-circuiting.
         let mut request_res = self
             .persisted_query_layer
             .supergraph_request(supergraph_request);

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -616,7 +616,6 @@ async fn subscription_task(
                         subgraph_schemas: execution_service_factory.subgraph_schemas.clone(),
                         plugins: plugins.clone(),
                         fetch_service_factory,
-
                     };
                 }
             }

--- a/dev-docs/layer-inventory.md
+++ b/dev-docs/layer-inventory.md
@@ -5,6 +5,30 @@ This is ordered from the point of view of a request to the router, starting at t
 
 Still missing are the execution and subgraph client parts of the onion, and layers added by plugins.
 
+## Axum
+Before entering the router service, we have some layers on our axum Router. These are already functioning properly in the tower service stack.
+
+- "Metrics handler"
+  - It only implements the `apollo.router.operations` metric.
+  - This is using `axum::middleware::from_fn`, so it is functioning properly as a tower layer.
+- TraceLayer
+  - This one is from `tower-http`!
+- CorsLayer
+  - This one is from `tower-http`!
+- "License handler"
+  - Logs a warning if the commercial licence is expired
+  - Rejects requests if the commercial licence is "halted" (expired + a grace period)
+  - This is using `axum::middleware::from_fn`, so it is functioning properly as a tower layer.
+- RequestDecompressionLayer
+  - This one is from `tower-http`!
+
+Now, we enter `handle_graphql`.
+
+- Compression
+  - This is manually written inside `handle_graphql`, but could conceptually be considered a layer.
+  - I don't see an obvious reason for why this could not use a standard tower-http compression layer.
+- Then we create a router service and oneshot it.
+
 ## Router service
 The router service consists of some layers in "front" of the service "proper", and of several layers *inside the router service*, which we appear to call manually.
 

--- a/layer_inventory.md
+++ b/layer_inventory.md
@@ -23,18 +23,22 @@ Proper (`RouterService`):
 - Persisted queries: Expansion
   - This expands requests that use persisted query IDs, and rejects freeform GraphQL requests if not allowed per router configuration.
   - This is *not* a real layer right now. I suspect it should be.
+  - **It is not Clone**, but it looks easy to make it Clone: we can just derive it on this layer and on the ManifestPoller type it contains (which already uses Arc internally)
 - APQs
+  - Clients can submit a hash+query body to add a query to the cache. Afterward, clients can use only the hash, and this layer will populate the query string in the request body before query analysis.
   - This is *not* a real layer right now. I suspect it should be.
-  - TODO(@goto-bus-stop) document what this does and what it needs
+  - **It is not Clone**. I think it's nothing that a little Arc can't solve, but I didn't trace it deeply enough to be sure.
 - Query analysis
   - This does query parsing and validation and schema-aware hashing,
     and field/enum usage tracking for apollo studio.
   - This is *not* a real layer right now. I suspect it should be.
+  - It is Clone!
   - This includes an explicit call to the AuthorizationPlugin. I suspect the AuthorizationPlugin should instead add its own layer for this, but chances are there was a good reason to do it this way, like not having precise enough hook-points. Still, maybe it can be a separate layer that we add manually.
   - Query analysis also exposes a method that is used by the query planner service, which could just as well be a standalone function in my opinion.
 - Persisted queries: Safelisting
   - This is *not* a real layer right now. I suspect it should be.
   - For requests *not* using persisted queries, this layer checks incoming GraphQL documents against the "free-form GraphQL behaviour" configuration (essentially: safelisting), and rejects requests that are not allowed.
+  - For Clone-ness, see "Persisted queries: Expansion"
 - Straggler bits, not part of sub-layers. I think some of these should be normal layers, and some of them should be just a `.map_response()` layer in the service stack.
   - It does something with the `Vary` header.
   - It adjusts the status code to 499 if the request was canceled.
@@ -48,4 +52,4 @@ Proper (`RouterService`):
   - It is Clone!
   - This layer sets the Content-Type header on the response.
 - AllowOnlyHttpPostMutationsLayer is the final step before going into the supergraph service proper.
-  - It is not Clone today but it can trivially be derived.
+  - **It is not Clone** today but it can trivially be derived.

--- a/layer_inventory.md
+++ b/layer_inventory.md
@@ -1,0 +1,43 @@
+This is ordered from the point of view of a request to the router, starting at the outer boundary and going "deeper" into the layer onion.
+
+## Router service
+The router service consists of some layers in "front" of the service "proper", and of several layers *inside the router service*, which we appear to call manually.
+
+I suspect that this is bad and that we should try to make these layers part of a normal tower service stack.
+
+Front (RouterCreator):
+- StaticPageLayer
+  - If configured, responds to any request that accepts a "text/html" response (*at all*, regardless of preference), with a fixed HTML response.
+  - It is Clone!
+  - This must occur before content negotiation, which rejects "Accept: text/html" requests.
+- **content negotiation**: RouterLayer
+  - It is Clone!
+  - This layer rejects requests with invalid Accept or Content-Type headers.
+
+Proper (RouterService):
+- Batching
+  - This is not a layer but the code can sort of be understood conceptually like one.
+  - Splits apart the incoming request into multiple requests that go through the rest of the pipeline, and puts the responses back together.
+- Persisted queries, part 1
+- APQs
+- Query analysis
+  - This does query parsing and validation and schema-aware hashing,
+    and field/enum usage tracking for apollo studio.
+  - This is *not* a real layer right now. I suspect it should be.
+  - This includes an explicit call to the AuthorizationPlugin. I suspect the AuthorizationPlugin should instead add its own layer for this, but chances are there was a good reason to do it this way, like not having precise enough hook-points. Still, maybe it can be a separate layer that we add manually.
+  - Query analysis also exposes a method that is used by the query planner service, which could just as well be a standalone function in my opinion.
+- Persisted queries, part 2
+- Straggler bits, not part of sub-layers:
+  - It does something with the `Vary` header.
+  - It adjusts the status code to 499 if the request was canceled.
+  - It does various JSON serialization bits.
+  - It does various telemetry bits such as counting errors.
+  - It appears to do the exact same thing as the content negotiation SupergraphLayer to populate the Content-Type header. **We should definitely get rid of this**.
+
+## Supergraph service
+
+- **content negotiation**: SupergraphLayer
+  - It is Clone!
+  - This layer sets the Content-Type header on the response.
+- AllowOnlyHttpPostMutationsLayer is the final step before going into the supergraph service proper.
+  - It is not Clone today but it can trivially be derived.


### PR DESCRIPTION
Targeting https://github.com/apollographql/router/pull/6486.

This is an attempt to interpret the world, not to change it, but some stylistic nits may have slipped in :)

This PR documents the "front-end" of our service stack, namely everything before query planning. I'll work on the "back-end" (execution, subgraph requests etc) next.