### PR TITLE
Pattern for iterating over directive applications

### DIFF
--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -396,6 +396,7 @@ impl FederationSchema {
                     schema_directive: provides_directive_application,
                     sibling_directives: directives,
                     target: field_definition_position,
+                    target_return_type: field_definition.ty.inner_named_type(),
                 }));
             }
         }
@@ -447,6 +448,8 @@ pub(crate) struct ProvidesDirective<'schema> {
     sibling_directives: &'schema apollo_compiler::ast::DirectiveList,
     /// The schema position to which this directive is applied
     target: &'schema ObjectFieldDefinitionPosition,
+    /// The return type of the target field
+    target_return_type: &'schema Name,
 }
 
 /// A GraphQL schema with federation data that is known to be valid, and cheap to clone.

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -226,8 +226,8 @@ impl FederationSchema {
     pub(crate) fn context_directive_applications(
         &self,
     ) -> FallibleDirectiveIterator<ContextDirective> {
-        let federation_spec = get_federation_spec_definition_from_subgraph(&self)?;
-        let context_directive_definition = federation_spec.context_directive_definition(&self)?;
+        let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
+        let context_directive_definition = federation_spec.context_directive_definition(self)?;
         let context_directive_referencers = self
             .referencers()
             .get_directive(&context_directive_definition.name)?;
@@ -281,12 +281,13 @@ impl FederationSchema {
         Ok(applications)
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn from_context_directive_applications(
         &self,
     ) -> FallibleDirectiveIterator<FromContextDirective> {
-        let federation_spec = get_federation_spec_definition_from_subgraph(&self)?;
+        let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
         let from_context_directive_definition =
-            federation_spec.from_context_directive_definition(&self)?;
+            federation_spec.from_context_directive_definition(self)?;
         let from_context_directive_referencers = self
             .referencers()
             .get_directive(&from_context_directive_definition.name)?;
@@ -327,7 +328,7 @@ impl FederationSchema {
 
     pub(crate) fn key_directive_applications(&self) -> FallibleDirectiveIterator<KeyDirective> {
         let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
-        let key_directive_definition = federation_spec.key_directive_definition(&self)?;
+        let key_directive_definition = federation_spec.key_directive_definition(self)?;
         let key_directive_referencers = self
             .referencers()
             .get_directive(&key_directive_definition.name)?;
@@ -373,8 +374,8 @@ impl FederationSchema {
     pub(crate) fn provides_directive_applications(
         &self,
     ) -> FallibleDirectiveIterator<ProvidesDirective> {
-        let federation_spec = get_federation_spec_definition_from_subgraph(&self)?;
-        let provides_directive_definition = federation_spec.provides_directive_definition(&self)?;
+        let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
+        let provides_directive_definition = federation_spec.provides_directive_definition(self)?;
         let provides_directive_referencers = self
             .referencers()
             .get_directive(&provides_directive_definition.name)?;
@@ -404,8 +405,8 @@ impl FederationSchema {
     pub(crate) fn requires_directive_applications(
         &self,
     ) -> FallibleDirectiveIterator<RequiresDirective> {
-        let federation_spec = get_federation_spec_definition_from_subgraph(&self)?;
-        let requires_directive_definition = federation_spec.requires_directive_definition(&self)?;
+        let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
+        let requires_directive_definition = federation_spec.requires_directive_definition(self)?;
         let requires_directive_referencers = self
             .referencers()
             .get_directive(&requires_directive_definition.name)?;

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -234,51 +234,54 @@ impl FederationSchema {
 
         let mut applications = Vec::new();
         for interface_type_position in &context_directive_referencers.interface_types {
-            // TODO: Push these errors onto applications vec
-            let interface_type = interface_type_position
-                .get(self.schema())
-                .expect("can get self");
-            let directives = &interface_type.directives;
-            for directive in directives.get_all(&context_directive_definition.name) {
-                let arguments = federation_spec.context_directive_arguments(directive);
-                applications.push(arguments.map(|args| ContextDirective {
-                    arguments: args,
-                    schema_directive: directive,
-                    sibling_directives: directives,
-                    target: interface_type_position.clone().into(),
-                }));
+            match interface_type_position.get(self.schema()) {
+                Ok(interface_type) => {
+                    let directives = &interface_type.directives;
+                    for directive in directives.get_all(&context_directive_definition.name) {
+                        let arguments = federation_spec.context_directive_arguments(directive);
+                        applications.push(arguments.map(|args| ContextDirective {
+                            arguments: args,
+                            schema_directive: directive,
+                            sibling_directives: directives,
+                            target: interface_type_position.clone().into(),
+                        }));
+                    }
+                }
+                Err(error) => applications.push(Err(error.into())),
             }
         }
         for object_type_position in &context_directive_referencers.object_types {
-            // TODO: Push these errors onto applications vec
-            let object_type = object_type_position
-                .get(self.schema())
-                .expect("can get self");
-            let directives = &object_type.directives;
-            for directive in directives.get_all(&context_directive_definition.name) {
-                let arguments = federation_spec.context_directive_arguments(directive);
-                applications.push(arguments.map(|args| ContextDirective {
-                    arguments: args,
-                    schema_directive: directive,
-                    sibling_directives: directives,
-                    target: object_type_position.clone().into(),
-                }));
+            match object_type_position.get(self.schema()) {
+                Ok(object_type) => {
+                    let directives = &object_type.directives;
+                    for directive in directives.get_all(&context_directive_definition.name) {
+                        let arguments = federation_spec.context_directive_arguments(directive);
+                        applications.push(arguments.map(|args| ContextDirective {
+                            arguments: args,
+                            schema_directive: directive,
+                            sibling_directives: directives,
+                            target: object_type_position.clone().into(),
+                        }));
+                    }
+                }
+                Err(error) => applications.push(Err(error.into())),
             }
         }
         for union_type_position in &context_directive_referencers.union_types {
-            // TODO: Push these errors onto applications vec
-            let union_type = union_type_position
-                .get(self.schema())
-                .expect("can get self");
-            let directives = &union_type.directives;
-            for directive in directives.get_all(&context_directive_definition.name) {
-                let arguments = federation_spec.context_directive_arguments(directive);
-                applications.push(arguments.map(|args| ContextDirective {
-                    arguments: args,
-                    schema_directive: directive,
-                    sibling_directives: directives,
-                    target: union_type_position.clone().into(),
-                }));
+            match union_type_position.get(self.schema()) {
+                Ok(union_type) => {
+                    let directives = &union_type.directives;
+                    for directive in directives.get_all(&context_directive_definition.name) {
+                        let arguments = federation_spec.context_directive_arguments(directive);
+                        applications.push(arguments.map(|args| ContextDirective {
+                            arguments: args,
+                            schema_directive: directive,
+                            sibling_directives: directives,
+                            target: union_type_position.clone().into(),
+                        }));
+                    }
+                }
+                Err(error) => applications.push(Err(error.into())),
             }
         }
         Ok(applications)
@@ -298,35 +301,39 @@ impl FederationSchema {
         for interface_field_argument_position in
             &from_context_directive_referencers.interface_field_arguments
         {
-            let interface_field_argument = interface_field_argument_position
-                .get(self.schema())
-                .expect("can get self");
-            let directives = &interface_field_argument.directives;
-            for directive in directives.get_all(&from_context_directive_definition.name) {
-                let arguments = federation_spec.from_context_directive_arguments(directive);
-                applications.push(arguments.map(|args| FromContextDirective {
-                    arguments: args,
-                    schema_directive: directive,
-                    sibling_directives: directives,
-                    target: interface_field_argument_position.clone().into(),
-                }));
+            match interface_field_argument_position.get(self.schema()) {
+                Ok(interface_field_argument) => {
+                    let directives = &interface_field_argument.directives;
+                    for directive in directives.get_all(&from_context_directive_definition.name) {
+                        let arguments = federation_spec.from_context_directive_arguments(directive);
+                        applications.push(arguments.map(|args| FromContextDirective {
+                            arguments: args,
+                            schema_directive: directive,
+                            sibling_directives: directives,
+                            target: interface_field_argument_position.clone().into(),
+                        }));
+                    }
+                }
+                Err(error) => applications.push(Err(error.into())),
             }
         }
         for object_field_argument_position in
             &from_context_directive_referencers.object_field_arguments
         {
-            let object_field_argument = object_field_argument_position
-                .get(self.schema())
-                .expect("can get self");
-            let directives = &object_field_argument.directives;
-            for directive in directives.get_all(&from_context_directive_definition.name) {
-                let arguments = federation_spec.from_context_directive_arguments(directive);
-                applications.push(arguments.map(|args| FromContextDirective {
-                    arguments: args,
-                    schema_directive: directive,
-                    sibling_directives: directives,
-                    target: object_field_argument_position.clone().into(),
-                }));
+            match object_field_argument_position.get(self.schema()) {
+                Ok(object_field_argument) => {
+                    let directives = &object_field_argument.directives;
+                    for directive in directives.get_all(&from_context_directive_definition.name) {
+                        let arguments = federation_spec.from_context_directive_arguments(directive);
+                        applications.push(arguments.map(|args| FromContextDirective {
+                            arguments: args,
+                            schema_directive: directive,
+                            sibling_directives: directives,
+                            target: object_field_argument_position.clone().into(),
+                        }));
+                    }
+                }
+                Err(error) => applications.push(Err(error.into())),
             }
         }
         Ok(applications)
@@ -341,33 +348,37 @@ impl FederationSchema {
 
         let mut applications: Vec<Result<KeyDirective, FederationError>> = Vec::new();
         for object_type_position in &key_directive_referencers.object_types {
-            let object_type = object_type_position
-                .get(self.schema())
-                .expect("can get self");
-            let directives = &object_type.directives;
-            for directive in directives.get_all(&key_directive_definition.name) {
-                let arguments = federation_spec.key_directive_arguments(directive);
-                applications.push(arguments.map(|args| KeyDirective {
-                    arguments: args,
-                    schema_directive: directive,
-                    sibling_directives: directives,
-                    target: object_type_position.clone().into(),
-                }));
+            match object_type_position.get(self.schema()) {
+                Ok(object_type) => {
+                    let directives = &object_type.directives;
+                    for directive in directives.get_all(&key_directive_definition.name) {
+                        let arguments = federation_spec.key_directive_arguments(directive);
+                        applications.push(arguments.map(|args| KeyDirective {
+                            arguments: args,
+                            schema_directive: directive,
+                            sibling_directives: directives,
+                            target: object_type_position.clone().into(),
+                        }));
+                    }
+                }
+                Err(error) => applications.push(Err(error.into())),
             }
         }
         for interface_type_position in &key_directive_referencers.interface_types {
-            let interface_type = interface_type_position
-                .get(self.schema())
-                .expect("can get self");
-            let directives = &interface_type.directives;
-            for directive in directives.get_all(&key_directive_definition.name) {
-                let arguments = federation_spec.key_directive_arguments(directive);
-                applications.push(arguments.map(|args| KeyDirective {
-                    arguments: args,
-                    schema_directive: directive,
-                    sibling_directives: directives,
-                    target: interface_type_position.clone().into(),
-                }));
+            match interface_type_position.get(self.schema()) {
+                Ok(interface_type) => {
+                    let directives = &interface_type.directives;
+                    for directive in directives.get_all(&key_directive_definition.name) {
+                        let arguments = federation_spec.key_directive_arguments(directive);
+                        applications.push(arguments.map(|args| KeyDirective {
+                            arguments: args,
+                            schema_directive: directive,
+                            sibling_directives: directives,
+                            target: interface_type_position.clone().into(),
+                        }));
+                    }
+                }
+                Err(error) => applications.push(Err(error.into())),
             }
         }
         Ok(applications)
@@ -384,20 +395,24 @@ impl FederationSchema {
 
         let mut applications: Vec<Result<ProvidesDirective, FederationError>> = Vec::new();
         for field_definition_position in &provides_directive_referencers.object_fields {
-            let field_definition = field_definition_position.get(self.schema())?;
-            let directives = &field_definition.directives;
-            for provides_directive_application in
-                directives.get_all(&provides_directive_definition.name)
-            {
-                let arguments =
-                    federation_spec.provides_directive_arguments(provides_directive_application);
-                applications.push(arguments.map(|args| ProvidesDirective {
-                    arguments: args,
-                    schema_directive: provides_directive_application,
-                    sibling_directives: directives,
-                    target: field_definition_position,
-                    target_return_type: field_definition.ty.inner_named_type(),
-                }));
+            match field_definition_position.get(self.schema()) {
+                Ok(field_definition) => {
+                    let directives = &field_definition.directives;
+                    for provides_directive_application in
+                        directives.get_all(&provides_directive_definition.name)
+                    {
+                        let arguments = federation_spec
+                            .provides_directive_arguments(provides_directive_application);
+                        applications.push(arguments.map(|args| ProvidesDirective {
+                            arguments: args,
+                            schema_directive: provides_directive_application,
+                            sibling_directives: directives,
+                            target: field_definition_position,
+                            target_return_type: field_definition.ty.inner_named_type(),
+                        }));
+                    }
+                }
+                Err(error) => applications.push(Err(error.into())),
             }
         }
         Ok(applications)

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -367,6 +367,9 @@ impl ExternalMetadata {
             let has_extends_directive = key_directive
                 .sibling_directives
                 .has(&extends_directive_definition.name);
+            // PORT_NOTE: The JS codebase treats the "extend" GraphQL keyword as applying to
+            // only the extension it's on, while it treats the "@extends" directive as applying
+            // to all definitions/extensions in the subgraph. We accordingly do the same.
             if has_extends_directive
                 || key_directive
                     .schema_directive

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -140,7 +140,7 @@ impl SubgraphMetadata {
         for provides_directive in applications.into_iter().filter_map(|res| res.ok()) {
             provided_fields.extend(collect_target_fields_from_field_set(
                 unwrap_schema(schema),
-                provides_directive.target.type_name.clone(),
+                provides_directive.target_return_type.clone(),
                 provides_directive.arguments.fields,
                 false,
             )?);


### PR DESCRIPTION
Implements a pattern for iterating over all applications of a particular directive. In JS, this is called as `directive.applications()` on some directive definition. In Rust, the directive definition itself doesn't have a pointer back to the `FederationSchema`, so the schema will return the iterators. There is a different iterator for each directive because the contained fields don't have useful common types, and this tries to provide a simply, strongly-typed directive representation for consumption.

<!-- FED-513 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
