### PR TITLE
merge dev into next

### DIFF
--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -2431,7 +2431,14 @@ async fn test_supergraph_timeout() {
 
     // we do the entire supergraph rebuilding instead of using `from_supergraph_mock_callback_and_configuration`
     // because we need the plugins to apply on the supergraph
-    let mut plugins = create_plugins(&conf, &schema, planner.subgraph_schemas(), None, None)
+    let subgraph_schemas = Arc::new(
+        planner
+            .subgraph_schemas()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.schema.clone()))
+            .collect(),
+    );
+    let mut plugins = create_plugins(&conf, &schema, subgraph_schemas, None, None)
         .await
         .unwrap();
 

--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -149,7 +149,9 @@ pub(crate) mod test_utils {
     pub(crate) fn collect_metrics() -> Metrics {
         let mut metrics = Metrics::default();
         let (_, reader) = meter_provider_and_readers();
-        reader.collect(&mut metrics.resource_metrics).unwrap();
+        reader
+            .collect(&mut metrics.resource_metrics)
+            .expect("Failed to collect metrics. Did you forget to use `async{}.with_metrics()`? See dev-docs/metrics.md");
         metrics
     }
 
@@ -926,6 +928,10 @@ macro_rules! assert_metric {
     };
 }
 
+/// Assert the value of a counter metric that has the given name and attributes.
+///
+/// In asynchronous tests, you must use [`FutureMetricsExt::with_metrics`]. See dev-docs/metrics.md
+/// for details: <https://github.com/apollographql/router/blob/4fc63d55104c81c77e6e0a3cca615eac28e39dc3/dev-docs/metrics.md#testing>
 #[cfg(test)]
 macro_rules! assert_counter {
     ($($name:ident).+, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
@@ -965,6 +971,10 @@ macro_rules! assert_counter {
     };
 }
 
+/// Assert the value of a counter metric that has the given name and attributes.
+///
+/// In asynchronous tests, you must use [`FutureMetricsExt::with_metrics`]. See dev-docs/metrics.md
+/// for details: <https://github.com/apollographql/router/blob/4fc63d55104c81c77e6e0a3cca615eac28e39dc3/dev-docs/metrics.md#testing>
 #[cfg(test)]
 macro_rules! assert_up_down_counter {
 
@@ -998,6 +1008,10 @@ macro_rules! assert_up_down_counter {
     };
 }
 
+/// Assert the value of a gauge metric that has the given name and attributes.
+///
+/// In asynchronous tests, you must use [`FutureMetricsExt::with_metrics`]. See dev-docs/metrics.md
+/// for details: <https://github.com/apollographql/router/blob/4fc63d55104c81c77e6e0a3cca615eac28e39dc3/dev-docs/metrics.md#testing>
 #[cfg(test)]
 macro_rules! assert_gauge {
 
@@ -1064,6 +1078,10 @@ macro_rules! assert_histogram_count {
     };
 }
 
+/// Assert the sum value of a histogram metric with the given name and attributes.
+///
+/// In asynchronous tests, you must use [`FutureMetricsExt::with_metrics`]. See dev-docs/metrics.md
+/// for details: <https://github.com/apollographql/router/blob/4fc63d55104c81c77e6e0a3cca615eac28e39dc3/dev-docs/metrics.md#testing>
 #[cfg(test)]
 macro_rules! assert_histogram_sum {
 
@@ -1097,6 +1115,10 @@ macro_rules! assert_histogram_sum {
     };
 }
 
+/// Assert that a histogram metric exists with the given name and attributes.
+///
+/// In asynchronous tests, you must use [`FutureMetricsExt::with_metrics`]. See dev-docs/metrics.md
+/// for details: <https://github.com/apollographql/router/blob/4fc63d55104c81c77e6e0a3cca615eac28e39dc3/dev-docs/metrics.md#testing>
 #[cfg(test)]
 macro_rules! assert_histogram_exists {
 
@@ -1130,6 +1152,10 @@ macro_rules! assert_histogram_exists {
     };
 }
 
+/// Assert that a histogram metric does not exist with the given name and attributes.
+///
+/// In asynchronous tests, you must use [`FutureMetricsExt::with_metrics`]. See dev-docs/metrics.md
+/// for details: <https://github.com/apollographql/router/blob/4fc63d55104c81c77e6e0a3cca615eac28e39dc3/dev-docs/metrics.md#testing>
 #[cfg(test)]
 macro_rules! assert_histogram_not_exists {
 
@@ -1163,6 +1189,13 @@ macro_rules! assert_histogram_not_exists {
     };
 }
 
+/// Assert that all metrics match an [insta] snapshot.
+///
+/// Consider using [assert_non_zero_metrics_snapshot] to produce more grokkable snapshots if
+/// zero-valued metrics are not relevant to your test.
+///
+/// In asynchronous tests, you must use [`FutureMetricsExt::with_metrics`]. See dev-docs/metrics.md
+/// for details: <https://github.com/apollographql/router/blob/4fc63d55104c81c77e6e0a3cca615eac28e39dc3/dev-docs/metrics.md#testing>
 #[cfg(test)]
 #[allow(unused_macros)]
 macro_rules! assert_metrics_snapshot {
@@ -1181,6 +1214,10 @@ macro_rules! assert_metrics_snapshot {
     };
 }
 
+/// Assert that all metrics with a non-zero value match an [insta] snapshot.
+///
+/// In asynchronous tests, you must use [`FutureMetricsExt::with_metrics`]. See dev-docs/metrics.md
+/// for details: <https://github.com/apollographql/router/blob/4fc63d55104c81c77e6e0a3cca615eac28e39dc3/dev-docs/metrics.md#testing>
 #[cfg(test)]
 #[allow(unused_macros)]
 macro_rules! assert_non_zero_metrics_snapshot {

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -45,7 +45,6 @@ use tower::ServiceBuilder;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
 use crate::notification::Notify;
-use crate::query_planner::fetch::SubgraphSchemas;
 use crate::router_factory::Endpoint;
 use crate::services::execution;
 use crate::services::router;
@@ -75,7 +74,7 @@ pub struct PluginInit<T> {
     pub(crate) supergraph_schema: Arc<Valid<Schema>>,
 
     /// The parsed subgraph schemas from the query planner, keyed by subgraph name
-    pub(crate) subgraph_schemas: Arc<SubgraphSchemas>,
+    pub(crate) subgraph_schemas: Arc<HashMap<String, Arc<Valid<Schema>>>>,
 
     /// Launch ID
     pub(crate) launch_id: Option<Arc<String>>,
@@ -176,7 +175,7 @@ where
         supergraph_sdl: Arc<String>,
         supergraph_schema_id: Arc<String>,
         supergraph_schema: Arc<Valid<Schema>>,
-        subgraph_schemas: Option<Arc<SubgraphSchemas>>,
+        subgraph_schemas: Option<Arc<HashMap<String, Arc<Valid<Schema>>>>>,
         launch_id: Option<Option<Arc<String>>>,
         notify: Notify<String, graphql::Response>,
     ) -> Self {
@@ -201,7 +200,7 @@ where
         supergraph_sdl: Arc<String>,
         supergraph_schema_id: Arc<String>,
         supergraph_schema: Arc<Valid<Schema>>,
-        subgraph_schemas: Option<Arc<SubgraphSchemas>>,
+        subgraph_schemas: Option<Arc<HashMap<String, Arc<Valid<Schema>>>>>,
         launch_id: Option<Arc<String>>,
         notify: Notify<String, graphql::Response>,
     ) -> Result<Self, BoxError> {
@@ -224,7 +223,7 @@ where
         supergraph_sdl: Option<Arc<String>>,
         supergraph_schema_id: Option<Arc<String>>,
         supergraph_schema: Option<Arc<Valid<Schema>>>,
-        subgraph_schemas: Option<Arc<SubgraphSchemas>>,
+        subgraph_schemas: Option<Arc<HashMap<String, Arc<Valid<Schema>>>>>,
         launch_id: Option<Arc<String>>,
         notify: Option<Notify<String, graphql::Response>>,
     ) -> Self {

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -742,7 +742,7 @@ mod tests {
         let mut demand_controlled_subgraph_schemas = HashMap::new();
         for (subgraph_name, subgraph_schema) in planner.subgraph_schemas().iter() {
             let demand_controlled_subgraph_schema =
-                DemandControlledSchema::new(subgraph_schema.clone()).unwrap();
+                DemandControlledSchema::new(subgraph_schema.schema.clone()).unwrap();
             demand_controlled_subgraph_schemas
                 .insert(subgraph_name.to_string(), demand_controlled_subgraph_schema);
         }

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -248,7 +248,13 @@ mod test {
             .await
             .unwrap();
         let schema = planner.schema();
-        let subgraph_schemas = planner.subgraph_schemas();
+        let subgraph_schemas = Arc::new(
+            planner
+                .subgraph_schemas()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.schema.clone()))
+                .collect(),
+        );
 
         let builder = PluggableSupergraphServiceBuilder::new(planner);
 

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -110,7 +110,12 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
             .supergraph_schema_id(crate::spec::Schema::schema_id(&supergraph_sdl).into())
             .supergraph_sdl(supergraph_sdl)
             .supergraph_schema(Arc::new(parsed_schema))
-            .subgraph_schemas(subgraph_schemas)
+            .subgraph_schemas(Arc::new(
+                subgraph_schemas
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.schema.clone()))
+                    .collect(),
+            ))
             .notify(Notify::default())
             .build();
 

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -531,7 +531,13 @@ mod test {
         let planner = QueryPlannerService::new(schema.clone(), config.clone())
             .await
             .unwrap();
-        let subgraph_schemas = planner.subgraph_schemas();
+        let subgraph_schemas = Arc::new(
+            planner
+                .subgraph_schemas()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.schema.clone()))
+                .collect(),
+        );
 
         let mut builder =
             PluggableSupergraphServiceBuilder::new(planner).with_configuration(config.clone());

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 use std::task;
 
-use apollo_compiler::validation::Valid;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
 use query_planner::QueryPlannerPlugin;
@@ -61,7 +59,7 @@ pub(crate) struct CachingQueryPlanner<T: Clone> {
     >,
     delegate: T,
     schema: Arc<Schema>,
-    subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+    subgraph_schemas: Arc<SubgraphSchemas>,
     plugins: Arc<Plugins>,
     enable_authorization_directives: bool,
     config_mode_hash: Arc<QueryHash>,
@@ -94,7 +92,7 @@ where
     pub(crate) async fn new(
         delegate: T,
         schema: Arc<Schema>,
-        subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+        subgraph_schemas: Arc<SubgraphSchemas>,
         configuration: &Configuration,
         plugins: Plugins,
     ) -> Result<CachingQueryPlanner<T>, BoxError> {
@@ -339,9 +337,7 @@ where
 }
 
 impl CachingQueryPlanner<QueryPlannerService> {
-    pub(crate) fn subgraph_schemas(
-        &self,
-    ) -> Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>> {
+    pub(crate) fn subgraph_schemas(&self) -> Arc<SubgraphSchemas> {
         self.delegate.subgraph_schemas()
     }
 

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use apollo_compiler::validation::Valid;
 use futures::future::join_all;
 use futures::prelude::*;
 use tokio::sync::broadcast;
@@ -25,6 +24,7 @@ use crate::json_ext::Value;
 use crate::json_ext::ValueExt;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::query_planner::fetch::FetchNode;
+use crate::query_planner::fetch::SubgraphSchemas;
 use crate::query_planner::fetch::Variables;
 use crate::query_planner::FlattenNode;
 use crate::query_planner::Primary;
@@ -56,7 +56,7 @@ impl QueryPlan {
         service_factory: &'a Arc<FetchServiceFactory>,
         supergraph_request: &'a Arc<http::Request<Request>>,
         schema: &'a Arc<Schema>,
-        subgraph_schemas: &'a Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+        subgraph_schemas: &'a Arc<SubgraphSchemas>,
         sender: mpsc::Sender<Response>,
         subscription_handle: Option<SubscriptionHandle>,
         subscription_config: &'a Option<SubscriptionConfig>,
@@ -112,7 +112,7 @@ pub(crate) struct ExecutionParameters<'a> {
     pub(crate) context: &'a Context,
     pub(crate) service_factory: &'a Arc<FetchServiceFactory>,
     pub(crate) schema: &'a Arc<Schema>,
-    pub(crate) subgraph_schemas: &'a Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+    pub(crate) subgraph_schemas: &'a Arc<SubgraphSchemas>,
     pub(crate) supergraph_request: &'a Arc<http::Request<Request>>,
     pub(crate) deferred_fetches: &'a HashMap<String, broadcast::Sender<(Value, Vec<Error>)>>,
     pub(crate) query: &'a Arc<Query>,

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -1,6 +1,5 @@
 //! Calls out to the apollo-federation crate
 
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -9,7 +8,6 @@ use std::task::Poll;
 use std::time::Instant;
 
 use apollo_compiler::ast;
-use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_federation::error::FederationError;
 use apollo_federation::error::SingleFederationError;
@@ -42,6 +40,8 @@ use crate::plugins::telemetry::config::ApolloSignatureNormalizationAlgorithm;
 use crate::plugins::telemetry::config::Conf as TelemetryConfig;
 use crate::query_planner::convert::convert_root_query_plan_node;
 use crate::query_planner::fetch::QueryHash;
+use crate::query_planner::fetch::SubgraphSchema;
+use crate::query_planner::fetch::SubgraphSchemas;
 use crate::query_planner::labeler::add_defer_labels;
 use crate::services::layers::query_analysis::ParsedDocument;
 use crate::services::layers::query_analysis::ParsedDocumentInner;
@@ -67,7 +67,7 @@ const INTERNAL_INIT_ERROR: &str = "internal";
 pub(crate) struct QueryPlannerService {
     planner: Arc<QueryPlanner>,
     schema: Arc<Schema>,
-    subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+    subgraph_schemas: Arc<SubgraphSchemas>,
     configuration: Arc<Configuration>,
     enable_authorization_directives: bool,
     _federation_instrument: ObservableGauge<u64>,
@@ -191,7 +191,15 @@ impl QueryPlannerService {
             planner
                 .subgraph_schemas()
                 .iter()
-                .map(|(name, schema)| (name.to_string(), Arc::new(schema.schema().clone())))
+                .map(|(name, schema)| {
+                    (
+                        name.to_string(),
+                        SubgraphSchema {
+                            implementers_map: schema.schema().implementers_map(),
+                            schema: Arc::new(schema.schema().clone()),
+                        },
+                    )
+                })
                 .collect(),
         );
 
@@ -218,9 +226,7 @@ impl QueryPlannerService {
         self.schema.clone()
     }
 
-    pub(crate) fn subgraph_schemas(
-        &self,
-    ) -> Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>> {
+    pub(crate) fn subgraph_schemas(&self) -> Arc<SubgraphSchemas> {
         self.subgraph_schemas.clone()
     }
 
@@ -383,6 +389,7 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
                     let hash = QueryHashVisitor::hash_query(
                         this.schema.supergraph_schema(),
                         &this.schema.raw_sdl,
+                        &this.schema.implementers_map,
                         &executable_document,
                         operation_name.as_deref(),
                     )
@@ -508,6 +515,7 @@ impl QueryPlannerService {
             let hash = QueryHashVisitor::hash_query(
                 self.schema.supergraph_schema(),
                 &self.schema.raw_sdl,
+                &self.schema.implementers_map,
                 &executable_document,
                 key.operation_name.as_deref(),
             )
@@ -595,6 +603,8 @@ pub(crate) fn metric_rust_qp_init(init_error_kind: Option<&'static str>) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use test_log::test;
     use tower::ServiceExt;
 

--- a/apollo-router/src/query_planner/subscription.rs
+++ b/apollo-router/src/query_planner/subscription.rs
@@ -70,7 +70,7 @@ impl SubscriptionNode {
         subgraph_schemas: &SubgraphSchemas,
     ) -> Result<(), ValidationErrors> {
         let schema = &subgraph_schemas[self.service_name.as_ref()];
-        self.operation.init_parsed(schema)?;
+        self.operation.init_parsed(&schema.schema)?;
         Ok(())
     }
 }

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -1882,8 +1882,14 @@ fn broken_plan_does_not_panic() {
         estimated_size: Default::default(),
     };
     let subgraph_schema = apollo_compiler::Schema::parse_and_validate(subgraph_schema, "").unwrap();
-    let mut subgraph_schemas = HashMap::new();
-    subgraph_schemas.insert("X".to_owned(), Arc::new(subgraph_schema));
+    let mut subgraph_schemas = HashMap::default();
+    subgraph_schemas.insert(
+        "X".to_owned(),
+        query_planner::fetch::SubgraphSchema {
+            implementers_map: subgraph_schema.implementers_map(),
+            schema: Arc::new(subgraph_schema),
+        },
+    );
     let result = Arc::make_mut(&mut plan.root)
         .init_parsed_operations_and_hash_subqueries(&subgraph_schemas, "");
     assert_eq!(

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -311,11 +311,19 @@ impl YamlRouterFactory {
         let span = tracing::info_span!("plugins");
 
         // Process the plugins.
+        let subgraph_schemas = Arc::new(
+            planner
+                .subgraph_schemas()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.schema.clone()))
+                .collect(),
+        );
+
         let plugins: Arc<Plugins> = Arc::new(
             create_plugins(
                 &configuration,
                 &schema,
-                planner.subgraph_schemas(),
+                subgraph_schemas,
                 initial_telemetry_plugin,
                 extra_plugins,
             )

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -1,11 +1,9 @@
 //! Tower service for connectors.
 
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Poll;
 
-use apollo_compiler::validation::Valid;
 use apollo_federation::sources::connect::Connector;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
@@ -37,6 +35,7 @@ use crate::plugins::connectors::tracing::connect_spec_version_instrument;
 use crate::plugins::connectors::tracing::CONNECTOR_TYPE_HTTP;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::plugins::telemetry::consts::CONNECT_SPAN_NAME;
+use crate::query_planner::fetch::SubgraphSchemas;
 use crate::services::router::body::RouterBody;
 use crate::services::ConnectRequest;
 use crate::services::ConnectResponse;
@@ -63,7 +62,7 @@ pub(crate) const CONNECTOR_INFO_CONTEXT_KEY: &str = "apollo_router::connector::i
 pub(crate) struct ConnectorService {
     pub(crate) http_service_factory: Arc<IndexMap<String, HttpClientServiceFactory>>,
     pub(crate) _schema: Arc<Schema>,
-    pub(crate) _subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+    pub(crate) _subgraph_schemas: Arc<SubgraphSchemas>,
     pub(crate) _subscription_config: Option<SubscriptionConfig>,
     pub(crate) connectors_by_service_name: Arc<IndexMap<Arc<str>, Connector>>,
 }
@@ -312,7 +311,7 @@ fn handle_subrequest_http_error(err: BoxError, connector: &Connector) -> BoxErro
 #[derive(Clone)]
 pub(crate) struct ConnectorServiceFactory {
     pub(crate) schema: Arc<Schema>,
-    pub(crate) subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+    pub(crate) subgraph_schemas: Arc<SubgraphSchemas>,
     pub(crate) http_service_factory: Arc<IndexMap<String, HttpClientServiceFactory>>,
     pub(crate) subscription_config: Option<SubscriptionConfig>,
     pub(crate) connectors_by_service_name: Arc<IndexMap<Arc<str>, Connector>>,
@@ -322,7 +321,7 @@ pub(crate) struct ConnectorServiceFactory {
 impl ConnectorServiceFactory {
     pub(crate) fn new(
         schema: Arc<Schema>,
-        subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+        subgraph_schemas: Arc<SubgraphSchemas>,
         http_service_factory: Arc<IndexMap<String, HttpClientServiceFactory>>,
         subscription_config: Option<SubscriptionConfig>,
         connectors_by_service_name: Arc<IndexMap<Arc<str>, Connector>>,

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -1,6 +1,5 @@
 //! Implements the Execution phase of the request lifecycle.
 
-use std::collections::HashMap;
 use std::future::ready;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -9,7 +8,6 @@ use std::task::Poll;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-use apollo_compiler::validation::Valid;
 use futures::future::BoxFuture;
 use futures::stream::once;
 use futures::Stream;
@@ -47,6 +45,7 @@ use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN;
 use crate::plugins::telemetry::apollo::Config as ApolloTelemetryConfig;
 use crate::plugins::telemetry::config::ApolloMetricsReferenceMode;
 use crate::plugins::telemetry::Telemetry;
+use crate::query_planner::fetch::SubgraphSchemas;
 use crate::query_planner::subscription::SubscriptionHandle;
 use crate::services::execution;
 use crate::services::fetch_service::FetchServiceFactory;
@@ -62,7 +61,7 @@ use crate::spec::Schema;
 #[derive(Clone)]
 pub(crate) struct ExecutionService {
     pub(crate) schema: Arc<Schema>,
-    pub(crate) subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+    pub(crate) subgraph_schemas: Arc<SubgraphSchemas>,
     pub(crate) fetch_service_factory: Arc<FetchServiceFactory>,
     /// Subscription config if enabled
     subscription_config: Option<SubscriptionConfig>,
@@ -632,7 +631,7 @@ async fn consume_responses(
 #[derive(Clone)]
 pub(crate) struct ExecutionServiceFactory {
     pub(crate) schema: Arc<Schema>,
-    pub(crate) subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
+    pub(crate) subgraph_schemas: Arc<SubgraphSchemas>,
     pub(crate) plugins: Arc<Plugins>,
     pub(crate) fetch_service_factory: Arc<FetchServiceFactory>,
 }

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -559,7 +559,14 @@ async fn subscription_task(
                 // If the configuration was dropped in the meantime, we ignore this update and will
                 // pick up the next one.
                 if let Some(conf) = new_configuration.upgrade() {
-                    let plugins = match create_plugins(&conf, &execution_service_factory.schema, execution_service_factory.subgraph_schemas.clone(), None, None).await {
+                    let subgraph_schemas = Arc::new(
+                        execution_service_factory
+                            .subgraph_schemas
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.schema.clone()))
+                            .collect(),
+                    );
+                    let plugins = match create_plugins(&conf, &execution_service_factory.schema, subgraph_schemas, None, None).await {
                         Ok(plugins) => Arc::new(plugins),
                         Err(err) => {
                             tracing::error!("cannot re-create plugins with the new configuration (closing existing subscription): {err:?}");

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -269,6 +269,7 @@ impl Query {
         let hash = QueryHashVisitor::hash_query(
             schema.supergraph_schema(),
             &schema.raw_sdl,
+            &schema.implementers_map,
             &executable_document,
             operation_name,
         )
@@ -323,10 +324,13 @@ impl Query {
         let operation = get_operation(document, operation_name)?;
         let operation = Operation::from_hir(&operation, schema, &mut defer_stats, &fragments)?;
 
-        let mut visitor =
-            QueryHashVisitor::new(schema.supergraph_schema(), &schema.raw_sdl, document).map_err(
-                |e| SpecError::QueryHashing(format!("could not calculate the query hash: {e}")),
-            )?;
+        let mut visitor = QueryHashVisitor::new(
+            schema.supergraph_schema(),
+            &schema.raw_sdl,
+            &schema.implementers_map,
+            document,
+        )
+        .map_err(|e| SpecError::QueryHashing(format!("could not calculate the query hash: {e}")))?;
         traverse::document(&mut visitor, document, operation_name).map_err(|e| {
             SpecError::QueryHashing(format!("could not calculate the query hash: {e}"))
         })?;

--- a/docs/source/routing/performance/caching/entity.mdx
+++ b/docs/source/routing/performance/caching/entity.mdx
@@ -216,16 +216,15 @@ This entry contains an object with the `all` field to affect all subgraph reques
 You can invalidate entity cache entries with a [specifically formatted request](#invalidation-request-format once you [configure your router](#configuration) appropriately. For example, if price data changes before a price entity's TTL expires, you can send an invalidation request.
 
 ```mermaid
-
 flowchart RL
 	subgraph QueryResponse["Cache invalidation POST"]
 		n1["{
-			&emsp;&emsp;&quot;kind&quot;: &quot;subgraph&quot;,
-			&emsp;&emsp;&quot;subgraph&quot;: &quot;price&quot;,
-			&emsp;&emsp;&quot;type&quot;: &quot;Price&quot;,
-			&emsp;&emsp;&quot;key&quot;: {
-			&emsp;&emsp;&emsp;&emsp;&quot;id&quot;: &quot;101&quot;
-			&emsp;&emsp;}
+			&nbsp;&nbsp;&nbsp;&nbsp;&quot;kind&quot;: &quot;subgraph&quot;,
+			&nbsp;&nbsp;&nbsp;&nbsp;&quot;subgraph&quot;: &quot;price&quot;,
+			&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;: &quot;Price&quot;,
+			&nbsp;&nbsp;&nbsp;&nbsp;&quot;key&quot;: {
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;id&quot;: &quot;101&quot;
+			&nbsp;&nbsp;&nbsp;&nbsp;}
 		}"]
     end
 
@@ -236,18 +235,18 @@ flowchart RL
 	end
 
 	subgraph PriceQueryFragment["Price Query Fragment (e.g. TTL 2200)"]
-		n2[" ̶{̶
-    	&emsp;&emsp;&quot; ̶p̶r̶i̶c̶e̶&quot;:  ̶{̶
-        &emsp;&emsp;&emsp;&emsp;&quot; ̶i̶d̶&quot;:  ̶1̶0̶1̶,
-        &emsp;&emsp;&emsp;&emsp;&quot; ̶p̶r̶o̶d̶u̶c̶t̶_̶i̶d̶&quot;:  ̶1̶2̶,
-        &emsp;&emsp;&emsp;&emsp;&quot; ̶a̶m̶o̶u̶n̶t̶&quot;:  ̶1̶5̶0̶0̶,
-        &emsp;&emsp;&emsp;&emsp;&quot;̶c̶u̶r̶r̶e̶n̶c̶y̶_̶c̶o̶d̶e̶&quot;: &quot; ̶U̶S̶D̶&quot;
-    	&emsp;&emsp; ̶}̶
-		 ̶}̶"]
+		n2["<del>{
+    	&nbsp;&nbsp;&nbsp;&nbsp;&quot;price&quot;: {
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;id&quot;: 101,
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;product_id&quot;: 12,
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;amount&quot;: 1500,
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;currency_code&quot;: &quot;USD&quot;
+    	&nbsp;&nbsp;&nbsp;&nbsp;}
+		}</del>"]
 	end
 
 	Router
-	Database[("&emsp;&emsp;&emsp;")]
+	Database[("&nbsp;&nbsp;&nbsp;&nbsp;")]
 
     QueryResponse --> Router
 	Purchases --> Router

--- a/docs/source/routing/performance/caching/in-memory.mdx
+++ b/docs/source/routing/performance/caching/in-memory.mdx
@@ -40,7 +40,7 @@ supergraph:
 
 ### Cache warm-up
 
-When loading a new schema, a query plan might change for some queries, so cached query plans cannot be reused. 
+When loading a new schema, a query plan might change for some queries, so cached query plans cannot be reused.
 
 To prevent increased latency upon query plan cache invalidation, the router precomputes query plans for the most used queries from the cache when a new schema is loaded.
 
@@ -79,19 +79,6 @@ then look at `apollo_router_schema_loading_time` and `apollo.router.query_planni
 #### Cache warm-up with distributed caching
 
 If the router is using distributed caching for query plans, the warm-up phase will also store the new query plans in Redis. Since all Router instances might have the same distributions of queries in their in-memory cache, the list of queries is shuffled before warm-up, so each Router instance can plan queries in a different order and share their results through the cache.
-
-#### Schema aware query hashing
-
-The query plan cache key uses a hashing algorithm specifically designed for GraphQL queries, using the schema. If a schema update does not affect a query (example: a field was added), then the query hash will stay the same. The query plan cache can use that key during warm up to check if a cached entry can be reused instead of planning it again.
-
-It can be activated through this option:
-
-```yaml title="router.yaml"
-supergraph:
-  query_planning:
-    warmed_up_queries: 100
-    experimental_reuse_query_plans: true
-```
 
 ## Caching automatic persisted queries (APQ)
 


### PR DESCRIPTION
Step 1 of https://github.com/apollographql/router/pull/6576. After this we can merge next back into dev. *This PR*'s merge commit will turn into the LTS 1.x branch.

The trickiest part here is to apply the changes from #6570 to the connectors code. Basically it's just about changing some `HashMap<Valid<Schema>>` types to the new `SubgraphSchemas` type.