### PR TITLE
Fix missing content type

### DIFF
--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1557,7 +1557,6 @@ async fn do_fetch(
     } else {
         get_graphql_content_type(service_name, &parts)
     };
-    // let content_type = get_graphql_content_type(service_name, &parts);
 
     let body = if content_type.is_ok() {
         let body = body


### PR DESCRIPTION
Batching intermittently throw error. Debug log says resp is missing content type. In our case, it looks like istio returned raw resp somehow which doesn't contain content-type header. 

Fix is to make sure body is always read and processed, even if the `Content-Type` header is missing when the response is chunked and the Content-Type header is missing.

<img width="869" alt="image" src="https://github.com/user-attachments/assets/c91c9be3-4661-4ca3-b2f1-987418428053" />


Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
