### PR TITLE
Fix increased memory usage in `sysinfo` since Router 1.59.0 (backport #6634)

### DIFF
--- a/.changesets/fix_simon_rayonless_sysinfo.md
+++ b/.changesets/fix_simon_rayonless_sysinfo.md
@@ -1,0 +1,12 @@
+### Fix increased memory usage in `sysinfo` since Router 1.59.0 ([PR #6634](https://github.com/apollographql/router/pull/6634))
+
+In version 1.59.0, Apollo Router started using the `sysinfo` crate to gather metrics about available CPUs and RAM. By default, that crate uses `rayon` internally to parallelize its handling of system processes. In turn, rayon creates a pool of long-lived threads.
+
+In a particular benchmark on a 32-core Linux server, this caused resident memory use to increase by about 150 MB. This is likely a combination of stack space (which only gets freed when the thread terminates) and per-thread space reserved by the heap allocator to reduce cross-thread synchronization cost.
+
+This regression is now fixed by:
+
+* Disabling `sysinfo`’s use of `rayon`, so the thread pool is not created and system processes information is gathered in a sequential loop.
+* Making `sysinfo` not gather that information in the first place since Router does not use it.
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/6634

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6603,7 +6603,6 @@ dependencies = [
  "libc",
  "memchr",
  "ntapi",
- "rayon",
  "windows 0.57.0",
 ]
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -212,7 +212,7 @@ serde_yaml = "0.8.26"
 static_assertions = "1.1.0"
 strum_macros = "0.26.0"
 sys-info = "0.9.1"
-sysinfo = { version = "0.32.0", features = ["windows"] }
+sysinfo = { version = "0.32.0", features = ["system", "windows"], default_features = false }
 thiserror = "1.0.61"
 tokio.workspace = true
 tokio-stream = { version = "0.1.15", features = ["sync", "net"] }

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -44,7 +44,8 @@ struct SystemGetter {
 impl SystemGetter {
     fn new() -> Self {
         let mut system = System::new();
-        system.refresh_all();
+        system.refresh_cpu_all();
+        system.refresh_memory();
         Self {
             system,
             start: Instant::now(),


### PR DESCRIPTION
In version 1.59.0, Apollo Router started using the `sysinfo` crate to gather metrics about available CPUs and RAM. By default, that crate uses `rayon` internally to parallelize its handling of system processes. In turn, rayon creates a pool of long-lived threads.

In a particular benchmark on a 32-core Linux server, this caused resident memory use to increase by about 150 MB. This is likely a combination of stack space (which only gets freed when the thread terminates) and per-thread space reserved by the heap allocator to reduce cross-thread synchronization cost.

This regression is now fixed by:

* Disabling `sysinfo`’s use of `rayon`, so the thread pool is not created and system processes information is gathered in a sequential loop.
* Making `sysinfo` not gather that information in the first place since Router does not use it.


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

<hr>

This is a backport of pull request #6634