### PR TITLE
Improve PluginTestHarness for multi call (backport #6623)

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4049,6 +4049,10 @@ expression: "&schema"
         }
       ]
     },
+    "MyTestPluginConfig": {
+      "description": "Config for the test plugin",
+      "type": "object"
+    },
     "Operation": {
       "oneOf": [
         {
@@ -4192,6 +4196,10 @@ expression: "&schema"
     "Plugins": {
       "additionalProperties": false,
       "properties": {
+        "apollo_testing.my_test_plugin": {
+          "$ref": "#/definitions/MyTestPluginConfig",
+          "description": "#/definitions/MyTestPluginConfig"
+        },
         "experimental.broken": {
           "$ref": "#/definitions/Config2",
           "description": "#/definitions/Config2"

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -622,19 +622,15 @@ mod test {
             .config(config)
             .build()
             .await;
-
         let ctx = context();
-
         let resp = plugin
-            .call_execution(
-                execution::Request::fake_builder().context(ctx).build(),
-                |req| {
-                    execution::Response::fake_builder()
-                        .context(req.context)
-                        .build()
-                        .unwrap()
-                },
-            )
+            .execution_service(|req| async {
+                Ok(execution::Response::fake_builder()
+                    .context(req.context)
+                    .build()
+                    .unwrap())
+            })
+            .call(execution::Request::fake_builder().context(ctx).build())
             .await
             .unwrap();
 
@@ -662,11 +658,12 @@ mod test {
             .build();
         req.executable_document = Some(Arc::new(Valid::assume_valid(ExecutableDocument::new())));
         let resp = plugin
-            .call_subgraph(req, |req| {
-                subgraph::Response::fake_builder()
+            .subgraph_service("test", |req| async {
+                Ok(subgraph::Response::fake_builder()
                     .context(req.context)
-                    .build()
+                    .build())
             })
+            .call(req)
             .await
             .unwrap();
 

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
@@ -230,7 +230,7 @@ pub(crate) mod test {
                 .await;
 
             harness
-                .call_supergraph(request, |req| {
+                .supergraph_service(|req| async {
                     let response: serde_json::Value = serde_json::from_str(include_str!(
                         "../../../demand_control/cost_calculator/fixtures/federated_ships_named_response.json"
                     ))
@@ -239,8 +239,8 @@ pub(crate) mod test {
                         .data(response["data"].clone())
                         .context(req.context)
                         .build()
-                        .unwrap()
                 })
+                .call(request)
                 .await
                 .unwrap();
 
@@ -277,7 +277,7 @@ pub(crate) mod test {
                 .build()
                 .await;
             harness
-                .call_supergraph(request, |req| {
+                .supergraph_service(|req| async {
                     let response: serde_json::Value = serde_json::from_str(include_str!(
                         "../../../demand_control/cost_calculator/fixtures/federated_ships_fragment_response.json"
                     ))
@@ -286,8 +286,9 @@ pub(crate) mod test {
                         .data(response["data"].clone())
                         .context(req.context)
                         .build()
-                        .unwrap()
+
                 })
+                .call(request)
                 .await
                 .unwrap();
 
@@ -332,7 +333,7 @@ pub(crate) mod test {
                 .await;
 
             harness
-                .call_supergraph(request, |req| {
+                .supergraph_service(|req| async {
                     let response: serde_json::Value = serde_json::from_str(include_str!(
                         "../../../demand_control/cost_calculator/fixtures/federated_ships_named_response.json"
                     ))
@@ -341,8 +342,8 @@ pub(crate) mod test {
                         .data(response["data"].clone())
                         .context(req.context)
                         .build()
-                        .unwrap()
                 })
+                .call(request)
                 .await
                 .unwrap();
 
@@ -374,7 +375,7 @@ pub(crate) mod test {
                 .await;
 
             harness
-                .call_supergraph(request, |req| {
+                .supergraph_service(|req| async {
                     let response: serde_json::Value = serde_json::from_str(include_str!(
                         "../../../demand_control/cost_calculator/fixtures/federated_ships_fragment_response.json"
                     ))
@@ -383,8 +384,8 @@ pub(crate) mod test {
                         .data(response["data"].clone())
                         .context(req.context)
                         .build()
-                        .unwrap()
                 })
+                .call(request)
                 .await
                 .unwrap();
 

--- a/apollo-router/src/plugins/telemetry/logging/mod.rs
+++ b/apollo-router/src/plugins/telemetry/logging/mod.rs
@@ -17,19 +17,19 @@ mod test {
 
         async {
             let mut response = test_harness
-                .call_router(
+                .router_service(|_r| async {
+                    tracing::info!("response");
+                    Ok(router::Response::fake_builder()
+                        .header("custom-header", "val1")
+                        .data(serde_json::json!({"data": "res"}))
+                        .build()
+                        .expect("expecting valid response"))
+                })
+                .call(
                     router::Request::fake_builder()
                         .body("query { foo }")
                         .build()
                         .expect("expecting valid request"),
-                    |_r| async {
-                        tracing::info!("response");
-                        Ok(router::Response::fake_builder()
-                            .header("custom-header", "val1")
-                            .data(serde_json::json!({"data": "res"}))
-                            .build()
-                            .expect("expecting valid response"))
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -46,20 +46,19 @@ mod test {
 
         async {
             let mut response = test_harness
-                .call_supergraph(
+                .supergraph_service(|_r| async {
+                    tracing::info!("response");
+                    supergraph::Response::fake_builder()
+                        .header("custom-header", "val1")
+                        .data(serde_json::json!({"data": "res"}))
+                        .build()
+                })
+                .call(
                     supergraph::Request::fake_builder()
                         .query("query { foo }")
                         .variable("a", "b")
                         .build()
                         .expect("expecting valid request"),
-                    |_r| {
-                        tracing::info!("response");
-                        supergraph::Response::fake_builder()
-                            .header("custom-header", "val1")
-                            .data(serde_json::json!({"data": "res"}))
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");
@@ -76,7 +75,14 @@ mod test {
 
         async {
             test_harness
-                .call_subgraph(
+                .subgraph_service("subgraph", |_r| async {
+                    tracing::info!("response");
+                    subgraph::Response::fake2_builder()
+                        .header("custom-header", "val1")
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                })
+                .call(
                     subgraph::Request::fake_builder()
                         .subgraph_name("subgraph")
                         .subgraph_request(http::Request::new(
@@ -85,14 +91,6 @@ mod test {
                                 .build(),
                         ))
                         .build(),
-                    |_r| {
-                        tracing::info!("response");
-                        subgraph::Response::fake2_builder()
-                            .header("custom-header", "val1")
-                            .data(serde_json::json!({"data": "res"}).to_string())
-                            .build()
-                            .expect("expecting valid response")
-                    },
                 )
                 .await
                 .expect("expecting successful response");


### PR DESCRIPTION
The PluginTestHarness previously created services on every call.
However this is no good for testing plugins in the new world where services are reused.

The harness has been modified to return service handles that allow calls to be made against the service:

```
let test_harness: PluginTestHarness<MyTestPlugin> =
            PluginTestHarness::builder().build().await;

        let mut service = test_harness.router_service(|_req| async {
            Ok(router::Response::fake_builder()
                .data(serde_json::json!({"data": {"field": "value"}}))
                .header("x-custom-header", "test-value")
                .build()
                .unwrap())
        });

        for _ in 0..2 {
            let response = service.call_default().await.unwrap();
            assert_eq!(
                response.response.headers().get("x-custom-header"),
                Some(&HeaderValue::from_static("test-value"))
            );
        }

```



---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6623 done by [Mergify](https://mergify.com).