### PR TITLE
fix(state-machine): remove claims from license state log

### DIFF
--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -525,7 +525,13 @@ where
 
         // Process all the events in turn until we get to error state or we run out of events.
         while let Some(event) = messages.next().await {
-            let event_name = format!("{event:?}");
+            let event_name = match &event {
+                Event::UpdateLicense(license_state) => {
+                    format!("UpdateLicense({})", license_state.get_name())
+                }
+                event => format!("{event:?}"),
+            };
+
             let previous_state = format!("{state:?}");
 
             state = match event {

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -660,12 +660,12 @@ impl LicenseState {
         }
     }
 
-    pub(crate) fn get_name(&self) -> String {
+    pub(crate) fn get_name(&self) -> &'static str {
         match self {
-            Self::Licensed { limits: _ } => "Licensed".to_string(),
-            Self::LicensedWarn { limits: _ } => "LicensedWarn".to_string(),
-            Self::LicensedHalt { limits: _ } => "LicensedHalt".to_string(),
-            Self::Unlicensed => "Unlicensed".to_string(),
+            Self::Licensed { limits: _ } => "Licensed",
+            Self::LicensedWarn { limits: _ } => "LicensedWarn",
+            Self::LicensedHalt { limits: _ } => "LicensedHalt",
+            Self::Unlicensed => "Unlicensed",
         }
     }
 }

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -659,6 +659,15 @@ impl LicenseState {
             _ => None,
         }
     }
+
+    pub(crate) fn get_name(&self) -> String {
+        match self {
+            Self::Licensed { limits: _ } => "Licensed".to_string(),
+            Self::LicensedWarn { limits: _ } => "LicensedWarn".to_string(),
+            Self::LicensedHalt { limits: _ } => "LicensedHalt".to_string(),
+            Self::Unlicensed => "Unlicensed".to_string(),
+        }
+    }
 }
 
 impl Display for License {


### PR DESCRIPTION
*Description here*

removes claims from the event name in the state machine. 

used to look like:

```
INFO  state machine transitioned event="UpdateLicense(Licensed)"
```

currently looks like:

```
INFO  state machine transitioned event="UpdateLicense(Licensed { limits: Some(LicenseLimits { tps: Some(TpsLimit { capacity: 300, interval: 60s }) }) })"
```

and this change brings it back to:

```
INFO  state machine transitioned event="UpdateLicense(Licensed)"
```


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
