### PR TITLE
Move preview_connectors config to connectors for GA

### DIFF
--- a/.changesets/feat_pubmodmatt_connectors_ga_config.md
+++ b/.changesets/feat_pubmodmatt_connectors_ga_config.md
@@ -1,0 +1,3 @@
+### Move preview_connectors config to connectors for GA ([PR #6699](https://github.com/apollographql/router/pull/6699))
+
+Apollo Connectors is now [generally available](https://www.apollographql.com/docs/graphos/reference/feature-launch-stages#general-availability). See the [connectors changelog](https://www.apollographql.com/docs/graphos/schema-design/connectors/changelog) for instructions on how to migrate preview router configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+# [2.0.0]
+
+## 🚀 Features
+
+### General availability of Apollo Connectors
+
+Apollo Connectors is now [generally available](https://www.apollographql.com/docs/graphos/reference/feature-launch-stages#general-availability). See the [connectors changelog](https://www.apollographql.com/docs/graphos/schema-design/connectors/changelog) for instructions on how to migrate preview router configuration.
+
 # [2.0.0-preview.0] - 2024-10-01
 
 Learn more about [migrating from 1.x to 2.0](https://www.apollographql.com/docs/graphos/reference/migration/from-router-v1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
-# [2.0.0]
-
-## 🚀 Features
-
-### General availability of Apollo Connectors
-
-Apollo Connectors is now [generally available](https://www.apollographql.com/docs/graphos/reference/feature-launch-stages#general-availability). See the [connectors changelog](https://www.apollographql.com/docs/graphos/schema-design/connectors/changelog) for instructions on how to migrate preview router configuration.
-
 # [2.0.0-preview.0] - 2024-10-01
 
 Learn more about [migrating from 1.x to 2.0](https://www.apollographql.com/docs/graphos/reference/migration/from-router-v1).

--- a/apollo-router/src/configuration/connector.rs
+++ b/apollo-router/src/configuration/connector.rs
@@ -10,7 +10,7 @@ pub(crate) struct ConnectorConfiguration<T>
 where
     T: Serialize + JsonSchema,
 {
-    // Map of subgraph_name.connector_source_name to configuration
+    /// Map of subgraph_name.connector_source_name to configuration
     #[serde(default)]
     pub(crate) sources: HashMap<String, T>,
 }

--- a/apollo-router/src/configuration/expansion.rs
+++ b/apollo-router/src/configuration/expansion.rs
@@ -169,7 +169,7 @@ fn dev_mode_defaults() -> Vec<Override> {
             .value_type(ValueType::Bool)
             .build(),
         Override::builder()
-            .config_path("preview_connectors.debug_extensions")
+            .config_path("connectors.debug_extensions")
             .value(true)
             .value_type(ValueType::Bool)
             .build(),

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -402,7 +402,7 @@ impl InstrumentData {
 
         populate_config_instrument!(
             apollo.router.config.connectors,
-            "$.preview_connectors",
+            "$.connectors",
             opt.debug_extensions,
             "$[?(@.debug_extensions == true)]",
             opt.expose_sources_in_context,

--- a/apollo-router/src/configuration/migrations/0035-preview_connectors.yaml
+++ b/apollo-router/src/configuration/migrations/0035-preview_connectors.yaml
@@ -1,0 +1,5 @@
+description: Apollo Connectors is no longer in preview
+actions:
+  - type: move
+    from: preview_connectors
+    to: connectors

--- a/apollo-router/src/configuration/migrations/0036-preview_connectors_subgraphs.yaml
+++ b/apollo-router/src/configuration/migrations/0036-preview_connectors_subgraphs.yaml
@@ -3,5 +3,4 @@ actions:
   - type: log
     level: warn
     path: connectors.subgraphs
-    # TODO: add doc link about how to migrate subgraphs and $config
     log: "In the General Availability (GA) release of Apollo Connectors, `subgraphs` has been replaced by `sources`. Please update your configuration."

--- a/apollo-router/src/configuration/migrations/0036-preview_connectors_subgraphs.yaml
+++ b/apollo-router/src/configuration/migrations/0036-preview_connectors_subgraphs.yaml
@@ -1,0 +1,7 @@
+description: Apollo Connectors GA has replaced `subgraphs` configuration with `sources`
+actions:
+  - type: log
+    level: warn
+    path: connectors.subgraphs
+    # TODO: add doc link about how to migrate subgraphs and $config
+    log: "In the General Availability (GA) release of Apollo Connectors, `subgraphs` has been replaced by `sources`. Please update your configuration."

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__dev_mode.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__dev_mode.snap
@@ -2,6 +2,8 @@
 source: apollo-router/src/configuration/expansion.rs
 expression: value
 ---
+connectors:
+  debug_extensions: true
 homepage:
   enabled: false
   some_other_config: should remain
@@ -9,8 +11,6 @@ include_subgraph_errors:
   all: true
 plugins:
   experimental.expose_query_plan: true
-preview_connectors:
-  debug_extensions: true
 sandbox:
   enabled: true
 supergraph:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1860,6 +1860,7 @@ expression: "&schema"
             "description": "#/definitions/AuthConfig"
           },
           "default": {},
+          "description": "Map of subgraph_name.connector_source_name to configuration",
           "type": "object"
         }
       },
@@ -2112,12 +2113,22 @@ expression: "&schema"
           "nullable": true,
           "type": "integer"
         },
+        "sources": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SourceConfiguration",
+            "description": "#/definitions/SourceConfiguration"
+          },
+          "default": {},
+          "description": "Map of subgraph_name.connector_source_name to source configuration",
+          "type": "object"
+        },
         "subgraphs": {
           "additionalProperties": {
             "$ref": "#/definitions/SubgraphConnectorConfiguration",
             "description": "#/definitions/SubgraphConnectorConfiguration"
           },
           "default": {},
+          "deprecated": true,
           "description": "A map of subgraph name to connectors config for that subgraph",
           "type": "object"
         }
@@ -5708,6 +5719,12 @@ expression: "&schema"
       "additionalProperties": false,
       "description": "Configuration for a `@source` directive",
       "properties": {
+        "$config": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Other values that can be used by connectors via `{$config.<key>}`",
+          "type": "object"
+        },
         "max_requests_per_operation": {
           "default": null,
           "description": "The maximum number of requests for this source",
@@ -8735,6 +8752,10 @@ expression: "&schema"
       "$ref": "#/definitions/Batching",
       "description": "#/definitions/Batching"
     },
+    "connectors": {
+      "$ref": "#/definitions/ConnectorsConfig",
+      "description": "#/definitions/ConnectorsConfig"
+    },
     "coprocessor": {
       "$ref": "#/definitions/Conf4",
       "description": "#/definitions/Conf4"
@@ -8803,10 +8824,6 @@ expression: "&schema"
     "plugins": {
       "$ref": "#/definitions/Plugins",
       "description": "#/definitions/Plugins"
-    },
-    "preview_connectors": {
-      "$ref": "#/definitions/ConnectorsConfig",
-      "description": "#/definitions/ConnectorsConfig"
     },
     "preview_entity_cache": {
       "$ref": "#/definitions/Config8",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@connectors_preview.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@connectors_preview.router.yaml.snap
@@ -1,0 +1,14 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+connectors:
+  debug_extensions: true
+  expose_sources_in_context: true
+  max_requests_per_operation_per_source: 50
+  subgraphs:
+    subgraph_name:
+      sources:
+        source_name:
+          override_url: "http://localhost:5280"

--- a/apollo-router/src/configuration/testdata/metrics/connectors.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/connectors.router.yaml
@@ -1,4 +1,4 @@
-preview_connectors:
+connectors:
   debug_extensions: true
   expose_sources_in_context: true
   max_requests_per_operation_per_source: 100

--- a/apollo-router/src/configuration/testdata/migrations/connectors_preview.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/connectors_preview.router.yaml
@@ -1,0 +1,10 @@
+preview_connectors:
+  debug_extensions: true
+  expose_sources_in_context: true
+  max_requests_per_operation_per_source: 50
+  # If support for subgraphs is eventually removed, the following will need to be removed
+  subgraphs:
+    subgraph_name:
+      sources:
+        source_name:
+          override_url: http://localhost:5280

--- a/apollo-router/src/plugins/connectors/configuration.rs
+++ b/apollo-router/src/plugins/connectors/configuration.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use super::incompatible::warn_incompatible_plugins;
 use crate::plugins::connectors::plugin::PLUGIN_NAME;
+use crate::services::connector_service::ConnectorSourceRef;
 use crate::Configuration;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -17,7 +18,12 @@ use crate::Configuration;
 pub(crate) struct ConnectorsConfig {
     /// A map of subgraph name to connectors config for that subgraph
     #[serde(default)]
+    #[deprecated(note = "use `sources`")]
     pub(crate) subgraphs: HashMap<String, SubgraphConnectorConfiguration>,
+
+    /// Map of subgraph_name.connector_source_name to source configuration
+    #[serde(default)]
+    pub(crate) sources: HashMap<String, SourceConfiguration>,
 
     /// Enables connector debugging information on response extensions if the feature is enabled
     #[serde(default)]
@@ -43,6 +49,7 @@ pub(crate) struct ConnectorsConfig {
     pub(crate) expose_sources_in_context: bool,
 }
 
+// TODO: remove this after deprecation period
 /// Configuration for a connector subgraph
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
 #[serde(deny_unknown_fields, default)]
@@ -64,6 +71,10 @@ pub(crate) struct SourceConfiguration {
 
     /// The maximum number of requests for this source
     pub(crate) max_requests_per_operation: Option<usize>,
+
+    /// Other values that can be used by connectors via `{$config.<key>}`
+    #[serde(rename = "$config")]
+    pub(crate) custom: CustomConfiguration,
 }
 
 /// Modifies connectors with values from the configuration
@@ -72,7 +83,7 @@ pub(crate) fn apply_config(
     mut connectors: Connectors,
 ) -> Connectors {
     // Enabling connectors might end up interfering with other router features, so we insert warnings
-    // into the logs for any incompatibilites found.
+    // into the logs for any incompatibilities found.
     warn_incompatible_plugins(router_config, &connectors);
 
     let Some(config) = router_config.apollo_plugins.plugins.get(PLUGIN_NAME) else {
@@ -83,6 +94,20 @@ pub(crate) fn apply_config(
     };
 
     for connector in Arc::make_mut(&mut connectors.by_service_name).values_mut() {
+        if let Ok(source_ref) = ConnectorSourceRef::try_from(&mut *connector) {
+            if let Some(source_config) = config.sources.get(&source_ref.to_string()) {
+                if let Some(url) = source_config.override_url.as_ref() {
+                    connector.transport.source_url = Some(url.clone());
+                }
+                if let Some(max_requests) = source_config.max_requests_per_operation {
+                    connector.max_requests = Some(max_requests);
+                }
+                connector.config = Some(source_config.custom.clone());
+            }
+        }
+
+        // TODO: remove this after deprecation period
+        #[allow(deprecated)]
         let Some(subgraph_config) = config.subgraphs.get(&connector.id.subgraph_name) else {
             continue;
         };
@@ -99,7 +124,6 @@ pub(crate) fn apply_config(
                 connector.max_requests = Some(max_requests);
             }
         }
-
         connector.config = Some(subgraph_config.custom.clone());
     }
     connectors

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -179,6 +179,6 @@ impl Plugin for Connectors {
     }
 }
 
-pub(crate) const PLUGIN_NAME: &str = "preview_connectors";
+pub(crate) const PLUGIN_NAME: &str = "connectors";
 
 register_plugin!("apollo", PLUGIN_NAME, Connectors);

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -63,9 +63,9 @@ async fn value_from_config() {
         "query { me { id name username} }",
         Default::default(),
         Some(json!({
-            "preview_connectors": {
-                "subgraphs": {
-                    "connectors": {
+            "connectors": {
+                "sources": {
+                    "connectors.json": {
                         "$config": {
                             "id": 1,
                         }
@@ -108,7 +108,7 @@ async fn max_requests() {
         "query { users { id name username } }",
         Default::default(),
         Some(json!({
-          "preview_connectors": {
+          "connectors": {
             "max_requests_per_operation_per_source": 2
           }
         })),
@@ -173,7 +173,7 @@ async fn source_max_requests() {
         "query { users { id name username } }",
         Default::default(),
         Some(json!({
-          "preview_connectors": {
+          "connectors": {
             "subgraphs": {
               "connectors": {
                 "sources": {
@@ -570,7 +570,7 @@ async fn test_headers() {
         "query { users { id } }",
         Default::default(),
         Some(json!({
-            "preview_connectors": {
+            "connectors": {
                 "subgraphs": {
                     "connectors": {
                         "$config": {
@@ -1450,7 +1450,7 @@ async fn test_sources_in_context() {
         "query Posts { posts { id body title author { name username } } }",
         Default::default(),
         Some(json!({
-          "preview_connectors": {
+          "connectors": {
             "expose_sources_in_context": true
           },
           "coprocessor": {
@@ -1518,7 +1518,7 @@ async fn test_variables() {
         "{ f(arg: \"arg\") { arg context config sibling status extra f(arg: \"arg\") { arg context config sibling status } } }",
         Default::default(),
         Some(json!({
-          "preview_connectors": {
+          "connectors": {
             "subgraphs": {
               "connectors": {
                 "$config": {
@@ -1804,14 +1804,10 @@ async fn execute(
     let common_config = json!({
         "include_subgraph_errors": { "all": true },
         "override_subgraph_url": {"graphql": subgraph_uri},
-        "preview_connectors": {
-            "subgraphs": {
-                "connectors": {
-                    "sources": {
-                        "json": {
-                            "override_url": connector_uri
-                        }
-                    }
+        "connectors": {
+            "sources": {
+                "connectors.json": {
+                    "override_url": connector_uri
                 }
             }
         }

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -692,7 +692,7 @@ pub(crate) async fn create_plugins(
     add_optional_apollo_plugin!("demand_control");
 
     // This relative ordering is documented in `docs/source/customizations/native.mdx`:
-    add_optional_apollo_plugin!("preview_connectors");
+    add_optional_apollo_plugin!("connectors");
     add_optional_apollo_plugin!("rhai");
     add_optional_apollo_plugin!("coprocessor");
     add_user_plugins!();

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -1,5 +1,6 @@
 //! Tower service for connectors.
 
+use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Poll;
@@ -97,6 +98,23 @@ impl TryFrom<&Connector> for ConnectorSourceRef {
             subgraph_name: value.id.subgraph_name.to_string(),
             source_name: value.id.source_name.clone().ok_or(())?,
         })
+    }
+}
+
+impl TryFrom<&mut Connector> for ConnectorSourceRef {
+    type Error = ();
+
+    fn try_from(value: &mut Connector) -> Result<Self, Self::Error> {
+        Ok(Self {
+            subgraph_name: value.id.subgraph_name.to_string(),
+            source_name: value.id.source_name.clone().ok_or(())?,
+        })
+    }
+}
+
+impl Display for ConnectorSourceRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.subgraph_name, self.source_name)
     }
 }
 

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1179,10 +1179,6 @@ fn merge_overrides(
     }
     if let Some(sources) = config
         .as_object_mut()
-        .and_then(|o| o.get_mut("preview_connectors"))
-        .and_then(|o| o.as_object_mut())
-        .and_then(|o| o.get_mut("subgraphs"))
-        .and_then(|o| o.as_object_mut())
         .and_then(|o| o.get_mut("connectors"))
         .and_then(|o| o.as_object_mut())
         .and_then(|o| o.get_mut("sources"))
@@ -1191,7 +1187,7 @@ fn merge_overrides(
         for (name, url) in overrides2 {
             let mut obj = serde_json::Map::new();
             obj.insert("override_url".to_string(), url.clone());
-            sources.insert(name.to_string(), Value::Object(obj));
+            sources.insert(format!("connectors.{}", name), Value::Object(obj));
         }
     }
 

--- a/apollo-router/tests/samples/enterprise/connectors-debugging/configuration.yaml
+++ b/apollo-router/tests/samples/enterprise/connectors-debugging/configuration.yaml
@@ -1,13 +1,11 @@
 include_subgraph_errors:
   all: true
 
-preview_connectors:
+connectors:
   debug_extensions: true
-  subgraphs:
-    connectors:
-      sources:
-        jsonPlaceholder:
-          override_url: http://localhost:4007
+  sources:
+    connectors.jsonPlaceholder:
+      override_url: http://localhost:4007
 
 telemetry:
   exporters:

--- a/apollo-router/tests/samples/enterprise/connectors-defer/configuration.yaml
+++ b/apollo-router/tests/samples/enterprise/connectors-defer/configuration.yaml
@@ -1,12 +1,10 @@
 include_subgraph_errors:
   all: true
 
-preview_connectors:
-  subgraphs:
-    connectors:
-      sources:
-        jsonPlaceholder:
-          override_url: http://localhost:4007
+connectors:
+  sources:
+    connectors.jsonPlaceholder:
+      override_url: http://localhost:4007
 
 telemetry:
   exporters:

--- a/apollo-router/tests/samples/enterprise/connectors-demand-control/configuration.yaml
+++ b/apollo-router/tests/samples/enterprise/connectors-demand-control/configuration.yaml
@@ -9,12 +9,10 @@ demand_control:
       list_size: 1
       max: 100
 
-preview_connectors:
-  subgraphs:
-    connectors:
-      sources:
-        jsonPlaceholder:
-          override_url: http://localhost:4008
+connectors:
+  sources:
+    connectors.jsonPlaceholder:
+      override_url: http://localhost:4008
 
 telemetry:
   exporters:

--- a/apollo-router/tests/samples/enterprise/connectors-pqs/configuration.yaml
+++ b/apollo-router/tests/samples/enterprise/connectors-pqs/configuration.yaml
@@ -1,12 +1,10 @@
 include_subgraph_errors:
   all: true
 
-preview_connectors:
-  subgraphs:
-    connectors:
-      sources:
-        one:
-          override_url: http://localhost:4001
+connectors:
+  sources:
+    connectors.one:
+      override_url: http://localhost:4001
 
 telemetry:
   exporters:

--- a/apollo-router/tests/samples/enterprise/connectors/configuration.yaml
+++ b/apollo-router/tests/samples/enterprise/connectors/configuration.yaml
@@ -3,12 +3,10 @@ override_subgraph_url:
 include_subgraph_errors:
   all: true
 
-preview_connectors:
-  subgraphs:
-    connectors:
-      sources:
-        jsonPlaceholder:
-          override_url: http://localhost:4007
+connectors:
+  sources:
+    connectors.jsonPlaceholder:
+      override_url: http://localhost:4007
 
 telemetry:
   exporters:

--- a/docs/source/routing/observability/telemetry/instrumentation/selectors.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/selectors.mdx
@@ -108,17 +108,19 @@ The subgraph service executes multiple times during query execution, with each e
 
 Apollo Connectors for REST APIs make HTTP calls to the upstream HTTP API. These selectors let you extract metrics from these HTTP requests and responses.
 
-| Selector                         | Defaultable | Values           | Description                                                       |
-|----------------------------------|-------------|------------------|-------------------------------------------------------------------|
-| `subgraph_name`                  | No          | `true`\|`false`  | The name of the subgraph containing the connector                 |
-| `connector_source `              | No          | `name`           | The name of the `@source` associated with this connector, if any  |
-| `connector_http_request_header`  | Yes         |                  | The name of a connector request header                            |
-| `connector_http_response_header` | Yes         |                  | The name of a connector response header                           |
-| `connector_http_response_status` | No          | `code`\|`reason` | The status of a connector response                                |
-| `connector_http_method`          | No          | `true`\|`false`  | The HTTP method of a connector request                            |
-| `connector_url_template `        | No          | `true`\|`false`  | The URL template of a connector request                           |
-| `static`                         | No          |                  | A static string value                                             |
-| `error`                          | No          | `reason`         | A string value containing error reason when it's a critical error |
+| Selector                              | Defaultable | Values              | Description                                                       |
+|---------------------------------------|-------------|---------------------|-------------------------------------------------------------------|
+| `subgraph_name`                       | No          | `true`\|`false`     | The name of the subgraph containing the connector                 |
+| `connector_source `                   | No          | `name`              | The name of the `@source` associated with this connector, if any  |
+| `connector_http_request_header`       | Yes         |                     | The name of a connector request header                            |
+| `connector_http_response_header`      | Yes         |                     | The name of a connector response header                           |
+| `connector_http_response_status`      | No          | `code`\|`reason`    | The status of a connector response                                |
+| `connector_http_method`               | No          | `true`\|`false`     | The HTTP method of a connector request                            |
+| `connector_url_template `             | No          | `true`\|`false`     | The URL template of a connector request                           |
+| `connector_request_mapping_problems`  | No          | `problems`\|`count` | Any mapping problems with the connector request                   |
+| `connector_response_mapping_problems` | No          | `problems`\|`count` | Any mapping problems with the connector response                  |
+| `static`                              | No          |                     | A static string value                                             |
+| `error`                               | No          | `reason`            | A string value containing error reason when it's a critical error |
 
 
 ### GraphQL


### PR DESCRIPTION
Rename `preview_connectors` router config to `connectors`. In addition, `subgraphs` is now moved to `sources`, and under that, settings for a source are under `<subgraph name>.<source name>`. This matches other connectors config, for example, under `telemetry` and `authorization`.

The `$config` item has also changed, from being global to all sources in a subgraph, to being specific to a source under the `<subgraph name>.<source name>` entry.

A migrator is added to rename `preview_connectors` to `connectors`, but we cannot migrate the other changes. A warning is emitted if the `subgraphs` config was in use (which includes `$config` under `subgraphs`). Both the old `subgraphs` and new `sources` are allowed currently. This can be changed after a deprecation period, to remove the `subgraphs` form.

## Example

### Preview Config

```yaml
preview_connectors:
  max_requests_per_operation_per_source: 100 # This applies globally to all connectors
  subgraphs:
    example: # The name of the subgraph
      $config:
        my.config.value: true # applies to all sources in this subgraph
      sources:
        v1: # Refers to @source(name: "v1")
          # These apply to connectors with this source (v1) in this subgraph (example)
          override_url: 'https://api.example.com/v1/beta'
          max_requests_per_operation: 50
```

### GA Config

```yaml
connectors:
  max_requests_per_operation_per_source: 100 # This applies globally to all connectors
  sources:
    example.v1: # subgraph.source
      # These apply to connectors with this source (v1) in this subgraph (example)
      override_url: 'https://api.example.com/v1/beta'
      max_requests_per_operation: 50
      $config:
        my.config.value: true # applies only to this source
    
```

<!-- start metadata -->
<!-- [CNN-504] -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-504]: https://apollographql.atlassian.net/browse/CNN-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ