### PR TITLE
Update connectors request to use a String instead of RouterBody

### DIFF
--- a/apollo-router/src/plugins/connectors/http_json_transport.rs
+++ b/apollo-router/src/plugins/connectors/http_json_transport.rs
@@ -712,7 +712,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_debug_snapshot!(req, @r###"
+        assert_debug_snapshot!(req, @r#"
         (
             Http(
                 HttpRequest {
@@ -724,14 +724,14 @@ mod tests {
                             "content-type": "application/json",
                             "content-length": "8",
                         },
-                        body: UnsyncBoxBody,
+                        body: "{\"a\":42}",
                     },
                     debug: None,
                 },
             ),
             [],
         )
-        "###);
+        "#);
 
         let TransportRequest::Http(HttpRequest { inner: req, .. }) = req.0;
         let body = body::into_string(req.into_body()).await.unwrap();
@@ -770,7 +770,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_debug_snapshot!(req, @r###"
+        assert_debug_snapshot!(req, @r#"
         (
             Http(
                 HttpRequest {
@@ -782,14 +782,14 @@ mod tests {
                             "content-type": "application/x-www-form-urlencoded",
                             "content-length": "4",
                         },
-                        body: UnsyncBoxBody,
+                        body: "a=42",
                     },
                     debug: None,
                 },
             ),
             [],
         )
-        "###);
+        "#);
 
         let TransportRequest::Http(HttpRequest { inner: req, .. }) = req.0;
         let body = body::into_string(req.into_body()).await.unwrap();

--- a/apollo-router/src/plugins/connectors/http_json_transport.rs
+++ b/apollo-router/src/plugins/connectors/http_json_transport.rs
@@ -26,7 +26,6 @@ use crate::plugins::connectors::plugin::debug::SelectionData;
 use crate::services::connect;
 use crate::services::connector::request_service::transport::http::HttpRequest;
 use crate::services::connector::request_service::TransportRequest;
-use crate::services::router;
 
 pub(crate) fn make_request(
     transport: &HttpJsonTransport,
@@ -64,19 +63,21 @@ pub(crate) fn make_request(
                         .map_err(HttpJsonTransportError::FormBodySerialization)?;
                     form_body = Some(encoded.clone());
                     let len = encoded.bytes().len();
-                    (router::body::from_bytes(encoded), len)
+                    let body_string = encoded;
+                    (body_string, len)
                 } else {
                     request = request.header(CONTENT_TYPE, mime::APPLICATION_JSON.essence_str());
                     let bytes = serde_json::to_vec(json_body)?;
                     let len = bytes.len();
-                    (router::body::from_bytes(bytes), len)
+                    let body_string = serde_json::to_string(json_body)?;
+                    (body_string, len)
                 }
             } else {
-                (router::body::empty(), 0)
+                ("".into(), 0)
             };
             (json_body, form_body, body, content_length, apply_to_errors)
         } else {
-            (None, None, router::body::empty(), 0, vec![])
+            (None, None, "".into(), 0, vec![])
         };
 
     match transport.method {

--- a/apollo-router/src/plugins/connectors/http_json_transport.rs
+++ b/apollo-router/src/plugins/connectors/http_json_transport.rs
@@ -63,8 +63,7 @@ pub(crate) fn make_request(
                         .map_err(HttpJsonTransportError::FormBodySerialization)?;
                     form_body = Some(encoded.clone());
                     let len = encoded.bytes().len();
-                    let body_string = encoded;
-                    (body_string, len)
+                    (encoded, len)
                 } else {
                     request = request.header(CONTENT_TYPE, mime::APPLICATION_JSON.essence_str());
                     let bytes = serde_json::to_vec(json_body)?;

--- a/apollo-router/src/plugins/connectors/plugin/debug.rs
+++ b/apollo-router/src/plugins/connectors/plugin/debug.rs
@@ -4,7 +4,6 @@ use serde::Serialize;
 use serde_json_bytes::json;
 
 use crate::plugins::connectors::mapping::Problem;
-use crate::services::router::body::RouterBody;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub(crate) struct ConnectorContext {
@@ -124,7 +123,7 @@ struct ConnectorDebugSelection {
 }
 
 pub(crate) fn serialize_request(
-    req: &http::Request<RouterBody>,
+    req: &http::Request<String>,
     kind: String,
     json_body: Option<&serde_json_bytes::Value>,
     selection_data: Option<SelectionData>,

--- a/apollo-router/src/plugins/telemetry/config_new/connector/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/selectors.rs
@@ -324,7 +324,6 @@ mod tests {
     use crate::services::connector::request_service::TransportRequest;
     use crate::services::connector::request_service::TransportResponse;
     use crate::services::router::body;
-    use crate::services::router::body::RouterBody;
     use crate::Context;
 
     const TEST_SUBGRAPH_NAME: &str = "test_subgraph_name";
@@ -373,12 +372,12 @@ mod tests {
         }
     }
 
-    fn http_request() -> http::Request<RouterBody> {
-        http::Request::builder().body(body::empty()).unwrap()
+    fn http_request() -> http::Request<String> {
+        http::Request::builder().body("".into()).unwrap()
     }
 
-    fn http_request_with_header() -> http::Request<RouterBody> {
-        let mut http_request = http::Request::builder().body(body::empty()).unwrap();
+    fn http_request_with_header() -> http::Request<String> {
+        let mut http_request = http::Request::builder().body("".into()).unwrap();
         http_request.headers_mut().insert(
             TEST_HEADER_NAME,
             HeaderValue::from_static(TEST_HEADER_VALUE),
@@ -386,12 +385,12 @@ mod tests {
         http_request
     }
 
-    fn connector_request(http_request: http::Request<RouterBody>) -> Request {
+    fn connector_request(http_request: http::Request<String>) -> Request {
         connector_request_with_mapping_problems(http_request, vec![])
     }
 
     fn connector_request_with_mapping_problems(
-        http_request: http::Request<RouterBody>,
+        http_request: http::Request<String>,
         mapping_problems: Vec<Problem>,
     ) -> Request {
         Request {

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -1201,7 +1201,7 @@ mod tests {
 
         async {
             let context = crate::Context::default();
-            let mut http_request = http::Request::builder().body(body::empty()).unwrap();
+            let mut http_request = http::Request::builder().body("".into()).unwrap();
             http_request
                 .headers_mut()
                 .insert("x-log-request", HeaderValue::from_static("log"));
@@ -1283,7 +1283,7 @@ mod tests {
 
         async {
             let context = crate::Context::default();
-            let mut http_request = http::Request::builder().body(body::empty()).unwrap();
+            let mut http_request = http::Request::builder().body("".into()).unwrap();
             http_request
                 .headers_mut()
                 .insert("x-log-response", HeaderValue::from_static("log"));

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -2637,7 +2637,6 @@ mod tests {
     use http::StatusCode;
     use http::Uri;
     use multimap::MultiMap;
-    use router::body;
     use rust_embed::RustEmbed;
     use schemars::gen::SchemaGenerator;
     use serde::Deserialize;
@@ -3241,7 +3240,7 @@ mod tests {
                                     let mut http_request = http::Request::builder()
                                         .method(Method::from_str(&http_method).expect("method"))
                                         .uri(Uri::from_str(&uri).expect("uri"))
-                                        .body(body.map(body::from_bytes).unwrap_or(body::empty()))
+                                        .body(body.unwrap_or("".into()))
                                         .unwrap();
                                     *http_request.headers_mut() = convert_http_headers(headers);
                                     let transport_request =

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -812,7 +812,7 @@ connector:
                 subgraph_events.on_response(&subgraph_resp);
 
                 let context = crate::Context::default();
-                let mut http_request = http::Request::builder().body(body::empty()).unwrap();
+                let mut http_request = http::Request::builder().body("".into()).unwrap();
                 http_request
                     .headers_mut()
                     .insert("x-log-request", HeaderValue::from_static("log"));
@@ -1163,7 +1163,7 @@ subgraph:
                 subgraph_events.on_response(&subgraph_resp);
 
                 let context = crate::Context::default();
-                let mut http_request = http::Request::builder().body(body::empty()).unwrap();
+                let mut http_request = http::Request::builder().body("".into()).unwrap();
                 http_request
                     .headers_mut()
                     .insert("x-log-request", HeaderValue::from_static("log"));

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -41,7 +41,6 @@ use crate::services::connector::request_service::transport::http::HttpResponse;
 use crate::services::http::HttpClientServiceFactory;
 use crate::services::new_service::ServiceFactory;
 use crate::services::router;
-use crate::services::router::body::RouterBody;
 use crate::services::Plugins;
 use crate::Context;
 
@@ -274,21 +273,24 @@ impl tower::Service<Request> for ConnectorRequestService {
                     TransportRequest::Http(http_request) => {
                         debug_request = http_request.debug;
 
-                        let http_request = log_request(
-                            http_request.inner,
+                        log_request(
+                            &http_request.inner,
                             log_request_level,
                             &request.connector.id.label,
-                        )
-                        .await?;
+                        );
 
                         if let Some(http_client_service_factory) = http_client_service_factory
                             .get(&request.service_name)
                             .cloned()
                         {
+                            let (parts, body) = http_request.inner.into_parts();
+                            let final_request =
+                                http::Request::from_parts(parts, router::body::from_bytes(body));
+
                             http_client_service_factory
                                 .create(&original_subgraph_name)
                                 .oneshot(crate::services::http::HttpRequest {
-                                    http_request,
+                                    http_request: final_request,
                                     context: request.context.clone(),
                                 })
                                 .await
@@ -325,20 +327,18 @@ impl tower::Service<Request> for ConnectorRequestService {
 }
 
 /// Log an event for this request, if configured
-async fn log_request(
-    request: http::Request<RouterBody>,
+fn log_request(
+    request: &http::Request<String>,
     log_request_level: Option<EventLevel>,
     label: &str,
-) -> Result<http::Request<RouterBody>, BoxError> {
+) {
     if let Some(level) = log_request_level {
-        let (parts, body) = request.into_parts();
-
         let mut attrs = Vec::with_capacity(5);
 
         #[cfg(test)]
         let headers = {
-            let mut headers: IndexMap<String, http::HeaderValue> = parts
-                .headers
+            let mut headers: IndexMap<String, http::HeaderValue> = request
+                .headers()
                 .clone()
                 .into_iter()
                 .filter_map(|(name, val)| Some((name?.to_string(), val)))
@@ -347,7 +347,7 @@ async fn log_request(
             headers
         };
         #[cfg(not(test))]
-        let headers = parts.headers.clone();
+        let headers = request.headers().clone();
 
         attrs.push(KeyValue::new(
             HTTP_REQUEST_HEADERS,
@@ -355,24 +355,19 @@ async fn log_request(
         ));
         attrs.push(KeyValue::new(
             HTTP_REQUEST_METHOD,
-            opentelemetry::Value::String(parts.method.as_str().to_string().into()),
+            opentelemetry::Value::String(request.method().as_str().to_string().into()),
         ));
         attrs.push(KeyValue::new(
             HTTP_REQUEST_URI,
-            opentelemetry::Value::String(format!("{}", parts.uri).into()),
+            opentelemetry::Value::String(format!("{}", request.uri()).into()),
         ));
         attrs.push(KeyValue::new(
             HTTP_REQUEST_VERSION,
-            opentelemetry::Value::String(format!("{:?}", parts.version).into()),
+            opentelemetry::Value::String(format!("{:?}", request.version()).into()),
         ));
-        let body_bytes = router::body::into_bytes(body).await?;
         attrs.push(KeyValue::new(
             HTTP_REQUEST_BODY,
-            opentelemetry::Value::String(
-                String::from_utf8(body_bytes.clone().to_vec())
-                    .unwrap_or_default()
-                    .into(),
-            ),
+            opentelemetry::Value::String(request.body().clone().into()),
         ));
         log_event(
             level,
@@ -380,13 +375,6 @@ async fn log_request(
             attrs,
             &format!("Request to connector {label:?}"),
         );
-
-        Ok(http::Request::<RouterBody>::from_parts(
-            parts,
-            router::body::from_bytes(body_bytes),
-        ))
-    } else {
-        Ok(request)
     }
 }
 

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -284,13 +284,13 @@ impl tower::Service<Request> for ConnectorRequestService {
                             .cloned()
                         {
                             let (parts, body) = http_request.inner.into_parts();
-                            let final_request =
+                            let http_request =
                                 http::Request::from_parts(parts, router::body::from_bytes(body));
 
                             http_client_service_factory
                                 .create(&original_subgraph_name)
                                 .oneshot(crate::services::http::HttpRequest {
-                                    http_request: final_request,
+                                    http_request,
                                     context: request.context.clone(),
                                 })
                                 .await

--- a/apollo-router/src/services/connector/request_service/transport/http.rs
+++ b/apollo-router/src/services/connector/request_service/transport/http.rs
@@ -1,12 +1,11 @@
 //! HTTP transport for Apollo Connectors
 use crate::plugins::connectors::plugin::debug::ConnectorDebugHttpRequest;
-use crate::services::router::body::RouterBody;
 
 /// Request to an HTTP transport
 #[derive(Debug)]
 #[non_exhaustive]
 pub(crate) struct HttpRequest {
-    pub(crate) inner: http::Request<RouterBody>,
+    pub(crate) inner: http::Request<String>,
     pub(crate) debug: Option<ConnectorDebugHttpRequest>,
 }
 


### PR DESCRIPTION
Update connectors request to use a String instead of RouterBody and convert to RouterBody just-in-time to be consistent with how subgraphs are handled.

Why?

1. Simplify code
2. Unblock traffic shaping
3. Unblock coprocessors
4. Make it consistent with the existing subgraph code

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
