### PR TITLE
Hide leading `...` for inline `PathWithSubSelection`

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -293,14 +293,17 @@ impl PrettyPrintable for NamedSelection {
                     result.push_str(sub.as_str());
                 }
             }
-            Self::Path {
-                inline,
-                alias,
-                path,
-            } => {
-                if *inline {
-                    result.push_str("... ");
-                }
+            Self::Path { alias, path, .. } => {
+                // TODO Once we reintroduce conditional selections, I believe we
+                // should print the ... even for PathWithSubSelection selections
+                // which were not originally written with the ... (but for which
+                // *inline is nevertheless true), because the version with ...
+                // will be equivalent to the version without, and using the ...
+                // makes it much more obvious that the output of the selection
+                // will be inlined into the parent object.
+                // if *inline {
+                //     result.push_str("...");
+                // }
                 if let Some(alias) = alias {
                     result.push_str(alias.pretty_print().as_str());
                     result.push(' ');
@@ -452,6 +455,18 @@ mod tests {
         );
 
         test_permutations(sub_selection, sub);
+    }
+
+    #[test]
+    fn it_prints_an_inline_path_with_subselection() {
+        // This test ensures we do not print a leading ... before some.path,
+        // even though we will probably want to do so once ... and conditional
+        // selections are implemented. The printing of the leading ... was due
+        // to an incomplete removal of experimental support for conditional
+        // selections, which was put on hold to de-risk the GA release.
+        let source = "before\nsome.path {\n  inline\n  me\n}\nafter";
+        let sel = JSONSelection::parse(source).unwrap();
+        test_permutations(sel, source);
     }
 
     #[test]


### PR DESCRIPTION
My PR #6458 originally included support for conditional inline selections, which would have required a leading `...` for clarity, unlike the existing [`PathWithSubSelection`](https://github.com/apollographql/router/blob/dev/apollo-federation/src/sources/connect/json_selection/README.md#pathwithsubselection-) syntax.

We decided to hold back conditional selection support for the GA release, so I removed it from that PR, but I missed a spot in the pretty-printing code. I've now cleaned that up and added a regression test, with some comments about what we might do in the future, when we get back to implementing conditional selections.

Thanks to @nicholascioli for catching this oversight with fuzz testing.