### PR TITLE
Upgrade to Rust 1.85 (backport #6836)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,14 +344,11 @@ commands:
       - run:
           name: Install cargo deny, about, edit
           command: |
-            # Until we are able to update rustc to at least 1.81.0,
-            # we need special handling of the cargo-about command.
-            rustup install 1.83.0
-            cargo +1.83.0 install --locked --version 0.6.6 cargo-about
             if [[ ! -f "$HOME/.cargo/bin/cargo-deny$EXECUTABLE_SUFFIX" ]]; then
               cargo install --locked --version 0.14.21 cargo-deny
               cargo install --locked --version 0.12.2 cargo-edit
               cargo install --locked --version 0.12.0 cargo-fuzz
+              cargo install --locked --version 0.6.6 cargo-about
             fi
 
             if [[ ! -f "$HOME/.cargo/bin/cargo-nextest$EXECUTABLE_SUFFIX" ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,16 +1431,14 @@ dependencies = [
 
 [[package]]
 name = "buildstructor"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3907aac66c65520545ae3cb3c195306e20d5ed5c90bfbb992e061cf12a104d0"
+checksum = "caabaaee17b2a78d7aa349a33edc9090c6bb47e6dfb25b0da281df57628bba68"
 dependencies = [
- "lazy_static",
  "proc-macro2",
  "quote",
  "str_inflector",
  "syn 2.0.90",
- "thiserror",
  "try_match",
 ]
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,15 +18,11 @@ The **Apollo Router Core** is a configurable, high-performance **graph router** 
 
 ## Development
 
-You will need a recent version of rust (`1.83.0` works well as of writing).
-Installing rust [using rustup](https://www.rust-lang.org/tools/install) is
-the recommended way to do it as it will automatically install the toolchain version
-specified in `rust-toolchain.toml`, including rustfmt and clippy
-that are not always included by default in other rust distribution channels:
-
-```
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
+You will need a recent version of rust, as specified in `rust-toolchain.toml`.
+We recommend [using rustup](https://www.rust-lang.org/tools/install)
+as it will automatically install the requiried toolchain version,
+including rustfmt and clippy
+that are not always included by default in other rust distribution channels.
 
 In addition, you will need to [install protoc](https://grpc.io/docs/protoc-installation/).
 

--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -199,8 +199,7 @@ fn is_core_directive_definition(definition: &DirectiveDefinition) -> bool {
             })
         && definition
             .argument_by_name("as")
-            // Definition may be omitted in old graphs
-            .map_or(true, |argument| *argument.ty == ty!(String))
+            .is_none_or(|argument| *argument.ty == ty!(String))
 }
 
 /// Returns whether a given directive is the @link or @core directive that imports the @link or
@@ -220,7 +219,7 @@ fn is_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
                 .specified_argument_by_name("as")
                 .and_then(|value| value.as_str())
                 .unwrap_or(default_link_name.as_str());
-            return url.map_or(false, |url| {
+            return url.is_ok_and(|url| {
                 url.identity == Identity::link_identity() && directive.name == expected_name
             });
         }
@@ -236,7 +235,7 @@ fn is_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
                 .specified_argument_by_name("as")
                 .and_then(|value| value.as_str())
                 .unwrap_or("core");
-            return url.map_or(false, |url| {
+            return url.is_ok_and(|url| {
                 url.identity == Identity::core_identity() && directive.name == expected_name
             });
         }

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -175,7 +175,7 @@ impl InlineFragmentSelection {
             // 2. if it's the same type as the current type: it's not restricting types further.
             // 3. if the current type is an object more generally: because in that case the condition
             //   cannot be restricting things further (it's typically a less precise interface/union).
-            let useless_fragment = this_condition.map_or(true, |type_condition| {
+            let useless_fragment = this_condition.is_none_or(|type_condition| {
                 self.inline_fragment.schema == *schema && type_condition == parent_type
             });
             if useless_fragment || parent_type.is_object_type() {

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -8,7 +8,7 @@ description = "A configurable, high-performance routing runtime for Apollo Feder
 license = "Elastic-2.0"
 
 # renovate-automation: rustc version
-rust-version = "1.83.0"
+rust-version = "1.85.0"
 edition = "2021"
 build = "build/main.rs"
 default-run = "router"
@@ -73,7 +73,7 @@ async-trait.workspace = true
 axum = { version = "0.6.20", features = ["headers", "json", "original-uri"] }
 base64 = "0.22.0"
 bloomfilter = "1.0.13"
-buildstructor = "0.5.4"
+buildstructor = "0.6.0"
 bytes = "1.6.0"
 clap = { version = "4.5.8", default-features = false, features = [
     "env",

--- a/apollo-router/README.md
+++ b/apollo-router/README.md
@@ -27,4 +27,4 @@ Most Apollo Router Core features can be defined using our [YAML configuration](h
 If you prefer to write customizations in Rust or need more advanced customizations, see our section on [native customizations](https://www.apollographql.com/docs/router/customizations/native) for information on how to use `apollo-router` as a Rust library.  We also publish Rust-specific documentation on our [`apollo-router` crate docs](https://docs.rs/crate/apollo-router).
 
 <!-- renovate-automation: rustc version -->
-The minimum supported Rust version (MSRV) for this version of `apollo-router` is **1.83.0**.
+The minimum supported Rust version (MSRV) for this version of `apollo-router` is **1.85.0**.

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -892,7 +892,7 @@ fn format_selection_set(
             let use_separator = field_str
                 .chars()
                 .last()
-                .map_or(false, |c| c.is_alphanumeric() || c == '_');
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
             if i < fields.len() - 1 && use_separator {
                 f.write_str(" ")?;
             }
@@ -978,7 +978,7 @@ fn format_field(
                     || arg_string
                         .chars()
                         .last()
-                        .map_or(true, |c| c.is_alphanumeric() || c == '_'))
+                        .is_none_or(|c| c.is_alphanumeric() || c == '_'))
             {
                 write!(f, "{}", separator)?;
             }

--- a/apollo-router/src/apollo_studio_interop/tests.rs
+++ b/apollo-router/src/apollo_studio_interop/tests.rs
@@ -130,6 +130,7 @@ async fn test_enhanced_inline_input_object() {
     let doc = ExecutableDocument::parse(&schema, query_str, "query.graphql").unwrap();
 
     let generated = generate_enhanced(&doc, &Some("InputObjectTypeQuery".into()), &schema);
+    #[allow(clippy::literal_string_with_formatting_args)]
     let expected_sig = "# InputObjectTypeQuery\nquery InputObjectTypeQuery{inputTypeQuery(input:{inputString:\"\",inputInt:0,inputBoolean:null,nestedType:{someFloat:0},enumInput:SOME_VALUE_1,nestedTypeList:[],listInput:[]}){enumResponse}}";
     assert_expected_signature(&generated, expected_sig);
 }

--- a/apollo-router/src/configuration/cors.rs
+++ b/apollo-router/src/configuration/cors.rs
@@ -77,7 +77,6 @@ fn default_cors_methods() -> Vec<String> {
 #[buildstructor::buildstructor]
 impl Cors {
     #[builder]
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         allow_any_origin: Option<bool>,
         allow_credentials: Option<bool>,

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -275,7 +275,6 @@ fn test_listen() -> ListenAddr {
 #[buildstructor::buildstructor]
 impl Configuration {
     #[builder]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn new(
         supergraph: Option<Supergraph>,
         health_check: Option<HealthCheck>,
@@ -410,7 +409,6 @@ impl Default for Configuration {
 #[buildstructor::buildstructor]
 impl Configuration {
     #[builder]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn fake_new(
         supergraph: Option<Supergraph>,
         health_check: Option<HealthCheck>,
@@ -689,7 +687,6 @@ fn default_defer_support() -> bool {
 #[buildstructor::buildstructor]
 impl Supergraph {
     #[builder]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn new(
         listen: Option<ListenAddr>,
         path: Option<String>,
@@ -718,7 +715,6 @@ impl Supergraph {
 #[buildstructor::buildstructor]
 impl Supergraph {
     #[builder]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn fake_new(
         listen: Option<ListenAddr>,
         path: Option<String>,
@@ -1502,7 +1498,7 @@ impl Batching {
                     subgraph_batching_config
                         .subgraphs
                         .get(service_name)
-                        .map_or(true, |x| x.enabled)
+                        .is_none_or(|x| x.enabled)
                 } else {
                     // If it isn't, require:
                     // - an enabled subgraph entry

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -492,6 +492,7 @@ cors:
 
 #[test]
 fn line_precise_config_errors_with_errors_after_first_field_env_expansion() {
+    #[allow(clippy::literal_string_with_formatting_args)]
     let error = validate_yaml_configuration(
         r#"
 supergraph:

--- a/apollo-router/src/context/extensions/mod.rs
+++ b/apollo-router/src/context/extensions/mod.rs
@@ -131,7 +131,7 @@ impl Extensions {
     /// Check whether the extension set is empty or not.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.map.as_ref().map_or(true, |map| map.is_empty())
+        self.map.as_ref().is_none_or(|map| map.is_empty())
     }
 
     /// Get the numer of extensions available.

--- a/apollo-router/src/graphql/response.rs
+++ b/apollo-router/src/graphql/response.rs
@@ -59,7 +59,6 @@ pub struct Response {
 impl Response {
     /// Constructor
     #[builder(visibility = "pub")]
-    #[allow(clippy::too_many_arguments)]
     fn new(
         label: Option<String>,
         data: Option<Value>,

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -536,7 +536,7 @@ impl ValueExt for Value {
             && self
                 .get(TYPENAME)
                 .and_then(|v| v.as_str())
-                .map_or(true, |typename| {
+                .is_none_or(|typename| {
                     typename == maybe_type || schema.is_subtype(maybe_type, typename)
                 })
     }

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -426,7 +426,7 @@ mod router_context {
     // Register a contains function for Context so that "in" works
     #[rhai_fn(name = "contains", pure)]
     pub(crate) fn context_contains(x: &mut Context, key: &str) -> bool {
-        x.get(key).map_or(false, |v: Option<Dynamic>| v.is_some())
+        x.get(key).is_ok_and(|v: Option<Dynamic>| v.is_some())
     }
 
     // Register a Context indexer so we can get/set context

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -171,7 +171,7 @@ impl Plugin for Rhai {
                             ) {
                                 let mut proceed = false;
                                 for path in event.paths {
-                                    if path.extension().map_or(false, |ext| ext == "rhai") {
+                                    if path.extension().is_some_and(|ext| ext == "rhai") {
                                         proceed = true;
                                         break;
                                     }

--- a/apollo-router/src/plugins/telemetry/config_new/conditions.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditions.rs
@@ -295,7 +295,7 @@ where
                 let right_att = gt[1]
                     .on_response_event(response, ctx)
                     .map(AttributeValue::from);
-                left_att.zip(right_att).map_or(false, |(l, r)| l > r)
+                left_att.zip(right_att).is_some_and(|(l, r)| l > r)
             }
             Condition::Lt(gt) => {
                 let left_att = gt[0]
@@ -304,7 +304,7 @@ where
                 let right_att = gt[1]
                     .on_response_event(response, ctx)
                     .map(AttributeValue::from);
-                left_att.zip(right_att).map_or(false, |(l, r)| l < r)
+                left_att.zip(right_att).is_some_and(|(l, r)| l < r)
             }
             Condition::Exists(exist) => exist.on_response_event(response, ctx).is_some(),
             Condition::All(all) => all.iter().all(|c| c.evaluate_event_response(response, ctx)),
@@ -325,12 +325,12 @@ where
             Condition::Gt(gt) => {
                 let left_att = gt[0].on_response(response).map(AttributeValue::from);
                 let right_att = gt[1].on_response(response).map(AttributeValue::from);
-                left_att.zip(right_att).map_or(false, |(l, r)| l > r)
+                left_att.zip(right_att).is_some_and(|(l, r)| l > r)
             }
             Condition::Lt(gt) => {
                 let left_att = gt[0].on_response(response).map(AttributeValue::from);
                 let right_att = gt[1].on_response(response).map(AttributeValue::from);
-                left_att.zip(right_att).map_or(false, |(l, r)| l < r)
+                left_att.zip(right_att).is_some_and(|(l, r)| l < r)
             }
             Condition::Exists(exist) => exist.on_response(response).is_some(),
             Condition::All(all) => all.iter().all(|c| c.evaluate_response(response)),
@@ -351,12 +351,12 @@ where
             Condition::Gt(gt) => {
                 let left_att = gt[0].on_error(error, ctx).map(AttributeValue::from);
                 let right_att = gt[1].on_error(error, ctx).map(AttributeValue::from);
-                left_att.zip(right_att).map_or(false, |(l, r)| l > r)
+                left_att.zip(right_att).is_some_and(|(l, r)| l > r)
             }
             Condition::Lt(gt) => {
                 let left_att = gt[0].on_error(error, ctx).map(AttributeValue::from);
                 let right_att = gt[1].on_error(error, ctx).map(AttributeValue::from);
-                left_att.zip(right_att).map_or(false, |(l, r)| l < r)
+                left_att.zip(right_att).is_some_and(|(l, r)| l < r)
             }
             Condition::Exists(exist) => exist.on_error(error, ctx).is_some(),
             Condition::All(all) => all.iter().all(|c| c.evaluate_error(error, ctx)),
@@ -387,7 +387,7 @@ where
                 let right_att = gt[1]
                     .on_response_field(ty, field, value, ctx)
                     .map(AttributeValue::from);
-                left_att.zip(right_att).map_or(false, |(l, r)| l > r)
+                left_att.zip(right_att).is_some_and(|(l, r)| l > r)
             }
             Condition::Lt(gt) => {
                 let left_att = gt[0]
@@ -396,7 +396,7 @@ where
                 let right_att = gt[1]
                     .on_response_field(ty, field, value, ctx)
                     .map(AttributeValue::from);
-                left_att.zip(right_att).map_or(false, |(l, r)| l < r)
+                left_att.zip(right_att).is_some_and(|(l, r)| l < r)
             }
             Condition::Exists(exist) => exist.on_response_field(ty, field, value, ctx).is_some(),
             Condition::All(all) => all

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -458,7 +458,7 @@ impl io::Write for WriteAdaptor<'_> {
             .write_str(s)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-        Ok(s.as_bytes().len())
+        Ok(s.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1480,7 +1480,7 @@ impl Telemetry {
 
             if context
                 .get(STUDIO_EXCLUDE)
-                .map_or(false, |x| x.unwrap_or_default())
+                .is_ok_and(|x| x.unwrap_or_default())
             {
                 // The request was excluded don't report the details, but do report the operation count
                 SingleStatsReport {

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -339,7 +339,6 @@ enum TreeData {
 #[buildstructor::buildstructor]
 impl Exporter {
     #[builder]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub(crate) fn new<'a>(
         endpoint: &'a Url,
         otlp_endpoint: &'a Url,

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -70,6 +70,7 @@ pub(crate) struct PluginTestHarness<T: Into<Box<dyn DynPlugin>>> {
 #[buildstructor::buildstructor]
 impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     #[builder]
+    #[allow(clippy::needless_lifetimes)] // needless in `new` but not in generated builder methods
     pub(crate) async fn new<'a, 'b>(config: Option<&'a str>, schema: Option<&'b str>) -> Self {
         let factory = crate::plugin::plugins()
             .find(|factory| factory.type_id == TypeId::of::<T>())

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -113,11 +113,9 @@ impl<T> Externalizable<T>
 where
     T: Debug + DeserializeOwned + Serialize + Send + Sync,
 {
-    #[builder(visibility = "pub(crate)")]
     /// This is the constructor (or builder) to use when constructing a Router
     /// `Externalizable`.
-    ///
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
+    #[builder(visibility = "pub(crate)")]
     fn router_new(
         stage: PipelineStep,
         control: Option<Control>,
@@ -154,11 +152,9 @@ where
         }
     }
 
-    #[builder(visibility = "pub(crate)")]
     /// This is the constructor (or builder) to use when constructing a Supergraph
     /// `Externalizable`.
-    ///
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
+    #[builder(visibility = "pub(crate)")]
     fn supergraph_new(
         stage: PipelineStep,
         control: Option<Control>,
@@ -195,11 +191,9 @@ where
         }
     }
 
-    #[builder(visibility = "pub(crate)")]
     /// This is the constructor (or builder) to use when constructing an Execution
     /// `Externalizable`.
-    ///
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
+    #[builder(visibility = "pub(crate)")]
     fn execution_new(
         stage: PipelineStep,
         control: Option<Control>,
@@ -237,11 +231,9 @@ where
         }
     }
 
-    #[builder(visibility = "pub(crate)")]
     /// This is the constructor (or builder) to use when constructing a Subgraph
     /// `Externalizable`.
-    ///
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
+    #[builder(visibility = "pub(crate)")]
     fn subgraph_new(
         stage: PipelineStep,
         control: Option<Control>,

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -72,7 +72,6 @@ impl Request {
     /// This is the constructor (or builder) to use when constructing a real Request.
     ///
     /// Required parameters are required in non-testing code to create a Request.
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub")]
     fn new(
         context: Context,
@@ -95,7 +94,6 @@ impl Request {
     /// This is the constructor (or builder) to use when constructing a fake Request.
     ///
     /// Required parameters are required in non-testing code to create a Request.
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub")]
     fn fake_new(
         context: Option<Context>,
@@ -203,7 +201,6 @@ impl Response {
     /// This is the constructor (or builder) to use when constructing a real Response..
     ///
     /// Required parameters are required in non-testing code to create a Response..
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub")]
     fn new(
         label: Option<String>,
@@ -269,7 +266,6 @@ impl Response {
     /// This is the constructor (or builder) to use when constructing a real Response..
     ///
     /// Required parameters are required in non-testing code to create a Response..
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub(crate)")]
     fn infallible_new(
         label: Option<String>,
@@ -351,7 +347,6 @@ impl Response {
     /// This is the constructor (or builder) to use when constructing a fake Response..
     ///
     /// Required parameters are required in non-testing code to create a Response..
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub")]
     fn fake_new(
         label: Option<String>,

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -241,7 +241,6 @@ impl Response {
     /// The parameters are not optional, because in a live situation all of these properties must be
     /// set and be correct to create a Response.
     #[builder(visibility = "pub")]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn new(
         label: Option<String>,
         data: Option<Value>,
@@ -290,7 +289,6 @@ impl Response {
     /// Response. It's usually enough for testing, when a fully constructed Response is
     /// difficult to construct and not required for the purposes of the test.
     #[builder(visibility = "pub")]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn fake_new(
         label: Option<String>,
         data: Option<Value>,
@@ -325,7 +323,6 @@ impl Response {
     /// Response. It's usually enough for testing, when a fully constructed Response is
     /// difficult to construct and not required for the purposes of the test.
     #[builder(visibility = "pub")]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     fn fake2_new(
         label: Option<String>,
         data: Option<Value>,

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -68,7 +68,6 @@ impl Request {
     /// This is the constructor (or builder) to use when constructing a real Request.
     ///
     /// Required parameters are required in non-testing code to create a Request.
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub")]
     fn new(
         query: Option<String>,
@@ -184,7 +183,6 @@ impl Response {
     /// This is the constructor (or builder) to use when constructing a real Response..
     ///
     /// Required parameters are required in non-testing code to create a Response..
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub")]
     fn new(
         label: Option<String>,
@@ -230,7 +228,6 @@ impl Response {
     /// difficult to construct and not required for the purposes of the test.
     ///
     /// In addition, fake responses are expected to be valid, and will panic if given invalid values.
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub")]
     fn fake_new(
         label: Option<String>,
@@ -308,7 +305,6 @@ impl Response {
     /// This is the constructor (or builder) to use when constructing a real Response..
     ///
     /// Required parameters are required in non-testing code to create a Response..
-    #[allow(clippy::too_many_arguments)]
     #[builder(visibility = "pub(crate)")]
     fn infallible_new(
         label: Option<String>,

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -397,7 +397,6 @@ impl Telemetry {
 #[buildstructor]
 impl IntegrationTest {
     #[builder]
-    #[allow(clippy::too_many_arguments)] // not typically used directly, only defines the builder
     pub async fn new(
         config: String,
         telemetry: Option<Telemetry>,
@@ -569,7 +568,9 @@ impl IntegrationTest {
                         level: String,
                         message: String,
                     }
-                    let log = serde_json::from_str::<Log>(&line).unwrap();
+                    let Ok(log) = serde_json::from_str::<Log>(&line) else {
+                        panic!("line: '{line}' isn't JSON, might you have some debug output in the logging?");
+                    };
                     // Omit this message from snapshots since it depends on external environment
                     if !log.message.starts_with("RUST_BACKTRACE=full detected") {
                         collected.push(format!(

--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -249,7 +249,7 @@ async fn it_uploads_a_massive_file() -> Result<(), BoxError> {
     // Upload a stream of 10GB
     const ONE_MB: usize = 1024 * 1024;
     const TEN_GB: usize = 10 * 1024 * ONE_MB;
-    const FILE_CHUNK: [u8; ONE_MB] = [0xAA; ONE_MB];
+    static FILE_CHUNK: [u8; ONE_MB] = [0xAA; ONE_MB];
     const CHUNK_COUNT: usize = TEN_GB / ONE_MB;
 
     // Upload a file that is 1GB in size of 0xAA
@@ -743,7 +743,7 @@ async fn it_fails_with_file_count_limits() -> Result<(), BoxError> {
 async fn it_fails_with_file_size_limit() -> Result<(), BoxError> {
     // Create a file that passes the limit set in the config (512KB)
     const ONE_MB: usize = 1024 * 1024;
-    const FILE_CHUNK: [u8; ONE_MB] = [0xAA; ONE_MB];
+    static FILE_CHUNK: [u8; ONE_MB] = [0xAA; ONE_MB];
 
     // Construct the parts of the multipart request as defined by the schema for multiple files
     let request = helper::create_request(

--- a/apollo-router/tests/integration/telemetry/mod.rs
+++ b/apollo-router/tests/integration/telemetry/mod.rs
@@ -30,7 +30,6 @@ struct TraceSpec {
 
 #[buildstructor::buildstructor]
 impl TraceSpec {
-    #[allow(clippy::too_many_arguments)]
     #[builder]
     pub fn new(
         operation_name: Option<String>,

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.83.0 as build
+FROM rust:1.85.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router

--- a/docs/source/routing/customization/custom-binary.mdx
+++ b/docs/source/routing/customization/custom-binary.mdx
@@ -16,7 +16,7 @@ Learn how to compile a custom binary from Apollo Router Core source, which is re
 ## Prerequisites
 
 <!-- renovate-automation: rustc version -->
-To compile the router, you need to have [Rust 1.83.0 or later](https://www.rust-lang.org/tools/install) installed.
+To compile the router, you need to have [Rust 1.85.0 or later](https://www.rust-lang.org/tools/install) installed.
 
 After you install the above, also install the `cargo-scaffold` tool:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # renovate-automation: rustc version
-channel = "1.83.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This version brings async closures, the 2024 edition, and more: https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html 




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6836 done by [Mergify](https://mergify.com).