### PR TITLE
Update team names in CODEOWNERS (backport #6936)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 /docs/ @apollographql/docs
 /.changesets/ @apollographql/docs
-/apollo-federation/ @dariuszkuc @sachindshinde @goto-bus-stop @SimonSapin @lrlna @TylerBloom @duckki
+/apollo-federation/ @apollographql/fed-core @apollographql/rust-platform
 /apollo-federation/src/sources/connect @apollographql/connectors
 /apollo-router/ @apollographql/router-core @apollographql/fed-core
 /apollo-router-benchmarks/ @apollographql/router-core @apollographql/fed-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 /docs/ @apollographql/docs
 /.changesets/ @apollographql/docs
 /apollo-federation/ @dariuszkuc @sachindshinde @goto-bus-stop @SimonSapin @lrlna @TylerBloom @duckki
-/apollo-federation/src/sources/connect/json_selection @benjamn
-/apollo-router/ @apollographql/polaris @apollographql/atlas
-/apollo-router-benchmarks/ @apollographql/polaris @apollographql/atlas
-/apollo-router-scaffold/ @apollographql/polaris @apollographql/atlas
-/examples/ @apollographql/polaris @apollographql/atlas
-/.github/CODEOWNERS @apollographql/polaris @apollographql/atlas
+/apollo-federation/src/sources/connect @apollographql/connectors
+/apollo-router/ @apollographql/router-core @apollographql/fed-core
+/apollo-router-benchmarks/ @apollographql/router-core @apollographql/fed-core
+/apollo-router-scaffold/ @apollographql/router-core @apollographql/fed-core
+/examples/ @apollographql/router-core @apollographql/fed-core
+/.github/CODEOWNERS @apollographql/router-core @apollographql/fed-core


### PR DESCRIPTION
Updating these to new names that we're using internally.  I will backport this to a couple places to ensure they're not used still in actively enforced places.<hr>This is an automatic backport of pull request #6936 done by [Mergify](https://mergify.com).