### PR TITLE
refactor(federation): QP correctness checker refactoring

### DIFF
--- a/apollo-federation/src/correctness/query_plan_analysis.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis.rs
@@ -116,6 +116,10 @@ impl ResponseShape {
 
 //==================================================================================================
 // Interpretation of QueryPlan
+// - `interpret_*_node` functions returns the response shape that will be fetched by the node,
+//   including its sub-nodes.
+// - They take the `state` parameter that represents everything that has been fetched so far,
+//   which is used to check the soundness property of the query plan.
 
 fn format_federation_error(e: FederationError) -> String {
     match e {
@@ -162,18 +166,7 @@ fn interpret_top_level_plan_node(
         }
         TopLevelPlanNode::Defer(defer) => interpret_defer_node(schema, state, &conditions, defer),
         TopLevelPlanNode::Subscription(subscription) => {
-            let mut result =
-                interpret_fetch_node(schema, state, &conditions, &subscription.primary)?;
-            if let Some(rest) = &subscription.rest {
-                let rest = interpret_plan_node(schema, &result, &conditions, rest)?;
-                result.merge_with(&rest).map_err(|e| {
-                    format!(
-                        "Failed to merge response shapes in subscription node: {}\nrest: {rest}",
-                        format_federation_error(e),
-                    )
-                })?;
-            }
-            Ok(result)
+            interpret_subscription_node(schema, state, &conditions, subscription)
         }
     }
 }
@@ -207,7 +200,7 @@ fn interpret_plan_node(
 // - Also, multiple type conditions can be accumulated (meaning the conjunction of them).
 fn rename_at_path(
     schema: &ValidFederationSchema,
-    state: &ResponseShape,
+    response: &ResponseShape,
     mut type_filter: Vec<Name>,
     path: &[FetchDataPathElement],
     new_name: Name,
@@ -220,9 +213,9 @@ fn rename_at_path(
             if _conditions.is_some() {
                 return Err("rename_at_path: unexpected key conditions".to_string());
             }
-            let Some(defs) = state.get(name) else {
-                // If some sub-states don't have the name, skip it and return the same state.
-                return Ok(state.clone());
+            let Some(defs) = response.get(name) else {
+                // If the response doesn't have the named key, skip it and return the same response.
+                return Ok(response.clone());
             };
             let rename_here = rest.is_empty();
             // Compute the normalized type condition for the type filter.
@@ -245,7 +238,7 @@ fn rename_at_path(
             } else {
                 None
             };
-            // Interpret the node in every matching sub-state.
+            // Apply renaming in every matching sub-response.
             let mut updated_defs = PossibleDefinitions::default(); // for the old name
             let mut target_defs = PossibleDefinitions::default(); // for the new name
             for (type_cond, defs_per_type_cond) in defs.iter() {
@@ -262,7 +255,7 @@ fn rename_at_path(
                     continue;
                 }
 
-                // otherwise, rename in the sub-states
+                // otherwise, rename in the sub-response
                 let updated_variants =
                     defs_per_type_cond
                         .conditional_variants()
@@ -292,7 +285,7 @@ fn rename_at_path(
                     defs_per_type_cond.with_updated_conditional_variants(updated_variants);
                 updated_defs.insert(type_cond.clone(), updated_defs_per_type_cond);
             }
-            let mut result = state.clone();
+            let mut result = response.clone();
             result.insert(name.clone(), updated_defs);
             if rename_here {
                 // also, update the new response key
@@ -323,7 +316,7 @@ fn rename_at_path(
         }
         FetchDataPathElement::TypenameEquals(type_name) => {
             type_filter.push(type_name.clone());
-            rename_at_path(schema, state, type_filter, rest, new_name)
+            rename_at_path(schema, response, type_filter, rest, new_name)
         }
         FetchDataPathElement::Parent => {
             Err("rename_at_path: unexpected parent path element".to_string())
@@ -333,7 +326,7 @@ fn rename_at_path(
 
 fn apply_rewrites(
     schema: &ValidFederationSchema,
-    state: &ResponseShape,
+    response: &ResponseShape,
     rewrite: &FetchDataRewrite,
 ) -> Result<ResponseShape, String> {
     match rewrite {
@@ -342,7 +335,7 @@ fn apply_rewrites(
         }
         FetchDataRewrite::KeyRenamer(renamer) => rename_at_path(
             schema,
-            state,
+            response,
             Default::default(), // new type filter
             &renamer.path,
             renamer.rename_key_to.clone(),
@@ -366,8 +359,8 @@ fn interpret_fetch_node(
     }
     .map_err(|e| {
         format!(
-            "Failed to compute the response shape from fetch node: {}\nnode: {fetch}",
-            format_federation_error(e),
+            "Failed to compute the response shape from fetch node: {e}\
+             node: {fetch}"
         )
     })?;
     for rewrite in &fetch.output_rewrites {
@@ -421,16 +414,14 @@ fn interpret_condition_node(
             let else_val = interpret_plan_node(schema, state, &sub_conditions_neg, else_clause)?;
             let mut result = if_val;
             result.merge_with(&else_val).map_err(|e| {
-                format!(
-                    "Failed to merge response shapes from then and else clauses:\n{}",
-                    format_federation_error(e),
-                )
+                format!("Failed to merge response shapes from then and else clauses:\n{e}",)
             })?;
             Ok(result)
         }
     }
 }
 
+/// The inner recursive part of `interpret_flatten_node`.
 fn interpret_plan_node_at_path(
     schema: &ValidFederationSchema,
     state: &ResponseShape,
@@ -443,87 +434,27 @@ fn interpret_plan_node_at_path(
         return Ok(Some(interpret_plan_node(schema, state, conditions, node)?));
     };
     match first {
-        FetchDataPathElement::Key(name, next_type_condition) => {
-            // Note: `next_type_condition` is applied to the next key down the path.
-            let filter_type_cond = type_condition
-                .map(|cond| {
-                    let obj_types: Result<Vec<ObjectTypeDefinitionPosition>, FederationError> =
-                        cond.iter()
-                            .map(|name| {
-                                let ty: ObjectTypeDefinitionPosition =
-                                    schema.get_type(name.clone())?.try_into()?;
-                                Ok(ty)
-                            })
-                            .collect();
-                    let obj_types = obj_types.map_err(format_federation_error)?;
-                    Ok::<_, String>(NormalizedTypeCondition::from_object_types(
-                        obj_types.into_iter(),
-                    ))
-                })
-                .transpose()?;
-            let Some(defs) = state.get(name) else {
-                // If some sub-states don't have the name, skip it and return None.
-                // However, one of the `defs` must have one sub-state that has the name (see below).
+        FetchDataPathElement::Key(response_key, next_type_condition) => {
+            let Some(state_defs) = state.get(response_key) else {
+                // If some sub-states don't have the key, skip them and return None.
                 return Ok(None);
             };
-            // Interpret the node in every matching sub-state.
-            let mut updated_defs = PossibleDefinitions::default();
-            for (type_cond, defs_per_type_cond) in defs.iter() {
-                if let Some(filter_type_cond) = &filter_type_cond {
-                    if !filter_type_cond.implies(type_cond) {
-                        // Not applicable => same as before
-                        updated_defs.insert(type_cond.clone(), defs_per_type_cond.clone());
-                        continue;
-                    }
-                }
-                let updated_variants =
-                    defs_per_type_cond
-                        .conditional_variants()
-                        .iter()
-                        .filter_map(|variant| {
-                            let Some(sub_state) = variant.sub_selection_response_shape() else {
-                                return Some(Err(format!(
-                                    "No sub-selection at path: {}",
-                                    path.iter()
-                                        .map(|p| p.to_string())
-                                        .collect::<Vec<_>>()
-                                        .join(".")
-                                )));
-                            };
-                            let updated_sub_state = interpret_plan_node_at_path(
-                                schema,
-                                sub_state,
-                                conditions,
-                                next_type_condition.as_ref(),
-                                rest,
-                                node,
-                            );
-                            match updated_sub_state {
-                                Err(e) => Some(Err(e)),
-                                Ok(updated_sub_state) => {
-                                    updated_sub_state.map(|updated_sub_state| {
-                                        Ok(variant.with_updated_sub_selection_response_shape(
-                                            updated_sub_state,
-                                        ))
-                                    })
-                                }
-                            }
-                        });
-                let updated_variants: Result<Vec<_>, _> = updated_variants.collect();
-                let updated_variants = updated_variants?;
-                if !updated_variants.is_empty() {
-                    let updated_defs_per_type_cond =
-                        defs_per_type_cond.with_updated_conditional_variants(updated_variants);
-                    updated_defs.insert(type_cond.clone(), updated_defs_per_type_cond);
-                }
-            }
-            if updated_defs.is_empty() {
-                // Nothing to interpret here => return None
+            let response_defs = interpret_plan_node_for_matching_conditions(
+                schema,
+                state_defs,
+                type_condition,
+                conditions,
+                next_type_condition,
+                rest,
+                node,
+            )?;
+            if response_defs.is_empty() {
+                // No state definitions match the given condition => return None
                 return Ok(None);
             }
-            let mut result = state.clone();
-            result.insert(name.clone(), updated_defs);
-            Ok(Some(result))
+            let mut response_shape = ResponseShape::new(state.default_type_condition().clone());
+            response_shape.insert(response_key.clone(), response_defs);
+            Ok(Some(response_shape))
         }
         FetchDataPathElement::AnyIndex(next_type_condition) => {
             if type_condition.is_some() {
@@ -539,13 +470,88 @@ fn interpret_plan_node_at_path(
     }
 }
 
+/// Interpret the plan node for all matching conditions.
+/// Returns a collection of definitions by the type and Boolean conditions.
+fn interpret_plan_node_for_matching_conditions(
+    schema: &ValidFederationSchema,
+    state_defs: &PossibleDefinitions,
+    type_condition: Option<&Vec<Name>>,
+    boolean_conditions: &[Literal],
+    next_type_condition: &Option<Vec<Name>>,
+    next_path: &[FetchDataPathElement],
+    node: &PlanNode,
+) -> Result<PossibleDefinitions, String> {
+    // Note: `next_type_condition` is applied to the next key down the path.
+    let filter_type_cond = normalize_type_condition(schema, &type_condition)?;
+    let mut response_defs = PossibleDefinitions::default();
+    for (type_cond, defs_per_type_cond) in state_defs.iter() {
+        if let Some(filter_type_cond) = &filter_type_cond {
+            if !filter_type_cond.implies(type_cond) {
+                // Not applicable => skip
+                continue;
+            }
+        }
+        let response_variants =
+            defs_per_type_cond
+                .conditional_variants()
+                .iter()
+                .filter_map(|variant| {
+                    let Some(sub_state) = variant.sub_selection_response_shape() else {
+                        return Some(Err(format!("No sub-selection for variant: {variant}")));
+                    };
+                    let sub_rs = interpret_plan_node_at_path(
+                        schema,
+                        sub_state,
+                        boolean_conditions,
+                        next_type_condition.as_ref(),
+                        next_path,
+                        node,
+                    );
+                    match sub_rs {
+                        Err(e) => Some(Err(e)),
+                        Ok(sub_rs) => sub_rs.map(|sub_rs| {
+                            Ok(variant.with_updated_sub_selection_response_shape(sub_rs))
+                        }),
+                    }
+                });
+        let response_variants: Result<Vec<_>, _> = response_variants.collect();
+        let response_variants = response_variants?;
+        if !response_variants.is_empty() {
+            let response_defs_per_type_cond =
+                defs_per_type_cond.with_updated_conditional_variants(response_variants);
+            response_defs.insert(type_cond.clone(), response_defs_per_type_cond);
+        }
+    }
+    Ok(response_defs)
+}
+
+fn normalize_type_condition(
+    schema: &ValidFederationSchema,
+    type_condition: &Option<&Vec<Name>>,
+) -> Result<Option<NormalizedTypeCondition>, String> {
+    let Some(type_condition) = type_condition else {
+        return Ok(None);
+    };
+    let obj_types: Result<Vec<_>, _> = type_condition
+        .iter()
+        .map(|name| {
+            let ty: ObjectTypeDefinitionPosition = schema.get_type(name.clone())?.try_into()?;
+            Ok(ty)
+        })
+        .collect();
+    let obj_types = obj_types.map_err(format_federation_error)?;
+    Ok(Some(NormalizedTypeCondition::from_object_types(
+        obj_types.into_iter(),
+    )))
+}
+
 fn interpret_flatten_node(
     schema: &ValidFederationSchema,
     state: &ResponseShape,
     conditions: &[Literal],
     flatten: &FlattenNode,
 ) -> Result<ResponseShape, String> {
-    let result = interpret_plan_node_at_path(
+    let response_shape = interpret_plan_node_at_path(
         schema,
         state,
         conditions,
@@ -553,13 +559,13 @@ fn interpret_flatten_node(
         &flatten.path,
         &flatten.node,
     )?;
-    let Some(result) = result else {
+    let Some(response_shape) = response_shape else {
         // `flatten.path` is addressing a non-existing response object.
         // Ideally, this should not happen, but QP may try to fetch infeasible selections.
         // TODO: Report this as a over-fetching later.
-        return Ok(state.clone());
+        return Ok(ResponseShape::new(state.default_type_condition().clone()));
     };
-    Ok(result.simplify_boolean_conditions())
+    Ok(response_shape.simplify_boolean_conditions())
 }
 
 fn interpret_sequence_node(
@@ -568,13 +574,22 @@ fn interpret_sequence_node(
     conditions: &[Literal],
     sequence: &SequenceNode,
 ) -> Result<ResponseShape, String> {
-    let mut response_shape = state.clone();
+    let mut state = state.clone();
+    let mut response_shape = ResponseShape::new(state.default_type_condition().clone());
     for node in &sequence.nodes {
-        let node_rs = interpret_plan_node(schema, &response_shape, conditions, node)?;
+        let node_rs = interpret_plan_node(schema, &state, conditions, node)?;
+
+        // Update both state and response_shape
+        state.merge_with(&node_rs).map_err(|e| {
+            format!(
+                "Failed to merge state in sequence node: {e}\
+                 node: {node}",
+            )
+        })?;
         response_shape.merge_with(&node_rs).map_err(|e| {
             format!(
-                "Failed to merge response shapes in sequence node: {}\nnode: {node}",
-                format_federation_error(e),
+                "Failed to merge response shapes in sequence node: {e}\
+                 node: {node}"
             )
         })?;
     }
@@ -587,14 +602,14 @@ fn interpret_parallel_node(
     conditions: &[Literal],
     parallel: &ParallelNode,
 ) -> Result<ResponseShape, String> {
-    let mut response_shape = state.clone();
+    let mut response_shape = ResponseShape::new(state.default_type_condition().clone());
     for node in &parallel.nodes {
         // Note: Use the same original state for each parallel node
         let node_rs = interpret_plan_node(schema, state, conditions, node)?;
         response_shape.merge_with(&node_rs).map_err(|e| {
             format!(
-                "Failed to merge response shapes in parallel node: {}\nnode: {node}",
-                format_federation_error(e),
+                "Failed to merge response shapes in parallel node: {e}\
+                 node: {node}"
             )
         })?;
     }
@@ -607,28 +622,66 @@ fn interpret_defer_node(
     conditions: &[Literal],
     defer: &DeferNode,
 ) -> Result<ResponseShape, String> {
-    // new `state` after the primary node
-    let state = if let Some(primary_node) = &defer.primary.node {
-        &interpret_plan_node(schema, state, conditions, primary_node)?
+    let mut response_shape;
+    let mut state = state.clone();
+    if let Some(primary_node) = &defer.primary.node {
+        response_shape = interpret_plan_node(schema, &state, conditions, primary_node)?;
+        // Update the `state` after the primary node
+        state.merge_with(&response_shape).map_err(|e| {
+            format!(
+                "Failed to merge state in defer node: {e}\
+                 state: {state}\
+                 primary node response shape: {response_shape}",
+            )
+        })?;
     } else {
-        state
-    };
+        response_shape = ResponseShape::new(state.default_type_condition().clone());
+    }
 
     // interpret the deferred nodes and merge their response shapes.
-    let mut result = state.clone();
     for defer_block in &defer.deferred {
         let Some(node) = &defer_block.node else {
             // Nothing to do => skip
             continue;
         };
-        // Note: Use the same primary node state for each parallel node
-        let node_rs = interpret_plan_node(schema, state, conditions, node)?;
-        result.merge_with(&node_rs).map_err(|e| {
+        // Note: Use the same state (after the primary) for each deferred node
+        let defer_rs = interpret_plan_node(schema, &state, conditions, node)?;
+        response_shape.merge_with(&defer_rs).map_err(|e| {
             format!(
-                "Failed to merge response shapes in deferred node: {}\nnode: {node}",
-                format_federation_error(e),
+                "Failed to merge response shapes in deferred node: {e}\
+                 previous response_shape: {response_shape}\
+                 deferred block response shape: {defer_rs}",
             )
         })?;
     }
-    Ok(result)
+    Ok(response_shape)
+}
+
+fn interpret_subscription_node(
+    schema: &ValidFederationSchema,
+    state: &ResponseShape,
+    conditions: &[Literal],
+    subscription: &crate::query_plan::SubscriptionNode,
+) -> Result<ResponseShape, String> {
+    let mut response_shape =
+        interpret_fetch_node(schema, state, conditions, &subscription.primary)?;
+    if let Some(rest) = &subscription.rest {
+        let mut state = state.clone();
+        state.merge_with(&response_shape).map_err(|e| {
+            format!(
+                "Failed to merge state in subscription node: {e}\
+                 state: {state}\
+                 primary response shape: {response_shape}",
+            )
+        })?;
+        let rest_rs = interpret_plan_node(schema, &state, conditions, rest)?;
+        response_shape.merge_with(&rest_rs).map_err(|e| {
+            format!(
+                "Failed to merge response shapes in subscription node: {e}\
+                 previous response shape: {response_shape}\
+                 rest response shape: {rest_rs}",
+            )
+        })?;
+    }
+    Ok(response_shape)
 }

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -114,6 +114,7 @@ fn runtime_types_implies(
 
 /// Constructs a set of object types
 /// - Slow: calls `possible_runtime_types` and sorts the result.
+/// - Note: May return an empty set if the type has no runtime types.
 fn get_ground_types(
     ty: &CompositeTypeDefinitionPosition,
     schema: &ValidFederationSchema,
@@ -172,8 +173,7 @@ impl DisplayTypeCondition {
 #[derive(Debug, Clone)]
 pub struct NormalizedTypeCondition {
     // The set of object types that are used for comparison.
-    // - The empty ground_set means the `_Entity` type.
-    // - The ground_set must be non-empty, if it's not the `_Entity` type.
+    // - The ground_set must be non-empty.
     // - The ground_set must be sorted by type name.
     ground_set: Vec<ObjectTypeDefinitionPosition>,
 
@@ -198,15 +198,20 @@ impl std::hash::Hash for NormalizedTypeCondition {
 // Public constructors & accessors
 impl NormalizedTypeCondition {
     /// Construct a new type condition with a single named type condition.
+    /// - Returns None if the name type has no runtime types (an interface with no implementors).
     pub(crate) fn from_type_name(
         name: Name,
         schema: &ValidFederationSchema,
-    ) -> Result<Self, FederationError> {
+    ) -> Result<Option<Self>, FederationError> {
         let ty: CompositeTypeDefinitionPosition = schema.get_type(name)?.try_into()?;
-        Ok(NormalizedTypeCondition {
-            ground_set: get_ground_types(&ty, schema)?,
+        let ground_set = get_ground_types(&ty, schema)?;
+        if ground_set.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(NormalizedTypeCondition {
+            ground_set,
             for_display: DisplayTypeCondition::new(ty),
-        })
+        }))
     }
 
     pub(crate) fn from_object_type(ty: &ObjectTypeDefinitionPosition) -> Self {
@@ -216,24 +221,19 @@ impl NormalizedTypeCondition {
         }
     }
 
+    /// Precondition: `types` must be non-empty.
     pub(crate) fn from_object_types(
         types: impl Iterator<Item = ObjectTypeDefinitionPosition>,
-    ) -> Self {
+    ) -> Result<Self, FederationError> {
         let mut ground_set: Vec<_> = types.collect();
+        if ground_set.is_empty() {
+            bail!("Unexpected empty type list for from_object_types")
+        }
         ground_set.sort_by(|a, b| a.type_name.cmp(&b.type_name));
-        NormalizedTypeCondition {
+        Ok(NormalizedTypeCondition {
             ground_set,
             for_display: DisplayTypeCondition::deduced(),
-        }
-    }
-
-    /// Special constructor with empty conditions (logically contains *all* types).
-    /// - Used for the `_Entity` type.
-    pub(crate) fn unconstrained() -> Self {
-        NormalizedTypeCondition {
-            ground_set: Vec::new(),
-            for_display: DisplayTypeCondition::deduced(),
-        }
+        })
     }
 
     pub(crate) fn ground_set(&self) -> &[ObjectTypeDefinitionPosition] {
@@ -266,7 +266,6 @@ impl NormalizedTypeCondition {
         display_rest.is_empty() && display_first.is_object_type()
     }
 
-    /// precondition: `self` and `other` are not empty.
     pub fn implies(&self, other: &Self) -> bool {
         self.ground_set.iter().all(|t| other.ground_set.contains(t))
     }
@@ -274,6 +273,7 @@ impl NormalizedTypeCondition {
 
 impl NormalizedTypeCondition {
     /// Construct a new type condition with a named type condition added.
+    /// - Returns None if the new type condition is unsatisfiable.
     pub(crate) fn add_type_name(
         &self,
         name: Name,
@@ -282,14 +282,6 @@ impl NormalizedTypeCondition {
         let other_ty: CompositeTypeDefinitionPosition =
             schema.get_type(name.clone())?.try_into()?;
         let other_types = get_ground_types(&other_ty, schema)?;
-        if self.ground_set.is_empty() {
-            // Special case: The `self` is the `_Entity` type.
-            // - Just returns `other`, since _Entity ∩ other = other.
-            return Ok(Some(NormalizedTypeCondition {
-                ground_set: other_types,
-                for_display: DisplayTypeCondition::new(other_ty),
-            }));
-        }
         let ground_set: Vec<ObjectTypeDefinitionPosition> = self
             .ground_set
             .iter()
@@ -313,11 +305,13 @@ impl NormalizedTypeCondition {
         }
     }
 
+    /// Compute the `field`'s type condition considering the parent type condition.
+    /// - Returns None if the resulting type condition has no possible object types.
     fn field_type_condition(
         &self,
         field: &Field,
         schema: &ValidFederationSchema,
-    ) -> Result<Self, FederationError> {
+    ) -> Result<Option<Self>, FederationError> {
         let declared_type = field.ty().inner_named_type();
 
         // Collect all possible object types for the field in the given parent type condition.
@@ -345,22 +339,27 @@ impl NormalizedTypeCondition {
             let pos_types = schema.possible_runtime_types(pos)?;
             ground_types.extend(pos_types.into_iter());
         }
-
-        // Simple case #2 - `declared_type` is same as the collected types.
-        let declared_type_cond =
-            NormalizedTypeCondition::from_type_name(declared_type.clone(), schema)?;
-        if declared_type_cond.ground_set.len() == ground_types.len()
-            && declared_type_cond
-                .ground_set
-                .iter()
-                .all(|t| ground_types.contains(t))
-        {
-            return Ok(declared_type_cond);
+        if ground_types.is_empty() {
+            return Ok(None);
         }
 
-        Ok(NormalizedTypeCondition::from_object_types(
+        // Simple case #2 - `declared_type` is same as the collected types.
+        if let Some(declared_type_cond) =
+            NormalizedTypeCondition::from_type_name(declared_type.clone(), schema)?
+        {
+            if declared_type_cond.ground_set.len() == ground_types.len()
+                && declared_type_cond
+                    .ground_set
+                    .iter()
+                    .all(|t| ground_types.contains(t))
+            {
+                return Ok(Some(declared_type_cond));
+            }
+        }
+
+        Ok(Some(NormalizedTypeCondition::from_object_types(
             ground_types.into_iter(),
-        ))
+        )?))
     }
 }
 
@@ -388,7 +387,9 @@ impl Literal {
 // A clause is a conjunction of literals.
 // Empty Clause means "true".
 // "false" can't be represented. Any cases with false condition must be dropped entirely.
-// This vector must be deduplicated.
+// This vector must be sorted by the variable name.
+// This vector must be deduplicated (every variant appears only once).
+// Thus, no conflicting literals are allowed (e.g., `x` and `¬x`).
 #[derive(Debug, Clone, Default, Eq)]
 pub struct Clause(Vec<Literal>);
 
@@ -890,12 +891,8 @@ impl ResponseShapeContext {
         match selection {
             Selection::Field(field) => self.process_field_selection(response_shape, field),
             Selection::FragmentSpread(fragment_spread) => {
-                let fragment_def = self
-                    .fragment_defs
-                    .get(&fragment_spread.fragment_name)
-                    .ok_or_else(|| {
-                        internal_error!("Fragment not found: {}", fragment_spread.fragment_name)
-                    })?;
+                let fragment_def =
+                    get_fragment_definition(&self.fragment_defs, &fragment_spread.fragment_name)?;
                 // Note: `@skip/@include` directives are not allowed on fragment definitions.
                 //       Thus, no need to check their directives for Boolean conditions.
                 self.process_fragment_selection(
@@ -964,19 +961,21 @@ impl ResponseShapeContext {
             // A brand new context with the new type condition.
             // - Still inherits the boolean conditions for simplification purposes.
             let parent_type = field.selection_set.ty.clone();
-            let type_condition = self
-                .type_condition
-                .field_type_condition(field, &self.schema)?;
-            let context = ResponseShapeContext {
-                schema: self.schema.clone(),
-                fragment_defs: self.fragment_defs.clone(),
-                parent_type,
-                type_condition,
-                inherited_clause,
-                current_clause: Clause::default(), // empty
-                skip_introspection: false,         // false by default
-            };
-            Some(context.process_selection_set(&field.selection_set)?)
+            self.type_condition
+                .field_type_condition(field, &self.schema)?
+                .map(|type_condition| {
+                    let context = ResponseShapeContext {
+                        schema: self.schema.clone(),
+                        fragment_defs: self.fragment_defs.clone(),
+                        parent_type,
+                        type_condition,
+                        inherited_clause,
+                        current_clause: Clause::default(), // empty
+                        skip_introspection: false,         // false by default
+                    };
+                    context.process_selection_set(&field.selection_set)
+                })
+                .transpose()?
         };
         // Record this selection's definition.
         let value = response_shape
@@ -1081,6 +1080,16 @@ fn get_operation_and_fragment_definitions(
     Ok((first.clone(), fragment_defs))
 }
 
+fn get_fragment_definition<'a>(
+    fragment_defs: &'a Arc<IndexMap<Name, Node<Fragment>>>,
+    fragment_name: &Name,
+) -> Result<&'a Node<Fragment>, FederationError> {
+    let fragment_def = fragment_defs
+        .get(fragment_name)
+        .ok_or_else(|| internal_error!("Fragment definition not found: {}", fragment_name))?;
+    Ok(fragment_def)
+}
+
 pub fn compute_response_shape_for_operation(
     operation_doc: &Valid<ExecutableDocument>,
     schema: &ValidFederationSchema,
@@ -1090,7 +1099,11 @@ pub fn compute_response_shape_for_operation(
     // Start a new root context and process the root selection set.
     // - Not using `process_selection_set` because there is no parent context.
     let parent_type = operation.selection_set.ty.clone();
-    let type_condition = NormalizedTypeCondition::from_type_name(parent_type.clone(), schema)?;
+    let Some(type_condition) =
+        NormalizedTypeCondition::from_type_name(parent_type.clone(), schema)?
+    else {
+        bail!("Unexpected empty type condition for the root type: {parent_type}")
+    };
     let context = ResponseShapeContext {
         schema: schema.clone(),
         fragment_defs,
@@ -1110,10 +1123,12 @@ pub fn compute_the_root_type_condition_for_operation(
     Ok(operation.selection_set.ty.clone())
 }
 
+/// Entity fetch operation may have multiple entity selections.
+/// This function returns a vector of response shapes per each individual entity selection.
 pub fn compute_response_shape_for_entity_fetch_operation(
     operation_doc: &Valid<ExecutableDocument>,
     schema: &ValidFederationSchema,
-) -> Result<ResponseShape, FederationError> {
+) -> Result<Vec<ResponseShape>, FederationError> {
     let (operation, fragment_defs) = get_operation_and_fragment_definitions(operation_doc)?;
 
     // drill down the `_entities` selection set
@@ -1131,24 +1146,53 @@ pub fn compute_response_shape_for_entity_fetch_operation(
         bail!("Entity fetch is expected to have a field selection named `_entities`")
     }
 
-    // Start a new root context and process the `_entities` selection set.
-    // - Not using `process_selection_set` because there is no parent context.
-    let parent_type = crate::subgraph::spec::ENTITY_UNION_NAME.clone();
-    let type_condition = NormalizedTypeCondition::unconstrained();
-    let context = ResponseShapeContext {
-        schema: schema.clone(),
-        fragment_defs,
-        parent_type: parent_type.clone(),
-        type_condition: type_condition.clone(),
-        inherited_clause: Clause::default(), // empty
-        current_clause: Clause::default(),   // empty
-        skip_introspection: false,           // false by default
-    };
-    // Note: Can't call `context.process_selection_set` here, since the type condition is
-    //       special for the `_entities` field.
-    let mut response_shape = ResponseShape::new(parent_type);
-    context.process_selection_set_within(&mut response_shape, &field.selection_set)?;
-    Ok(response_shape)
+    field
+        .selection_set
+        .selections
+        .iter()
+        .map(|selection| {
+            let type_condition = get_fragment_type_condition(&fragment_defs, selection)?;
+            let Some(normalized_type_condition) =
+                NormalizedTypeCondition::from_type_name(type_condition.clone(), schema)?
+            else {
+                bail!("Unexpected empty type condition for the entity type: {type_condition}")
+            };
+            let context = ResponseShapeContext {
+                schema: schema.clone(),
+                fragment_defs: fragment_defs.clone(),
+                parent_type: type_condition.clone(),
+                type_condition: normalized_type_condition,
+                inherited_clause: Clause::default(), // empty
+                current_clause: Clause::default(),   // empty
+                skip_introspection: false,           // false by default
+            };
+            let mut response_shape = ResponseShape::new(type_condition);
+            context.process_selection(&mut response_shape, selection)?;
+            Ok(response_shape)
+        })
+        .collect()
+}
+
+fn get_fragment_type_condition(
+    fragment_defs: &Arc<FragmentMap>,
+    selection: &Selection,
+) -> Result<Name, FederationError> {
+    Ok(match selection {
+        Selection::FragmentSpread(fragment_spread) => {
+            let fragment_def =
+                get_fragment_definition(fragment_defs, &fragment_spread.fragment_name)?;
+            fragment_def.type_condition().clone()
+        }
+        Selection::InlineFragment(inline) => {
+            let Some(type_condition) = &inline.type_condition else {
+                bail!(
+                    "Expected a type condition on the inline fragment under the `_entities` selection"
+                )
+            };
+            type_condition.clone()
+        }
+        _ => bail!("Expected a fragment under the `_entities` selection"),
+    })
 }
 
 //==================================================================================================
@@ -1173,8 +1217,7 @@ impl fmt::Display for DisplayTypeCondition {
 impl fmt::Display for NormalizedTypeCondition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.ground_set.is_empty() {
-            write!(f, "<any>")?;
-            return Ok(());
+            return Err(fmt::Error);
         }
 
         write!(f, "{}", self.for_display)?;

--- a/apollo-federation/src/correctness/response_shape_compare.rs
+++ b/apollo-federation/src/correctness/response_shape_compare.rs
@@ -118,17 +118,16 @@ pub(crate) fn compare_response_shapes_with_constraint<T: PathConstraint>(
 }
 
 /// Collect and merge all definitions applicable to the given type condition.
+/// Returns `None` if no definitions are applicable.
 fn collect_definitions_for_type_condition(
     defs: &PossibleDefinitions,
     filter_cond: &NormalizedTypeCondition,
-) -> Result<PossibleDefinitionsPerTypeCondition, ComparisonError> {
+) -> Result<Option<PossibleDefinitionsPerTypeCondition>, ComparisonError> {
     let mut filter_iter = defs
         .iter()
         .filter(|(type_cond, _)| filter_cond.implies(type_cond));
     let Some((_type_cond, first)) = filter_iter.next() else {
-        return Err(ComparisonError::new(format!(
-            "no definitions found for type condition: {filter_cond}"
-        )));
+        return Ok(None);
     };
     let mut digest = first.clone();
     // Merge the rest of filter_iter into digest.
@@ -142,7 +141,7 @@ fn collect_definitions_for_type_condition(
                 ))
             })
     )?;
-    Ok(digest)
+    Ok(Some(digest))
 }
 
 fn path_constraint_allows_type_condition<T: PathConstraint>(
@@ -181,19 +180,18 @@ fn compare_possible_definitions<T: PathConstraint>(
 
         // First try: Use the single exact match (common case).
         if let Some(other_def) = other.get(this_cond) {
-            let result = compare_possible_definitions_per_type_condition(
+            if let Ok(result) = compare_possible_definitions_per_type_condition(
                 &updated_constraint,
                 this_def,
                 other_def,
-            );
-            if let Ok(result) = result {
+            ) {
                 return Ok(result);
             }
             // fall through
         }
 
         // Second try: Collect all definitions implied by the `this_cond`.
-        if let Ok(other_def) = collect_definitions_for_type_condition(other, this_cond) {
+        if let Some(other_def) = collect_definitions_for_type_condition(other, this_cond)? {
             let result = compare_possible_definitions_per_type_condition(
                 &updated_constraint,
                 this_def,
@@ -206,11 +204,11 @@ fn compare_possible_definitions<T: PathConstraint>(
                     if this_cond.ground_set().len() == 1 {
                         // Single object type has no other option. Stop and report the error.
                         let detail = detail_single_object_type_condition(this_cond);
-                        return Err(ComparisonError::new(format!(
-                            "mismatch for type condition: {this_cond}{detail}\n{}",
-                            err.description()
+                        return Err(err.add_description(&format!(
+                            "mismatch for type condition: {this_cond}{detail}",
                         )));
                     }
+                    // fall through
                 }
             }
             // fall through
@@ -221,12 +219,12 @@ fn compare_possible_definitions<T: PathConstraint>(
         let mut ground_set_iter = ground_set_iter.filter(|ty| path_constraint.allows(ty));
         ground_set_iter.try_for_each(|ground_ty| {
             let filter_cond = NormalizedTypeCondition::from_object_type(ground_ty);
-            let other_def =
-                collect_definitions_for_type_condition(other, &filter_cond).map_err(|e| {
-                    e.add_description(&format!(
-                        "missing type condition: {this_cond} (case: {ground_ty})"
-                    ))
-                })?;
+            let Some(other_def) = collect_definitions_for_type_condition(other, &filter_cond)?
+            else {
+                return Err(ComparisonError::new(format!(
+                    "no definitions found for type condition: {this_cond} (case: {ground_ty})"
+                )));
+            };
             let updated_constraint = path_constraint.under_type_condition(&filter_cond);
             compare_possible_definitions_per_type_condition(
                 &updated_constraint,


### PR DESCRIPTION
This is a pure refactoring in preparation of the soundness check feature implementation.

### Summary
It will be easier to review commit by commit.

* 1st commit: Revised `collect_definitions_for_type_condition` to return an `Result<Option<...` value.
    * Separating the None case from errors.
* 2nd commit: Clarified the `interpret_*_node` function semantics in query_plan_analysis.
    * `state` parameter is only used for `requires` checking (used by the soundness check later).
    * `interpret_*_node` functions return only newly fetched responses.
    * So, the `state` argument value never flows into the return value.
    * This was the original intention and it won't change the behavior of the checker.
* 3rd commit: Improved entity fetch node handling
    *  Fetch node may have multiple entity fetches in its subgraph operation.
    * Previously, the whole operation was analyzed at once.
    * Now, each entity case is analyzed separately.
    * This won't change the current behavior, but it will be handy for the soundness check later.
    * Also, this simplifies `NormalizedTypeCondition` struct.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**
This is an internal testing functionality. No impact on public features.