### PR TITLE
Ensure `build_query_plan()` cancels when the request cancels

### DIFF
--- a/.changesets/fix_stance_intercom_body_director.md
+++ b/.changesets/fix_stance_intercom_body_director.md
@@ -1,0 +1,5 @@
+### Ensure query planning exits when its request times out ([PR #6840](https://github.com/apollographql/router/pull/6840))
+
+When a request times out/is cancelled, resources allocated to that request should be released. Previously, query planning could potentially keep running after the request is cancelled. After this fix, query planning now exits shortly after the request is cancelled. If you need query planning to run longer, you can [increase the request timeout](https://www.apollographql.com/docs/graphos/routing/performance/traffic-shaping#timeouts).
+
+By [@SimonSapin](https://github.com/SimonSapin) and [@sachindshinde](https://github.com/sachindshinde) in https://github.com/apollographql/router/pull/6840

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -300,6 +300,8 @@ pub enum SingleFederationError {
     DeferredSubscriptionUnsupported,
     #[error("{message}")]
     QueryPlanComplexityExceeded { message: String },
+    #[error("the caller requested cancellation")]
+    PlanningCancelled,
 }
 
 impl SingleFederationError {
@@ -494,6 +496,7 @@ impl SingleFederationError {
             SingleFederationError::QueryPlanComplexityExceeded { .. } => {
                 ErrorCode::QueryPlanComplexityExceededError
             }
+            SingleFederationError::PlanningCancelled => ErrorCode::Internal,
         }
     }
 }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1541,9 +1541,12 @@ impl SelectionSet {
         Ok(())
     }
 
-    pub(crate) fn expand_all_fragments(&self) -> Result<SelectionSet, FederationError> {
+    pub(crate) fn expand_all_fragments(
+        &self,
+        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+    ) -> Result<SelectionSet, FederationError> {
         let mut expanded_selections = vec![];
-        SelectionSet::expand_selection_set(&mut expanded_selections, self)?;
+        SelectionSet::expand_selection_set(&mut expanded_selections, self, check_cancellation)?;
 
         let mut expanded = SelectionSet {
             schema: self.schema.clone(),
@@ -1557,12 +1560,14 @@ impl SelectionSet {
     fn expand_selection_set(
         destination: &mut Vec<Selection>,
         selection_set: &SelectionSet,
+        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
     ) -> Result<(), FederationError> {
         for value in selection_set.selections.values() {
+            check_cancellation()?;
             match value {
                 Selection::Field(field_selection) => {
                     let selections = match &field_selection.selection_set {
-                        Some(s) => Some(s.expand_all_fragments()?),
+                        Some(s) => Some(s.expand_all_fragments(check_cancellation)?),
                         None => None,
                     };
                     destination.push(Selection::from_field(
@@ -1580,12 +1585,14 @@ impl SelectionSet {
                         SelectionSet::expand_selection_set(
                             destination,
                             &spread_selection.selection_set,
+                            check_cancellation,
                         )?;
                     } else {
                         // convert to inline fragment
                         let expanded = InlineFragmentSelection::from_fragment_spread_selection(
                             selection_set.type_position.clone(), // the parent type of this inline selection
                             spread_selection,
+                            check_cancellation,
                         )?;
                         destination.push(Selection::InlineFragment(Arc::new(expanded)));
                     }
@@ -1594,7 +1601,9 @@ impl SelectionSet {
                     destination.push(
                         InlineFragmentSelection::new(
                             inline_selection.inline_fragment.clone(),
-                            inline_selection.selection_set.expand_all_fragments()?,
+                            inline_selection
+                                .selection_set
+                                .expand_all_fragments(check_cancellation)?,
                         )
                         .into(),
                     );
@@ -2716,6 +2725,7 @@ impl InlineFragmentSelection {
     pub(crate) fn from_fragment_spread_selection(
         parent_type_position: CompositeTypeDefinitionPosition,
         fragment_spread_selection: &Arc<FragmentSpreadSelection>,
+        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
     ) -> Result<InlineFragmentSelection, FederationError> {
         let schema = fragment_spread_selection.spread.schema.schema();
         for directive in fragment_spread_selection.spread.directives.iter() {
@@ -2753,7 +2763,7 @@ impl InlineFragmentSelection {
             },
             fragment_spread_selection
                 .selection_set
-                .expand_all_fragments()?,
+                .expand_all_fragments(check_cancellation)?,
         ))
     }
 
@@ -3749,10 +3759,11 @@ pub(crate) fn normalize_operation(
     named_fragments: NamedFragments,
     schema: &ValidFederationSchema,
     interface_types_with_interface_objects: &IndexSet<InterfaceTypeDefinitionPosition>,
+    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
 ) -> Result<Operation, FederationError> {
     let mut normalized_selection_set =
         SelectionSet::from_selection_set(&operation.selection_set, &named_fragments, schema)?;
-    normalized_selection_set = normalized_selection_set.expand_all_fragments()?;
+    normalized_selection_set = normalized_selection_set.expand_all_fragments(check_cancellation)?;
     // We clear up the fragments since we've expanded all.
     // Also note that expanding fragment usually generate unnecessary fragments/inefficient
     // selections, so it basically always make sense to flatten afterwards. Besides, fragment

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -64,6 +64,8 @@ pub(crate) use contains::*;
 pub(crate) use directive_list::DirectiveList;
 pub(crate) use merging::*;
 pub(crate) use rebase::*;
+#[cfg(test)]
+pub(crate) use tests::never_cancel;
 
 pub(crate) const TYPENAME_FIELD: Name = name!("__typename");
 
@@ -1543,7 +1545,7 @@ impl SelectionSet {
 
     pub(crate) fn expand_all_fragments(
         &self,
-        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<SelectionSet, FederationError> {
         let mut expanded_selections = vec![];
         SelectionSet::expand_selection_set(&mut expanded_selections, self, check_cancellation)?;
@@ -1560,7 +1562,7 @@ impl SelectionSet {
     fn expand_selection_set(
         destination: &mut Vec<Selection>,
         selection_set: &SelectionSet,
-        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<(), FederationError> {
         for value in selection_set.selections.values() {
             check_cancellation()?;
@@ -2725,7 +2727,7 @@ impl InlineFragmentSelection {
     pub(crate) fn from_fragment_spread_selection(
         parent_type_position: CompositeTypeDefinitionPosition,
         fragment_spread_selection: &Arc<FragmentSpreadSelection>,
-        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<InlineFragmentSelection, FederationError> {
         let schema = fragment_spread_selection.spread.schema.schema();
         for directive in fragment_spread_selection.spread.directives.iter() {
@@ -3759,7 +3761,7 @@ pub(crate) fn normalize_operation(
     named_fragments: NamedFragments,
     schema: &ValidFederationSchema,
     interface_types_with_interface_objects: &IndexSet<InterfaceTypeDefinitionPosition>,
-    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
 ) -> Result<Operation, FederationError> {
     let mut normalized_selection_set =
         SelectionSet::from_selection_set(&operation.selection_set, &named_fragments, schema)?;

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -13,6 +13,7 @@ use super::SelectionKey;
 use super::SelectionSet;
 use super::normalize_operation;
 use crate::error::FederationError;
+use crate::error::SingleFederationError;
 use crate::query_graph::graph_path::OpPathElement;
 use crate::schema::ValidFederationSchema;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
@@ -65,8 +66,14 @@ pub(super) fn parse_and_expand(
         fragments,
         schema,
         &Default::default(),
-        &|| Ok(()),
+        &never_cancel,
     )
+}
+
+/// The `normalize_operation()` function has a `check_cancellation` parameter that we'll want to
+/// configure to never cancel during tests. We create a convenience function here for that purpose.
+pub(crate) fn never_cancel() -> Result<(), SingleFederationError> {
+    Ok(())
 }
 
 #[test]
@@ -106,7 +113,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();
@@ -161,7 +168,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();
@@ -204,7 +211,7 @@ type Query {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
 
@@ -240,7 +247,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -284,7 +291,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -331,7 +338,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -376,7 +383,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -423,7 +430,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skip1: Boolean!, $skip2: Boolean!) {
@@ -475,7 +482,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -542,7 +549,7 @@ type V {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -602,7 +609,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -649,7 +656,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -700,7 +707,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -749,7 +756,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -798,7 +805,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skip1: Boolean!, $skip2: Boolean!) {
@@ -851,7 +858,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -920,7 +927,7 @@ type V {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -967,7 +974,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -1007,7 +1014,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -1058,7 +1065,7 @@ scalar FieldSet
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &interface_objects,
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -1198,7 +1205,7 @@ mod make_selection_tests {
             Default::default(),
             &schema,
             &Default::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1298,7 +1305,7 @@ mod lazy_map_tests {
             Default::default(),
             &schema,
             &Default::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1357,7 +1364,7 @@ mod lazy_map_tests {
             Default::default(),
             &schema,
             &Default::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1563,7 +1570,7 @@ fn test_expand_all_fragments1() {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -60,7 +60,13 @@ pub(super) fn parse_and_expand(
         .expect("must have anonymous operation");
     let fragments = NamedFragments::new(&doc.fragments, schema);
 
-    normalize_operation(operation, fragments, schema, &Default::default())
+    normalize_operation(
+        operation,
+        fragments,
+        schema,
+        &Default::default(),
+        &|| Ok(()),
+    )
 }
 
 #[test]
@@ -100,6 +106,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();
@@ -154,6 +161,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();
@@ -196,6 +204,7 @@ type Query {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
 
@@ -231,6 +240,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test {
@@ -274,6 +284,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -320,6 +331,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -364,6 +376,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -410,6 +423,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test($skip1: Boolean!, $skip2: Boolean!) {
@@ -461,6 +475,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test {
@@ -527,6 +542,7 @@ type V {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test {
@@ -586,6 +602,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test {
@@ -632,6 +649,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -682,6 +700,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -730,6 +749,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -778,6 +798,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test($skip1: Boolean!, $skip2: Boolean!) {
@@ -830,6 +851,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test {
@@ -898,6 +920,7 @@ type V {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query Test {
@@ -944,6 +967,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -983,6 +1007,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -1033,6 +1058,7 @@ scalar FieldSet
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &interface_objects,
+            &|| Ok(()),
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -1172,6 +1198,7 @@ mod make_selection_tests {
             Default::default(),
             &schema,
             &Default::default(),
+            &|| Ok(()),
         )
         .unwrap();
 
@@ -1271,6 +1298,7 @@ mod lazy_map_tests {
             Default::default(),
             &schema,
             &Default::default(),
+            &|| Ok(()),
         )
         .unwrap();
 
@@ -1329,6 +1357,7 @@ mod lazy_map_tests {
             Default::default(),
             &schema,
             &Default::default(),
+            &|| Ok(()),
         )
         .unwrap();
 
@@ -1534,6 +1563,7 @@ fn test_expand_all_fragments1() {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &|| Ok(()),
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -2989,7 +2989,7 @@ impl OpGraphPath {
         context: &OpGraphPathContext,
         condition_resolver: &mut impl ConditionResolver,
         override_conditions: &EnabledOverrideConditions,
-        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<(Option<Vec<SimultaneousPaths>>, Option<bool>), FederationError> {
         let span = debug_span!(
             "Trying to advance directly",
@@ -3784,7 +3784,7 @@ impl SimultaneousPaths {
     /// the options for the `SimultaneousPaths` as a whole.
     fn flat_cartesian_product(
         options_for_each_path: Vec<Vec<SimultaneousPaths>>,
-        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<Vec<SimultaneousPaths>, FederationError> {
         // This can be written more tersely with a bunch of `reduce()`/`flat_map()`s and friends,
         // but when interfaces type-explode into many implementations, this can end up with fairly
@@ -3981,7 +3981,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
         operation_element: &OpPathElement,
         condition_resolver: &mut impl ConditionResolver,
         override_conditions: &EnabledOverrideConditions,
-        check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<Option<Vec<SimultaneousPathsWithLazyIndirectPaths>>, FederationError> {
         debug!(
             "Trying to advance paths for operation: path = {}, operation = {operation_element}",

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -715,9 +715,14 @@ mod tests {
             "Query(Test) --[t]--> T(Test) --[otherId]--> ID(Test)"
         );
 
-        let normalized_operation =
-            normalize_operation(operation, Default::default(), &schema, &Default::default())
-                .unwrap();
+        let normalized_operation = normalize_operation(
+            operation,
+            Default::default(),
+            &schema,
+            &Default::default(),
+            &|| Ok(()),
+        )
+        .unwrap();
         let selection_set = Arc::new(normalized_operation.selection_set);
 
         let paths = vec![

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -581,6 +581,7 @@ mod tests {
 
     use crate::error::FederationError;
     use crate::operation::Field;
+    use crate::operation::never_cancel;
     use crate::operation::normalize_operation;
     use crate::query_graph::QueryGraph;
     use crate::query_graph::QueryGraphEdgeTransition;
@@ -720,7 +721,7 @@ mod tests {
             Default::default(),
             &schema,
             &Default::default(),
-            &|| Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let selection_set = Arc::new(normalized_operation.selection_set);

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3488,7 +3488,7 @@ pub(crate) fn compute_nodes_for_tree(
     initial_node_path: FetchDependencyGraphNodePath,
     initial_defer_context: DeferContext,
     initial_conditions: &OpGraphPathContext,
-    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
 ) -> Result<IndexSet<NodeIndex>, FederationError> {
     snapshot!("OpPathTree", initial_tree.to_string(), "path_tree");
     let mut stack = vec![ComputeNodesStackItem {
@@ -3600,7 +3600,7 @@ fn compute_nodes_for_key_resolution<'a>(
     edge_id: EdgeIndex,
     new_context: &'a OpGraphPathContext,
     created_nodes: &mut IndexSet<NodeIndex>,
-    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
 ) -> Result<ComputeNodesStackItem<'a>, FederationError> {
     let edge = stack_item.tree.graph.edge_weight(edge_id)?;
     let Some(conditions) = &child.conditions else {
@@ -3855,7 +3855,7 @@ fn compute_nodes_for_op_path_element<'a>(
     child: &'a Arc<PathTreeChild<OpGraphPathTrigger, Option<EdgeIndex>>>,
     operation_element: &OpPathElement,
     created_nodes: &mut IndexSet<NodeIndex>,
-    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
 ) -> Result<ComputeNodesStackItem<'a>, FederationError> {
     let Some(edge_id) = child.edge else {
         // A null edge means that the operation does nothing
@@ -4442,7 +4442,7 @@ fn handle_conditions_tree(
     query_graph_edge_id_if_typename_needed: Option<EdgeIndex>,
     defer_context: &DeferContext,
     created_nodes: &mut IndexSet<NodeIndex>,
-    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
 ) -> Result<ConditionsNodeData, FederationError> {
     // In many cases, we can optimize conditions by merging the fields into previously existing
     // nodes. However, we only do this when the current node has only a single parent (it's hard to

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3488,6 +3488,7 @@ pub(crate) fn compute_nodes_for_tree(
     initial_node_path: FetchDependencyGraphNodePath,
     initial_defer_context: DeferContext,
     initial_conditions: &OpGraphPathContext,
+    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
 ) -> Result<IndexSet<NodeIndex>, FederationError> {
     snapshot!("OpPathTree", initial_tree.to_string(), "path_tree");
     let mut stack = vec![ComputeNodesStackItem {
@@ -3500,6 +3501,7 @@ pub(crate) fn compute_nodes_for_tree(
     }];
     let mut created_nodes = IndexSet::default();
     while let Some(stack_item) = stack.pop() {
+        check_cancellation()?;
         let node =
             FetchDependencyGraph::node_weight_mut(&mut dependency_graph.graph, stack_item.node_id)?;
         for selection_set in &stack_item.tree.local_selection_sets {
@@ -3545,6 +3547,7 @@ pub(crate) fn compute_nodes_for_tree(
                                 edge_id,
                                 new_context,
                                 &mut created_nodes,
+                                check_cancellation,
                             )?);
                         }
                         QueryGraphEdgeTransition::RootTypeResolution { root_kind } => {
@@ -3572,6 +3575,7 @@ pub(crate) fn compute_nodes_for_tree(
                         child,
                         operation,
                         &mut created_nodes,
+                        check_cancellation,
                     )?);
                 }
             }
@@ -3596,6 +3600,7 @@ fn compute_nodes_for_key_resolution<'a>(
     edge_id: EdgeIndex,
     new_context: &'a OpGraphPathContext,
     created_nodes: &mut IndexSet<NodeIndex>,
+    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
 ) -> Result<ComputeNodesStackItem<'a>, FederationError> {
     let edge = stack_item.tree.graph.edge_weight(edge_id)?;
     let Some(conditions) = &child.conditions else {
@@ -3611,6 +3616,7 @@ fn compute_nodes_for_key_resolution<'a>(
         stack_item.node_path.clone(),
         stack_item.defer_context.for_conditions(),
         &Default::default(),
+        check_cancellation,
     )?;
     created_nodes.extend(conditions_nodes.iter().copied());
     // Then we can "take the edge", creating a new node.
@@ -3849,6 +3855,7 @@ fn compute_nodes_for_op_path_element<'a>(
     child: &'a Arc<PathTreeChild<OpGraphPathTrigger, Option<EdgeIndex>>>,
     operation_element: &OpPathElement,
     created_nodes: &mut IndexSet<NodeIndex>,
+    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
 ) -> Result<ComputeNodesStackItem<'a>, FederationError> {
     let Some(edge_id) = child.edge else {
         // A null edge means that the operation does nothing
@@ -3955,6 +3962,7 @@ fn compute_nodes_for_op_path_element<'a>(
             },
             &updated.defer_context,
             created_nodes,
+            check_cancellation,
         )?;
 
         if let Some(matching_context_ids) = &child.matching_context_ids {
@@ -4434,6 +4442,7 @@ fn handle_conditions_tree(
     query_graph_edge_id_if_typename_needed: Option<EdgeIndex>,
     defer_context: &DeferContext,
     created_nodes: &mut IndexSet<NodeIndex>,
+    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
 ) -> Result<ConditionsNodeData, FederationError> {
     // In many cases, we can optimize conditions by merging the fields into previously existing
     // nodes. However, we only do this when the current node has only a single parent (it's hard to
@@ -4517,6 +4526,7 @@ fn handle_conditions_tree(
         fetch_node_path.clone(),
         defer_context.for_conditions(),
         &OpGraphPathContext::default(),
+        check_cancellation,
     )?;
 
     if newly_created_node_ids.is_empty() {

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -617,7 +617,7 @@ pub(crate) fn compute_root_fetch_groups(
     dependency_graph: &mut FetchDependencyGraph,
     path: &OpPathTree,
     type_conditioned_fetching_enabled: bool,
-    check_cancellation: &impl Fn() -> Result<(), SingleFederationError>,
+    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
 ) -> Result<(), FederationError> {
     // The root of the pathTree is one of the "fake" root of the subgraphs graph,
     // which belongs to no subgraph but points to each ones.

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/overrides.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/overrides.rs
@@ -24,7 +24,8 @@ fn it_handles_progressive_override_on_root_fields() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
         QueryPlan {
@@ -117,7 +118,8 @@ fn it_handles_progressive_override_on_entity_fields() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
           QueryPlan {
@@ -276,7 +278,8 @@ fn it_handles_progressive_override_on_nested_entity_fields() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
           QueryPlan {

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/overrides/shareable.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/overrides/shareable.rs
@@ -45,7 +45,8 @@ fn it_overrides_to_s2_when_label_is_provided() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
           QueryPlan {
@@ -157,7 +158,8 @@ fn it_overrides_f1_to_s3_when_label_is_provided() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
           QueryPlan {

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -160,7 +160,7 @@ impl IntrospectionCache {
         let schema = schema.clone();
         let doc = doc.clone();
         let priority = compute_job::Priority::P1; // Low priority
-        let response = compute_job::execute(priority, move || {
+        let response = compute_job::execute(priority, move |_| {
             Self::execute_introspection(max_depth, &schema, &doc)
         })?
         // `expect()` propagates any panic that potentially happens in the closure, but:

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -132,11 +132,13 @@ impl QueryPlannerService {
         let doc = doc.clone();
         let rust_planner = self.planner.clone();
         let priority = compute_job::Priority::P8; // High priority
-        let job = move || -> Result<_, QueryPlannerError> {
+        let job = move |status: compute_job::JobStatus<'_, _>| -> Result<_, QueryPlannerError> {
             let start = Instant::now();
 
+            let check = move || status.check_for_cooperative_cancellation();
             let query_plan_options = QueryPlanOptions {
                 override_conditions: plan_options.override_conditions,
+                check_for_cooperative_cancellation: Some(&check),
             };
 
             let result = operation


### PR DESCRIPTION
When a request is cancelled, resources (compute time/memory) allocated to that request should be released. However, query planning is an exception, and currently keeps running after the request is cancelled. This PR adds cooperative cancellation to `build_query_plan()`, to ensure that when the request is cancelled, query planning errors shortly after.