### PR TITLE
docs: fix build

### DIFF
--- a/docs/source/routing/graphos-reporting.mdx
+++ b/docs/source/routing/graphos-reporting.mdx
@@ -17,8 +17,7 @@ export APOLLO_GRAPH_REF=<YOUR_GRAPH_ID>@<VARIANT_NAME>
 
 <MinVersion version="1.49.0">
 
-<a id="usage-reporting-via-opentelemetry-protocol-otlp"></a>
-### GraphOS tracing via OpenTelemetry Protocol (OTLP)
+### Usage reporting via OpenTelemetry Protocol (OTLP)
 
 </MinVersion>
 
@@ -26,18 +25,15 @@ Prior to router v1.49.0, all GraphOS reporting was performed using a [private tr
 
 As the ecosystem around OpenTelemetry (OTel) has rapidly expanded, Apollo evaluated migrating its internal tracing system to use an OTel-based protocol.
 
-Starting in v1.49.0, the router can use OpenTelemetry Protocol (OTLP) to report traces to GraphOS. The benefits of reporting via OTLP include:
+Starting in v1.49.0, the router can use OpenTelemetry Protocol (OTLP) to report operation usage metrics to GraphOS. The benefits of reporting via OTLP include:
 
 - A comprehensive way to visualize the router execution path in GraphOS Studio.
 - Additional spans that were previously not included in Studio traces, such as query parsing, planning, execution, and more.
 - Additional metadata such as subgraph fetch details, router idle / busy timing, and more.
 
-Usage metrics are still using the Apollo Usage Reporting protocol.
+#### Configuring usage reporting via OTLP
 
-<a id="configuring-usage-reporting-via-otlp"></a>
-#### Configuring trace reporting via OTLP
-
-You can enable trace reporting via OTLP by an option that can also configure the ratio of traces sent via OTLP and Apollo Usage Reporting protocol:
+You can enable usage reporting via OTLP by an option that can also configure the ratio of traces sent via OTLP and Apollo Usage Reporting protocol:
 
 - In router v1.x, this is controlled using the `experimental_otlp_tracing_sampler` option and is disabled by default.
 


### PR DESCRIPTION
This reverts commit 2660308f9f2a66109ccb3b3d27608734a0244e14.

That commit introduced a mdx error preventing all docs builds across apollo: https://github.com/apollographql/apollo-kotlin/pull/6387#issuecomment-2667974068

I'll re-apply it later but correctly...

cc @martinbonnin 