### PR TITLE
Upgrade apollo-router crate to Rust edition 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6114,9 +6114,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -6127,9 +6127,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ reqwest = { version = "0.11.0", default-features = false, features = [
     "stream",
 ] }
 
-schemars = { version = "0.8.16", features = ["url"] }
+schemars = { version = "0.8.22", features = ["url"] }
 serde = { version = "1.0.198", features = ["derive", "rc"] }
 serde_json = { version = "1.0.114", features = [
     "preserve_order",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -9,7 +9,7 @@ license = "Elastic-2.0"
 
 # renovate-automation: rustc version
 rust-version = "1.85.0"
-edition = "2021"
+edition = "2024"
 build = "build/main.rs"
 default-run = "router"
 


### PR DESCRIPTION
The schemars blocker is now fixed upstream. The local changes needed were already done in https://github.com/apollographql/router/pull/6850 and https://github.com/apollographql/router/pull/6854.