### PR TITLE
Fix backpressure for compute jobs (backport #6761)

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -366,6 +366,12 @@ name = "samples"
 path = "tests/samples_tests.rs"
 harness = false
 
+[[test]]
+# This test is separated because it needs to run in a dedicated process.
+# nextest does this by default, but using a separate [[test]] also makes it work with `cargo test`.
+name = "compute_backpressure"
+path = "tests/compute_backpressure.rs"
+
 [[bench]]
 name = "huge_requests"
 harness = false

--- a/apollo-router/src/ageing_priority_queue.rs
+++ b/apollo-router/src/ageing_priority_queue.rs
@@ -14,6 +14,12 @@ pub(crate) enum Priority {
     P8,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum SendError {
+    QueueIsFull,
+    Disconnected,
+}
+
 const INNER_QUEUES_COUNT: usize = Priority::P8 as usize - Priority::P1 as usize + 1;
 
 /// Indices start at 0 for highest priority
@@ -33,8 +39,8 @@ where
     /// Items in **lower** indices queues are handled sooner
     inner_queues:
         [(crossbeam_channel::Sender<T>, crossbeam_channel::Receiver<T>); INNER_QUEUES_COUNT],
-    queued_count: AtomicUsize,
-    soft_capacity: usize,
+    pub(crate) queued_count: AtomicUsize,
+    capacity: usize,
 }
 
 pub(crate) struct Receiver<'a, T>
@@ -49,12 +55,12 @@ impl<T> AgeingPriorityQueue<T>
 where
     T: Send + 'static,
 {
-    pub(crate) fn soft_bounded(soft_capacity: usize) -> Self {
+    pub(crate) fn bounded(capacity: usize) -> Self {
         Self {
             // Using unbounded channels: callers must use `is_full` to implement backpressure
             inner_queues: std::array::from_fn(|_| crossbeam_channel::unbounded()),
             queued_count: AtomicUsize::new(0),
-            soft_capacity,
+            capacity,
         }
     }
 
@@ -62,15 +68,17 @@ where
         self.queued_count.load(Ordering::Relaxed)
     }
 
-    pub(crate) fn is_full(&self) -> bool {
-        self.queued_count() >= self.soft_capacity
-    }
-
     /// Panics if `priority` is not in `AVAILABLE_PRIORITIES`
-    pub(crate) fn send(&self, priority: Priority, message: T) {
-        self.queued_count.fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn send(&self, priority: Priority, message: T) -> Result<(), SendError> {
+        self.queued_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |previous_count| {
+                (previous_count < self.capacity).then_some(previous_count + 1)
+            })
+            .map_err(|_| SendError::QueueIsFull)?;
         let (inner_sender, _) = &self.inner_queues[index_from_priority(priority)];
-        inner_sender.send(message).expect("disconnected channel")
+        inner_sender
+            .send(message)
+            .map_err(|crossbeam_channel::SendError(_)| SendError::Disconnected)
     }
 
     pub(crate) fn receiver(&self) -> Receiver<'_, T> {
@@ -96,6 +104,8 @@ where
         let selected = self.select.select();
         let index = selected.index();
         let (_tx, rx) = &self.shared.inner_queues[index];
+        // This `expect` can never panic because this channel can never be disconnected
+        // because its sender is right here in `_tx`.
         let item = selected.recv(rx).expect("disconnected channel");
         self.shared.queued_count.fetch_sub(1, Ordering::Relaxed);
         self.age(index);
@@ -108,9 +118,11 @@ where
             let [higher_priority, lower_priority] = window else {
                 panic!("expected windows of length 2")
             };
-            let (higher_priority_sender, _) = higher_priority;
+            let (higher_priority_sender, _higher_priority_receiver) = higher_priority;
             let (_, lower_priority_receiver) = lower_priority;
             if let Ok(message) = lower_priority_receiver.try_recv() {
+                // This `expect` can never panic because this channel can never be disconnected
+                // because its sender is right here in `_higher_priority_receiver`.
                 higher_priority_sender
                     .send(message)
                     .expect("disconnected channel")
@@ -121,17 +133,16 @@ where
 
 #[test]
 fn test_priorities() {
-    let queue = AgeingPriorityQueue::soft_bounded(3);
+    let queue = AgeingPriorityQueue::bounded(4);
     assert_eq!(queue.queued_count(), 0);
-    assert!(!queue.is_full());
-    queue.send(Priority::P1, "p1");
-    assert!(!queue.is_full());
-    queue.send(Priority::P2, "p2");
-    assert!(!queue.is_full());
-    queue.send(Priority::P3, "p3");
-    // The queue is now "full" but sending still works, it’s up to the caller to stop sending
-    assert!(queue.is_full());
-    queue.send(Priority::P2, "p2 again");
+    queue.send(Priority::P1, "p1").unwrap();
+    assert_eq!(queue.queued_count(), 1);
+    queue.send(Priority::P2, "p2").unwrap();
+    queue.send(Priority::P3, "p3").unwrap();
+    queue.send(Priority::P2, "p2 again").unwrap();
+    assert_eq!(queue.queued_count(), 4);
+    // The queue is full now, this send() fails:
+    queue.send(Priority::P3, "p5").unwrap_err();
     assert_eq!(queue.queued_count(), 4);
 
     let mut receiver = queue.receiver();

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -16,9 +16,12 @@ use crate::configuration::RedisCache;
 pub(crate) mod redis;
 mod size_estimation;
 pub(crate) mod storage;
+use std::convert::Infallible;
+
 pub(crate) use size_estimation::estimate_size;
 
-type WaitMap<K, V> = Arc<Mutex<HashMap<K, broadcast::Sender<V>>>>;
+type WaitMap<K, V, UncachedError> =
+    Arc<Mutex<HashMap<K, broadcast::Sender<Result<V, UncachedError>>>>>;
 pub(crate) const DEFAULT_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(512) {
     Some(v) => v,
     None => unreachable!(),
@@ -26,15 +29,20 @@ pub(crate) const DEFAULT_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(
 
 /// Cache implementation with query deduplication
 #[derive(Clone)]
-pub(crate) struct DeduplicatingCache<K: KeyType, V: ValueType> {
-    wait_map: WaitMap<K, V>,
+pub(crate) struct DeduplicatingCache<K, V, UncachedError = Infallible>
+where
+    K: KeyType,
+    V: ValueType,
+{
+    wait_map: WaitMap<K, V, UncachedError>,
     storage: CacheStorage<K, V>,
 }
 
-impl<K, V> DeduplicatingCache<K, V>
+impl<K, V, UncachedError> DeduplicatingCache<K, V, UncachedError>
 where
     K: KeyType + 'static,
     V: ValueType + 'static,
+    UncachedError: Clone + Send + 'static,
 {
     pub(crate) async fn with_capacity(
         capacity: NonZeroUsize,
@@ -60,7 +68,7 @@ where
         &self,
         key: &K,
         init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
-    ) -> Entry<K, V> {
+    ) -> Entry<K, V, UncachedError> {
         // waiting on a value from the cache is a potentially long(millisecond scale) task that
         // can involve a network call to an external database. To reduce the waiting time, we
         // go through a wait map to register interest in data associated with a key.
@@ -99,7 +107,7 @@ where
                 drop(locked_wait_map);
 
                 if let Some(value) = self.storage.get(key, init_from_redis).await {
-                    self.send(sender, key, value.clone()).await;
+                    self.send(sender, key, Ok(value.clone())).await;
 
                     return Entry {
                         inner: EntryInner::Value(value),
@@ -126,7 +134,12 @@ where
         self.storage.insert_in_memory(key, value).await;
     }
 
-    async fn send(&self, sender: broadcast::Sender<V>, key: &K, value: V) {
+    async fn send(
+        &self,
+        sender: broadcast::Sender<Result<V, UncachedError>>,
+        key: &K,
+        value: Result<V, UncachedError>,
+    ) {
         // Lock the wait map to prevent more subscribers racing with our send
         // notification
         let mut locked_wait_map = self.wait_map.lock().await;
@@ -143,44 +156,49 @@ where
     }
 }
 
-pub(crate) struct Entry<K: KeyType, V: ValueType> {
-    inner: EntryInner<K, V>,
+pub(crate) struct Entry<K: KeyType, V: ValueType, UncachedError> {
+    inner: EntryInner<K, V, UncachedError>,
 }
-enum EntryInner<K: KeyType, V: ValueType> {
+enum EntryInner<K: KeyType, V: ValueType, UncachedError> {
     First {
         key: K,
-        sender: broadcast::Sender<V>,
-        cache: DeduplicatingCache<K, V>,
+        sender: broadcast::Sender<Result<V, UncachedError>>,
+        cache: DeduplicatingCache<K, V, UncachedError>,
         _drop_signal: oneshot::Sender<()>,
     },
     Receiver {
-        receiver: broadcast::Receiver<V>,
+        receiver: broadcast::Receiver<Result<V, UncachedError>>,
     },
     Value(V),
 }
 
 #[derive(Debug)]
-pub(crate) enum EntryError {
-    Closed,
+pub(crate) enum EntryError<UncachedError> {
     IsFirst,
+    RecvError,
+    UncachedError(UncachedError),
 }
 
-impl<K, V> Entry<K, V>
+impl<K, V, UncachedError> Entry<K, V, UncachedError>
 where
     K: KeyType + 'static,
     V: ValueType + 'static,
+    UncachedError: Clone + Send + 'static,
 {
     pub(crate) fn is_first(&self) -> bool {
         matches!(self.inner, EntryInner::First { .. })
     }
 
-    pub(crate) async fn get(self) -> Result<V, EntryError> {
+    pub(crate) async fn get(self) -> Result<V, EntryError<UncachedError>> {
         match self.inner {
             // there was already a value in cache
             EntryInner::Value(v) => Ok(v),
-            EntryInner::Receiver { mut receiver } => {
-                receiver.recv().await.map_err(|_| EntryError::Closed)
-            }
+            EntryInner::Receiver { mut receiver } => match receiver.recv().await {
+                Ok(Ok(value)) => Ok(value),
+                Ok(Err(e)) => Err(EntryError::UncachedError(e)),
+                Err(broadcast::error::RecvError::Closed)
+                | Err(broadcast::error::RecvError::Lagged(_)) => Err(EntryError::RecvError),
+            },
             _ => Err(EntryError::IsFirst),
         }
     }
@@ -194,13 +212,13 @@ where
         } = self.inner
         {
             cache.insert(key.clone(), value.clone()).await;
-            cache.send(sender, &key, value).await;
+            cache.send(sender, &key, Ok(value)).await;
         }
     }
 
     /// sends the value without storing it into the cache
     #[allow(unused)]
-    pub(crate) async fn send(self, value: V) {
+    pub(crate) async fn send(self, value: Result<V, UncachedError>) {
         if let EntryInner::First {
             sender, cache, key, ..
         } = self.inner
@@ -224,9 +242,10 @@ mod tests {
     #[tokio::test]
     async fn example_cache_usage() {
         let k = "key".to_string();
-        let cache = DeduplicatingCache::with_capacity(NonZeroUsize::new(1).unwrap(), None, "test")
-            .await
-            .unwrap();
+        let cache: DeduplicatingCache<String, String> =
+            DeduplicatingCache::with_capacity(NonZeroUsize::new(1).unwrap(), None, "test")
+                .await
+                .unwrap();
 
         let entry = cache.get(&k, |_| Ok(())).await;
 

--- a/apollo-router/src/compute_job.rs
+++ b/apollo-router/src/compute_job.rs
@@ -8,6 +8,7 @@ use tokio::sync::oneshot;
 
 use crate::ageing_priority_queue::AgeingPriorityQueue;
 pub(crate) use crate::ageing_priority_queue::Priority;
+use crate::ageing_priority_queue::SendError;
 use crate::metrics::meter_provider;
 
 /// We generate backpressure in tower `poll_ready` when the number of queued jobs
@@ -31,9 +32,47 @@ fn thread_pool_size() -> usize {
     }
 }
 
+/// Compute job queue is full
+#[derive(thiserror::Error, Debug, displaydoc::Display, Clone)]
+pub(crate) struct ComputeBackPressureError;
+
+#[derive(Debug)]
+pub(crate) enum MaybeBackPressureError<E> {
+    /// Doing the same request again later would result in the same error (e.g. invalid query).
+    ///
+    /// This error can be cached.
+    PermanentError(E),
+
+    /// Doing the same request again later might work.
+    ///
+    /// This error must not be cached.
+    TemporaryError(ComputeBackPressureError),
+}
+
+impl<E> From<E> for MaybeBackPressureError<E> {
+    fn from(error: E) -> Self {
+        Self::PermanentError(error)
+    }
+}
+
+impl ComputeBackPressureError {
+    pub(crate) fn to_graphql_error(&self) -> crate::graphql::Error {
+        crate::graphql::Error::builder()
+            .message("Your request has been concurrency limited during query processing")
+            .extension_code("REQUEST_CONCURRENCY_LIMITED")
+            .build()
+    }
+}
+
+impl crate::graphql::IntoGraphQLErrors for ComputeBackPressureError {
+    fn into_graphql_errors(self) -> Result<Vec<crate::graphql::Error>, Self> {
+        Ok(vec![self.to_graphql_error()])
+    }
+}
+
 type Job = Box<dyn FnOnce() + Send + 'static>;
 
-fn queue() -> &'static AgeingPriorityQueue<Job> {
+pub(crate) fn queue() -> &'static AgeingPriorityQueue<Job> {
     static QUEUE: OnceLock<AgeingPriorityQueue<Job>> = OnceLock::new();
     QUEUE.get_or_init(|| {
         let pool_size = thread_pool_size();
@@ -52,7 +91,7 @@ fn queue() -> &'static AgeingPriorityQueue<Job> {
                 }
             });
         }
-        AgeingPriorityQueue::soft_bounded(QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size)
+        AgeingPriorityQueue::bounded(QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size)
     })
 }
 
@@ -60,7 +99,7 @@ fn queue() -> &'static AgeingPriorityQueue<Job> {
 pub(crate) fn execute<T, F>(
     priority: Priority,
     job: F,
-) -> impl Future<Output = std::thread::Result<T>>
+) -> Result<impl Future<Output = std::thread::Result<T>>, ComputeBackPressureError>
 where
     F: FnOnce() -> T + Send + UnwindSafe + 'static,
     T: Send + 'static,
@@ -70,12 +109,30 @@ where
         // Ignore the error if the oneshot receiver was dropped
         let _ = tx.send(std::panic::catch_unwind(job));
     });
-    queue().send(priority, job);
-    async { rx.await.expect("channel disconnected") }
-}
-
-pub(crate) fn is_full() -> bool {
-    queue().is_full()
+    let queue = queue();
+    queue.send(priority, job).map_err(|e| match e {
+        SendError::QueueIsFull => {
+            u64_counter!(
+                "apollo.router.compute_jobs.queue_is_full",
+                "Number of requests rejected because the queue for compute jobs is full",
+                1u64
+            );
+            ComputeBackPressureError
+        }
+        SendError::Disconnected => {
+            // This never panics because this channel can never be disconnect:
+            // the receiver is owned by `queue` which we can access here:
+            let _proof_of_life: &'static AgeingPriorityQueue<_> = queue;
+            unreachable!()
+        }
+    })?;
+    Ok(async move {
+        // This `expect` never panics because this oneshot channel can never be disconnect:
+        // the sender is owned by `job` which, if we reach here, was successfully sent to the queue.
+        // The queue or thread pool never drop a job without executing it.
+        // When executing, `catch_unwind` ensures that the sender cannot be dropped without sending.
+        rx.await.expect("channel disconnected")
+    })
 }
 
 pub(crate) fn create_queue_size_gauge() -> ObservableGauge<u64> {
@@ -100,6 +157,7 @@ mod tests {
     async fn test_executes_on_different_thread() {
         let test_thread = std::thread::current().id();
         let job_thread = execute(Priority::P4, || std::thread::current().id())
+            .unwrap()
             .await
             .unwrap();
         assert_ne!(job_thread, test_thread)
@@ -114,11 +172,13 @@ mod tests {
         let one = execute(Priority::P8, || {
             std::thread::sleep(Duration::from_millis(1_000));
             1
-        });
+        })
+        .unwrap();
         let two = execute(Priority::P8, || {
             std::thread::sleep(Duration::from_millis(1_000));
             1 + 1
-        });
+        })
+        .unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
         assert_eq!(one.await.unwrap(), 1);
         assert_eq!(two.await.unwrap(), 2);

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -201,10 +201,12 @@ impl From<QueryPlannerError> for FetchError {
 }
 
 /// Error types for CacheResolver
-#[derive(Error, Debug, Display, Clone, Serialize, Deserialize)]
+#[derive(Error, Debug, Display, Clone)]
 pub(crate) enum CacheResolverError {
     /// value retrieval failed: {0}
     RetrievalError(Arc<QueryPlannerError>),
+    /// {0}
+    Backpressure(crate::compute_job::ComputeBackPressureError),
     /// batch processing failed: {0}
     BatchingError(String),
 }
@@ -217,6 +219,7 @@ impl IntoGraphQLErrors for CacheResolverError {
                 .clone()
                 .into_graphql_errors()
                 .map_err(|_err| CacheResolverError::RetrievalError(retrieval_error)),
+            CacheResolverError::Backpressure(e) => Ok(vec![e.to_graphql_error()]),
             CacheResolverError::BatchingError(msg) => Ok(vec![Error::builder()
                 .message(msg)
                 .extension_code("BATCH_PROCESSING_FAILED")
@@ -264,9 +267,6 @@ pub(crate) enum QueryPlannerError {
 
     /// query planning panicked: {0}
     JoinError(String),
-
-    /// Cache resolution failed: {0}
-    CacheResolverError(Arc<CacheResolverError>),
 
     /// empty query plan. This behavior is unexpected and we suggest opening an issue to apollographql/router with a reproduction.
     EmptyPlan(UsageReporting), // usage_reporting_signature
@@ -440,12 +440,6 @@ impl QueryPlannerError {
 impl From<JoinError> for QueryPlannerError {
     fn from(err: JoinError) -> Self {
         QueryPlannerError::JoinError(err.to_string())
-    }
-}
-
-impl From<CacheResolverError> for QueryPlannerError {
-    fn from(err: CacheResolverError) -> Self {
-        QueryPlannerError::CacheResolverError(Arc::new(err))
     }
 }
 

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -114,4 +114,8 @@ pub mod _private {
     pub use crate::plugin::PLUGINS;
     // For tests
     pub use crate::router_factory::create_test_service_factory_from_yaml;
+
+    pub fn compute_job_queued_count() -> &'static std::sync::atomic::AtomicUsize {
+        &crate::compute_job::queue().queued_count
+    }
 }

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -21,6 +21,9 @@ use crate::cache::estimate_size;
 use crate::cache::storage::InMemoryCache;
 use crate::cache::storage::ValueType;
 use crate::cache::DeduplicatingCache;
+use crate::cache::EntryError;
+use crate::compute_job::ComputeBackPressureError;
+use crate::compute_job::MaybeBackPressureError;
 use crate::configuration::PersistedQueriesPrewarmQueryPlanCache;
 use crate::error::CacheResolverError;
 use crate::error::QueryPlannerError;
@@ -77,7 +80,11 @@ impl std::fmt::Debug for ConfigModeHash {
 #[derive(Clone)]
 pub(crate) struct CachingQueryPlanner<T: Clone> {
     cache: Arc<
-        DeduplicatingCache<CachingQueryKey, Result<QueryPlannerContent, Arc<QueryPlannerError>>>,
+        DeduplicatingCache<
+            CachingQueryKey,
+            Result<QueryPlannerContent, Arc<QueryPlannerError>>,
+            ComputeBackPressureError,
+        >,
     >,
     delegate: T,
     schema: Arc<Schema>,
@@ -106,7 +113,7 @@ where
     T: tower::Service<
             QueryPlannerRequest,
             Response = QueryPlannerResponse,
-            Error = QueryPlannerError,
+            Error = MaybeBackPressureError<QueryPlannerError>,
         > + Send,
     <T as tower::Service<QueryPlannerRequest>>::Future: Send,
 {
@@ -255,7 +262,7 @@ where
 
         let mut count = 0usize;
         let mut reused = 0usize;
-        for WarmUpCachingQueryKey {
+        'all_cache_keys_loop: for WarmUpCachingQueryKey {
             query,
             operation_name,
             hash,
@@ -307,48 +314,61 @@ where
                 })
                 .await;
             if entry.is_first() {
-                let doc = match query_analysis
-                    .parse_document(&query, operation_name.as_deref())
-                    .await
-                {
-                    Ok(doc) => doc,
-                    Err(error) => {
-                        let e = Arc::new(QueryPlannerError::SpecError(error));
-                        tokio::spawn(async move {
-                            entry.insert(Err(e)).await;
-                        });
-                        continue;
-                    }
-                };
-
-                let request = QueryPlannerRequest {
-                    query,
-                    operation_name,
-                    document: doc,
-                    metadata: caching_key.metadata,
-                    plan_options: caching_key.plan_options,
-                };
-
-                let res = match service.ready().await {
-                    Ok(service) => service.call(request).await,
-                    Err(_) => break,
-                };
-
-                match res {
-                    Ok(QueryPlannerResponse { content, .. }) => {
-                        if let Some(content) = content.clone() {
-                            count += 1;
+                let doc = loop {
+                    match query_analysis
+                        .parse_document(&query, operation_name.as_deref())
+                        .await
+                    {
+                        Ok(doc) => break doc,
+                        Err(MaybeBackPressureError::PermanentError(error)) => {
+                            let e = Arc::new(QueryPlannerError::SpecError(error));
                             tokio::spawn(async move {
-                                entry.insert(Ok(content.clone())).await;
+                                entry.insert(Err(e)).await;
                             });
+                            continue 'all_cache_keys_loop;
+                        }
+                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError)) => {
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                            // try again
                         }
                     }
-                    Err(error) => {
-                        count += 1;
-                        let e = Arc::new(error);
-                        tokio::spawn(async move {
-                            entry.insert(Err(e)).await;
-                        });
+                };
+
+                loop {
+                    let request = QueryPlannerRequest {
+                        query: query.clone(),
+                        operation_name: operation_name.clone(),
+                        document: doc.clone(),
+                        metadata: caching_key.metadata.clone(),
+                        plan_options: caching_key.plan_options.clone(),
+                    };
+                    let res = match service.ready().await {
+                        Ok(service) => service.call(request).await,
+                        Err(_) => break 'all_cache_keys_loop,
+                    };
+
+                    match res {
+                        Ok(QueryPlannerResponse { content, .. }) => {
+                            if let Some(content) = content.clone() {
+                                count += 1;
+                                tokio::spawn(async move {
+                                    entry.insert(Ok(content.clone())).await;
+                                });
+                            }
+                            break;
+                        }
+                        Err(MaybeBackPressureError::PermanentError(error)) => {
+                            count += 1;
+                            let e = Arc::new(error);
+                            tokio::spawn(async move {
+                                entry.insert(Err(e)).await;
+                            });
+                            break;
+                        }
+                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError)) => {
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                            // try again
+                        }
                     }
                 }
             }
@@ -375,7 +395,7 @@ where
     T: tower::Service<
         QueryPlannerRequest,
         Response = QueryPlannerResponse,
-        Error = QueryPlannerError,
+        Error = MaybeBackPressureError<QueryPlannerError>,
     >,
     <T as tower::Service<QueryPlannerRequest>>::Future: Send,
 {
@@ -415,7 +435,7 @@ where
     T: tower::Service<
             QueryPlannerRequest,
             Response = QueryPlannerResponse,
-            Error = QueryPlannerError,
+            Error = MaybeBackPressureError<QueryPlannerError>,
         > + Clone
         + Send
         + 'static,
@@ -499,13 +519,21 @@ where
                 async move {
                     let service = match self.delegate.ready().await {
                         Ok(service) => service,
-                        Err(error) => {
+                        Err(MaybeBackPressureError::PermanentError(error)) => {
                             let e = Arc::new(error);
                             let err = e.clone();
                             tokio::spawn(async move {
                                 entry.insert(Err(err)).await;
                             });
                             return Err(CacheResolverError::RetrievalError(e));
+                        }
+                        Err(MaybeBackPressureError::TemporaryError(error)) => {
+                            let err = error.clone();
+                            tokio::spawn(async move {
+                                // Temporary errors are never cached
+                                entry.send(Err(err)).await;
+                            });
+                            return Err(CacheResolverError::Backpressure(error));
                         }
                     };
 
@@ -529,7 +557,7 @@ where
                                     });
                                 } else {
                                     tokio::spawn(async move {
-                                        entry.send(Ok(content)).await;
+                                        entry.send(Ok(Ok(content))).await;
                                     });
                                 }
                             }
@@ -542,7 +570,7 @@ where
                             }
                             Ok(QueryPlannerResponse { content, errors })
                         }
-                        Err(error) => {
+                        Err(MaybeBackPressureError::PermanentError(error)) => {
                             let e = Arc::new(error);
                             let err = e.clone();
                             tokio::spawn(async move {
@@ -555,6 +583,14 @@ where
                             }
                             Err(CacheResolverError::RetrievalError(e))
                         }
+                        Err(MaybeBackPressureError::TemporaryError(error)) => {
+                            let err = error.clone();
+                            tokio::spawn(async move {
+                                // Temporary errors are never cached
+                                entry.send(Err(err)).await;
+                            });
+                            Err(CacheResolverError::Backpressure(error))
+                        }
                     }
                 }
                 .in_current_span(),
@@ -566,10 +602,11 @@ where
                 )))
             })?
         } else {
-            let res = entry
-                .get()
-                .await
-                .map_err(|_| QueryPlannerError::UnhandledPlannerResult)?;
+            let res = entry.get().await.map_err(|e| match e {
+                EntryError::IsFirst | // IsFirst should be unreachable
+                EntryError::RecvError => QueryPlannerError::UnhandledPlannerResult.into(),
+                EntryError::UncachedError(e) => CacheResolverError::Backpressure(e),
+            })?;
 
             match res {
                 Ok(content) => {
@@ -713,7 +750,7 @@ mod tests {
             fn sync_call(
                 &self,
                 key: QueryPlannerRequest,
-            ) -> Result<QueryPlannerResponse, QueryPlannerError>;
+            ) -> Result<QueryPlannerResponse, MaybeBackPressureError<QueryPlannerError>>;
         }
 
         impl Clone for MyQueryPlanner {
@@ -724,7 +761,7 @@ mod tests {
     impl Service<QueryPlannerRequest> for MockMyQueryPlanner {
         type Response = QueryPlannerResponse;
 
-        type Error = QueryPlannerError;
+        type Error = MaybeBackPressureError<QueryPlannerError>;
 
         type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -749,7 +786,7 @@ mod tests {
             planner
                 .expect_sync_call()
                 .times(0..2)
-                .returning(|_| Err(QueryPlannerError::UnhandledPlannerResult));
+                .returning(|_| Err(QueryPlannerError::UnhandledPlannerResult.into()));
             planner
         });
 

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -24,6 +24,7 @@ use super::PlanNode;
 use super::QueryKey;
 use crate::apollo_studio_interop::generate_usage_reporting;
 use crate::compute_job;
+use crate::compute_job::MaybeBackPressureError;
 use crate::error::FederationErrorBridge;
 use crate::error::QueryPlannerError;
 use crate::error::ServiceBuildError;
@@ -127,11 +128,11 @@ impl QueryPlannerService {
         // before we potentially share it in Arc with a background thread
         // for "both" mode.
         init_query_plan_root_node: impl Fn(&mut PlanNode) -> Result<(), ValidationErrors>,
-    ) -> Result<QueryPlanResult, QueryPlannerError> {
+    ) -> Result<QueryPlanResult, MaybeBackPressureError<QueryPlannerError>> {
         let doc = doc.clone();
         let rust_planner = self.planner.clone();
         let priority = compute_job::Priority::P8; // High priority
-        let (plan, mut root_node) = compute_job::execute(priority, move || {
+        let job = move || -> Result<_, QueryPlannerError> {
             let start = Instant::now();
 
             let query_plan_options = QueryPlanOptions {
@@ -160,15 +161,16 @@ impl QueryPlannerService {
             let elapsed = start.elapsed().as_secs_f64();
             metric_query_planning_plan_duration(RUST_QP_MODE, elapsed);
 
-            result.map(|plan| {
-                let root_node = convert_root_query_plan_node(&plan);
-                (plan, root_node)
-            })
-        })
-        .await
-        .expect("query planner panicked")?;
+            let plan = result?;
+            let root_node = convert_root_query_plan_node(&plan);
+            Ok((plan, root_node))
+        };
+        let (plan, mut root_node) = compute_job::execute(priority, job)
+            .map_err(MaybeBackPressureError::TemporaryError)?
+            .await
+            .expect("query planner panicked")?;
         if let Some(node) = &mut root_node {
-            init_query_plan_root_node(node)?;
+            init_query_plan_root_node(node).map_err(QueryPlannerError::from)?;
         }
 
         Ok(QueryPlanResult {
@@ -278,7 +280,7 @@ impl QueryPlannerService {
         plan_options: PlanOptions,
         doc: &ParsedDocument,
         query_metrics: OperationLimits<u32>,
-    ) -> Result<QueryPlannerContent, QueryPlannerError> {
+    ) -> Result<QueryPlannerContent, MaybeBackPressureError<QueryPlannerError>> {
         let plan_result = self
             .plan_inner(doc, operation.clone(), plan_options, |root_node| {
                 root_node.init_parsed_operations_and_hash_subqueries(&self.subgraph_schemas)?;
@@ -339,7 +341,7 @@ impl QueryPlannerService {
             })
         } else {
             failfast_debug!("empty query plan");
-            Err(QueryPlannerError::EmptyPlan(usage_reporting))
+            Err(QueryPlannerError::EmptyPlan(usage_reporting).into())
         }
     }
 }
@@ -347,16 +349,12 @@ impl QueryPlannerService {
 impl Service<QueryPlannerRequest> for QueryPlannerService {
     type Response = QueryPlannerResponse;
 
-    type Error = QueryPlannerError;
+    type Error = MaybeBackPressureError<QueryPlannerError>;
 
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if crate::compute_job::is_full() {
-            Poll::Pending
-        } else {
-            Poll::Ready(Ok(()))
-        }
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: QueryPlannerRequest) -> Self::Future {
@@ -378,13 +376,16 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
                 Err(e) => {
                     return Err(QueryPlannerError::SpecError(SpecError::TransformError(
                         e.to_string(),
-                    )))
+                    ))
+                    .into())
                 }
                 Ok(modified_query) => {
                     let executable_document = modified_query
                         .to_executable_validate(api_schema)
                         // Assume transformation creates a valid document: ignore conversion errors
-                        .map_err(|e| SpecError::ValidationError(e.into()))?;
+                        .map_err(|e| {
+                            QueryPlannerError::from(SpecError::ValidationError(e.into()))
+                        })?;
                     let hash = this
                         .schema
                         .schema_id
@@ -394,7 +395,8 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
                         Arc::new(executable_document),
                         operation_name.as_deref(),
                         Arc::new(hash),
-                    )?;
+                    )
+                    .map_err(QueryPlannerError::from)?;
                 }
             }
 
@@ -438,7 +440,7 @@ impl QueryPlannerService {
         &self,
         mut key: QueryKey,
         mut doc: ParsedDocument,
-    ) -> Result<QueryPlannerContent, QueryPlannerError> {
+    ) -> Result<QueryPlannerContent, MaybeBackPressureError<QueryPlannerError>> {
         let mut query_metrics = Default::default();
         let mut selections = self
             .parse_selections(
@@ -467,9 +469,9 @@ impl QueryPlannerService {
             .await
         {
             ControlFlow::Continue(()) => (),
-            ControlFlow::Break(response) => {
+            ControlFlow::Break(result) => {
                 return Ok(QueryPlannerContent::CachedIntrospectionResponse {
-                    response: Box::new(response),
+                    response: Box::new(result.map_err(MaybeBackPressureError::TemporaryError)?),
                 })
             }
         }
@@ -512,13 +514,14 @@ impl QueryPlannerService {
             key.filtered_query = new_query;
             let executable_document = new_doc
                 .to_executable_validate(self.schema.api_schema())
-                .map_err(|e| SpecError::ValidationError(e.into()))?;
+                .map_err(|e| QueryPlannerError::from(SpecError::ValidationError(e.into())))?;
             doc = ParsedDocumentInner::new(
                 new_doc,
                 Arc::new(executable_document),
                 key.operation_name.as_deref(),
                 Arc::new(new_hash),
-            )?;
+            )
+            .map_err(QueryPlannerError::from)?;
             selections.unauthorized.paths = unauthorized_paths;
         }
 
@@ -698,7 +701,9 @@ mod tests {
                 .unwrap_err();
 
         match err {
-            QueryPlannerError::EmptyPlan(usage_reporting) => {
+            MaybeBackPressureError::PermanentError(QueryPlannerError::EmptyPlan(
+                usage_reporting,
+            )) => {
                 insta::with_settings!({sort_maps => true}, {
                     insta::assert_json_snapshot!("empty_query_plan_usage_reporting", usage_reporting);
                 });
@@ -1088,7 +1093,7 @@ mod tests {
             &configuration,
         )?;
 
-        planner
+        let result = planner
             .get(
                 QueryKey {
                     original_query: original_query.to_string(),
@@ -1099,7 +1104,12 @@ mod tests {
                 },
                 doc,
             )
-            .await
+            .await;
+        match result {
+            Ok(x) => Ok(x),
+            Err(MaybeBackPressureError::PermanentError(e)) => Err(e),
+            Err(MaybeBackPressureError::TemporaryError(e)) => panic!("{e:?}"),
+        }
     }
 
     #[tokio::test]

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -17,6 +17,7 @@ use crate::apollo_studio_interop::generate_extended_references;
 use crate::apollo_studio_interop::ExtendedReferenceStats;
 use crate::apollo_studio_interop::UsageReporting;
 use crate::compute_job;
+use crate::compute_job::MaybeBackPressureError;
 use crate::context::OPERATION_KIND;
 use crate::context::OPERATION_NAME;
 use crate::graphql::Error;
@@ -33,6 +34,7 @@ use crate::spec::Query;
 use crate::spec::QueryHash;
 use crate::spec::Schema;
 use crate::spec::SpecError;
+use crate::spec::GRAPHQL_VALIDATION_FAILURE_ERROR_KEY;
 use crate::Configuration;
 use crate::Context;
 
@@ -79,7 +81,7 @@ impl QueryAnalysisLayer {
         &self,
         query: &str,
         operation_name: Option<&str>,
-    ) -> Result<ParsedDocument, SpecError> {
+    ) -> Result<ParsedDocument, MaybeBackPressureError<SpecError>> {
         let query = query.to_string();
         let operation_name = operation_name.map(|o| o.to_string());
         let schema = self.schema.clone();
@@ -102,9 +104,10 @@ impl QueryAnalysisLayer {
         };
         // TODO: is this correct?
         let job = std::panic::AssertUnwindSafe(job);
-        compute_job::execute(priority, job)
+        Ok(compute_job::execute(priority, job)
+            .map_err(MaybeBackPressureError::TemporaryError)?
             .await
-            .expect("Query::parse_document panicked")
+            .expect("Query::parse_document panicked")?)
     }
 
     pub(crate) async fn supergraph_request(
@@ -153,15 +156,17 @@ impl QueryAnalysisLayer {
 
         let res = match entry {
             None => match self.parse_document(&query, op_name.as_deref()).await {
-                Err(errors) => {
-                    (*self.cache.lock().await).put(
-                        QueryAnalysisKey {
-                            query,
-                            operation_name: op_name.clone(),
-                        },
-                        Err(errors.clone()),
-                    );
-                    Err(errors)
+                Err(e) => {
+                    if let MaybeBackPressureError::PermanentError(errors) = &e {
+                        (*self.cache.lock().await).put(
+                            QueryAnalysisKey {
+                                query,
+                                operation_name: op_name.clone(),
+                            },
+                            Err(errors.clone()),
+                        );
+                    }
+                    Err(e)
                 }
                 Ok(doc) => {
                     let context = Context::new();
@@ -194,7 +199,7 @@ impl QueryAnalysisLayer {
                     Ok((context, doc))
                 }
             },
-            Some(c) => c,
+            Some(cached_result) => cached_result.map_err(MaybeBackPressureError::PermanentError),
         };
 
         match res {
@@ -227,7 +232,7 @@ impl QueryAnalysisLayer {
                     context: request.context,
                 })
             }
-            Err(errors) => {
+            Err(MaybeBackPressureError::PermanentError(errors)) => {
                 request.context.extensions().with_lock(|mut lock| {
                     lock.insert(Arc::new(UsageReporting {
                         stats_report_key: errors.get_error_key().to_string(),
@@ -244,6 +249,20 @@ impl QueryAnalysisLayer {
                 Err(SupergraphResponse::builder()
                     .errors(errors)
                     .status_code(StatusCode::BAD_REQUEST)
+                    .context(request.context)
+                    .build()
+                    .expect("response is valid"))
+            }
+            Err(MaybeBackPressureError::TemporaryError(error)) => {
+                request.context.extensions().with_lock(|mut lock| {
+                    lock.insert(Arc::new(UsageReporting {
+                        stats_report_key: GRAPHQL_VALIDATION_FAILURE_ERROR_KEY.to_string(),
+                        referenced_fields_by_type: HashMap::new(),
+                    }))
+                });
+                Err(SupergraphResponse::builder()
+                    .error(error.to_graphql_error())
+                    .status_code(StatusCode::SERVICE_UNAVAILABLE)
                     .context(request.context)
                     .build()
                     .expect("response is valid"))

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use static_assertions::assert_impl_all;
 
 use super::layers::query_analysis::ParsedDocument;
+use crate::compute_job::MaybeBackPressureError;
 use crate::error::QueryPlannerError;
 use crate::graphql;
 use crate::query_planner::QueryPlan;
@@ -116,12 +117,12 @@ impl Response {
     }
 }
 
-pub(crate) type BoxService = tower::util::BoxService<Request, Response, QueryPlannerError>;
+pub(crate) type ServiceError = MaybeBackPressureError<QueryPlannerError>;
+pub(crate) type BoxService = tower::util::BoxService<Request, Response, ServiceError>;
 #[allow(dead_code)]
-pub(crate) type BoxCloneService =
-    tower::util::BoxCloneService<Request, Response, QueryPlannerError>;
+pub(crate) type BoxCloneService = tower::util::BoxCloneService<Request, Response, ServiceError>;
 #[allow(dead_code)]
-pub(crate) type ServiceResult = Result<Response, QueryPlannerError>;
+pub(crate) type ServiceResult = Result<Response, ServiceError>;
 #[allow(dead_code)]
 pub(crate) type Body = hyper::Body;
 #[allow(dead_code)]

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -214,11 +214,6 @@ impl Service<RouterRequest> for RouterService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // This service eventually calls `QueryAnalysisLayer::parse_document()`
-        // which calls `compute_job::execute()`
-        if crate::compute_job::is_full() {
-            return Poll::Pending;
-        }
         Poll::Ready(Ok(()))
     }
 

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -186,16 +186,24 @@ async fn service_call(
     .await
     {
         Ok(resp) => resp,
-        Err(err) => match err.into_graphql_errors() {
-            Ok(gql_errors) => {
-                return Ok(SupergraphResponse::infallible_builder()
-                    .context(context)
-                    .errors(gql_errors)
-                    .status_code(StatusCode::BAD_REQUEST) // If it's a graphql error we return a status code 400
-                    .build());
+        Err(err) => {
+            let status = match &err {
+                CacheResolverError::Backpressure(_) => StatusCode::SERVICE_UNAVAILABLE,
+                CacheResolverError::RetrievalError(_) | CacheResolverError::BatchingError(_) => {
+                    StatusCode::BAD_REQUEST
+                }
+            };
+            match err.into_graphql_errors() {
+                Ok(gql_errors) => {
+                    return Ok(SupergraphResponse::infallible_builder()
+                        .context(context)
+                        .errors(gql_errors)
+                        .status_code(status) // If it's a graphql error we return a status code 400
+                        .build());
+                }
+                Err(err) => return Err(err.into()),
             }
-            Err(err) => return Err(err.into()),
-        },
+        }
     };
 
     if !errors.is_empty() {

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -162,3 +162,9 @@ impl IntoGraphQLErrors for SpecError {
         }
     }
 }
+
+impl From<std::convert::Infallible> for SpecError {
+    fn from(value: std::convert::Infallible) -> Self {
+        match value {}
+    }
+}

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -1075,9 +1075,9 @@ impl Operation {
                         .as_ref()
                         .and_then(|v| parse_hir_value(v)),
                 };
-                Ok((name, variable))
+                (name, variable)
             })
-            .collect::<Result<_, _>>()?;
+            .collect();
 
         Ok(Operation {
             selection_set,

--- a/apollo-router/tests/compute_backpressure.rs
+++ b/apollo-router/tests/compute_backpressure.rs
@@ -1,0 +1,73 @@
+use std::sync::atomic::Ordering;
+
+use tower::Service as _;
+use tower::ServiceExt as _;
+
+// This test is separated because it needs to run in a dedicated process.
+// nextest does this by default, but using a separate [[test]] also makes it work with `cargo test`.
+
+#[tokio::test]
+async fn test_compute_backpressure_response() {
+    let mut harness = apollo_router::TestHarness::builder()
+        .build_router()
+        .await
+        .unwrap();
+    macro_rules! call {
+        ($query: expr) => {{
+            let request = apollo_router::services::supergraph::Request::canned_builder()
+                .query($query)
+                .build()
+                .unwrap()
+                .try_into()
+                .unwrap();
+            let mut response = harness.ready().await.unwrap().call(request).await.unwrap();
+            let bytes = response.next_response().await.unwrap().unwrap();
+            let graphql_response: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            serde_json::json!({
+                "status": response.response.status().as_u16(),
+                "body": graphql_response
+            })
+        }};
+    }
+
+    insta::assert_yaml_snapshot!(call!("{__typename} # 1"), @r###"
+        ---
+        status: 200
+        body:
+          data:
+            __typename: Query
+    "###);
+
+    apollo_router::_private::compute_job_queued_count().fetch_add(1_000_000, Ordering::Relaxed);
+
+    // Slightly different query so parsing isn’t cached and "compute" is needed.
+    // When the queue is full we quickly return an error
+    let start = std::time::Instant::now();
+    let response = call!("{__typename} # 2");
+    let latency = start.elapsed();
+    assert!(
+        latency < std::time::Duration::from_millis(100),
+        "latency = {latency:?}, status = {:?}",
+        &response["status"]
+    );
+    insta::assert_yaml_snapshot!(response, @r###"
+        ---
+        status: 503
+        body:
+          errors:
+            - message: Your request has been concurrency limited during query processing
+              extensions:
+                code: REQUEST_CONCURRENCY_LIMITED
+    "###);
+
+    apollo_router::_private::compute_job_queued_count().fetch_sub(1_000_000, Ordering::Relaxed);
+
+    // Router gracefully recovers
+    insta::assert_yaml_snapshot!(call!("{__typename} # 3"), @r###"
+        ---
+        status: 200
+        body:
+          data:
+            __typename: Query
+    "###);
+}

--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -65,6 +65,7 @@ The coprocessor operations metric has the following attributes:
 ### Compute jobs
 
 - `apollo.router.compute_jobs.queued` - A gauge of the number of jobs queued for the thread pool dedicated to CPU-heavy components like GraphQL parsing and validation, and the (new) query planner.
+- `apollo.router.compute_jobs.queue_is_full` - A counter of requests rejected because the queue was full
 
 ### Uplink
 


### PR DESCRIPTION
Since version 1.58.0, Apollo Router has a dedicated thread pool for computation-heavy jobs with a priority queue. When the queue was full above a certain threshold, it attempted to exert backpressure by returning `Poll::Pending` in `tower::Service::poll_ready` for the query planner service. However this was not sufficient since `LoadShed` was not used together with `Poll::Pending`.

This PR moves to using error `Result`s to represent backpressure. As a consequence, we can now have a precise queue capacity checked when inserting instead of a "soft" capacity checked separately. Much of the diff is related to separating "permanent" errors that should be cached from "temporary" backpressure errors that should not be cached.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6761 done by [Mergify](https://mergify.com).