### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: backport 1.x
+    description: Add a label to backport to 1.x
+    conditions:
+      - label = backport-1.x
+    actions:
+      backport:
+        branches:
+          - 1.x
+        assignees:
+          - "{{ author }}"
+        bot_account:


### PR DESCRIPTION
This change has been made by @BrynCooke from the Mergify workflow automation editor.

This configuration will allow the `backport-1.x` label to be used to create a backport PR upon merge.

Alternatively developers can use @Mergifyio backport `1.x`
