### PR TITLE
connectors: add more feature warnings

### DIFF
--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -99,14 +99,14 @@ impl Storage {
 pub(crate) struct Config {
     /// Enable or disable the entity caching feature
     #[serde(default)]
-    enabled: bool,
+    pub(crate) enabled: bool,
 
     #[serde(default)]
     /// Expose cache keys in context
     expose_keys_in_context: bool,
 
     /// Configure invalidation per subgraph
-    subgraph: SubgraphConfiguration<Subgraph>,
+    pub(crate) subgraph: SubgraphConfiguration<Subgraph>,
 
     /// Global invalidation configuration
     invalidation: Option<InvalidationEndpointConfig>,

--- a/apollo-router/src/plugins/connectors/incompatible.rs
+++ b/apollo-router/src/plugins/connectors/incompatible.rs
@@ -5,6 +5,7 @@ use apq::APQIncompatPlugin;
 use authentication::AuthIncompatPlugin;
 use batching::BatchingIncompatPlugin;
 use headers::HeadersIncompatPlugin;
+use rhai::RhaiIncompatPlugin;
 use tls::TlsIncompatPlugin;
 use traffic_shaping::TrafficShapingIncompatPlugin;
 use url_override::UrlOverrideIncompatPlugin;
@@ -15,6 +16,7 @@ mod apq;
 mod authentication;
 mod batching;
 mod headers;
+mod rhai;
 mod tls;
 mod traffic_shaping;
 mod url_override;
@@ -83,6 +85,7 @@ pub(crate) fn warn_incompatible_plugins(config: &Configuration, connectors: &Con
         AuthIncompatPlugin::from_config(config).map(boxify!()),
         BatchingIncompatPlugin::from_config(config).map(boxify!()),
         HeadersIncompatPlugin::from_config(config).map(boxify!()),
+        RhaiIncompatPlugin::from_config(config).map(boxify!()),
         TlsIncompatPlugin::from_config(config).map(boxify!()),
         TrafficShapingIncompatPlugin::from_config(config).map(boxify!()),
         UrlOverrideIncompatPlugin::from_config(config).map(boxify!()),

--- a/apollo-router/src/plugins/connectors/incompatible.rs
+++ b/apollo-router/src/plugins/connectors/incompatible.rs
@@ -9,6 +9,7 @@ use demand_control::DemandControlIncompatPlugin;
 use entity_cache::EntityCacheIncompatPlugin;
 use headers::HeadersIncompatPlugin;
 use rhai::RhaiIncompatPlugin;
+use telemetry::TelemetryIncompatPlugin;
 use tls::TlsIncompatPlugin;
 use traffic_shaping::TrafficShapingIncompatPlugin;
 use url_override::UrlOverrideIncompatPlugin;
@@ -23,6 +24,7 @@ mod demand_control;
 mod entity_cache;
 mod headers;
 mod rhai;
+mod telemetry;
 mod tls;
 mod traffic_shaping;
 mod url_override;
@@ -95,6 +97,7 @@ pub(crate) fn warn_incompatible_plugins(config: &Configuration, connectors: &Con
         EntityCacheIncompatPlugin::from_config(config).map(boxify!()),
         HeadersIncompatPlugin::from_config(config).map(boxify!()),
         RhaiIncompatPlugin::from_config(config).map(boxify!()),
+        TelemetryIncompatPlugin::from_config(config).map(boxify!()),
         TlsIncompatPlugin::from_config(config).map(boxify!()),
         TrafficShapingIncompatPlugin::from_config(config).map(boxify!()),
         UrlOverrideIncompatPlugin::from_config(config).map(boxify!()),

--- a/apollo-router/src/plugins/connectors/incompatible.rs
+++ b/apollo-router/src/plugins/connectors/incompatible.rs
@@ -5,6 +5,7 @@ use apq::APQIncompatPlugin;
 use authentication::AuthIncompatPlugin;
 use batching::BatchingIncompatPlugin;
 use coprocessor::CoprocessorIncompatPlugin;
+use demand_control::DemandControlIncompatPlugin;
 use entity_cache::EntityCacheIncompatPlugin;
 use headers::HeadersIncompatPlugin;
 use rhai::RhaiIncompatPlugin;
@@ -18,6 +19,7 @@ mod apq;
 mod authentication;
 mod batching;
 mod coprocessor;
+mod demand_control;
 mod entity_cache;
 mod headers;
 mod rhai;
@@ -89,6 +91,7 @@ pub(crate) fn warn_incompatible_plugins(config: &Configuration, connectors: &Con
         AuthIncompatPlugin::from_config(config).map(boxify!()),
         BatchingIncompatPlugin::from_config(config).map(boxify!()),
         CoprocessorIncompatPlugin::from_config(config).map(boxify!()),
+        DemandControlIncompatPlugin::from_config(config).map(boxify!()),
         EntityCacheIncompatPlugin::from_config(config).map(boxify!()),
         HeadersIncompatPlugin::from_config(config).map(boxify!()),
         RhaiIncompatPlugin::from_config(config).map(boxify!()),

--- a/apollo-router/src/plugins/connectors/incompatible.rs
+++ b/apollo-router/src/plugins/connectors/incompatible.rs
@@ -4,6 +4,7 @@ use apollo_federation::sources::connect::expand::Connectors;
 use apq::APQIncompatPlugin;
 use authentication::AuthIncompatPlugin;
 use batching::BatchingIncompatPlugin;
+use coprocessor::CoprocessorIncompatPlugin;
 use headers::HeadersIncompatPlugin;
 use rhai::RhaiIncompatPlugin;
 use tls::TlsIncompatPlugin;
@@ -15,6 +16,7 @@ use crate::Configuration;
 mod apq;
 mod authentication;
 mod batching;
+mod coprocessor;
 mod headers;
 mod rhai;
 mod tls;
@@ -84,6 +86,7 @@ pub(crate) fn warn_incompatible_plugins(config: &Configuration, connectors: &Con
         APQIncompatPlugin::from_config(config).map(boxify!()),
         AuthIncompatPlugin::from_config(config).map(boxify!()),
         BatchingIncompatPlugin::from_config(config).map(boxify!()),
+        CoprocessorIncompatPlugin::from_config(config).map(boxify!()),
         HeadersIncompatPlugin::from_config(config).map(boxify!()),
         RhaiIncompatPlugin::from_config(config).map(boxify!()),
         TlsIncompatPlugin::from_config(config).map(boxify!()),

--- a/apollo-router/src/plugins/connectors/incompatible.rs
+++ b/apollo-router/src/plugins/connectors/incompatible.rs
@@ -5,6 +5,7 @@ use apq::APQIncompatPlugin;
 use authentication::AuthIncompatPlugin;
 use batching::BatchingIncompatPlugin;
 use headers::HeadersIncompatPlugin;
+use tls::TlsIncompatPlugin;
 use traffic_shaping::TrafficShapingIncompatPlugin;
 use url_override::UrlOverrideIncompatPlugin;
 
@@ -14,6 +15,7 @@ mod apq;
 mod authentication;
 mod batching;
 mod headers;
+mod tls;
 mod traffic_shaping;
 mod url_override;
 
@@ -81,6 +83,7 @@ pub(crate) fn warn_incompatible_plugins(config: &Configuration, connectors: &Con
         AuthIncompatPlugin::from_config(config).map(boxify!()),
         BatchingIncompatPlugin::from_config(config).map(boxify!()),
         HeadersIncompatPlugin::from_config(config).map(boxify!()),
+        TlsIncompatPlugin::from_config(config).map(boxify!()),
         TrafficShapingIncompatPlugin::from_config(config).map(boxify!()),
         UrlOverrideIncompatPlugin::from_config(config).map(boxify!()),
     ]

--- a/apollo-router/src/plugins/connectors/incompatible.rs
+++ b/apollo-router/src/plugins/connectors/incompatible.rs
@@ -5,6 +5,7 @@ use apq::APQIncompatPlugin;
 use authentication::AuthIncompatPlugin;
 use batching::BatchingIncompatPlugin;
 use coprocessor::CoprocessorIncompatPlugin;
+use entity_cache::EntityCacheIncompatPlugin;
 use headers::HeadersIncompatPlugin;
 use rhai::RhaiIncompatPlugin;
 use tls::TlsIncompatPlugin;
@@ -17,6 +18,7 @@ mod apq;
 mod authentication;
 mod batching;
 mod coprocessor;
+mod entity_cache;
 mod headers;
 mod rhai;
 mod tls;
@@ -87,6 +89,7 @@ pub(crate) fn warn_incompatible_plugins(config: &Configuration, connectors: &Con
         AuthIncompatPlugin::from_config(config).map(boxify!()),
         BatchingIncompatPlugin::from_config(config).map(boxify!()),
         CoprocessorIncompatPlugin::from_config(config).map(boxify!()),
+        EntityCacheIncompatPlugin::from_config(config).map(boxify!()),
         HeadersIncompatPlugin::from_config(config).map(boxify!()),
         RhaiIncompatPlugin::from_config(config).map(boxify!()),
         TlsIncompatPlugin::from_config(config).map(boxify!()),

--- a/apollo-router/src/plugins/connectors/incompatible/coprocessor.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/coprocessor.rs
@@ -1,0 +1,45 @@
+use itertools::Itertools as _;
+
+use super::IncompatiblePlugin;
+use crate::plugins::coprocessor;
+use crate::Configuration;
+
+pub(super) struct CoprocessorIncompatPlugin;
+
+impl CoprocessorIncompatPlugin {
+    pub(super) fn from_config(config: &Configuration) -> Option<Self> {
+        config
+            .apollo_plugins
+            .plugins
+            .get("coprocessor")
+            .and_then(|val| val.get("subgraph"))
+            .and_then(|val| val.get("all"))
+            .and_then(|raw| serde_json::from_value(raw.clone()).ok())
+            .map(|_: coprocessor::SubgraphStage| CoprocessorIncompatPlugin)
+    }
+}
+
+impl IncompatiblePlugin for CoprocessorIncompatPlugin {
+    fn is_applied_to_all(&self) -> bool {
+        // If the coprocessor is configured with a subgraph setting, then it is
+        // for sure applied to all as there is no other configuration available
+        true
+    }
+
+    fn configured_subgraphs(&self) -> super::ConfiguredSubgraphs<'_> {
+        // Coprocessors cannot be configured at the subgraph level
+        Default::default()
+    }
+
+    fn inform_incompatibilities(
+        &self,
+        subgraphs: std::collections::HashSet<&String>,
+        _connectors: &apollo_federation::sources::connect::expand::Connectors,
+    ) {
+        tracing::info!(
+            subgraphs = subgraphs.into_iter().join(","),
+            message = "coprocessors which hook into `subgraph_request` or `subgraph_response` won't be used by connector-enabled subgraphs",
+            see = "https://go.apollo.dev/connectors/incompat",
+        );
+    }
+}

--- a/apollo-router/src/plugins/connectors/incompatible/demand_control.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/demand_control.rs
@@ -1,0 +1,42 @@
+use itertools::Itertools as _;
+
+use super::IncompatiblePlugin;
+use crate::Configuration;
+
+pub(super) struct DemandControlIncompatPlugin;
+
+impl DemandControlIncompatPlugin {
+    pub(super) fn from_config(config: &Configuration) -> Option<Self> {
+        config
+            .apollo_plugins
+            .plugins
+            .get("demand_control")
+            .and_then(|val| val.get("enabled"))
+            .and_then(serde_json::Value::as_bool)
+            .and_then(|enabled| enabled.then_some(DemandControlIncompatPlugin))
+    }
+}
+
+impl IncompatiblePlugin for DemandControlIncompatPlugin {
+    fn is_applied_to_all(&self) -> bool {
+        // Demand control applies to all subgraphs if enabled
+        true
+    }
+
+    fn configured_subgraphs(&self) -> super::ConfiguredSubgraphs<'_> {
+        // Demand control cannot be configured per subgraph
+        Default::default()
+    }
+
+    fn inform_incompatibilities(
+        &self,
+        subgraphs: std::collections::HashSet<&String>,
+        _connectors: &apollo_federation::sources::connect::expand::Connectors,
+    ) {
+        tracing::warn!(
+            subgraphs = subgraphs.into_iter().join(","),
+            message = "demand control cost calculations do not take connector-enabled subgraphs into consideration",
+            see = "https://go.apollo.dev/connectors/incompat",
+        );
+    }
+}

--- a/apollo-router/src/plugins/connectors/incompatible/entity_cache.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/entity_cache.rs
@@ -1,0 +1,67 @@
+use itertools::Either;
+use itertools::Itertools as _;
+
+use super::IncompatiblePlugin;
+use crate::plugins::cache::entity;
+use crate::Configuration;
+
+pub(super) struct EntityCacheIncompatPlugin {
+    config: entity::Config,
+}
+
+impl EntityCacheIncompatPlugin {
+    pub(super) fn from_config(config: &Configuration) -> Option<Self> {
+        config
+            .apollo_plugins
+            .plugins
+            .get("preview_entity_cache")
+            .and_then(|raw| serde_json::from_value(raw.clone()).ok())
+            .and_then(|config: entity::Config| {
+                config
+                    .enabled
+                    .then_some(EntityCacheIncompatPlugin { config })
+            })
+    }
+}
+
+impl IncompatiblePlugin for EntityCacheIncompatPlugin {
+    fn is_applied_to_all(&self) -> bool {
+        self.config.subgraph.all.enabled
+    }
+
+    fn configured_subgraphs(&self) -> super::ConfiguredSubgraphs<'_> {
+        let (enabled, disabled) =
+            self.config
+                .subgraph
+                .subgraphs
+                .iter()
+                .partition_map(|(name, sub)| match sub.enabled {
+                    true => Either::Left(name),
+                    false => Either::Right(name),
+                });
+
+        super::ConfiguredSubgraphs { enabled, disabled }
+    }
+
+    fn inform_incompatibilities(
+        &self,
+        subgraphs: std::collections::HashSet<&String>,
+        _connectors: &apollo_federation::sources::connect::expand::Connectors,
+    ) {
+        for subgraph in subgraphs {
+            if self.config.subgraph.subgraphs.contains_key(subgraph) {
+                tracing::warn!(
+                    subgraph = subgraph,
+                    message = "plugin `preview_entity_cache` is explicitly configured for connector-enabled subgraph, which is not supported.",
+                    see = "https://go.apollo.dev/connectors/incompat",
+                );
+            } else {
+                tracing::info!(
+                    subgraph = subgraph,
+                    message = "plugin `preview_entity_cache` indirectly targets a connector-enabled subgraph, which is not supported.",
+                    see = "https://go.apollo.dev/connectors/incompat",
+                );
+            }
+        }
+    }
+}

--- a/apollo-router/src/plugins/connectors/incompatible/rhai.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/rhai.rs
@@ -1,0 +1,41 @@
+use itertools::Itertools as _;
+
+use super::IncompatiblePlugin;
+use crate::Configuration;
+
+pub(super) struct RhaiIncompatPlugin;
+
+impl RhaiIncompatPlugin {
+    pub(super) fn from_config(config: &Configuration) -> Option<Self> {
+        config
+            .apollo_plugins
+            .plugins
+            .get("rhai")
+            .map(|_| RhaiIncompatPlugin)
+    }
+}
+
+impl IncompatiblePlugin for RhaiIncompatPlugin {
+    fn is_applied_to_all(&self) -> bool {
+        // Rhai is always applied to all subgraphs since it modifies
+        // the lifecycle of each router request
+        true
+    }
+
+    fn configured_subgraphs(&self) -> super::ConfiguredSubgraphs<'_> {
+        // Rhai cannot be configured at the subgraph level
+        Default::default()
+    }
+
+    fn inform_incompatibilities(
+        &self,
+        subgraphs: std::collections::HashSet<&String>,
+        _connectors: &apollo_federation::sources::connect::expand::Connectors,
+    ) {
+        tracing::info!(
+            subgraphs = subgraphs.into_iter().join(","),
+            message = "rhai scripts which hook into `subgraph_request` or `subgraph_response` won't be used by connector-enabled subgraphs",
+            see = "https://go.apollo.dev/connectors/incompat",
+        );
+    }
+}

--- a/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
@@ -1,0 +1,66 @@
+use itertools::Either;
+use itertools::Itertools as _;
+
+use super::IncompatiblePlugin;
+use crate::plugins::telemetry::apollo;
+use crate::Configuration;
+
+pub(super) struct TelemetryIncompatPlugin {
+    config: apollo::SubgraphErrorConfig,
+}
+
+impl TelemetryIncompatPlugin {
+    pub(super) fn from_config(config: &Configuration) -> Option<Self> {
+        config
+            .apollo_plugins
+            .plugins
+            .get("telemetry")
+            .and_then(|val| val.get("apollo"))
+            .and_then(|raw| serde_json::from_value(raw.clone()).ok())
+            .map(|config: apollo::Config| TelemetryIncompatPlugin {
+                config: config.errors.subgraph,
+            })
+    }
+}
+
+impl IncompatiblePlugin for TelemetryIncompatPlugin {
+    fn is_applied_to_all(&self) -> bool {
+        self.config.all.send || self.config.all.redact
+    }
+
+    fn configured_subgraphs(&self) -> super::ConfiguredSubgraphs<'_> {
+        // While you can't necessarily disable telemetry errors per subgraph,
+        // you can technically disable doing anything with it.
+        let (enabled, disabled) =
+            self.config.subgraphs.iter().partition_map(|(name, sub)| {
+                match sub.send || sub.redact {
+                    true => Either::Left(name),
+                    false => Either::Right(name),
+                }
+            });
+
+        super::ConfiguredSubgraphs { enabled, disabled }
+    }
+
+    fn inform_incompatibilities(
+        &self,
+        subgraphs: std::collections::HashSet<&String>,
+        _connectors: &apollo_federation::sources::connect::expand::Connectors,
+    ) {
+        for subgraph in subgraphs {
+            if self.config.subgraphs.contains_key(subgraph) {
+                tracing::warn!(
+                    subgraph = subgraph,
+                    message = "plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is not supported",
+                    see = "https://go.apollo.dev/connectors/incompat",
+                );
+            } else {
+                tracing::info!(
+                    subgraph = subgraph,
+                    message = "plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is not supported",
+                    see = "https://go.apollo.dev/connectors/incompat",
+                );
+            }
+        }
+    }
+}

--- a/apollo-router/src/plugins/connectors/incompatible/tls.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/tls.rs
@@ -1,0 +1,60 @@
+use std::collections::HashSet;
+
+use super::ConfiguredSubgraphs;
+use super::IncompatiblePlugin;
+use crate::configuration::Tls;
+use crate::Configuration;
+
+pub(super) struct TlsIncompatPlugin {
+    config: Tls,
+}
+
+impl TlsIncompatPlugin {
+    pub(super) fn from_config(config: &Configuration) -> Option<Self> {
+        // TLS is always enaabled and gets default initialized
+        Some(Self {
+            config: config.tls.clone(),
+        })
+    }
+}
+
+impl IncompatiblePlugin for TlsIncompatPlugin {
+    fn is_applied_to_all(&self) -> bool {
+        let all = &self.config.subgraph.all;
+
+        // Since everything gets default initialized, we need to manually check
+        // that every field is not set :(
+        all.certificate_authorities.is_some() || all.client_authentication.is_some()
+    }
+
+    fn configured_subgraphs(&self) -> super::ConfiguredSubgraphs<'_> {
+        // TLS cannot be manually disabled per subgraph, so all configured are
+        // enabled.
+        ConfiguredSubgraphs {
+            enabled: self.config.subgraph.subgraphs.keys().collect(),
+            disabled: HashSet::with_hasher(Default::default()),
+        }
+    }
+
+    fn inform_incompatibilities(
+        &self,
+        subgraphs: std::collections::HashSet<&String>,
+        _connectors: &apollo_federation::sources::connect::expand::Connectors,
+    ) {
+        for subgraph in subgraphs {
+            if self.config.subgraph.subgraphs.contains_key(subgraph) {
+                tracing::warn!(
+                    subgraph = subgraph,
+                    message = "plugin `tls` is explicitly configured for connector-enabled subgraph, which is not supported",
+                    see = "https://go.apollo.dev/connectors/incompat",
+                );
+            } else {
+                tracing::info!(
+                    subgraph = subgraph,
+                    message = "plugin `tls` indirectly targets a connector-enabled subgraph, which is not supported",
+                    see = "https://go.apollo.dev/connectors/incompat",
+                );
+            }
+        }
+    }
+}

--- a/apollo-router/tests/integration/connectors.rs
+++ b/apollo-router/tests/integration/connectors.rs
@@ -606,9 +606,10 @@ mod tls {
             .config(
                 r#"
                 tls:
-                  subgraphs:
-                    connectors:
-                      certificate_authorities: "${file./path/to/product_ca.crt}"
+                  subgraph:
+                    subgraphs:
+                      connectors:
+                        certificate_authorities: "${file./path/to/product_ca.crt}"
         "#,
             )
             .supergraph(PathBuf::from_iter([

--- a/apollo-router/tests/integration/connectors.rs
+++ b/apollo-router/tests/integration/connectors.rs
@@ -458,6 +458,89 @@ mod batching {
     }
 }
 
+mod coprocessor {
+    use std::path::PathBuf;
+
+    use tower::BoxError;
+
+    use crate::integration::IntegrationTest;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
+        // Ensure that we have the test keys before running
+        // Note: The [IntegrationTest] ensures that these test credentials get
+        // set before running the router.
+        if std::env::var("TEST_APOLLO_KEY").is_err()
+            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
+        {
+            return Ok(());
+        };
+
+        let mut router = IntegrationTest::builder()
+            .config(
+                r#"
+                coprocessor:
+                  url: http://127.0.0.1:8081
+                  subgraph:
+                    all:
+                      request: {}
+        "#,
+            )
+            .supergraph(PathBuf::from_iter([
+                "tests",
+                "fixtures",
+                "connectors",
+                "quickstart.graphql",
+            ]))
+            .build()
+            .await;
+
+        router.start().await;
+        router
+        .wait_for_log_message(r#""subgraphs":"connectors","message":"coprocessors which hook into `subgraph_request` or `subgraph_response`"#)
+        .await;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_incompatible_warnings_for_supergraph() -> Result<(), BoxError> {
+        // Ensure that we have the test keys before running
+        // Note: The [IntegrationTest] ensures that these test credentials get
+        // set before running the router.
+        if std::env::var("TEST_APOLLO_KEY").is_err()
+            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
+        {
+            return Ok(());
+        };
+
+        let mut router = IntegrationTest::builder()
+            .config(
+                r#"
+                coprocessor:
+                  url: http://127.0.0.1:8081
+                  supergraph:
+                      request: {}
+        "#,
+            )
+            .supergraph(PathBuf::from_iter([
+                "tests",
+                "fixtures",
+                "connectors",
+                "quickstart.graphql",
+            ]))
+            .build()
+            .await;
+
+        router.start().await;
+        router
+        .assert_log_not_contains(r#""subgraphs":"connectors","message":"coprocessors which hook into `subgraph_request` or `subgraph_response`"#)
+        .await;
+
+        Ok(())
+    }
+}
+
 mod headers {
     use std::path::PathBuf;
 

--- a/apollo-router/tests/integration/connectors.rs
+++ b/apollo-router/tests/integration/connectors.rs
@@ -547,6 +547,88 @@ mod headers {
     }
 }
 
+mod tls {
+    use std::path::PathBuf;
+
+    use tower::BoxError;
+
+    use crate::integration::IntegrationTest;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
+        // Ensure that we have the test keys before running
+        // Note: The [IntegrationTest] ensures that these test credentials get
+        // set before running the router.
+        if std::env::var("TEST_APOLLO_KEY").is_err()
+            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
+        {
+            return Ok(());
+        };
+
+        let mut router = IntegrationTest::builder()
+            .config(
+                r#"
+                tls:
+                  subgraph:
+                    all:
+                      certificate_authorities: "${file./path/to/ca.crt}"
+        "#,
+            )
+            .supergraph(PathBuf::from_iter([
+                "tests",
+                "fixtures",
+                "connectors",
+                "quickstart.graphql",
+            ]))
+            .build()
+            .await;
+
+        router.start().await;
+        router
+        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `tls` indirectly targets a connector-enabled subgraph"#)
+        .await;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn incompatible_warnings_on_subgraph() -> Result<(), BoxError> {
+        // Ensure that we have the test keys before running
+        // Note: The [IntegrationTest] ensures that these test credentials get
+        // set before running the router.
+        if std::env::var("TEST_APOLLO_KEY").is_err()
+            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
+        {
+            return Ok(());
+        };
+
+        let mut router = IntegrationTest::builder()
+            .config(
+                r#"
+                tls:
+                  subgraphs:
+                    connectors:
+                      certificate_authorities: "${file./path/to/product_ca.crt}"
+        "#,
+            )
+            .supergraph(PathBuf::from_iter([
+                "tests",
+                "fixtures",
+                "connectors",
+                "quickstart.graphql",
+            ]))
+            .build()
+            .await;
+
+        router.start().await;
+        router
+        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `tls` is explicitly configured for connector-enabled subgraph"#)
+        .await;
+
+        Ok(())
+    }
+}
+
 mod traffic_shaping {
     use std::path::PathBuf;
 


### PR DESCRIPTION
This commit adds more warnings for the following features when used in connector-enabled subgraphs:

- TLS
- Rhai
- Coprocessors
- Preview Entity Cache
- Demand Control
- Telemetry

<!-- [CNN-583] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-583]: https://apollographql.atlassian.net/browse/CNN-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ