### PR TITLE
fix(helm): template interpolation syntax for Istio VirtualService

### DIFF
--- a/helm/chart/router/templates/virtualservice.yaml
+++ b/helm/chart/router/templates/virtualservice.yaml
@@ -20,13 +20,13 @@ metadata:
   {{- end }}
 spec:
   hosts:
-  {{ if .Values.virtualservice.Hosts }}
-  {{ - range .Values.virtualservice.Hosts }}
+  {{- if .Values.virtualservice.Hosts }}
+  {{- range .Values.virtualservice.Hosts }}
   - {{ . | quote }}
-  {{ - end }}
-  {{ - else }}
+  {{- end }}
+  {{- else }}
   - "*"
-  {{ - end }}
+  {{- end }}
   {{- if .Values.virtualservice.gatewayName }}
   gateways:
   - {{ .Values.virtualservice.gatewayName }}

--- a/helm/chart/router/templates/virtualservice.yaml
+++ b/helm/chart/router/templates/virtualservice.yaml
@@ -20,13 +20,13 @@ metadata:
   {{- end }}
 spec:
   hosts:
-  { { if .Values.virtualservice.Hosts } }
-  { { - range .Values.virtualservice.Hosts } }
-  - { { . | quote } }
-  { { - end } }
-  { { - else } }
+  {{ if .Values.virtualservice.Hosts }}
+  {{ - range .Values.virtualservice.Hosts }}
+  - {{ . | quote }}
+  {{ - end }}
+  {{ - else }}
   - "*"
-  { { - end } }
+  {{ - end }}
   {{- if .Values.virtualservice.gatewayName }}
   gateways:
   - {{ .Values.virtualservice.gatewayName }}

--- a/helm/chart/router/templates/virtualservice.yaml
+++ b/helm/chart/router/templates/virtualservice.yaml
@@ -3,7 +3,6 @@
 {{- $svcPort := .Values.service.port -}}
 {{- $hostName := printf "%s.%s.svc.cluster.local" $fullName .Release.Namespace }}
 
-{{ if .Values.virtualservice.enabled }}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -53,5 +52,4 @@ spec:
     {{- toYaml .Values.virtualservice.http.additionals | nindent 4 }}
   {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
The Istio VirtualService template in the Helm chart is syntactically invalid. In Go template syntax, there should not be any whitespace between braces.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
