### PR TITLE
Unsync box body does not play well with metrics tests

### DIFF
--- a/.changesets/maint_bryn_metrics_tests_unsync_box_body.md
+++ b/.changesets/maint_bryn_metrics_tests_unsync_box_body.md
@@ -1,0 +1,8 @@
+### Allow plugin test harness to use with_metrics for router_service ([PR #6655](https://github.com/apollographql/router/pull/6655))
+
+This PR implements a custom future that allows the plugin test harness to work at the router_service using the
+`with_metrics()` wrapper.
+Without this new future you get a cryptic error that body is not Sync.
+The custom future is only used for tests.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/6655

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -382,6 +382,7 @@ mod test_for_harness {
     use tokio::join;
 
     use super::*;
+    use crate::metrics::FutureMetricsExt;
     use crate::plugin::Plugin;
     use crate::services::router;
     use crate::services::router::body;
@@ -466,6 +467,28 @@ mod test_for_harness {
         // One of the calls should succeed, the other should fail due to concurrency limit
         assert!(results.iter().any(|r| r.is_ok()));
         assert!(results.iter().any(|r| r.is_err()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_router_service_metrics() {
+        async {
+            let test_harness: PluginTestHarness<MyTestPlugin> =
+                PluginTestHarness::builder().build().await;
+
+            let service = test_harness.router_service(|_req| async {
+                u64_counter!("test", "test", 1u64);
+                Ok(router::Response::fake_builder()
+                    .data(serde_json::json!({"data": {"field": "value"}}))
+                    .header("x-custom-header", "test-value")
+                    .build()
+                    .unwrap())
+            });
+
+            let _ = service.call_default().await;
+            assert_counter!("test", 1u64);
+        }
+        .with_metrics()
+        .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This PR implements a custom future that allows the plugin test harness to work at the router_service using the `with_metrics()` wrapper.

Without this new future you get a cryptic error about how body is not sync.

The custom future is only used for tests.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
