### PR TITLE
deps: update itertools to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
  "http 1.2.0",
  "indexmap 2.7.1",
  "insta",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "line-col",
  "multimap 0.10.0",
  "nom",
@@ -314,7 +314,7 @@ dependencies = [
  "hyperlocal",
  "indexmap 2.7.1",
  "insta",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "itoa",
  "jsonpath-rust",
  "jsonpath_lib",
@@ -1407,7 +1407,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -3886,6 +3886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4054,7 +4063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5226,7 +5235,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap 0.10.0",
@@ -5247,7 +5256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -7854,7 +7863,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -27,7 +27,7 @@ derive_more = "0.99.17"
 http.workspace = true
 hashbrown = "0.15.1"
 indexmap = { version = "2.2.6", features = ["serde"] }
-itertools = "0.13.0"
+itertools = "0.14.0"
 line-col = "0.2.1"
 multimap = "0.10.0"
 nom = "7.1.3"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -109,7 +109,7 @@ hyper = { version = "1.5.1", features = ["full"] }
 hyper-util = { version = "0.1.10", features = ["full"] }
 hyper-rustls = { version = "0.27.3", features = ["http1", "http2", "rustls-native-certs"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
-itertools = "0.13.0"
+itertools = "0.14.0"
 jsonpath_lib = "0.3.0"
 jsonpath-rust = "0.3.5"
 jsonschema = { version = "0.17.1", default-features = false }


### PR DESCRIPTION
Pulled out from https://github.com/apollographql/router/pull/6614.

This essentially adds a _new_ version to our tree because 0.13.0 is in use by prost; that will go away once we update prost.
