### PR TITLE
Remove the ability to auto-upgrade a router configuration at runtime

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -42,7 +42,6 @@ pub(crate) use self::schema::generate_config_schema;
 pub(crate) use self::schema::generate_upgrade;
 use self::subgraph::SubgraphConfiguration;
 use crate::cache::DEFAULT_CACHE_CAPACITY;
-use crate::configuration::schema::Mode;
 use crate::graphql;
 use crate::notification::Notify;
 use crate::plugin::plugins;
@@ -549,7 +548,7 @@ impl FromStr for Configuration {
     type Err = ConfigurationError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        schema::validate_yaml_configuration(s, Expansion::default()?, Mode::Upgrade)?.validate()
+        schema::validate_yaml_configuration(s, Expansion::default()?)?.validate()
     }
 }
 

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -27,7 +27,6 @@ use super::Configuration;
 use super::ConfigurationError;
 use super::APOLLO_PLUGIN_PREFIX;
 pub(crate) use crate::configuration::upgrade::generate_upgrade;
-pub(crate) use crate::configuration::upgrade::upgrade_configuration;
 
 const NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY: usize = 5;
 
@@ -76,15 +75,6 @@ pub(crate) fn generate_config_schema() -> RootSchema {
     schema
 }
 
-#[derive(Eq, PartialEq)]
-pub(crate) enum Mode {
-    Upgrade,
-
-    // This is used only in testing to ensure that we don't allow old config in our tests.
-    #[cfg(test)]
-    NoUpgrade,
-}
-
 /// Validate config yaml against the generated json schema.
 /// This is a tricky problem, and the solution here is by no means complete.
 /// In the case that validation cannot be performed then it will let serde validate as normal. The
@@ -102,7 +92,6 @@ pub(crate) enum Mode {
 pub(crate) fn validate_yaml_configuration(
     raw_yaml: &str,
     expansion: Expansion,
-    migration: Mode,
 ) -> Result<Configuration, ConfigurationError> {
     let defaulted_yaml = if raw_yaml.trim().is_empty() {
         "plugins:".to_string()
@@ -110,7 +99,7 @@ pub(crate) fn validate_yaml_configuration(
         raw_yaml.to_string()
     };
 
-    let mut yaml = serde_yaml::from_str(&defaulted_yaml).map_err(|e| {
+    let yaml = serde_yaml::from_str(&defaulted_yaml).map_err(|e| {
         ConfigurationError::InvalidConfiguration {
             message: "failed to parse yaml",
             error: e.to_string(),
@@ -132,16 +121,6 @@ pub(crate) fn validate_yaml_configuration(
             }
         }
     });
-
-    if migration == Mode::Upgrade {
-        let upgraded = upgrade_configuration(&yaml, true)?;
-        let expanded_yaml = expansion.expand(&upgraded)?;
-        if schema.validate(&expanded_yaml).is_ok() {
-            yaml = upgraded;
-        } else {
-            tracing::warn!("Configuration could not be upgraded automatically as it had errors. If you previously used this configuration with Router 1.x, please refer to the migration guide: https://www.apollographql.com/docs/graphos/reference/migration/from-router-v1")
-        }
-    }
 
     let expanded_yaml = expansion.expand(&yaml)?;
     let parsed_yaml = super::yaml::parse(raw_yaml)?;
@@ -265,6 +244,7 @@ pub(crate) fn validate_yaml_configuration(
         }
 
         if !errors.is_empty() {
+            tracing::warn!("Configuration had errors. If you previously used this configuration with Router 1.x, please refer to the upgrade guide: https://www.apollographql.com/docs/graphos/reference/upgrade/from-router-v1");
             return Err(ConfigurationError::InvalidConfiguration {
                 message: "configuration had errors",
                 error: format!("\n{errors}"),
@@ -296,6 +276,7 @@ pub(crate) fn validate_yaml_configuration(
         // It might mean you forgot to update
         // `impl<'de> serde::Deserialize<'de> for Configuration
         // In `/apollo-router/src/configuration/mod.rs`
+        tracing::warn!("Configuration had errors. If you previously used this configuration with Router 1.x, please refer to the upgrade guide: https://www.apollographql.com/docs/graphos/reference/upgrade/from-router-v1");
         return Err(ConfigurationError::InvalidConfiguration {
             message: "unknown fields",
             error: format!(

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -244,7 +244,7 @@ pub(crate) fn validate_yaml_configuration(
         }
 
         if !errors.is_empty() {
-            tracing::warn!("Configuration had errors. If you previously used this configuration with Router 1.x, please refer to the upgrade guide: https://www.apollographql.com/docs/graphos/reference/upgrade/from-router-v1");
+            tracing::warn!("Configuration had errors. It may be possible to update your configuration automatically. Execute 'router config upgrade --help' for more details. If you previously used this configuration with Router 1.x, please refer to the upgrade guide: https://www.apollographql.com/docs/graphos/reference/upgrade/from-router-v1");
             return Err(ConfigurationError::InvalidConfiguration {
                 message: "configuration had errors",
                 error: format!("\n{errors}"),
@@ -276,7 +276,7 @@ pub(crate) fn validate_yaml_configuration(
         // It might mean you forgot to update
         // `impl<'de> serde::Deserialize<'de> for Configuration
         // In `/apollo-router/src/configuration/mod.rs`
-        tracing::warn!("Configuration had errors. If you previously used this configuration with Router 1.x, please refer to the upgrade guide: https://www.apollographql.com/docs/graphos/reference/upgrade/from-router-v1");
+        tracing::warn!("Configuration had errors. It may be possible to update your configuration automatically. Execute 'router config upgrade --help' for more details. If you previously used this configuration with Router 1.x, please refer to the upgrade guide: https://www.apollographql.com/docs/graphos/reference/upgrade/from-router-v1");
         return Err(ConfigurationError::InvalidConfiguration {
             message: "unknown fields",
             error: format!(

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -127,7 +127,6 @@ subgraphs:
   account: true
   "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     assert_eq!(
@@ -156,7 +155,6 @@ unknown:
   foo: true
   "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     assert_eq!(
@@ -181,7 +179,6 @@ fn empty_config() {
         r#"
   "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect("should have been ok with an empty config");
 }
@@ -198,7 +195,6 @@ telemetry:
   another_non_existant: 3
   "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     insta::assert_snapshot!(error.to_string());
@@ -216,7 +212,6 @@ supergraph:
   another_one: true
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     insta::assert_snapshot!(error.to_string());
@@ -232,7 +227,6 @@ supergraph:
   listen: true
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     insta::assert_snapshot!(error.to_string());
@@ -250,7 +244,6 @@ cors:
   allow_headers: [ Content-Type, 5 ]
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     insta::assert_snapshot!(error.to_string());
@@ -270,7 +263,6 @@ cors:
     - 5
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     insta::assert_snapshot!(error.to_string());
@@ -285,7 +277,6 @@ cors:
   allow_headers: [ "*" ]
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect("should not have resulted in an error");
     let error = cfg
@@ -304,7 +295,6 @@ cors:
   methods: [ GET, "*" ]
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect("should not have resulted in an error");
     let error = cfg
@@ -323,7 +313,6 @@ cors:
   allow_any_origin: true
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect("should not have resulted in an error");
     let error = cfg
@@ -342,7 +331,6 @@ cors:
     - "*"
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect("should not have resulted in an error");
     let error = cfg
@@ -413,11 +401,7 @@ fn validate_project_config_files() {
             };
 
             for yaml in yamls {
-                if let Err(e) = validate_yaml_configuration(
-                    &yaml,
-                    Expansion::default().unwrap(),
-                    Mode::NoUpgrade,
-                ) {
+                if let Err(e) = validate_yaml_configuration(&yaml, Expansion::default().unwrap()) {
                     panic!(
                         "{} configuration error: \n{}",
                         entry.path().to_string_lossy(),
@@ -438,7 +422,6 @@ supergraph:
   introspection: ${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("Must have an error because we expect a boolean");
     insta::assert_snapshot!(error.to_string());
@@ -457,7 +440,6 @@ cors:
   allow_headers: [ Content-Type, "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE}" ]
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     insta::assert_snapshot!(error.to_string());
@@ -479,7 +461,6 @@ cors:
     - "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}"
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     insta::assert_snapshot!(error.to_string());
@@ -497,7 +478,6 @@ supergraph:
   another_one: foo
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
     insta::assert_snapshot!(error.to_string());
@@ -511,7 +491,6 @@ supergraph:
   introspection: ${env.TEST_CONFIG_UNKNOWN_WITH_NO_DEFAULT}
         "#,
         Expansion::default().unwrap(),
-        Mode::NoUpgrade,
     )
     .expect_err("must have an error because the env variable is unknown");
     insta::assert_snapshot!(error.to_string());
@@ -528,7 +507,6 @@ supergraph:
             .prefix("TEST_CONFIG")
             .supported_mode("env")
             .build(),
-        Mode::NoUpgrade,
     )
     .expect_err("must have an error because the mode is unknown");
     insta::assert_snapshot!(error.to_string());
@@ -546,7 +524,6 @@ supergraph:
             .prefix("TEST_CONFIG")
             .supported_mode("env")
             .build(),
-        Mode::NoUpgrade,
     )
     .expect("must have expanded successfully");
 }
@@ -567,7 +544,6 @@ supergraph:
             path.to_string_lossy()
         ),
         Expansion::builder().supported_mode("file").build(),
-        Mode::NoUpgrade,
     )
     .expect("must have expanded successfully");
 
@@ -594,11 +570,7 @@ fn upgrade_old_configuration() {
             let new_config =
                 serde_yaml::to_string(&new_config).expect("must be able to serialize config");
 
-            let result = validate_yaml_configuration(
-                &new_config,
-                Expansion::builder().build(),
-                Mode::NoUpgrade,
-            );
+            let result = validate_yaml_configuration(&new_config, Expansion::builder().build());
 
             match result {
                 Ok(_) => {
@@ -742,7 +714,6 @@ tls:
 "#,
         ),
         Expansion::builder().supported_mode("file").build(),
-        Mode::NoUpgrade,
     )
     .expect("should not have resulted in an error");
     cfg.tls.supergraph.unwrap().tls_config().unwrap();

--- a/docs/source/reference/router/configuration.mdx
+++ b/docs/source/reference/router/configuration.mdx
@@ -1251,12 +1251,7 @@ After you generate the schema, configure your text editor. Here are the instruct
 
 New releases of the router might introduce breaking changes to the [YAML config file's](#yaml-config-file) expected format, usually to extend existing functionality or improve usability.
 
-**If you run a new version of your router with a configuration file that it no longer supports:**
-
-1. The router emits a warning on startup.
-2. The router attempts to translate your provided configuration to the new expected format.
-   - If the translation succeeds without errors, the router starts up as usual.
-   - If the translation fails, the router terminates.
+**If you run a new version of your router with a configuration file that it no longer supports, it emits a warning on startup and terminates.** 
 
 If you encounter this warning, you can use the `router config upgrade` command to see the new expected format for your existing configuration file:
 


### PR DESCRIPTION
In Router 1.x, during configuration parsing/validation the router
upgrade migrations could be applied "auto-magically" to generate a valid
runtime representation of a config for the life of the executing
process.
    
This can be problematic, since it makes de-bugging and support more
challenging than we'd like.
    
We want to retain the ability to upgrade a configuration using
migrations, but we don't want to auto-magically do this during runtime.
It should be the user's decision to make an explicit upgrade.
    
This is what this PR does. Various impacted tests are updated.
    
I also updated the link to the "migration" guide to be a link to the
"upgrade" guide at its new location.

<!-- https://apollographql.atlassian.net/browse/ROUTER-1064 -->