### PR TITLE
Remove hot reload support for `--supergraph-urls`

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -548,10 +548,12 @@ impl Executable {
                 tracing::info!("{apollo_router_msg}");
                 tracing::info!("{apollo_telemetry_msg}");
 
+                if opt.hot_reload {
+                    tracing::warn!("Schema hot reloading is disabled for --supergraph-urls / APOLLO_ROUTER_SUPERGRAPH_URLS.");
+                }
+
                 SchemaSource::URLs {
                     urls: supergraph_urls.clone(),
-                    watch: opt.hot_reload,
-                    period: INITIAL_UPLINK_POLL_INTERVAL,
                 }
             }
             (_, None, None, _, Some(apollo_key_path)) => {

--- a/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_by_url_fallback@logs.snap
+++ b/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_by_url_fallback@logs.snap
@@ -1,15 +1,10 @@
 ---
 source: apollo-router/src/router/event/schema.rs
 expression: yaml
+snapshot_kind: text
 ---
 - fields:
     http.response.status_code: 400
     url.full: "[url.full]"
   level: WARN
   message: failed to fetch supergraph schema
-- fields:
-    http.response.status_code: 400
-    url.full: "[url.full]"
-  level: WARN
-  message: failed to fetch supergraph schema
-

--- a/docs/source/reference/migration/from-router-v1.mdx
+++ b/docs/source/reference/migration/from-router-v1.mdx
@@ -49,6 +49,14 @@ Source code generated using Scaffold will continue to compile; so existing Rust 
 
 The router no longer uses the `--apollo-uplink-poll-interval` command-line argument, or the `APOLLO_UPLINK_POLL_INTERVAL` environment variable. It already did something unusual in v1.x: the configured interval would only be used for the very first poll, and not any subsequent polls.
 
+### Hot reloading `--supergraph-urls`, `APOLLO_ROUTER_SUPERGRAPH_URLS`
+
+<!-- PR: TODO(@goto-bus-stop) -->
+
+The `--supergraph-urls` command-line argument or the `APOLLO_ROUTER_SUPERGRAPH_URLS` environment variable no longer support hot reloading. In v1.x, if hot reloading was enabled, the router would repeatedly fetch the URLs on the interval specified by `--apollo-uplink-poll-interval`.
+
+If hot reloading from a remote URL is desired, consider running a script to download the supergraph URL on an interval, and point the router to the downloaded file on the filesystem.
+
 ## Upgrading to GraphOS Router v2.x
 
 Upgrading from GraphOS Router v1.x to v2.x requires the following steps.

--- a/docs/source/reference/migration/from-router-v1.mdx
+++ b/docs/source/reference/migration/from-router-v1.mdx
@@ -51,7 +51,7 @@ The router no longer uses the `--apollo-uplink-poll-interval` command-line argum
 
 ### Hot reloading `--supergraph-urls`, `APOLLO_ROUTER_SUPERGRAPH_URLS`
 
-<!-- PR: TODO(@goto-bus-stop) -->
+<!-- PR: https://github.com/apollographql/router/pull/6567 -->
 
 The `--supergraph-urls` command-line argument or the `APOLLO_ROUTER_SUPERGRAPH_URLS` environment variable no longer support hot reloading. In v1.x, if hot reloading was enabled, the router would repeatedly fetch the URLs on the interval specified by `--apollo-uplink-poll-interval`.
 

--- a/docs/source/reference/router/configuration.mdx
+++ b/docs/source/reference/router/configuration.mdx
@@ -104,7 +104,7 @@ This reference lists and describes the options supported by the `router` binary.
 </td>
 <td>
 
-The [supergraph schema](/federation/federated-types/overview#supergraph-schema) of a router. Specified by absolute or relative path (`-s` / `--supergraph <supergraph_path>`, or `APOLLO_ROUTER_SUPERGRAPH_PATH`), or a comma-separated list of URLs (`APOLLO_ROUTER_SUPERGRAPH_URLS`).
+The [supergraph schema](/federation/federated-types/overview#supergraph-schema) of a router. Specified by absolute or relative path (`-s` / `--supergraph <supergraph_path>`, or `APOLLO_ROUTER_SUPERGRAPH_PATH`), or a comma-separated list of URLs (`--supergraph-urls <urls>`, or `APOLLO_ROUTER_SUPERGRAPH_URLS`).
 
 > &#x1F4A1; Avoid embedding tokens in `APOLLO_ROUTER_SUPERGRAPH_URLS` because the URLs may appear in log messages.
 


### PR DESCRIPTION
Follow-up to https://github.com/apollographql/router/pull/6268.

Using `--supergraph-urls` is still supported! Only hot reloading it is not.

The `--supergraph-urls` command-line argument or the `APOLLO_ROUTER_SUPERGRAPH_URLS` environment variable no longer support hot reloading. In v1.x, if hot reloading was enabled, the router would repeatedly fetch the URLs on the interval specified by `--apollo-uplink-poll-interval`.

If hot reloading from a remote URL is desired, consider running a script to download the supergraph URL on an interval, and point the router to the downloaded file on the filesystem.

<!-- [ROUTER-879] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-879]: https://apollographql.atlassian.net/browse/ROUTER-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ