### PR TITLE
Use explicit default on omitted telemetry endpoints

### DIFF
--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -43,16 +43,6 @@ where
         }
         self
     }
-    fn try_with<B>(
-        self,
-        option: &Option<B>,
-        apply: fn(Self, &B) -> Result<Self, BoxError>,
-    ) -> Result<Self, BoxError> {
-        if let Some(option) = option {
-            return apply(self, option);
-        }
-        Ok(self)
-    }
 }
 
 impl<T> GenericWith<T> for T where Self: Sized {}

--- a/apollo-router/src/plugins/telemetry/endpoint.rs
+++ b/apollo-router/src/plugins/telemetry/endpoint.rs
@@ -20,8 +20,8 @@ pub(crate) struct UriEndpoint {
 
 impl UriEndpoint {
     /// Converts an endpoint to a URI using the default endpoint as reference for any URI parts that are missing.
-    pub(crate) fn to_uri(&self, default_endpoint: &Uri) -> Option<Uri> {
-        self.uri.as_ref().map(|uri| {
+    pub(crate) fn extend_to_full_uri(&self, default_endpoint: &Uri) -> Uri {
+        if let Some(uri) = &self.uri {
             let mut parts = uri.clone().into_parts();
             if parts.scheme.is_none() {
                 parts.scheme = default_endpoint.scheme().cloned();
@@ -64,7 +64,9 @@ impl UriEndpoint {
 
             Uri::from_parts(parts)
                 .expect("uri cannot be invalid as it was constructed from existing parts")
-        })
+        } else {
+            default_endpoint.clone()
+        }
     }
 }
 
@@ -216,53 +218,50 @@ mod test {
     }
 
     #[test]
-    fn test_to_url() {
+    fn test_extend_to_full_uri() {
+        assert_eq!(
+            UriEndpoint::default()
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
+            Uri::from_static("http://localhost:9411/path2")
+        );
         assert_eq!(
             UriEndpoint::from(Uri::from_static("example.com"))
-                .to_uri(&Uri::from_static("http://localhost:9411/path2"))
-                .unwrap(),
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
             Uri::from_static("http://example.com:9411/path2")
         );
         assert_eq!(
             UriEndpoint::from(Uri::from_static("example.com:2000"))
-                .to_uri(&Uri::from_static("http://localhost:9411/path2"))
-                .unwrap(),
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
             Uri::from_static("http://example.com:2000/path2")
         );
         assert_eq!(
             UriEndpoint::from(Uri::from_static("http://example.com:2000/"))
-                .to_uri(&Uri::from_static("http://localhost:9411/path2"))
-                .unwrap(),
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
             Uri::from_static("http://example.com:2000/")
         );
         assert_eq!(
             UriEndpoint::from(Uri::from_static("http://example.com:2000/path1"))
-                .to_uri(&Uri::from_static("http://localhost:9411/path2"))
-                .unwrap(),
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
             Uri::from_static("http://example.com:2000/path1")
         );
         assert_eq!(
             UriEndpoint::from(Uri::from_static("http://example.com:2000"))
-                .to_uri(&Uri::from_static("http://localhost:9411/path2"))
-                .unwrap(),
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
             Uri::from_static("http://example.com:2000")
         );
         assert_eq!(
             UriEndpoint::from(Uri::from_static("http://example.com/path1"))
-                .to_uri(&Uri::from_static("http://localhost:9411/path2"))
-                .unwrap(),
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
             Uri::from_static("http://example.com:9411/path1")
         );
         assert_eq!(
             UriEndpoint::from(Uri::from_static("http://:2000/path1"))
-                .to_uri(&Uri::from_static("http://localhost:9411/path2"))
-                .unwrap(),
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
             Uri::from_static("http://localhost:2000/path1")
         );
         assert_eq!(
             UriEndpoint::from(Uri::from_static("/path1"))
-                .to_uri(&Uri::from_static("http://localhost:9411/path2"))
-                .unwrap(),
+                .extend_to_full_uri(&Uri::from_static("http://localhost:9411/path2")),
             Uri::from_static("http://localhost:9411/path1")
         );
     }

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use http::uri::Parts;
 use http::uri::PathAndQuery;
 use http::Uri;
 use opentelemetry::sdk::metrics::reader::TemporalitySelector;
@@ -22,7 +21,6 @@ use tonic::transport::Identity;
 use tower::BoxError;
 use url::Url;
 
-use crate::plugins::telemetry::config::GenericWith;
 use crate::plugins::telemetry::endpoint::UriEndpoint;
 use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 
@@ -78,84 +76,57 @@ impl Config {
     ) -> Result<T, BoxError> {
         match self.protocol {
             Protocol::Grpc => {
-                let endpoint = self.endpoint.to_uri(&DEFAULT_GRPC_ENDPOINT);
-                let grpc = self.grpc.clone();
-                let exporter = opentelemetry_otlp::new_exporter()
+                let endpoint = self.endpoint.extend_to_full_uri(&DEFAULT_GRPC_ENDPOINT);
+                let mut exporter = opentelemetry_otlp::new_exporter()
                     .tonic()
                     .with_timeout(self.batch_processor.max_export_timeout)
-                    .with(&endpoint, |b, endpoint| {
-                        b.with_endpoint(endpoint.to_string())
-                    })
-                    .with(&grpc.try_from(&endpoint)?, |b, t| {
-                        b.with_tls_config(t.clone())
-                    })
-                    .with_metadata(MetadataMap::from_headers(self.grpc.metadata.clone()))
-                    .into();
-                Ok(exporter)
+                    .with_endpoint(endpoint.to_string())
+                    .with_metadata(MetadataMap::from_headers(self.grpc.metadata.clone()));
+
+                if let Some(tls_config) = self.grpc.clone().tls_config(&endpoint)? {
+                    exporter = exporter.with_tls_config(tls_config);
+                }
+
+                Ok(exporter.into())
             }
             Protocol::Http => {
-                let endpoint = add_missing_path(
-                    kind,
-                    self.endpoint
-                        .to_uri(&DEFAULT_HTTP_ENDPOINT)
-                        .map(|e| e.into_parts()),
-                )?;
+                let mut endpoint = self.endpoint.extend_to_full_uri(&DEFAULT_HTTP_ENDPOINT);
+                if let TelemetryDataKind::Traces = kind {
+                    endpoint = add_missing_traces_path(endpoint)?;
+                }
                 let http = self.http.clone();
                 let exporter = opentelemetry_otlp::new_exporter()
                     .http()
                     .with_timeout(self.batch_processor.max_export_timeout)
-                    .with(&endpoint, |b, endpoint| {
-                        b.with_endpoint(endpoint.to_string())
-                    })
-                    .with_headers(http.headers)
-                    .into();
-
-                Ok(exporter)
+                    .with_endpoint(endpoint.to_string())
+                    .with_headers(http.headers);
+                Ok(exporter.into())
             }
         }
     }
 }
 
 // Waiting for https://github.com/open-telemetry/opentelemetry-rust/issues/1618 to be fixed
-fn add_missing_path(
-    kind: TelemetryDataKind,
-    mut endpoint_parts: Option<Parts>,
-) -> Result<Option<Uri>, BoxError> {
-    if let Some(endpoint_parts) = &mut endpoint_parts {
-        if let TelemetryDataKind::Traces = kind {
-            match &mut endpoint_parts.path_and_query {
-                Some(path_and_query) => {
-                    if !path_and_query.path().ends_with(DEFAULT_HTTP_ENDPOINT_PATH) {
-                        match path_and_query.query() {
-                            Some(query) => {
-                                endpoint_parts.path_and_query =
-                                    Some(PathAndQuery::from_str(&format!(
-                                        "{}{DEFAULT_HTTP_ENDPOINT_PATH}?{query}",
-                                        path_and_query.path().trim_end_matches('/')
-                                    ))?);
-                            }
-                            None => {
-                                *path_and_query = PathAndQuery::from_str(&format!(
-                                    "{}{DEFAULT_HTTP_ENDPOINT_PATH}",
-                                    path_and_query.path().trim_end_matches('/')
-                                ))?;
-                            }
-                        }
-                    }
-                }
-                None => {
-                    endpoint_parts.path_and_query =
-                        Some(PathAndQuery::from_static(DEFAULT_HTTP_ENDPOINT_PATH));
-                }
-            }
+fn add_missing_traces_path(uri: Uri) -> Result<Uri, BoxError> {
+    let mut parts = uri.into_parts();
+    parts.path_and_query = Some(match parts.path_and_query {
+        Some(path_and_query) if path_and_query.path().ends_with(DEFAULT_HTTP_ENDPOINT_PATH) => {
+            path_and_query
         }
-    }
-    let endpoint = match endpoint_parts {
-        Some(endpoint_parts) => Some(Uri::from_parts(endpoint_parts)?),
-        None => None,
-    };
+        Some(path_and_query) => match path_and_query.query() {
+            Some(query) => PathAndQuery::from_str(&format!(
+                "{}{DEFAULT_HTTP_ENDPOINT_PATH}?{query}",
+                path_and_query.path().trim_end_matches('/')
+            ))?,
+            None => PathAndQuery::from_str(&format!(
+                "{}{DEFAULT_HTTP_ENDPOINT_PATH}",
+                path_and_query.path().trim_end_matches('/')
+            ))?,
+        },
+        None => PathAndQuery::from_static(DEFAULT_HTTP_ENDPOINT_PATH),
+    });
 
-    Ok(endpoint)
+    Ok(Uri::from_parts(parts)?)
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
@@ -189,35 +160,22 @@ fn header_map(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Sch
 }
 
 impl GrpcExporter {
-    // Return a TlsConfig if it has something actually set.
-    pub(crate) fn try_from(
-        self,
-        endpoint: &Option<Uri>,
-    ) -> Result<Option<ClientTlsConfig>, BoxError> {
-        if let Some(endpoint) = endpoint {
-            let endpoint = endpoint.to_string().parse::<Url>().map_err(|e| {
-                BoxError::from(format!("invalid GRPC endpoint {}, {}", endpoint, e))
-            })?;
-            let domain_name = self.default_tls_domain(&endpoint);
+    pub(crate) fn tls_config(&self, endpoint: &Uri) -> Result<Option<ClientTlsConfig>, BoxError> {
+        let endpoint = endpoint
+            .to_string()
+            .parse::<Url>()
+            .map_err(|e| BoxError::from(format!("invalid GRPC endpoint {}, {}", endpoint, e)))?;
+        let domain_name = self.default_tls_domain(&endpoint);
 
-            if self.ca.is_some()
-                || self.key.is_some()
-                || self.cert.is_some()
-                || domain_name.is_some()
-            {
-                return Some(
-                    ClientTlsConfig::new()
-                        .with(&domain_name, |b, d| b.domain_name(*d))
-                        .try_with(&self.ca, |b, c| {
-                            Ok(b.ca_certificate(Certificate::from_pem(c)))
-                        })?
-                        .try_with(
-                            &self.cert.clone().zip(self.key.clone()),
-                            |b, (cert, key)| Ok(b.identity(Identity::from_pem(cert, key))),
-                        ),
-                )
-                .transpose();
-            }
+        if let (Some(ca), Some(key), Some(cert), Some(domain_name)) =
+            (&self.ca, &self.key, &self.cert, domain_name)
+        {
+            return Ok(Some(
+                ClientTlsConfig::new()
+                    .domain_name(domain_name)
+                    .ca_certificate(Certificate::from_pem(ca.clone()))
+                    .identity(Identity::from_pem(cert.clone(), key.clone())),
+            ));
         }
         Ok(None)
     }
@@ -311,38 +269,30 @@ mod tests {
     }
 
     #[test]
-    fn test_add_missing_path() {
+    fn test_add_missing_traces_path() {
         let url = Uri::from_str("https://api.apm.com:433/v1/traces").unwrap();
-        let url = add_missing_path(TelemetryDataKind::Traces, url.into_parts().into())
-            .unwrap()
-            .unwrap();
+        let url = add_missing_traces_path(url).unwrap();
         assert_eq!(
             url.to_string(),
             String::from("https://api.apm.com:433/v1/traces")
         );
 
         let url = Uri::from_str("https://api.apm.com:433/").unwrap();
-        let url = add_missing_path(TelemetryDataKind::Traces, url.into_parts().into())
-            .unwrap()
-            .unwrap();
+        let url = add_missing_traces_path(url).unwrap();
         assert_eq!(
             url.to_string(),
             String::from("https://api.apm.com:433/v1/traces")
         );
 
         let url = Uri::from_str("https://api.apm.com:433/?hi=hello").unwrap();
-        let url = add_missing_path(TelemetryDataKind::Traces, url.into_parts().into())
-            .unwrap()
-            .unwrap();
+        let url = add_missing_traces_path(url).unwrap();
         assert_eq!(
             url.to_string(),
             String::from("https://api.apm.com:433/v1/traces?hi=hello")
         );
 
         let url = Uri::from_str("https://api.apm.com:433/v1?hi=hello").unwrap();
-        let url = add_missing_path(TelemetryDataKind::Traces, url.into_parts().into())
-            .unwrap()
-            .unwrap();
+        let url = add_missing_traces_path(url).unwrap();
         assert_eq!(
             url.to_string(),
             String::from("https://api.apm.com:433/v1/v1/traces?hi=hello")

--- a/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
@@ -141,12 +141,12 @@ impl TracingConfigurator for Config {
         });
 
         let fixed_span_names = self.fixed_span_names;
+        let endpoint = &self
+            .endpoint
+            .extend_to_full_uri(&Uri::from_static(DEFAULT_ENDPOINT));
 
         let exporter = datadog_exporter::new_pipeline()
-            .with(
-                &self.endpoint.to_uri(&Uri::from_static(DEFAULT_ENDPOINT)),
-                |builder, e| builder.with_agent_endpoint(e.to_string().trim_end_matches('/')),
-            )
+            .with_agent_endpoint(endpoint.to_string().trim_end_matches('/'))
             .with(&resource_mappings, |builder, resource_mappings| {
                 let resource_mappings = resource_mappings.clone();
                 builder.with_resource_mapping(move |span, _model_config| {

--- a/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
@@ -122,18 +122,12 @@ impl TracingConfigurator for Config {
                     batch_processor
                 );
 
+                let endpoint = collector.endpoint.extend_to_full_uri(&DEFAULT_ENDPOINT);
                 let exporter = opentelemetry_jaeger::new_collector_pipeline()
                     .with_trace_config(common.into())
                     .with(&collector.username, |b, u| b.with_username(u))
                     .with(&collector.password, |b, p| b.with_password(p))
-                    .with(
-                        &collector
-                            .endpoint
-                            .to_uri(&DEFAULT_ENDPOINT)
-                            // https://github.com/open-telemetry/opentelemetry-rust/issues/1280 Default jaeger endpoint for collector looks incorrect
-                            .or_else(|| Some(DEFAULT_ENDPOINT.clone())),
-                        |b, p| b.with_endpoint(p.to_string()),
-                    )
+                    .with_endpoint(endpoint.to_string())
                     .with_reqwest()
                     .with_batch_processor_config(batch_processor.clone().into())
                     .build_collector_exporter::<runtime::Tokio>()?;

--- a/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
@@ -50,10 +50,9 @@ impl TracingConfigurator for Config {
     ) -> Result<Builder, BoxError> {
         tracing::info!("configuring Zipkin tracing: {}", self.batch_processor);
         let common: sdk::trace::Config = trace.into();
+        let endpoint = self.endpoint.extend_to_full_uri(&DEFAULT_ENDPOINT);
         let exporter = opentelemetry_zipkin::new_pipeline()
-            .with(&self.endpoint.to_uri(&DEFAULT_ENDPOINT), |b, endpoint| {
-                b.with_collector_endpoint(endpoint.to_string())
-            })
+            .with_collector_endpoint(endpoint.to_string())
             .with(
                 &common.resource.get(SERVICE_NAME),
                 |builder, service_name| {


### PR DESCRIPTION
Fixes default OLTP collector endpoint.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
