### PR TITLE
fix(Cargo.lock): fixed a compliance error due to RUSTSEC-2025-0009

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,9 +1636,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -5804,15 +5804,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
  "untrusted",
  "windows-sys 0.52.0",
 ]


### PR DESCRIPTION
### Compliance error
```
error[vulnerability]: Some AES functions may panic when overflow checking is enabled.
    ┌─ /home/circleci/project/Cargo.lock:499:1
    │
499 │ ring 0.17.8 registry+https://github.com/rust-lang/crates.io-index
    │ ----------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2025-0009
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0009
```

### Solution
I ran `cargo update -p ring` per the solution suggested on the advisory.
