### PR TITLE
Experimental operation error metrics: rename source -> service

### DIFF
--- a/.changesets/exp_njm_operation_error_metrics.md
+++ b/.changesets/exp_njm_operation_error_metrics.md
@@ -1,14 +1,15 @@
 ### Experimental per-operation error metrics ([PR #6443](https://github.com/apollographql/router/pull/6443), [PR #6666](https://github.com/apollographql/router/pull/6666))
 
 Adds a new experimental OpenTelemetry metric that includes error counts at a per-operation and per-client level. These metrics contain the following attributes:
-* Operation name
-* Operation type (query/mutation/subscription)
-* Apollo operation ID
-* Client name
-* Client version
-* Error code
-* Path
-* Source (subgraph name)
+
+- Operation name
+- Operation type (query/mutation/subscription)
+- Apollo operation ID
+- Client name
+- Client version
+- Error code
+- Path
+- Service (subgraph name)
 
 This metric is currently only sent to GraphOS and is not available in 3rd-party OTel destinations. The metric can be enabled using the configuration `telemetry.apollo.errors.experimental_otlp_error_metrics: enabled`.
 

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -897,7 +897,7 @@ impl RouterService {
                     "apollo.client.version" = client_version.clone(),
                     "graphql.error.extensions.code" = code_str,
                     "graphql.error.path" = path,
-                    "apollo.router.error.source" = service
+                    "apollo.router.error.service" = service
                 );
             }
         }

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -697,7 +697,7 @@ async fn it_stores_operation_error_when_config_is_enabled() {
                 KeyValue::new("apollo.client.version", client_version),
                 KeyValue::new("graphql.error.extensions.code", "SOME_ERROR_CODE"),
                 KeyValue::new("graphql.error.path", "/obj/field"),
-                KeyValue::new("apollo.router.error.source", "mySubgraph"),
+                KeyValue::new("apollo.router.error.service", "mySubgraph"),
             ]
         );
         assert_counter!(
@@ -711,7 +711,7 @@ async fn it_stores_operation_error_when_config_is_enabled() {
                 KeyValue::new("apollo.client.version", client_version),
                 KeyValue::new("graphql.error.extensions.code", "SOME_OTHER_ERROR_CODE"),
                 KeyValue::new("graphql.error.path", "/obj/arr/@/firstElementField"),
-                KeyValue::new("apollo.router.error.source", "myOtherSubgraph"),
+                KeyValue::new("apollo.router.error.service", "myOtherSubgraph"),
             ]
         );
     }


### PR DESCRIPTION
*Description here*

Slight modification based on https://github.com/apollographql/router/pull/6666.  Changing the attribute name for one of the dimensions ("source" -> "service") so that it matches with the name currently being used by the errors themselves.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
