### PR TITLE
with_metrics() doesn't require `Send`

### DIFF
--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -1193,7 +1193,7 @@ macro_rules! assert_non_zero_metrics_snapshot {
 }
 
 #[cfg(test)]
-pub(crate) type MetricFuture<T> = Pin<Box<dyn Future<Output = <T as Future>::Output> + Send>>;
+pub(crate) type MetricFuture<T> = Pin<Box<dyn Future<Output = <T as Future>::Output>>>;
 
 #[cfg(test)]
 pub(crate) trait FutureMetricsExt<T> {
@@ -1204,8 +1204,8 @@ pub(crate) trait FutureMetricsExt<T> {
         MetricFuture<Self>,
     >
     where
-        Self: Sized + Future + Send + 'static,
-        <Self as Future>::Output: Send + 'static,
+        Self: Sized + Future + 'static,
+        <Self as Future>::Output: 'static,
     {
         test_utils::AGGREGATE_METER_PROVIDER_ASYNC.scope(
             Default::default(),
@@ -1217,7 +1217,7 @@ pub(crate) trait FutureMetricsExt<T> {
                 .await;
                 result
             }
-            .boxed(),
+            .boxed_local(),
         )
     }
 }

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -382,6 +382,7 @@ mod test_for_harness {
     use tokio::join;
 
     use super::*;
+    use crate::metrics::FutureMetricsExt;
     use crate::plugin::Plugin;
     use crate::services::router;
     use crate::services::router::body;
@@ -574,5 +575,27 @@ mod test_for_harness {
             response.http_response.headers().get("x-custom-header"),
             Some(&HeaderValue::from_static("test-value"))
         );
+    }
+
+    #[tokio::test]
+    async fn test_router_service_metrics() {
+        async {
+            let test_harness: PluginTestHarness<MyTestPlugin> =
+                PluginTestHarness::builder().build().await;
+
+            let service = test_harness.router_service(|_req| async {
+                u64_counter!("test", "test", 1u64);
+                Ok(router::Response::fake_builder()
+                    .data(serde_json::json!({"data": {"field": "value"}}))
+                    .header("x-custom-header", "test-value")
+                    .build()
+                    .unwrap())
+            });
+
+            let _ = service.call_default().await;
+            assert_counter!("test", 1u64);
+        }
+        .with_metrics()
+        .await;
     }
 }


### PR DESCRIPTION
The Router service is required to use UnsyncBoxBody because futures::Stream is not Sync. Changing this to use a different Streams implementation (e.g.: tokio) is a lot of work and not guaranteed to improve things.

This causes issues for `with_metrics()` since it requires the provided closure to be `Send` so that it can be boxed(). Actually, `with_metrics()` doesn't have to box the created closure, it could use `boxed_local()`.

That leads to a simple change to `with_metrics()` which means Router service can be used with it and all existing tests continue to function.