### PR TITLE
add log dump to integration panic

### DIFF
--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -870,7 +870,10 @@ impl IntegrationTest {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         self.dump_stack_traces();
-        panic!("'{msg}' not detected in logs");
+        panic!(
+            "'{msg}' not detected in logs. Log dump below:\n\n{logs}",
+            logs = self.logs.join("\n")
+        );
     }
 
     #[allow(dead_code)]

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -884,7 +884,10 @@ impl IntegrationTest {
             }
         }
 
-        panic!("'{msg}' not detected in logs");
+        panic!(
+            "'{msg}' not detected in logs. Log dump below:\n\n{logs}",
+            logs = self.logs.join("\n")
+        );
     }
 
     #[allow(dead_code)]
@@ -894,7 +897,10 @@ impl IntegrationTest {
             if let Ok(line) = self.stdio_rx.try_recv() {
                 if line.contains(msg) {
                     self.dump_stack_traces();
-                    panic!("'{msg}' detected in logs");
+                    panic!(
+                        "'{msg}' detected in logs. Log dump below:\n\n{logs}",
+                        logs = self.logs.join("\n")
+                    );
                 }
             }
             tokio::time::sleep(Duration::from_millis(10)).await;


### PR DESCRIPTION
This commit adds back a dump of the logs when running the test harness so that failing tests dump their log for better debugging.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
