### PR TITLE
docs: jwt_claims

### DIFF
--- a/docs/source/routing/customization/coprocessor.mdx
+++ b/docs/source/routing/customization/coprocessor.mdx
@@ -1264,7 +1264,7 @@ This configuration prompts the router to send an HTTP POST request to your copro
 }
 ```
 
-When your coprocessor receives this request from the router, it should add claims to the request's [`context`](#context) and return them in the response to the router. Specifically, the coprocessor should add an entry with a claims object. The key must be `apollo_authentication::JWT::claims`, and the value should be the claims required by the authorization directives you intend to use. For example, if you want to use [`@requireScopes`](/router/configuration/authorization#requiresscopes), the response may look something like this:
+When your coprocessor receives this request from the router, it should add claims to the request's [`context`](#context) and return them in the response to the router. Specifically, the coprocessor should add an entry with a claims object. The key must be `apollo::authentication::jwt_claims`, and the value should be the claims required by the authorization directives you intend to use. For example, if you want to use [`@requireScopes`](/router/configuration/authorization#requiresscopes), the response may look something like this:
 
 ```json
 {
@@ -1275,7 +1275,7 @@ When your coprocessor receives this request from the router, it should add claim
   "context": {
     "entries": {
       "accepts-json": true,
-      "apollo_authentication::JWT::claims": {
+      "apollo::authentication::jwt_claims": {
         "scope": "profile:read profile:write"
       }
     }

--- a/docs/source/routing/security/authorization.mdx
+++ b/docs/source/routing/security/authorization.mdx
@@ -122,7 +122,7 @@ Claims are the individual details of a request's authentication and scope. They 
 
 To provide the router with the claims it needs, you must either configure JSON Web Token (JWT) authentication or add an external coprocessor that adds claims to a request's context. In some cases (explained below), you may require both.
 
-- **JWT authentication configuration**: If you configure [JWT authentication](/router/configuration/authn-jwt), the GraphOS Router [automatically adds a JWT token's claims](/router/configuration/authn-jwt#working-with-jwt-claims) to the request's context at the `apollo_authentication::JWT::claims` key.
+- **JWT authentication configuration**: If you configure [JWT authentication](/router/configuration/authn-jwt), the GraphOS Router [automatically adds a JWT token's claims](/router/configuration/authn-jwt#working-with-jwt-claims) to the request's context at the `apollo::authentication::jwt_claims` key.
 - **Adding claims via coprocessor**: If you can't use JWT authentication, you can [add claims with a coprocessor](/router/customizations/coprocessor#adding-authorization-claims-via-coprocessor). Coprocessors let you hook into the GraphOS Router's request-handling lifecycle with custom code.
 - **Augmenting JWT claims via coprocessor**: Your authorization policies may require information beyond what your JSON web tokens provide. For example, a token's claims may include user IDs, which you then use to look up user roles. For situations like this, you can [augment the claims](/router/configuration/authn-jwt#claim-augmentation-via-coprocessors) from your JSON web tokens with coprocessors.
 
@@ -161,24 +161,24 @@ Depending on the scopes present on the request, the router filters out unauthori
 
 > You can use Boolean logic to define the required scopes. See [Combining required scopes](#combining-required-scopes-with-andor-logic) for details.
 
-The directive validates the required scopes by loading the claims object at the `apollo_authentication::JWT::claims` key in a request's context.
+The directive validates the required scopes by loading the claims object at the `apollo::authentication::jwt_claims` key in a request's context.
 The claims object's `scope` key's value should be a space-separated string of scopes in the format defined by the [OAuth2 RFC for access token scopes](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
 
 ```rhai
-claims = context["apollo_authentication::JWT::claims"]
+claims = context["apollo::authentication::jwt_claims"]
 claims["scope"] = "scope1 scope2 scope3"
 ```
 
 <ExpansionPanel title="What if my request scopes aren't in OAuth2 format?">
 
-If the `apollo_authentication::JWT::claims` object holds scopes in another format, for example, an array of strings, or at a key other than `"scope"`, you can edit the claims with a [Rhai script](/graphos/routing/customization/rhai).
+If the `apollo::authentication::jwt_claims` object holds scopes in another format, for example, an array of strings, or at a key other than `"scope"`, you can edit the claims with a [Rhai script](/graphos/routing/customization/rhai).
 
 The example below extracts an array of scopes from the `"roles"` claim and reformats them as a space-separated string.
 
 ```Rhai
 fn router_service(service) {
   let request_callback = |request| {
-    let claims = request.context["apollo_authentication::JWT::claims"];
+    let claims = request.context["apollo::authentication::jwt_claims"];
     let roles = claims["roles"];
 
     let scope = "";
@@ -194,7 +194,7 @@ fn router_service(service) {
     }
 
     claims["scope"] = scope;
-    request.context["apollo_authentication::JWT::claims"] = claims;
+    request.context["apollo::authentication::jwt_claims"] = claims;
   };
   service.map_request(request_callback);
 }
@@ -341,7 +341,7 @@ The router returns `null` for unauthorized fields and applies the [standard Grap
 </MinVersion>
 
 The `@authenticated` directive marks specific fields and types as requiring authentication.
-It works by checking for the `apollo_authentication::JWT::claims` key in a request's context, that is added either by the JWT authentication plugin, when the request contains a valid JWT, or by an authentication coprocessor.
+It works by checking for the `apollo::authentication::jwt_claims` key in a request's context, that is added either by the JWT authentication plugin, when the request contains a valid JWT, or by an authentication coprocessor.
 If the key exists, it means the request is authenticated, and the router executes the query in its entirety.
 If the request is unauthenticated, the router removes `@authenticated` fields before planning the query and only executes the parts of the query that don't require authentication.
 
@@ -591,7 +591,7 @@ A coprocessor can then receive a request with this format:
   "id": "d0a8245df0efe8aa38a80dba1147fb2e",
   "context": {
     "entries": {
-      "apollo_authentication::JWT::claims": {
+      "apollo::authentication::jwt_claims": {
         "exp": 10000000000,
         "sub": "457f6bb6-789c-4e8b-8560-f3943a09e72a"
       },
@@ -615,7 +615,7 @@ A user can read their own profile, so `read_profile` will succeed. But only the 
   "id": "d0a8245df0efe8aa38a80dba1147fb2e",
   "context": {
     "entries": {
-      "apollo_authentication::JWT::claims": {
+      "apollo::authentication::jwt_claims": {
         "exp": 10000000000,
         "sub": "457f6bb6-789c-4e8b-8560-f3943a09e72a"
       },
@@ -650,7 +650,7 @@ You can then use the following Rhai script to parse and evaluate the `policies` 
 ```rhai
 fn supergraph_service(service) {
   let request_callback = |request| {
-    let claims = request.context["apollo_authentication::JWT::claims"];
+    let claims = request.context["apollo::authentication::jwt_claims"];
     let policies = request.context["apollo::authorization::required_policies"];
 
     if policies != () {
@@ -716,7 +716,7 @@ A request must both be authenticated **AND** have the required `read:user` scope
 
 <Note>
 
-Recall that the `@authenticated` directive only checks for the existence of the `apollo_authentication::JWT::claims` key in a request's context, so authentication is guaranteed if the request includes scopes.
+Recall that the `@authenticated` directive only checks for the existence of the `apollo::authentication::jwt_claims` key in a request's context, so authentication is guaranteed if the request includes scopes.
 
 </Note>
 

--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -201,7 +201,7 @@ The default value is `false`.
 
 ## Working with JWT claims
 
-After the GraphOS Router validates a client request's JWT, it adds that token's **claims** to the request's context at this key: `apollo_authentication::JWT::claims`
+After the GraphOS Router validates a client request's JWT, it adds that token's **claims** to the request's context at this key: `apollo::authentication::jwt_claims`
 
 > - If no JWT is present for a client request, this context value is the empty tuple, `()`.
 > - If a JWT _is_ present but validation of the JWT fails, the router _rejects_ the request.
@@ -299,7 +299,7 @@ This script should be run in the router's `SupergraphService`, which executes be
 ```rhai title="claims_validation.rhai"
 fn process_request(request) {
     // Router.APOLLO_AUTHENTICATION_JWT_CLAIMS is a Rhai-scope
-    // constant with value `apollo_authentication::JWT::claims`
+    // constant with value `apollo::authentication::jwt_claims`
     let claims = request.context[Router.APOLLO_AUTHENTICATION_JWT_CLAIMS];
     if claims == () || !claims.contains("iss") || claims["iss"] != "https://idp.local" {
         throw #{
@@ -381,7 +381,7 @@ The router sends requests to the coprocessor with this format:
   "id": "d0a8245df0efe8aa38a80dba1147fb2e",
   "context": {
     "entries": {
-      "apollo_authentication::JWT::claims": {
+      "apollo::authentication::jwt_claims": {
         "exp": 10000000000,
         "sub": "457f6bb6-789c-4e8b-8560-f3943a09e72a"
       }
@@ -401,7 +401,7 @@ The coprocessor can then look up the user with the identifier specified in the `
   "id": "d0a8245df0efe8aa38a80dba1147fb2e",
   "context": {
     "entries": {
-      "apollo_authentication::JWT::claims": {
+      "apollo::authentication::jwt_claims": {
         "exp": 10000000000,
         "sub": "457f6bb6-789c-4e8b-8560-f3943a09e72a",
         "scope": "profile:read profile:write"


### PR DESCRIPTION
Fix router 2.x docs to use updated `apollo::authentication::jwt_claims` name