### PR TITLE
In case of broken config add warning message with url to migration guide

### DIFF
--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -139,7 +139,7 @@ pub(crate) fn validate_yaml_configuration(
         if schema.validate(&expanded_yaml).is_ok() {
             yaml = upgraded;
         } else {
-            tracing::warn!("configuration could not be upgraded automatically as it had errors")
+            tracing::warn!("Configuration could not be upgraded automatically as it had errors. If you previously used this configuration with Router 1.x, please refer to the migration guide: https://www.apollographql.com/docs/graphos/reference/migration/from-router-v1")
         }
     }
 


### PR DESCRIPTION
Prints out a message with a link to the migration guide whenever a configuration is found to be invalid.

<!-- start metadata -->
<!-- ROUTER-401 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
