### PR TITLE
fix(federation): fixed a bug losing `__typename` selection in query plan (backport #6555)

### DIFF
--- a/.changesets/fix_lost_typename_attachment.md
+++ b/.changesets/fix_lost_typename_attachment.md
@@ -1,0 +1,5 @@
+### Fixed a query planner bug where some `__typename` selections could be missing in query plans
+
+The query planner uses an optimization technique called "sibling typename", which attaches `__typename` selections to their sibling selections so the planner won't need to plan them separately. The bug was that, when there are multiple identical selections and one of them has a `__typename` attached, the query planner could pick the one without the attachment, effectively losing a `__typename` selection. The query planner now favors the one with a `__typename` attached, so that the attached `__typename` selections won't be lost anymore.
+
+By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/6824

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -49,6 +49,7 @@ use crate::query_graph::condition_resolver::ConditionResolution;
 use crate::query_graph::condition_resolver::ConditionResolver;
 use crate::query_graph::condition_resolver::UnsatisfiedConditionReason;
 use crate::query_graph::path_tree::OpPathTree;
+use crate::query_graph::path_tree::Preference;
 use crate::query_graph::QueryGraph;
 use crate::query_graph::QueryGraphEdgeTransition;
 use crate::query_graph::QueryGraphNodeType;
@@ -327,6 +328,34 @@ impl Display for OpPath {
             }
         }
         Ok(())
+    }
+}
+
+impl Preference for OpPathElement {
+    fn preferred_over(&self, other: &Self) -> Option<bool> {
+        match (self, other) {
+            (OpPathElement::Field(x), OpPathElement::Field(y)) => {
+                // We prefer the one with a sibling typename (= Less).
+                // Otherwise, not comparable.
+                match (&x.sibling_typename, &y.sibling_typename) {
+                    (Some(_), None) => Some(true),
+                    (None, Some(_)) => Some(false),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+impl Preference for OpGraphPathTrigger {
+    fn preferred_over(&self, other: &Self) -> Option<bool> {
+        match (self, other) {
+            (OpGraphPathTrigger::OpPathElement(x), OpGraphPathTrigger::OpPathElement(y)) => {
+                x.preferred_over(y)
+            }
+            _ => None,
+        }
     }
 }
 

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
@@ -398,7 +398,8 @@ fn test_indirect_branch_merging_with_typename_sibling() {
     // This operation has two `f` selection instances: One with __typename sibling and one without.
     // It creates multiple identical branches in the form of `... on A { f }` with different `f`.
     // The query plan must chose one over the other, which is implementation specific.
-    // Currently, the last one is chosen.
+    // This test is to make sure we choose the one with a typename sibling attached, thus
+    // we won't lose the requested `__typename` selection.
     assert_plan!(
         &planner,
         r#"
@@ -444,6 +445,7 @@ fn test_indirect_branch_merging_with_typename_sibling() {
             } =>
             {
               ... on A {
+                __typename
                 f
               }
               ... on B {


### PR DESCRIPTION
Fixed `PathTree::from_paths` to prefer trigger value with a typename sibling attached.


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests
<hr>This is an automatic backport of pull request #6555 done by [Mergify](https://mergify.com).