### PR TITLE
Try not to panic when span lookups fail

### DIFF
--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -261,8 +261,11 @@ impl ApolloExporter {
         let retries = if has_traces { 5 } else { 1 };
 
         for i in 0..retries {
-            // We know these requests can be cloned
-            let task_req = req.try_clone().expect("requests must be clone-able");
+            let task_req = req.try_clone().ok_or_else(|| {
+                ApolloExportError::ServerError(
+                    "Tried to clone a request that cannot be cloned".to_string(),
+                )
+            })?;
             match self.client.execute(task_req).await {
                 Ok(v) => {
                     let status = v.status();

--- a/apollo-router/src/plugins/telemetry/config_new/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/mod.rs
@@ -145,8 +145,9 @@ pub(crate) trait DatadogId {
 }
 impl DatadogId for TraceId {
     fn to_datadog(&self) -> String {
-        let bytes = &self.to_bytes()[std::mem::size_of::<u64>()..std::mem::size_of::<u128>()];
-        u64::from_be_bytes(bytes.try_into().unwrap()).to_string()
+        let mut bytes: [u8; 8] = Default::default();
+        bytes.copy_from_slice(&self.to_bytes()[8..16]);
+        u64::from_be_bytes(bytes).to_string()
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/otel/tracer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/tracer.rs
@@ -83,19 +83,17 @@ impl PreSampledTracer for SdkTracer {
         let (flags, trace_state) = if let Some(result) = &builder.sampling_result {
             process_sampling_result(result, parent_trace_flags)
         } else {
-            builder.sampling_result = Some(self.should_sample().should_sample(
+            let sampling_result = self.should_sample().should_sample(
                 Some(parent_cx),
                 trace_id,
                 &builder.name,
                 builder.span_kind.as_ref().unwrap_or(&SpanKind::Internal),
                 builder.attributes.as_ref().unwrap_or(&Vec::new()),
                 builder.links.as_deref().unwrap_or(&[]),
-            ));
-
-            process_sampling_result(
-                builder.sampling_result.as_ref().unwrap(),
-                parent_trace_flags,
-            )
+            );
+            let processed_result = process_sampling_result(&sampling_result, parent_trace_flags);
+            builder.sampling_result = Some(sampling_result);
+            processed_result
         }
         .unwrap_or_default();
 

--- a/apollo-router/src/plugins/telemetry/tracing/datadog/agent_sampling.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog/agent_sampling.rs
@@ -86,16 +86,14 @@ impl ShouldSample for DatadogAgentSampling {
         result.trace_state = result.trace_state.with_measuring(true);
         // We always want to set the sampling.priority attribute in case we are communicating with the agent via otlp.
         // Reverse engineered from https://github.com/DataDog/datadog-agent/blob/c692f62423f93988b008b669008f9199a5ad196b/pkg/trace/api/otlp.go#L502
-        result.attributes.push(KeyValue::new(
-            "sampling.priority",
-            Value::I64(
-                result
-                    .trace_state
-                    .sampling_priority()
-                    .expect("sampling priority")
-                    .as_i64(),
-            ),
-        ));
+        if let Some(priority) = result.trace_state.sampling_priority() {
+            result.attributes.push(KeyValue::new(
+                "sampling.priority",
+                Value::I64(priority.as_i64()),
+            ));
+        } else {
+            tracing::error!("Failed to set trace sampling priority.");
+        }
         result
     }
 }


### PR DESCRIPTION
Primarily updates calls for span lookups to log an error when the lookup doesn't find a span. The OTel layer hooks unfortunately do not return results, but I think a no-op with an error log is preferably than a panic in the case of a missing span. Additionally, this rewrites a few small blocks to avoid calls to unwrap/expect and propagate errors where possible. 

<!-- ROUTER-936 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
