### PR TITLE
docs: remove request retry mention from traffic-shaping

### DIFF
--- a/docs/source/routing/performance/traffic-shaping.mdx
+++ b/docs/source/routing/performance/traffic-shaping.mdx
@@ -190,7 +190,6 @@ Traffic shaping always executes these steps in the same order, to ensure a consi
 - variable deduplication
 - query deduplication
 - timeout
-- request retry
 - rate limiting
 - compression
 - sending the request to the subgraph

--- a/docs/source/routing/performance/traffic-shaping.mdx
+++ b/docs/source/routing/performance/traffic-shaping.mdx
@@ -184,7 +184,7 @@ traffic_shaping:
 
 ### Ordering
 
-Traffic shaping always executes these steps in the same order, to ensure a consistent behaviour. Declaration order in the configuration will not affect the runtime order:
+Traffic shaping always executes these steps in the same order, to ensure a consistent behavior. Declaration order in the configuration will not affect the runtime order:
 
 - preparing the subgraph request
 - variable deduplication


### PR DESCRIPTION
A user noted that since `experimental_retry` was [removed from traffic shaping](https://github.com/apollographql/router/pull/6338) we should no longer mention it as a task in the [ordering section](https://www.apollographql.com/docs/graphos/routing/performance/traffic-shaping#ordering).