### PR TITLE
Remove now unused CODEOWNERS line for apollo-router-scaffold

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,5 @@
 /apollo-router/ @apollographql/router-core @apollographql/fed-core
 /apollo-router/src/plugins/connectors @apollographql/connectors
 /apollo-router-benchmarks/ @apollographql/router-core @apollographql/fed-core
-/apollo-router-scaffold/ @apollographql/router-core @apollographql/fed-core
 /examples/ @apollographql/router-core @apollographql/fed-core
 /.github/CODEOWNERS @apollographql/router-core @apollographql/fed-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,6 @@
 /apollo-router/ @apollographql/router-core @apollographql/fed-core
 /apollo-router/src/plugins/connectors @apollographql/connectors
 /apollo-router-benchmarks/ @apollographql/router-core @apollographql/fed-core
+/apollo-router-scaffold/ @apollographql/router-core @apollographql/fed-core
 /examples/ @apollographql/router-core @apollographql/fed-core
 /.github/CODEOWNERS @apollographql/router-core @apollographql/fed-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 /.changesets/ @apollographql/docs
 /apollo-federation/ @dariuszkuc @sachindshinde @goto-bus-stop @SimonSapin @lrlna @TylerBloom @duckki
 /apollo-federation/src/sources/connect @apollographql/connectors
-/apollo-router/ @apollographql/polaris @apollographql/atlas
+/apollo-router/ @apollographql/router-core @apollographql/fed-core
 /apollo-router/src/plugins/connectors @apollographql/connectors
-/apollo-router-benchmarks/ @apollographql/polaris @apollographql/atlas
-/apollo-router-scaffold/ @apollographql/polaris @apollographql/atlas
-/examples/ @apollographql/polaris @apollographql/atlas
-/.github/CODEOWNERS @apollographql/polaris @apollographql/atlas
+/apollo-router-benchmarks/ @apollographql/router-core @apollographql/fed-core
+/apollo-router-scaffold/ @apollographql/router-core @apollographql/fed-core
+/examples/ @apollographql/router-core @apollographql/fed-core
+/.github/CODEOWNERS @apollographql/router-core @apollographql/fed-core


### PR DESCRIPTION
Per comment from @goto-bus-stop  in https://github.com/apollographql/router/pull/6936#discussion_r1983194113