### PR TITLE
Change RouterLimits to LicenseEnforcement

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -3950,6 +3950,9 @@ expression: "&schema"
       ],
       "type": "object"
     },
+    "LicenseEnforcementConfig": {
+      "type": "object"
+    },
     "ListLength": {
       "oneOf": [
         {
@@ -5129,9 +5132,6 @@ expression: "&schema"
           "description": "#/definitions/DefaultedStandardInstrument_for_extendable_attribute_apollo_router::plugins::telemetry::config_new::attributes::RouterAttributes_apollo_router::plugins::telemetry::config_new::selectors::RouterSelector"
         }
       },
-      "type": "object"
-    },
-    "RouterLimitsConfig": {
       "type": "object"
     },
     "RouterRequestConf": {
@@ -8743,6 +8743,10 @@ expression: "&schema"
       "$ref": "#/definitions/Config7",
       "description": "#/definitions/Config7"
     },
+    "license_enforcement": {
+      "$ref": "#/definitions/LicenseEnforcementConfig",
+      "description": "#/definitions/LicenseEnforcementConfig"
+    },
     "limits": {
       "$ref": "#/definitions/Config2",
       "description": "#/definitions/Config2"
@@ -8778,10 +8782,6 @@ expression: "&schema"
     "rhai": {
       "$ref": "#/definitions/Conf7",
       "description": "#/definitions/Conf7"
-    },
-    "router_limits": {
-      "$ref": "#/definitions/RouterLimitsConfig",
-      "description": "#/definitions/RouterLimitsConfig"
     },
     "sandbox": {
       "$ref": "#/definitions/Sandbox",

--- a/apollo-router/src/plugins/license_enforcement/mod.rs
+++ b/apollo-router/src/plugins/license_enforcement/mod.rs
@@ -27,7 +27,7 @@ use crate::services::RouterResponse;
 #[derive(PartialEq, Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 /// The limits placed on a router in virtue of what's in a user's license
-pub(crate) struct RouterLimits {
+pub(crate) struct LicenseEnforcement {
     /// Transactions per second allowed based on license tier
     pub(crate) tps: Option<TpsLimitConf>,
 }
@@ -45,11 +45,11 @@ pub(crate) struct TpsLimitConf {
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema, Serialize)]
-pub(crate) struct RouterLimitsConfig {}
+pub(crate) struct LicenseEnforcementConfig {}
 
 #[async_trait::async_trait]
-impl PluginPrivate for RouterLimits {
-    type Config = RouterLimitsConfig;
+impl PluginPrivate for LicenseEnforcement {
+    type Config = LicenseEnforcementConfig;
 
     async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
         let tps = init.license.get_limits().and_then(|limits| {
@@ -102,7 +102,7 @@ impl PluginPrivate for RouterLimits {
     }
 }
 
-register_private_plugin!("apollo", "router_limits", RouterLimits);
+register_private_plugin!("apollo", "license_enforcement", LicenseEnforcement);
 
 #[cfg(test)]
 mod test {
@@ -127,7 +127,7 @@ mod test {
             }),
         };
 
-        let test_harness: PluginTestHarness<RouterLimits> =
+        let test_harness: PluginTestHarness<LicenseEnforcement> =
             PluginTestHarness::builder().license(license).build().await;
 
         let service = test_harness.router_service(|_req| async {
@@ -179,7 +179,7 @@ mod test {
                 }),
             };
 
-            let test_harness: PluginTestHarness<RouterLimits> =
+            let test_harness: PluginTestHarness<LicenseEnforcement> =
                 PluginTestHarness::builder().license(license).build().await;
 
             let service = test_harness.router_service(|_req| async {

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -34,12 +34,12 @@ mod forbid_mutations;
 mod headers;
 pub(crate) mod healthcheck;
 mod include_subgraph_errors;
+pub(crate) mod license_enforcement;
 pub(crate) mod limits;
 pub(crate) mod override_url;
 pub(crate) mod progressive_override;
 mod record_replay;
 pub(crate) mod rhai;
-pub(crate) mod router_limits;
 pub(crate) mod subscription;
 pub(crate) mod telemetry;
 #[cfg(test)]

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -676,10 +676,10 @@ pub(crate) async fn create_plugins(
         }
     }
     add_mandatory_apollo_plugin!("limits");
+    add_mandatory_apollo_plugin!("license_enforcement");
     add_mandatory_apollo_plugin!("health_check");
     add_mandatory_apollo_plugin!("traffic_shaping");
     add_mandatory_apollo_plugin!("fleet_detector");
-    add_mandatory_apollo_plugin!("license_enforcement");
 
     add_optional_apollo_plugin!("forbid_mutations");
     add_optional_apollo_plugin!("subscription");

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -679,7 +679,7 @@ pub(crate) async fn create_plugins(
     add_mandatory_apollo_plugin!("health_check");
     add_mandatory_apollo_plugin!("traffic_shaping");
     add_mandatory_apollo_plugin!("fleet_detector");
-    add_mandatory_apollo_plugin!("router_limits");
+    add_mandatory_apollo_plugin!("license_enforcement");
 
     add_optional_apollo_plugin!("forbid_mutations");
     add_optional_apollo_plugin!("subscription");


### PR DESCRIPTION
The RouterLimits plugin has a name that can easily be confused with Limits.

This PR changes RouterLimits to LicenseEnforcement and moves the plugin to before the healthcheck.
This means that in a scenario where someone accidentally uses a commercial feature in their cluster with autoscaling they will not get scale up events.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
