### PR TITLE
Remove mutex from apollo telemetry exporter

### DIFF
--- a/apollo-router/src/plugins/telemetry/apollo_otlp_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_otlp_exporter.rs
@@ -70,20 +70,16 @@ impl ApolloOtlpExporter {
         let mut metadata = MetadataMap::new();
         metadata.insert("apollo.api.key", MetadataValue::try_from(apollo_key)?);
         let mut otlp_exporter = match protocol {
-            Protocol::Grpc => {
-                let span_exporter = SpanExporterBuilder::from(
-                    opentelemetry_otlp::new_exporter()
-                        .tonic()
-                        .with_tls_config(ClientTlsConfig::new().with_native_roots())
-                        .with_timeout(batch_config.max_export_timeout)
-                        .with_endpoint(endpoint.to_string())
-                        .with_metadata(metadata)
-                        .with_compression(opentelemetry_otlp::Compression::Gzip),
-                )
-                .build_span_exporter()?;
-
-                span_exporter
-            }
+            Protocol::Grpc => SpanExporterBuilder::from(
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_tls_config(ClientTlsConfig::new().with_native_roots())
+                    .with_timeout(batch_config.max_export_timeout)
+                    .with_endpoint(endpoint.to_string())
+                    .with_metadata(metadata)
+                    .with_compression(opentelemetry_otlp::Compression::Gzip),
+            )
+            .build_span_exporter()?,
             // So far only using HTTP path for testing - the Studio backend only accepts GRPC today.
             Protocol::Http => SpanExporterBuilder::from(
                 opentelemetry_otlp::new_exporter()

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -14,7 +14,6 @@ use base64::Engine as _;
 use derivative::Derivative;
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use futures::TryFutureExt;
 use itertools::Itertools;
 use lru::LruCache;
 use opentelemetry::metrics::MeterProvider;
@@ -319,7 +318,7 @@ pub(crate) struct Exporter {
     #[derivative(Debug = "ignore")]
     report_exporter: Option<Arc<ApolloExporter>>,
     #[derivative(Debug = "ignore")]
-    otlp_exporter: Option<Arc<ApolloOtlpExporter>>,
+    otlp_exporter: Option<ApolloOtlpExporter>,
     otlp_tracing_ratio: f64,
     field_execution_weight: f64,
     errors_configuration: ErrorsConfiguration,
@@ -407,7 +406,7 @@ impl Exporter {
                 None
             },
             otlp_exporter: if otlp_tracing_ratio > 0f64 {
-                Some(Arc::new(ApolloOtlpExporter::new(
+                Some(ApolloOtlpExporter::new(
                     otlp_endpoint,
                     otlp_tracing_protocol,
                     batch_config,
@@ -415,7 +414,7 @@ impl Exporter {
                     apollo_graph_ref,
                     schema_id,
                     errors_configuration,
-                )?))
+                )?)
             } else {
                 None
             },
@@ -1158,51 +1157,41 @@ impl SpanExporter for Exporter {
         self.span_lru_size_instrument
             .update(self.spans_by_parent_id.len() as u64);
 
-        #[allow(clippy::manual_map)] // https://github.com/rust-lang/rust-clippy/issues/8346
-        let report_exporter = match self.report_exporter.as_ref() {
-            Some(exporter) => Some(exporter.clone()),
-            None => None,
-        };
-        #[allow(clippy::manual_map)] // https://github.com/rust-lang/rust-clippy/issues/8346
-        let otlp_exporter = match self.otlp_exporter.as_ref() {
-            Some(exporter) => Some(exporter.clone()),
-            None => None,
-        };
-
-        let fut = async move {
-            if send_otlp && !otlp_trace_spans.is_empty() {
-                otlp_exporter
-                    .as_ref()
-                    .expect("expected an otel exporter")
-                    .export(otlp_trace_spans.into_iter().flatten().collect())
-                    .await
-            } else if send_reports && !traces.is_empty() {
-                let mut report = telemetry::apollo::Report::default();
-                report += SingleReport::Traces(TracesReport { traces });
-                report_exporter
-                    .as_ref()
-                    .expect("expected an apollo exporter")
+        if send_otlp && !otlp_trace_spans.is_empty() {
+            self.otlp_exporter
+                .as_mut()
+                .expect("expected an otel exporter")
+                .export(otlp_trace_spans.into_iter().flatten().collect())
+        } else if send_reports && !traces.is_empty() {
+            let mut report = telemetry::apollo::Report::default();
+            report += SingleReport::Traces(TracesReport { traces });
+            let exporter = self
+                .report_exporter
+                .as_ref()
+                .expect("expected an apollo exporter")
+                .clone();
+            async move {
+                exporter
                     .submit_report(report)
-                    .map_err(|e| TraceError::ExportFailed(Box::new(e)))
                     .await
-            } else {
-                ExportResult::Ok(())
+                    .map_err(|e| TraceError::ExportFailed(Box::new(e)))
             }
-        };
-        fut.boxed()
+            .boxed()
+        } else {
+            async { ExportResult::Ok(()) }.boxed()
+        }
     }
 
     fn shutdown(&mut self) {
         // Currently only handled in the OTLP case.
-        if let Some(exporter) = &self.otlp_exporter {
+        if let Some(exporter) = &mut self.otlp_exporter {
             exporter.shutdown()
         };
     }
 
-    fn set_resource(&mut self, resource: &Resource) {
-        if let Some(exporter) = &self.otlp_exporter {
-            exporter.set_resource(resource);
-        }
+    fn set_resource(&mut self, _resource: &Resource) {
+        // This is intentionally a NOOP. The reason for this is that we do not allow users to set the resource attributes
+        // for telemetry that is sent to Apollo. To do so would expose potential private information that the user did not intend for us.
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -1192,6 +1192,7 @@ impl SpanExporter for Exporter {
     fn set_resource(&mut self, _resource: &Resource) {
         // This is intentionally a NOOP. The reason for this is that we do not allow users to set the resource attributes
         // for telemetry that is sent to Apollo. To do so would expose potential private information that the user did not intend for us.
+        tracing::warn!("setting resource attributes is not allowed for Apollo telemetry");
     }
 }
 


### PR DESCRIPTION
The telemetry exporter had a mutex that seems unnecessary and increases the risk of deadlock.

In addition, we now call out explicitly that the apollo exporter will not use resources set by the `set_resources` function. This was never called in practice, but it's better to be safe.



<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*
I'm not putting in a changelog because there is no material change to the code except the removal of the mutex.
There are no docs changes.
Existing export tests pass.
There are no new unit tests written. 
However we could do with some new tests in future as we are relying on integration testing.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
