### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,8 +11,8 @@ pull_request_rules:
           - "{{ author }}"
         bot_account: "{{ author }}"
 defaults:
-    actions:
-        backport:
-            assignees:
-            - "{{ author }}"
-            bot_account: "{{ author }}"
+  actions:
+    backport:
+      assignees:
+        - "{{ author }}"
+      bot_account: "{{ author }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,3 +10,9 @@ pull_request_rules:
         assignees:
           - "{{ author }}"
         bot_account: "{{ author }}"
+defaults:
+    actions:
+        backport:
+            assignees:
+            - "{{ author }}"
+            bot_account: "{{ author }}"


### PR DESCRIPTION
This change has been made by @BrynCooke from the Mergify config editor.

This will make PRs created by manually triggering a backport via command use the account of the user who executed the command (hopefully fixing the CLA bot issue).

Developers MUST have logged into mergify dashboard at least once for this to work: https://dashboard.mergify.com/


PRs that were tested:

Original: https://github.com/BrynCooke/router/pull/27
Backport: https://github.com/BrynCooke/router/pull/28


