### PR TITLE
Use HTTP 503 Service Unavailable for free plan rate limit

### DIFF
--- a/apollo-router/src/plugins/router_limits/mod.rs
+++ b/apollo-router/src/plugins/router_limits/mod.rs
@@ -81,7 +81,7 @@ impl PluginPrivate for RouterLimits {
                                 .extension_code(extension_code)
                                 .build();
                             Ok(RouterResponse::error_builder()
-                                .status_code(StatusCode::TOO_MANY_REQUESTS)
+                                .status_code(StatusCode::SERVICE_UNAVAILABLE)
                                 .error(error)
                                 .context(ctx)
                                 .build()
@@ -158,7 +158,7 @@ mod test {
         // * the third, delayed req succeeds
 
         assert!(r1.is_ok_and(|resp| resp.response.status().is_success()));
-        assert!(r2.is_ok_and(|resp| resp.response.status() == StatusCode::TOO_MANY_REQUESTS));
+        assert!(r2.is_ok_and(|resp| resp.response.status() == StatusCode::SERVICE_UNAVAILABLE));
         assert!(r3
             .await
             .is_ok_and(|resp| resp.response.status().is_success()));


### PR DESCRIPTION
[HTTP 429 Too Many Requests](https://www.rfc-editor.org/rfc/rfc6585#section-4) normally means that a specific user or client is making too many requests, but the TPS limit counts total requests per Router instance regardless of how many clients are making them. [HTTP 503 Service Unavailable](https://www.rfc-editor.org/rfc/rfc9110#status.503) is more appropriate and should be returned instead since “temporary overload” is a possible reason for unavailability.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
