### PR TITLE
update CircleCI base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,7 @@ commands:
                 command: |
                   if [[ ! -d "$HOME/.deb" ]]; then
                     mkdir $HOME/.deb
+                    sudo apt-get update
                     sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install libssl-dev libdw-dev
                   fi
                   sudo dpkg -i $HOME/.deb/*.deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,18 +12,18 @@ orbs:
 executors:
   amd_linux_build: &amd_linux_build_executor
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
     resource_class: xlarge
     environment:
       CARGO_BUILD_JOBS: 4
       RUST_TEST_THREADS: 6
   amd_linux_helm: &amd_linux_helm_executor
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
     resource_class: small
   amd_linux_test: &amd_linux_test_executor
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
       - image: cimg/redis:7.4.1
       - image: jaegertracing/all-in-one:1.54.0
       - image: openzipkin/zipkin:3.4.3
@@ -929,7 +929,7 @@ jobs:
 
   publish_github_release:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
     resource_class: small
     environment:
       <<: *common_job_environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ commands:
                   if [[ ! -d "$HOME/.deb" ]]; then
                     mkdir $HOME/.deb
                     sudo apt-get update
-                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install build-essential libssl-dev libdw-dev gcc-10
+                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install build-essential libssl-dev libdw-dev
                   fi
                   sudo dpkg -i $HOME/.deb/*.deb
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,8 @@ commands:
                   if [[ ! -d "$HOME/.deb" ]]; then
                     mkdir $HOME/.deb
                     sudo apt-get update
-                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install libssl-dev libdw-dev
+                    sudo apt remove gcc-9
+                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install libssl-dev libdw-dev gcc-10
                   fi
                   sudo dpkg -i $HOME/.deb/*.deb
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,9 +238,13 @@ commands:
                   if [[ ! -d "$HOME/.deb" ]]; then
                     mkdir $HOME/.deb
                     sudo apt-get update
-                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install build-essential
-                    sudo apt remove gcc-9
-                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install libssl-dev libdw-dev gcc-10
+                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install build-essential libssl-dev libdw-dev gcc-10
+                    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+                    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+                    cc --version
+                    gcc --version
+                    g++ --version
+                    ld --version
                   fi
                   sudo dpkg -i $HOME/.deb/*.deb
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,13 @@ executors:
       CARGO_BUILD_JOBS: 4
   arm_linux_build: &arm_linux_build_executor
     machine:
-      image: ubuntu-2004:2024.01.1
+      image: cimg/base:current
     resource_class: arm.large
     environment:
       CARGO_BUILD_JOBS: 8
   arm_linux_test: &arm_linux_test_executor
     machine:
-      image: ubuntu-2004:2024.01.1
+      image: cimg/base:current
     resource_class: arm.xlarge
     environment:
       CARGO_BUILD_JOBS: 8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,12 +239,6 @@ commands:
                     mkdir $HOME/.deb
                     sudo apt-get update
                     sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install build-essential libssl-dev libdw-dev gcc-10
-                    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
-                    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
-                    cc --version
-                    gcc --version
-                    g++ --version
-                    ld --version
                   fi
                   sudo dpkg -i $HOME/.deb/*.deb
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,7 @@ commands:
                   if [[ ! -d "$HOME/.deb" ]]; then
                     mkdir $HOME/.deb
                     sudo apt-get update
+                    sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install build-essential
                     sudo apt remove gcc-9
                     sudo apt-get --download-only -o Dir::Cache="$HOME/.deb" -o Dir::Cache::archives="$HOME/.deb" install libssl-dev libdw-dev gcc-10
                   fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,14 +32,14 @@ executors:
     environment:
       CARGO_BUILD_JOBS: 4
   arm_linux_build: &arm_linux_build_executor
-    machine:
-      image: cimg/base:current
+    docker:
+      - image: cimg/base:current
     resource_class: arm.large
     environment:
       CARGO_BUILD_JOBS: 8
   arm_linux_test: &arm_linux_test_executor
-    machine:
-      image: cimg/base:current
+    docker:
+      - image: cimg/base:current
     resource_class: arm.xlarge
     environment:
       CARGO_BUILD_JOBS: 8


### PR DESCRIPTION
This commit fixes an issue with a downstream dependency (`aws-lc-sys`) caused by using an old version of GCC by updating the base CircleCI image to `current`.

This was realistically a long-time coming because the previous tag of `stable` was deprecated in favor of `current` back in 2022.

Below is a quote from the [docker hub page](https://hub.docker.com/r/cimg/base) explaining the change to the tag names:

> current - This image tag points to the latest, production ready base image. This is a replacement for the old stable tag. This image should be used by projects that want a decent level of stability but would like to get occasional software updates. It is typically updated once a month.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
