### PR TITLE
Allow JWT authorization options to support multiple issuers

### DIFF
--- a/.changesets/feat_6172_jwtmultipleissuers.md
+++ b/.changesets/feat_6172_jwtmultipleissuers.md
@@ -1,0 +1,13 @@
+### Allow JWT authorization options to support multiple issuers ([Issue #6172](https://github.com/apollographql/router/issues/6172))
+
+Allow JWT authorization options to support multiple issuers using the same jwks, similar to the support found on other tech stacks/frameworks.
+
+Configuration change:
+
+Any `issuer` defined on each currently existing `jwks` needs to migrated to an entry in the `issuers` list.  
+
+example:
+https://www.npmjs.com/package/jsonwebtoken
+> issuer (optional): string or array of strings of valid values for the iss field.
+
+By [@theJC](https://github.com/theJC) in https://github.com/apollographql/router/pull/6887

--- a/apollo-router/src/configuration/migrations/0037-jwt-issuer-becomes-issuers.yaml
+++ b/apollo-router/src/configuration/migrations/0037-jwt-issuer-becomes-issuers.yaml
@@ -1,0 +1,36 @@
+description: issuer becomes array of issuers
+# I could not figure out how to do for all elements in array in proteus, so did 10 jwks, hopefully nobody has that many!
+actions:
+  - type: move
+    from: authentication.router.jwt.jwks[0].issuer
+    to: authentication.router.jwt.jwks[0].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[1].issuer
+    to: authentication.router.jwt.jwks[1].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[2].issuer
+    to: authentication.router.jwt.jwks[2].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[3].issuer
+    to: authentication.router.jwt.jwks[3].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[4].issuer
+    to: authentication.router.jwt.jwks[4].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[5].issuer
+    to: authentication.router.jwt.jwks[5].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[6].issuer
+    to: authentication.router.jwt.jwks[6].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[7].issuer
+    to: authentication.router.jwt.jwks[7].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[8].issuer
+    to: authentication.router.jwt.jwks[8].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[9].issuer
+    to: authentication.router.jwt.jwks[9].issuers[]
+  - type: move
+    from: authentication.router.jwt.jwks[10].issuer
+    to: authentication.router.jwt.jwks[10].issuers[]

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4106,10 +4106,14 @@ expression: "&schema"
           },
           "type": "array"
         },
-        "issuer": {
-          "description": "Expected issuer for tokens verified by that JWKS",
+        "issuers": {
+          "description": "Expected issuers for tokens verified by that JWKS",
+          "items": {
+            "type": "string"
+          },
           "nullable": true,
-          "type": "string"
+          "type": "array",
+          "uniqueItems": true
         },
         "poll_interval": {
           "default": {

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@jwt_issuer_to_issuers.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@jwt_issuer_to_issuers.yaml.snap
@@ -1,0 +1,23 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: "https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json"
+          poll_interval: "<optional poll interval>"
+          headers:
+            - name: User-Agent
+              value: router
+          issuers:
+            - "https://issuer.one"
+        - url: "https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json"
+          poll_interval: "<optional poll interval>"
+          headers:
+            - name: User-Agent
+              value: router
+          issuers:
+            - "https://issuer.two"

--- a/apollo-router/src/configuration/testdata/migrations/jwt_issuer_to_issuers.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/jwt_issuer_to_issuers.yaml
@@ -1,0 +1,16 @@
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
+          issuer: https://issuer.one
+          poll_interval: <optional poll interval>
+          headers:
+            - name: User-Agent
+              value: router
+        - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
+          issuer: https://issuer.two
+          poll_interval: <optional poll interval>
+          headers:
+            - name: User-Agent
+              value: router

--- a/apollo-router/src/plugins/authentication/error.rs
+++ b/apollo-router/src/plugins/authentication/error.rs
@@ -40,7 +40,7 @@ pub(crate) enum AuthenticationError {
     /// Cannot find a suitable key for: alg: '{0:?}', kid: '{1:?}' in JWKS list
     CannotFindSuitableKey(Algorithm, Option<String>),
 
-    /// Invalid issuer: the token's `iss` was '{token}', but signed with a key from '{expected}'
+    /// Invalid issuer: the token's `iss` was '{token}', but signed with a key from JWKS configured to only accept from '{expected}'
     InvalidIssuer { expected: String, token: String },
 
     /// Unsupported key algorithm: {0}

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -36,6 +36,7 @@ use crate::plugin::serde::deserialize_header_name;
 use crate::plugin::serde::deserialize_header_value;
 use crate::plugins::authentication::connector::ConnectorAuth;
 use crate::plugins::authentication::error::ErrorContext;
+use crate::plugins::authentication::jwks::Issuers;
 use crate::plugins::authentication::jwks::JwksConfig;
 use crate::plugins::authentication::subgraph::make_signing_params;
 use crate::services::APPLICATION_JSON_HEADER_VALUE;
@@ -124,8 +125,8 @@ struct JwksConf {
     )]
     #[schemars(with = "String", default = "default_poll_interval")]
     poll_interval: Duration,
-    /// Expected issuer for tokens verified by that JWKS
-    issuer: Option<String>,
+    /// Expected issuers for tokens verified by that JWKS
+    issuers: Option<Issuers>,
     /// List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`
     #[schemars(with = "Option<Vec<String>>", default)]
     #[serde(default)]
@@ -335,7 +336,7 @@ impl AuthenticationPlugin {
             let url: Url = Url::from_str(jwks_conf.url.as_str())?;
             list.push(JwksConfig {
                 url,
-                issuer: jwks_conf.issuer.clone(),
+                issuers: jwks_conf.issuers.clone(),
                 algorithms: jwks_conf
                     .algorithms
                     .as_ref()
@@ -540,7 +541,7 @@ fn authenticate(
     // Note: This will search through JWKS in the order in which they are defined
     // in configuration.
     if let Some(keys) = jwks::search_jwks(jwks_manager, &criteria) {
-        let (issuer, token_data) = match jwks::decode_jwt(jwt, keys, criteria) {
+        let (issuers, token_data) = match jwks::decode_jwt(jwt, keys, criteria) {
             Ok(data) => data,
             Err((auth_error, status_code)) => {
                 return failure_message(
@@ -553,19 +554,26 @@ fn authenticate(
             }
         };
 
-        if let Some(configured_issuer) = issuer {
+        if let Some(configured_issuers) = issuers {
             if let Some(token_issuer) = token_data
                 .claims
                 .as_object()
                 .and_then(|o| o.get("iss"))
                 .and_then(|value| value.as_str())
             {
-                if configured_issuer != token_issuer {
+                if !configured_issuers.contains(token_issuer) {
+                    let mut issuers_for_error: Vec<String> =
+                        configured_issuers.into_iter().collect();
+                    issuers_for_error.sort(); // done to maintain consistent ordering in error message
                     return failure_message(
                         request,
                         config,
                         AuthenticationError::InvalidIssuer {
-                            expected: configured_issuer,
+                            expected: issuers_for_error
+                                .iter()
+                                .map(|issuer| issuer.to_string())
+                                .collect::<Vec<_>>()
+                                .join(", "),
                             token: token_issuer.to_string(),
                         },
                         StatusCode::INTERNAL_SERVER_ERROR,

--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -48,7 +48,9 @@ Otherwise, if you issue JWTs via a popular third-party IdP (Auth0, Okta, PingOne
        jwt:
          jwks: # This key is required.
            - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
-             issuer: <optional name of issuer>
+             issuers: # optional list of issuers
+               - https://issuer.one
+               - https://issuer.two
              poll_interval: <optional poll interval>
              headers: # optional list of static headers added to the HTTP request to the JWKS URL
                - name: User-Agent
@@ -110,7 +112,7 @@ The following configuration options are supported:
 - `url`: **required** URL from which the JWKS file will be read. Must be a valid URL.
   - **If you use a third-party IdP,** consult its documentation to determine its JWKS URL.
   - **If you use your own custom IdP,** you need to make its JWKS available at a router-accessible URL if you haven't already. For more information, see [Creating your own JWKS](#creating-your-own-jwks-advanced).
-- `issuer`: **optional** name of the issuer, that will be compared to the `iss` claim in the JWT if present. If it does not match, the request will be rejected.
+- `issuers`: **optional** list of issuers accepted, that will be compared to the `iss` claim in the JWT if present. If one does not match, the request will be rejected.
 - `algorithms`: **optional** list of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`
 - `poll_interval`: **optional** interval in human-readable format (e.g. `60s` or `1hour 30s`) at which the JWKS will be polled for changes. If not specified, the JWKS endpoint will be polled every 60 seconds.
 - `headers`: **optional** a list of headers sent when downloading from the JWKS URL

--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -112,7 +112,7 @@ The following configuration options are supported:
 - `url`: **required** URL from which the JWKS file will be read. Must be a valid URL.
   - **If you use a third-party IdP,** consult its documentation to determine its JWKS URL.
   - **If you use your own custom IdP,** you need to make its JWKS available at a router-accessible URL if you haven't already. For more information, see [Creating your own JWKS](#creating-your-own-jwks-advanced).
-- `issuers`: **optional** list of issuers accepted, that will be compared to the `iss` claim in the JWT if present. If one does not match, the request will be rejected.
+- `issuers`: **optional** list of issuers accepted, that will be compared to the `iss` claim in the JWT if present. If none match, the request will be rejected.
 - `algorithms`: **optional** list of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`
 - `poll_interval`: **optional** interval in human-readable format (e.g. `60s` or `1hour 30s`) at which the JWKS will be polled for changes. If not specified, the JWKS endpoint will be polled every 60 seconds.
 - `headers`: **optional** a list of headers sent when downloading from the JWKS URL


### PR DESCRIPTION
Allow JWT authorization options to support multiple issuers using the same jwks.
This capability is supported on other tech stacks/frameworks, and Indeed requires this for some of its environments.

example:
[https://www.npmjs.com/package/jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken#:~:text=issuer%20(optional)%3A%20string%20or%20array%20of%20strings%20of%20valid%20values%20for%20the%20iss%20field.)
> issuer (optional): string or array of strings of valid values for the iss field.

Fixes #6172 , #6736

Before this change, a JWK configuration only allowed customers to specify a single issuer.  Now it supports a list of issuers that are valid for keys provided by a JWKS provider:

Before:
```
authentication:
  router:
    jwt:
      jwks:
        - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
          issuer: https://issuer.one
          poll_interval: <optional poll interval>
          headers:
            - name: User-Agent
              value: router
```

After:
```
authentication:
  router:
    jwt:
      jwks:
        - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
          issuers: 
            - https://issuer.one
            - https://issuer.two
          poll_interval: <optional poll interval>
          headers:
            - name: User-Agent
              value: router
```

<!-- start metadata -->
<!-- [ROUTER-1136] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1136]: https://apollographql.atlassian.net/browse/ROUTER-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ