### PR TITLE
Ensure `build_query_plan()` cancels when the request cancels (backport #6840)

### DIFF
--- a/.changesets/fix_stance_intercom_body_director.md
+++ b/.changesets/fix_stance_intercom_body_director.md
@@ -1,0 +1,5 @@
+### Ensure query planning exits when its request times out ([PR #6840](https://github.com/apollographql/router/pull/6840))
+
+When a request times out/is cancelled, resources allocated to that request should be released. Previously, query planning could potentially keep running after the request is cancelled. After this fix, query planning now exits shortly after the request is cancelled. If you need query planning to run longer, you can [increase the request timeout](https://www.apollographql.com/docs/graphos/routing/performance/traffic-shaping#timeouts).
+
+By [@SimonSapin](https://github.com/SimonSapin) and [@sachindshinde](https://github.com/sachindshinde) in https://github.com/apollographql/router/pull/6840

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -298,6 +298,8 @@ pub enum SingleFederationError {
     DeferredSubscriptionUnsupported,
     #[error("{message}")]
     QueryPlanComplexityExceeded { message: String },
+    #[error("the caller requested cancellation")]
+    PlanningCancelled,
 }
 
 impl SingleFederationError {
@@ -492,6 +494,7 @@ impl SingleFederationError {
             SingleFederationError::QueryPlanComplexityExceeded { .. } => {
                 ErrorCode::QueryPlanComplexityExceededError
             }
+            SingleFederationError::PlanningCancelled => ErrorCode::Internal,
         }
     }
 }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -64,6 +64,8 @@ pub(crate) use contains::*;
 pub(crate) use directive_list::DirectiveList;
 pub(crate) use merging::*;
 pub(crate) use rebase::*;
+#[cfg(test)]
+pub(crate) use tests::never_cancel;
 
 pub(crate) const TYPENAME_FIELD: Name = name!("__typename");
 
@@ -1541,9 +1543,12 @@ impl SelectionSet {
         Ok(())
     }
 
-    pub(crate) fn expand_all_fragments(&self) -> Result<SelectionSet, FederationError> {
+    pub(crate) fn expand_all_fragments(
+        &self,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
+    ) -> Result<SelectionSet, FederationError> {
         let mut expanded_selections = vec![];
-        SelectionSet::expand_selection_set(&mut expanded_selections, self)?;
+        SelectionSet::expand_selection_set(&mut expanded_selections, self, check_cancellation)?;
 
         let mut expanded = SelectionSet {
             schema: self.schema.clone(),
@@ -1557,12 +1562,14 @@ impl SelectionSet {
     fn expand_selection_set(
         destination: &mut Vec<Selection>,
         selection_set: &SelectionSet,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<(), FederationError> {
         for value in selection_set.selections.values() {
+            check_cancellation()?;
             match value {
                 Selection::Field(field_selection) => {
                     let selections = match &field_selection.selection_set {
-                        Some(s) => Some(s.expand_all_fragments()?),
+                        Some(s) => Some(s.expand_all_fragments(check_cancellation)?),
                         None => None,
                     };
                     destination.push(Selection::from_field(
@@ -1580,12 +1587,14 @@ impl SelectionSet {
                         SelectionSet::expand_selection_set(
                             destination,
                             &spread_selection.selection_set,
+                            check_cancellation,
                         )?;
                     } else {
                         // convert to inline fragment
                         let expanded = InlineFragmentSelection::from_fragment_spread_selection(
                             selection_set.type_position.clone(), // the parent type of this inline selection
                             spread_selection,
+                            check_cancellation,
                         )?;
                         destination.push(Selection::InlineFragment(Arc::new(expanded)));
                     }
@@ -1594,7 +1603,9 @@ impl SelectionSet {
                     destination.push(
                         InlineFragmentSelection::new(
                             inline_selection.inline_fragment.clone(),
-                            inline_selection.selection_set.expand_all_fragments()?,
+                            inline_selection
+                                .selection_set
+                                .expand_all_fragments(check_cancellation)?,
                         )
                         .into(),
                     );
@@ -2718,6 +2729,7 @@ impl InlineFragmentSelection {
     pub(crate) fn from_fragment_spread_selection(
         parent_type_position: CompositeTypeDefinitionPosition,
         fragment_spread_selection: &Arc<FragmentSpreadSelection>,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<InlineFragmentSelection, FederationError> {
         let schema = fragment_spread_selection.spread.schema.schema();
         for directive in fragment_spread_selection.spread.directives.iter() {
@@ -2755,7 +2767,7 @@ impl InlineFragmentSelection {
             },
             fragment_spread_selection
                 .selection_set
-                .expand_all_fragments()?,
+                .expand_all_fragments(check_cancellation)?,
         ))
     }
 
@@ -3751,10 +3763,11 @@ pub(crate) fn normalize_operation(
     named_fragments: NamedFragments,
     schema: &ValidFederationSchema,
     interface_types_with_interface_objects: &IndexSet<InterfaceTypeDefinitionPosition>,
+    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
 ) -> Result<Operation, FederationError> {
     let mut normalized_selection_set =
         SelectionSet::from_selection_set(&operation.selection_set, &named_fragments, schema)?;
-    normalized_selection_set = normalized_selection_set.expand_all_fragments()?;
+    normalized_selection_set = normalized_selection_set.expand_all_fragments(check_cancellation)?;
     // We clear up the fragments since we've expanded all.
     // Also note that expanding fragment usually generate unnecessary fragments/inefficient
     // selections, so it basically always make sense to flatten afterwards. Besides, fragment

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -13,6 +13,7 @@ use super::Selection;
 use super::SelectionKey;
 use super::SelectionSet;
 use crate::error::FederationError;
+use crate::error::SingleFederationError;
 use crate::query_graph::graph_path::OpPathElement;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
@@ -60,7 +61,19 @@ pub(super) fn parse_and_expand(
         .expect("must have anonymous operation");
     let fragments = NamedFragments::new(&doc.fragments, schema);
 
-    normalize_operation(operation, fragments, schema, &Default::default())
+    normalize_operation(
+        operation,
+        fragments,
+        schema,
+        &Default::default(),
+        &never_cancel,
+    )
+}
+
+/// The `normalize_operation()` function has a `check_cancellation` parameter that we'll want to
+/// configure to never cancel during tests. We create a convenience function here for that purpose.
+pub(crate) fn never_cancel() -> Result<(), SingleFederationError> {
+    Ok(())
 }
 
 #[test]
@@ -100,6 +113,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();
@@ -154,6 +168,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();
@@ -196,6 +211,7 @@ type Query {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
 
@@ -231,6 +247,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -274,6 +291,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -320,6 +338,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -364,6 +383,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -410,6 +430,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skip1: Boolean!, $skip2: Boolean!) {
@@ -461,6 +482,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -527,6 +549,7 @@ type V {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -586,6 +609,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -632,6 +656,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -682,6 +707,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -730,6 +756,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skipIf: Boolean!) {
@@ -778,6 +805,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test($skip1: Boolean!, $skip2: Boolean!) {
@@ -830,6 +858,7 @@ type T {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -898,6 +927,7 @@ type V {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query Test {
@@ -944,6 +974,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -983,6 +1014,7 @@ type Foo {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -1033,6 +1065,7 @@ scalar FieldSet
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &interface_objects,
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -1172,6 +1205,7 @@ mod make_selection_tests {
             Default::default(),
             &schema,
             &Default::default(),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1271,6 +1305,7 @@ mod lazy_map_tests {
             Default::default(),
             &schema,
             &Default::default(),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1329,6 +1364,7 @@ mod lazy_map_tests {
             Default::default(),
             &schema,
             &Default::default(),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1534,6 +1570,7 @@ fn test_expand_all_fragments1() {
             NamedFragments::new(&executable_document.fragments, &schema),
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         normalized_operation.named_fragments = Default::default();

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -2978,6 +2978,7 @@ impl OpGraphPath {
         context: &OpGraphPathContext,
         condition_resolver: &mut impl ConditionResolver,
         override_conditions: &EnabledOverrideConditions,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<(Option<Vec<SimultaneousPaths>>, Option<bool>), FederationError> {
         let span = debug_span!("Trying to advance {self} directly with {operation_element}");
         let _guard = span.enter();
@@ -3244,6 +3245,7 @@ impl OpGraphPath {
                                     &implementation_inline_fragment.into(),
                                     condition_resolver,
                                     override_conditions,
+                                    check_cancellation,
                                 )?;
                             // If we find no options for that implementation, we bail (as we need to
                             // simultaneously advance all implementations).
@@ -3274,6 +3276,7 @@ impl OpGraphPath {
                                         operation_element,
                                         condition_resolver,
                                         override_conditions,
+                                        check_cancellation,
                                     )?;
                                 let Some(field_options_for_implementation) =
                                     field_options_for_implementation
@@ -3310,6 +3313,7 @@ impl OpGraphPath {
                         }
                         let all_options = SimultaneousPaths::flat_cartesian_product(
                             options_for_each_implementation,
+                            check_cancellation,
                         )?;
                         if let Some(interface_path) = interface_path {
                             let (interface_path, all_options) =
@@ -3447,6 +3451,7 @@ impl OpGraphPath {
                                     &implementation_inline_fragment.into(),
                                     condition_resolver,
                                     override_conditions,
+                                    check_cancellation,
                                 )?;
                             let Some(implementation_options) = implementation_options else {
                                 drop(guard);
@@ -3469,6 +3474,7 @@ impl OpGraphPath {
                         }
                         let all_options = SimultaneousPaths::flat_cartesian_product(
                             options_for_each_implementation,
+                            check_cancellation,
                         )?;
                         debug!("Type-exploded options: {}", DisplaySlice(&all_options));
                         Ok((Some(all_options), None))
@@ -3735,6 +3741,7 @@ impl SimultaneousPaths {
     /// the options for the `SimultaneousPaths` as a whole.
     fn flat_cartesian_product(
         options_for_each_path: Vec<Vec<SimultaneousPaths>>,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<Vec<SimultaneousPaths>, FederationError> {
         // This can be written more tersely with a bunch of `reduce()`/`flat_map()`s and friends,
         // but when interfaces type-explode into many implementations, this can end up with fairly
@@ -3765,6 +3772,7 @@ impl SimultaneousPaths {
 
         // Compute the cartesian product.
         for _ in 0..num_options {
+            check_cancellation()?;
             let num_simultaneous_paths = options_for_each_path
                 .iter()
                 .zip(&option_indexes)
@@ -3930,6 +3938,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
         operation_element: &OpPathElement,
         condition_resolver: &mut impl ConditionResolver,
         override_conditions: &EnabledOverrideConditions,
+        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<Option<Vec<SimultaneousPathsWithLazyIndirectPaths>>, FederationError> {
         debug!(
             "Trying to advance paths for operation: path = {}, operation = {operation_element}",
@@ -3944,6 +3953,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
         // references to `self`, which means cloning these paths when iterating.
         let paths = self.paths.0.clone();
         for (path_index, path) in paths.iter().enumerate() {
+            check_cancellation()?;
             debug!("Computing options for {path}");
             let span = debug_span!(" |");
             let gaurd = span.enter();
@@ -3961,6 +3971,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
                         &updated_context,
                         condition_resolver,
                         override_conditions,
+                        check_cancellation,
                     )?;
                 debug!("{advance_options:?}");
                 drop(gaurd);
@@ -4033,6 +4044,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
                                 &updated_context,
                                 condition_resolver,
                                 override_conditions,
+                                check_cancellation,
                             )?;
                         // If we can't advance the operation element after that path, ignore it,
                         // it's just not an option.
@@ -4121,6 +4133,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
                     &updated_context,
                     condition_resolver,
                     override_conditions,
+                    check_cancellation,
                 )?;
                 options = advance_options.unwrap_or_else(Vec::new);
                 debug!("{options:?}");
@@ -4137,7 +4150,8 @@ impl SimultaneousPathsWithLazyIndirectPaths {
             }
         }
 
-        let all_options = SimultaneousPaths::flat_cartesian_product(options_for_each_path)?;
+        let all_options =
+            SimultaneousPaths::flat_cartesian_product(options_for_each_path, check_cancellation)?;
         debug!("{all_options:?}");
         Ok(Some(self.create_lazy_options(all_options, updated_context)))
     }

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -580,11 +580,7 @@ mod tests {
     use petgraph::visit::EdgeRef;
 
     use crate::error::FederationError;
-<<<<<<< HEAD
-=======
-    use crate::operation::Field;
     use crate::operation::never_cancel;
->>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
     use crate::operation::normalize_operation;
     use crate::operation::Field;
     use crate::query_graph::build_query_graph::build_query_graph;

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -580,6 +580,11 @@ mod tests {
     use petgraph::visit::EdgeRef;
 
     use crate::error::FederationError;
+<<<<<<< HEAD
+=======
+    use crate::operation::Field;
+    use crate::operation::never_cancel;
+>>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
     use crate::operation::normalize_operation;
     use crate::operation::Field;
     use crate::query_graph::build_query_graph::build_query_graph;
@@ -715,9 +720,14 @@ mod tests {
             "Query(Test) --[t]--> T(Test) --[otherId]--> ID(Test)"
         );
 
-        let normalized_operation =
-            normalize_operation(operation, Default::default(), &schema, &Default::default())
-                .unwrap();
+        let normalized_operation = normalize_operation(
+            operation,
+            Default::default(),
+            &schema,
+            &Default::default(),
+            &never_cancel,
+        )
+        .unwrap();
         let selection_set = Arc::new(normalized_operation.selection_set);
 
         let paths = vec![

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::num::NonZeroU32;
+use std::ops::ControlFlow;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -170,8 +171,8 @@ pub struct QueryPlanningStatistics {
     pub evaluated_plan_paths: Cell<usize>,
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct QueryPlanOptions {
+#[derive(Default, Clone)]
+pub struct QueryPlanOptions<'a> {
     /// A set of labels which will be used _during query planning_ to
     /// enable/disable edges with a matching label in their override condition.
     /// Edges with override conditions require their label to be present or absent
@@ -179,6 +180,24 @@ pub struct QueryPlanOptions {
     /// progressive @override feature.
     // PORT_NOTE: In JS implementation this was a Map
     pub override_conditions: Vec<String>,
+
+    pub check_for_cooperative_cancellation: Option<&'a dyn Fn() -> ControlFlow<()>>,
+}
+
+impl std::fmt::Debug for QueryPlanOptions<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueryPlanOptions")
+            .field("override_conditions", &self.override_conditions)
+            .field(
+                "check_for_cooperative_cancellation",
+                if self.check_for_cooperative_cancellation.is_some() {
+                    &"Some(...)"
+                } else {
+                    &"None"
+                },
+            )
+            .finish()
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -348,6 +367,11 @@ impl QueryPlanner {
             NamedFragments::new(&document.fragments, &self.api_schema),
             &self.api_schema,
             &self.interface_types_with_interface_objects,
+            &|| {
+                QueryPlanningParameters::check_cancellation_with(
+                    &options.check_for_cooperative_cancellation,
+                )
+            },
         )?;
 
         let NormalizedDefer {
@@ -414,6 +438,7 @@ impl QueryPlanner {
             override_conditions: EnabledOverrideConditions(IndexSet::from_iter(
                 options.override_conditions,
             )),
+            check_for_cooperative_cancellation: options.check_for_cooperative_cancellation,
             fetch_id_generator: Arc::new(FetchIdGenerator::new()),
         };
 
@@ -553,6 +578,7 @@ fn compute_root_serial_dependency_graph(
                 &mut fetch_dependency_graph,
                 &prev_path,
                 parameters.config.type_conditioned_fetching,
+                &|| parameters.check_cancellation(),
             )?;
         } else {
             // PORT_NOTE: It is unclear if they correct thing to do here is get the next ID, use
@@ -591,6 +617,7 @@ pub(crate) fn compute_root_fetch_groups(
     dependency_graph: &mut FetchDependencyGraph,
     path: &OpPathTree,
     type_conditioned_fetching_enabled: bool,
+    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
 ) -> Result<(), FederationError> {
     // The root of the pathTree is one of the "fake" root of the subgraphs graph,
     // which belongs to no subgraph but points to each ones.
@@ -640,6 +667,7 @@ pub(crate) fn compute_root_fetch_groups(
             )?,
             Default::default(),
             &Default::default(),
+            check_cancellation,
         )?;
     }
     Ok(())

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -1,3 +1,4 @@
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use apollo_compiler::collections::IndexSet;
@@ -87,6 +88,26 @@ pub(crate) struct QueryPlanningParameters<'a> {
     pub(crate) config: QueryPlannerConfig,
     pub(crate) statistics: &'a QueryPlanningStatistics,
     pub(crate) override_conditions: EnabledOverrideConditions,
+    pub(crate) check_for_cooperative_cancellation: Option<&'a dyn Fn() -> ControlFlow<()>>,
+}
+
+impl QueryPlanningParameters<'_> {
+    pub(crate) fn check_cancellation(&self) -> Result<(), SingleFederationError> {
+        Self::check_cancellation_with(&self.check_for_cooperative_cancellation)
+    }
+
+    pub(crate) fn check_cancellation_with(
+        check: &Option<&dyn Fn() -> ControlFlow<()>>,
+    ) -> Result<(), SingleFederationError> {
+        if let Some(check) = check {
+            match check() {
+                ControlFlow::Continue(()) => Ok(()),
+                ControlFlow::Break(()) => Err(SingleFederationError::PlanningCancelled),
+            }
+        } else {
+            Ok(())
+        }
+    }
 }
 
 pub(crate) struct QueryPlanningTraversal<'a, 'b> {
@@ -339,6 +360,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
     )]
     fn find_best_plan_inner(&mut self) -> Result<Option<&BestQueryPlanInfo>, FederationError> {
         while !self.open_branches.is_empty() {
+            self.parameters.check_cancellation()?;
             snapshot!(
                 "OpenBranches",
                 snapshot_helper::open_branches_to_string(&self.open_branches),
@@ -401,11 +423,13 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         );
 
         for option in options.iter_mut() {
+            self.parameters.check_cancellation()?;
             let followups_for_option = option.advance_with_operation_element(
                 self.parameters.supergraph_schema.clone(),
                 &operation_element,
                 /*resolver*/ self,
                 &self.parameters.override_conditions,
+                &|| self.parameters.check_cancellation(),
             )?;
             let Some(followups_for_option) = followups_for_option else {
                 // There is no valid way to advance the current operation element from this option
@@ -1042,6 +1066,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 dependency_graph,
                 path_tree,
                 type_conditioned_fetching_enabled,
+                &|| self.parameters.check_cancellation(),
             )?;
         } else {
             let query_graph_node = path_tree.graph.node_weight(path_tree.node)?;
@@ -1079,6 +1104,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 )?,
                 Default::default(),
                 &Default::default(),
+                &|| self.parameters.check_cancellation(),
             )?;
         }
 
@@ -1130,6 +1156,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             statistics: self.parameters.statistics,
             override_conditions: self.parameters.override_conditions.clone(),
             fetch_id_generator: self.parameters.fetch_id_generator.clone(),
+            check_for_cooperative_cancellation: self.parameters.check_for_cooperative_cancellation,
         };
         let best_plan_opt = QueryPlanningTraversal::new_inner(
             &parameters,

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/overrides.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/overrides.rs
@@ -24,7 +24,8 @@ fn it_handles_progressive_override_on_root_fields() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
         QueryPlan {
@@ -117,7 +118,8 @@ fn it_handles_progressive_override_on_entity_fields() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
           QueryPlan {
@@ -276,7 +278,8 @@ fn it_handles_progressive_override_on_nested_entity_fields() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
           QueryPlan {

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/overrides/shareable.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/overrides/shareable.rs
@@ -45,7 +45,8 @@ fn it_overrides_to_s2_when_label_is_provided() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
           QueryPlan {
@@ -157,7 +158,8 @@ fn it_overrides_f1_to_s3_when_label_is_provided() {
           }
         "#,
         QueryPlanOptions {
-            override_conditions: vec!["test".to_string()]
+            override_conditions: vec!["test".to_string()],
+            check_for_cooperative_cancellation: None,
         },
         @r###"
           QueryPlan {

--- a/apollo-router/src/compute_job.rs
+++ b/apollo-router/src/compute_job.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::ops::ControlFlow;
 use std::panic::UnwindSafe;
 use std::sync::OnceLock;
 
@@ -31,6 +32,72 @@ fn thread_pool_size() -> usize {
     }
 }
 
+<<<<<<< HEAD
+=======
+pub(crate) struct JobStatus<'a, T> {
+    result_sender: &'a oneshot::Sender<std::thread::Result<T>>,
+}
+
+impl<T> JobStatus<'_, T> {
+    /// Checks whether the oneshot receiver for the result of the job was dropped,
+    /// which means nothing is expecting the result anymore.
+    ///
+    /// This can happen if the Tokio task owning it is cancelled,
+    /// such as if a supergraph client disconnects or if a request times out.
+    ///
+    /// In this case, a long-running job should try to cancel itself
+    /// to avoid needless resource consumption.
+    pub(crate) fn check_for_cooperative_cancellation(&self) -> ControlFlow<()> {
+        if self.result_sender.is_closed() {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    }
+}
+
+/// We expect calling `oneshot::Sender::is_closed` to never leave the sender in a broken state.
+impl<T> UnwindSafe for JobStatus<'_, T> {}
+
+/// Compute job queue is full
+#[derive(thiserror::Error, Debug, displaydoc::Display, Clone)]
+pub(crate) struct ComputeBackPressureError;
+
+#[derive(Debug)]
+pub(crate) enum MaybeBackPressureError<E> {
+    /// Doing the same request again later would result in the same error (e.g. invalid query).
+    ///
+    /// This error can be cached.
+    PermanentError(E),
+
+    /// Doing the same request again later might work.
+    ///
+    /// This error must not be cached.
+    TemporaryError(ComputeBackPressureError),
+}
+
+impl<E> From<E> for MaybeBackPressureError<E> {
+    fn from(error: E) -> Self {
+        Self::PermanentError(error)
+    }
+}
+
+impl ComputeBackPressureError {
+    pub(crate) fn to_graphql_error(&self) -> crate::graphql::Error {
+        crate::graphql::Error::builder()
+            .message("Your request has been concurrency limited during query processing")
+            .extension_code("REQUEST_CONCURRENCY_LIMITED")
+            .build()
+    }
+}
+
+impl crate::graphql::IntoGraphQLErrors for ComputeBackPressureError {
+    fn into_graphql_errors(self) -> Result<Vec<crate::graphql::Error>, Self> {
+        Ok(vec![self.to_graphql_error()])
+    }
+}
+
+>>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
 type Job = Box<dyn FnOnce() + Send + 'static>;
 
 fn queue() -> &'static AgeingPriorityQueue<Job> {
@@ -62,13 +129,15 @@ pub(crate) fn execute<T, F>(
     job: F,
 ) -> impl Future<Output = std::thread::Result<T>>
 where
-    F: FnOnce() -> T + Send + UnwindSafe + 'static,
+    F: FnOnce(JobStatus<'_, T>) -> T + Send + UnwindSafe + 'static,
     T: Send + 'static,
 {
     let (tx, rx) = oneshot::channel();
     let job = Box::new(move || {
+        let status = JobStatus { result_sender: &tx };
+        let result = std::panic::catch_unwind(move || job(status));
         // Ignore the error if the oneshot receiver was dropped
-        let _ = tx.send(std::panic::catch_unwind(job));
+        let _ = tx.send(result);
     });
     queue().send(priority, job);
     async { rx.await.expect("channel disconnected") }
@@ -99,7 +168,12 @@ mod tests {
     #[tokio::test]
     async fn test_executes_on_different_thread() {
         let test_thread = std::thread::current().id();
+<<<<<<< HEAD
         let job_thread = execute(Priority::P4, || std::thread::current().id())
+=======
+        let job_thread = execute(Priority::P4, |_| std::thread::current().id())
+            .unwrap()
+>>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
             .await
             .unwrap();
         assert_ne!(job_thread, test_thread)
@@ -111,11 +185,17 @@ mod tests {
             return;
         }
         let start = Instant::now();
-        let one = execute(Priority::P8, || {
+        let one = execute(Priority::P8, |_| {
             std::thread::sleep(Duration::from_millis(1_000));
             1
+<<<<<<< HEAD
         });
         let two = execute(Priority::P8, || {
+=======
+        })
+        .unwrap();
+        let two = execute(Priority::P8, |_| {
+>>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
             std::thread::sleep(Duration::from_millis(1_000));
             1 + 1
         });

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -138,23 +138,11 @@ impl IntrospectionCache {
         let schema = schema.clone();
         let doc = doc.clone();
         let priority = compute_job::Priority::P1; // Low priority
-<<<<<<< HEAD
-        let response =
-            compute_job::execute(priority, move || Self::execute_introspection(&schema, &doc))
-                .await
-                .expect("Introspection panicked");
-=======
         let response = compute_job::execute(priority, move |_| {
-            Self::execute_introspection(max_depth, &schema, &doc)
-        })?
-        // `expect()` propagates any panic that potentially happens in the closure, but:
-        //
-        // * We try to avoid such panics in the first place and consider them bugs
-        // * The panic handler in `apollo-router/src/executable.rs` exits the process
-        //   so this error case should never be reached.
+            Self::execute_introspection(&schema, &doc)
+        })
         .await
         .expect("Introspection panicked");
->>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
         storage.insert(cache_key, response.clone()).await;
         response
     }

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -138,10 +138,23 @@ impl IntrospectionCache {
         let schema = schema.clone();
         let doc = doc.clone();
         let priority = compute_job::Priority::P1; // Low priority
+<<<<<<< HEAD
         let response =
             compute_job::execute(priority, move || Self::execute_introspection(&schema, &doc))
                 .await
                 .expect("Introspection panicked");
+=======
+        let response = compute_job::execute(priority, move |_| {
+            Self::execute_introspection(max_depth, &schema, &doc)
+        })?
+        // `expect()` propagates any panic that potentially happens in the closure, but:
+        //
+        // * We try to avoid such panics in the first place and consider them bugs
+        // * The panic handler in `apollo-router/src/executable.rs` exits the process
+        //   so this error case should never be reached.
+        .await
+        .expect("Introspection panicked");
+>>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
         storage.insert(cache_key, response.clone()).await;
         response
     }

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -131,11 +131,17 @@ impl QueryPlannerService {
         let doc = doc.clone();
         let rust_planner = self.planner.clone();
         let priority = compute_job::Priority::P8; // High priority
+<<<<<<< HEAD
         let (plan, mut root_node) = compute_job::execute(priority, move || {
+=======
+        let job = move |status: compute_job::JobStatus<'_, _>| -> Result<_, QueryPlannerError> {
+>>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
             let start = Instant::now();
 
+            let check = move || status.check_for_cooperative_cancellation();
             let query_plan_options = QueryPlanOptions {
                 override_conditions: plan_options.override_conditions,
+                check_for_cooperative_cancellation: Some(&check),
             };
 
             let result = operation

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -102,25 +102,9 @@ impl QueryAnalysisLayer {
                     conf.as_ref(),
                 )
             })
-<<<<<<< HEAD
-        };
-        // TODO: is this correct?
-        let job = std::panic::AssertUnwindSafe(job);
-        compute_job::execute(priority, job)
-            .await
-            .expect("Query::parse_document panicked")
-=======
         })
-        .map_err(MaybeBackPressureError::TemporaryError)?
         .await
-        // `expect()` propagates any panic that potentially happens in the closure, but:
-        //
-        // * We try to avoid such panics in the first place and consider them bugs
-        // * The panic handler in `apollo-router/src/executable.rs` exits the process
-        //   so this error case should never be reached.
         .expect("Query::parse_document panicked")
-        .map_err(MaybeBackPressureError::PermanentError)
->>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
     }
 
     pub(crate) async fn supergraph_request(

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -85,12 +85,15 @@ impl QueryAnalysisLayer {
         let schema = self.schema.clone();
         let conf = self.configuration.clone();
 
-        // Must be created *outside* of the spawn_blocking or the span is not connected to the
-        // parent
+        // Must be created *outside* of the compute_job or the span is not connected to the parent
         let span = tracing::info_span!(QUERY_PARSING_SPAN_NAME, "otel.kind" = "INTERNAL");
 
+        // TODO: is this correct?
+        let span = std::panic::AssertUnwindSafe(span);
+        let conf = std::panic::AssertUnwindSafe(conf);
+
         let priority = compute_job::Priority::P4; // Medium priority
-        let job = move || {
+        compute_job::execute(priority, move |_| {
             span.in_scope(|| {
                 Query::parse_document(
                     &query,
@@ -99,12 +102,25 @@ impl QueryAnalysisLayer {
                     conf.as_ref(),
                 )
             })
+<<<<<<< HEAD
         };
         // TODO: is this correct?
         let job = std::panic::AssertUnwindSafe(job);
         compute_job::execute(priority, job)
             .await
             .expect("Query::parse_document panicked")
+=======
+        })
+        .map_err(MaybeBackPressureError::TemporaryError)?
+        .await
+        // `expect()` propagates any panic that potentially happens in the closure, but:
+        //
+        // * We try to avoid such panics in the first place and consider them bugs
+        // * The panic handler in `apollo-router/src/executable.rs` exits the process
+        //   so this error case should never be reached.
+        .expect("Query::parse_document panicked")
+        .map_err(MaybeBackPressureError::PermanentError)
+>>>>>>> 2c554fc4 (Ensure `build_query_plan()` cancels when the request cancels (#6840))
     }
 
     pub(crate) async fn supergraph_request(


### PR DESCRIPTION
When a request is cancelled, resources (compute time/memory) allocated to that request should be released. However, query planning is an exception, and currently keeps running after the request is cancelled. This PR adds cooperative cancellation to `build_query_plan()`, to ensure that when the request is cancelled, query planning errors shortly after.<hr>This is an automatic backport of pull request #6840 done by [Mergify](https://mergify.com).