### PR TITLE
Remove incomplete `Pending`-based compute backpressure (1.x)

### DIFF
--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -352,11 +352,7 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if crate::compute_job::is_full() {
-            Poll::Pending
-        } else {
-            Poll::Ready(Ok(()))
-        }
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: QueryPlannerRequest) -> Self::Future {

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -214,11 +214,6 @@ impl Service<RouterRequest> for RouterService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // This service eventually calls `QueryAnalysisLayer::parse_document()`
-        // which calls `compute_job::execute()`
-        if crate::compute_job::is_full() {
-            return Poll::Pending;
-        }
         Poll::Ready(Ok(()))
     }
 


### PR DESCRIPTION
Since version 1.58.0, Apollo Router has a dedicated thread pool with a priority queue for computation-heavy jobs:
parsing + validation, query planning, and introspection.

Initially we tried to exert back-pressure by returning `Poll::Pending` in `tower::Service::poll_ready` for the query planner service when the queue is full above a certain threshold. But `Pending` is supposed to represent waiting _for something_, and we’re supposed to register a "waker" on the async context to notify Tokio to poll this task again when that thing happens. Additionally we’ve found that Tower-based back-pressure is completely broken in 1.x, and made significant changes in Router 2.x to fix it.

Backpressure like in 2.x is not gonna happen in 1.x, so remove the incorrect usage of `Pending` instead. This makes the compute job queue effectively unbounded.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
