### PR TITLE
change error message for unsupported options for `router config upgrade`

### DIFF
--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -89,7 +89,7 @@ pub(crate) fn upgrade_configuration(
         config = new_config;
     }
     if !effective_migrations.is_empty() && log_warnings {
-        tracing::warn!("router configuration contains deprecated options: \n\n{}\n\nThese will become errors in the future. Run `router config upgrade <path_to_router.yaml>` to see a suggested upgraded configuration.", effective_migrations.iter().enumerate().map(|(idx, m)|format!("  {}. {}", idx + 1, m.description)).join("\n\n"));
+        tracing::error!("router configuration contains unsupported options and needs to be upgraded to run the router: \n\n{}\n\n", effective_migrations.iter().enumerate().map(|(idx, m)|format!("  {}. {}", idx + 1, m.description)).join("\n\n"));
     }
     Ok(config)
 }


### PR DESCRIPTION
It doesn't make sense to point users to `router config upgrade` when this is only run during `router config upgrade`. Since we are starting from a clean slate in router 2.0.0, the effective_migrations are also all unsupported, rather than deprecated, options, and should be emitted as an error than a warn.

### Before
<img width="772" alt="Screenshot 2025-02-13 at 13 25 07" src="https://github.com/user-attachments/assets/3789543d-8f79-45b1-ad89-241c4c50efc9" />

### After
<img width="899" alt="Screenshot 2025-02-13 at 13 46 47" src="https://github.com/user-attachments/assets/262d6c7f-2322-42cc-84a6-ca9bd4e3e40f" />
