### PR TITLE
Validate body selection contains at least one variable

### DIFF
--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@body_selection.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@body_selection.graphql.snap
@@ -1,0 +1,42 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", result.errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/body_selection.graphql
+---
+[
+    Message {
+        code: InvalidJsonSelection,
+        message: "`@connect(http: {body:})` on `Query.dollar` must contain at least one variable reference",
+        locations: [
+            12:19..12:22,
+        ],
+    },
+    Message {
+        code: InvalidJsonSelection,
+        message: "`@connect(http: {body:})` on `Query.dollarField` must contain at least one variable reference",
+        locations: [
+            20:19..20:26,
+        ],
+    },
+    Message {
+        code: InvalidJsonSelection,
+        message: "`@connect(http: {body:})` on `Query.objectLiteral` must contain at least one variable reference",
+        locations: [
+            28:19..28:41,
+        ],
+    },
+    Message {
+        code: InvalidJsonSelection,
+        message: "`@connect(http: {body:})` on `Query.stringLiteral` must contain at least one variable reference",
+        locations: [
+            44:19..44:29,
+        ],
+    },
+    Message {
+        code: InvalidJsonSelection,
+        message: "`@connect(http: {body:})` on `Query.numericLiteral` must contain at least one variable reference",
+        locations: [
+            60:19..60:25,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/test_data/body_selection.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/body_selection.graphql
@@ -1,0 +1,64 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    dollar: String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$" # INVALID - there is no input
+        }
+        selection: "$"
+    )
+    dollarField: String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$.foo" # INVALID - there is no input
+        }
+        selection: "$"
+    )
+    objectLiteral: String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$({ userid: 'foo' })" # Could be valid, but currently not allowed
+        }
+        selection: "$"
+    )
+    objectLiteralWithVariable(userid: ID!): String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$({ userid: $args.userid })" # VALID
+        }
+        selection: "$"
+    )
+    stringLiteral: String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$('foo')" # INVALID - output is not valid JSON
+        }
+        selection: "$"
+    )
+    stringLiteralWithVariable(userid: ID!): String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$($args.userid)" # INVALID, but currently allowed - output is not valid JSON
+        }
+        selection: "$"
+    )
+    numericLiteral(userid: ID!): String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$(1)" # INVALID - output is not valid JSON
+        }
+        selection: "$"
+    )
+}


### PR DESCRIPTION
Validate that body selections contain at least one variable reference. Otherwise, they would either be selecting from input (which there is none) or just a static literal.

<!-- start metadata -->

<!-- [CNN-127] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-127]: https://apollographql.atlassian.net/browse/CNN-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ