### PR TITLE
Prevent deadlocks on metrics shutdown (backport #6800)

### DIFF
--- a/apollo-router/src/metrics/aggregation.rs
+++ b/apollo-router/src/metrics/aggregation.rs
@@ -122,10 +122,12 @@ impl AggregateMeterProvider {
         let mut inner = self.inner.lock().expect("lock poisoned");
         // As we are changing a meter provider we need to invalidate any registered instruments.
         // Clearing these allows any weak references at callsites to be invalidated.
+        // This must be done BEFORE the old provider is dropped to ensure that metrics are not lost.
+        // Once invalidated all metrics callsites will try to obtain new instruments, but will be blocked on the mutex.
         inner.registered_instruments.clear();
 
         //Now update the meter provider
-        if let Some(meter_provider) = meter_provider {
+        let old = if let Some(meter_provider) = meter_provider {
             inner
                 .providers
                 .insert(
@@ -135,13 +137,34 @@ impl AggregateMeterProvider {
                 .map(|(old_provider, _)| old_provider)
         } else {
             None
-        }
+        };
+        // Important! The mutex MUST be dropped before the old meter provider is dropped to avoid deadlocks in the case that the export function has metrics.
+        // This implicitly happens by returning the old meter provider.
+        // However, to avoid a potential footgun where someone removes the return value of this function I will explicitly drop the mutex guard.
+        drop(inner);
+
+        // Important! Now it is safe to drop the old meter provider, we return it, so we should be OK. If someone removes the return value of this function then
+        // this must instead be converted to a drop call.
+        old
     }
 
     /// Shutdown MUST be called from a blocking thread.
     pub(crate) fn shutdown(&self) {
+<<<<<<< HEAD
         let inner = self.inner.lock().expect("lock poisoned");
         for (meter_provider_type, (meter_provider, _)) in &inner.providers {
+=======
+        // Make sure that we don't deadlock by dropping the mutex guard before actual shutdown happens
+        // This means that if we have any misbehaving code that tries to access the meter provider during shutdown, e.g. for export metrics
+        // then we don't get stuck on the mutex.
+        let mut inner = self.inner.lock();
+        let mut swap = Inner::default();
+        std::mem::swap(&mut *inner, &mut swap);
+        drop(inner);
+
+        // Now that we have dropped the mutex guard we can safely shutdown the meter providers
+        for (meter_provider_type, (meter_provider, _)) in &swap.providers {
+>>>>>>> 3ca1883e (Prevent deadlocks on metrics shutdown (#6800))
             if let Err(e) = meter_provider.shutdown() {
                 ::tracing::error!(error = %e, meter_provider_type = ?meter_provider_type, "failed to shutdown meter provider")
             }
@@ -483,10 +506,13 @@ impl InstrumentProvider for AggregateInstrumentProvider {
 
 #[cfg(test)]
 mod test {
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicI64;
     use std::sync::Arc;
     use std::sync::Weak;
+    use std::time::Duration;
 
+<<<<<<< HEAD
     use opentelemetry::sdk::metrics::data::Gauge;
     use opentelemetry::sdk::metrics::data::ResourceMetrics;
     use opentelemetry::sdk::metrics::data::Temporality;
@@ -503,6 +529,26 @@ mod test {
     use opentelemetry_api::metrics::MeterProvider;
     use opentelemetry_api::metrics::Result;
     use opentelemetry_api::Context;
+=======
+    use async_trait::async_trait;
+    use opentelemetry::global::GlobalMeterProvider;
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry::metrics::Result;
+    use opentelemetry_sdk::metrics::data::Gauge;
+    use opentelemetry_sdk::metrics::data::ResourceMetrics;
+    use opentelemetry_sdk::metrics::data::Temporality;
+    use opentelemetry_sdk::metrics::exporter::PushMetricsExporter;
+    use opentelemetry_sdk::metrics::reader::AggregationSelector;
+    use opentelemetry_sdk::metrics::reader::MetricReader;
+    use opentelemetry_sdk::metrics::reader::TemporalitySelector;
+    use opentelemetry_sdk::metrics::Aggregation;
+    use opentelemetry_sdk::metrics::InstrumentKind;
+    use opentelemetry_sdk::metrics::ManualReader;
+    use opentelemetry_sdk::metrics::MeterProviderBuilder;
+    use opentelemetry_sdk::metrics::PeriodicReader;
+    use opentelemetry_sdk::metrics::Pipeline;
+    use opentelemetry_sdk::runtime;
+>>>>>>> 3ca1883e (Prevent deadlocks on metrics shutdown (#6800))
 
     use crate::metrics::aggregation::AggregateMeterProvider;
     use crate::metrics::aggregation::MeterProviderType;
@@ -720,5 +766,137 @@ mod test {
         };
         reader.collect(&mut resource_metrics).unwrap();
         assert_eq!(1, resource_metrics.scope_metrics.len());
+    }
+
+    struct TestExporter {
+        meter_provider: AggregateMeterProvider,
+        shutdown: Arc<AtomicBool>,
+    }
+
+    impl AggregationSelector for TestExporter {
+        fn aggregation(&self, _kind: InstrumentKind) -> Aggregation {
+            Aggregation::Default
+        }
+    }
+
+    impl TemporalitySelector for TestExporter {
+        fn temporality(&self, _kind: InstrumentKind) -> Temporality {
+            Temporality::Cumulative
+        }
+    }
+
+    #[async_trait]
+    impl PushMetricsExporter for TestExporter {
+        async fn export(&self, _metrics: &mut ResourceMetrics) -> Result<()> {
+            self.count();
+            Ok(())
+        }
+
+        async fn force_flush(&self) -> Result<()> {
+            self.count();
+            Ok(())
+        }
+
+        fn shutdown(&self) -> Result<()> {
+            self.count();
+            self.shutdown
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    impl TestExporter {
+        fn count(&self) {
+            let counter = self
+                .meter_provider
+                .versioned_meter("test", None::<String>, None::<String>, None)
+                .u64_counter("test.counter")
+                .init();
+            counter.add(1, &[]);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_shutdown_exporter_metrics() {
+        // See the `shutdown` method implementation as to why this is tricky.
+        // This test calls the meter provider from within the exporter to ensure there is no deadlock possible.
+        let meter_provider = AggregateMeterProvider::default();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let periodic_reader = reader(&meter_provider, &shutdown);
+
+        let delegate = MeterProviderBuilder::default()
+            .with_reader(periodic_reader)
+            .build();
+
+        meter_provider.set(
+            MeterProviderType::OtelDefault,
+            Some(FilterMeterProvider::public(GlobalMeterProvider::new(
+                delegate,
+            ))),
+        );
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        meter_provider.shutdown();
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(shutdown.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_reload_exporter_metrics() {
+        // When exporters that interact with the meter provider are being refreshed we want to ensure that they don't deadlock.
+        // I don't think that this could have ever happened, but best to be safe and add a test.
+        let meter_provider = AggregateMeterProvider::default();
+        let shutdown1 = Arc::new(AtomicBool::new(false));
+        let periodic_reader = reader(&meter_provider, &shutdown1);
+
+        let delegate = MeterProviderBuilder::default()
+            .with_reader(periodic_reader)
+            .build();
+
+        meter_provider.set(
+            MeterProviderType::OtelDefault,
+            Some(FilterMeterProvider::public(GlobalMeterProvider::new(
+                delegate,
+            ))),
+        );
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let shutdown2 = Arc::new(AtomicBool::new(false));
+        let periodic_reader = reader(&meter_provider, &shutdown2);
+
+        let delegate = MeterProviderBuilder::default()
+            .with_reader(periodic_reader)
+            .build();
+
+        // Setting the meter provider should not deadlock.
+        meter_provider.set(
+            MeterProviderType::OtelDefault,
+            Some(FilterMeterProvider::public(GlobalMeterProvider::new(
+                delegate,
+            ))),
+        );
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // The first meter provider should be shut down and the second is still active
+        assert!(shutdown1.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!shutdown2.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    fn reader(
+        meter_provider: &AggregateMeterProvider,
+        shutdown: &Arc<AtomicBool>,
+    ) -> PeriodicReader {
+        PeriodicReader::builder(
+            TestExporter {
+                meter_provider: meter_provider.clone(),
+                shutdown: shutdown.clone(),
+            },
+            runtime::Tokio,
+        )
+        .with_interval(Duration::from_millis(10))
+        .with_timeout(Duration::from_millis(10))
+        .build()
     }
 }


### PR DESCRIPTION
TLDR:
The aggregate meter provider had not taken into account the possibility that we would add metrics directly to metrics exporters. This meant that if a meter has metrics in them then the circularity would cause a deadlock.

This only happens on shutdown, but I have added tests for reload just in case.

The longer description:

It is very unusual for telemetry exporters to emit telemetry themselves. None of the regular Otel exporters do this and it's the sort of circular reference that can go wrong. The Apollo exporter does this.

This PR builds upon #6790 to ensure that on the event an exporter does try and access the meter provider during shutdown the AggregateMeterProvider will not deadlock.

### How was this spotted?
Our CI has code to detect deadlocks and it will dump stack traces when this happens. The flaky integration tests were giving us exactly the information needed to diagnose this.

```  _ZN78_$LT$parking_lot..raw_mutex..RawMutex$u20$as$u20$lock_api..mutex..RawMutex$GT$4lock17h4e3f4c73a79ef0a5E
  _ZN8lock_api5mutex18Mutex$LT$R$C$T$GT$4lock17h55347004122c3b76E
  _ZN13apollo_router7metrics11aggregation22AggregateMeterProvider28create_registered_instrument17h5bb8a00d8987210eE
  _ZN13apollo_router7plugins9telemetry20apollo_otlp_exporter18ApolloOtlpExporter6export28_$u7b$$u7b$closure$u7d$$u7d$17h5dcfb14b3dbf8bb9E
```
Note the apollo exporter blocked on trying to create an instrument.

### Why not remove the metric? 
Well actually metric during export are rather useful. For instance recently we introduced a metric to help users understand when an exporter is falling behind.
Successful exports is a useful metric to retain to allow us to figure out if there are problems contacting apollo.

### Could there still be issues?
Yes, I'm going to move on to the rest of the pipeline to see if there are any other mutexes that could cause issues. If there are some in Otel then we may have to modify the way we setup metrics.

### Other benefits
This will likely improve our flaky CI

<!--ROUTER-1086-->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

No docs required. This is an internal change.
Integration tests exist, they should be less flaky.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6800 done by [Mergify](https://mergify.com).