### PR TITLE
(Demand Control) Properly short-circuit __typename scoring on response fields

### DIFF
--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_ships_typename_query.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_ships_typename_query.graphql
@@ -1,0 +1,7 @@
+query NamedQuery {
+    users {
+        __typename
+        licenseNumber
+        name
+    }
+}

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_ships_typename_response.json
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_ships_typename_response.json
@@ -1,0 +1,16 @@
+{
+    "data": {
+        "users": [
+            {
+                "__typename": "User",
+                "licenseNumber": 1,
+                "name": "Kate Chopin"
+            },
+            {
+                "__typename": "User",
+                "licenseNumber": 2,
+                "name": "Paul Auster"
+            }
+        ]
+    }
+}

--- a/apollo-router/src/plugins/demand_control/cost_calculator/snapshots/apollo_router__plugins__demand_control__cost_calculator__static_cost__tests__federated_query_with_typenames@logs.snap
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/snapshots/apollo_router__plugins__demand_control__cost_calculator__static_cost__tests__federated_query_with_typenames@logs.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+expression: yaml
+---
+[]

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -630,8 +630,10 @@ mod tests {
     use bytes::Bytes;
     use test_log::test;
     use tower::Service;
+    use tracing::instrument::WithSubscriber;
 
     use super::*;
+    use crate::assert_snapshot_subscriber;
     use crate::plugins::authorization::CacheKeyMetadata;
     use crate::query_planner::QueryPlannerService;
     use crate::services::layers::query_analysis::ParsedDocument;
@@ -1061,6 +1063,22 @@ mod tests {
 
         assert_eq!(conservative_estimate, 10200.0);
         assert_eq!(narrow_estimate, 35.0);
+    }
+
+    #[test(tokio::test)]
+    async fn federated_query_with_typenames() {
+        let schema = include_str!("./fixtures/federated_ships_schema.graphql");
+        let query = include_str!("./fixtures/federated_ships_typename_query.graphql");
+        let variables = "{}";
+        let response = include_bytes!("./fixtures/federated_ships_typename_response.json");
+
+        async {
+            assert_eq!(actual_cost(schema, query, variables, response), 2.0);
+        }
+        // This was previously logging a warning for every __typename in the response. At the time of writing,
+        // this should not produce logs. Generally, it should not produce undue noise for valid requests.
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
     }
 
     #[test(tokio::test)]


### PR DESCRIPTION
When scoring responses with `__typename`, the lookups were failing and producing far too many warn logs. In request scoring, we short-circuit on this field because it isn't included in the pre-processed schema. This change does the same on response scoring, and it changes the log messages from warn to debug logs.

<!-- ROUTER-1020 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
