### PR TITLE
Improve PluginTestHarness for multi call

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4207,6 +4207,10 @@ expression: "&schema"
         }
       ]
     },
+    "MyTestPluginConfig": {
+      "description": "Config for the test plugin",
+      "type": "object"
+    },
     "Operation": {
       "oneOf": [
         {
@@ -4350,6 +4354,10 @@ expression: "&schema"
     "Plugins": {
       "additionalProperties": false,
       "properties": {
+        "apollo_testing.my_test_plugin": {
+          "$ref": "#/definitions/MyTestPluginConfig",
+          "description": "#/definitions/MyTestPluginConfig"
+        },
         "experimental.broken": {
           "$ref": "#/definitions/Config2",
           "description": "#/definitions/Config2"

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -622,19 +622,15 @@ mod test {
             .config(config)
             .build()
             .await;
-
         let ctx = context();
-
         let resp = plugin
-            .call_execution(
-                execution::Request::fake_builder().context(ctx).build(),
-                |req| {
-                    execution::Response::fake_builder()
-                        .context(req.context)
-                        .build()
-                        .unwrap()
-                },
-            )
+            .execution_service(|req| async {
+                Ok(execution::Response::fake_builder()
+                    .context(req.context)
+                    .build()
+                    .unwrap())
+            })
+            .call(execution::Request::fake_builder().context(ctx).build())
             .await
             .unwrap();
 
@@ -662,11 +658,12 @@ mod test {
             .build();
         req.executable_document = Some(Arc::new(Valid::assume_valid(ExecutableDocument::new())));
         let resp = plugin
-            .call_subgraph(req, |req| {
-                subgraph::Response::fake_builder()
+            .subgraph_service("test", |req| async {
+                Ok(subgraph::Response::fake_builder()
                     .context(req.context)
-                    .build()
+                    .build())
             })
+            .call(req)
             .await
             .unwrap();
 

--- a/apollo-router/src/plugins/limits/mod.rs
+++ b/apollo-router/src/plugins/limits/mod.rs
@@ -250,16 +250,16 @@ mod test {
     async fn test_body_content_length_limit_exceeded() {
         let plugin = plugin().await;
         let resp = plugin
-            .call_router(
+            .router_service(|r| async {
+                let body = r.router_request.into_body();
+                let _ = router::body::into_bytes(body).await?;
+                panic!("should have failed to read stream")
+            })
+            .call(
                 router::Request::fake_builder()
                     .body(router::body::from_bytes("This is a test"))
                     .build()
                     .unwrap(),
-                |r| async {
-                    let body = r.router_request.into_body();
-                    let _ = router::body::into_bytes(body).await?;
-                    panic!("should have failed to read stream")
-                },
             )
             .await;
         assert!(resp.is_ok());
@@ -281,17 +281,17 @@ mod test {
     async fn test_body_content_length_limit_ok() {
         let plugin = plugin().await;
         let resp = plugin
-            .call_router(
+            .router_service(|r| async {
+                let body = r.router_request.into_body();
+                let body = router::body::into_bytes(body).await;
+                assert!(body.is_ok());
+                Ok(router::Response::fake_builder().build().unwrap())
+            })
+            .call(
                 router::Request::fake_builder()
                     .body(router::body::empty())
                     .build()
                     .unwrap(),
-                |r| async {
-                    let body = r.router_request.into_body();
-                    let body = router::body::into_bytes(body).await;
-                    assert!(body.is_ok());
-                    Ok(router::Response::fake_builder().build().unwrap())
-                },
             )
             .await;
 
@@ -314,13 +314,13 @@ mod test {
     async fn test_header_content_length_limit_exceeded() {
         let plugin = plugin().await;
         let resp = plugin
-            .call_router(
+            .router_service(|_| async { panic!("should have rejected request") })
+            .call(
                 router::Request::fake_builder()
                     .header("Content-Length", "100")
                     .body(router::body::empty())
                     .build()
                     .unwrap(),
-                |_| async { panic!("should have rejected request") },
             )
             .await;
         assert!(resp.is_ok());
@@ -342,13 +342,13 @@ mod test {
     async fn test_header_content_length_limit_ok() {
         let plugin = plugin().await;
         let resp = plugin
-            .call_router(
+            .router_service(|_| async { Ok(router::Response::fake_builder().build().unwrap()) })
+            .call(
                 router::Request::fake_builder()
                     .header("Content-Length", "5")
                     .body(router::body::empty())
                     .build()
                     .unwrap(),
-                |_| async { Ok(router::Response::fake_builder().build().unwrap()) },
             )
             .await;
         assert!(resp.is_ok());
@@ -371,12 +371,12 @@ mod test {
         // We should not be translating errors that are not limit errors into graphql errors
         let plugin = plugin().await;
         let resp = plugin
-            .call_router(
+            .router_service(|_| async { Err(BoxError::from("error")) })
+            .call(
                 router::Request::fake_builder()
                     .body(router::body::empty())
                     .build()
                     .unwrap(),
-                |_| async { Err(BoxError::from("error")) },
             )
             .await;
         assert!(resp.is_err());
@@ -386,31 +386,31 @@ mod test {
     async fn test_limits_dynamic_update() {
         let plugin = plugin().await;
         let resp = plugin
-            .call_router(
+            .router_service(|r| async move {
+                // Before we go for the body, we'll update the limit
+                r.context.extensions().with_lock(|lock| {
+                    let control: &BodyLimitControl =
+                        lock.get().expect("mut have body limit control");
+                    assert_eq!(control.remaining(), 10);
+                    assert_eq!(control.limit(), 10);
+                    control.update_limit(100);
+                });
+                let body = r.router_request.into_body();
+                let _ = router::body::into_bytes(body).await?;
+
+                // Now let's check progress
+                r.context.extensions().with_lock(|lock| {
+                    let control: &BodyLimitControl =
+                        lock.get().expect("mut have body limit control");
+                    assert_eq!(control.remaining(), 86);
+                });
+                Ok(router::Response::fake_builder().build().unwrap())
+            })
+            .call(
                 router::Request::fake_builder()
                     .body(router::body::from_bytes("This is a test"))
                     .build()
                     .unwrap(),
-                |r| async move {
-                    // Before we go for the body, we'll update the limit
-                    r.context.extensions().with_lock(|lock| {
-                        let control: &BodyLimitControl =
-                            lock.get().expect("mut have body limit control");
-                        assert_eq!(control.remaining(), 10);
-                        assert_eq!(control.limit(), 10);
-                        control.update_limit(100);
-                    });
-                    let body = r.router_request.into_body();
-                    let _ = router::body::into_bytes(body).await?;
-
-                    // Now let's check progress
-                    r.context.extensions().with_lock(|lock| {
-                        let control: &BodyLimitControl =
-                            lock.get().expect("mut have body limit control");
-                        assert_eq!(control.remaining(), 86);
-                    });
-                    Ok(router::Response::fake_builder().build().unwrap())
-                },
             )
             .await;
         assert!(resp.is_ok());

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -865,13 +865,7 @@ mod tests {
 
         async {
             test_harness
-                .call_router(
-                    router::Request::fake_builder()
-                        .header(CONTENT_LENGTH, "0")
-                        .header("custom-header", "val1")
-                        .header("x-log-request", HeaderValue::from_static("log"))
-                        .build()
-                        .unwrap(),
+                .router_service(
                     |_r|async  {
                         Ok(router::Response::fake_builder()
                             .header("custom-header", "val1")
@@ -881,6 +875,14 @@ mod tests {
                             .build()
                             .expect("expecting valid response"))
                     },
+                )
+                .call(
+                    router::Request::fake_builder()
+                        .header(CONTENT_LENGTH, "0")
+                        .header("custom-header", "val1")
+                        .header("x-log-request", HeaderValue::from_static("log"))
+                        .build()
+                        .unwrap()
                 )
                 .await
                 .expect("expecting successful response");
@@ -901,11 +903,8 @@ mod tests {
         async {
             // Without the header to enable custom event
             test_harness
-                .call_router(
-                    router::Request::fake_builder()
-                        .header("custom-header", "val1")
-                        .build()
-                        .unwrap(),
+                .router_service(
+
                     |_r| async {
                         let context_with_error = Context::new();
                         let _ = context_with_error
@@ -919,6 +918,10 @@ mod tests {
                             .expect("expecting valid response"))
                     },
                 )
+                .call(router::Request::fake_builder()
+                    .header("custom-header", "val1")
+                    .build()
+                    .unwrap())
                 .await
                 .expect("expecting successful response");
         }
@@ -938,11 +941,7 @@ mod tests {
         async {
             // Without the header to enable custom event
             test_harness
-                .call_router(
-                    router::Request::fake_builder()
-                        .header("custom-header", "val1")
-                        .build()
-                        .unwrap(),
+                .router_service(
                     |_r| async {
                         Ok(router::Response::fake_builder()
                             .header("custom-header", "val1")
@@ -953,6 +952,10 @@ mod tests {
                             .expect("expecting valid response"))
                     },
                 )
+                .call(router::Request::fake_builder()
+                    .header("custom-header", "val1")
+                    .build()
+                    .unwrap())
                 .await
                 .expect("expecting successful response");
         }
@@ -971,20 +974,19 @@ mod tests {
 
         async {
             test_harness
-                .call_supergraph(
+                .supergraph_service(|_r| async {
+                    supergraph::Response::fake_builder()
+                        .header("custom-header", "val1")
+                        .header("x-log-request", HeaderValue::from_static("log"))
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                })
+                .call(
                     supergraph::Request::fake_builder()
                         .query("query { foo }")
                         .header("x-log-request", HeaderValue::from_static("log"))
                         .build()
                         .unwrap(),
-                    |_r| {
-                        supergraph::Response::fake_builder()
-                            .header("custom-header", "val1")
-                            .header("x-log-request", HeaderValue::from_static("log"))
-                            .data(serde_json::json!({"data": "res"}).to_string())
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -1006,33 +1008,32 @@ mod tests {
             let ctx = Context::new();
             ctx.insert(OPERATION_NAME, String::from("Test")).unwrap();
             test_harness
-                .call_supergraph(
+                .supergraph_service(|_r| async {
+                    supergraph::Response::fake_builder()
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                })
+                .call(
                     supergraph::Request::fake_builder()
                         .query("query Test { foo }")
                         .context(ctx)
                         .build()
                         .unwrap(),
-                    |_r| {
-                        supergraph::Response::fake_builder()
-                            .data(serde_json::json!({"data": "res"}).to_string())
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
             test_harness
-                .call_supergraph(
+                .supergraph_service(|_r| async {
+                    Ok(supergraph::Response::fake_builder()
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                        .expect("expecting valid response"))
+                })
+                .call(
                     supergraph::Request::fake_builder()
                         .query("query { foo }")
                         .build()
                         .unwrap(),
-                    |_r| {
-                        supergraph::Response::fake_builder()
-                            .data(serde_json::json!({"data": "res"}).to_string())
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -1050,24 +1051,23 @@ mod tests {
 
         async {
             test_harness
-                .call_supergraph(
+                .supergraph_service(|_r| async {
+                    let context_with_error = Context::new();
+                    let _ = context_with_error
+                        .insert(CONTAINS_GRAPHQL_ERROR, true)
+                        .unwrap();
+                    supergraph::Response::fake_builder()
+                        .header("custom-header", "val1")
+                        .header("x-log-request", HeaderValue::from_static("log"))
+                        .context(context_with_error)
+                        .data(serde_json_bytes::json!({"errors": [{"message": "res"}]}))
+                        .build()
+                })
+                .call(
                     supergraph::Request::fake_builder()
                         .query("query { foo }")
                         .build()
                         .unwrap(),
-                    |_r| {
-                        let context_with_error = Context::new();
-                        let _ = context_with_error
-                            .insert(CONTAINS_GRAPHQL_ERROR, true)
-                            .unwrap();
-                        supergraph::Response::fake_builder()
-                            .header("custom-header", "val1")
-                            .header("x-log-request", HeaderValue::from_static("log"))
-                            .context(context_with_error)
-                            .data(serde_json_bytes::json!({"errors": [{"message": "res"}]}))
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -1085,19 +1085,18 @@ mod tests {
 
         async {
             test_harness
-                .call_supergraph(
+                .supergraph_service(|_r| async {
+                    supergraph::Response::fake_builder()
+                        .header("custom-header", "val1")
+                        .header("x-log-response", HeaderValue::from_static("log"))
+                        .data(serde_json_bytes::json!({"errors": [{"message": "res"}]}))
+                        .build()
+                })
+                .call(
                     supergraph::Request::fake_builder()
                         .query("query { foo }")
                         .build()
                         .unwrap(),
-                    |_r| {
-                        supergraph::Response::fake_builder()
-                            .header("custom-header", "val1")
-                            .header("x-log-response", HeaderValue::from_static("log"))
-                            .data(serde_json_bytes::json!({"errors": [{"message": "res"}]}))
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -1123,19 +1122,18 @@ mod tests {
                 .headers_mut()
                 .insert("x-log-request", HeaderValue::from_static("log"));
             test_harness
-                .call_subgraph(
+                .subgraph_service("subgraph", |_r| async {
+                    subgraph::Response::fake2_builder()
+                        .header("custom-header", "val1")
+                        .header("x-log-request", HeaderValue::from_static("log"))
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                })
+                .call(
                     subgraph::Request::fake_builder()
                         .subgraph_name("subgraph")
                         .subgraph_request(subgraph_req)
                         .build(),
-                    |_r| {
-                        subgraph::Response::fake2_builder()
-                            .header("custom-header", "val1")
-                            .header("x-log-request", HeaderValue::from_static("log"))
-                            .data(serde_json::json!({"data": "res"}).to_string())
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -1161,20 +1159,19 @@ mod tests {
                 .headers_mut()
                 .insert("x-log-request", HeaderValue::from_static("log"));
             test_harness
-                .call_subgraph(
+                .subgraph_service("subgraph", |_r| async {
+                    subgraph::Response::fake2_builder()
+                        .header("custom-header", "val1")
+                        .header("x-log-response", HeaderValue::from_static("log"))
+                        .subgraph_name("subgraph")
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                })
+                .call(
                     subgraph::Request::fake_builder()
                         .subgraph_name("subgraph")
                         .subgraph_request(subgraph_req)
                         .build(),
-                    |_r| {
-                        subgraph::Response::fake2_builder()
-                            .header("custom-header", "val1")
-                            .header("x-log-response", HeaderValue::from_static("log"))
-                            .subgraph_name("subgraph")
-                            .data(serde_json::json!({"data": "res"}).to_string())
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -1210,14 +1207,17 @@ mod tests {
                 context: context.clone(),
             };
             test_harness
-                .call_http_client("subgraph", http_request, |http_request| HttpResponse {
-                    http_response: http::Response::builder()
-                        .status(200)
-                        .header("x-log-request", HeaderValue::from_static("log"))
-                        .body(body::empty())
-                        .expect("expecting valid response"),
-                    context: http_request.context.clone(),
+                .http_client_service("subgraph", |http_request| async move {
+                    Ok(HttpResponse {
+                        http_response: http::Response::builder()
+                            .status(200)
+                            .header("x-log-request", HeaderValue::from_static("log"))
+                            .body(body::empty())
+                            .expect("expecting valid response"),
+                        context: http_request.context.clone(),
+                    })
                 })
+                .call(http_request)
                 .await
                 .expect("expecting successful response");
         }
@@ -1252,14 +1252,17 @@ mod tests {
                 context: context.clone(),
             };
             test_harness
-                .call_http_client("subgraph", http_request, |http_request| HttpResponse {
-                    http_response: http::Response::builder()
-                        .status(200)
-                        .header("x-log-response", HeaderValue::from_static("log"))
-                        .body(body::empty())
-                        .expect("expecting valid response"),
-                    context: http_request.context.clone(),
+                .http_client_service("subgraph", |http_request| async move {
+                    Ok(HttpResponse {
+                        http_response: http::Response::builder()
+                            .status(200)
+                            .header("x-log-response", HeaderValue::from_static("log"))
+                            .body(body::empty())
+                            .expect("expecting valid response"),
+                        context: http_request.context.clone(),
+                    })
                 })
+                .call(http_request)
                 .await
                 .expect("expecting successful response");
         }

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
@@ -230,7 +230,7 @@ pub(crate) mod test {
                 .await;
 
             harness
-                .call_supergraph(request, |req| {
+                .supergraph_service(|req| async {
                     let response: serde_json::Value = serde_json::from_str(include_str!(
                         "../../../demand_control/cost_calculator/fixtures/federated_ships_named_response.json"
                     ))
@@ -239,8 +239,8 @@ pub(crate) mod test {
                         .data(response["data"].clone())
                         .context(req.context)
                         .build()
-                        .unwrap()
                 })
+                .call(request)
                 .await
                 .unwrap();
 
@@ -277,7 +277,7 @@ pub(crate) mod test {
                 .build()
                 .await;
             harness
-                .call_supergraph(request, |req| {
+                .supergraph_service(|req| async {
                     let response: serde_json::Value = serde_json::from_str(include_str!(
                         "../../../demand_control/cost_calculator/fixtures/federated_ships_fragment_response.json"
                     ))
@@ -286,8 +286,9 @@ pub(crate) mod test {
                         .data(response["data"].clone())
                         .context(req.context)
                         .build()
-                        .unwrap()
+
                 })
+                .call(request)
                 .await
                 .unwrap();
 
@@ -332,7 +333,7 @@ pub(crate) mod test {
                 .await;
 
             harness
-                .call_supergraph(request, |req| {
+                .supergraph_service(|req| async {
                     let response: serde_json::Value = serde_json::from_str(include_str!(
                         "../../../demand_control/cost_calculator/fixtures/federated_ships_named_response.json"
                     ))
@@ -341,8 +342,8 @@ pub(crate) mod test {
                         .data(response["data"].clone())
                         .context(req.context)
                         .build()
-                        .unwrap()
                 })
+                .call(request)
                 .await
                 .unwrap();
 
@@ -374,7 +375,7 @@ pub(crate) mod test {
                 .await;
 
             harness
-                .call_supergraph(request, |req| {
+                .supergraph_service(|req| async {
                     let response: serde_json::Value = serde_json::from_str(include_str!(
                         "../../../demand_control/cost_calculator/fixtures/federated_ships_fragment_response.json"
                     ))
@@ -383,8 +384,8 @@ pub(crate) mod test {
                         .data(response["data"].clone())
                         .context(req.context)
                         .build()
-                        .unwrap()
                 })
+                .call(request)
                 .await
                 .unwrap();
 

--- a/apollo-router/src/plugins/telemetry/logging/mod.rs
+++ b/apollo-router/src/plugins/telemetry/logging/mod.rs
@@ -17,19 +17,19 @@ mod test {
 
         async {
             let mut response = test_harness
-                .call_router(
+                .router_service(|_r| async {
+                    tracing::info!("response");
+                    Ok(router::Response::fake_builder()
+                        .header("custom-header", "val1")
+                        .data(serde_json::json!({"data": "res"}))
+                        .build()
+                        .expect("expecting valid response"))
+                })
+                .call(
                     router::Request::fake_builder()
                         .body(router::body::from_bytes("query { foo }"))
                         .build()
                         .expect("expecting valid request"),
-                    |_r| async {
-                        tracing::info!("response");
-                        Ok(router::Response::fake_builder()
-                            .header("custom-header", "val1")
-                            .data(serde_json::json!({"data": "res"}))
-                            .build()
-                            .expect("expecting valid response"))
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -46,20 +46,19 @@ mod test {
 
         async {
             let mut response = test_harness
-                .call_supergraph(
+                .supergraph_service(|_r| async {
+                    tracing::info!("response");
+                    supergraph::Response::fake_builder()
+                        .header("custom-header", "val1")
+                        .data(serde_json::json!({"data": "res"}))
+                        .build()
+                })
+                .call(
                     supergraph::Request::fake_builder()
                         .query("query { foo }")
                         .variable("a", "b")
                         .build()
                         .expect("expecting valid request"),
-                    |_r| {
-                        tracing::info!("response");
-                        supergraph::Response::fake_builder()
-                            .header("custom-header", "val1")
-                            .data(serde_json::json!({"data": "res"}))
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -76,7 +75,14 @@ mod test {
 
         async {
             test_harness
-                .call_subgraph(
+                .subgraph_service("subgraph", |_r| async {
+                    tracing::info!("response");
+                    subgraph::Response::fake2_builder()
+                        .header("custom-header", "val1")
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                })
+                .call(
                     subgraph::Request::fake_builder()
                         .subgraph_name("subgraph")
                         .subgraph_request(http::Request::new(
@@ -85,14 +91,6 @@ mod test {
                                 .build(),
                         ))
                         .build(),
-                    |_r| {
-                        tracing::info!("response");
-                        subgraph::Response::fake2_builder()
-                            .header("custom-header", "val1")
-                            .data(serde_json::json!({"data": "res"}).to_string())
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -1,13 +1,15 @@
+use apollo_compiler::validation::Valid;
+use pin_project_lite::pin_project;
+use serde_json::Value;
 use std::any::TypeId;
 use std::future::Future;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
-
-use apollo_compiler::validation::Valid;
-use serde_json::Value;
+use std::task::Poll;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower_service::Service;
 
 use crate::plugin::DynPlugin;
@@ -35,23 +37,22 @@ use crate::Notify;
 ///         let test_harness: PluginTestHarness<Telemetry> = PluginTestHarness::builder().build().await;
 ///
 ///         async {
-///             let mut response = test_harness
-///                 .call_router(
-///                     router::Request::fake_builder()
-///                         .body("query { foo }")
-///                         .build()
-///                         .expect("expecting valid request"),
-///                     |_r| {
-///                         tracing::info!("response");
-///                         router::Response::fake_builder()
-///                             .header("custom-header", "val1")
-///                             .data(serde_json::json!({"data": "res"}))
-///                             .build()
-///                             .expect("expecting valid response")
-///                     },
-///                 )
-///                 .await
-///                 .expect("expecting successful response");
+///            let test_harness: PluginTestHarness<MyTestPlugin> =
+///             PluginTestHarness::builder().build().await;
+///
+///             let mut service = test_harness.router_service(|_req| async {
+///                 Ok(router::Response::fake_builder()
+///                     .data(serde_json::json!({"data": {"field": "value"}}))
+///                     .header("x-custom-header", "test-value")
+///                     .build()
+///                     .unwrap())
+///                 });
+///
+///             let response = service.call_default().await.unwrap();
+///             assert_eq!(
+///                 response.response.headers().get("x-custom-header"),
+///                 Some(&HeaderValue::from_static("test-value"))
+///             );
 ///
 ///             response.next_response().await;
 ///         }
@@ -130,12 +131,10 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) async fn call_router<F>(
+    pub(crate) fn router_service<F>(
         &self,
-        request: router::Request,
         response_fn: fn(router::Request) -> F,
-    ) -> Result<router::Response, BoxError>
+    ) -> ServiceHandle<router::Request, router::BoxService>
     where
         F: Future<Output = Result<router::Response, BoxError>> + Send + 'static,
     {
@@ -144,69 +143,71 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
                 .service_fn(move |req: router::Request| async move { (response_fn)(req).await }),
         );
 
-        self.plugin.router_service(service).call(request).await
+        ServiceHandle::new(self.plugin.router_service(service))
     }
 
-    pub(crate) async fn call_supergraph(
+    pub(crate) fn supergraph_service<F>(
         &self,
-        request: supergraph::Request,
-        response_fn: fn(supergraph::Request) -> supergraph::Response,
-    ) -> Result<supergraph::Response, BoxError> {
-        let service: supergraph::BoxService = supergraph::BoxService::new(
-            ServiceBuilder::new()
-                .service_fn(move |req: supergraph::Request| async move { Ok((response_fn)(req)) }),
-        );
+        response_fn: fn(supergraph::Request) -> F,
+    ) -> ServiceHandle<supergraph::Request, supergraph::BoxService>
+    where
+        F: Future<Output = Result<supergraph::Response, BoxError>> + Send + 'static,
+    {
+        let service: supergraph::BoxService =
+            supergraph::BoxService::new(ServiceBuilder::new().service_fn(
+                move |req: supergraph::Request| async move { (response_fn)(req).await },
+            ));
 
-        self.plugin.supergraph_service(service).call(request).await
+        ServiceHandle::new(self.plugin.supergraph_service(service))
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn call_execution(
+    pub(crate) fn execution_service<F>(
         &self,
-        request: execution::Request,
-        response_fn: fn(execution::Request) -> execution::Response,
-    ) -> Result<execution::Response, BoxError> {
+        response_fn: fn(execution::Request) -> F,
+    ) -> ServiceHandle<execution::Request, execution::BoxService>
+    where
+        F: Future<Output = Result<execution::Response, BoxError>> + Send + 'static,
+    {
         let service: execution::BoxService = execution::BoxService::new(
             ServiceBuilder::new()
-                .service_fn(move |req: execution::Request| async move { Ok((response_fn)(req)) }),
+                .service_fn(move |req: execution::Request| async move { (response_fn)(req).await }),
         );
 
-        self.plugin.execution_service(service).call(request).await
+        ServiceHandle::new(self.plugin.execution_service(service))
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn call_subgraph(
+    pub(crate) fn subgraph_service<F>(
         &self,
-        request: subgraph::Request,
-        response_fn: fn(subgraph::Request) -> subgraph::Response,
-    ) -> Result<subgraph::Response, BoxError> {
-        let name = request.subgraph_name.clone();
+        subgraph: &str,
+        response_fn: fn(subgraph::Request) -> F,
+    ) -> ServiceHandle<subgraph::Request, subgraph::BoxService>
+    where
+        F: Future<Output = Result<subgraph::Response, BoxError>> + Send + 'static,
+    {
         let service: subgraph::BoxService = subgraph::BoxService::new(
             ServiceBuilder::new()
-                .service_fn(move |req: subgraph::Request| async move { Ok((response_fn)(req)) }),
+                .service_fn(move |req: subgraph::Request| async move { (response_fn)(req).await }),
         );
-
-        self.plugin
-            .subgraph_service(&name.expect("subgraph name must be populated"), service)
-            .call(request)
-            .await
+        ServiceHandle::new(self.plugin.subgraph_service(subgraph, service))
     }
+
     #[allow(dead_code)]
-    pub(crate) async fn call_http_client(
+    pub(crate) fn http_client_service<F>(
         &self,
-        subgraph_name: &str,
-        request: http::HttpRequest,
-        response_fn: fn(http::HttpRequest) -> http::HttpResponse,
-    ) -> Result<http::HttpResponse, BoxError> {
+        subgraph: &str,
+        response_fn: fn(http::HttpRequest) -> F,
+    ) -> ServiceHandle<http::HttpRequest, http::BoxService>
+    where
+        F: Future<Output = Result<http::HttpResponse, BoxError>> + Send + 'static,
+    {
         let service: http::BoxService = http::BoxService::new(
             ServiceBuilder::new()
-                .service_fn(move |req: http::HttpRequest| async move { Ok((response_fn)(req)) }),
+                .service_fn(move |req: http::HttpRequest| async move { (response_fn)(req).await }),
         );
 
-        self.plugin
-            .http_client_service(subgraph_name, service)
-            .call(request)
-            .await
+        ServiceHandle::new(self.plugin.http_client_service(subgraph, service))
     }
 }
 
@@ -221,5 +222,333 @@ where
             .as_any()
             .downcast_ref()
             .expect("plugin should be of type T")
+    }
+}
+
+pub(crate) struct ServiceHandle<Req, S>
+where
+    S: Service<Req, Error = BoxError>,
+{
+    _phantom: std::marker::PhantomData<Req>,
+    service: Arc<tokio::sync::Mutex<S>>,
+}
+
+impl Clone for ServiceHandle<router::Request, router::BoxService> {
+    fn clone(&self) -> Self {
+        Self {
+            _phantom: Default::default(),
+            service: self.service.clone(),
+        }
+    }
+}
+
+impl<Req, S> ServiceHandle<Req, S>
+where
+    S: Service<Req, Error = BoxError>,
+{
+    pub(crate) fn new(service: S) -> Self {
+        Self {
+            _phantom: Default::default(),
+            service: Arc::new(tokio::sync::Mutex::new(service)),
+        }
+    }
+
+    /// Await the service to be ready and make a call to the service.
+    pub(crate) async fn call(&self, request: Req) -> Result<S::Response, BoxError> {
+        // This is a bit of a dance to ensure that we wait until the service is readu to call, make
+        // the call and then drop the mutex guard before the call is executed.
+        // This means that other calls to the service can take place.
+        let mut service = self.service.lock().await;
+        let fut = service.ready().await?.call(request);
+        drop(service);
+        fut.await
+    }
+
+    /// Call using the default request for the service.
+    pub(crate) async fn call_default(&self) -> Result<S::Response, BoxError>
+    where
+        Req: FakeDefault,
+    {
+        self.call(FakeDefault::default()).await
+    }
+
+    /// Returns if the service is ready
+    pub(crate) async fn is_ready(&self) -> bool {
+        PollReadyFuture {
+            _phantom: Default::default(),
+            service: self.service.clone().lock_owned().await,
+        }
+        .await
+    }
+}
+
+pin_project! {
+    struct PollReadyFuture<Req, S>
+    where
+        S: Service<Req>,
+    {
+        _phantom: std::marker::PhantomData<Req>,
+        #[pin]
+        service: tokio::sync::OwnedMutexGuard<S>,
+    }
+}
+
+impl<Req, S> Future for PollReadyFuture<Req, S>
+where
+    S: Service<Req>,
+{
+    type Output = bool;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let mut this = self.project();
+        match this.service.poll_ready(cx) {
+            Poll::Ready(_) => Poll::Ready(true),
+            Poll::Pending => Poll::Ready(false),
+        }
+    }
+}
+
+pub(crate) trait FakeDefault {
+    fn default() -> Self;
+}
+
+impl FakeDefault for router::Request {
+    fn default() -> Self {
+        router::Request::fake_builder().build().unwrap()
+    }
+}
+
+impl FakeDefault for supergraph::Request {
+    fn default() -> Self {
+        supergraph::Request::fake_builder().build().unwrap()
+    }
+}
+
+impl FakeDefault for execution::Request {
+    fn default() -> Self {
+        execution::Request::fake_builder().build()
+    }
+}
+
+impl FakeDefault for subgraph::Request {
+    fn default() -> Self {
+        subgraph::Request::fake_builder().build()
+    }
+}
+
+impl FakeDefault for http::HttpRequest {
+    fn default() -> Self {
+        http::HttpRequest {
+            http_request: Default::default(),
+            context: Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_for_harness {
+    use ::http::HeaderMap;
+    use ::http::HeaderValue;
+    use async_trait::async_trait;
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+    use tokio::join;
+
+    use super::*;
+    use crate::plugin::Plugin;
+    use crate::services::router;
+    use crate::services::router::body;
+    use crate::services::router::BoxService;
+
+    /// Config for the test plugin
+    #[derive(JsonSchema, Deserialize)]
+    struct MyTestPluginConfig {}
+
+    struct MyTestPlugin {}
+    #[async_trait]
+    impl Plugin for MyTestPlugin {
+        type Config = MyTestPluginConfig;
+
+        async fn new(_init: PluginInit<Self::Config>) -> Result<Self, BoxError>
+        where
+            Self: Sized,
+        {
+            Ok(Self {})
+        }
+
+        fn router_service(&self, service: BoxService) -> BoxService {
+            ServiceBuilder::new()
+                .load_shed()
+                .concurrency_limit(1)
+                .service(service)
+                .boxed()
+        }
+
+        fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+            // This purposely does not use load_shed to allow us to test readiness.
+            ServiceBuilder::new()
+                .concurrency_limit(1)
+                .service(service)
+                .boxed()
+        }
+    }
+    register_plugin!("apollo_testing", "my_test_plugin", MyTestPlugin);
+
+    #[tokio::test]
+    async fn test_router_service() {
+        let test_harness: PluginTestHarness<MyTestPlugin> =
+            PluginTestHarness::builder().build().await;
+
+        let service = test_harness.router_service(|_req| async {
+            Ok(router::Response::fake_builder()
+                .data(serde_json::json!({"data": {"field": "value"}}))
+                .header("x-custom-header", "test-value")
+                .build()
+                .unwrap())
+        });
+
+        for _ in 0..2 {
+            let response = service.call_default().await.unwrap();
+            assert!(service.is_ready().await);
+            assert_eq!(
+                response.response.headers().get("x-custom-header"),
+                Some(&HeaderValue::from_static("test-value"))
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_router_service_multi_threaded() {
+        let test_harness: PluginTestHarness<MyTestPlugin> =
+            PluginTestHarness::builder().build().await;
+
+        let service = test_harness.router_service(|_req| async {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            Ok(router::Response::fake_builder()
+                .data(serde_json::json!({"data": {"field": "value"}}))
+                .header("x-custom-header", "test-value")
+                .build()
+                .unwrap())
+        });
+
+        let f1 = service.call_default();
+        let f2 = service.call_default();
+
+        let (r1, r2) = join!(f1, f2);
+        let results = vec![r1, r2];
+        // One of the calls should succeed, the other should fail due to concurrency limit
+        assert!(results.iter().any(|r| r.is_ok()));
+        assert!(results.iter().any(|r| r.is_err()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_is_ready() {
+        let test_harness: PluginTestHarness<MyTestPlugin> =
+            PluginTestHarness::builder().build().await;
+
+        let service = test_harness.supergraph_service(|_req| async {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            Ok(supergraph::Response::fake_builder()
+                .data(serde_json::json!({"data": {"field": "value"}}))
+                .header("x-custom-header", "test-value")
+                .build()
+                .unwrap())
+        });
+
+        // Join will progress each future in turn, so we are guaranteed that the service will enter not
+        // ready state..
+        let request = service.call_default();
+        let (resp, ready) = join!(request, service.is_ready());
+        assert!(resp.is_ok());
+        assert!(!ready);
+        // Now that the first request has completed, the service should be ready again
+        assert!(service.is_ready().await)
+    }
+
+    #[tokio::test]
+    async fn test_supergraph_service() {
+        let test_harness: PluginTestHarness<MyTestPlugin> =
+            PluginTestHarness::builder().build().await;
+
+        let service = test_harness.supergraph_service(|_req| async {
+            Ok(supergraph::Response::fake_builder()
+                .data(serde_json::json!({"data": {"field": "value"}}))
+                .header("x-custom-header", "test-value")
+                .build()
+                .unwrap())
+        });
+
+        let response = service.call_default().await.unwrap();
+        assert_eq!(
+            response.response.headers().get("x-custom-header"),
+            Some(&HeaderValue::from_static("test-value"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execution_service() {
+        let test_harness: PluginTestHarness<MyTestPlugin> =
+            PluginTestHarness::builder().build().await;
+
+        let service = test_harness.execution_service(|_req| async {
+            Ok(execution::Response::fake_builder()
+                .data(serde_json::json!({"data": {"field": "value"}}))
+                .header("x-custom-header", "test-value")
+                .build()
+                .unwrap())
+        });
+
+        let response = service.call_default().await.unwrap();
+        assert_eq!(
+            response.response.headers().get("x-custom-header"),
+            Some(&HeaderValue::from_static("test-value"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subgraph_service() {
+        let test_harness: PluginTestHarness<MyTestPlugin> =
+            PluginTestHarness::builder().build().await;
+
+        let service = test_harness.subgraph_service("test_subgraph", |_req| async {
+            let mut headers = HeaderMap::new();
+            headers.insert("x-custom-header", "test-value".parse().unwrap());
+            Ok(subgraph::Response::fake_builder()
+                .data(serde_json::json!({"data": {"field": "value"}}))
+                .headers(headers)
+                .build())
+        });
+
+        let response = service.call_default().await.unwrap();
+        assert_eq!(
+            response.response.headers().get("x-custom-header"),
+            Some(&HeaderValue::from_static("test-value"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_http_client_service() {
+        let test_harness: PluginTestHarness<MyTestPlugin> =
+            PluginTestHarness::builder().build().await;
+
+        let service = test_harness.http_client_service("test_client", |req| async {
+            Ok(http::HttpResponse {
+                http_response: ::http::Response::builder()
+                    .status(200)
+                    .header("x-custom-header", "test-value")
+                    .body(body::empty())
+                    .expect("valid response"),
+                context: req.context,
+            })
+        });
+
+        let response = service.call_default().await.unwrap();
+        assert_eq!(
+            response.http_response.headers().get("x-custom-header"),
+            Some(&HeaderValue::from_static("test-value"))
+        );
     }
 }

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -1,12 +1,13 @@
-use apollo_compiler::validation::Valid;
-use pin_project_lite::pin_project;
-use serde_json::Value;
 use std::any::TypeId;
 use std::future::Future;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Poll;
+
+use apollo_compiler::validation::Valid;
+use pin_project_lite::pin_project;
+use serde_json::Value;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;


### PR DESCRIPTION
The PluginTestHarness previously created services on every call.
However this is no good for testing plugins in the new world where services are reused.

The harness has been modified to return service handles that allow calls to be made against the service:

```
let test_harness: PluginTestHarness<MyTestPlugin> =
            PluginTestHarness::builder().build().await;

        let mut service = test_harness.router_service(|_req| async {
            Ok(router::Response::fake_builder()
                .data(serde_json::json!({"data": {"field": "value"}}))
                .header("x-custom-header", "test-value")
                .build()
                .unwrap())
        });

        for _ in 0..2 {
            let response = service.call_default().await.unwrap();
            assert_eq!(
                response.response.headers().get("x-custom-header"),
                Some(&HeaderValue::from_static("test-value"))
            );
        }

```


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
