### PR TITLE
Proposal to make licensing terminology more generic

### DIFF
--- a/docs/source/reference/graphos-features.mdx
+++ b/docs/source/reference/graphos-features.mdx
@@ -1,7 +1,7 @@
 ---
 title: GraphOS Router Features
-subtitle: Use router features enabled by GraphOS and the Enterprise plan
-description: Unlock Enterprise features for the GraphOS Router by connecting it to Apollo GraphOS.
+subtitle: Use router features enabled by GraphOS and licensed plans
+description: Unlock additional features for the GraphOS Router by connecting it to Apollo GraphOS.
 redirectFrom: 
   - /router/enterprise-features
 ---
@@ -14,28 +14,28 @@ A router connected to GraphOS, whether cloud-hosted or self-hosted, is called a 
 
 For details on these features, see [this blog post](https://blog.apollographql.com/apollo-router-v1-12-improved-router-security-performance-and-extensibility) in addition to the documentation links above.
 
-## Enterprise plan features
+## Commercially licensed plan features
 
 <Tip>
 
-Try the Enterprise features of GraphOS Router with a free [GraphOS trial](https://www.apollographql.com/pricing).
+Try the commercially licensed features of GraphOS Router with a free [GraphOS trial](https://www.apollographql.com/pricing).
 
 </Tip>
 
 To enable support for Enterprise features in GraphOS Router:
 
-- Your organization must have a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).
+- Your organization must have a [GraphOS licensed plan](https://www.apollographql.com/pricing/).
 - You must run GraphOS Router v1.12 or later. [Download the latest version.](/graphos/reference/router/self-hosted-install#1-download-and-extract-the-router-binary)
-    - Certain Enterprise features might require a later router version. See a particular feature's documentation for details.
+    - Certain licensed features might require a later router version. See a particular feature's documentation for details.
 - Your router instances must connect to GraphOS with a **graph API key** and **graph ref** associated with your organization.
     - You connect your router to GraphOS by setting [these environment variables](/graphos/reference/router/configuration#environment-variables) when starting the router.
     - If your router _already_ connects to your GraphOS Enterprise organization, no further action is required.
 
-After enabling support, you can begin using all [Enterprise features](#graphos-router-features).
+After enabling support, you can begin using licensed [commercial features](#graphos-router-features).
 
-### The Enterprise license
+### The commercial license
 
-Whenever your router instance starts up and connects to GraphOS, it fetches a **license**, which is the credential that authorizes its use of Enterprise features:
+Whenever your router instance starts up and connects to GraphOS, it fetches a **license**, which is the credential that authorizes its use of commercial features:
 
 ```mermaid
 flowchart LR;
@@ -56,13 +56,13 @@ A router instance's license is valid for the duration of your organization's cur
 
 <MinVersion version="1.37.0">
 
-### Offline Enterprise license
+### Offline commercial license
 
 </MinVersion>
 
 <Tip>
 
-Offline Enterprise license support is available on an as-needed basis. Send a request to your Apollo contact to enable it for your GraphOS Studio organization.
+Offline license support is available on an as-needed basis. Send a request to your Apollo contact to enable it for your GraphOS Studio organization.
 
 </Tip>
 


### PR DESCRIPTION
Apollo may add, change, or remove various pricing plans at some point in the future.

We should either:
1. Define "Enterprise license" to be specifically the features which require a license of some kind 
2. Use a more general term for these features/licenses, such as "commercial" license as they are not available in OSS

This PR is a first draft at the latter route, change some references of `Enterprise license` to `Commercial license`, or in some cases just `licensed features`.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
