### PR TITLE
Add assertion helpers to plugin test harness

### DIFF
--- a/apollo-router/src/plugins/limits/mod.rs
+++ b/apollo-router/src/plugins/limits/mod.rs
@@ -430,12 +430,10 @@ mod test {
     }
 
     async fn plugin() -> PluginTestHarness<LimitsPlugin> {
-        let plugin: PluginTestHarness<LimitsPlugin> = PluginTestHarness::new(
-            Some(include_str!("fixtures/content_length_limit.router.yaml")),
-            None,
-            None,
-        )
-        .await;
+        let plugin: PluginTestHarness<LimitsPlugin> = PluginTestHarness::builder()
+            .config(include_str!("fixtures/content_length_limit.router.yaml"))
+            .build()
+            .await;
         plugin
     }
 }

--- a/apollo-router/src/plugins/test/router_ext.rs
+++ b/apollo-router/src/plugins/test/router_ext.rs
@@ -1,0 +1,192 @@
+use std::fmt::Debug;
+
+use http_body_util::BodyExt;
+use itertools::Itertools;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use serde_json::json;
+
+use crate::plugins::test::RequestTestExt;
+use crate::plugins::test::ResponseTestExt;
+use crate::services::RouterRequest;
+use crate::services::RouterResponse;
+use crate::services::router;
+
+fn canned_request_body() -> Value {
+    json!({
+            "query":"query SimpleQuery {\ntopProducts {\n  name\n  price\n   \n}\n}"
+    })
+}
+
+fn canned_response_body() -> Value {
+    json!({
+        "data": {
+            "field": "value"
+        }
+    })
+}
+
+impl RequestTestExt<router::Request, router::Response> for RouterRequest {
+    fn canned_request() -> router::Request {
+        router::Request::fake_builder()
+            .body(canned_request_body().to_string())
+            .build()
+            .expect("canned request")
+    }
+
+    fn canned_result(self) -> router::ServiceResult {
+        router::Response::fake_builder()
+            .context(self.context.clone())
+            .data(json! ({"field": "value"}))
+            .build()
+    }
+
+    fn assert_context_eq<T>(&self, key: &str, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug,
+    {
+        let ctx_value = self
+            .context
+            .get::<_, T>(key)
+            .expect("context value not deserializable")
+            .expect("context value not found");
+        pretty_assertions::assert_eq!(ctx_value, value, "context '{}' value mismatch", key);
+    }
+
+    fn assert_context_contains(&self, key: &str) {
+        if !self.context.contains_key(key) {
+            panic!("context '{}' value not found", key)
+        }
+    }
+
+    fn assert_context_not_contains(&self, key: &str) {
+        if self.context.contains_key(key) {
+            panic!("context '{}' value was present", key)
+        }
+    }
+
+    fn assert_header_eq(&self, key: &str, value: &str) {
+        let header_value = self
+            .router_request
+            .headers()
+            .get(key)
+            .unwrap_or_else(|| panic!("header '{}' not found", key));
+        pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
+    }
+
+    async fn assert_body_eq<T>(&mut self, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug + Serialize,
+    {
+        let body_value = self
+            .router_request
+            .body_mut()
+            .collect()
+            .await
+            .expect("no body");
+        let body_bytes = body_value.to_bytes();
+        if body_bytes.is_empty() {
+            panic!("body value is empty");
+        }
+        let body_value = serde_json::from_slice::<serde_json::Value>(&body_bytes)
+            .expect("body value not deserializable");
+        let expected_value = serde_json::to_value(value).expect("expected value not serializable");
+        pretty_assertions::assert_eq!(
+            serde_yaml::to_string(&body_value).expect("could not serialize"),
+            serde_yaml::to_string(&expected_value).expect("could not serialize")
+        );
+    }
+
+    async fn assert_canned_body(&mut self) {
+        self.assert_body_eq(canned_request_body()).await
+    }
+}
+
+impl ResponseTestExt for RouterResponse {
+    fn assert_context_eq<T>(&self, key: &str, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug,
+    {
+        let ctx_value = self
+            .context
+            .get::<_, T>(key)
+            .expect("context value not deserializable")
+            .expect("context value not found");
+        pretty_assertions::assert_eq!(ctx_value, value, "context '{}' value mismatch", key);
+    }
+
+    fn assert_context_contains(&self, key: &str) {
+        if !self.context.contains_key(key) {
+            panic!("context '{}' value not found", key)
+        }
+    }
+
+    fn assert_context_not_contains(&self, key: &str) {
+        if self.context.contains_key(key) {
+            panic!("context '{}' value was present", key)
+        }
+    }
+
+    fn assert_header_eq(&self, key: &str, value: &str) {
+        let header_value = self
+            .response
+            .headers()
+            .get(key)
+            .unwrap_or_else(|| panic!("header '{}' not found", key));
+        pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
+    }
+
+    async fn assert_body_eq<T>(&mut self, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug + Serialize,
+    {
+        let body_value = self.response.body_mut().collect().await.expect("no body");
+        let body_bytes = body_value.to_bytes();
+        if body_bytes.is_empty() {
+            panic!("body value is empty");
+        }
+        let body_value = serde_json::from_slice::<serde_json::Value>(&body_bytes)
+            .expect("body value not deserializable");
+        let expected_value = serde_json::to_value(value).expect("expected value not serializable");
+        pretty_assertions::assert_eq!(
+            serde_yaml::to_string(&body_value).expect("could not serialize"),
+            serde_yaml::to_string(&expected_value).expect("could not serialize")
+        );
+    }
+
+    async fn assert_contains_error(&mut self, error: &Value) {
+        let body_value = self.response.body_mut().collect().await.expect("no body");
+        let body_bytes = body_value.to_bytes();
+        if body_bytes.is_empty() {
+            panic!("body value is empty");
+        }
+        let body_value = serde_json::from_slice::<serde_json::Value>(&body_bytes)
+            .expect("body value not deserializable");
+
+        let errors = body_value
+            .get("errors")
+            .expect("errors not found")
+            .as_array()
+            .expect("expected object");
+        if !errors.iter().contains(error) {
+            panic!(
+                "Expected error {}\nActual errors\n{}",
+                serde_yaml::to_string(error).expect("error"),
+                serde_yaml::to_string(errors).expect("errors")
+            )
+        }
+    }
+
+    async fn assert_canned_body(&mut self) {
+        self.assert_body_eq(canned_response_body()).await
+    }
+
+    fn assert_status_code(&self, status_code: ::http::StatusCode) {
+        pretty_assertions::assert_eq!(
+            self.response.status(),
+            status_code,
+            "http status code mismatch"
+        );
+    }
+}

--- a/apollo-router/src/plugins/test/subgraph_ext.rs
+++ b/apollo-router/src/plugins/test/subgraph_ext.rs
@@ -1,0 +1,174 @@
+use std::fmt::Debug;
+
+use itertools::Itertools;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use serde_json::json;
+
+use crate::graphql;
+use crate::plugins::test::RequestTestExt;
+use crate::plugins::test::ResponseTestExt;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
+use crate::services::subgraph;
+
+fn canned_request_body() -> Value {
+    json!({
+            "query":"query SimpleQuery {\ntopProducts {\n  name\n  price\n   \n}\n}"
+    })
+}
+
+fn canned_query() -> &'static str {
+    "query SimpleQuery {\ntopProducts {\n  name\n  price\n   \n}\n}"
+}
+
+fn canned_response_body() -> Value {
+    json!({
+        "field": "value"
+    })
+}
+
+fn canned_response_body_data() -> Value {
+    json!({
+        "data": {
+            "field": "value"
+        }
+    })
+}
+
+impl RequestTestExt<subgraph::Request, subgraph::Response> for SubgraphRequest {
+    fn canned_request() -> subgraph::Request {
+        subgraph::Request::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(graphql::Request::builder().query(canned_query()).build())
+                    .expect("canned request"),
+            )
+            .build()
+    }
+
+    fn canned_result(self) -> subgraph::ServiceResult {
+        Ok(subgraph::Response::fake_builder()
+            .context(self.context.clone())
+            .data(canned_response_body())
+            .build())
+    }
+
+    fn assert_context_eq<T>(&self, key: &str, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug,
+    {
+        let ctx_value = self
+            .context
+            .get::<_, T>(key)
+            .expect("context value not deserializable")
+            .expect("context value not found");
+        pretty_assertions::assert_eq!(ctx_value, value, "context '{}' value mismatch", key);
+    }
+
+    fn assert_context_contains(&self, key: &str) {
+        if !self.context.contains_key(key) {
+            panic!("context '{}' value not found", key)
+        }
+    }
+
+    fn assert_context_not_contains(&self, key: &str) {
+        if self.context.contains_key(key) {
+            panic!("context '{}' value was present", key)
+        }
+    }
+
+    fn assert_header_eq(&self, key: &str, value: &str) {
+        let header_value = self
+            .subgraph_request
+            .headers()
+            .get(key)
+            .unwrap_or_else(|| panic!("header '{}' not found", key));
+        pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
+    }
+
+    async fn assert_body_eq<T>(&mut self, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug + Serialize,
+    {
+        pretty_assertions::assert_eq!(
+            serde_yaml::to_string(&self.subgraph_request.body()).expect("could not serialize"),
+            serde_yaml::to_string(&value).expect("could not serialize")
+        );
+    }
+
+    async fn assert_canned_body(&mut self) {
+        self.assert_body_eq(canned_request_body()).await
+    }
+}
+
+impl ResponseTestExt for SubgraphResponse {
+    fn assert_context_eq<T>(&self, key: &str, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug,
+    {
+        let ctx_value = self
+            .context
+            .get::<_, T>(key)
+            .expect("context value not deserializable")
+            .expect("context value not found");
+        pretty_assertions::assert_eq!(ctx_value, value, "context '{}' value mismatch", key);
+    }
+
+    fn assert_context_contains(&self, key: &str) {
+        if !self.context.contains_key(key) {
+            panic!("context '{}' value not found", key)
+        }
+    }
+
+    fn assert_context_not_contains(&self, key: &str) {
+        if self.context.contains_key(key) {
+            panic!("context '{}' value was present", key)
+        }
+    }
+
+    fn assert_header_eq(&self, key: &str, value: &str) {
+        let header_value = self
+            .response
+            .headers()
+            .get(key)
+            .unwrap_or_else(|| panic!("header '{}' not found", key));
+        pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
+    }
+
+    async fn assert_body_eq<T>(&mut self, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug + Serialize,
+    {
+        pretty_assertions::assert_eq!(
+            serde_yaml::to_string(&self.response.body_mut()).expect("could not serialize"),
+            serde_yaml::to_string(&value).expect("could not serialize")
+        );
+    }
+
+    async fn assert_contains_error(&mut self, error: &Value) {
+        let errors = &self.response.body().errors;
+        let serialized = serde_json::to_value(errors).expect("could not serialize");
+        let serialized_errors = serialized.as_array().expect("expected array");
+        if !serialized_errors.iter().contains(error) {
+            panic!(
+                "Expected error {}\nActual errors\n{}",
+                serde_yaml::to_string(error).expect("error"),
+                serde_yaml::to_string(errors).expect("errors")
+            )
+        }
+    }
+
+    async fn assert_canned_body(&mut self) {
+        self.assert_body_eq(canned_response_body_data()).await
+    }
+
+    fn assert_status_code(&self, status_code: ::http::StatusCode) {
+        pretty_assertions::assert_eq!(
+            self.response.status(),
+            status_code,
+            "http status code mismatch"
+        );
+    }
+}

--- a/apollo-router/src/plugins/test/supergraph_ext.rs
+++ b/apollo-router/src/plugins/test/supergraph_ext.rs
@@ -1,0 +1,183 @@
+use std::fmt::Debug;
+
+use futures::StreamExt;
+use itertools::Itertools;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use serde_json::json;
+
+use crate::graphql;
+use crate::plugins::test::RequestTestExt;
+use crate::plugins::test::ResponseTestExt;
+use crate::services::SupergraphRequest;
+use crate::services::SupergraphResponse;
+use crate::services::supergraph;
+
+fn canned_request_body() -> Value {
+    json!({
+            "query":"query SimpleQuery {\ntopProducts {\n  name\n  price\n   \n}\n}"
+    })
+}
+
+fn canned_request_query() -> &'static str {
+    "query SimpleQuery {\ntopProducts {\n  name\n  price\n   \n}\n}"
+}
+
+fn canned_response_body() -> Value {
+    json!({
+            "field": "value"
+    })
+}
+
+fn canned_response_body_array() -> Value {
+    json!([{
+        "data": {
+            "field": "value"
+        }
+    }])
+}
+
+impl RequestTestExt<supergraph::Request, supergraph::Response> for SupergraphRequest {
+    fn canned_request() -> supergraph::Request {
+        supergraph::Request::fake_builder()
+            .query(canned_request_query())
+            .build()
+            .expect("canned request")
+    }
+
+    fn canned_result(self) -> supergraph::ServiceResult {
+        supergraph::Response::fake_builder()
+            .context(self.context.clone())
+            .data(canned_response_body())
+            .build()
+    }
+
+    fn assert_context_eq<T>(&self, key: &str, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug,
+    {
+        let ctx_value = self
+            .context
+            .get::<_, T>(key)
+            .expect("context value not deserializable")
+            .expect("context value not found");
+        pretty_assertions::assert_eq!(ctx_value, value, "context '{}' value mismatch", key);
+    }
+
+    fn assert_context_contains(&self, key: &str) {
+        if !self.context.contains_key(key) {
+            panic!("context '{}' value not found", key)
+        }
+    }
+
+    fn assert_context_not_contains(&self, key: &str) {
+        if self.context.contains_key(key) {
+            panic!("context '{}' value was present", key)
+        }
+    }
+
+    fn assert_header_eq(&self, key: &str, value: &str) {
+        let header_value = self
+            .supergraph_request
+            .headers()
+            .get(key)
+            .unwrap_or_else(|| panic!("header '{}' not found", key));
+        pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
+    }
+
+    async fn assert_body_eq<T>(&mut self, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug + Serialize,
+    {
+        pretty_assertions::assert_eq!(
+            serde_yaml::to_string(&self.supergraph_request.body_mut())
+                .expect("could not serialize"),
+            serde_yaml::to_string(&value).expect("could not serialize")
+        );
+    }
+
+    async fn assert_canned_body(&mut self) {
+        self.assert_body_eq(canned_request_body()).await
+    }
+}
+
+impl ResponseTestExt for SupergraphResponse {
+    fn assert_context_eq<T>(&self, key: &str, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug,
+    {
+        let ctx_value = self
+            .context
+            .get::<_, T>(key)
+            .expect("context value not deserializable")
+            .expect("context value not found");
+        pretty_assertions::assert_eq!(ctx_value, value, "context '{}' value mismatch", key);
+    }
+
+    fn assert_context_contains(&self, key: &str) {
+        if !self.context.contains_key(key) {
+            panic!("context '{}' value not found", key)
+        }
+    }
+
+    fn assert_context_not_contains(&self, key: &str) {
+        if self.context.contains_key(key) {
+            panic!("context '{}' value was present", key)
+        }
+    }
+
+    fn assert_header_eq(&self, key: &str, value: &str) {
+        let header_value = self
+            .response
+            .headers()
+            .get(key)
+            .unwrap_or_else(|| panic!("header '{}' not found", key));
+        pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
+    }
+
+    async fn assert_body_eq<T>(&mut self, value: T)
+    where
+        T: for<'de> Deserialize<'de> + Eq + PartialEq + Debug + Serialize,
+    {
+        let response_stream = self.response.body_mut();
+        let responses: Vec<_> = response_stream.collect().await;
+        pretty_assertions::assert_eq!(
+            serde_yaml::to_string(&responses).expect("could not serialize"),
+            serde_yaml::to_string(&value).expect("could not serialize")
+        );
+    }
+
+    async fn assert_contains_error(&mut self, error: &Value) {
+        let responses: Vec<graphql::Response> = self.response.body_mut().collect::<Vec<_>>().await;
+        let errors: Vec<Value> = responses.iter().fold(Vec::new(), |mut errors, r| {
+            errors.append(
+                &mut r
+                    .errors
+                    .iter()
+                    .map(|e| serde_json::to_value(e).expect("could not serialize error"))
+                    .collect::<Vec<_>>(),
+            );
+            errors
+        });
+        if !errors.iter().contains(error) {
+            panic!(
+                "Expected error {}\nActual errors\n{}",
+                serde_yaml::to_string(error).expect("error"),
+                serde_yaml::to_string(&errors).expect("errors")
+            )
+        }
+    }
+
+    async fn assert_canned_body(&mut self) {
+        self.assert_body_eq(canned_response_body_array()).await
+    }
+
+    fn assert_status_code(&self, status_code: ::http::StatusCode) {
+        pretty_assertions::assert_eq!(
+            self.response.status(),
+            status_code,
+            "http status code mismatch"
+        );
+    }
+}


### PR DESCRIPTION
Allows easy checking of headers/context/body etc.

This doesn't affect production code as it is only for tests.

Example:

```rust
#[tokio::test]
    async fn test_subgraph_service_assertions() {
        let test_harness: PluginTestHarness<MyTestPlugin> =
            PluginTestHarness::builder().build().await;

        let service = test_harness.subgraph_service("test_subgraph", |mut req| async move {
            req.assert_context_contains("request-context-key");
            req.assert_context_not_contains("non-existent-key");
            req.assert_context_eq("request-context-key", "request-context-value".to_string());
            req.assert_header_eq("x-request-header", "request-value");
            req.assert_body_eq(serde_json::json!({"query": "topProducts"}))
                .await;
            let context = req.context.clone();
            context
                .insert("response-context-key", "response-context-value".to_string())
                .expect("context");
            let mut headers = HeaderMap::new();
            headers.insert("x-custom-header", "test-value".parse().unwrap());
            Ok(subgraph::Response::fake_builder()
                .data(serde_json::json!({"field": "value"}))
                .headers(headers)
                .context(context)
                .build())
        });

        let context = Context::new();
        context
            .insert("request-context-key", "request-context-value".to_string())
            .unwrap();
        let mut response = service
            .call(
                subgraph::Request::fake_builder()
                    .subgraph_request(
                        ::http::Request::builder()
                            .header("x-request-header", "request-value")
                            .body(
                                graphql::Request::fake_builder()
                                    .query("topProducts".to_string())
                                    .build(),
                            )
                            .unwrap(),
                    )
                    .context(context)
                    .build(),
            )
            .await
            .unwrap();
        response.assert_header_eq("x-custom-header", "test-value");
        response.assert_context_contains("response-context-key");
        response.assert_context_eq("response-context-key", "response-context-value".to_string());
        response.assert_context_not_contains("non-existent-key");
        response.assert_status_code(::http::StatusCode::OK);
        response
            .assert_body_eq(serde_json::json!({"data": {"field": "value"}}))
            .await;
    }
```



<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
