### PR TITLE
Entity caching: sort entity keys before hashing the key (backport #6799)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5906,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json_bytes"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ecd92a088fb2500b2f146c9ddc5da9950bb7264d3f00932cd2a6fb369c26c46"
+checksum = "a6a27c10711f94d1042b4c96d483556ec84371864e25d0e1cf3dc1024b0880b1"
 dependencies = [
  "ahash",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,18 +54,8 @@ apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"
 hex = { version = "0.4.3", features = ["serde"] }
-<<<<<<< HEAD
 http = "0.2.11"
 insta = { version = "1.38.0", features = ["json", "redactions", "yaml"] }
-=======
-http = "1.1.0"
-insta = { version = "1.38.0", features = [
-    "json",
-    "redactions",
-    "yaml",
-    "glob",
-] }
->>>>>>> 9990cec6 (Entity caching: sort entity keys before hashing the key (#6799))
 once_cell = "1.19.0"
 reqwest = { version = "0.11.0", default-features = false, features = [
     "rustls-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,18 @@ apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"
 hex = { version = "0.4.3", features = ["serde"] }
+<<<<<<< HEAD
 http = "0.2.11"
 insta = { version = "1.38.0", features = ["json", "redactions", "yaml"] }
+=======
+http = "1.1.0"
+insta = { version = "1.38.0", features = [
+    "json",
+    "redactions",
+    "yaml",
+    "glob",
+] }
+>>>>>>> 9990cec6 (Entity caching: sort entity keys before hashing the key (#6799))
 once_cell = "1.19.0"
 reqwest = { version = "0.11.0", default-features = false, features = [
     "rustls-tls",
@@ -71,7 +81,7 @@ serde_json = { version = "1.0.114", features = [
     "preserve_order",
     "float_roundtrip",
 ] }
-serde_json_bytes = { version = "0.2.4", features = ["preserve_order"] }
+serde_json_bytes = { version = "0.2.5", features = ["preserve_order"] }
 sha1 = "0.10.6"
 tempfile = "3.10.1"
 tokio = { version = "1.36.0", features = ["full"] }

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -1242,6 +1242,7 @@ pub(crate) fn hash_additional_data(
     let repr_key = ByteString::from(REPRESENTATIONS);
     // Removing the representations variable because it's already part of the cache key
     let representations = body.variables.remove(&repr_key);
+    body.variables.sort_keys();
     digest.update(serde_json::to_vec(&body.variables).unwrap());
     if let Some(representations) = representations {
         body.variables.insert(repr_key, representations);
@@ -1361,9 +1362,11 @@ fn extract_cache_keys(
     Ok(res)
 }
 
-pub(crate) fn hash_entity_key(representation: &Value) -> String {
+/// Returns a hash for the given representation, independent of field order. Destructively sorts any objects in the input.
+pub(crate) fn hash_entity_key(representation: &mut Value) -> String {
     // We have to hash the representation because it can contains PII
     let mut digest = Sha256::new();
+    representation.sort_all_objects();
     digest.update(serde_json::to_string(&representation).unwrap().as_bytes());
     hex::encode(digest.finalize().as_slice())
 }
@@ -1612,5 +1615,29 @@ impl Ord for CacheKeyStatus {
             (CacheKeyStatus::Cached, CacheKeyStatus::New) => std::cmp::Ordering::Less,
             (CacheKeyStatus::Cached, CacheKeyStatus::Cached) => std::cmp::Ordering::Equal,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_entity_key_ordering() {
+        let mut representations = serde_json_bytes::json!([{
+            "id1": "test",
+            "id2": "test2"
+        }]);
+        let first_hash_key = hash_entity_key(&mut representations);
+        let mut representations = serde_json_bytes::json!([{
+            "id2": "test2",
+            "id1": "test"
+        }]);
+        let second_hash_key = hash_entity_key(&mut representations);
+
+        assert_eq!(
+            first_hash_key, second_hash_key,
+            "these 2 hashes should be equals because ordering doesn't matter"
+        );
     }
 }


### PR DESCRIPTION
Part of https://github.com/apollographql/router/issues/6673


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6799 done by [Mergify](https://mergify.com).