### PR TITLE
Body selection shape validation

### DIFF
--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -8,6 +8,7 @@ pub mod expand;
 mod header;
 mod json_selection;
 mod models;
+mod range;
 pub(crate) mod spec;
 mod string_template;
 mod url_template;

--- a/apollo-federation/src/sources/connect/range.rs
+++ b/apollo-federation/src/sources/connect/range.rs
@@ -1,0 +1,83 @@
+//! Helpers for working with [`Range`]
+
+use std::cmp::max;
+use std::cmp::min;
+use std::ops::Range;
+
+pub(super) trait RangeExt {
+    /// Narrow a range by applying another range whose values are relative to the start of this
+    /// range. The result is cropped to the original range - that is, it cannot extend the original
+    /// range. The original range also cannot be narrowed to zero - if the new range would be
+    /// empty, the original range is returned. If the other range is `None`, the original range is
+    /// not modified.
+    fn narrow(&self, other: Option<&Self>) -> Self;
+}
+
+impl RangeExt for Range<usize> {
+    fn narrow(&self, other: Option<&Self>) -> Self {
+        if let Some(other) = other {
+            // Normalize inputs to ensure start < end
+            let normalized_other = if other.start < other.end {
+                other
+            } else {
+                &(other.end..other.start)
+            };
+            let normalized_self = if self.start < self.end {
+                self
+            } else {
+                &(self.end..self.start)
+            };
+
+            // Check for overflow
+            let other_start = if normalized_other.start > usize::MAX - normalized_self.start {
+                usize::MAX
+            } else {
+                normalized_other.start + normalized_self.start
+            };
+            let other_end = if normalized_other.end > usize::MAX - normalized_self.start {
+                usize::MAX
+            } else {
+                normalized_other.end + normalized_self.start
+            };
+
+            // Narrow the range
+            let start = max(normalized_self.start, other_start);
+            let end = min(normalized_self.end, other_end);
+            if start >= end {
+                self.clone()
+            } else {
+                start..end
+            }
+        } else {
+            self.clone()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(0..10, Some(0..5), 0..5)]
+    #[case(0..10, Some(5..15), 5..10)]
+    #[case(0..10, Some(15..25), 0..10)]
+    #[case(50..100, Some(25..50), 75..100)]
+    #[case(50..100, Some(25..100), 75..100)]
+    #[case(20..10, Some(2..4), 12..14)]
+    #[case(20..10, Some(4..2), 12..14)]
+    #[case(10..20, Some(4..2), 12..14)]
+    #[case(0..10, Some(15..20), 0..10)]
+    #[case(0..10, None, 0..10)]
+    #[case(usize::MAX - 10..usize::MAX, Some(5..200), usize::MAX - 5..usize::MAX)]
+    #[allow(clippy::reversed_empty_ranges)]
+    fn test_narrow(
+        #[case] range: Range<usize>,
+        #[case] other: Option<Range<usize>>,
+        #[case] expected: Range<usize>,
+    ) {
+        assert_eq!(range.narrow(other.as_ref()), expected);
+    }
+}

--- a/apollo-federation/src/sources/connect/validation/expression.rs
+++ b/apollo-federation/src/sources/connect/validation/expression.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use shape::Shape;
 use shape::ShapeCase;
 
+use crate::sources::connect::range::RangeExt;
 use crate::sources::connect::string_template::Error;
 use crate::sources::connect::string_template::Expression;
 use crate::sources::connect::validation::coordinates::ConnectDirectiveCoordinate;
@@ -89,11 +90,7 @@ pub(crate) fn validate(expression: &Expression, context: &Context) -> Result<(),
         .errors()
         .map(|err| Error {
             message: err.message.clone(),
-            location: err
-                .range
-                .as_ref()
-                .map(|range| range.start + location.start..range.end + location.start)
-                .unwrap_or_else(|| location.clone()),
+            location: location.narrow(err.range.as_ref()),
         })
         .collect();
     if !errors.is_empty() {

--- a/apollo-federation/src/sources/connect/validation/extended_type.rs
+++ b/apollo-federation/src/sources/connect/validation/extended_type.rs
@@ -252,16 +252,14 @@ fn validate_field(
             .iter()
             .find(|(name, _)| name == &CONNECT_BODY_ARGUMENT_NAME)
         {
-            if let Err(err) = validate_body_selection(
+            errors.extend(validate_body_selection(
                 connect_directive,
                 connect_coordinate,
                 object,
                 field,
                 schema,
                 body,
-            ) {
-                errors.push(err);
-            }
+            ));
         }
 
         if let Some(source_name) = connect_directive

--- a/apollo-federation/src/sources/connect/validation/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/selection.rs
@@ -11,6 +11,7 @@ use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::ObjectType;
 use apollo_compiler::Node;
 use itertools::Itertools;
+use shape::ShapeCase;
 
 use super::coordinates::ConnectDirectiveCoordinate;
 use super::coordinates::SelectionCoordinate;
@@ -23,6 +24,7 @@ use crate::sources::connect::expand::visitors::GroupVisitor;
 use crate::sources::connect::json_selection::ExternalVarPaths;
 use crate::sources::connect::json_selection::NamedSelection;
 use crate::sources::connect::json_selection::Ranged;
+use crate::sources::connect::range::RangeExt;
 use crate::sources::connect::spec::schema::CONNECT_SELECTION_ARGUMENT_NAME;
 use crate::sources::connect::validation::coordinates::connect_directive_http_body_coordinate;
 use crate::sources::connect::validation::graphql::GraphQLString;
@@ -91,58 +93,92 @@ pub(super) fn validate_body_selection(
     field: &Component<FieldDefinition>,
     schema: &SchemaInfo,
     selection_node: &Node<Value>,
-) -> Result<(), Message> {
+) -> Vec<Message> {
     let coordinate =
         connect_directive_http_body_coordinate(&connect_directive.name, parent_type, &field.name);
 
-    let selection_str =
-        GraphQLString::new(selection_node, &schema.sources).map_err(|_| Message {
-            code: Code::GraphQLError,
-            message: format!("{coordinate} must be a string."),
-            locations: selection_node
-                .line_column_range(&schema.sources)
-                .into_iter()
-                .collect(),
-        })?;
-
-    let selection = JSONSelection::parse(selection_str.as_str()).map_err(|err| Message {
-        code: Code::InvalidJsonSelection,
-        message: format!("{coordinate} is not a valid JSONSelection: {err}"),
-        locations: selection_node
-            .line_column_range(&schema.sources)
-            .into_iter()
-            .collect(),
-    })?;
-
+    // Ensure that the body selection is a valid JSON selection string
+    let selection_str = match GraphQLString::new(selection_node, &schema.sources) {
+        Ok(selection_str) => selection_str,
+        Err(_) => {
+            return vec![Message {
+                code: Code::GraphQLError,
+                message: format!("{coordinate} must be a string."),
+                locations: selection_node
+                    .line_column_range(&schema.sources)
+                    .into_iter()
+                    .collect(),
+            }]
+        }
+    };
+    let selection = match JSONSelection::parse(selection_str.as_str()) {
+        Ok(selection) => selection,
+        Err(err) => {
+            return vec![Message {
+                code: Code::InvalidJsonSelection,
+                message: format!("{coordinate} is not a valid JSONSelection: {err}"),
+                locations: selection_node
+                    .line_column_range(&schema.sources)
+                    .into_iter()
+                    .collect(),
+            }]
+        }
+    };
     if selection.is_empty() {
-        return Err(Message {
+        return vec![Message {
             code: Code::InvalidJsonSelection,
             message: format!("{coordinate} is empty"),
             locations: selection_node
                 .line_column_range(&schema.sources)
                 .into_iter()
                 .collect(),
-        });
-    }
-    let var_paths = selection.external_var_paths();
-    if var_paths.is_empty() {
-        return Err(Message {
-            code: Code::InvalidJsonSelection,
-            message: format!("{coordinate} must contain at least one variable reference"),
-            locations: selection_node
-                .line_column_range(&schema.sources)
-                .into_iter()
-                .collect(),
-        });
+        }];
     }
 
+    // Validate the selection shape
+    let shape = selection.shape();
+    let expression_location = 0..selection_str.as_str().len();
+    let mut messages = Vec::new();
+    messages.extend(shape.errors().map(|err| {
+        Message {
+            code: Code::InvalidJsonSelection,
+            message: format!("In {coordinate}: {}", err.message),
+            locations: selection_str
+                .line_col_for_subslice(expression_location.narrow(err.range.as_ref()), schema)
+                .into_iter()
+                .collect(),
+        }
+    }));
+    match shape.case() {
+        ShapeCase::Name(name, _) if name == "$root" => messages.push(Message {
+            code: Code::InvalidJsonSelection,
+            message: format!("In {coordinate}: invalid body selection - body selections have no input to select from"),
+            locations: selection_str
+                .line_col_for_subslice(expression_location, schema)
+                .into_iter()
+                .collect(),
+        }),
+        ShapeCase::String(_) | ShapeCase::Int(_) | ShapeCase::Float | ShapeCase::Bool(_) => messages.push(Message {
+            code: Code::InvalidJsonSelection,
+            message: format!("In {coordinate}: body selection cannot be a scalar literal"),
+            locations: selection_str
+                .line_col_for_subslice(expression_location, schema)
+                .into_iter()
+                .collect(),
+        }),
+        // TODO: Handle All, One, Array, etc.
+        _ => {}
+    }
+
+    // Validate variable references
+    let var_paths = selection.external_var_paths();
     let context = VariableContext::new(
         connect_coordinate.field_coordinate.object,
         connect_coordinate.field_coordinate.field,
         Phase::Request,
         Target::Body,
     );
-    validate_selection_variables(
+    if let Some(message) = validate_selection_variables(
         &VariableResolver::new(context.clone(), schema),
         coordinate,
         selection_str,
@@ -150,6 +186,12 @@ pub(super) fn validate_body_selection(
         context,
         var_paths,
     )
+    .err()
+    {
+        messages.push(message)
+    };
+
+    messages
 }
 
 /// Validate variable references in a JSON Selection

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@body_selection.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@body_selection.graphql.snap
@@ -6,37 +6,51 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/body_sele
 [
     Message {
         code: InvalidJsonSelection,
-        message: "`@connect(http: {body:})` on `Query.dollar` must contain at least one variable reference",
+        message: "In `@connect(http: {body:})` on `Query.dollar`: invalid body selection - body selections have no input to select from",
         locations: [
-            12:19..12:22,
+            12:20..12:21,
         ],
     },
     Message {
         code: InvalidJsonSelection,
-        message: "`@connect(http: {body:})` on `Query.dollarField` must contain at least one variable reference",
+        message: "In `@connect(http: {body:})` on `Query.dollarField`: invalid body selection - body selections have no input to select from",
         locations: [
-            20:19..20:26,
+            20:20..20:25,
         ],
     },
     Message {
         code: InvalidJsonSelection,
-        message: "`@connect(http: {body:})` on `Query.objectLiteral` must contain at least one variable reference",
+        message: "In `@connect(http: {body:})` on `Query.stringLiteral`: body selection cannot be a scalar literal",
         locations: [
-            28:19..28:41,
+            44:20..44:28,
         ],
     },
     Message {
         code: InvalidJsonSelection,
-        message: "`@connect(http: {body:})` on `Query.stringLiteral` must contain at least one variable reference",
+        message: "In `@connect(http: {body:})` on `Query.numericLiteral`: body selection cannot be a scalar literal",
         locations: [
-            44:19..44:29,
+            60:20..60:24,
         ],
     },
     Message {
         code: InvalidJsonSelection,
-        message: "`@connect(http: {body:})` on `Query.numericLiteral` must contain at least one variable reference",
+        message: "In `@connect(http: {body:})` on `Query.invalidArrowMethod`: Method ->no_such_method not found",
         locations: [
-            60:19..60:25,
+            68:49..68:63,
+        ],
+    },
+    Message {
+        code: InvalidJsonSelection,
+        message: "In `@connect(http: {body:})` on `Query.invalidVariable`: unknown variable `$nosuchvariable`, must be one of $args, $config, $context, $this",
+        locations: [
+            76:32..76:47,
+        ],
+    },
+    Message {
+        code: InvalidJsonSelection,
+        message: "In `@connect(http: {body:})` on `Query.stringLiteralFromArrowMethod`: body selection cannot be a scalar literal",
+        locations: [
+            84:20..84:62,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/test_data/body_selection.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/body_selection.graphql
@@ -25,7 +25,7 @@ type Query {
     @connect(
         http: {
             POST: "http://127.0.0.1",
-            body: "$({ userid: 'foo' })" # Could be valid, but currently not allowed
+            body: "$({ userid: 'foo' })" # VALID
         }
         selection: "$"
     )
@@ -58,6 +58,30 @@ type Query {
         http: {
             POST: "http://127.0.0.1",
             body: "$(1)" # INVALID - output is not valid JSON
+        }
+        selection: "$"
+    )
+    invalidArrowMethod(userid: ID!): String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$({ userid: $args.userid })->no_such_method" # INVALID - no such method
+        }
+        selection: "$"
+    )
+    invalidVariable(userid: ID!): String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$({ userid: $nosuchvariable })" # INVALID - no such variable
+        }
+        selection: "$"
+    )
+    stringLiteralFromArrowMethod(userid: ID!): String
+    @connect(
+        http: {
+            POST: "http://127.0.0.1",
+            body: "$({ userid: $args.userid })->jsonStringify" # INVALID - results in string literal
         }
         selection: "$"
     )


### PR DESCRIPTION
* Use the shape system to validate connectors body selections. This adds validations for arrow methods, and makes it possible to validate that the output type is sensible.
* Add an extension trait to simplify working with offset ranges

<!-- start metadata -->
<!-- [CNN-581] -->
---


**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-581]: https://apollographql.atlassian.net/browse/CNN-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ