### PR TITLE
chore: default_features -> default-features in cargo.toml

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -207,7 +207,7 @@ serde_yaml = "0.8.26"
 static_assertions = "1.1.0"
 strum_macros = "0.26.0"
 sys-info = "0.9.1"
-sysinfo = { version = "0.32.0", features = ["system", "windows"], default_features = false }
+sysinfo = { version = "0.32.0", features = ["system", "windows"], default-features = false }
 thiserror = "1.0.61"
 tokio.workspace = true
 tokio-stream = { version = "0.1.15", features = ["sync", "net"] }


### PR DESCRIPTION
A mini syntax tweak that solves a warning on each Cargo run.

```
warning: ./apollo-router/Cargo.toml: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
```
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

Nothing beyond visual inspection deemed necessary for such a trivial change.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
