### PR TITLE
Add $APOLLO_ROUTER_COMPUTE_THREADS environment variable (backport #6746)

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -11,6 +11,7 @@ license = "Elastic-2.0"
 rust-version = "1.83.0"
 edition = "2021"
 build = "build/main.rs"
+default-run = "router"
 
 [[bin]]
 name = "router"

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -333,12 +333,16 @@ pub fn main() -> Result<()> {
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
-    if let Some(nb) = std::env::var("APOLLO_ROUTER_NUM_CORES")
+
+    // This environment variable is intentionally undocumented.
+    // See also APOLLO_ROUTER_COMPUTE_THREADS in apollo-router/src/compute_job.rs
+    if let Some(nb) = std::env::var("APOLLO_ROUTER_IO_THREADS")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
     {
         builder.worker_threads(nb);
     }
+
     let runtime = builder.build()?;
     runtime.block_on(Executable::builder().start())
 }

--- a/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
+++ b/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
@@ -1,7 +1,6 @@
 ---
 source: apollo-router/src/services/layers/persisted_queries/mod.rs
 expression: yaml
-snapshot_kind: text
 ---
 - fields:
     operation_body: "query SomeQuery { me { id } }"


### PR DESCRIPTION
Router creates a thread pool dedicated to "compute jobs" to avoid blocking Tokio threads. By default this pool has as many threads as available CPUs. This can now be changed by setting the `$APOLLO_ROUTER_COMPUTE_THREADS` environment variable to an integer value. This feature is intentionally undocumented and should be considered "experimental".

Also rename the pre-existing (also undocumented) `$APOLLO_ROUTER_NUM_CORES` to `$APOLLO_ROUTER_IO_THREADS` to better reflect what it does.

Drive-by unrelated change: make `cargo run` default to the main router executable.

----

Manual testing instructions: in a terminal, run:

```sh
APOLLO_ROUTER_COMPUTE_THREADS=4 cargo run -- \
  -c router.yaml -s examples/graphql/supergraph.graphql --dev \
  --log error,apollo_router=info,apollo_router::compute_job=debug
```

After seeing a log line with `GraphQL endpoint exposed at http://127.0.0.1:4000/`, in another terminal, run:

```sh
curl -s -H 'accept: application/json' -H 'content-type: application/json' 'http://127.0.0.1:4000/' -d '{"query":"{__typename}"}'
```

(This step is needed because the thread pool is created lazily on first use.) The first terminal should now have a log line with `Compute thread pool size: $APOLLO_ROUTER_COMPUTE_THREADS = 4`.



---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
  * Undocumented `$APOLLO_ROUTER_NUM_CORES` no longer works
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6746 done by [Mergify](https://mergify.com).