### PR TITLE
docs: clarify cloud subscriptions config

### DIFF
--- a/docs/source/routing/cloud/subscriptions.mdx
+++ b/docs/source/routing/cloud/subscriptions.mdx
@@ -75,7 +75,7 @@ Subscriptions are enabled automatically for GraphOS Cloud with the following def
 
 ```yaml
 subscription:
-  enabled: true
+  enabled: true # Enabled by default, you don't need to add this to your configuration
   mode:
     passthrough:
       all:


### PR DESCRIPTION
Clarifies that `enabled:true` is enabled by default.