### PR TITLE
docs: remove mention of apollo_router_http_requests in metrics exporter docs

### DIFF
--- a/docs/source/reference/router/telemetry/metrics-exporters/overview.mdx
+++ b/docs/source/reference/router/telemetry/metrics-exporters/overview.mdx
@@ -26,7 +26,6 @@ Common metrics configuration contains global settings for all exporters:
 * [Service name](#service_name)
 * [Resource attributes](#resource)
 * [Custom default histogram buckets](#buckets)
-* [`apollo_router_http_requests` attributes](#attributes)
 * [OpenTelemetry views](#views)
 
 ### `service_name`
@@ -163,7 +162,6 @@ telemetry:
 | `service_name`      | `unknown_service:router` | The OpenTelemetry service name.                               |
 | `service_namespace` |                          | The OpenTelemetry namespace.                                  |
 | `resource`          |                          | The OpenTelemetry resource to attach to metrics.              |
-| `attributes`        |                          | Customization for the apollo_router_http_requests instrument. |
 | `views`             |                          | Override default buckets or configuration for metrics (including dropping the metric itself) |
 
 


### PR DESCRIPTION
`apollo_router_http_requests` metrics were removed in Router 2.0 by https://github.com/apollographql/router/pull/6361. This removes the remaining mentions of them in documention.

`docs/source/reference/migration/from-router-v1.mdx` documents:

> This is replaced by `http.server.request.duration` metric for requests from clients to router and `http.client.request.duration` for requests from router to subgraphs.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
