### PR TITLE
Add ability to specify path as regex in snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "serde_derive_default",
  "serde_json",
  "serde_json_bytes",
+ "serde_regex",
  "serde_urlencoded",
  "serde_yaml",
  "serial_test",
@@ -6282,6 +6283,16 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -53,7 +53,7 @@ telemetry_next = []
 ci = []
 
 # Enables the HTTP snapshot server for testing
-snapshot = ["axum-server"]
+snapshot = ["axum-server", "serde_regex"]
 
 [package.metadata.docs.rs]
 features = ["docs_rs"]
@@ -203,6 +203,7 @@ serde.workspace = true
 serde_derive_default = "0.1"
 serde_json_bytes.workspace = true
 serde_json.workspace = true
+serde_regex = { version = "1.1.0", optional = true }
 serde_urlencoded = "0.7.1"
 serde_yaml = "0.8.26"
 static_assertions = "1.1.0"
@@ -313,6 +314,7 @@ rhai = { version = "1.17.1", features = [
     "internals",
     "testing-environ",
 ] }
+serde_regex = { version = "1.1.0" }
 serial_test = { version = "3.1.1" }
 tempfile.workspace = true
 test-log = { version = "0.2.16", default-features = false, features = [


### PR DESCRIPTION
Add the ability to specify a `regex` for the URL path in a shapshot file. This is useful when constructing tests that may result in a number of HTTP requests where responses can be reused, or where the path is dynamically generated during the test (such as a randomly generated identifier).

```json
    "request": {
        "method": "GET",
        "path": null,
        "regex": "users/.*/posts",
        "body": null
    },
```

The snapshot server first looks for an exact match to the URL path in the map, then sequentially applies each `regex` if no exact match if found. Performance could degrade if there were a lot of `regex` snapshots, but this should be reasonable for a small number of snapshots.

The regular expression provided will need to escape any special characters used by the `regex` crate, such as the `?` in query parameters, using `\\`.

The `regex` is never set when taking snapshots from the upstream API. The only way to use it is to manually edit a snapshot file, typically by converting an existing snapshot by changing `path` to `regex` and replacing the variable part of the path with wilcards.

These changes are backward compatible with existing snapshot files, so there is no need to update any source controlled snapshots.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
