### PR TITLE
Propagate request cancellation from the router service to the query planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "ryu",
  "schemars",
+ "scopeguard",
  "semver",
  "serde",
  "serde_derive_default",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -262,6 +262,7 @@ ryu = "1.0.15"
 form_urlencoded = "1.2.1"
 apollo-environment-detector = "0.1.0"
 log = "0.4.22"
+scopeguard = "1.2.0"
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -467,7 +467,7 @@ mod test {
             .build()
             .expect("expecting valid request")
             .try_into()
-            .unwrap();
+            .expect("expecting router request");
 
         let response = router_service
             .ready()


### PR DESCRIPTION
Follow-up to #6840 with a missing piece, and some tests.

This uses `scopeguard` to abort the QueryPlannerService future when
the CachingQueryPlanner future aborts.

By continuing to use a tokio task, and a separate abort handle, we can
adjust the abort conditions later (such as introducing a separate QP
timeout, independent of request cancellation).

**Todos**:
- [ ] An integration-type test (at least testing the entire pipeline starting at the RouterService)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
