### PR TITLE
fix: explictly support `extend schema @link` for connectors

### DIFF
--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -39,6 +39,7 @@ use apollo_compiler::schema::Component;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::ObjectType;
+use apollo_compiler::schema::SchemaBuilder;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
@@ -94,7 +95,10 @@ pub struct ValidationResult {
 pub fn validate(source_text: &str, file_name: &str) -> ValidationResult {
     // TODO: Use parse_and_validate (adding in directives as needed)
     // TODO: Handle schema errors rather than relying on JavaScript to catch it later
-    let schema = Schema::parse(source_text, file_name)
+    let schema = SchemaBuilder::new()
+        .adopt_orphan_extensions()
+        .parse(source_text, file_name)
+        .build()
         .unwrap_or_else(|schema_with_errors| schema_with_errors.partial);
     let connect_identity = ConnectSpec::identity();
     let Some((link, link_directive)) = Link::for_identity(&schema, &connect_identity) else {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@all_fields_selected_repro.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@all_fields_selected_repro.graphql.snap
@@ -1,0 +1,35 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", result.errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/all_fields_selected_repro.graphql
+---
+[
+    Message {
+        code: ConnectorsUnresolvedField,
+        message: "No connector resolves field `Cart.items`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
+        locations: [
+            13:3..13:19,
+        ],
+    },
+    Message {
+        code: ConnectorsUnresolvedField,
+        message: "No connector resolves field `Variant.id`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
+        locations: [
+            17:3..17:10,
+        ],
+    },
+    Message {
+        code: ConnectorsUnresolvedField,
+        message: "No connector resolves field `Variant.price`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
+        locations: [
+            18:3..18:27,
+        ],
+    },
+    Message {
+        code: MissingEntityConnector,
+        message: "Entity resolution for `@key(fields: \"userId\")` on `Cart` is not implemented by a connector. See https://go.apollo.dev/connectors/directives/#rules-for-entity-true",
+        locations: [
+            11:11..11:33,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/test_data/all_fields_selected_repro.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/all_fields_selected_repro.graphql
@@ -1,0 +1,19 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.10"
+    import: ["@key", "@requires", "@override", "@external", "@shareable"]
+  )
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@source", "@connect"]
+  )
+
+type Cart @key(fields: "userId") {
+  userId: ID!
+  items: [Variant] # whoops forgot the @connect
+}
+
+type Variant @key(fields: "id", resolvable: false) {
+  id: ID!
+  price: Float! @shareable
+}


### PR DESCRIPTION
before this change, if you use `extend schema` to add the link directive and you don't define `Query`, the schema extension is dropped and the validations don't see the link. this means that all connector validations are skipped!

<!-- https://apollographql.atlassian.net/browse/CNN-573 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
