### PR TITLE
Allow naked `LitExpr::LitPath` in expression parsing context

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/README.md
+++ b/apollo-federation/src/sources/connect/json_selection/README.md
@@ -99,7 +99,8 @@ PathStep             ::= "." Key | "->" Identifier MethodArgs?
 Key                  ::= Identifier | LitString
 Identifier           ::= [a-zA-Z_] NO_SPACE [0-9a-zA-Z_]*
 MethodArgs           ::= "(" (LitExpr ("," LitExpr)* ","?)? ")"
-LitExpr              ::= LitPrimitive | LitObject | LitArray | PathSelection
+LitExpr              ::= LitPath | LitPrimitive | LitObject | LitArray | PathSelection
+LitPath              ::= (LitPrimitive | LitObject | LitArray) PathStep+
 LitPrimitive         ::= LitString | LitNumber | "true" | "false" | "null"
 LitString            ::= "'" ("\\'" | [^'])* "'" | '"' ('\\"' | [^"])* '"'
 LitNumber            ::= "-"? ([0-9]+ ("." [0-9]*)? | "." [0-9]+)
@@ -672,25 +673,46 @@ The `->echo` method is still useful when you want to do something with the input
 value (which is bound to `@` within the echoed expression), rather than ignoring
 the input value (using `@` nowhere in the expression).
 
-The `$(...)` syntax can be useful within a `LitExpr` as well:
+#### The difference between `array.field->map(...)` and `$(array.field)->map(...)`
 
-```graphql
-# $(-1) needs wrapping in order to apply the ->mul method
-suffix: results.slice($(-1)->mul($args.suffixLength))
+When you apply a field selection to an array (as in `array.field`), the field
+selection is automatically mapped over each element of the array, producing a
+new array of all the field values.
 
-# Instead of something like this:
-# suffix: results.slice($->echo(-1)->mul($args.suffixLength))
+If the field selection has a further `->method` applied to it (as in
+`array.field->map(...)`), the method will be applied to each of the resulting
+field values _individually_, rather than to the array as a whole, which is
+probably not what you want given that you're using `->map` (unless each field
+value is an array, and you want an array of all those arrays, after mapping).
+
+The `$(...)` wrapping syntax can be useful to control this behavior, because it
+allows writing `$(array.field)->map(...)`, which provides the complete array of
+field values as a single input to the `->map` method:
+
+```json
+// Input JSON
+{
+  "array": [
+    { "field": 1 },
+    { "field": 2 },
+    { "field": 3 }
+  ]
+}
 ```
 
-In fairness, due to the commutavity of multiplication, this particular case
-could have been written as `suffix: results.slice($args.suffixLength->mul(-1))`,
-but not all methods allow reversing the input and arguments so easily, and this
-syntax works in part because it still parenthesizes the `-1` literal value,
-forcing `LitExpr` parsing, much like the new `ExprPath` syntax.
+```graphql
+# Produces [2, 4, 6] by doubling each field value
+doubled: $(array.field)->map(@->mul(2))
 
-When you don't need to apply a `.key` or `->method` to a literal value within a
-`LitExpr`, you do not need to wrap it with `$(...)`, so the `ExprPath` syntax is
-relatively uncommon within `LitExpr` expressions.
+# Produces [[2], [4], [6]], since ->map applied to a non-array produces a
+# single-element array wrapping the result of the mapping expression applied
+# to that individual value
+nested: array.field->map(@->mul(2))
+```
+
+In this capacity, the `$(...)` syntax is useful for controlling
+associativity/grouping/precedence, similar to parenthesized expressions in other
+programming languages.
 
 ### `PathStep ::=`
 
@@ -832,6 +854,55 @@ powerful ways, e.g. `page: list->slice(0, $limit)`.
 Also, as a minor syntactic convenience, `LitObject` literals can have
 `Identifier` or `LitString` keys, whereas JSON objects can have only
 double-quoted string literal keys.
+
+### `LitPath ::=`
+
+![LitPath](./grammar/LitPath.svg)
+
+A `LitPath` is a special form of `PathSelection` (similar to `VarPath`,
+`KeyPath`, `AtPath`, and `ExprPath`) that can be used _only_ within `LitExpr`
+expressions, allowing the head of the path to be any `LitExpr` value, with a
+non-empty tail of `PathStep` items afterward:
+
+```graphql
+object: $({
+  sd: "asdf"->slice(1, 3),
+  sum: 1234->add(5678),
+  celsius: 98.6->sub(32)->mul(5)->div(9),
+  nine: -1->add(10),
+  false: true->not,
+  true: false->not,
+  twenty: { a: 1, b: 2 }.b->mul(10),
+  last: [1, 2, 3]->last,
+  justA: "abc"->first,
+  justC: "abc"->last,
+})
+```
+
+Note that expressions like `true->not` and `"asdf"->slice(1, 3)` have a
+different interpretation in the default selection syntax (outside of `LitExpr`
+parsing), since `true` and `"asdf"` will be interpreted as field names there,
+not as literal values. If you want to refer to a quoted field value within a
+`LitExpr`, you can use the `$.` variable prefix to disambiguate it:
+
+```graphql
+object: $({
+  fieldEntries: $."quoted field"->entries,
+  stringPrefix: "quoted field"->slice(0, "quoted"->size),
+})
+```
+
+You can still nest the `$(...)` inside itself (or use it within `->` method
+arguments), as in
+
+```graphql
+justA: $($("abc")->first)
+nineAgain: $($(-1)->add($(10)))
+```
+
+In these examples, only the outermost `$(...)` wrapper is required, though the
+inner wrappers may be used to clarify the structure of the expression, similar
+to parentheses in other languages.
 
 ### `LitPrimitive ::=`
 

--- a/apollo-federation/src/sources/connect/json_selection/grammar/LitExpr.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/LitExpr.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="205" height="169">
+<svg xmlns="http://www.w3.org/2000/svg" width="205" height="213">
    <defs>
       <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -32,35 +32,42 @@
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#LitPath"
+      xlink:title="LitPath">
+      <rect x="51" y="3" width="64" height="32"/>
+      <rect x="49" y="1" width="64" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="21">LitPath</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#LitPrimitive"
       xlink:title="LitPrimitive">
-      <rect x="51" y="3" width="90" height="32"/>
-      <rect x="49" y="1" width="90" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="21">LitPrimitive</text>
+      <rect x="51" y="47" width="90" height="32"/>
+      <rect x="49" y="45" width="90" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="65">LitPrimitive</text>
    </a>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#LitObject"
       xlink:title="LitObject">
-      <rect x="51" y="47" width="76" height="32"/>
-      <rect x="49" y="45" width="76" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="65">LitObject</text>
+      <rect x="51" y="91" width="76" height="32"/>
+      <rect x="49" y="89" width="76" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="109">LitObject</text>
    </a>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#LitArray"
       xlink:title="LitArray">
-      <rect x="51" y="91" width="68" height="32"/>
-      <rect x="49" y="89" width="68" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="109">LitArray</text>
+      <rect x="51" y="135" width="68" height="32"/>
+      <rect x="49" y="133" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="153">LitArray</text>
    </a>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#PathSelection"
       xlink:title="PathSelection">
-      <rect x="51" y="135" width="106" height="32"/>
-      <rect x="49" y="133" width="106" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="153">PathSelection</text>
+      <rect x="51" y="179" width="106" height="32"/>
+      <rect x="49" y="177" width="106" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="197">PathSelection</text>
    </a>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m90 0 h10 m0 0 h16 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m76 0 h10 m0 0 h30 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m68 0 h10 m0 0 h38 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m23 -132 h-3"/>
+         d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h42 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m90 0 h10 m0 0 h16 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m76 0 h10 m0 0 h30 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m68 0 h10 m0 0 h38 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m23 -176 h-3"/>
    <polygon points="195 17 203 13 203 21"/>
    <polygon points="195 17 187 13 187 21"/>
 </svg>

--- a/apollo-federation/src/sources/connect/json_selection/grammar/LitPath.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/LitPath.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="327" height="141">
+   <defs>
+      <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+   </defs>
+   <polygon points="9 33 1 29 1 37"/>
+   <polygon points="17 33 9 29 9 37"/>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#LitPrimitive"
+      xlink:title="LitPrimitive">
+      <rect x="51" y="19" width="90" height="32"/>
+      <rect x="49" y="17" width="90" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="37">LitPrimitive</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#LitObject"
+      xlink:title="LitObject">
+      <rect x="51" y="63" width="76" height="32"/>
+      <rect x="49" y="61" width="76" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="81">LitObject</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#LitArray"
+      xlink:title="LitArray">
+      <rect x="51" y="107" width="68" height="32"/>
+      <rect x="49" y="105" width="68" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="125">LitArray</text>
+   </a>
+   <a xmlns:xlink="http://www.w3.org/1999/xlink"
+      xlink:href="#PathStep"
+      xlink:title="PathStep">
+      <rect x="201" y="19" width="78" height="32"/>
+      <rect x="199" y="17" width="78" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="209" y="37">PathStep</text>
+   </a>
+   <path class="line"
+         d="m17 33 h2 m20 0 h10 m90 0 h10 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m76 0 h10 m0 0 h14 m-120 -10 v20 m130 0 v-20 m-130 20 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m68 0 h10 m0 0 h22 m40 -88 h10 m78 0 h10 m-118 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m98 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-98 0 h10 m0 0 h88 m23 32 h-3"/>
+   <polygon points="317 33 325 29 325 37"/>
+   <polygon points="317 33 309 29 309 37"/>
+</svg>

--- a/apollo-federation/src/sources/connect/json_selection/lit_expr.rs
+++ b/apollo-federation/src/sources/connect/json_selection/lit_expr.rs
@@ -19,6 +19,7 @@ use nom::sequence::tuple;
 
 use super::ExternalVarPaths;
 use super::ParseResult;
+use super::PathList;
 use super::helpers::spaces_or_comments;
 use super::location::Ranged;
 use super::location::Span;
@@ -39,21 +40,66 @@ pub(crate) enum LitExpr {
     Object(IndexMap<WithRange<Key>, WithRange<LitExpr>>),
     Array(Vec<WithRange<LitExpr>>),
     Path(PathSelection),
+
+    // Whereas the LitExpr::Path variant wraps a PathSelection that obeys the
+    // parsing rules of the outer selection syntax (i.e. default JSONSelection
+    // syntax, not LitExpr syntax), this LitExpr::LitPath variant can be parsed
+    // only as part of a LitExpr, and allows the value at the root of the path
+    // to be any LitExpr literal expression, without needing a $(...) wrapper,
+    // allowing you to write "asdf"->slice(0, 2) when you're already in an
+    // expression parsing context, rather than $(asdf)->slice(0, 2).
+    //
+    // The WithRange<LitExpr> argument is the root expression (never a
+    // LitExpr::Path), and the WithRange<PathList> argument represents the rest
+    // of the path, which is never PathList::Empty, because that would mean the
+    // LitExpr could stand on its own, using one of the other variants.
+    LitPath(WithRange<LitExpr>, WithRange<PathList>),
 }
 
 impl LitExpr {
-    // LitExpr      ::= LitPrimitive | LitObject | LitArray | PathSelection
+    // LitExpr ::= LitPath | LitPrimitive | LitObject | LitArray | PathSelection
     pub(crate) fn parse(input: Span) -> ParseResult<WithRange<Self>> {
         let (input, _) = spaces_or_comments(input)?;
-        alt((
-            Self::parse_primitive,
-            Self::parse_object,
-            Self::parse_array,
-            map(PathSelection::parse, |p| {
-                let range = p.range();
-                WithRange::new(Self::Path(p), range)
+
+        match alt((Self::parse_primitive, Self::parse_object, Self::parse_array))(input) {
+            Ok((suffix, initial_literal)) => {
+                // If we parsed an initial literal expression, it may be the
+                // entire result, but we also want to greedily parse one or more
+                // PathStep items that follow it, according to the rule
+                //
+                //    LitPath ::= (LitPrimitive | LitObject | LitArray) PathStep+
+                //
+                // This allows paths beginning with literal values without the
+                // initial $(...) expression wrapper, so you can write
+                // $(123->add(111)) instead of $($(123)->add(111)) when you're
+                // already in a LitExpr parsing context.
+                //
+                // We begin parsing the path at depth 1 rather than 0 because
+                // we've already parsed the initial literal at depth 0, so the
+                // subpath should obey the parsing rules for for depth > 0.
+                match PathList::parse_with_depth(suffix, 1) {
+                    Ok((remainder, subpath)) => {
+                        if matches!(subpath.as_ref(), PathList::Empty) {
+                            return Ok((remainder, initial_literal));
+                        }
+                        let full_range = merge_ranges(initial_literal.range(), subpath.range());
+                        Ok((
+                            remainder,
+                            WithRange::new(Self::LitPath(initial_literal, subpath), full_range),
+                        ))
+                    }
+                    // If we failed to parse a path, return initial_literal as-is.
+                    Err(_) => Ok((suffix, initial_literal)),
+                }
+            }
+
+            // If we failed to parse a primitive, object, or array, try parsing
+            // a PathSelection (which cannot be a LitPath).
+            Err(_) => PathSelection::parse(input).map(|(remainder, path)| {
+                let range = path.range();
+                (remainder, WithRange::new(Self::Path(path), range))
             }),
-        ))(input)
+        }
     }
 
     // LitPrimitive ::= LitString | LitNumber | "true" | "false" | "null"
@@ -281,6 +327,10 @@ impl ExternalVarPaths for LitExpr {
             Self::Path(path) => {
                 paths.extend(path.external_var_paths());
             }
+            Self::LitPath(literal, subpath) => {
+                paths.extend(literal.external_var_paths());
+                paths.extend(subpath.external_var_paths());
+            }
         }
         paths
     }
@@ -291,7 +341,9 @@ mod tests {
     use super::super::known_var::KnownVariable;
     use super::super::location::strip_ranges::StripRanges;
     use super::*;
+    use crate::sources::connect::json_selection::MethodArgs;
     use crate::sources::connect::json_selection::PathList;
+    use crate::sources::connect::json_selection::PrettyPrintable;
     use crate::sources::connect::json_selection::fixtures::Namespace;
     use crate::sources::connect::json_selection::helpers::span_is_all_spaces_or_comments;
     use crate::sources::connect::json_selection::location::new_span;
@@ -641,5 +693,292 @@ mod tests {
                 expected,
             );
         }
+    }
+
+    #[test]
+    fn test_literal_methods() {
+        #[track_caller]
+        fn check_parse_and_print(input: &str, expected: LitExpr) {
+            let expected_inline = expected.pretty_print_with_indentation(true, 0);
+            match LitExpr::parse(new_span(input)) {
+                Ok((remainder, parsed)) => {
+                    assert!(span_is_all_spaces_or_comments(remainder));
+                    assert_eq!(parsed.strip_ranges(), WithRange::new(expected, None));
+                    assert_eq!(parsed.pretty_print_with_indentation(true, 0), input);
+                    assert_eq!(expected_inline, input);
+                }
+                Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
+            };
+        }
+
+        check_parse_and_print(
+            "$(\"a\")->first",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::String("a".to_string()).into_with_range(),
+                    PathList::Method(
+                        WithRange::new("first".to_string(), None),
+                        None,
+                        PathList::Empty.into_with_range(),
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$(\"a\"->first)",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::LitPath(
+                        LitExpr::String("a".to_string()).into_with_range(),
+                        PathList::Method(
+                            WithRange::new("first".to_string(), None),
+                            None,
+                            PathList::Empty.into_with_range(),
+                        )
+                        .into_with_range(),
+                    )
+                    .into_with_range(),
+                    PathList::Empty.into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$(1234)->add(1111)",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::Number(serde_json::Number::from(1234)).into_with_range(),
+                    PathList::Method(
+                        WithRange::new("add".to_string(), None),
+                        Some(MethodArgs {
+                            args: vec![
+                                LitExpr::Number(serde_json::Number::from(1111)).into_with_range(),
+                            ],
+                            range: None,
+                        }),
+                        PathList::Empty.into_with_range(),
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$(1234->add(1111))",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::LitPath(
+                        LitExpr::Number(serde_json::Number::from(1234)).into_with_range(),
+                        PathList::Method(
+                            WithRange::new("add".to_string(), None),
+                            Some(MethodArgs {
+                                args: vec![
+                                    LitExpr::Number(serde_json::Number::from(1111))
+                                        .into_with_range(),
+                                ],
+                                range: None,
+                            }),
+                            PathList::Empty.into_with_range(),
+                        )
+                        .into_with_range(),
+                    )
+                    .into_with_range(),
+                    PathList::Empty.into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$(value->mul(10))",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::Path(PathSelection {
+                        path: PathList::Key(
+                            Key::field("value").into_with_range(),
+                            PathList::Method(
+                                WithRange::new("mul".to_string(), None),
+                                Some(MethodArgs {
+                                    args: vec![
+                                        LitExpr::Number(serde_json::Number::from(10))
+                                            .into_with_range(),
+                                    ],
+                                    range: None,
+                                }),
+                                PathList::Empty.into_with_range(),
+                            )
+                            .into_with_range(),
+                        )
+                        .into_with_range(),
+                    })
+                    .into_with_range(),
+                    PathList::Empty.into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$(value.key->typeof)",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::Path(PathSelection {
+                        path: PathList::Key(
+                            Key::field("value").into_with_range(),
+                            PathList::Key(
+                                Key::field("key").into_with_range(),
+                                PathList::Method(
+                                    WithRange::new("typeof".to_string(), None),
+                                    None,
+                                    PathList::Empty.into_with_range(),
+                                )
+                                .into_with_range(),
+                            )
+                            .into_with_range(),
+                        )
+                        .into_with_range(),
+                    })
+                    .into_with_range(),
+                    PathList::Empty.into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$(value.key)->typeof",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::Path(PathSelection {
+                        path: PathList::Key(
+                            Key::field("value").into_with_range(),
+                            PathList::Key(
+                                Key::field("key").into_with_range(),
+                                PathList::Empty.into_with_range(),
+                            )
+                            .into_with_range(),
+                        )
+                        .into_with_range(),
+                    })
+                    .into_with_range(),
+                    PathList::Method(
+                        WithRange::new("typeof".to_string(), None),
+                        None,
+                        PathList::Empty.into_with_range(),
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$([1, 2, 3])->last",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::Array(vec![
+                        LitExpr::Number(serde_json::Number::from(1)).into_with_range(),
+                        LitExpr::Number(serde_json::Number::from(2)).into_with_range(),
+                        LitExpr::Number(serde_json::Number::from(3)).into_with_range(),
+                    ])
+                    .into_with_range(),
+                    PathList::Method(
+                        WithRange::new("last".to_string(), None),
+                        None,
+                        PathList::Empty.into_with_range(),
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$([1, 2, 3]->last)",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::LitPath(
+                        LitExpr::Array(vec![
+                            LitExpr::Number(serde_json::Number::from(1)).into_with_range(),
+                            LitExpr::Number(serde_json::Number::from(2)).into_with_range(),
+                            LitExpr::Number(serde_json::Number::from(3)).into_with_range(),
+                        ])
+                        .into_with_range(),
+                        PathList::Method(
+                            WithRange::new("last".to_string(), None),
+                            None,
+                            PathList::Empty.into_with_range(),
+                        )
+                        .into_with_range(),
+                    )
+                    .into_with_range(),
+                    PathList::Empty.into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$({ a: \"ay\", b: 1 }).a",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::Object({
+                        let mut map = IndexMap::default();
+                        map.insert(
+                            Key::field("a").into_with_range(),
+                            LitExpr::String("ay".to_string()).into_with_range(),
+                        );
+                        map.insert(
+                            Key::field("b").into_with_range(),
+                            LitExpr::Number(serde_json::Number::from(1)).into_with_range(),
+                        );
+                        map
+                    })
+                    .into_with_range(),
+                    PathList::Key(
+                        Key::field("a").into_with_range(),
+                        PathList::Empty.into_with_range(),
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
+
+        check_parse_and_print(
+            "$({ a: \"ay\", b: 2 }.a)",
+            LitExpr::Path(PathSelection {
+                path: PathList::Expr(
+                    LitExpr::LitPath(
+                        LitExpr::Object({
+                            let mut map = IndexMap::default();
+                            map.insert(
+                                Key::field("a").into_with_range(),
+                                LitExpr::String("ay".to_string()).into_with_range(),
+                            );
+                            map.insert(
+                                Key::field("b").into_with_range(),
+                                LitExpr::Number(serde_json::Number::from(2)).into_with_range(),
+                            );
+                            map
+                        })
+                        .into_with_range(),
+                        PathList::Key(
+                            Key::field("a").into_with_range(),
+                            PathList::Empty.into_with_range(),
+                        )
+                        .into_with_range(),
+                    )
+                    .into_with_range(),
+                    PathList::Empty.into_with_range(),
+                )
+                .into_with_range(),
+            }),
+        );
     }
 }

--- a/apollo-federation/src/sources/connect/json_selection/location.rs
+++ b/apollo-federation/src/sources/connect/json_selection/location.rs
@@ -295,6 +295,9 @@ pub(crate) mod strip_ranges {
                         LitExpr::Array(new_vec)
                     }
                     LitExpr::Path(path) => LitExpr::Path(path.strip_ranges()),
+                    LitExpr::LitPath(literal, subpath) => {
+                        LitExpr::LitPath(literal.strip_ranges(), subpath.strip_ranges())
+                    }
                 },
                 None,
             )

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -264,6 +264,18 @@ impl PrettyPrintable for LitExpr {
                 let path = path.pretty_print_with_indentation(inline, indentation);
                 result.push_str(path.as_str());
             }
+            Self::LitPath(literal, subpath) => {
+                result.push_str(
+                    literal
+                        .pretty_print_with_indentation(inline, indentation)
+                        .as_str(),
+                );
+                result.push_str(
+                    subpath
+                        .pretty_print_with_indentation(inline, indentation)
+                        .as_str(),
+                );
+            }
         }
 
         result

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-2.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-2.snap
@@ -1,0 +1,105 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: selection_hello_slice_v0_2
+---
+Named(
+    SubSelection {
+        selections: [
+            Path {
+                alias: Some(
+                    Alias {
+                        name: WithRange {
+                            node: Field(
+                                "sliced",
+                            ),
+                            range: Some(
+                                0..6,
+                            ),
+                        },
+                        range: Some(
+                            0..7,
+                        ),
+                    },
+                ),
+                inline: false,
+                path: PathSelection {
+                    path: WithRange {
+                        node: Expr(
+                            WithRange {
+                                node: LitPath(
+                                    WithRange {
+                                        node: String(
+                                            "hello",
+                                        ),
+                                        range: Some(
+                                            10..17,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Method(
+                                            WithRange {
+                                                node: "slice",
+                                                range: Some(
+                                                    19..24,
+                                                ),
+                                            },
+                                            Some(
+                                                MethodArgs {
+                                                    args: [
+                                                        WithRange {
+                                                            node: Number(
+                                                                Number(1),
+                                                            ),
+                                                            range: Some(
+                                                                25..26,
+                                                            ),
+                                                        },
+                                                        WithRange {
+                                                            node: Number(
+                                                                Number(3),
+                                                            ),
+                                                            range: Some(
+                                                                28..29,
+                                                            ),
+                                                        },
+                                                    ],
+                                                    range: Some(
+                                                        24..30,
+                                                    ),
+                                                },
+                                            ),
+                                            WithRange {
+                                                node: Empty,
+                                                range: Some(
+                                                    30..30,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            17..30,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    10..30,
+                                ),
+                            },
+                            WithRange {
+                                node: Empty,
+                                range: Some(
+                                    31..31,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            8..31,
+                        ),
+                    },
+                },
+            },
+        ],
+        range: Some(
+            0..31,
+        ),
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-3.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-3.snap
@@ -1,0 +1,43 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: selection_true_not_v0_2
+---
+Path(
+    PathSelection {
+        path: WithRange {
+            node: Key(
+                WithRange {
+                    node: Field(
+                        "true",
+                    ),
+                    range: Some(
+                        0..4,
+                    ),
+                },
+                WithRange {
+                    node: Method(
+                        WithRange {
+                            node: "not",
+                            range: Some(
+                                6..9,
+                            ),
+                        },
+                        None,
+                        WithRange {
+                            node: Empty,
+                            range: Some(
+                                9..9,
+                            ),
+                        },
+                    ),
+                    range: Some(
+                        4..9,
+                    ),
+                },
+            ),
+            range: Some(
+                0..9,
+            ),
+        },
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-4.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-4.snap
@@ -1,0 +1,43 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: selection_false_not_v0_2
+---
+Path(
+    PathSelection {
+        path: WithRange {
+            node: Key(
+                WithRange {
+                    node: Field(
+                        "false",
+                    ),
+                    range: Some(
+                        0..5,
+                    ),
+                },
+                WithRange {
+                    node: Method(
+                        WithRange {
+                            node: "not",
+                            range: Some(
+                                7..10,
+                            ),
+                        },
+                        None,
+                        WithRange {
+                            node: Empty,
+                            range: Some(
+                                10..10,
+                            ),
+                        },
+                    ),
+                    range: Some(
+                        5..10,
+                    ),
+                },
+            ),
+            range: Some(
+                0..10,
+            ),
+        },
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-5.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-5.snap
@@ -1,0 +1,73 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: selection_object_path_v0_2
+---
+Path(
+    PathSelection {
+        path: WithRange {
+            node: Expr(
+                WithRange {
+                    node: LitPath(
+                        WithRange {
+                            node: Object(
+                                {
+                                    WithRange {
+                                        node: Field(
+                                            "a",
+                                        ),
+                                        range: Some(
+                                            4..5,
+                                        ),
+                                    }: WithRange {
+                                        node: Number(
+                                            Number(123),
+                                        ),
+                                        range: Some(
+                                            7..10,
+                                        ),
+                                    },
+                                },
+                            ),
+                            range: Some(
+                                2..12,
+                            ),
+                        },
+                        WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "a",
+                                    ),
+                                    range: Some(
+                                        13..14,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        14..14,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                12..14,
+                            ),
+                        },
+                    ),
+                    range: Some(
+                        2..14,
+                    ),
+                },
+                WithRange {
+                    node: Empty,
+                    range: Some(
+                        15..15,
+                    ),
+                },
+            ),
+            range: Some(
+                0..15,
+            ),
+        },
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-6.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2-6.snap
@@ -1,0 +1,97 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: selection_array_path_v0_2
+---
+Path(
+    PathSelection {
+        path: WithRange {
+            node: Expr(
+                WithRange {
+                    node: LitPath(
+                        WithRange {
+                            node: Array(
+                                [
+                                    WithRange {
+                                        node: Number(
+                                            Number(1),
+                                        ),
+                                        range: Some(
+                                            3..4,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Number(
+                                            Number(2),
+                                        ),
+                                        range: Some(
+                                            6..7,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Number(
+                                            Number(3),
+                                        ),
+                                        range: Some(
+                                            9..10,
+                                        ),
+                                    },
+                                ],
+                            ),
+                            range: Some(
+                                2..11,
+                            ),
+                        },
+                        WithRange {
+                            node: Method(
+                                WithRange {
+                                    node: "get",
+                                    range: Some(
+                                        13..16,
+                                    ),
+                                },
+                                Some(
+                                    MethodArgs {
+                                        args: [
+                                            WithRange {
+                                                node: Number(
+                                                    Number(1),
+                                                ),
+                                                range: Some(
+                                                    17..18,
+                                                ),
+                                            },
+                                        ],
+                                        range: Some(
+                                            16..19,
+                                        ),
+                                    },
+                                ),
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        19..19,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                11..19,
+                            ),
+                        },
+                    ),
+                    range: Some(
+                        2..19,
+                    ),
+                },
+                WithRange {
+                    node: Empty,
+                    range: Some(
+                        20..20,
+                    ),
+                },
+            ),
+            range: Some(
+                0..20,
+            ),
+        },
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/naked_literal_path_for_connect_v0_2.snap
@@ -1,0 +1,54 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: selection_null_stringify_v0_2
+---
+Path(
+    PathSelection {
+        path: WithRange {
+            node: Expr(
+                WithRange {
+                    node: LitPath(
+                        WithRange {
+                            node: Null,
+                            range: Some(
+                                2..6,
+                            ),
+                        },
+                        WithRange {
+                            node: Method(
+                                WithRange {
+                                    node: "jsonStringify",
+                                    range: Some(
+                                        8..21,
+                                    ),
+                                },
+                                None,
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        21..21,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                6..21,
+                            ),
+                        },
+                    ),
+                    range: Some(
+                        2..21,
+                    ),
+                },
+                WithRange {
+                    node: Empty,
+                    range: Some(
+                        22..22,
+                    ),
+                },
+            ),
+            range: Some(
+                0..22,
+            ),
+        },
+    },
+)


### PR DESCRIPTION
PR #5994 introduced the `$(...)` wrapper for injecting `LitExpr` JSON expression literals into selection syntax. Along with `->` method arguments, the `$(...)` wrapper is one of two ways to enter an expression parsing context, where the syntax to be parsed is closer to JSON than to GraphQL, and thus more convenient for crafting new/input data, as compared with the selection syntax, which is oriented towards selecting/transforming existing data.

Once parsing has entered the expression context, you shouldn't need to keep using `$(...)` to wrap JSON expressions. For many literal expressions, this is true: for example, you can write `$({ a: 1, b: 2 })` rather than `$({ a: $(1), b: $(2) })`. However, if you wanted to apply a `->` method or grab a `.key` from a JSON literal expression, the grammar previously required you to wrap that expression with `$(...)`, as in `$({ slice: $("asdf")->slice(0, 2) })`. This PR allows that expression to be written without the inner `$("asdf")` wrapper, giving `$({ slice: "asdf"->slice(0, 2) })`, which is arguably easier to read.

This new syntax works for any JSON literal, not just strings, so you can have `1234->add(1111)` or even `{ a: 1, b: 2 }.b` or `[1, 2, 3]->last` as `LitPath` expressions. Two cases here are worth highlighting:

1. Previously, a string literal expression with a path, like `"asdf"->first`, would have been interpreted/parsed as a quoted field selection, equivalent to `$.asdf->first`, meaning the `"asdf"` is not really a string literal, and `"asdf"->first` probably would not return the string `"a"`. The quoted field syntax is useful for non-identifier field names, but in my opinion the string literal interpretation is much less surprising (in the `LitExpr` parsing mode) than the field interpretation. This PR changes the meaning of that syntax, but only within the expression parsing context. If you want to select a quoted field now (in an expression context), you can still write `$."quoted field"->last`, using the `$.` to disambiguate, just as you can do in a selection context. Three other JSON literal have a similar ambiguity: `null->...`, `true->...` and `false->...` refer to input _fields_ called `null`, `true`, and `false` (respectively) in the outer selection syntax, but now refer to the corresponding JSON values in an expression context (again, much less surprising than before, IMO).

2. JSON number literals are allowed to be negative, using the `-` unary operator like most programming languages. However, if you write `-1->add(10)` in an expression context, it's important to know the `->` has a lower precedence than the `-`, so the `-1` gets parsed first, and then `->add(10)` operates on that negative value, giving 9 rather than -11. You might expect -11 if you're used to `-` having a lower precedence, negating the whole expression at the end, but that's not how it works here. The `LitPath` expression `-1->add(10)` is equivalent to `$(-1)->add(10)`, in other words.

Thanks to @nicholascioli for noticing that `"quoted field"->first` was previously mis-parsing in an expression context, because our greedy parser was parsing `"quoted field"` as a string literal and then failing on the unexpected `->first` suffix. Among the other benefits, this PR should fix that problem.