### PR TITLE
chore: Delegate setting "latest" to RELEASE_CHECKLIST.md, rather than CI. (backport #6809)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -967,17 +967,10 @@ jobs:
                   cd artifacts && sha1sum *.tar.gz > sha1sums.txt
             - run:
                 name: Create GitHub Release
+                # We always create the version as a "pre-release" version.
+                # It is promoted to latest in a separate step in RELEASE_CHECKLIST.md
                 command: >
-                  case "$VERSION" in
-
-                    # If the VERSION contains a dash, consider it a pre-release version.
-                    # This is in-line with SemVer's expectations/designations!
-                    *-*) gh release create $VERSION --prerelease --notes-file /dev/null --title $VERSION artifacts/* ;;
-
-                    # In all other cases, publish it as the latest version.
-                    *) gh release create $VERSION --notes-file /dev/null --title $VERSION artifacts/* ;;
-
-                  esac
+                  gh release create $VERSION --prerelease --notes-file /dev/null --title $VERSION artifacts/* ;;
             - run:
                 name: Docker build
                 command: |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -438,7 +438,15 @@ Start following the steps below to start a release PR.  The process is **not ful
     gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" release edit v"${APOLLO_ROUTER_RELEASE_VERSION}" -F ./this_release.md
     ```
 
-18. Finally, publish the Crates (`apollo-federation` followed by `apollo-router`) from your local computer from the `main` branch (this also needs to be moved to CI, but requires changing the release containers to be Rust-enabled and to restore the caches):
+18. (Conditional) If this is meant to be marked as the latest version, edit the release and add the "Latest" label:
+
+    > Note: As of this writing, we will only mark 1.x versions as Latest.
+
+    ```
+    gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" release edit v"${APOLLO_ROUTER_RELEASE_VERSION}" --latest
+    ```
+
+19. Finally, publish the Crates (`apollo-federation` followed by `apollo-router`) from your local computer from the `main` branch (this also needs to be moved to CI, but requires changing the release containers to be Rust-enabled and to restore the caches):
 
     > Note: This command may appear unnecessarily specific, but it will help avoid publishing a version to Crates.io that doesn't match what you're currently releasing. (e.g., in the event that you've changed branches in another window)
 
@@ -447,7 +455,7 @@ Start following the steps below to start a release PR.  The process is **not ful
       cargo publish -p apollo-router@"${APOLLO_ROUTER_RELEASE_VERSION}"
     ```
 
-19. (Optional) To have a "social banner" for this release, run [this `htmlq` command](https://crates.io/crates/htmlq) (`cargo install htmlq`, or on MacOS `brew install htmlq`; its `jq` for HTML), open the link it produces, copy the image to your clipboard:
+20. (Optional) To have a "social banner" for this release, run [this `htmlq` command](https://crates.io/crates/htmlq) (`cargo install htmlq`, or on MacOS `brew install htmlq`; its `jq` for HTML), open the link it produces, copy the image to your clipboard:
 
     ```
     curl -s "https://github.com/apollographql/router/releases/tag/v${APOLLO_ROUTER_RELEASE_VERSION}" | htmlq 'meta[property="og:image"]' --attribute content


### PR DESCRIPTION


We have a notion of "Latest" which is represented by GitHub.  This indicates what appears on our GitHub Repo homepage, but also what our cURL installer installs when you use `latest`.  (No surprise as it's built on GitHub artifacts which also use that as [its "latest"](https://github.com/apollographql/router/releases/latest))

Because we now have two different "major" versions on the Router repository, we need to make sure they don't both compete for which is "latest".  Removing this from CI and moving this to an explicit step in `RELEASE_CHECKLIST.mdd` is a temporary solution and we can figure out how to operationalize it further next. (Which could actually involve re-introducing this commit, but only on the 2.x line, or something, but there are also other signals we could automatically react to.)

<img width="264" alt="image" src="https://github.com/user-attachments/assets/d78492b3-9e8f-43c8-b94f-46b5c8197030" />

[ROUTER-1014]: https://apollographql.atlassian.net/browse/ROUTER-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #6809 done by [Mergify](https://mergify.com).