### PR TITLE
Install Rust-based tools on CI from pre-compiled binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,20 +369,20 @@ commands:
       - run:
           name: Install cargo deny, about, edit
           command: |
-            # if [[ ! -f "$HOME/.cargo/bin/cargo-binstall$EXECUTABLE_SUFFIX" ]]; then
+            if [[ ! -f "$HOME/.cargo/bin/cargo-binstall$EXECUTABLE_SUFFIX" ]]; then
               curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-            # fi
+            fi
 
-            # if [[ ! -f "$HOME/.cargo/bin/cargo-deny$EXECUTABLE_SUFFIX" ]]; then
+            if [[ ! -f "$HOME/.cargo/bin/cargo-deny$EXECUTABLE_SUFFIX" ]]; then
               cargo binstall -y --version 0.14.21 cargo-deny
               cargo binstall -y --version 0.12.2 cargo-edit
               cargo binstall -y --version 0.12.0 cargo-fuzz
               cargo binstall -y --version 0.6.6 cargo-about
-            # fi
+            fi
 
-            # if [[ ! -f "$HOME/.cargo/bin/cargo-nextest$EXECUTABLE_SUFFIX" ]]; then
+            if [[ ! -f "$HOME/.cargo/bin/cargo-nextest$EXECUTABLE_SUFFIX" ]]; then
               cargo binstall -y --version 0.9.70 cargo-nextest
-            # fi
+            fi
 
   fetch_dependencies:
     steps:


### PR DESCRIPTION
Installing from source can take up to 8 minutes:
https://app.circleci.com/pipelines/github/apollographql/router/31305/workflows/792ab4bc-cfcd-4120-bfbb-d86405cf5964/jobs/230568/steps

Installing binaries takes 5 seconds:
https://app.circleci.com/pipelines/github/apollographql/router/31322/workflows/dcca4c65-e4bb-46ad-a05a-c0b9f6c77e11/jobs/230688/steps