### PR TITLE
docs: add note for prometheus separator behavior (backport #6837)

### DIFF
--- a/docs/source/routing/observability/telemetry/metrics-exporters/prometheus.mdx
+++ b/docs/source/routing/observability/telemetry/metrics-exporters/prometheus.mdx
@@ -10,6 +10,13 @@ Enable and configure the [Prometheus](https://www.prometheus.io/) exporter for m
 
 For general metrics configuration, refer to [Router Metrics Configuration](/router/configuration/telemetry/exporters/metrics/overview).
 
+<Note>
+
+The Prometheus exporter replaces `.` characters with `_` in instrument names.
+For example, the [`apollo.router.cache.miss.time.count` instrument](/graphos/routing/observability/telemetry/instrumentation/standard-instruments#cache) is exported as `apollo_router_cache_miss_time_count` with the Prometheus exporter.
+
+</Note>
+
 ## Prometheus configuration
 
 To export metrics to Prometheus, enable the Prometheus endpoint and set its address and path in [`router.yaml`](/router/configuration/overview#yaml-config-file):


### PR DESCRIPTION
Calls out difference in prometheus exporter<hr>This is an automatic backport of pull request #6837 done by [Mergify](https://mergify.com).