### PR TITLE
[JSONSelection] `ComputOutputShape` refactoring to support `ShapedSelection`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6465,9 +6465,9 @@ dependencies = [
 
 [[package]]
 name = "shape"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70179a0773695f4fc0b3e8e59f356064ed1532492e52bcf7e0dfef42934ec4c5"
+checksum = "7417fe45205214f2386c2dfbedc2173c4a7d7d2178cae2446b037fc6b89ec7cd"
 dependencies = [
  "apollo-compiler",
  "indexmap 2.7.0",

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -43,7 +43,7 @@ url = "2"
 either = "1.13.0"
 tracing = "0.1.40"
 ron = { version = "0.8.1", optional = true }
-shape = "0.4.1"
+shape = "0.4.2"
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/src/sources/connect/json_selection/apply_to.rs
+++ b/apollo-federation/src/sources/connect/json_selection/apply_to.rs
@@ -95,18 +95,18 @@ impl JSONSelection {
     pub fn compute_output_shape(
         &self,
         input_shape: Shape,
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape {
         match self {
             Self::Named(selection) => selection.compute_output_shape(
                 input_shape.clone(),
                 input_shape.clone(),
-                named_var_shapes,
+                named_shapes,
             ),
             Self::Path(path_selection) => path_selection.compute_output_shape(
                 input_shape.clone(),
                 input_shape.clone(),
-                named_var_shapes,
+                named_shapes,
             ),
         }
     }
@@ -162,7 +162,7 @@ pub(super) trait ApplyToInternal {
         // including the initial `$` character. This map typically does not
         // change during the compute_output_shape recursion, and so can be
         // passed down by immutable reference.
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape;
 }
 
@@ -279,14 +279,14 @@ impl ApplyToInternal for JSONSelection {
         &self,
         input_shape: Shape,
         dollar_shape: Shape,
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape {
         match self {
             Self::Named(selection) => {
-                selection.compute_output_shape(input_shape, dollar_shape, named_var_shapes)
+                selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
             }
             Self::Path(path_selection) => {
-                path_selection.compute_output_shape(input_shape, dollar_shape, named_var_shapes)
+                path_selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
             }
         }
     }
@@ -390,7 +390,7 @@ impl ApplyToInternal for NamedSelection {
         &self,
         input_shape: Shape,
         dollar_shape: Shape,
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape {
         let mut output = Shape::empty_map();
 
@@ -403,15 +403,14 @@ impl ApplyToInternal for NamedSelection {
                 output.insert(
                     output_key.to_string(),
                     if let Some(selection) = selection {
-                        selection.compute_output_shape(field_shape, dollar_shape, named_var_shapes)
+                        selection.compute_output_shape(field_shape, dollar_shape, named_shapes)
                     } else {
                         field_shape
                     },
                 );
             }
             Self::Path { alias, path, .. } => {
-                let path_shape =
-                    path.compute_output_shape(input_shape, dollar_shape, named_var_shapes);
+                let path_shape = path.compute_output_shape(input_shape, dollar_shape, named_shapes);
                 if let Some(alias) = alias {
                     output.insert(alias.name().to_string(), path_shape);
                 } else {
@@ -421,7 +420,7 @@ impl ApplyToInternal for NamedSelection {
             Self::Group(alias, sub_selection) => {
                 output.insert(
                     alias.name().to_string(),
-                    sub_selection.compute_output_shape(input_shape, dollar_shape, named_var_shapes),
+                    sub_selection.compute_output_shape(input_shape, dollar_shape, named_shapes),
                 );
             }
         };
@@ -459,7 +458,7 @@ impl ApplyToInternal for PathSelection {
         &self,
         input_shape: Shape,
         dollar_shape: Shape,
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape {
         match self.path.as_ref() {
             PathList::Key(_, _) => {
@@ -469,14 +468,14 @@ impl ApplyToInternal for PathSelection {
                 self.path.compute_output_shape(
                     dollar_shape.clone(),
                     dollar_shape.clone(),
-                    named_var_shapes,
+                    named_shapes,
                 )
             }
             // If this is not a KeyPath, keep evaluating against input_shape.
             // This logic parallels PathSelection::apply_to_path (above).
             _ => self
                 .path
-                .compute_output_shape(input_shape, dollar_shape, named_var_shapes),
+                .compute_output_shape(input_shape, dollar_shape, named_shapes),
         }
     }
 }
@@ -592,7 +591,7 @@ impl ApplyToInternal for WithRange<PathList> {
         &self,
         input_shape: Shape,
         dollar_shape: Shape,
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape {
         match self.as_ref() {
             PathList::Var(ranged_var_name, tail) => {
@@ -601,12 +600,12 @@ impl ApplyToInternal for WithRange<PathList> {
                     input_shape
                 } else if var_name == &KnownVariable::Dollar {
                     dollar_shape.clone()
-                } else if let Some(shape) = named_var_shapes.get(var_name.as_str()) {
+                } else if let Some(shape) = named_shapes.get(var_name.as_str()) {
                     shape.clone()
                 } else {
                     Shape::name(var_name.as_str())
                 };
-                tail.compute_output_shape(var_shape, dollar_shape, named_var_shapes)
+                tail.compute_output_shape(var_shape, dollar_shape, named_shapes)
             }
 
             // For the first key in a path, PathSelection::compute_output_shape
@@ -627,7 +626,7 @@ impl ApplyToInternal for WithRange<PathList> {
                         rest.compute_output_shape(
                             case.field(key.as_str()),
                             dollar_shape.clone(),
-                            named_var_shapes,
+                            named_shapes,
                         )
                     }
                 })),
@@ -645,7 +644,7 @@ impl ApplyToInternal for WithRange<PathList> {
                                 rest.compute_output_shape(
                                     shape.field(key.as_str()),
                                     dollar_shape.clone(),
-                                    named_var_shapes,
+                                    named_shapes,
                                 )
                             }
                         })
@@ -657,7 +656,7 @@ impl ApplyToInternal for WithRange<PathList> {
                         rest.compute_output_shape(
                             tail.field(key.as_str()),
                             dollar_shape.clone(),
-                            named_var_shapes,
+                            named_shapes,
                         )
                     };
 
@@ -667,14 +666,14 @@ impl ApplyToInternal for WithRange<PathList> {
                 _ => rest.compute_output_shape(
                     input_shape.field(key.as_str()),
                     dollar_shape.clone(),
-                    named_var_shapes,
+                    named_shapes,
                 ),
             },
 
             PathList::Expr(expr, tail) => tail.compute_output_shape(
-                expr.compute_output_shape(input_shape, dollar_shape.clone(), named_var_shapes),
+                expr.compute_output_shape(input_shape, dollar_shape.clone(), named_shapes),
                 dollar_shape.clone(),
-                named_var_shapes,
+                named_shapes,
             ),
 
             PathList::Method(method_name, method_args, tail) => {
@@ -701,7 +700,7 @@ impl ApplyToInternal for WithRange<PathList> {
                                     method_args.as_ref(),
                                     case.clone(),
                                     dollar_shape.clone(),
-                                    named_var_shapes,
+                                    named_shapes,
                                 )
                             }
                         })),
@@ -710,7 +709,7 @@ impl ApplyToInternal for WithRange<PathList> {
                             method_args.as_ref(),
                             input_shape,
                             dollar_shape.clone(),
-                            named_var_shapes,
+                            named_shapes,
                         ),
                     };
 
@@ -720,7 +719,7 @@ impl ApplyToInternal for WithRange<PathList> {
                         tail.compute_output_shape(
                             method_result_shape,
                             dollar_shape.clone(),
-                            named_var_shapes,
+                            named_shapes,
                         )
                     }
                 } else {
@@ -730,7 +729,7 @@ impl ApplyToInternal for WithRange<PathList> {
             }
 
             PathList::Selection(selection) => {
-                selection.compute_output_shape(input_shape, dollar_shape, named_var_shapes)
+                selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
             }
 
             PathList::Empty => input_shape,
@@ -780,7 +779,7 @@ impl ApplyToInternal for WithRange<LitExpr> {
         &self,
         input_shape: Shape,
         dollar_shape: Shape,
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape {
         match self.as_ref() {
             LitExpr::Null => Shape::null(),
@@ -805,7 +804,7 @@ impl ApplyToInternal for WithRange<LitExpr> {
                         value.compute_output_shape(
                             input_shape.clone(),
                             dollar_shape.clone(),
-                            named_var_shapes,
+                            named_shapes,
                         ),
                     );
                 }
@@ -818,14 +817,14 @@ impl ApplyToInternal for WithRange<LitExpr> {
                     shapes.push(value.compute_output_shape(
                         input_shape.clone(),
                         dollar_shape.clone(),
-                        named_var_shapes,
+                        named_shapes,
                     ));
                 }
                 Shape::array(shapes, Shape::none())
             }
 
             LitExpr::Path(path) => {
-                path.compute_output_shape(input_shape, dollar_shape, named_var_shapes)
+                path.compute_output_shape(input_shape, dollar_shape, named_shapes)
             }
         }
     }
@@ -889,7 +888,7 @@ impl ApplyToInternal for SubSelection {
         &self,
         input_shape: Shape,
         _previous_dollar_shape: Shape,
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape {
         // Just as SubSelection::apply_to_path calls apply_to_array when data is
         // an array, so compute_output_shape recursively computes the output
@@ -897,15 +896,13 @@ impl ApplyToInternal for SubSelection {
         if let ShapeCase::Array { prefix, tail } = input_shape.case() {
             let new_prefix = prefix
                 .iter()
-                .map(|shape| {
-                    self.compute_output_shape(shape.clone(), shape.clone(), named_var_shapes)
-                })
+                .map(|shape| self.compute_output_shape(shape.clone(), shape.clone(), named_shapes))
                 .collect::<Vec<_>>();
 
             let new_tail = if tail.is_none() {
                 tail.clone()
             } else {
-                self.compute_output_shape(tail.clone(), tail.clone(), named_var_shapes)
+                self.compute_output_shape(tail.clone(), tail.clone(), named_shapes)
             };
 
             return Shape::array(new_prefix, new_tail);
@@ -934,7 +931,7 @@ impl ApplyToInternal for SubSelection {
                 named_selection.compute_output_shape(
                     input_shape.clone(),
                     dollar_shape.clone(),
-                    named_var_shapes,
+                    named_shapes,
                 ),
             ]);
 

--- a/apollo-federation/src/sources/connect/json_selection/apply_to.rs
+++ b/apollo-federation/src/sources/connect/json_selection/apply_to.rs
@@ -7,8 +7,6 @@ use apollo_compiler::collections::IndexSet;
 use serde_json_bytes::json;
 use serde_json_bytes::Map as JSONMap;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use super::helpers::json_merge;
 use super::helpers::json_type_name;
@@ -72,44 +70,6 @@ impl JSONSelection {
 
         (value, errors.into_iter().collect())
     }
-
-    pub fn shape(&self) -> Shape {
-        self.compute_output_shape(
-            // If we don't know anything about the shape of the input data, we
-            // can represent the data symbolically using the $root variable
-            // shape. Subproperties needed from this shape will show up as
-            // subpaths like $root.books.4.isbn in the output shape.
-            //
-            // While we do not currently have a $root variable available as a
-            // KnownVariable during apply_to_path execution, we might consider
-            // adding it, since it would align with the way we process other
-            // variable shapes. For now, $root exists only as a shape name that
-            // we are inventing right here.
-            Shape::name("$root"),
-            // If we wanted to specify anything about the shape of the $root
-            // variable, we could define a shape for "$root" in this map.
-            &IndexMap::default(),
-        )
-    }
-
-    pub fn compute_output_shape(
-        &self,
-        input_shape: Shape,
-        named_shapes: &IndexMap<String, Shape>,
-    ) -> Shape {
-        match self {
-            Self::Named(selection) => selection.compute_output_shape(
-                input_shape.clone(),
-                input_shape.clone(),
-                named_shapes,
-            ),
-            Self::Path(path_selection) => path_selection.compute_output_shape(
-                input_shape.clone(),
-                input_shape.clone(),
-                named_shapes,
-            ),
-        }
-    }
 }
 
 pub(super) trait ApplyToInternal {
@@ -145,25 +105,6 @@ pub(super) trait ApplyToInternal {
 
         (Some(JSON::Array(output)), errors)
     }
-
-    /// Computes the static output shape produced by a JSONSelection, by
-    /// traversing the selection AST, recursively calling `compute_output_shape`
-    /// on the current data/variable shapes at each level.
-    fn compute_output_shape(
-        &self,
-        // Shape of the `@` variable, which typically changes with each
-        // recursive call to compute_output_shape.
-        input_shape: Shape,
-        // Shape of the `$` variable, which is bound to the closest enclosing
-        // subselection object, or the root data object if there is no enclosing
-        // subselection.
-        dollar_shape: Shape,
-        // Shapes of other named variables, with the variable name `String`
-        // including the initial `$` character. This map typically does not
-        // change during the compute_output_shape recursion, and so can be
-        // passed down by immutable reference.
-        named_shapes: &IndexMap<String, Shape>,
-    ) -> Shape;
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
@@ -274,22 +215,6 @@ impl ApplyToInternal for JSONSelection {
             Self::Path(path_selection) => path_selection.apply_to_path(data, vars, input_path),
         }
     }
-
-    fn compute_output_shape(
-        &self,
-        input_shape: Shape,
-        dollar_shape: Shape,
-        named_shapes: &IndexMap<String, Shape>,
-    ) -> Shape {
-        match self {
-            Self::Named(selection) => {
-                selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
-            }
-            Self::Path(path_selection) => {
-                path_selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
-            }
-        }
-    }
 }
 
 impl ApplyToInternal for NamedSelection {
@@ -385,48 +310,6 @@ impl ApplyToInternal for NamedSelection {
 
         (output, errors)
     }
-
-    fn compute_output_shape(
-        &self,
-        input_shape: Shape,
-        dollar_shape: Shape,
-        named_shapes: &IndexMap<String, Shape>,
-    ) -> Shape {
-        let mut output = Shape::empty_map();
-
-        match self {
-            Self::Field(alias_opt, key, selection) => {
-                let output_key = alias_opt
-                    .as_ref()
-                    .map_or(key.as_str(), |alias| alias.name());
-                let field_shape = dollar_shape.field(key.as_str());
-                output.insert(
-                    output_key.to_string(),
-                    if let Some(selection) = selection {
-                        selection.compute_output_shape(field_shape, dollar_shape, named_shapes)
-                    } else {
-                        field_shape
-                    },
-                );
-            }
-            Self::Path { alias, path, .. } => {
-                let path_shape = path.compute_output_shape(input_shape, dollar_shape, named_shapes);
-                if let Some(alias) = alias {
-                    output.insert(alias.name().to_string(), path_shape);
-                } else {
-                    return path_shape;
-                }
-            }
-            Self::Group(alias, sub_selection) => {
-                output.insert(
-                    alias.name().to_string(),
-                    sub_selection.compute_output_shape(input_shape, dollar_shape, named_shapes),
-                );
-            }
-        };
-
-        Shape::object(output, Shape::none())
-    }
 }
 
 impl ApplyToInternal for PathSelection {
@@ -451,31 +334,6 @@ impl ApplyToInternal for PathSelection {
             // guarantee its existence at compile time, somehow.
             // (PathList::Key(_, _), None) => todo!(),
             _ => self.path.apply_to_path(data, vars, input_path),
-        }
-    }
-
-    fn compute_output_shape(
-        &self,
-        input_shape: Shape,
-        dollar_shape: Shape,
-        named_shapes: &IndexMap<String, Shape>,
-    ) -> Shape {
-        match self.path.as_ref() {
-            PathList::Key(_, _) => {
-                // If this is a KeyPath, we need to evaluate the path starting
-                // from the current $ shape, so we pass dollar_shape as the data
-                // *and* dollar_shape to self.path.compute_output_shape.
-                self.path.compute_output_shape(
-                    dollar_shape.clone(),
-                    dollar_shape.clone(),
-                    named_shapes,
-                )
-            }
-            // If this is not a KeyPath, keep evaluating against input_shape.
-            // This logic parallels PathSelection::apply_to_path (above).
-            _ => self
-                .path
-                .compute_output_shape(input_shape, dollar_shape, named_shapes),
         }
     }
 }
@@ -586,155 +444,6 @@ impl ApplyToInternal for WithRange<PathList> {
             }
         }
     }
-
-    fn compute_output_shape(
-        &self,
-        input_shape: Shape,
-        dollar_shape: Shape,
-        named_shapes: &IndexMap<String, Shape>,
-    ) -> Shape {
-        match self.as_ref() {
-            PathList::Var(ranged_var_name, tail) => {
-                let var_name = ranged_var_name.as_ref();
-                let var_shape = if var_name == &KnownVariable::AtSign {
-                    input_shape
-                } else if var_name == &KnownVariable::Dollar {
-                    dollar_shape.clone()
-                } else if let Some(shape) = named_shapes.get(var_name.as_str()) {
-                    shape.clone()
-                } else {
-                    Shape::name(var_name.as_str())
-                };
-                tail.compute_output_shape(var_shape, dollar_shape, named_shapes)
-            }
-
-            // For the first key in a path, PathSelection::compute_output_shape
-            // will have set our input_shape equal to its dollar_shape, thereby
-            // ensuring that some.nested.path is equivalent to
-            // $.some.nested.path.
-            PathList::Key(key, rest) => match input_shape.case() {
-                // At runtime we abandon evaluating the PathList when we
-                // encounter None, so we do not want to call
-                // rest.compute_output_shape recursively when the
-                // input_shape.is_none(), and we also want to pass through None
-                // as a member of any Shape::one input unions.
-                ShapeCase::None => input_shape,
-                ShapeCase::One(cases) => Shape::one(cases.iter().map(|case| {
-                    if case.is_none() {
-                        case.clone()
-                    } else {
-                        rest.compute_output_shape(
-                            case.field(key.as_str()),
-                            dollar_shape.clone(),
-                            named_shapes,
-                        )
-                    }
-                })),
-
-                ShapeCase::Array { prefix, tail } => {
-                    // Map rest.compute_output_shape over the prefix and rest
-                    // elements of the array shape, so we don't have to map
-                    // array shapes for the other PathList variants.
-                    let mapped_prefix = prefix
-                        .iter()
-                        .map(|shape| {
-                            if shape.is_none() {
-                                shape.clone()
-                            } else {
-                                rest.compute_output_shape(
-                                    shape.field(key.as_str()),
-                                    dollar_shape.clone(),
-                                    named_shapes,
-                                )
-                            }
-                        })
-                        .collect::<Vec<_>>();
-
-                    let mapped_rest = if tail.is_none() {
-                        tail.clone()
-                    } else {
-                        rest.compute_output_shape(
-                            tail.field(key.as_str()),
-                            dollar_shape.clone(),
-                            named_shapes,
-                        )
-                    };
-
-                    Shape::array(mapped_prefix, mapped_rest)
-                }
-
-                _ => rest.compute_output_shape(
-                    input_shape.field(key.as_str()),
-                    dollar_shape.clone(),
-                    named_shapes,
-                ),
-            },
-
-            PathList::Expr(expr, tail) => tail.compute_output_shape(
-                expr.compute_output_shape(input_shape, dollar_shape.clone(), named_shapes),
-                dollar_shape.clone(),
-                named_shapes,
-            ),
-
-            PathList::Method(method_name, method_args, tail) => {
-                if input_shape.is_none() {
-                    // Following WithRange<PathList>::apply_to_path, we do not
-                    // want to apply methods to missing input data.
-                    return input_shape;
-                }
-
-                if let Some(method) = ArrowMethod::lookup(method_name) {
-                    let method_result_shape = match input_shape.case() {
-                        // At runtime we never invoke an arrow method with an
-                        // input_shape of None, so we avoid calling method.shape
-                        // when the input_shape is None, or for None members of
-                        // Shape::one unions (though the None member is passed
-                        // through to the resulting Shape::one union).
-                        ShapeCase::None => input_shape,
-                        ShapeCase::One(cases) => Shape::one(cases.iter().map(|case| {
-                            if case.is_none() {
-                                case.clone()
-                            } else {
-                                method.shape(
-                                    method_name,
-                                    method_args.as_ref(),
-                                    case.clone(),
-                                    dollar_shape.clone(),
-                                    named_shapes,
-                                )
-                            }
-                        })),
-                        _ => method.shape(
-                            method_name,
-                            method_args.as_ref(),
-                            input_shape,
-                            dollar_shape.clone(),
-                            named_shapes,
-                        ),
-                    };
-
-                    if method_result_shape.is_none() {
-                        method_result_shape.clone()
-                    } else {
-                        tail.compute_output_shape(
-                            method_result_shape,
-                            dollar_shape.clone(),
-                            named_shapes,
-                        )
-                    }
-                } else {
-                    let message = format!("Method ->{} not found", method_name.as_str());
-                    Shape::error_with_range(message.as_str(), method_name.range())
-                }
-            }
-
-            PathList::Selection(selection) => {
-                selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
-            }
-
-            PathList::Empty => input_shape,
-        }
-    }
 }
 
 impl ApplyToInternal for WithRange<LitExpr> {
@@ -772,60 +481,6 @@ impl ApplyToInternal for WithRange<LitExpr> {
                 (Some(JSON::Array(output)), errors)
             }
             LitExpr::Path(path) => path.apply_to_path(data, vars, input_path),
-        }
-    }
-
-    fn compute_output_shape(
-        &self,
-        input_shape: Shape,
-        dollar_shape: Shape,
-        named_shapes: &IndexMap<String, Shape>,
-    ) -> Shape {
-        match self.as_ref() {
-            LitExpr::Null => Shape::null(),
-            LitExpr::Bool(value) => Shape::bool_value(*value),
-            LitExpr::String(value) => Shape::string_value(value.as_str()),
-
-            LitExpr::Number(value) => {
-                if let Some(n) = value.as_i64() {
-                    Shape::int_value(n)
-                } else if value.is_f64() {
-                    Shape::float()
-                } else {
-                    Shape::error("Number neither Int nor Float")
-                }
-            }
-
-            LitExpr::Object(map) => {
-                let mut fields = Shape::empty_map();
-                for (key, value) in map {
-                    fields.insert(
-                        key.as_string(),
-                        value.compute_output_shape(
-                            input_shape.clone(),
-                            dollar_shape.clone(),
-                            named_shapes,
-                        ),
-                    );
-                }
-                Shape::object(fields, Shape::none())
-            }
-
-            LitExpr::Array(vec) => {
-                let mut shapes = Vec::with_capacity(vec.len());
-                for value in vec {
-                    shapes.push(value.compute_output_shape(
-                        input_shape.clone(),
-                        dollar_shape.clone(),
-                        named_shapes,
-                    ));
-                }
-                Shape::array(shapes, Shape::none())
-            }
-
-            LitExpr::Path(path) => {
-                path.compute_output_shape(input_shape, dollar_shape, named_shapes)
-            }
         }
     }
 }
@@ -882,68 +537,6 @@ impl ApplyToInternal for SubSelection {
         }
 
         (Some(output), errors)
-    }
-
-    fn compute_output_shape(
-        &self,
-        input_shape: Shape,
-        _previous_dollar_shape: Shape,
-        named_shapes: &IndexMap<String, Shape>,
-    ) -> Shape {
-        // Just as SubSelection::apply_to_path calls apply_to_array when data is
-        // an array, so compute_output_shape recursively computes the output
-        // shapes of each array element shape.
-        if let ShapeCase::Array { prefix, tail } = input_shape.case() {
-            let new_prefix = prefix
-                .iter()
-                .map(|shape| self.compute_output_shape(shape.clone(), shape.clone(), named_shapes))
-                .collect::<Vec<_>>();
-
-            let new_tail = if tail.is_none() {
-                tail.clone()
-            } else {
-                self.compute_output_shape(tail.clone(), tail.clone(), named_shapes)
-            };
-
-            return Shape::array(new_prefix, new_tail);
-        }
-
-        // If the input shape is a named shape, it might end up being an array,
-        // so we need to hedge the output shape using a wildcard that maps over
-        // array elements.
-        let input_shape = input_shape.any_item();
-
-        // The SubSelection rebinds the $ variable to the selected input object,
-        // so we can ignore _previous_dollar_shape.
-        let dollar_shape = input_shape.clone();
-
-        // Build up the merged object shape using Shape::all to merge the
-        // individual named_selection object shapes.
-        let mut all_shape = Shape::empty_object();
-
-        for named_selection in self.selections.iter() {
-            // Simplifying as we go with Shape::all keeps all_shape relatively
-            // small in the common case when all named_selection items return an
-            // object shape, since those object shapes can all be merged
-            // together into one object.
-            all_shape = Shape::all([
-                all_shape,
-                named_selection.compute_output_shape(
-                    input_shape.clone(),
-                    dollar_shape.clone(),
-                    named_shapes,
-                ),
-            ]);
-
-            // If any named_selection item returns null instead of an object,
-            // that nullifies the whole object and allows shape computation to
-            // bail out early.
-            if all_shape.is_null() {
-                break;
-            }
-        }
-
-        all_shape
     }
 }
 
@@ -2505,97 +2098,6 @@ mod tests {
         assert_eq!(
             selection!("$.another.'pesky string literal!'.\"identifier\"").apply_to(&data),
             (Some(json!(123)), vec![],),
-        );
-    }
-
-    #[test]
-    fn test_compute_output_shape() {
-        assert_eq!(selection!("").shape().pretty_print(), "{}");
-
-        assert_eq!(
-            selection!("id name").shape().pretty_print(),
-            "{ id: $root.*.id, name: $root.*.name }",
-        );
-
-        // // On hold until variadic $(...) is merged (PR #6456).
-        // assert_eq!(
-        //     selection!("$.data { thisOrThat: $(maybe.this, maybe.that) }")
-        //         .shape()
-        //         .pretty_print(),
-        //     // Technically $.data could be an array, so this should be a union
-        //     // of this shape and a list of this shape, except with
-        //     // $root.data.0.maybe.{this,that} shape references.
-        //     //
-        //     // We could try to say that any { ... } shape represents either an
-        //     // object or a list of objects, by policy, to avoid having to write
-        //     // One<{...}, List<{...}>> everywhere a SubSelection appears.
-        //     //
-        //     // But then we don't know where the array indexes should go...
-        //     "{ thisOrThat: One<$root.data.*.maybe.this, $root.data.*.maybe.that> }",
-        // );
-
-        assert_eq!(
-            selection!(r#"
-                id
-                name
-                friends: friend_ids { id: @ }
-                alias: arrayOfArrays { x y }
-                ys: arrayOfArrays.y xs: arrayOfArrays.x
-            "#).shape().pretty_print(),
-
-            // This output shape is wrong if $root.friend_ids turns out to be an
-            // array, and it's tricky to see how to transform the shape to what
-            // it would have been if we knew that, where friends: List<{ id:
-            // $root.friend_ids.* }> (note the * meaning any array index),
-            // because who's to say it's not the id field that should become the
-            // List, rather than the friends field?
-            "{ alias: { x: $root.*.arrayOfArrays.*.x, y: $root.*.arrayOfArrays.*.y }, friends: { id: $root.*.friend_ids.* }, id: $root.*.id, name: $root.*.name, xs: $root.*.arrayOfArrays.x, ys: $root.*.arrayOfArrays.y }",
-        );
-
-        assert_eq!(
-            selection!(r#"
-                id
-                name
-                friends: friend_ids->map({ id: @ })
-                alias: arrayOfArrays { x y }
-                ys: arrayOfArrays.y xs: arrayOfArrays.x
-            "#).shape().pretty_print(),
-            "{ alias: { x: $root.*.arrayOfArrays.*.x, y: $root.*.arrayOfArrays.*.y }, friends: List<{ id: $root.*.friend_ids.* }>, id: $root.*.id, name: $root.*.name, xs: $root.*.arrayOfArrays.x, ys: $root.*.arrayOfArrays.y }",
-        );
-
-        assert_eq!(
-            selection!("$->echo({ thrice: [@, @, @] })")
-                .shape()
-                .pretty_print(),
-            "{ thrice: [$root, $root, $root] }",
-        );
-
-        assert_eq!(
-            selection!("$->echo({ thrice: [@, @, @] })->entries")
-                .shape()
-                .pretty_print(),
-            "[{ key: \"thrice\", value: [$root, $root, $root] }]",
-        );
-
-        assert_eq!(
-            selection!("$->echo({ thrice: [@, @, @] })->entries.key")
-                .shape()
-                .pretty_print(),
-            "[\"thrice\"]",
-        );
-
-        assert_eq!(
-            selection!("$->echo({ thrice: [@, @, @] })->entries.value")
-                .shape()
-                .pretty_print(),
-            "[[$root, $root, $root]]",
-        );
-
-        assert_eq!(
-            selection!("$->echo({ wrapped: @ })->entries { k: key v: value }")
-                .shape()
-                .pretty_print(),
-            "[{ k: \"wrapped\", v: $root }]",
         );
     }
 }

--- a/apollo-federation/src/sources/connect/json_selection/methods.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods.rs
@@ -78,14 +78,14 @@ macro_rules! impl_arrow_method {
                 method_args: Option<&MethodArgs>,
                 input_shape: Shape,
                 dollar_shape: Shape,
-                named_var_shapes: &IndexMap<&str, Shape>,
+                named_shapes: &IndexMap<String, Shape>,
             ) -> Shape {
                 $shape_fn_name(
                     method_name,
                     method_args,
                     input_shape,
                     dollar_shape,
-                    named_var_shapes,
+                    named_shapes,
                 )
             }
         }
@@ -123,7 +123,7 @@ pub(super) trait ArrowMethodImpl {
         // Other variable shapes may also be provided here, though in general
         // variables and their subproperties can be represented abstractly using
         // $var.nested.property ShapeCase::Name shapes.
-        named_var_shapes: &IndexMap<&str, Shape>,
+        named_shapes: &IndexMap<String, Shape>,
     ) -> Shape;
 }
 

--- a/apollo-federation/src/sources/connect/json_selection/methods/future.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future.rs
@@ -54,7 +54,7 @@ fn typeof_shape(
     _method_args: Option<&MethodArgs>,
     _input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     // TODO Compute this union type once and clone it here.
     Shape::one([
@@ -106,7 +106,7 @@ fn eq_shape(
     _method_args: Option<&MethodArgs>,
     _input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     Shape::bool()
 }
@@ -169,7 +169,7 @@ fn match_if_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     dollar_shape: Shape,
-    named_var_shapes: &IndexMap<&str, Shape>,
+    named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     use super::super::methods::public::match_shape;
     // Since match_shape does not inspect the candidate expressions, we can
@@ -180,7 +180,7 @@ fn match_if_shape(
         method_args,
         input_shape,
         dollar_shape,
-        named_var_shapes,
+        named_shapes,
     )
 }
 
@@ -289,7 +289,7 @@ fn math_shape(
     _method_args: Option<&MethodArgs>,
     _input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     Shape::error("TODO: math_shape")
 }
@@ -415,7 +415,7 @@ fn has_shape(
     _method_args: Option<&MethodArgs>,
     _input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     // TODO We could be more clever here (sometimes) based on the input_shape
     // and argument shapes.
@@ -624,14 +624,14 @@ fn get_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     dollar_shape: Shape,
-    named_var_shapes: &IndexMap<&str, Shape>,
+    named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     if let Some(MethodArgs { args, .. }) = method_args {
         if let Some(index_literal) = args.first() {
             let index_shape = index_literal.compute_output_shape(
                 input_shape.clone(),
                 dollar_shape.clone(),
-                named_var_shapes,
+                named_shapes,
             );
             return match index_shape.case() {
                 ShapeCase::String(value_opt) => match input_shape.case() {
@@ -773,7 +773,7 @@ fn keys_shape(
     _method_args: Option<&MethodArgs>,
     input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     match input_shape.case() {
         ShapeCase::Object { fields, rest, .. } => {
@@ -846,7 +846,7 @@ fn values_shape(
     _method_args: Option<&MethodArgs>,
     input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     match input_shape.case() {
         ShapeCase::Object { fields, rest, .. } => {
@@ -886,7 +886,7 @@ fn not_shape(
     _method_args: Option<&MethodArgs>,
     input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     match input_shape.case() {
         ShapeCase::Bool(Some(value)) => Shape::bool_value(!*value),
@@ -948,7 +948,7 @@ fn or_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     dollar_shape: Shape,
-    named_var_shapes: &IndexMap<&str, Shape>,
+    named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     match input_shape.case() {
         ShapeCase::Bool(Some(true)) => {
@@ -968,11 +968,8 @@ fn or_shape(
 
     if let Some(MethodArgs { args, .. }) = method_args {
         for arg in args {
-            let arg_shape = arg.compute_output_shape(
-                input_shape.clone(),
-                dollar_shape.clone(),
-                named_var_shapes,
-            );
+            let arg_shape =
+                arg.compute_output_shape(input_shape.clone(), dollar_shape.clone(), named_shapes);
             match arg_shape.case() {
                 ShapeCase::Bool(Some(true)) => {
                     return Shape::bool_value(true);
@@ -1034,7 +1031,7 @@ fn and_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     dollar_shape: Shape,
-    named_var_shapes: &IndexMap<&str, Shape>,
+    named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     match input_shape.case() {
         ShapeCase::Bool(Some(false)) => {
@@ -1054,11 +1051,8 @@ fn and_shape(
 
     if let Some(MethodArgs { args, .. }) = method_args {
         for arg in args {
-            let arg_shape = arg.compute_output_shape(
-                input_shape.clone(),
-                dollar_shape.clone(),
-                named_var_shapes,
-            );
+            let arg_shape =
+                arg.compute_output_shape(input_shape.clone(), dollar_shape.clone(), named_shapes);
             match arg_shape.case() {
                 ShapeCase::Bool(Some(false)) => {
                     return Shape::bool_value(false);

--- a/apollo-federation/src/sources/connect/json_selection/methods/future.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future.rs
@@ -17,6 +17,7 @@ use crate::sources::connect::json_selection::lit_expr::LitExpr;
 use crate::sources::connect::json_selection::location::merge_ranges;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
+use crate::sources::connect::json_selection::shape::ComputeOutputShape;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;

--- a/apollo-federation/src/sources/connect/json_selection/methods/public.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public.rs
@@ -52,10 +52,10 @@ fn echo_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     dollar_shape: Shape,
-    named_var_shapes: &IndexMap<&str, Shape>,
+    named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     if let Some(first_arg) = method_args.and_then(|args| args.args.first()) {
-        return first_arg.compute_output_shape(input_shape, dollar_shape, named_var_shapes);
+        return first_arg.compute_output_shape(input_shape, dollar_shape, named_shapes);
     }
     Shape::error_with_range(
         format!("Method ->{} requires one argument", method_name.as_ref()),
@@ -130,7 +130,7 @@ fn map_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     dollar_shape: Shape,
-    named_var_shapes: &IndexMap<&str, Shape>,
+    named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     if let Some(first_arg) = method_args.and_then(|args| args.args.first()) {
         match input_shape.case() {
@@ -141,21 +141,21 @@ fn map_shape(
                         first_arg.compute_output_shape(
                             shape.clone(),
                             dollar_shape.clone(),
-                            named_var_shapes,
+                            named_shapes,
                         )
                     })
                     .collect::<Vec<_>>();
                 let new_tail = first_arg.compute_output_shape(
                     tail.clone(),
                     dollar_shape.clone(),
-                    named_var_shapes,
+                    named_shapes,
                 );
                 Shape::array(new_prefix, new_tail)
             }
             _ => Shape::list(first_arg.compute_output_shape(
                 input_shape.any_item(),
                 dollar_shape.clone(),
-                named_var_shapes,
+                named_shapes,
             )),
         }
     } else {
@@ -227,7 +227,7 @@ pub(super) fn match_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     dollar_shape: Shape,
-    named_var_shapes: &IndexMap<&str, Shape>,
+    named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     if let Some(MethodArgs { args, .. }) = method_args {
         let mut result_union = Vec::new();
@@ -247,7 +247,7 @@ pub(super) fn match_shape(
                     let value_shape = pair[1].compute_output_shape(
                         input_shape.clone(),
                         dollar_shape.clone(),
-                        named_var_shapes,
+                        named_shapes,
                     );
                     result_union.push(value_shape);
                 }
@@ -331,7 +331,7 @@ fn first_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     if method_args.is_some() {
         return Shape::error_with_range(
@@ -410,7 +410,7 @@ fn last_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     if method_args.is_some() {
         return Shape::error_with_range(
@@ -546,7 +546,7 @@ fn slice_shape(
     _method_args: Option<&MethodArgs>,
     input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     // There are more clever shapes we could compute here (when start and end
     // are statically known integers and input_shape is an array or string with
@@ -630,7 +630,7 @@ fn size_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     if method_args.is_some() {
         return Shape::error_with_range(
@@ -725,7 +725,7 @@ fn entries_shape(
     method_args: Option<&MethodArgs>,
     input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     if method_args.is_some() {
         return Shape::error_with_range(
@@ -822,7 +822,7 @@ fn json_stringify_shape(
     _method_args: Option<&MethodArgs>,
     _input_shape: Shape,
     _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    _named_shapes: &IndexMap<String, Shape>,
 ) -> Shape {
     Shape::string()
 }

--- a/apollo-federation/src/sources/connect/json_selection/methods/public.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public.rs
@@ -16,6 +16,7 @@ use crate::sources::connect::json_selection::lit_expr::LitExpr;
 use crate::sources::connect::json_selection::location::merge_ranges;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
+use crate::sources::connect::json_selection::shape::ComputeOutputShape;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;

--- a/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
@@ -213,7 +213,10 @@ fn test_map_method() {
             (Some(json!(["123"])), vec![]),
         );
         let mut named_shapes = IndexMap::default();
-        named_shapes.insert("$root".to_string(), Shape::from_json_bytes(&single_value_data));
+        named_shapes.insert(
+            "$root".to_string(),
+            Shape::from_json_bytes(&single_value_data),
+        );
         let output_shape = json_selection.output_shape(&named_shapes);
         assert_eq!(output_shape.pretty_print(), "List<String>");
     }

--- a/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
@@ -1,3 +1,4 @@
+use apollo_compiler::collections::IndexMap;
 use insta::assert_debug_snapshot;
 use serde_json_bytes::json;
 
@@ -211,10 +212,9 @@ fn test_map_method() {
             json_selection.apply_to(&single_value_data),
             (Some(json!(["123"])), vec![]),
         );
-        let output_shape = json_selection.compute_output_shape(
-            Shape::from_json_bytes(&single_value_data),
-            &IndexMap::default(),
-        );
+        let mut named_shapes = IndexMap::default();
+        named_shapes.insert("$root".to_string(), Shape::from_json_bytes(&single_value_data));
+        let output_shape = json_selection.output_shape(&named_shapes);
         assert_eq!(output_shape.pretty_print(), "List<String>");
     }
 }

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -8,6 +8,7 @@ mod methods;
 mod parser;
 mod pretty;
 mod selection_set;
+mod shape;
 
 pub use apply_to::*;
 // Pretty code is currently only used in tests, so this cfg is to suppress the

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -823,6 +823,10 @@ impl PathList {
         }
     }
 
+    pub(super) fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
     fn variable_path_parts(&self) -> Vec<VariablePathPart> {
         match self {
             Self::Key(key, rest) => {

--- a/apollo-federation/src/sources/connect/json_selection/shape.rs
+++ b/apollo-federation/src/sources/connect/json_selection/shape.rs
@@ -1,0 +1,545 @@
+use apollo_compiler::collections::IndexMap;
+use shape::Shape;
+use shape::ShapeCase;
+
+use super::known_var::KnownVariable;
+use super::lit_expr::LitExpr;
+use super::location::WithRange;
+use super::methods::ArrowMethod;
+use super::JSONSelection;
+use super::NamedSelection;
+use super::PathList;
+use super::PathSelection;
+use super::Ranged;
+use super::SubSelection;
+
+impl JSONSelection {
+    /// A quick way to get the most generic possible [`Shape`] for this
+    /// [`JSONSelection`], without any additional named shapes specified.
+    #[allow(dead_code)]
+    pub(crate) fn shape(&self) -> Shape {
+        self.output_shape(&IndexMap::default())
+    }
+
+    /// Computes the static output shape produced by a JSONSelection, given a
+    /// map of named input shapes, including the `$root` shape describing the
+    /// top-level data object.
+    pub(crate) fn output_shape(&self, named_shapes: &IndexMap<String, Shape>) -> Shape {
+        let input_shape = if let Some(shape) = named_shapes.get("$root") {
+            shape.clone()
+        } else {
+            // Even if named_shapes has no entry for $root, we can still
+            // represent it symbolically, accumulating subpaths as we go.
+            Shape::name("$root")
+        };
+
+        let dollar_shape = input_shape.clone();
+
+        match self {
+            Self::Named(selection) => {
+                selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
+            }
+            Self::Path(path_selection) => {
+                path_selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
+            }
+        }
+    }
+}
+
+pub(crate) trait ComputeOutputShape {
+    /// Computes the static output shape produced by a JSONSelection, by
+    /// traversing the selection AST, recursively calling `compute_output_shape`
+    /// on the current data/variable shapes at each level.
+    fn compute_output_shape(
+        &self,
+        // Shape of the `@` variable, which typically changes with each
+        // recursive call to compute_output_shape.
+        input_shape: Shape,
+        // Shape of the `$` variable, which is bound to the closest enclosing
+        // subselection object, or the root data object if there is no enclosing
+        // subselection.
+        dollar_shape: Shape,
+        // Shapes of other named variables, with the variable name `String`
+        // including the initial `$` character. This map typically does not
+        // change during the compute_output_shape recursion, and so can be
+        // passed down by immutable reference.
+        named_shapes: &IndexMap<String, Shape>,
+    ) -> Shape;
+}
+
+impl<T: ComputeOutputShape> ComputeOutputShape for WithRange<T> {
+    fn compute_output_shape(
+        &self,
+        input_shape: Shape,
+        dollar_shape: Shape,
+        named_shapes: &IndexMap<String, Shape>,
+    ) -> Shape {
+        self.as_ref()
+            .compute_output_shape(input_shape, dollar_shape, named_shapes)
+    }
+}
+
+impl ComputeOutputShape for JSONSelection {
+    fn compute_output_shape(
+        &self,
+        input_shape: Shape,
+        dollar_shape: Shape,
+        named_shapes: &IndexMap<String, Shape>,
+    ) -> Shape {
+        match self {
+            Self::Named(selection) => {
+                selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
+            }
+            Self::Path(path_selection) => {
+                path_selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
+            }
+        }
+    }
+}
+
+impl ComputeOutputShape for NamedSelection {
+    fn compute_output_shape(
+        &self,
+        input_shape: Shape,
+        dollar_shape: Shape,
+        named_shapes: &IndexMap<String, Shape>,
+    ) -> Shape {
+        let mut output = Shape::empty_map();
+
+        match self {
+            Self::Field(alias_opt, key, selection) => {
+                let output_key = alias_opt
+                    .as_ref()
+                    .map_or(key.as_str(), |alias| alias.name());
+                let field_shape = dollar_shape.field(key.as_str());
+                output.insert(
+                    output_key.to_string(),
+                    if let Some(selection) = selection {
+                        selection.compute_output_shape(field_shape, dollar_shape, named_shapes)
+                    } else {
+                        field_shape
+                    },
+                );
+            }
+            Self::Path { alias, path, .. } => {
+                let path_shape = path.compute_output_shape(input_shape, dollar_shape, named_shapes);
+                if let Some(alias) = alias {
+                    output.insert(alias.name().to_string(), path_shape);
+                } else {
+                    return path_shape;
+                }
+            }
+            Self::Group(alias, sub_selection) => {
+                output.insert(
+                    alias.name().to_string(),
+                    sub_selection.compute_output_shape(input_shape, dollar_shape, named_shapes),
+                );
+            }
+        };
+
+        Shape::object(output, Shape::none())
+    }
+}
+
+impl ComputeOutputShape for PathSelection {
+    fn compute_output_shape(
+        &self,
+        input_shape: Shape,
+        dollar_shape: Shape,
+        named_shapes: &IndexMap<String, Shape>,
+    ) -> Shape {
+        match self.path.as_ref() {
+            PathList::Key(_, _) => {
+                // If this is a KeyPath, we need to evaluate the path starting
+                // from the current $ shape, so we pass dollar_shape as the data
+                // *and* dollar_shape to self.path.compute_output_shape.
+                self.path.compute_output_shape(
+                    dollar_shape.clone(),
+                    dollar_shape.clone(),
+                    named_shapes,
+                )
+            }
+            // If this is not a KeyPath, keep evaluating against input_shape.
+            // This logic parallels PathSelection::apply_to_path (above).
+            _ => self
+                .path
+                .compute_output_shape(input_shape, dollar_shape, named_shapes),
+        }
+    }
+}
+
+impl ComputeOutputShape for PathList {
+    fn compute_output_shape(
+        &self,
+        input_shape: Shape,
+        dollar_shape: Shape,
+        named_shapes: &IndexMap<String, Shape>,
+    ) -> Shape {
+        match self {
+            Self::Var(ranged_var_name, tail) => {
+                let var_name = ranged_var_name.as_ref();
+                let var_shape = if var_name == &KnownVariable::AtSign {
+                    input_shape
+                } else if var_name == &KnownVariable::Dollar {
+                    dollar_shape.clone()
+                } else if let Some(shape) = named_shapes.get(var_name.as_str()) {
+                    shape.clone()
+                } else {
+                    Shape::name(var_name.as_str())
+                };
+                tail.compute_output_shape(var_shape, dollar_shape, named_shapes)
+            }
+
+            // For the first key in a path, PathSelection::compute_output_shape
+            // will have set our input_shape equal to its dollar_shape, thereby
+            // ensuring that some.nested.path is equivalent to
+            // $.some.nested.path.
+            Self::Key(key, rest) => match input_shape.case() {
+                // At runtime we abandon evaluating the PathList when we
+                // encounter None, so we do not want to call
+                // rest.compute_output_shape recursively when the
+                // input_shape.is_none(), and we also want to pass through None
+                // as a member of any Shape::one input unions.
+                ShapeCase::None => input_shape,
+                ShapeCase::One(cases) => Shape::one(cases.iter().map(|case| {
+                    if case.is_none() {
+                        case.clone()
+                    } else {
+                        rest.compute_output_shape(
+                            case.field(key.as_str()),
+                            dollar_shape.clone(),
+                            named_shapes,
+                        )
+                    }
+                })),
+
+                ShapeCase::Array { prefix, tail } => {
+                    // Map rest.compute_output_shape over the prefix and rest
+                    // elements of the array shape, so we don't have to map
+                    // array shapes for the other PathList variants.
+                    let mapped_prefix = prefix
+                        .iter()
+                        .map(|shape| {
+                            if shape.is_none() {
+                                shape.clone()
+                            } else {
+                                rest.compute_output_shape(
+                                    shape.field(key.as_str()),
+                                    dollar_shape.clone(),
+                                    named_shapes,
+                                )
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    let mapped_rest = if tail.is_none() {
+                        tail.clone()
+                    } else {
+                        rest.compute_output_shape(
+                            tail.field(key.as_str()),
+                            dollar_shape.clone(),
+                            named_shapes,
+                        )
+                    };
+
+                    Shape::array(mapped_prefix, mapped_rest)
+                }
+
+                _ => rest.compute_output_shape(
+                    input_shape.field(key.as_str()),
+                    dollar_shape.clone(),
+                    named_shapes,
+                ),
+            },
+
+            Self::Expr(expr, tail) => tail.compute_output_shape(
+                expr.compute_output_shape(input_shape, dollar_shape.clone(), named_shapes),
+                dollar_shape.clone(),
+                named_shapes,
+            ),
+
+            Self::Method(method_name, method_args, tail) => {
+                if input_shape.is_none() {
+                    // Following WithRange<PathList>::apply_to_path, we do not
+                    // want to apply methods to missing input data.
+                    return input_shape;
+                }
+
+                if let Some(method) = ArrowMethod::lookup(method_name) {
+                    let method_result_shape = match input_shape.case() {
+                        // At runtime we never invoke an arrow method with an
+                        // input_shape of None, so we avoid calling method.shape
+                        // when the input_shape is None, or for None members of
+                        // Shape::one unions (though the None member is passed
+                        // through to the resulting Shape::one union).
+                        ShapeCase::None => input_shape,
+                        ShapeCase::One(cases) => Shape::one(cases.iter().map(|case| {
+                            if case.is_none() {
+                                case.clone()
+                            } else {
+                                method.shape(
+                                    method_name,
+                                    method_args.as_ref(),
+                                    case.clone(),
+                                    dollar_shape.clone(),
+                                    named_shapes,
+                                )
+                            }
+                        })),
+                        _ => method.shape(
+                            method_name,
+                            method_args.as_ref(),
+                            input_shape,
+                            dollar_shape.clone(),
+                            named_shapes,
+                        ),
+                    };
+
+                    if method_result_shape.is_none() {
+                        method_result_shape.clone()
+                    } else {
+                        tail.compute_output_shape(
+                            method_result_shape,
+                            dollar_shape.clone(),
+                            named_shapes,
+                        )
+                    }
+                } else {
+                    let message = format!("Method ->{} not found", method_name.as_str());
+                    Shape::error_with_range(message.as_str(), method_name.range())
+                }
+            }
+
+            Self::Selection(selection) => {
+                selection.compute_output_shape(input_shape, dollar_shape, named_shapes)
+            }
+
+            Self::Empty => input_shape,
+        }
+    }
+}
+
+impl ComputeOutputShape for LitExpr {
+    fn compute_output_shape(
+        &self,
+        input_shape: Shape,
+        dollar_shape: Shape,
+        named_shapes: &IndexMap<String, Shape>,
+    ) -> Shape {
+        match self {
+            Self::Null => Shape::null(),
+            Self::Bool(value) => Shape::bool_value(*value),
+            Self::String(value) => Shape::string_value(value.as_str()),
+
+            Self::Number(value) => {
+                if let Some(n) = value.as_i64() {
+                    Shape::int_value(n)
+                } else if value.is_f64() {
+                    Shape::float()
+                } else {
+                    Shape::error("Number neither Int nor Float")
+                }
+            }
+
+            Self::Object(map) => {
+                let mut fields = Shape::empty_map();
+                for (key, value) in map {
+                    fields.insert(
+                        key.as_string(),
+                        value.compute_output_shape(
+                            input_shape.clone(),
+                            dollar_shape.clone(),
+                            named_shapes,
+                        ),
+                    );
+                }
+                Shape::object(fields, Shape::none())
+            }
+
+            Self::Array(vec) => {
+                let mut shapes = Vec::with_capacity(vec.len());
+                for value in vec {
+                    shapes.push(value.compute_output_shape(
+                        input_shape.clone(),
+                        dollar_shape.clone(),
+                        named_shapes,
+                    ));
+                }
+                Shape::array(shapes, Shape::none())
+            }
+
+            Self::Path(path) => path.compute_output_shape(input_shape, dollar_shape, named_shapes),
+        }
+    }
+}
+
+impl ComputeOutputShape for SubSelection {
+    fn compute_output_shape(
+        &self,
+        input_shape: Shape,
+        dollar_shape: Shape,
+        named_shapes: &IndexMap<String, Shape>,
+    ) -> Shape {
+        match input_shape.case() {
+            ShapeCase::None => {
+                return input_shape;
+            }
+            ShapeCase::One(cases) => {
+                return Shape::one(cases.iter().map(|case| {
+                    if case.is_none() {
+                        case.clone()
+                    } else {
+                        self.compute_output_shape(case.clone(), dollar_shape.clone(), named_shapes)
+                    }
+                }));
+            }
+            ShapeCase::Array { prefix, tail } => {
+                let new_prefix = prefix.iter().map(|shape| {
+                    self.compute_output_shape(shape.clone(), dollar_shape.clone(), named_shapes)
+                });
+
+                let new_tail = if tail.is_none() {
+                    tail.clone()
+                } else {
+                    self.compute_output_shape(tail.clone(), dollar_shape.clone(), named_shapes)
+                };
+
+                return Shape::array(new_prefix, new_tail);
+            }
+            _ => {}
+        };
+
+        // If input_shape is a named shape, it might end up being an array, so
+        // for accuracy we apply the .* wildcard to indicate mapping over
+        // possible array elements.
+        let input_shape = input_shape.any_item();
+
+        // The SubSelection rebinds the $ variable to the selected input object,
+        // so we can ignore the previously received dollar_shape.
+        let dollar_shape = input_shape.clone();
+
+        // Build up the merged object shape using Shape::all to merge the
+        // individual named_selection object shapes.
+        let mut all_shape = Shape::empty_object();
+
+        for named_selection in self.selections.iter() {
+            // Simplifying as we go with Shape::all keeps all_shape relatively
+            // small in the common case when all named_selection items return an
+            // object shape, since those object shapes can all be merged
+            // together into one object.
+            all_shape = Shape::all([
+                all_shape,
+                named_selection.compute_output_shape(
+                    input_shape.clone(),
+                    dollar_shape.clone(),
+                    named_shapes,
+                ),
+            ]);
+
+            // If any named_selection item returns null instead of an object,
+            // that nullifies the whole object and allows shape computation to
+            // bail out early.
+            if all_shape.is_null() {
+                break;
+            }
+        }
+
+        all_shape
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::selection;
+
+    #[test]
+    fn test_compute_output_shape() {
+        assert_eq!(selection!("").shape().pretty_print(), "{}");
+
+        assert_eq!(
+            selection!("id name").shape().pretty_print(),
+            "{ id: $root.*.id, name: $root.*.name }",
+        );
+
+        // // On hold until variadic $(...) is merged (PR #6456).
+        // assert_eq!(
+        //     selection!("$.data { thisOrThat: $(maybe.this, maybe.that) }")
+        //         .shape()
+        //         .pretty_print(),
+        //     // Technically $.data could be an array, so this should be a union
+        //     // of this shape and a list of this shape, except with
+        //     // $root.data.0.maybe.{this,that} shape references.
+        //     //
+        //     // We could try to say that any { ... } shape represents either an
+        //     // object or a list of objects, by policy, to avoid having to write
+        //     // One<{...}, List<{...}>> everywhere a SubSelection appears.
+        //     //
+        //     // But then we don't know where the array indexes should go...
+        //     "{ thisOrThat: One<$root.data.*.maybe.this, $root.data.*.maybe.that> }",
+        // );
+
+        assert_eq!(
+            selection!(r#"
+                id
+                name
+                friends: friend_ids { id: @ }
+                alias: arrayOfArrays { x y }
+                ys: arrayOfArrays.y xs: arrayOfArrays.x
+            "#).shape().pretty_print(),
+
+            // This output shape is wrong if $root.friend_ids turns out to be an
+            // array, and it's tricky to see how to transform the shape to what
+            // it would have been if we knew that, where friends: List<{ id:
+            // $root.friend_ids.* }> (note the * meaning any array index),
+            // because who's to say it's not the id field that should become the
+            // List, rather than the friends field?
+            "{ alias: { x: $root.*.arrayOfArrays.*.x, y: $root.*.arrayOfArrays.*.y }, friends: { id: $root.*.friend_ids.* }, id: $root.*.id, name: $root.*.name, xs: $root.*.arrayOfArrays.x, ys: $root.*.arrayOfArrays.y }",
+        );
+
+        assert_eq!(
+            selection!(r#"
+                id
+                name
+                friends: friend_ids->map({ id: @ })
+                alias: arrayOfArrays { x y }
+                ys: arrayOfArrays.y xs: arrayOfArrays.x
+            "#).shape().pretty_print(),
+            "{ alias: { x: $root.*.arrayOfArrays.*.x, y: $root.*.arrayOfArrays.*.y }, friends: List<{ id: $root.*.friend_ids.* }>, id: $root.*.id, name: $root.*.name, xs: $root.*.arrayOfArrays.x, ys: $root.*.arrayOfArrays.y }",
+        );
+
+        assert_eq!(
+            selection!("$->echo({ thrice: [@, @, @] })")
+                .shape()
+                .pretty_print(),
+            "{ thrice: [$root, $root, $root] }",
+        );
+
+        assert_eq!(
+            selection!("$->echo({ thrice: [@, @, @] })->entries")
+                .shape()
+                .pretty_print(),
+            "[{ key: \"thrice\", value: [$root, $root, $root] }]",
+        );
+
+        assert_eq!(
+            selection!("$->echo({ thrice: [@, @, @] })->entries.key")
+                .shape()
+                .pretty_print(),
+            "[\"thrice\"]",
+        );
+
+        assert_eq!(
+            selection!("$->echo({ thrice: [@, @, @] })->entries.value")
+                .shape()
+                .pretty_print(),
+            "[[$root, $root, $root]]",
+        );
+
+        assert_eq!(
+            selection!("$->echo({ wrapped: @ })->entries { k: key v: value }")
+                .shape()
+                .pretty_print(),
+            "[{ k: \"wrapped\", v: $root }]",
+        );
+    }
+}


### PR DESCRIPTION
This PR collects a few refactoring changes I wanted to make before attempting PR #6658:
* Updating the `shape` crate to the latest published version, 0.4.2
* Renaming `named_var_shapes` parameters to `named_shapes`, since the map is not just for variables
* Moving the `compute_output_shape` method implementations from the `ApplyToInternal` trait to a new `ComputeOutputShape` trait
* Unifying the handling of `None`, union and intersection shapes, and errors across all `PathList` variants
  * Among other benefits, this means `->` methods never have to worry about receiving `None` or a union or intersection shape as their input shape, since we can handle those shapes automatically without invoking `method.shape(...)`

These changes should be mostly organizational and should have no runtime consequences outside the `compute_output_shape` code.