### PR TITLE
Explicitly ask rustup to install the active toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,9 +329,9 @@ commands:
               curl https://sh.rustup.rs -sSf -o rustup.sh
               chmod 755 ./rustup.sh
               ./rustup.sh -y --profile minimal --component clippy --component rustfmt --default-toolchain none
+              echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
+              export PATH="$HOME/.cargo/bin:$PATH"
             fi
-            echo '. "$HOME/.cargo/env"' >> "$BASH_ENV"
-            . "$HOME/.cargo/env"
             rustup toolchain install
             rustc -V
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,9 +329,9 @@ commands:
               curl https://sh.rustup.rs -sSf -o rustup.sh
               chmod 755 ./rustup.sh
               ./rustup.sh -y --profile minimal --component clippy --component rustfmt --default-toolchain none
-              echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
-              export PATH="$HOME/.cargo/bin:$PATH"
             fi
+            echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
+            export PATH="$HOME/.cargo/bin:$PATH"
             rustup toolchain install
             rustc -V
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,9 +329,11 @@ commands:
               curl https://sh.rustup.rs -sSf -o rustup.sh
               chmod 755 ./rustup.sh
               ./rustup.sh -y --profile minimal --component clippy --component rustfmt --default-toolchain none
-              $HOME/.cargo/bin/rustc -V
             fi
-            echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
+            echo '. "$HOME/.cargo/env"' >> "$BASH_ENV"
+            . "$HOME/.cargo/env"
+            rustup toolchain install
+            rustc -V
 
       - when:
           condition:


### PR DESCRIPTION
It no longer does implicitly: https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html

This hopefully fixes errors like: https://app.circleci.com/pipelines/github/apollographql/router/31290/workflows/ae3f29fe-a970-4ee4-8361-269eb1290577/jobs/230487?invite=true#step-108-710_67