### PR TITLE
Instrument coprocessor request with http_request span

### DIFF
--- a/.changesets/feat_coprocessorhttprequestspan.md
+++ b/.changesets/feat_coprocessorhttprequestspan.md
@@ -1,0 +1,6 @@
+### Instrument coprocessor request with http_request span ([Issue #6739](https://github.com/apollographql/router/issues/6739))
+
+Instrument coprocessor http_requests with spans, identically to what is done for subgraph http_requests.  Helps provide
+insight into latency that may be introduced over the network stack when communicating with coprocessor. 
+
+By [Jon Christiansen](https://github.com/theJC) in https://github.com/apollographql/router/pull/6776

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -6,14 +6,6 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::subgraph::SubgraphRequestId;
-use crate::plugins::telemetry::consts::HTTP_REQUEST_SPAN_NAME;
-use crate::plugins::telemetry::otel::OpenTelemetrySpanExt;
-use crate::plugins::telemetry::reload::prepare_context;
-use crate::query_planner::QueryPlan;
-use crate::services::router;
-use crate::services::router::body::RouterBody;
-use crate::Context;
 use http::header::ACCEPT;
 use http::header::CONTENT_TYPE;
 use http::HeaderMap;
@@ -29,6 +21,15 @@ use strum_macros::Display;
 use tower::BoxError;
 use tower::Service;
 use tracing::Instrument;
+
+use super::subgraph::SubgraphRequestId;
+use crate::plugins::telemetry::consts::HTTP_REQUEST_SPAN_NAME;
+use crate::plugins::telemetry::otel::OpenTelemetrySpanExt;
+use crate::plugins::telemetry::reload::prepare_context;
+use crate::query_planner::QueryPlan;
+use crate::services::router;
+use crate::services::router::body::RouterBody;
+use crate::Context;
 
 pub(crate) const DEFAULT_EXTERNALIZATION_TIMEOUT: Duration = Duration::from_secs(1);
 

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -313,16 +313,13 @@ where
                 0
             }
         });
-        let path = schema_uri.path();
 
         let http_req_span = tracing::info_span!(HTTP_REQUEST_SPAN_NAME,
             "otel.kind" = "CLIENT",
-            "net.peer.name" = %host,
-            "net.peer.port" = %port,
-            "http.route" = %path,
-            "http.url" = %schema_uri,
-            "net.transport" = "ip_tcp",
-            
+            "http.request.method" = "POST",
+            "server.address" = %host,
+            "server.port" = %port,
+            "url.full" = %schema_uri,
         );
 
         get_text_map_propagator(|propagator| {

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -322,8 +322,7 @@ where
             "http.route" = %path,
             "http.url" = %schema_uri,
             "net.transport" = "ip_tcp",
-            //"apollo.subgraph.name" = %service_name,
-            //"graphql.operation.name" = %operation_name,
+            
         );
 
         get_text_map_propagator(|propagator| {


### PR DESCRIPTION
Instrument coprocessor request with http_request span, to be consistent in observability to subgraph http requests.

Code basically copy/pasted from [apollo-router/src/services/http/service.rs](https://github.com/apollographql/router/blob/4a8feb5727bf9e0ce77012591046f133d6c70c6d/apollo-router/src/services/http/service.rs#L272-L288)

Provides Apollo's customers insight into latency that may be introduced over the network stack when communicating with coprocessor. 

Fixes #6739

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

Manual test:
![Screenshot 2025-02-12 at 2 38 37 AM](https://github.com/user-attachments/assets/504385a1-8885-4261-8a7c-7b21b31f714f)

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

