### PR TITLE
Reduce demand control allocations on start/reload

### DIFF
--- a/.changesets/maint_tninesling_skip_disabled_dc_plugin.md
+++ b/.changesets/maint_tninesling_skip_disabled_dc_plugin.md
@@ -1,0 +1,5 @@
+### Reduce demand control allocations on start/reload ([PR #6754](https://github.com/apollographql/router/pull/6754))
+
+When enabled, preallocates capacity for demand control's processed schema and shrinks to fit after processing. When disabled, skips the type processing entirely to minimize startup impact.
+
+By [@tninesling](https://github.com/tninesling) in https://github.com/apollographql/router/pull/6754

--- a/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
@@ -165,7 +165,7 @@ impl DemandControlledSchema {
                 ExtendedType::Interface(ty) => {
                     let type_fields = output_field_definitions
                         .entry(type_name.clone())
-                        .or_default();
+                        .or_insert_with(|| HashMap::with_capacity(ty.fields.len()));
                     for (field_name, field_definition) in &ty.fields {
                         type_fields.insert(
                             field_name.clone(),
@@ -176,7 +176,7 @@ impl DemandControlledSchema {
                 ExtendedType::Object(ty) => {
                     let type_fields = output_field_definitions
                         .entry(type_name.clone())
-                        .or_default();
+                        .or_insert_with(|| HashMap::with_capacity(ty.fields.len()));
                     for (field_name, field_definition) in &ty.fields {
                         type_fields.insert(
                             field_name.clone(),
@@ -187,7 +187,7 @@ impl DemandControlledSchema {
                 ExtendedType::InputObject(ty) => {
                     let type_fields = input_field_definitions
                         .entry(type_name.clone())
-                        .or_default();
+                        .or_insert_with(|| HashMap::with_capacity(ty.fields.len()));
                     for (field_name, field_definition) in &ty.fields {
                         type_fields.insert(
                             field_name.clone(),

--- a/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
@@ -156,9 +156,9 @@ impl DemandControlledSchema {
     pub(crate) fn new(schema: Arc<Valid<Schema>>) -> Result<Self, DemandControlError> {
         let fed_schema = ValidFederationSchema::new((*schema).clone())?;
         let mut input_field_definitions: HashMap<Name, HashMap<Name, InputDefinition>> =
-            HashMap::new();
+            HashMap::with_capacity(schema.types.len());
         let mut output_field_definitions: HashMap<Name, HashMap<Name, FieldDefinition>> =
-            HashMap::new();
+            HashMap::with_capacity(schema.types.len());
 
         for (type_name, type_) in &schema.types {
             match type_ {
@@ -201,10 +201,22 @@ impl DemandControlledSchema {
             }
         }
 
+        input_field_definitions.shrink_to_fit();
+        output_field_definitions.shrink_to_fit();
+
         Ok(Self {
             inner: fed_schema,
             input_field_definitions,
             output_field_definitions,
+        })
+    }
+
+    pub(crate) fn empty(schema: Arc<Valid<Schema>>) -> Result<Self, DemandControlError> {
+        let fed_schema = ValidFederationSchema::new((*schema).clone())?;
+        Ok(Self {
+            inner: fed_schema,
+            input_field_definitions: Default::default(),
+            output_field_definitions: Default::default(),
         })
     }
 

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -306,6 +306,19 @@ impl Plugin for DemandControl {
     type Config = DemandControlConfig;
 
     async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+        if !init.config.enabled {
+            return Ok(DemandControl {
+                strategy_factory: StrategyFactory::new(
+                    init.config.clone(),
+                    Arc::new(DemandControlledSchema::empty(
+                        init.supergraph_schema.clone(),
+                    )?),
+                    Arc::new(HashMap::new()),
+                ),
+                config: init.config,
+            });
+        }
+
         let demand_controlled_supergraph_schema =
             DemandControlledSchema::new(init.supergraph_schema.clone())?;
         let mut demand_controlled_subgraph_schemas = HashMap::new();


### PR DESCRIPTION
When enabled, preallocates capacity for demand control's processed schema and shrinks to fit after processing. When disabled, skips the type processing entirely to minimize startup impact.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
