### PR TITLE
fix: connectors, pqs, and __typename

### DIFF
--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -1164,57 +1164,6 @@ mod tests {
                 selection: Named(
                     SubSelection {
                         selections: [
-                            Path {
-                                alias: Some(
-                                    Alias {
-                                        name: WithRange {
-                                            node: Field(
-                                                "__typename",
-                                            ),
-                                            range: None,
-                                        },
-                                        range: None,
-                                    },
-                                ),
-                                inline: false,
-                                path: PathSelection {
-                                    path: WithRange {
-                                        node: Var(
-                                            WithRange {
-                                                node: $,
-                                                range: None,
-                                            },
-                                            WithRange {
-                                                node: Method(
-                                                    WithRange {
-                                                        node: "echo",
-                                                        range: None,
-                                                    },
-                                                    Some(
-                                                        MethodArgs {
-                                                            args: [
-                                                                WithRange {
-                                                                    node: String(
-                                                                        "_Entity",
-                                                                    ),
-                                                                    range: None,
-                                                                },
-                                                            ],
-                                                            range: None,
-                                                        },
-                                                    ),
-                                                    WithRange {
-                                                        node: Empty,
-                                                        range: None,
-                                                    },
-                                                ),
-                                                range: None,
-                                            },
-                                        ),
-                                        range: None,
-                                    },
-                                },
-                            },
                             Field(
                                 None,
                                 WithRange {
@@ -1272,57 +1221,6 @@ mod tests {
                 selection: Named(
                     SubSelection {
                         selections: [
-                            Path {
-                                alias: Some(
-                                    Alias {
-                                        name: WithRange {
-                                            node: Field(
-                                                "__typename",
-                                            ),
-                                            range: None,
-                                        },
-                                        range: None,
-                                    },
-                                ),
-                                inline: false,
-                                path: PathSelection {
-                                    path: WithRange {
-                                        node: Var(
-                                            WithRange {
-                                                node: $,
-                                                range: None,
-                                            },
-                                            WithRange {
-                                                node: Method(
-                                                    WithRange {
-                                                        node: "echo",
-                                                        range: None,
-                                                    },
-                                                    Some(
-                                                        MethodArgs {
-                                                            args: [
-                                                                WithRange {
-                                                                    node: String(
-                                                                        "_Entity",
-                                                                    ),
-                                                                    range: None,
-                                                                },
-                                                            ],
-                                                            range: None,
-                                                        },
-                                                    ),
-                                                    WithRange {
-                                                        node: Empty,
-                                                        range: None,
-                                                    },
-                                                ),
-                                                range: None,
-                                            },
-                                        ),
-                                        range: None,
-                                    },
-                                },
-                            },
                             Field(
                                 None,
                                 WithRange {
@@ -1482,57 +1380,6 @@ mod tests {
                 selection: Named(
                     SubSelection {
                         selections: [
-                            Path {
-                                alias: Some(
-                                    Alias {
-                                        name: WithRange {
-                                            node: Field(
-                                                "__typename",
-                                            ),
-                                            range: None,
-                                        },
-                                        range: None,
-                                    },
-                                ),
-                                inline: false,
-                                path: PathSelection {
-                                    path: WithRange {
-                                        node: Var(
-                                            WithRange {
-                                                node: $,
-                                                range: None,
-                                            },
-                                            WithRange {
-                                                node: Method(
-                                                    WithRange {
-                                                        node: "echo",
-                                                        range: None,
-                                                    },
-                                                    Some(
-                                                        MethodArgs {
-                                                            args: [
-                                                                WithRange {
-                                                                    node: String(
-                                                                        "_Entity",
-                                                                    ),
-                                                                    range: None,
-                                                                },
-                                                            ],
-                                                            range: None,
-                                                        },
-                                                    ),
-                                                    WithRange {
-                                                        node: Empty,
-                                                        range: None,
-                                                    },
-                                                ),
-                                                range: None,
-                                            },
-                                        ),
-                                        range: None,
-                                    },
-                                },
-                            },
                             Field(
                                 None,
                                 WithRange {
@@ -1590,57 +1437,6 @@ mod tests {
                 selection: Named(
                     SubSelection {
                         selections: [
-                            Path {
-                                alias: Some(
-                                    Alias {
-                                        name: WithRange {
-                                            node: Field(
-                                                "__typename",
-                                            ),
-                                            range: None,
-                                        },
-                                        range: None,
-                                    },
-                                ),
-                                inline: false,
-                                path: PathSelection {
-                                    path: WithRange {
-                                        node: Var(
-                                            WithRange {
-                                                node: $,
-                                                range: None,
-                                            },
-                                            WithRange {
-                                                node: Method(
-                                                    WithRange {
-                                                        node: "echo",
-                                                        range: None,
-                                                    },
-                                                    Some(
-                                                        MethodArgs {
-                                                            args: [
-                                                                WithRange {
-                                                                    node: String(
-                                                                        "_Entity",
-                                                                    ),
-                                                                    range: None,
-                                                                },
-                                                            ],
-                                                            range: None,
-                                                        },
-                                                    ),
-                                                    WithRange {
-                                                        node: Empty,
-                                                        range: None,
-                                                    },
-                                                ),
-                                                range: None,
-                                            },
-                                        ),
-                                        range: None,
-                                    },
-                                },
-                            },
                             Field(
                                 None,
                                 WithRange {

--- a/apollo-router/tests/samples/enterprise/connectors-pqs/README.md
+++ b/apollo-router/tests/samples/enterprise/connectors-pqs/README.md
@@ -1,0 +1,1 @@
+This is a regression test for a problem that occurs when using PQs and connectors. See apollo-federation/src/sources/connect/json_selection/selection_set.rs

--- a/apollo-router/tests/samples/enterprise/connectors-pqs/configuration.yaml
+++ b/apollo-router/tests/samples/enterprise/connectors-pqs/configuration.yaml
@@ -1,0 +1,21 @@
+include_subgraph_errors:
+  all: true
+
+preview_connectors:
+  subgraphs:
+    connectors:
+      sources:
+        one:
+          override_url: http://localhost:4001
+
+telemetry:
+  exporters:
+    logging:
+      stdout:
+        format: text
+
+persisted_queries:
+  enabled: true
+  log_unknown: true
+  local_manifests:
+    - tests/samples/enterprise/connectors-pqs/manifest.json

--- a/apollo-router/tests/samples/enterprise/connectors-pqs/http_snapshots.json
+++ b/apollo-router/tests/samples/enterprise/connectors-pqs/http_snapshots.json
@@ -1,0 +1,51 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "path": "api/search?query=Boston",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "Locations": [
+          {
+            "Coords": {
+              "Lat": "1.1",
+              "Lon": "2.2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "path": "weather/1.1,2.2",
+      "body": null
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": [
+          "application/json; charset=utf-8"
+        ]
+      },
+      "body": {
+        "currentConditions": {
+          "snow": 1.1,
+          "temp": 2.2,
+          "windspeed": 3.3,
+          "conditions": "cold",
+          "snowdepth": 4.4
+        }
+      }
+    }
+  }
+]

--- a/apollo-router/tests/samples/enterprise/connectors-pqs/manifest.json
+++ b/apollo-router/tests/samples/enterprise/connectors-pqs/manifest.json
@@ -1,0 +1,12 @@
+{
+  "format": "apollo-persisted-query-manifest",
+  "version": 1,
+  "operations": [
+    {
+      "id": "87b3393750af706fde5c3bbdf37533012f4d4eeecb82f621b596c34249428153",
+      "name": "getWeatherData",
+      "type": "query",
+      "body": "query getWeatherData($search: String!) {\n  geoByAddress(search: $search) {\n    lat\n    long\n    weather {\n      conditions\n      forecastSnowFall\n      temperature\n      windSpeed\n      currentSnowDepth\n      __typename\n    }\n    __typename\n  }\n}"
+    }
+  ]
+}

--- a/apollo-router/tests/samples/enterprise/connectors-pqs/plan.json
+++ b/apollo-router/tests/samples/enterprise/connectors-pqs/plan.json
@@ -1,0 +1,54 @@
+{
+  "enterprise": true,
+  "redis": false,
+  "snapshot": true,
+  "actions": [
+    {
+      "type": "Start",
+      "schema_path": "./supergraph.graphql",
+      "configuration_path": "./configuration.yaml",
+      "subgraphs": {
+        "one": {
+          "snapshot": {
+            "path": "./http_snapshots.json",
+            "base_url": "http://localhost:4001"
+          }
+        }
+      }
+    },
+    {
+      "type": "Request",
+      "request": {
+        "variables": {
+          "search": "Boston"
+        },
+        "extensions": {
+          "persistedQuery": {
+            "version": 1,
+            "sha256Hash": "87b3393750af706fde5c3bbdf37533012f4d4eeecb82f621b596c34249428153"
+          }
+        }
+      },
+      "expected_response": {
+        "data": {
+          "geoByAddress": {
+            "lat": "1.1",
+            "long": "2.2",
+            "weather": {
+              "conditions": "cold",
+              "forecastSnowFall": 1.1,
+              "temperature": 2.2,
+              "windSpeed": 3.3,
+              "currentSnowDepth": 4.4,
+              "__typename": "Weather"
+            },
+            "__typename": "Geo"
+          }
+        }
+      }
+    },
+    {
+      "type": "Stop"
+    }
+  ]
+}

--- a/apollo-router/tests/samples/enterprise/connectors-pqs/supergraph.graphql
+++ b/apollo-router/tests/samples/enterprise/connectors-pqs/supergraph.graphql
@@ -1,0 +1,83 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "one", http: {baseURL: "http://localhost:4001"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Geo
+  @join__type(graph: CONNECTORS)
+{
+  lat: String!
+  long: String!
+  weather: Weather
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  geoByAddress(search: String!): Geo @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "one", http: {GET: "/api/search?query={$args.search}"}, selection: "lat: Locations->first.Coords.Lat\nlong: Locations->first.Coords.Lon\nweather: {\n  lat: Locations->first.Coords.Lat\n  long: Locations->first.Coords.Lon\n}"})
+  getWeatherData(lat: String!, long: String!): Weather @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "one", http: {GET: "/weather/{$args.lat},{$args.long}"}, selection: "lat: $args.lat\nlong: $args.long\n$.currentConditions {\n  forecastSnowFall: snow\n  temperature: temp\n  windSpeed: windspeed\n  conditions\n  currentSnowDepth: snowdepth\n}", entity: true})
+}
+
+type Weather
+  @join__type(graph: CONNECTORS, key: "lat long", resolvable: false)
+{
+  lat: String!
+  long: String!
+  temperature: Float
+  windSpeed: Float
+  conditions: String
+  forecastSnowFall: Float
+  currentSnowDepth: Float
+}

--- a/apollo-router/tests/samples/enterprise/connectors-pqs/supergraph.yaml
+++ b/apollo-router/tests/samples/enterprise/connectors-pqs/supergraph.yaml
@@ -1,0 +1,63 @@
+federation_version: =2.10.0-preview.6
+subgraphs:
+  connectors:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.10", import: ["@key"])
+          @link(
+            url: "https://specs.apollo.dev/connect/v0.1"
+            import: ["@connect", "@source"]
+          )
+          @source(name: "one", http: { baseURL: "http://localhost:4001" })
+
+        type Geo {
+          lat: String!
+          long: String!
+          weather: Weather
+        }
+
+        type Weather @key(fields: "lat long", resolvable: false) {
+          lat: String!
+          long: String!
+          temperature: Float
+          windSpeed: Float
+          conditions: String
+          forecastSnowFall: Float
+          currentSnowDepth: Float
+        }
+
+        type Query {
+          geoByAddress(search: String!): Geo
+            @connect(
+              source: "one"
+              http: { GET: "/api/search?query={$args.search}" }
+              selection: """
+              lat: Locations->first.Coords.Lat
+              long: Locations->first.Coords.Lon
+              weather: {
+                lat: Locations->first.Coords.Lat
+                long: Locations->first.Coords.Lon
+              }
+              """
+            )
+
+          getWeatherData (lat: String!, long: String!) : Weather
+            @connect(
+              source: "one"
+              http: { GET: "/weather/{$args.lat},{$args.long}" }
+              selection: """
+              lat: $args.lat
+              long: $args.long
+              $.currentConditions {
+                forecastSnowFall: snow
+                temperature: temp
+                windSpeed: windspeed
+                conditions
+                currentSnowDepth: snowdepth
+              }
+              """
+              entity: true
+            )
+        }


### PR DESCRIPTION
i'm not sure why, but __typename selections appear in certain fetch node operations only for PQs. our current __typename handling would emit `__typename: $("_Entity")` which is never correct (_Entity is a union), so i added an extra guard against this.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
