### PR TITLE
Limit the depth of introspection queries

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -627,6 +627,11 @@ pub(crate) struct Supergraph {
     /// Default: false
     pub(crate) introspection: bool,
 
+    /// Limit the depth of nested list fields in introspection queries
+    /// to protect avoid generating huge responses.
+    /// Default: false
+    pub(crate) introspection_check_max_depth: bool,
+
     /// Enable QP generation of fragments for subgraph requests
     /// Default: true
     pub(crate) generate_query_fragments: bool,
@@ -670,6 +675,7 @@ impl Supergraph {
         listen: Option<ListenAddr>,
         path: Option<String>,
         introspection: Option<bool>,
+        introspection_check_max_depth: Option<bool>,
         defer_support: Option<bool>,
         query_planning: Option<QueryPlanning>,
         generate_query_fragments: Option<bool>,
@@ -680,6 +686,8 @@ impl Supergraph {
             listen: listen.unwrap_or_else(default_graphql_listen),
             path: path.unwrap_or_else(default_graphql_path),
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
+            introspection_check_max_depth: introspection_check_max_depth
+                .unwrap_or_else(default_graphql_introspection_check_max_depth),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
             query_planning: query_planning.unwrap_or_default(),
             generate_query_fragments: generate_query_fragments
@@ -699,6 +707,7 @@ impl Supergraph {
         listen: Option<ListenAddr>,
         path: Option<String>,
         introspection: Option<bool>,
+        introspection_check_max_depth: Option<bool>,
         defer_support: Option<bool>,
         query_planning: Option<QueryPlanning>,
         generate_query_fragments: Option<bool>,
@@ -709,6 +718,8 @@ impl Supergraph {
             listen: listen.unwrap_or_else(test_listen),
             path: path.unwrap_or_else(default_graphql_path),
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
+            introspection_check_max_depth: introspection_check_max_depth
+                .unwrap_or_else(default_graphql_introspection_check_max_depth),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
             query_planning: query_planning.unwrap_or_default(),
             generate_query_fragments: generate_query_fragments
@@ -1438,6 +1449,10 @@ fn default_graphql_path() -> String {
 
 fn default_graphql_introspection() -> bool {
     false
+}
+
+fn default_graphql_introspection_check_max_depth() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, Default, Error, Display, Serialize, Deserialize, JsonSchema)]

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -6863,6 +6863,11 @@ expression: "&schema"
           "description": "Enable introspection Default: false",
           "type": "boolean"
         },
+        "introspection_check_max_depth": {
+          "default": false,
+          "description": "Limit the depth of nested list fields in introspection queries to protect avoid generating huge responses. Default: false",
+          "type": "boolean"
+        },
         "listen": {
           "$ref": "#/definitions/ListenAddr",
           "description": "#/definitions/ListenAddr"

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -17,11 +17,21 @@ const DEFAULT_INTROSPECTION_CACHE_CAPACITY: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(5) };
 
 #[derive(Clone)]
-pub(crate) enum IntrospectionCache {
+pub(crate) struct IntrospectionCache(Mode);
+
+#[derive(Clone)]
+enum Mode {
     Disabled,
     Enabled {
         storage: Arc<CacheStorage<String, graphql::Response>>,
+        max_depth: MaxDepth,
     },
+}
+
+#[derive(Copy, Clone)]
+enum MaxDepth {
+    Check,
+    Ignore,
 }
 
 impl IntrospectionCache {
@@ -32,16 +42,23 @@ impl IntrospectionCache {
                 "introspection",
             ));
             storage.activate();
-            Self::Enabled { storage }
+            Self(Mode::Enabled {
+                storage,
+                max_depth: if configuration.supergraph.introspection_check_max_depth {
+                    MaxDepth::Check
+                } else {
+                    MaxDepth::Ignore
+                },
+            })
         } else {
-            Self::Disabled
+            Self(Mode::Disabled)
         }
     }
 
     pub(crate) fn activate(&self) {
-        match self {
-            IntrospectionCache::Disabled => {}
-            IntrospectionCache::Enabled { storage } => storage.activate(),
+        match &self.0 {
+            Mode::Disabled => {}
+            Mode::Enabled { storage, .. } => storage.activate(),
         }
     }
 
@@ -62,9 +79,13 @@ impl IntrospectionCache {
                     ControlFlow::Break(self.cached_introspection(schema, key, doc).await)?
                 }
             } else if !doc.has_explicit_root_fields {
-                // root __typename only, probably a small query
-                // Execute it without caching:
-                ControlFlow::Break(Self::execute_introspection(schema, doc))?
+                // Root __typename only
+
+                // No list field so depth is already known to be zero:
+                let max_depth = MaxDepth::Ignore;
+
+                // Probably a small query, execute it without caching:
+                ControlFlow::Break(Self::execute_introspection(max_depth, schema, doc))?
             }
         }
         ControlFlow::Continue(())
@@ -117,9 +138,9 @@ impl IntrospectionCache {
         key: &QueryKey,
         doc: &ParsedDocument,
     ) -> graphql::Response {
-        let storage = match self {
-            IntrospectionCache::Enabled { storage } => storage,
-            IntrospectionCache::Disabled => {
+        let (storage, max_depth) = match &self.0 {
+            Mode::Enabled { storage, max_depth } => (storage, *max_depth),
+            Mode::Disabled => {
                 let error = graphql::Error::builder()
                     .message(String::from("introspection has been disabled"))
                     .extension_code("INTROSPECTION_DISABLED")
@@ -138,32 +159,47 @@ impl IntrospectionCache {
         let schema = schema.clone();
         let doc = doc.clone();
         let priority = compute_job::Priority::P1; // Low priority
-        let response =
-            compute_job::execute(priority, move || Self::execute_introspection(&schema, &doc))
-                .await
-                .expect("Introspection panicked");
+        let response = compute_job::execute(priority, move || {
+            Self::execute_introspection(max_depth, &schema, &doc)
+        })
+        .await
+        .expect("Introspection panicked");
         storage.insert(cache_key, response.clone()).await;
         response
     }
 
-    fn execute_introspection(schema: &spec::Schema, doc: &ParsedDocument) -> graphql::Response {
+    fn execute_introspection(
+        max_depth: MaxDepth,
+        schema: &spec::Schema,
+        doc: &ParsedDocument,
+    ) -> graphql::Response {
         let api_schema = schema.api_schema();
         let operation = &doc.operation;
         let variable_values = Default::default();
-        match apollo_compiler::request::coerce_variable_values(
-            api_schema,
-            operation,
-            &variable_values,
-        )
-        .and_then(|variable_values| {
-            apollo_compiler::introspection::partial_execute(
-                api_schema,
-                &schema.implementers_map,
-                &doc.executable,
-                operation,
-                &variable_values,
-            )
-        }) {
+        let max_depth_result = match max_depth {
+            MaxDepth::Check => {
+                apollo_compiler::introspection::check_max_depth(&doc.executable, operation)
+            }
+            MaxDepth::Ignore => Ok(()),
+        };
+        let result = max_depth_result
+            .and_then(|()| {
+                apollo_compiler::request::coerce_variable_values(
+                    api_schema,
+                    operation,
+                    &variable_values,
+                )
+            })
+            .and_then(|variable_values| {
+                apollo_compiler::introspection::partial_execute(
+                    api_schema,
+                    &schema.implementers_map,
+                    &doc.executable,
+                    operation,
+                    &variable_values,
+                )
+            });
+        match result {
             Ok(response) => response.into(),
             Err(e) => {
                 let error = e.to_graphql_error(&doc.executable.sources);

--- a/apollo-router/tests/integration/introspection.rs
+++ b/apollo-router/tests/integration/introspection.rs
@@ -178,16 +178,185 @@ async fn mixed() {
     "###);
 }
 
+const QUERY_DEPTH_2: &str = r#"{
+  __type(name: "Query") {
+    fields {
+      type {
+        fields {
+          type {
+            kind
+          }
+        }
+      }
+    }
+  }
+}"#;
+
+const QUERY_DEPTH_3: &str = r#"{
+  __type(name: "Query") {
+    fields {
+      type {
+        fields {
+          type {
+            fields {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}"#;
+
+#[tokio::test]
+async fn just_under_max_depth() {
+    let request = Request::fake_builder()
+        .query(QUERY_DEPTH_2)
+        .build()
+        .unwrap();
+    let response = make_request(request).await;
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "__type": {
+          "fields": [
+            {
+              "type": {
+                "fields": [
+                  {
+                    "type": {
+                      "kind": "NON_NULL"
+                    }
+                  },
+                  {
+                    "type": {
+                      "kind": "SCALAR"
+                    }
+                  },
+                  {
+                    "type": {
+                      "kind": "SCALAR"
+                    }
+                  },
+                  {
+                    "type": {
+                      "kind": "LIST"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": {
+                "fields": null
+              }
+            }
+          ]
+        }
+      }
+    }
+    "###);
+}
+
+#[tokio::test]
+async fn just_over_max_depth() {
+    let request = Request::fake_builder()
+        .query(QUERY_DEPTH_3)
+        .build()
+        .unwrap();
+    let response = make_request(request).await;
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "errors": [
+        {
+          "message": "Maximum introspection depth exceeded",
+          "locations": [
+            {
+              "line": 7,
+              "column": 13
+            }
+          ]
+        }
+      ]
+    }
+    "###);
+}
+
+#[tokio::test]
+async fn just_over_max_depth_with_check_disabled() {
+    let request = Request::fake_builder()
+        .query(QUERY_DEPTH_3)
+        .build()
+        .unwrap();
+    let response = make_request_with_extra_config(request, |conf| {
+        conf["supergraph"]
+            .as_object_mut()
+            .unwrap()
+            .insert("introspection_check_max_depth".into(), false.into());
+    })
+    .await;
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "__type": {
+          "fields": [
+            {
+              "type": {
+                "fields": [
+                  {
+                    "type": {
+                      "fields": null
+                    }
+                  },
+                  {
+                    "type": {
+                      "fields": null
+                    }
+                  },
+                  {
+                    "type": {
+                      "fields": null
+                    }
+                  },
+                  {
+                    "type": {
+                      "fields": null
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": {
+                "fields": null
+              }
+            }
+          ]
+        }
+      }
+    }
+    "###);
+}
+
 async fn make_request(request: Request) -> apollo_router::graphql::Response {
+    make_request_with_extra_config(request, |_| {}).await
+}
+
+async fn make_request_with_extra_config(
+    request: Request,
+    modify_config: impl FnOnce(&mut serde_json::Value),
+) -> apollo_router::graphql::Response {
+    let mut conf = json!({
+        "supergraph": {
+            "introspection": true,
+        },
+        "include_subgraph_errors": {
+            "all": true,
+        },
+    });
+    modify_config(&mut conf);
     apollo_router::TestHarness::builder()
-        .configuration_json(json!({
-            "supergraph": {
-                "introspection": true,
-            },
-            "include_subgraph_errors": {
-                "all": true,
-            },
-        }))
+        .configuration_json(conf)
         .unwrap()
         .subgraph_hook(|subgraph_name, default| match subgraph_name {
             "accounts" => MockSubgraph::builder()


### PR DESCRIPTION
The [schema-intropsection schema](https://spec.graphql.org/draft/#sec-Schema-Introspection.Schema-Introspection-Schema) is recursive: a client can query the fields of the types of some other fields, and so on arbitrarily deep. This can produce responses that grow much faster than the size of the request.

To protect against abusive Router now refuses to execute introspection queries that nest list fields too deep and returns an error instead. The criteria matches `MaxIntrospectionDepthRule` in graphql-js, but may change in future versions.

In case it rejects legitimate queries, this check can be disabled in Router configuration:

```yaml
supergraph:
  introspection: true  # Needed to enable schema introspection in the first place
  introspection_check_max_depth: false  # Defaults to true
```

<!-- ROUTER-896 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
