### PR TITLE
chore(federation): use attributes on debug spans instead of fmt syntax

### DIFF
--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -2949,7 +2949,11 @@ impl OpGraphPath {
         condition_resolver: &mut impl ConditionResolver,
         override_conditions: &EnabledOverrideConditions,
     ) -> Result<(Option<Vec<SimultaneousPaths>>, Option<bool>), FederationError> {
-        let span = debug_span!("Trying to advance {self} directly with {operation_element}");
+        let span = debug_span!(
+            "Trying to advance directly",
+            from = %self,
+            operation_element = %operation_element,
+        );
         let _guard = span.enter();
         let tail_weight = self.graph.node_weight(self.tail)?;
         let QueryGraphNodeType::SchemaType(tail_type_pos) = &tail_weight.type_ else {
@@ -3236,7 +3240,10 @@ impl OpGraphPath {
                                 "Trying to collect field from options {implementation_options:?}"
                             );
                             for implementation_option in &mut implementation_options {
-                                let span = debug_span!("For {implementation_option}");
+                                let span = debug_span!(
+                                    "implementation option",
+                                    implementation_option = %implementation_option
+                                );
                                 let _guard = span.enter();
                                 let field_options_for_implementation = implementation_option
                                     .advance_with_operation_element(
@@ -3394,7 +3401,10 @@ impl OpGraphPath {
                         debug!("Trying to type-explode into intersection between current type and {type_condition_name} = [{}]", intersection.clone().format(","));
                         let mut options_for_each_implementation = vec![];
                         for implementation_type_pos in intersection {
-                            let span = debug_span!("Trying {implementation_type_pos}");
+                            let span = debug_span!(
+                                "attempt type explosion",
+                                implementation_type = %implementation_type_pos
+                            );
                             let guard = span.enter();
                             let implementation_inline_fragment = InlineFragment {
                                 schema: self.graph.schema_by_source(&tail_weight.source)?.clone(),


### PR DESCRIPTION
Span names do not support `format!` syntax. Instead fields can be used. The `%` operator tells `tracing` to use the Display impl.

Spotted while trying out https://github.com/apollographql/router/pull/6717 :)
