### PR TITLE
(fix) Header propagation rule passthrough (backport #6690)

### DIFF
--- a/.changesets/fix_bryn_header_propagation_or.md
+++ b/.changesets/fix_bryn_header_propagation_or.md
@@ -1,0 +1,51 @@
+### Header propagation rules passthrough ([PR #6690](https://github.com/apollographql/router/pull/6690))
+
+Header propagation contains logic to prevent headers from being propagated more than once. This was broken
+in https://github.com/apollographql/router/pull/6281 which always considered a header propagated regardless if a rule
+actually matched.
+
+This PR alters the logic so that only when a header is populated then the header is marked as fixed.
+
+The following will now work again:
+
+```
+headers:
+  all:
+    request:
+      - propagate:
+          named: a
+          rename: b
+      - propagate:
+          named: b
+```
+
+Note that defaulting a head WILL populate a header, so make sure to include your defaults last in your propagation
+rules.
+
+```
+headers:
+  all:
+    request:
+      - propagate:
+          named: a
+          rename: b
+          default: defaulted # This will prevent any further rule evaluation for header `b`
+      - propagate:
+          named: b
+```
+
+Instead, make sure that your headers are defaulted last:
+
+```
+headers:
+  all:
+    request:
+      - propagate:
+          named: a
+          rename: b
+      - propagate:
+          named: b
+          default: defaulted # OK
+```
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/6690

--- a/apollo-router/src/plugins/headers/fixtures/propagate_passthrough.router.yaml
+++ b/apollo-router/src/plugins/headers/fixtures/propagate_passthrough.router.yaml
@@ -1,0 +1,10 @@
+headers:
+  all:
+    request:
+      - propagate:
+          matching: .*
+      - propagate:
+          named: a
+          rename: b
+      - propagate:
+          named: b

--- a/apollo-router/src/plugins/headers/fixtures/propagate_passthrough_defaulted.router.yaml
+++ b/apollo-router/src/plugins/headers/fixtures/propagate_passthrough_defaulted.router.yaml
@@ -1,0 +1,9 @@
+headers:
+  all:
+    request:
+      - propagate:
+          named: a
+          rename: b
+      - propagate:
+          named: b
+          default: defaulted

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -403,13 +403,14 @@ impl<S> HeadersService<S> {
                         if values.iter().count() == 0 {
                             if let Some(default) = default {
                                 headers.append(target_header, default.clone());
+                                already_propagated.insert(target_header.as_str());
                             }
                         } else {
                             for value in values {
                                 headers.append(target_header, value.clone());
+                                already_propagated.insert(target_header.as_str());
                             }
                         }
-                        already_propagated.insert(target_header.as_str());
                     }
                 }
                 Operation::Propagate(Propagate::Matching { matching }) => {
@@ -459,10 +460,10 @@ mod test {
     use tower::BoxError;
 
     use super::*;
+    use crate::graphql;
     use crate::graphql::Request;
     use crate::plugin::test::MockSubgraphService;
-    use crate::plugins::headers::Config;
-    use crate::plugins::headers::HeadersLayer;
+    use crate::plugins::test::PluginTestHarness;
     use crate::query_planner::fetch::OperationKind;
     use crate::services::SubgraphRequest;
     use crate::services::SubgraphResponse;
@@ -1066,5 +1067,88 @@ mod test {
 
             true
         }
+    }
+
+    async fn assert_headers(
+        config: &'static str,
+        input: Vec<(&'static str, &'static str)>,
+        output: Vec<(&'static str, &'static str)>,
+    ) {
+        let test_harness = PluginTestHarness::<Headers>::builder()
+            .config(config)
+            .build()
+            .await;
+        let service = test_harness.subgraph_service("test", move |r| {
+            let output = output.clone();
+            async move {
+                // Assert the headers here
+                let headers = r.subgraph_request.headers();
+                for (name, value) in output.iter() {
+                    if let Some(header) = headers.get(*name) {
+                        assert_eq!(header.to_str().unwrap(), *value);
+                    } else {
+                        panic!("missing header {}", name);
+                    }
+                }
+                Ok(subgraph::Response::fake_builder().build())
+            }
+        });
+
+        let mut req = http::Request::builder();
+        for (name, value) in input.iter() {
+            req = req.header(*name, *value);
+        }
+
+        service
+            .call(
+                subgraph::Request::fake_builder()
+                    .supergraph_request(Arc::new(
+                        req.body(graphql::Request::default())
+                            .expect("valid request"),
+                    ))
+                    .build(),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_propagate_passthrough() {
+        assert_headers(
+            include_str!("fixtures/propagate_passthrough.router.yaml"),
+            vec![("a", "av"), ("c", "cv")],
+            vec![("a", "av"), ("b", "av"), ("c", "cv")],
+        )
+        .await;
+
+        assert_headers(
+            include_str!("fixtures/propagate_passthrough.router.yaml"),
+            vec![("b", "bv"), ("c", "cv")],
+            vec![("b", "bv"), ("c", "cv")],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_propagate_passthrough_defaulted() {
+        assert_headers(
+            include_str!("fixtures/propagate_passthrough_defaulted.router.yaml"),
+            vec![("a", "av")],
+            vec![("b", "av")],
+        )
+        .await;
+
+        assert_headers(
+            include_str!("fixtures/propagate_passthrough_defaulted.router.yaml"),
+            vec![("b", "bv")],
+            vec![("b", "bv")],
+        )
+        .await;
+        assert_headers(
+            include_str!("fixtures/propagate_passthrough_defaulted.router.yaml"),
+            vec![("c", "cv")],
+            vec![("b", "defaulted")],
+        )
+        .await;
     }
 }

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -133,15 +133,22 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     #[allow(dead_code)]
     pub(crate) async fn call_router<F>(
         &self,
+<<<<<<< HEAD
         request: router::Request,
         response_fn: fn(router::Request) -> F,
     ) -> Result<router::Response, BoxError>
+=======
+        response_fn: impl Fn(router::Request) -> F + Send + Sync + Clone + 'static,
+    ) -> ServiceHandle<router::Request, router::BoxService>
+>>>>>>> ea7f255a ((fix) Header propagation rule passthrough (#6690))
     where
         F: Future<Output = Result<router::Response, BoxError>> + Send + 'static,
     {
         let service: router::BoxService = router::BoxService::new(
-            ServiceBuilder::new()
-                .service_fn(move |req: router::Request| async move { (response_fn)(req).await }),
+            ServiceBuilder::new().service_fn(move |req: router::Request| {
+                let response_fn = response_fn.clone();
+                async move { (response_fn)(req).await }
+            }),
         );
 
         self.plugin.router_service(service).call(request).await
@@ -149,12 +156,25 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
 
     pub(crate) async fn call_supergraph(
         &self,
+<<<<<<< HEAD
         request: supergraph::Request,
         response_fn: fn(supergraph::Request) -> supergraph::Response,
     ) -> Result<supergraph::Response, BoxError> {
         let service: supergraph::BoxService = supergraph::BoxService::new(
             ServiceBuilder::new()
                 .service_fn(move |req: supergraph::Request| async move { Ok((response_fn)(req)) }),
+=======
+        response_fn: impl Fn(supergraph::Request) -> F + Send + Sync + Clone + 'static,
+    ) -> ServiceHandle<supergraph::Request, supergraph::BoxService>
+    where
+        F: Future<Output = Result<supergraph::Response, BoxError>> + Send + 'static,
+    {
+        let service: supergraph::BoxService = supergraph::BoxService::new(
+            ServiceBuilder::new().service_fn(move |req: supergraph::Request| {
+                let response_fn = response_fn.clone();
+                async move { (response_fn)(req).await }
+            }),
+>>>>>>> ea7f255a ((fix) Header propagation rule passthrough (#6690))
         );
 
         self.plugin.supergraph_service(service).call(request).await
@@ -163,12 +183,25 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     #[allow(dead_code)]
     pub(crate) async fn call_execution(
         &self,
+<<<<<<< HEAD
         request: execution::Request,
         response_fn: fn(execution::Request) -> execution::Response,
     ) -> Result<execution::Response, BoxError> {
         let service: execution::BoxService = execution::BoxService::new(
             ServiceBuilder::new()
                 .service_fn(move |req: execution::Request| async move { Ok((response_fn)(req)) }),
+=======
+        response_fn: impl Fn(execution::Request) -> F + Send + Sync + Clone + 'static,
+    ) -> ServiceHandle<execution::Request, execution::BoxService>
+    where
+        F: Future<Output = Result<execution::Response, BoxError>> + Send + 'static,
+    {
+        let service: execution::BoxService = execution::BoxService::new(
+            ServiceBuilder::new().service_fn(move |req: execution::Request| {
+                let response_fn = response_fn.clone();
+                async move { (response_fn)(req).await }
+            }),
+>>>>>>> ea7f255a ((fix) Header propagation rule passthrough (#6690))
         );
 
         self.plugin.execution_service(service).call(request).await
@@ -177,6 +210,7 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     #[allow(dead_code)]
     pub(crate) async fn call_subgraph(
         &self,
+<<<<<<< HEAD
         request: subgraph::Request,
         response_fn: fn(subgraph::Request) -> subgraph::Response,
     ) -> Result<subgraph::Response, BoxError> {
@@ -185,6 +219,59 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
             ServiceBuilder::new()
                 .service_fn(move |req: subgraph::Request| async move { Ok((response_fn)(req)) }),
         );
+=======
+        subgraph: &str,
+        response_fn: impl Fn(subgraph::Request) -> F + Send + Sync + Clone + 'static,
+    ) -> ServiceHandle<subgraph::Request, subgraph::BoxService>
+    where
+        F: Future<Output = Result<subgraph::Response, BoxError>> + Send + 'static,
+    {
+        let service: subgraph::BoxService = subgraph::BoxService::new(
+            ServiceBuilder::new().service_fn(move |req: subgraph::Request| {
+                let response_fn = response_fn.clone();
+                async move { (response_fn)(req).await }
+            }),
+        );
+        ServiceHandle::new(self.plugin.subgraph_service(subgraph, service))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn http_client_service<F>(
+        &self,
+        subgraph: &str,
+        response_fn: impl Fn(http::HttpRequest) -> F + Send + Sync + Clone + 'static,
+    ) -> ServiceHandle<http::HttpRequest, http::BoxService>
+    where
+        F: Future<Output = Result<http::HttpResponse, BoxError>> + Send + 'static,
+    {
+        let service: http::BoxService = http::BoxService::new(ServiceBuilder::new().service_fn(
+            move |req: http::HttpRequest| {
+                let response_fn = response_fn.clone();
+                async move { (response_fn)(req).await }
+            },
+        ));
+
+        ServiceHandle::new(self.plugin.http_client_service(subgraph, service))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn call_connector_request_service(
+        &self,
+        request: connector::request_service::Request,
+        response_fn: impl Fn(connector::request_service::Request) -> connector::request_service::Response
+            + Send
+            + Sync
+            + Clone
+            + 'static,
+    ) -> Result<connector::request_service::Response, BoxError> {
+        let service: connector::request_service::BoxService =
+            connector::request_service::BoxService::new(ServiceBuilder::new().service_fn(
+                move |req: connector::request_service::Request| {
+                    let response_fn = response_fn.clone();
+                    async move { Ok((response_fn)(req)) }
+                },
+            ));
+>>>>>>> ea7f255a ((fix) Header propagation rule passthrough (#6690))
 
         self.plugin
             .subgraph_service(&name.expect("subgraph name must be populated"), service)

--- a/docs/source/routing/header-propagation.mdx
+++ b/docs/source/routing/header-propagation.mdx
@@ -42,7 +42,9 @@ You can specify which headers to propagate based on a matching [regex pattern](h
 
 <Note>
 
-The router _never_ propagates so-called [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Content-Length`) when propagating by pattern.
+    The router _never_ propagates so-called [hop-by-hop
+    headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Content-Length`)
+    when propagating by pattern.
 
 </Note>
 
@@ -169,6 +171,44 @@ headers:
 
 With this ordering, first all headers are added to the propagation list, then the `test` header is removed.
 
+## Rule fallthrough
+
+Headers will only propagate to a target header once via the first matching rule to do so. Ensure that defaulting of headers is done in the last rule so that other rules are not ignored:
+
+<p style="margin-bottom: 0;">❌</p>
+
+```yaml title="bad_configuration.yaml"
+headers:
+  all:
+    request:
+      - propagate:
+          named: "some-header"
+          default: "some default"
+      - propagate:
+          named: "some-other-header"
+          rename: "some-header"
+```
+
+In this example, `some-other-header` will not be propagated to `some-header` because it has already been defaulted by the previous rule.
+
+To correctly have fallthrough of rules make sure that any defaulting is done in the last rule:
+
+<p style="margin-bottom: 0;">✅</p>
+
+```yaml title="good_configuration.yaml"
+headers:
+  all:
+    request:
+      - propagate:
+          named: "some-header"
+      - propagate:
+          named: "some-other-header"
+          rename: "some-header"
+          default: "some default"
+```
+
+With this ordering, the `some-other-header` will be propagated to `some-header` if `some-header` is not present. If no header is present, `some-header` will be set to the default.
+
 ## Example
 
 Here's a complete example showing all the possible configuration options in use:
@@ -211,6 +251,7 @@ headers:
             name: "router-subgraph-name"
             value: "accounts"
 ```
+
 
 ## Response header propagation
 
@@ -258,7 +299,8 @@ fn subgraph_service(service, subgraph) {
 
 <Note>
 
-If you require a configuration-based solution for response header propagation, [please leave a comment on our issue tracker](https://github.com/apollographql/router/issues/1284).
+    If you require a configuration-based solution for response header propagation, [please leave a comment on our issue
+    tracker](https://github.com/apollographql/router/issues/1284).
 
 </Note>
 


### PR DESCRIPTION
Header propagation contains logic to prevent headers from being propagated more than once. This was broken in https://github.com/apollographql/router/pull/6281 which always considered a header propagated regardless  if a rule actually matched.

This PR alters the logic so that only when a header is populated then the header is marked as fixed.

The following will now work again:
```
headers:
  all:
    request:
      - propagate:
          named: a
          rename: b
      - propagate:
          named: b
```

Note that defaulting a head WILL populate a header, so make sure to include your defaults last in your propagation rules.

```
headers:
  all:
    request:
      - propagate:
          named: a
          rename: b
          default: defaulted # This will prevent any further rule evaluation for header `b`
      - propagate:
          named: b
```
Instead make sure that your headers are defaulted last:

```
headers:
  all:
    request:
      - propagate:
          named: a
          rename: b
      - propagate:
          named: b
          default: defaulted # OK
```





---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6690 done by [Mergify](https://mergify.com).