### PR TITLE
reproduction for a defer planning issue

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -34,6 +34,7 @@ fn some_name() {
 mod context;
 mod debug_max_evaluated_plans_configuration;
 mod defer;
+mod defer_repro;
 mod entities;
 mod fetch_operation_names;
 mod field_merging_with_skip_and_include;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/defer_repro.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/defer_repro.rs
@@ -1,0 +1,161 @@
+use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
+
+fn config_with_defer() -> QueryPlannerConfig {
+    let mut config = QueryPlannerConfig::default();
+    config.incremental_delivery.enable_defer = true;
+    config
+}
+#[test]
+fn defer_test_reproduction_works() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+        type Price {
+          id: ID! @shareable
+        }
+
+        type Query {
+          products(start: Int = 0, limit: Int = 3): [Product]
+        }
+
+        type Product {
+          id: ID! @shareable
+          name: String @shareable
+          price: Price @shareable
+        }
+        "#,
+        Subgraph2: r#"
+        type Price {
+          id: ID! @shareable
+        }
+
+        type Query {
+          product(id: ID!): Product
+        }
+
+        type Product @key(fields: "id") {
+          id: ID! @shareable
+          name: String @shareable
+          price: Price @shareable
+        }
+        "#,
+        Subgraph3: r#"
+        type Price @key(fields: "id") {
+          amount: Float
+          id: ID! @shareable
+        }
+
+        type Query {
+          price(id: ID!): Price
+        }
+        "#,
+    );
+    assert_plan!(planner,
+        r#"
+          {
+            products {
+              id
+              name
+              price {
+                amount
+              }
+            }
+          }
+        "#,
+        @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "Subgraph1") {
+          {
+            products {
+              id
+              name
+              price {
+                __typename
+                id
+              }
+            }
+          }
+        },
+        Flatten(path: "products.@.price") {
+          Fetch(service: "Subgraph3") {
+            {
+              ... on Price {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on Price {
+                amount
+              }
+            }
+          },
+        },
+      },
+    }
+    "#);
+}
+
+#[test]
+fn defer_test_reproduction() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+        type Price {
+          id: ID! @shareable
+        }
+
+        type Query {
+          products(start: Int = 0, limit: Int = 3): [Product]
+        }
+
+        type Product {
+          id: ID! @shareable
+          name: String @shareable
+          price: Price @shareable
+        }
+        "#,
+        Subgraph2: r#"
+        type Price {
+          id: ID! @shareable
+        }
+
+        type Query {
+          product(id: ID!): Product
+
+        }
+
+        type Product @key(fields: "id", resolvable: true) {
+          id: ID! @shareable
+          name: String @shareable
+          price: Price @shareable
+        }
+        "#,
+        Subgraph3: r#"
+        type Price @key(fields: "id", resolvable: true) {
+          amount: Float
+          id: ID! @shareable
+        }
+
+        type Query {
+          price(id: ID!): Price
+        }
+        "#,
+    );
+    assert_plan!(planner,
+        r#"
+          {
+            products {
+              id
+              name
+              ... @defer {
+                price {
+                  amount
+                }
+              }
+            }
+          }
+        "#,
+        @"");
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_reproduction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_reproduction.graphql
@@ -1,0 +1,84 @@
+# Composed from subgraphs with hash: a15fb07b3d6036fe12998e927508b6ac65d31cb1
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Price
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3, key: "id", resolvable: true)
+{
+  id: ID!
+  amount: Float @join__field(graph: SUBGRAPH3)
+}
+
+type Product
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2, key: "id", resolvable: true)
+{
+  id: ID!
+  name: String
+  price: Price
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  products(start: Int = 0, limit: Int = 3): [Product] @join__field(graph: SUBGRAPH1)
+  product(id: ID!): Product @join__field(graph: SUBGRAPH2)
+  price(id: ID!): Price @join__field(graph: SUBGRAPH3)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_reproduction_works.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_reproduction_works.graphql
@@ -1,0 +1,84 @@
+# Composed from subgraphs with hash: 8d760e90fbe5381a81d499774e79f97d13f6bc3f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Price
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3, key: "id")
+{
+  id: ID!
+  amount: Float @join__field(graph: SUBGRAPH3)
+}
+
+type Product
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  name: String
+  price: Price
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  products(start: Int = 0, limit: Int = 3): [Product] @join__field(graph: SUBGRAPH1)
+  product(id: ID!): Product @join__field(graph: SUBGRAPH2)
+  price(id: ID!): Price @join__field(graph: SUBGRAPH3)
+}


### PR DESCRIPTION
For comparison, JS 2.9.3 looks like this (note that it doesn't actually have a defer node)
```
# npx github:@apollosolutions/generate-query-plan --supergraph supergraph.graphql --operation deferred.graphql
Query Plan: 6.178ms
QueryPlan {
  Sequence {
    Fetch(service: "subgraph1") {
      {
        products {
          id
          name
          price {
            __typename
            id
          }
        }
      }
    },
    Flatten(path: "products.@.price") {
      Fetch(service: "subgraph3") {
        {
          ... on Price {
            __typename
            id
          }
        } =>
        {
          ... on Price {
            amount
          }
        }
      },
    },
  },
}
```

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
