### PR TITLE
Hopefully fix docs.rs build

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -55,9 +55,6 @@ ci = []
 # Enables the HTTP snapshot server for testing
 snapshot = ["axum-server", "serde_regex"]
 
-[package.metadata.docs.rs]
-features = ["docs_rs"]
-
 [dependencies]
 arc-swap = "1.6.0"
 anyhow = "1.0.86"


### PR DESCRIPTION
The `docs_rs` feature flag was removed together with router-bridge. Removing its reference from `Cargo.toml` happened in 1.x but somehow didn’t make it to the 2.x branch until now.

This hopefully fixes failures like https://docs.rs/crate/apollo-router/2.0.0/builds/1770433