### PR TITLE
docs: remove request retry mention from traffic-shaping (backport #6826)

### DIFF
--- a/docs/source/routing/performance/traffic-shaping.mdx
+++ b/docs/source/routing/performance/traffic-shaping.mdx
@@ -167,13 +167,12 @@ traffic_shaping:
 
 ### Ordering
 
-Traffic shaping always executes these steps in the same order, to ensure a consistent behaviour. Declaration order in the configuration will not affect the runtime order:
+Traffic shaping always executes these steps in the same order, to ensure a consistent behavior. Declaration order in the configuration will not affect the runtime order:
 
 - preparing the subgraph request
 - variable deduplication
 - query deduplication
 - timeout
-- request retry
 - rate limiting
 - compression
 - sending the request to the subgraph


### PR DESCRIPTION
A user noted that since `experimental_retry` was [removed from traffic shaping](https://github.com/apollographql/router/pull/6338) we should no longer mention it as a task in the [ordering section](https://www.apollographql.com/docs/graphos/routing/performance/traffic-shaping#ordering).<hr>This is an automatic backport of pull request #6826 done by [Mergify](https://mergify.com).