### PR TITLE
Add a log to report the ComputeJob Threadpool size and queue size inf…

### DIFF
--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -158,6 +158,11 @@ pub(crate) fn queue() -> &'static AgeingPriorityQueue<Job> {
                 }
             });
         }
+        tracing::info!(
+                "ComputeJob thread pool created.  threads:{} queue capacity:{}",
+                pool_size,
+                QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size
+            );
         AgeingPriorityQueue::bounded(QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size)
     })
 }


### PR DESCRIPTION
…ormation (#6662)

Make the ComputeJob Threadpool size and queue capacity info observable so that one can determine how many threads are actually spawned based on hardware deployed to.

A log is sufficient for my needs, but since the metrics on the actual queue size are being added, perhaps emanating metrics on these would be useful?


Fixes #6662 6662

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [X] Manual Tests

Example output:

`
2025-04-10T20:13:43.811866Z INFO router{http.route=/,http.request.method=POST,http.request.method=POST,http.request.method=POST,http.route=/,url.path=/,client.name=,client.version=,}  ComputeJob thread pool created.  threads:10 queue capacity:10000
`


**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
