### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,4 +9,4 @@ pull_request_rules:
           - 1.x
         assignees:
           - "{{ author }}"
-        bot_account:
+        bot_account: "{{ author }}"


### PR DESCRIPTION
This change has been made by @BrynCooke from the Mergify config editor.

This will cause PRs that are raised via the backport label to impersonate the user that created the original PR.

Example on my test repo:

<img width="696" alt="image" src="https://github.com/user-attachments/assets/99e309b4-5a8c-48a1-a701-5cdede05361d" />


