### PR TITLE
Fix backpressure for compute jobs

### DIFF
--- a/apollo-router/src/ageing_priority_queue.rs
+++ b/apollo-router/src/ageing_priority_queue.rs
@@ -14,6 +14,9 @@ pub(crate) enum Priority {
     P8,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct QueueIsFullError;
+
 const INNER_QUEUES_COUNT: usize = Priority::P8 as usize - Priority::P1 as usize + 1;
 
 /// Indices start at 0 for highest priority
@@ -34,7 +37,7 @@ where
     inner_queues:
         [(crossbeam_channel::Sender<T>, crossbeam_channel::Receiver<T>); INNER_QUEUES_COUNT],
     queued_count: AtomicUsize,
-    soft_capacity: usize,
+    capacity: usize,
 }
 
 pub(crate) struct Receiver<'a, T>
@@ -49,12 +52,12 @@ impl<T> AgeingPriorityQueue<T>
 where
     T: Send + 'static,
 {
-    pub(crate) fn soft_bounded(soft_capacity: usize) -> Self {
+    pub(crate) fn bounded(capacity: usize) -> Self {
         Self {
             // Using unbounded channels: callers must use `is_full` to implement backpressure
             inner_queues: std::array::from_fn(|_| crossbeam_channel::unbounded()),
             queued_count: AtomicUsize::new(0),
-            soft_capacity,
+            capacity,
         }
     }
 
@@ -62,15 +65,16 @@ where
         self.queued_count.load(Ordering::Relaxed)
     }
 
-    pub(crate) fn is_full(&self) -> bool {
-        self.queued_count() >= self.soft_capacity
-    }
-
     /// Panics if `priority` is not in `AVAILABLE_PRIORITIES`
-    pub(crate) fn send(&self, priority: Priority, message: T) {
-        self.queued_count.fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn send(&self, priority: Priority, message: T) -> Result<(), QueueIsFullError> {
+        self.queued_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |previous_count| {
+                (previous_count < self.capacity).then_some(previous_count + 1)
+            })
+            .map_err(|_| QueueIsFullError)?;
         let (inner_sender, _) = &self.inner_queues[index_from_priority(priority)];
-        inner_sender.send(message).expect("disconnected channel")
+        inner_sender.send(message).expect("disconnected channel");
+        Ok(())
     }
 
     pub(crate) fn receiver(&self) -> Receiver<'_, T> {
@@ -121,17 +125,16 @@ where
 
 #[test]
 fn test_priorities() {
-    let queue = AgeingPriorityQueue::soft_bounded(3);
+    let queue = AgeingPriorityQueue::bounded(4);
     assert_eq!(queue.queued_count(), 0);
-    assert!(!queue.is_full());
-    queue.send(Priority::P1, "p1");
-    assert!(!queue.is_full());
-    queue.send(Priority::P2, "p2");
-    assert!(!queue.is_full());
-    queue.send(Priority::P3, "p3");
-    // The queue is now "full" but sending still works, it’s up to the caller to stop sending
-    assert!(queue.is_full());
-    queue.send(Priority::P2, "p2 again");
+    queue.send(Priority::P1, "p1").unwrap();
+    assert_eq!(queue.queued_count(), 1);
+    queue.send(Priority::P2, "p2").unwrap();
+    queue.send(Priority::P3, "p3").unwrap();
+    queue.send(Priority::P2, "p2 again").unwrap();
+    assert_eq!(queue.queued_count(), 4);
+    // The queue is full now, this send() fails:
+    queue.send(Priority::P3, "p5").unwrap_err();
     assert_eq!(queue.queued_count(), 4);
 
     let mut receiver = queue.receiver();

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -16,9 +16,12 @@ use crate::configuration::RedisCache;
 pub(crate) mod redis;
 mod size_estimation;
 pub(crate) mod storage;
+use std::convert::Infallible;
+
 pub(crate) use size_estimation::estimate_size;
 
-type WaitMap<K, V> = Arc<Mutex<HashMap<K, broadcast::Sender<V>>>>;
+type WaitMap<K, V, UncachedError> =
+    Arc<Mutex<HashMap<K, broadcast::Sender<Result<V, UncachedError>>>>>;
 pub(crate) const DEFAULT_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(512) {
     Some(v) => v,
     None => unreachable!(),
@@ -26,15 +29,20 @@ pub(crate) const DEFAULT_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(
 
 /// Cache implementation with query deduplication
 #[derive(Clone)]
-pub(crate) struct DeduplicatingCache<K: KeyType, V: ValueType> {
-    wait_map: WaitMap<K, V>,
+pub(crate) struct DeduplicatingCache<K, V, UncachedError = Infallible>
+where
+    K: KeyType,
+    V: ValueType,
+{
+    wait_map: WaitMap<K, V, UncachedError>,
     storage: CacheStorage<K, V>,
 }
 
-impl<K, V> DeduplicatingCache<K, V>
+impl<K, V, UncachedError> DeduplicatingCache<K, V, UncachedError>
 where
     K: KeyType + 'static,
     V: ValueType + 'static,
+    UncachedError: Clone + Send + 'static,
 {
     pub(crate) async fn with_capacity(
         capacity: NonZeroUsize,
@@ -60,7 +68,7 @@ where
         &self,
         key: &K,
         init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
-    ) -> Entry<K, V> {
+    ) -> Entry<K, V, UncachedError> {
         // waiting on a value from the cache is a potentially long(millisecond scale) task that
         // can involve a network call to an external database. To reduce the waiting time, we
         // go through a wait map to register interest in data associated with a key.
@@ -99,7 +107,7 @@ where
                 drop(locked_wait_map);
 
                 if let Some(value) = self.storage.get(key, init_from_redis).await {
-                    self.send(sender, key, value.clone()).await;
+                    self.send(sender, key, Ok(value.clone())).await;
 
                     return Entry {
                         inner: EntryInner::Value(value),
@@ -126,7 +134,12 @@ where
         self.storage.insert_in_memory(key, value).await;
     }
 
-    async fn send(&self, sender: broadcast::Sender<V>, key: &K, value: V) {
+    async fn send(
+        &self,
+        sender: broadcast::Sender<Result<V, UncachedError>>,
+        key: &K,
+        value: Result<V, UncachedError>,
+    ) {
         // Lock the wait map to prevent more subscribers racing with our send
         // notification
         let mut locked_wait_map = self.wait_map.lock().await;
@@ -143,44 +156,49 @@ where
     }
 }
 
-pub(crate) struct Entry<K: KeyType, V: ValueType> {
-    inner: EntryInner<K, V>,
+pub(crate) struct Entry<K: KeyType, V: ValueType, UncachedError> {
+    inner: EntryInner<K, V, UncachedError>,
 }
-enum EntryInner<K: KeyType, V: ValueType> {
+enum EntryInner<K: KeyType, V: ValueType, UncachedError> {
     First {
         key: K,
-        sender: broadcast::Sender<V>,
-        cache: DeduplicatingCache<K, V>,
+        sender: broadcast::Sender<Result<V, UncachedError>>,
+        cache: DeduplicatingCache<K, V, UncachedError>,
         _drop_signal: oneshot::Sender<()>,
     },
     Receiver {
-        receiver: broadcast::Receiver<V>,
+        receiver: broadcast::Receiver<Result<V, UncachedError>>,
     },
     Value(V),
 }
 
 #[derive(Debug)]
-pub(crate) enum EntryError {
-    Closed,
+pub(crate) enum EntryError<UncachedError> {
     IsFirst,
+    RecvError,
+    UncachedError(UncachedError),
 }
 
-impl<K, V> Entry<K, V>
+impl<K, V, UncachedError> Entry<K, V, UncachedError>
 where
     K: KeyType + 'static,
     V: ValueType + 'static,
+    UncachedError: Clone + Send + 'static,
 {
     pub(crate) fn is_first(&self) -> bool {
         matches!(self.inner, EntryInner::First { .. })
     }
 
-    pub(crate) async fn get(self) -> Result<V, EntryError> {
+    pub(crate) async fn get(self) -> Result<V, EntryError<UncachedError>> {
         match self.inner {
             // there was already a value in cache
             EntryInner::Value(v) => Ok(v),
-            EntryInner::Receiver { mut receiver } => {
-                receiver.recv().await.map_err(|_| EntryError::Closed)
-            }
+            EntryInner::Receiver { mut receiver } => match receiver.recv().await {
+                Ok(Ok(value)) => Ok(value),
+                Ok(Err(e)) => Err(EntryError::UncachedError(e)),
+                Err(broadcast::error::RecvError::Closed)
+                | Err(broadcast::error::RecvError::Lagged(_)) => Err(EntryError::RecvError),
+            },
             _ => Err(EntryError::IsFirst),
         }
     }
@@ -194,13 +212,13 @@ where
         } = self.inner
         {
             cache.insert(key.clone(), value.clone()).await;
-            cache.send(sender, &key, value).await;
+            cache.send(sender, &key, Ok(value)).await;
         }
     }
 
     /// sends the value without storing it into the cache
     #[allow(unused)]
-    pub(crate) async fn send(self, value: V) {
+    pub(crate) async fn send(self, value: Result<V, UncachedError>) {
         if let EntryInner::First {
             sender, cache, key, ..
         } = self.inner
@@ -224,9 +242,10 @@ mod tests {
     #[tokio::test]
     async fn example_cache_usage() {
         let k = "key".to_string();
-        let cache = DeduplicatingCache::with_capacity(NonZeroUsize::new(1).unwrap(), None, "test")
-            .await
-            .unwrap();
+        let cache: DeduplicatingCache<String, String> =
+            DeduplicatingCache::with_capacity(NonZeroUsize::new(1).unwrap(), None, "test")
+                .await
+                .unwrap();
 
         let entry = cache.get(&k, |_| Ok(())).await;
 

--- a/apollo-router/src/compute_job.rs
+++ b/apollo-router/src/compute_job.rs
@@ -128,12 +128,10 @@ mod tests {
     #[tokio::test]
     async fn test_executes_on_different_thread() {
         let test_thread = std::thread::current().id();
-        let job_thread = execute(Priority::P4, || {
-            std::thread::current().id()
-        })
-        .unwrap()
-        .await
-        .unwrap();
+        let job_thread = execute(Priority::P4, || std::thread::current().id())
+            .unwrap()
+            .await
+            .unwrap();
         assert_ne!(job_thread, test_thread)
     }
 

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -205,6 +205,8 @@ impl From<QueryPlannerError> for FetchError {
 pub(crate) enum CacheResolverError {
     /// value retrieval failed: {0}
     RetrievalError(Arc<QueryPlannerError>),
+    /// {0}
+    Backpressure(crate::compute_job::ComputeBackPressureError),
     /// batch processing failed: {0}
     BatchingError(String),
 }
@@ -217,6 +219,7 @@ impl IntoGraphQLErrors for CacheResolverError {
                 .clone()
                 .into_graphql_errors()
                 .map_err(|_err| CacheResolverError::RetrievalError(retrieval_error)),
+            CacheResolverError::Backpressure(e) => Ok(vec![e.to_graphql_error()]),
             CacheResolverError::BatchingError(msg) => Ok(vec![Error::builder()
                 .message(msg)
                 .extension_code("BATCH_PROCESSING_FAILED")

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -201,7 +201,7 @@ impl From<QueryPlannerError> for FetchError {
 }
 
 /// Error types for CacheResolver
-#[derive(Error, Debug, Display, Clone, Serialize, Deserialize)]
+#[derive(Error, Debug, Display, Clone)]
 pub(crate) enum CacheResolverError {
     /// value retrieval failed: {0}
     RetrievalError(Arc<QueryPlannerError>),
@@ -264,9 +264,6 @@ pub(crate) enum QueryPlannerError {
 
     /// query planning panicked: {0}
     JoinError(String),
-
-    /// Cache resolution failed: {0}
-    CacheResolverError(Arc<CacheResolverError>),
 
     /// empty query plan. This behavior is unexpected and we suggest opening an issue to apollographql/router with a reproduction.
     EmptyPlan(UsageReporting), // usage_reporting_signature
@@ -440,12 +437,6 @@ impl QueryPlannerError {
 impl From<JoinError> for QueryPlannerError {
     fn from(err: JoinError) -> Self {
         QueryPlannerError::JoinError(err.to_string())
-    }
-}
-
-impl From<CacheResolverError> for QueryPlannerError {
-    fn from(err: CacheResolverError) -> Self {
-        QueryPlannerError::CacheResolverError(Arc::new(err))
     }
 }
 

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -160,10 +160,9 @@ impl IntrospectionCache {
         let schema = schema.clone();
         let doc = doc.clone();
         let priority = compute_job::Priority::P1; // Low priority
-        let response = compute_job::execute(
-            priority,
-            move || Self::execute_introspection(max_depth, &schema, &doc),
-        )?
+        let response = compute_job::execute(priority, move || {
+            Self::execute_introspection(max_depth, &schema, &doc)
+        })?
         // `expect()` propagates any panic that potentially happens in the closure, but:
         //
         // * We try to avoid such panics in the first place and consider them bugs

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -162,7 +162,6 @@ impl IntrospectionCache {
         let priority = compute_job::Priority::P1; // Low priority
         let response = compute_job::execute(
             priority,
-            compute_job::ComputeJobKind::Introspection,
             move || Self::execute_introspection(max_depth, &schema, &doc),
         )?
         // `expect()` propagates any panic that potentially happens in the closure, but:

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -7,6 +7,7 @@ use serde_json_bytes::json;
 
 use crate::cache::storage::CacheStorage;
 use crate::compute_job;
+use crate::compute_job::ComputeBackPressureError;
 use crate::graphql;
 use crate::query_planner::QueryKey;
 use crate::services::layers::query_analysis::ParsedDocument;
@@ -69,12 +70,12 @@ impl IntrospectionCache {
         schema: &Arc<spec::Schema>,
         key: &QueryKey,
         doc: &ParsedDocument,
-    ) -> ControlFlow<graphql::Response, ()> {
+    ) -> ControlFlow<Result<graphql::Response, ComputeBackPressureError>, ()> {
         Self::maybe_lone_root_typename(schema, doc)?;
         if doc.operation.is_query() {
             if doc.has_schema_introspection {
                 if doc.has_explicit_root_fields {
-                    ControlFlow::Break(Self::mixed_fields_error())?;
+                    ControlFlow::Break(Ok(Self::mixed_fields_error()))?;
                 } else {
                     ControlFlow::Break(self.cached_introspection(schema, key, doc).await)?
                 }
@@ -85,7 +86,7 @@ impl IntrospectionCache {
                 let max_depth = MaxDepth::Ignore;
 
                 // Probably a small query, execute it without caching:
-                ControlFlow::Break(Self::execute_introspection(max_depth, schema, doc))?
+                ControlFlow::Break(Ok(Self::execute_introspection(max_depth, schema, doc)))?
             }
         }
         ControlFlow::Continue(())
@@ -99,7 +100,7 @@ impl IntrospectionCache {
     fn maybe_lone_root_typename(
         schema: &Arc<spec::Schema>,
         doc: &ParsedDocument,
-    ) -> ControlFlow<graphql::Response, ()> {
+    ) -> ControlFlow<Result<graphql::Response, ComputeBackPressureError>, ()> {
         if doc.operation.selection_set.selections.len() == 1 {
             if let Selection::Field(field) = &doc.operation.selection_set.selections[0] {
                 if field.name == "__typename" && field.directives.is_empty() {
@@ -112,7 +113,7 @@ impl IntrospectionCache {
                         .expect("validation should have caught undefined root operation")
                         .as_str();
                     let data = json!({key: object_type_name});
-                    ControlFlow::Break(graphql::Response::builder().data(data).build())?
+                    ControlFlow::Break(Ok(graphql::Response::builder().data(data).build()))?
                 }
             }
         }
@@ -137,7 +138,7 @@ impl IntrospectionCache {
         schema: &Arc<spec::Schema>,
         key: &QueryKey,
         doc: &ParsedDocument,
-    ) -> graphql::Response {
+    ) -> Result<graphql::Response, ComputeBackPressureError> {
         let (storage, max_depth) = match &self.0 {
             Mode::Enabled { storage, max_depth } => (storage, *max_depth),
             Mode::Disabled => {
@@ -145,7 +146,7 @@ impl IntrospectionCache {
                     .message(String::from("introspection has been disabled"))
                     .extension_code("INTROSPECTION_DISABLED")
                     .build();
-                return graphql::Response::builder().error(error).build();
+                return Ok(graphql::Response::builder().error(error).build());
             }
         };
         let query = key.filtered_query.clone();
@@ -154,23 +155,25 @@ impl IntrospectionCache {
         // https://github.com/apollographql/router/issues/3831
         let cache_key = query;
         if let Some(response) = storage.get(&cache_key, |_| unreachable!()).await {
-            return response;
+            return Ok(response);
         }
         let schema = schema.clone();
         let doc = doc.clone();
         let priority = compute_job::Priority::P1; // Low priority
-        let response = compute_job::execute(priority, move || {
-            Self::execute_introspection(max_depth, &schema, &doc)
-        })
-        .await
+        let response = compute_job::execute(
+            priority,
+            compute_job::ComputeJobKind::Introspection,
+            move || Self::execute_introspection(max_depth, &schema, &doc),
+        )?
         // `expect()` propagates any panic that potentially happens in the closure, but:
         //
         // * We try to avoid such panics in the first place and consider them bugs
         // * The panic handler in `apollo-router/src/executable.rs` exits the process
         //   so this error case should never be reached.
+        .await
         .expect("Introspection panicked");
         storage.insert(cache_key, response.clone()).await;
-        response
+        Ok(response)
     }
 
     fn execute_introspection(

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -55,6 +55,7 @@ mod apollo_studio_interop;
 pub(crate) mod axum_factory;
 mod batching;
 mod cache;
+#[macro_use]
 mod compute_job;
 mod configuration;
 mod context;

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -327,9 +327,7 @@ where
                             });
                             continue 'all_cache_keys_loop;
                         }
-                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError(
-                            _,
-                        ))) => {
+                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError)) => {
                             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                             // try again
                         }
@@ -367,9 +365,7 @@ where
                             });
                             break;
                         }
-                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError(
-                            _,
-                        ))) => {
+                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError)) => {
                             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                             // try again
                         }

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -530,7 +530,7 @@ where
                                     });
                                 } else {
                                     tokio::spawn(async move {
-                                        entry.send(Ok(content)).await;
+                                        entry.send(Ok(Ok(content))).await;
                                     });
                                 }
                             }

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -21,6 +21,8 @@ use crate::cache::estimate_size;
 use crate::cache::storage::InMemoryCache;
 use crate::cache::storage::ValueType;
 use crate::cache::DeduplicatingCache;
+use crate::compute_job::ComputeBackPressureError;
+use crate::compute_job::MaybeBackPressureError;
 use crate::configuration::PersistedQueriesPrewarmQueryPlanCache;
 use crate::error::CacheResolverError;
 use crate::error::QueryPlannerError;
@@ -76,7 +78,11 @@ impl std::fmt::Debug for ConfigModeHash {
 #[derive(Clone)]
 pub(crate) struct CachingQueryPlanner<T: Clone> {
     cache: Arc<
-        DeduplicatingCache<CachingQueryKey, Result<QueryPlannerContent, Arc<QueryPlannerError>>>,
+        DeduplicatingCache<
+            CachingQueryKey,
+            Result<QueryPlannerContent, Arc<QueryPlannerError>>,
+            ComputeBackPressureError,
+        >,
     >,
     delegate: T,
     schema: Arc<Schema>,
@@ -105,7 +111,7 @@ where
     T: tower::Service<
             QueryPlannerRequest,
             Response = QueryPlannerResponse,
-            Error = QueryPlannerError,
+            Error = MaybeBackPressureError<QueryPlannerError>,
         > + Send,
     <T as tower::Service<QueryPlannerRequest>>::Future: Send,
 {
@@ -256,7 +262,7 @@ where
 
         let mut count = 0usize;
         let mut reused = 0usize;
-        for WarmUpCachingQueryKey {
+        'all_cache_keys_loop: for WarmUpCachingQueryKey {
             query,
             operation_name,
             hash,
@@ -308,48 +314,65 @@ where
                 })
                 .await;
             if entry.is_first() {
-                let doc = match query_analysis
-                    .parse_document(&query, operation_name.as_deref())
-                    .await
-                {
-                    Ok(doc) => doc,
-                    Err(error) => {
-                        let e = Arc::new(QueryPlannerError::SpecError(error));
-                        tokio::spawn(async move {
-                            entry.insert(Err(e)).await;
-                        });
-                        continue;
-                    }
-                };
-
-                let request = QueryPlannerRequest {
-                    query,
-                    operation_name,
-                    document: doc,
-                    metadata: caching_key.metadata,
-                    plan_options: caching_key.plan_options,
-                };
-
-                let res = match service.ready().await {
-                    Ok(service) => service.call(request).await,
-                    Err(_) => break,
-                };
-
-                match res {
-                    Ok(QueryPlannerResponse { content, .. }) => {
-                        if let Some(content) = content.clone() {
-                            count += 1;
+                let doc = loop {
+                    match query_analysis
+                        .parse_document(&query, operation_name.as_deref())
+                        .await
+                    {
+                        Ok(doc) => break doc,
+                        Err(MaybeBackPressureError::PermanentError(error)) => {
+                            let e = Arc::new(QueryPlannerError::SpecError(error));
                             tokio::spawn(async move {
-                                entry.insert(Ok(content.clone())).await;
+                                entry.insert(Err(e)).await;
                             });
+                            continue 'all_cache_keys_loop;
+                        }
+                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError(
+                            _,
+                        ))) => {
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                            // try again
                         }
                     }
-                    Err(error) => {
-                        count += 1;
-                        let e = Arc::new(error);
-                        tokio::spawn(async move {
-                            entry.insert(Err(e)).await;
-                        });
+                };
+
+                loop {
+                    let request = QueryPlannerRequest {
+                        query: query.clone(),
+                        operation_name: operation_name.clone(),
+                        document: doc.clone(),
+                        metadata: caching_key.metadata.clone(),
+                        plan_options: caching_key.plan_options.clone(),
+                    };
+                    let res = match service.ready().await {
+                        Ok(service) => service.call(request).await,
+                        Err(_) => break 'all_cache_keys_loop,
+                    };
+
+                    match res {
+                        Ok(QueryPlannerResponse { content, .. }) => {
+                            if let Some(content) = content.clone() {
+                                count += 1;
+                                tokio::spawn(async move {
+                                    entry.insert(Ok(content.clone())).await;
+                                });
+                            }
+                            break;
+                        }
+                        Err(MaybeBackPressureError::PermanentError(error)) => {
+                            count += 1;
+                            let e = Arc::new(error);
+                            tokio::spawn(async move {
+                                entry.insert(Err(e)).await;
+                            });
+                            break;
+                        }
+                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError(
+                            _,
+                        ))) => {
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                            // try again
+                        }
                     }
                 }
             }
@@ -376,7 +399,7 @@ where
     T: tower::Service<
         QueryPlannerRequest,
         Response = QueryPlannerResponse,
-        Error = QueryPlannerError,
+        Error = MaybeBackPressureError<QueryPlannerError>,
     >,
     <T as tower::Service<QueryPlannerRequest>>::Future: Send,
 {
@@ -416,7 +439,7 @@ where
     T: tower::Service<
             QueryPlannerRequest,
             Response = QueryPlannerResponse,
-            Error = QueryPlannerError,
+            Error = MaybeBackPressureError<QueryPlannerError>,
         > + Clone
         + Send
         + 'static,
@@ -500,13 +523,21 @@ where
                 async move {
                     let service = match self.delegate.ready().await {
                         Ok(service) => service,
-                        Err(error) => {
+                        Err(MaybeBackPressureError::PermanentError(error)) => {
                             let e = Arc::new(error);
                             let err = e.clone();
                             tokio::spawn(async move {
                                 entry.insert(Err(err)).await;
                             });
                             return Err(CacheResolverError::RetrievalError(e));
+                        }
+                        Err(MaybeBackPressureError::TemporaryError(error)) => {
+                            let err = error.clone();
+                            tokio::spawn(async move {
+                                // Temporary errors are never cached
+                                entry.send(Err(err)).await;
+                            });
+                            return Err(CacheResolverError::Backpressure(error));
                         }
                     };
 
@@ -543,7 +574,7 @@ where
                             }
                             Ok(QueryPlannerResponse { content, errors })
                         }
-                        Err(error) => {
+                        Err(MaybeBackPressureError::PermanentError(error)) => {
                             let e = Arc::new(error);
                             let err = e.clone();
                             tokio::spawn(async move {
@@ -555,6 +586,14 @@ where
                                 });
                             }
                             Err(CacheResolverError::RetrievalError(e))
+                        }
+                        Err(MaybeBackPressureError::TemporaryError(error)) => {
+                            let err = error.clone();
+                            tokio::spawn(async move {
+                                // Temporary errors are never cached
+                                entry.send(Err(err)).await;
+                            });
+                            Err(CacheResolverError::Backpressure(error))
                         }
                     }
                 }
@@ -714,7 +753,7 @@ mod tests {
             fn sync_call(
                 &self,
                 key: QueryPlannerRequest,
-            ) -> Result<QueryPlannerResponse, QueryPlannerError>;
+            ) -> Result<QueryPlannerResponse, MaybeBackPressureError<QueryPlannerError>>;
         }
 
         impl Clone for MyQueryPlanner {
@@ -725,7 +764,7 @@ mod tests {
     impl Service<QueryPlannerRequest> for MockMyQueryPlanner {
         type Response = QueryPlannerResponse;
 
-        type Error = QueryPlannerError;
+        type Error = MaybeBackPressureError<QueryPlannerError>;
 
         type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -750,7 +789,7 @@ mod tests {
             planner
                 .expect_sync_call()
                 .times(0..2)
-                .returning(|_| Err(QueryPlannerError::UnhandledPlannerResult));
+                .returning(|_| Err(QueryPlannerError::UnhandledPlannerResult.into()));
             planner
         });
 

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -165,16 +165,15 @@ impl QueryPlannerService {
             let root_node = convert_root_query_plan_node(&plan);
             Ok((plan, root_node))
         };
-        let (plan, mut root_node) =
-            compute_job::execute(priority, compute_job::ComputeJobKind::QueryPlanning, job)
-                .map_err(MaybeBackPressureError::TemporaryError)?
-                .await
-                // `expect()` propagates any panic that potentially happens in the closure, but:
-                //
-                // * We try to avoid such panics in the first place and consider them bugs
-                // * The panic handler in `apollo-router/src/executable.rs` exits the process
-                //   so this error case should never be reached.
-                .expect("query planner panicked")?;
+        let (plan, mut root_node) = compute_job::execute(priority, job)
+            .map_err(MaybeBackPressureError::TemporaryError)?
+            .await
+            // `expect()` propagates any panic that potentially happens in the closure, but:
+            //
+            // * We try to avoid such panics in the first place and consider them bugs
+            // * The panic handler in `apollo-router/src/executable.rs` exits the process
+            //   so this error case should never be reached.
+            .expect("query planner panicked")?;
         if let Some(node) = &mut root_node {
             init_query_plan_root_node(node).map_err(QueryPlannerError::from)?;
         }

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -20,6 +20,7 @@ use crate::apollo_studio_interop::generate_extended_references;
 use crate::apollo_studio_interop::ExtendedReferenceStats;
 use crate::apollo_studio_interop::UsageReporting;
 use crate::compute_job;
+use crate::compute_job::MaybeBackPressureError;
 use crate::context::OPERATION_KIND;
 use crate::context::OPERATION_NAME;
 use crate::graphql::Error;
@@ -36,6 +37,7 @@ use crate::spec::Query;
 use crate::spec::QueryHash;
 use crate::spec::Schema;
 use crate::spec::SpecError;
+use crate::spec::GRAPHQL_VALIDATION_FAILURE_ERROR_KEY;
 use crate::Configuration;
 use crate::Context;
 
@@ -86,7 +88,7 @@ impl QueryAnalysisLayer {
         &self,
         query: &str,
         operation_name: Option<&str>,
-    ) -> Result<ParsedDocument, SpecError> {
+    ) -> Result<ParsedDocument, MaybeBackPressureError<SpecError>> {
         let query = query.to_string();
         let operation_name = operation_name.map(|o| o.to_string());
         let schema = self.schema.clone();
@@ -109,14 +111,20 @@ impl QueryAnalysisLayer {
         };
         // TODO: is this correct?
         let job = std::panic::AssertUnwindSafe(job);
-        compute_job::execute(priority, job)
-            .await
-            // `expect()` propagates any panic that potentially happens in the closure, but:
-            //
-            // * We try to avoid such panics in the first place and consider them bugs
-            // * The panic handler in `apollo-router/src/executable.rs` exits the process
-            //   so this error case should never be reached.
-            .expect("Query::parse_document panicked")
+        compute_job::execute(
+            priority,
+            compute_job::ComputeJobKind::ParsingAndValidation,
+            job,
+        )
+        .map_err(MaybeBackPressureError::TemporaryError)?
+        .await
+        // `expect()` propagates any panic that potentially happens in the closure, but:
+        //
+        // * We try to avoid such panics in the first place and consider them bugs
+        // * The panic handler in `apollo-router/src/executable.rs` exits the process
+        //   so this error case should never be reached.
+        .expect("Query::parse_document panicked")
+        .map_err(MaybeBackPressureError::PermanentError)
     }
 
     /// Parses the GraphQL in the supergraph request and computes Apollo usage references.
@@ -171,15 +179,17 @@ impl QueryAnalysisLayer {
 
         let res = match entry {
             None => match self.parse_document(&query, op_name.as_deref()).await {
-                Err(errors) => {
-                    (*self.cache.lock().await).put(
-                        QueryAnalysisKey {
-                            query,
-                            operation_name: op_name.clone(),
-                        },
-                        Err(errors.clone()),
-                    );
-                    Err(errors)
+                Err(e) => {
+                    if let MaybeBackPressureError::PermanentError(errors) = &e {
+                        (*self.cache.lock().await).put(
+                            QueryAnalysisKey {
+                                query,
+                                operation_name: op_name.clone(),
+                            },
+                            Err(errors.clone()),
+                        );
+                    }
+                    Err(e)
                 }
                 Ok(doc) => {
                     let context = Context::new();
@@ -212,7 +222,7 @@ impl QueryAnalysisLayer {
                     Ok((context, doc))
                 }
             },
-            Some(c) => c,
+            Some(cached_result) => cached_result.map_err(MaybeBackPressureError::PermanentError),
         };
 
         match res {
@@ -245,7 +255,7 @@ impl QueryAnalysisLayer {
                     context: request.context,
                 })
             }
-            Err(errors) => {
+            Err(MaybeBackPressureError::PermanentError(errors)) => {
                 request.context.extensions().with_lock(|lock| {
                     lock.insert(Arc::new(UsageReporting {
                         stats_report_key: errors.get_error_key().to_string(),
@@ -262,6 +272,20 @@ impl QueryAnalysisLayer {
                 Err(SupergraphResponse::builder()
                     .errors(errors)
                     .status_code(StatusCode::BAD_REQUEST)
+                    .context(request.context)
+                    .build()
+                    .expect("response is valid"))
+            }
+            Err(MaybeBackPressureError::TemporaryError(error)) => {
+                request.context.extensions().with_lock(|lock| {
+                    lock.insert(Arc::new(UsageReporting {
+                        stats_report_key: GRAPHQL_VALIDATION_FAILURE_ERROR_KEY.to_string(),
+                        referenced_fields_by_type: HashMap::new(),
+                    }))
+                });
+                Err(SupergraphResponse::builder()
+                    .error(error.to_graphql_error())
+                    .status_code(StatusCode::SERVICE_UNAVAILABLE)
                     .context(request.context)
                     .build()
                     .expect("response is valid"))

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -111,20 +111,16 @@ impl QueryAnalysisLayer {
         };
         // TODO: is this correct?
         let job = std::panic::AssertUnwindSafe(job);
-        compute_job::execute(
-            priority,
-            compute_job::ComputeJobKind::ParsingAndValidation,
-            job,
-        )
-        .map_err(MaybeBackPressureError::TemporaryError)?
-        .await
-        // `expect()` propagates any panic that potentially happens in the closure, but:
-        //
-        // * We try to avoid such panics in the first place and consider them bugs
-        // * The panic handler in `apollo-router/src/executable.rs` exits the process
-        //   so this error case should never be reached.
-        .expect("Query::parse_document panicked")
-        .map_err(MaybeBackPressureError::PermanentError)
+        compute_job::execute(priority, job)
+            .map_err(MaybeBackPressureError::TemporaryError)?
+            .await
+            // `expect()` propagates any panic that potentially happens in the closure, but:
+            //
+            // * We try to avoid such panics in the first place and consider them bugs
+            // * The panic handler in `apollo-router/src/executable.rs` exits the process
+            //   so this error case should never be reached.
+            .expect("Query::parse_document panicked")
+            .map_err(MaybeBackPressureError::PermanentError)
     }
 
     /// Parses the GraphQL in the supergraph request and computes Apollo usage references.

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use static_assertions::assert_impl_all;
 
 use super::layers::query_analysis::ParsedDocument;
+use crate::compute_job::MaybeBackPressureError;
 use crate::error::QueryPlannerError;
 use crate::graphql;
 use crate::query_planner::QueryPlan;
@@ -116,12 +117,12 @@ impl Response {
     }
 }
 
-pub(crate) type BoxService = tower::util::BoxService<Request, Response, QueryPlannerError>;
+pub(crate) type ServiceError = MaybeBackPressureError<QueryPlannerError>;
+pub(crate) type BoxService = tower::util::BoxService<Request, Response, ServiceError>;
 #[allow(dead_code)]
-pub(crate) type BoxCloneService =
-    tower::util::BoxCloneService<Request, Response, QueryPlannerError>;
+pub(crate) type BoxCloneService = tower::util::BoxCloneService<Request, Response, ServiceError>;
 #[allow(dead_code)]
-pub(crate) type ServiceResult = Result<Response, QueryPlannerError>;
+pub(crate) type ServiceResult = Result<Response, ServiceError>;
 
 #[async_trait]
 pub(crate) trait QueryPlannerPlugin: Send + Sync + 'static {

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -217,7 +217,11 @@ async fn service_call(
     {
         Ok(resp) => resp,
         Err(err) => {
-            let status = StatusCode::BAD_REQUEST;
+            let status = match &err {
+                CacheResolverError::Backpressure(_) => StatusCode::SERVICE_UNAVAILABLE,
+                CacheResolverError::RetrievalError(_) |
+                CacheResolverError::BatchingError(_) => StatusCode::BAD_REQUEST,
+            };
             match err.into_graphql_errors() {
                 Ok(gql_errors) => {
                     return Ok(SupergraphResponse::infallible_builder()

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -219,8 +219,9 @@ async fn service_call(
         Err(err) => {
             let status = match &err {
                 CacheResolverError::Backpressure(_) => StatusCode::SERVICE_UNAVAILABLE,
-                CacheResolverError::RetrievalError(_) |
-                CacheResolverError::BatchingError(_) => StatusCode::BAD_REQUEST,
+                CacheResolverError::RetrievalError(_) | CacheResolverError::BatchingError(_) => {
+                    StatusCode::BAD_REQUEST
+                }
             };
             match err.into_graphql_errors() {
                 Ok(gql_errors) => {

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -162,3 +162,9 @@ impl IntoGraphQLErrors for SpecError {
         }
     }
 }
+
+impl From<std::convert::Infallible> for SpecError {
+    fn from(value: std::convert::Infallible) -> Self {
+        match value {}
+    }
+}

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -1075,9 +1075,9 @@ impl Operation {
                         .as_ref()
                         .and_then(|v| parse_hir_value(v)),
                 };
-                Ok((name, variable))
+                (name, variable)
             })
-            .collect::<Result<_, _>>()?;
+            .collect();
 
         Ok(Operation {
             selection_set,


### PR DESCRIPTION
Since version 1.58.0, Apollo Router has a dedicated thread pool for computation-heavy jobs with a priority queue. When the queue was full above a certain threshold, it attempted to exert backpressure by returning `Poll::Pending` in `tower::Service::poll_ready` for the query planner service. However this was not sufficient since `LoadShed` was not used together with `Poll::Pending`.

This PR moves to using error `Result`s to represent backpressure. As a consequence, we can now have a precise queue capacity checked when inserting instead of a "soft" capacity checked separately. Much of the diff is related to separating "permanent" errors that should be cached from "temporary" backpressure errors that should not be cached.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
