### PR TITLE
Update Cargo.lock for `uuid` change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7587,7 +7587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "getrandom 0.3.1",
- "js-sys",
  "serde",
 ]
 


### PR DESCRIPTION
In the `Cargo.lock`, `uuid@1.15.1` no longer depends on `js-sys`. Happened after the `apollo-compiler` [upgrade](https://github.com/apollographql/router/pull/6913) to `v1.27.0`, which removed its dependency on `uuid`. Not sure why CI didn't catch this in that PR.