### PR TITLE
chore: refactor federation to avoid referencing fragment spreads

### DIFF
--- a/apollo-federation/src/operation/contains.rs
+++ b/apollo-federation/src/operation/contains.rs
@@ -184,7 +184,7 @@ impl SelectionSet {
 mod tests {
     use super::Containment;
     use super::ContainmentOptions;
-    use crate::operation::NormalizedOperation;
+    use crate::operation::Operation;
     use crate::schema::ValidFederationSchema;
 
     fn containment_custom(left: &str, right: &str, ignore_missing_typename: bool) -> Containment {
@@ -223,8 +223,10 @@ mod tests {
         )
         .unwrap();
         let schema = ValidFederationSchema::new(schema).unwrap();
-        let left = NormalizedOperation::parse(schema.clone(), left, "left.graphql").unwrap();
-        let right = NormalizedOperation::parse(schema.clone(), right, "right.graphql").unwrap();
+        let left = Operation::parse(schema.clone(), left, "left.graphql")
+            .expect("operation is valid and can be parsed");
+        let right = Operation::parse(schema.clone(), right, "right.graphql")
+            .expect("operation is valid and can be parsed");
 
         left.selection_set.containment(
             &right.selection_set,

--- a/apollo-federation/src/operation/merging.rs
+++ b/apollo-federation/src/operation/merging.rs
@@ -5,12 +5,9 @@ use apollo_compiler::collections::IndexMap;
 
 use super::FieldSelection;
 use super::FieldSelectionValue;
-use super::FragmentSpreadSelection;
-use super::FragmentSpreadSelectionValue;
 use super::HasSelectionKey as _;
 use super::InlineFragmentSelection;
 use super::InlineFragmentSelectionValue;
-use super::NamedFragments;
 use super::Selection;
 use super::SelectionSet;
 use super::SelectionValue;
@@ -118,36 +115,6 @@ impl InlineFragmentSelectionValue<'_> {
     }
 }
 
-impl FragmentSpreadSelectionValue<'_> {
-    /// Merges the given normalized fragment spread selections into this one.
-    ///
-    /// # Preconditions
-    /// All selections must have the same selection key (fragment name + directives).
-    /// Otherwise this function produces invalid output.
-    ///
-    /// # Errors
-    /// Returns an error if the parent type or schema of any selection does not match `self`'s.
-    fn merge_into<'op>(
-        &mut self,
-        others: impl Iterator<Item = &'op FragmentSpreadSelection>,
-    ) -> Result<(), FederationError> {
-        let self_fragment_spread = &self.get().spread;
-        for other in others {
-            let other_fragment_spread = &other.spread;
-            ensure!(
-                other_fragment_spread.schema == self_fragment_spread.schema,
-                "Cannot merge fragment spread from different schemas",
-            );
-            // Nothing to do since the fragment spread is already part of the selection set.
-            // Fragment spreads are uniquely identified by fragment name and applied directives.
-            // Since there is already an entry for the same fragment spread, there is no point
-            // in attempting to merge its sub-selections, as the underlying entry should be
-            // exactly the same as the currently processed one.
-        }
-        Ok(())
-    }
-}
-
 impl SelectionSet {
     /// NOTE: This is a private API and should be used with care, use `add_selection_set` instead.
     ///
@@ -191,7 +158,6 @@ impl SelectionSet {
         others: impl Iterator<Item = &'op Selection>,
     ) -> Result<(), FederationError> {
         let mut fields = IndexMap::default();
-        let mut fragment_spreads = IndexMap::default();
         let mut inline_fragments = IndexMap::default();
         let target = Arc::make_mut(&mut self.selections);
         for other_selection in others {
@@ -209,20 +175,6 @@ impl SelectionSet {
                             .entry(other_key.to_owned_key())
                             .or_insert_with(Vec::new)
                             .push(other_field_selection);
-                    }
-                    Selection::FragmentSpread(self_fragment_spread_selection) => {
-                        let Selection::FragmentSpread(other_fragment_spread_selection) =
-                            other_selection
-                        else {
-                            bail!(
-                                "Fragment spread selection key for fragment \"{}\" references non-field selection",
-                                self_fragment_spread_selection.spread.fragment_name,
-                            );
-                        };
-                        fragment_spreads
-                            .entry(other_key.to_owned_key())
-                            .or_insert_with(Vec::new)
-                            .push(other_fragment_spread_selection);
                     }
                     Selection::InlineFragment(self_inline_fragment_selection) => {
                         let Selection::InlineFragment(other_inline_fragment_selection) =
@@ -262,17 +214,6 @@ impl SelectionSet {
                     if let Some(other_field_selections) = fields.shift_remove(&key) {
                         self_field_selection.merge_into(
                             other_field_selections.iter().map(|selection| &***selection),
-                        )?;
-                    }
-                }
-                SelectionValue::FragmentSpread(mut self_fragment_spread_selection) => {
-                    if let Some(other_fragment_spread_selections) =
-                        fragment_spreads.shift_remove(&key)
-                    {
-                        self_fragment_spread_selection.merge_into(
-                            other_fragment_spread_selections
-                                .iter()
-                                .map(|selection| &***selection),
                         )?;
                     }
                 }
@@ -340,9 +281,7 @@ impl SelectionSet {
         self.merge_into(std::iter::once(selection_set))
     }
 
-    /// Rebase given `SelectionSet` on self and then inserts it into the inner map. Assumes that given
-    /// selection set does not reference ANY named fragments. If it does, Use `add_selection_set_with_fragments`
-    /// instead.
+    /// Rebase given `SelectionSet` on self and then inserts it into the inner map.
     ///
     /// Should any sub selection with the same key already exist in the map, the existing selection
     /// and the given selection are merged, replacing the existing selection while keeping the same
@@ -354,25 +293,7 @@ impl SelectionSet {
         &mut self,
         selection_set: &SelectionSet,
     ) -> Result<(), FederationError> {
-        self.add_selection_set_with_fragments(selection_set, &Default::default())
-    }
-
-    /// Rebase given `SelectionSet` on self with the specified fragments and then inserts it into the
-    /// inner map.
-    ///
-    /// Should any sub selection with the same key already exist in the map, the existing selection
-    /// and the given selection are merged, replacing the existing selection while keeping the same
-    /// insertion index.
-    ///
-    /// # Errors
-    /// Returns an error if either selection set contains invalid GraphQL that prevents the merge.
-    pub(crate) fn add_selection_set_with_fragments(
-        &mut self,
-        selection_set: &SelectionSet,
-        named_fragments: &NamedFragments,
-    ) -> Result<(), FederationError> {
-        let rebased =
-            selection_set.rebase_on(&self.type_position, named_fragments, &self.schema)?;
+        let rebased = selection_set.rebase_on(&self.type_position, &self.schema)?;
         self.add_local_selection_set(&rebased)
     }
 }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -24,9 +24,11 @@ use std::sync::atomic;
 
 use apollo_compiler::Name;
 use apollo_compiler::Node;
+use apollo_compiler::collections::HashMap;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable;
+use apollo_compiler::executable::Fragment;
 use apollo_compiler::name;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::validation::Valid;
@@ -54,7 +56,7 @@ use crate::utils::FallibleIterator;
 mod contains;
 mod directive_list;
 mod merging;
-mod optimize;
+pub(crate) mod optimize;
 mod rebase;
 mod simplify;
 #[cfg(test)]
@@ -64,8 +66,6 @@ pub(crate) use contains::*;
 pub(crate) use directive_list::DirectiveList;
 pub(crate) use merging::*;
 pub(crate) use rebase::*;
-#[cfg(test)]
-pub(crate) use tests::never_cancel;
 
 pub(crate) const TYPENAME_FIELD: Name = name!("__typename");
 
@@ -190,56 +190,45 @@ impl ArgumentList {
 /// - Stores the schema that the operation is queried against.
 /// - Swaps `operation_type` with `root_kind` (using the analogous apollo-federation type).
 /// - Encloses collection types in `Arc`s to facilitate cheaper cloning.
-/// - Stores the fragments used by this operation (the executable document the operation was taken
-///   from may contain other fragments that are not used by this operation).
+/// - Expands all named fragments into inline fragments.
+/// - Deduplicates all selections within its selection sets.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Operation {
+pub struct NormalizedOperation {
     pub(crate) schema: ValidFederationSchema,
     pub(crate) root_kind: SchemaRootDefinitionKind,
     pub(crate) name: Option<Name>,
     pub(crate) variables: Arc<Vec<Node<executable::VariableDefinition>>>,
     pub(crate) directives: DirectiveList,
     pub(crate) selection_set: SelectionSet,
-    pub(crate) named_fragments: NamedFragments,
 }
 
-impl Operation {
+impl NormalizedOperation {
     /// Parse an operation from a source string.
     #[cfg(any(test, doc))]
     pub fn parse(
         schema: ValidFederationSchema,
         source_text: &str,
         source_name: &str,
-        operation_name: Option<&str>,
     ) -> Result<Self, FederationError> {
         let document = apollo_compiler::ExecutableDocument::parse_and_validate(
             schema.schema(),
             source_text,
             source_name,
         )?;
-        Operation::from_operation_document(schema, &document, operation_name)
-    }
-
-    pub fn from_operation_document(
-        schema: ValidFederationSchema,
-        document: &Valid<apollo_compiler::ExecutableDocument>,
-        operation_name: Option<&str>,
-    ) -> Result<Self, FederationError> {
-        let operation = document.operations.get(operation_name).map_err(|_| {
-            FederationError::internal(format!("No operation named {operation_name:?}"))
-        })?;
-        let named_fragments = NamedFragments::new(&document.fragments, &schema);
-        let selection_set =
-            SelectionSet::from_selection_set(&operation.selection_set, &named_fragments, &schema)?;
-        Ok(Operation {
-            schema,
+        let operation = document.operations.iter().next().expect("operation exists");
+        let normalized_operation = NormalizedOperation {
+            schema: schema.clone(),
             root_kind: operation.operation_type.into(),
             name: operation.name.clone(),
             variables: Arc::new(operation.variables.clone()),
             directives: operation.directives.clone().into(),
-            selection_set,
-            named_fragments,
-        })
+            selection_set: SelectionSet::from_selection_set(
+                &operation.selection_set,
+                &FragmentSpreadCache::init(&document.fragments, &schema),
+                &schema,
+            )?,
+        };
+        Ok(normalized_operation)
     }
 }
 
@@ -272,7 +261,6 @@ impl Hash for SelectionSet {
 mod selection_map;
 
 pub(crate) use selection_map::FieldSelectionValue;
-pub(crate) use selection_map::FragmentSpreadSelectionValue;
 pub(crate) use selection_map::HasSelectionKey;
 pub(crate) use selection_map::InlineFragmentSelectionValue;
 pub(crate) use selection_map::SelectionKey;
@@ -284,7 +272,6 @@ pub(crate) use selection_map::SelectionValue;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::IsVariant, serde::Serialize)]
 pub(crate) enum Selection {
     Field(Arc<FieldSelection>),
-    FragmentSpread(Arc<FragmentSpreadSelection>),
     InlineFragment(Arc<InlineFragmentSelection>),
 }
 
@@ -293,7 +280,6 @@ pub(crate) enum Selection {
 #[derive(Debug, Clone, derive_more::From)]
 pub(crate) enum OperationElement {
     Field(Field),
-    FragmentSpread(FragmentSpread),
     InlineFragment(InlineFragment),
 }
 
@@ -327,18 +313,9 @@ impl Selection {
     pub(crate) fn from_operation_element(
         element: OperationElement,
         sub_selections: Option<SelectionSet>,
-        named_fragments: &NamedFragments,
     ) -> Result<Selection, FederationError> {
         match element {
             OperationElement::Field(field) => Ok(Self::from_field(field, sub_selections)),
-            OperationElement::FragmentSpread(fragment_spread) => {
-                if sub_selections.is_some() {
-                    return Err(FederationError::internal(
-                        "unexpected fragment spread with sub-selections",
-                    ));
-                }
-                Ok(FragmentSpreadSelection::new(fragment_spread, named_fragments)?.into())
-            }
             OperationElement::InlineFragment(inline_fragment) => {
                 let Some(sub_selections) = sub_selections else {
                     return Err(FederationError::internal(
@@ -353,9 +330,6 @@ impl Selection {
     pub(crate) fn schema(&self) -> &ValidFederationSchema {
         match self {
             Selection::Field(field_selection) => &field_selection.field.schema,
-            Selection::FragmentSpread(fragment_spread_selection) => {
-                &fragment_spread_selection.spread.schema
-            }
             Selection::InlineFragment(inline_fragment_selection) => {
                 &inline_fragment_selection.inline_fragment.schema
             }
@@ -365,9 +339,6 @@ impl Selection {
     fn directives(&self) -> &DirectiveList {
         match self {
             Selection::Field(field_selection) => &field_selection.field.directives,
-            Selection::FragmentSpread(fragment_spread_selection) => {
-                &fragment_spread_selection.spread.directives
-            }
             Selection::InlineFragment(inline_fragment_selection) => {
                 &inline_fragment_selection.inline_fragment.directives
             }
@@ -379,10 +350,6 @@ impl Selection {
             Selection::Field(field_selection) => {
                 Ok(OpPathElement::Field(field_selection.field.clone()))
             }
-            Selection::FragmentSpread(_) => Err(SingleFederationError::Internal {
-                message: "Fragment spread does not have element".to_owned(),
-            }
-            .into()),
             Selection::InlineFragment(inline_fragment_selection) => Ok(
                 OpPathElement::InlineFragment(inline_fragment_selection.inline_fragment.clone()),
             ),
@@ -394,9 +361,6 @@ impl Selection {
             Selection::Field(field_selection) => {
                 Ok(OperationElement::Field(field_selection.field.clone()))
             }
-            Selection::FragmentSpread(fragment_spread_selection) => Ok(
-                OperationElement::FragmentSpread(fragment_spread_selection.spread.clone()),
-            ),
             Selection::InlineFragment(inline_fragment_selection) => Ok(
                 OperationElement::InlineFragment(inline_fragment_selection.inline_fragment.clone()),
             ),
@@ -407,7 +371,6 @@ impl Selection {
     pub(crate) fn selection_set(&self) -> Option<&SelectionSet> {
         match self {
             Selection::Field(field_selection) => field_selection.selection_set.as_ref(),
-            Selection::FragmentSpread(_) => None,
             Selection::InlineFragment(inline_fragment_selection) => {
                 Some(&inline_fragment_selection.selection_set)
             }
@@ -447,9 +410,6 @@ impl Selection {
                 Selection::InlineFragment(inline) => {
                     Ok(self_conditions.merge(inline.selection_set.conditions()?))
                 }
-                Selection::FragmentSpread(_x) => Err(FederationError::internal(
-                    "Unexpected fragment spread in Selection::conditions()",
-                )),
             }
         }
     }
@@ -471,9 +431,6 @@ impl Selection {
                 Ok(inline_fragment
                     .with_updated_selection_set(selection_set)
                     .into())
-            }
-            Selection::FragmentSpread(_) => {
-                Err(FederationError::internal("unexpected fragment spread"))
             }
         }
     }
@@ -506,16 +463,12 @@ impl Selection {
 
     pub(crate) fn any_element(
         &self,
-        parent_type_position: CompositeTypeDefinitionPosition,
         predicate: &mut impl FnMut(OpPathElement) -> Result<bool, FederationError>,
     ) -> Result<bool, FederationError> {
         match self {
             Selection::Field(field_selection) => field_selection.any_element(predicate),
             Selection::InlineFragment(inline_fragment_selection) => {
                 inline_fragment_selection.any_element(predicate)
-            }
-            Selection::FragmentSpread(fragment_spread_selection) => {
-                fragment_spread_selection.any_element(parent_type_position, predicate)
             }
         }
     }
@@ -524,12 +477,6 @@ impl Selection {
 impl From<FieldSelection> for Selection {
     fn from(value: FieldSelection) -> Self {
         Self::Field(value.into())
-    }
-}
-
-impl From<FragmentSpreadSelection> for Selection {
-    fn from(value: FragmentSpreadSelection) -> Self {
-        Self::FragmentSpread(value.into())
     }
 }
 
@@ -543,7 +490,6 @@ impl HasSelectionKey for Selection {
     fn key(&self) -> SelectionKey<'_> {
         match self {
             Selection::Field(field_selection) => field_selection.key(),
-            Selection::FragmentSpread(fragment_spread_selection) => fragment_spread_selection.key(),
             Selection::InlineFragment(inline_fragment_selection) => inline_fragment_selection.key(),
         }
     }
@@ -598,17 +544,6 @@ impl Ord for Selection {
                     }
                 }
             }
-            (Selection::InlineFragment(_), Selection::FragmentSpread(_)) => Ordering::Less,
-            (Selection::FragmentSpread(f1), Selection::FragmentSpread(f2)) => {
-                // compare fragment names
-                let compare_fragment_names = f1.spread.fragment_name.cmp(&f2.spread.fragment_name);
-                if compare_fragment_names == Ordering::Equal {
-                    compare_directives(&f1.spread.directives, &f2.spread.directives)
-                } else {
-                    compare_fragment_names
-                }
-            }
-            (Selection::FragmentSpread(_), _) => Ordering::Greater,
         }
     }
 }
@@ -623,41 +558,6 @@ impl PartialOrd for Selection {
 pub(crate) enum SelectionOrSet {
     Selection(Selection),
     SelectionSet(SelectionSet),
-}
-
-/// An analogue of the apollo-compiler type `Fragment` with these changes:
-/// - Stores the type condition explicitly, which means storing the schema and position (in
-///   apollo-compiler, this is in the `SelectionSet`).
-/// - Encloses collection types in `Arc`s to facilitate cheaper cloning.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Fragment {
-    pub(crate) schema: ValidFederationSchema,
-    pub(crate) name: Name,
-    pub(crate) type_condition_position: CompositeTypeDefinitionPosition,
-    pub(crate) directives: DirectiveList,
-    pub(crate) selection_set: SelectionSet,
-}
-
-impl Fragment {
-    fn from_fragment(
-        fragment: &executable::Fragment,
-        named_fragments: &NamedFragments,
-        schema: &ValidFederationSchema,
-    ) -> Result<Self, FederationError> {
-        Ok(Self {
-            schema: schema.clone(),
-            name: fragment.name.clone(),
-            type_condition_position: schema
-                .get_type(fragment.type_condition().clone())?
-                .try_into()?,
-            directives: fragment.directives.clone().into(),
-            selection_set: SelectionSet::from_selection_set(
-                &fragment.selection_set,
-                named_fragments,
-                schema,
-            )?,
-        })
-    }
 }
 
 mod field_selection {
@@ -911,156 +811,6 @@ mod field_selection {
 pub(crate) use field_selection::Field;
 pub(crate) use field_selection::FieldSelection;
 pub(crate) use field_selection::SiblingTypename;
-
-mod fragment_spread_selection {
-    use std::hash::Hash;
-    use std::hash::Hasher;
-
-    use apollo_compiler::Name;
-    use serde::Serialize;
-
-    use crate::operation::DirectiveList;
-    use crate::operation::HasSelectionKey;
-    use crate::operation::SelectionId;
-    use crate::operation::SelectionKey;
-    use crate::operation::SelectionSet;
-    use crate::operation::is_deferred_selection;
-    use crate::schema::ValidFederationSchema;
-    use crate::schema::position::CompositeTypeDefinitionPosition;
-
-    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-    pub(crate) struct FragmentSpreadSelection {
-        pub(crate) spread: FragmentSpread,
-        pub(crate) selection_set: SelectionSet,
-    }
-
-    impl HasSelectionKey for FragmentSpreadSelection {
-        fn key(&self) -> SelectionKey<'_> {
-            self.spread.key()
-        }
-    }
-
-    /// An analogue of the apollo-compiler type `FragmentSpread` with these changes:
-    /// - Stores the schema (may be useful for directives).
-    /// - Encloses collection types in `Arc`s to facilitate cheaper cloning.
-    #[derive(Debug, Clone, Serialize)]
-    pub(crate) struct FragmentSpread {
-        #[serde(skip)]
-        pub(crate) schema: ValidFederationSchema,
-        pub(crate) fragment_name: Name,
-        pub(crate) type_condition_position: CompositeTypeDefinitionPosition,
-        // directives applied on the fragment spread selection
-        pub(crate) directives: DirectiveList,
-        // directives applied within the fragment definition
-        //
-        // PORT_NOTE: The JS codebase combined the fragment spread's directives with the fragment
-        // definition's directives. This was invalid GraphQL as those directives may not be applicable
-        // on different locations. While we now keep track of those references, they are currently ignored.
-        pub(crate) fragment_directives: DirectiveList,
-        pub(crate) selection_id: SelectionId,
-    }
-
-    impl PartialEq for FragmentSpread {
-        fn eq(&self, other: &Self) -> bool {
-            self.key() == other.key()
-        }
-    }
-
-    impl Eq for FragmentSpread {}
-
-    impl Hash for FragmentSpread {
-        fn hash<H: Hasher>(&self, state: &mut H) {
-            self.key().hash(state);
-        }
-    }
-
-    impl HasSelectionKey for FragmentSpread {
-        fn key(&self) -> SelectionKey<'_> {
-            if is_deferred_selection(&self.directives) {
-                SelectionKey::Defer {
-                    deferred_id: self.selection_id,
-                }
-            } else {
-                SelectionKey::FragmentSpread {
-                    fragment_name: &self.fragment_name,
-                    directives: &self.directives,
-                }
-            }
-        }
-    }
-}
-
-pub(crate) use fragment_spread_selection::FragmentSpread;
-pub(crate) use fragment_spread_selection::FragmentSpreadSelection;
-
-impl FragmentSpreadSelection {
-    /// Normalize this fragment spread into a "normalized" spread representation with following
-    /// modifications
-    /// - Stores the schema (may be useful for directives).
-    /// - Encloses list of directives in `Arc`s to facilitate cheaper cloning.
-    /// - Stores unique selection ID (used for deferred fragments)
-    pub(crate) fn from_fragment_spread(
-        fragment_spread: &executable::FragmentSpread,
-        fragment: &Node<Fragment>,
-    ) -> Result<FragmentSpreadSelection, FederationError> {
-        let spread = FragmentSpread::from_fragment(fragment, &fragment_spread.directives);
-        Ok(FragmentSpreadSelection {
-            spread,
-            selection_set: fragment.selection_set.clone(),
-        })
-    }
-
-    /// Creates a fragment spread selection (in an optimized operation).
-    /// - `named_fragments`: Named fragment definitions that are rebased for the element's schema.
-    pub(crate) fn new(
-        fragment_spread: FragmentSpread,
-        named_fragments: &NamedFragments,
-    ) -> Result<Self, FederationError> {
-        let fragment_name = &fragment_spread.fragment_name;
-        let fragment = named_fragments.get(fragment_name).ok_or_else(|| {
-            FederationError::internal(format!("Fragment {} not found", fragment_name))
-        })?;
-        debug_assert_eq!(fragment_spread.schema, fragment.schema);
-        Ok(Self {
-            spread: fragment_spread,
-            selection_set: fragment.selection_set.clone(),
-        })
-    }
-
-    pub(crate) fn any_element(
-        &self,
-        parent_type_position: CompositeTypeDefinitionPosition,
-        predicate: &mut impl FnMut(OpPathElement) -> Result<bool, FederationError>,
-    ) -> Result<bool, FederationError> {
-        let inline_fragment = InlineFragment {
-            schema: self.spread.schema.clone(),
-            parent_type_position,
-            type_condition_position: Some(self.spread.type_condition_position.clone()),
-            directives: self.spread.directives.clone(),
-            selection_id: self.spread.selection_id,
-        };
-        if predicate(inline_fragment.into())? {
-            return Ok(true);
-        }
-        self.selection_set.any_element(predicate)
-    }
-}
-
-impl FragmentSpread {
-    pub(crate) fn from_fragment(
-        fragment: &Node<Fragment>,
-        spread_directives: &executable::DirectiveList,
-    ) -> FragmentSpread {
-        FragmentSpread {
-            schema: fragment.schema.clone(),
-            fragment_name: fragment.name.clone(),
-            type_condition_position: fragment.type_condition_position.clone(),
-            directives: spread_directives.clone().into(),
-            fragment_directives: fragment.directives.clone(),
-            selection_id: SelectionId::new(),
-        }
-    }
-}
 
 mod inline_fragment_selection {
     use std::hash::Hash;
@@ -1399,8 +1149,8 @@ impl SelectionSet {
             type_position.type_name().clone(),
             source_text,
         )?;
-        let named_fragments = NamedFragments::new(&IndexMap::default(), &schema);
-        SelectionSet::from_selection_set(&selection_set, &named_fragments, &schema)
+        let fragments = Default::default();
+        SelectionSet::from_selection_set(&selection_set, &fragments, &schema)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -1437,7 +1187,7 @@ impl SelectionSet {
     /// case.
     pub(crate) fn from_selection_set(
         selection_set: &executable::SelectionSet,
-        fragments: &NamedFragments,
+        fragments_cache: &FragmentSpreadCache,
         schema: &ValidFederationSchema,
     ) -> Result<SelectionSet, FederationError> {
         let type_position: CompositeTypeDefinitionPosition =
@@ -1447,7 +1197,7 @@ impl SelectionSet {
             &selection_set.selections,
             &type_position,
             &mut normalized_selections,
-            fragments,
+            fragments_cache,
             schema,
         )?;
         let mut merged = SelectionSet {
@@ -1464,7 +1214,7 @@ impl SelectionSet {
         selections: &[executable::Selection],
         parent_type_position: &CompositeTypeDefinitionPosition,
         destination: &mut Vec<Selection>,
-        fragments: &NamedFragments,
+        fragments_cache: &FragmentSpreadCache,
         schema: &ValidFederationSchema,
     ) -> Result<(), FederationError> {
         for selection in selections {
@@ -1473,7 +1223,7 @@ impl SelectionSet {
                     let Some(normalized_field_selection) = FieldSelection::from_field(
                         field_selection,
                         parent_type_position,
-                        fragments,
+                        fragments_cache,
                         schema,
                     )?
                     else {
@@ -1482,24 +1232,29 @@ impl SelectionSet {
                     destination.push(Selection::from(normalized_field_selection));
                 }
                 executable::Selection::FragmentSpread(fragment_spread_selection) => {
-                    let Some(fragment) = fragments.get(&fragment_spread_selection.fragment_name)
-                    else {
-                        return Err(SingleFederationError::Internal {
-                            message: format!(
-                                "Fragment spread referenced non-existent fragment \"{}\"",
-                                fragment_spread_selection.fragment_name,
-                            ),
-                        }
-                        .into());
-                    };
-                    // if we don't expand fragments, we need to normalize it
-                    let normalized_fragment_spread = FragmentSpreadSelection::from_fragment_spread(
+                    // convert to inline fragment
+                    let inline_fragment_selection = InlineFragmentSelection::from_fragment_spread(
+                        parent_type_position, // the parent type of this inline selection
                         fragment_spread_selection,
-                        fragment,
+                        fragments_cache,
+                        schema,
                     )?;
-                    destination.push(Selection::FragmentSpread(Arc::new(
-                        normalized_fragment_spread,
-                    )));
+                    // We can hoist/collapse named fragments if their type condition is on the
+                    // parent type and they don't have any directives.
+                    let fragment_type_condition = inline_fragment_selection
+                        .inline_fragment
+                        .type_condition_position
+                        .clone();
+                    if fragment_type_condition
+                        .is_some_and(|position| &position == parent_type_position)
+                        && fragment_spread_selection.directives.is_empty()
+                    {
+                        destination.extend(inline_fragment_selection.selection_set);
+                    } else {
+                        destination.push(Selection::InlineFragment(Arc::new(
+                            inline_fragment_selection,
+                        )));
+                    }
                 }
                 executable::Selection::InlineFragment(inline_fragment_selection) => {
                     let is_on_parent_type =
@@ -1522,7 +1277,7 @@ impl SelectionSet {
                             &inline_fragment_selection.selection_set.selections,
                             parent_type_position,
                             destination,
-                            fragments,
+                            fragments_cache,
                             schema,
                         )?;
                     } else {
@@ -1530,85 +1285,13 @@ impl SelectionSet {
                             InlineFragmentSelection::from_inline_fragment(
                                 inline_fragment_selection,
                                 parent_type_position,
-                                fragments,
+                                fragments_cache,
                                 schema,
                             )?;
                         destination.push(Selection::InlineFragment(Arc::new(
                             normalized_inline_fragment_selection,
                         )));
                     }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub(crate) fn expand_all_fragments(
-        &self,
-        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
-    ) -> Result<SelectionSet, FederationError> {
-        let mut expanded_selections = vec![];
-        SelectionSet::expand_selection_set(&mut expanded_selections, self, check_cancellation)?;
-
-        let mut expanded = SelectionSet {
-            schema: self.schema.clone(),
-            type_position: self.type_position.clone(),
-            selections: Arc::new(SelectionMap::new()),
-        };
-        expanded.merge_selections_into(expanded_selections.iter())?;
-        Ok(expanded)
-    }
-
-    fn expand_selection_set(
-        destination: &mut Vec<Selection>,
-        selection_set: &SelectionSet,
-        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
-    ) -> Result<(), FederationError> {
-        for value in selection_set.selections.values() {
-            check_cancellation()?;
-            match value {
-                Selection::Field(field_selection) => {
-                    let selections = match &field_selection.selection_set {
-                        Some(s) => Some(s.expand_all_fragments(check_cancellation)?),
-                        None => None,
-                    };
-                    destination.push(Selection::from_field(
-                        field_selection.field.clone(),
-                        selections,
-                    ))
-                }
-                Selection::FragmentSpread(spread_selection) => {
-                    // We can hoist/collapse named fragments if their type condition is on the
-                    // parent type and they don't have any directives.
-                    if spread_selection.spread.type_condition_position
-                        == selection_set.type_position
-                        && spread_selection.spread.directives.is_empty()
-                    {
-                        SelectionSet::expand_selection_set(
-                            destination,
-                            &spread_selection.selection_set,
-                            check_cancellation,
-                        )?;
-                    } else {
-                        // convert to inline fragment
-                        let expanded = InlineFragmentSelection::from_fragment_spread_selection(
-                            selection_set.type_position.clone(), // the parent type of this inline selection
-                            spread_selection,
-                            check_cancellation,
-                        )?;
-                        destination.push(Selection::InlineFragment(Arc::new(expanded)));
-                    }
-                }
-                Selection::InlineFragment(inline_selection) => {
-                    destination.push(
-                        InlineFragmentSelection::new(
-                            inline_selection.inline_fragment.clone(),
-                            inline_selection
-                                .selection_set
-                                .expand_all_fragments(check_cancellation)?,
-                        )
-                        .into(),
-                    );
                 }
             }
         }
@@ -1680,13 +1363,6 @@ impl SelectionSet {
                         .get_selection_set_mut()
                         .optimize_sibling_typenames(interface_types_with_interface_objects)?;
                 }
-                SelectionValue::FragmentSpread(fragment_spread) => {
-                    // at this point in time all fragment spreads should have been converted into inline fragments
-                    return Err(FederationError::internal(format!(
-                        "Error while optimizing sibling typename information, selection set contains {} named fragment",
-                        fragment_spread.get().spread.fragment_name
-                    )));
-                }
             }
         }
 
@@ -1722,9 +1398,6 @@ impl SelectionSet {
                 true
             }),
             Selection::InlineFragment(inline) => Ok(!inline.selection_set.is_empty()),
-            Selection::FragmentSpread(_) => {
-                Err(FederationError::internal("unexpected fragment spread"))
-            }
         })?;
         Ok(if filtered.selections.is_empty() {
             None
@@ -1789,7 +1462,6 @@ impl SelectionSet {
         schema: &ValidFederationSchema,
         parent_type: &CompositeTypeDefinitionPosition,
         selections: impl Iterator<Item = &'a Selection>,
-        named_fragments: &NamedFragments,
     ) -> Result<Selection, FederationError> {
         let mut iter = selections;
         let Some(first) = iter.next() else {
@@ -1801,22 +1473,16 @@ impl SelectionSet {
         let Some(second) = iter.next() else {
             // Optimize for the simple case of a single selection, as we don't have to do anything
             // complex to merge the sub-selections.
-            return first.rebase_on(parent_type, named_fragments, schema);
+            return first.rebase_on(parent_type, schema);
         };
 
-        let element = first
-            .operation_element()?
-            .rebase_on(parent_type, schema, named_fragments)?;
+        let element = first.operation_element()?.rebase_on(parent_type, schema)?;
         let sub_selection_parent_type: Option<CompositeTypeDefinitionPosition> =
             element.sub_selection_type_position()?;
 
         let Some(ref sub_selection_parent_type) = sub_selection_parent_type else {
             // This is a leaf, so all updates should correspond ot the same field and we just use the first.
-            return Selection::from_operation_element(
-                element,
-                /*sub_selection*/ None,
-                named_fragments,
-            );
+            return Selection::from_operation_element(element, /*sub_selection*/ None);
         };
 
         // This case has a sub-selection. Merge all sub-selection updates.
@@ -1836,9 +1502,8 @@ impl SelectionSet {
             schema,
             sub_selection_parent_type,
             sub_selection_updates.values().map(|v| v.iter()),
-            named_fragments,
         )?);
-        Selection::from_operation_element(element, updated_sub_selection, named_fragments)
+        Selection::from_operation_element(element, updated_sub_selection)
     }
 
     /// Build a selection set by aggregating all items from the `selection_key_groups` iterator.
@@ -1849,10 +1514,9 @@ impl SelectionSet {
         schema: &ValidFederationSchema,
         parent_type: &CompositeTypeDefinitionPosition,
         selection_key_groups: impl Iterator<Item = impl Iterator<Item = &'a Selection>>,
-        named_fragments: &NamedFragments,
     ) -> Result<SelectionSet, FederationError> {
         selection_key_groups
-            .map(|group| Self::make_selection(schema, parent_type, group, named_fragments))
+            .map(|group| Self::make_selection(schema, parent_type, group))
             .try_collect()
             .map(|result| SelectionSet {
                 schema: schema.clone(),
@@ -1874,7 +1538,6 @@ impl SelectionSet {
     // `Arc::make_mut` on the `Arc` fields of `self` didn't seem better than cloning Arc instances.
     pub(crate) fn lazy_map(
         &self,
-        named_fragments: &NamedFragments,
         mut mapper: impl FnMut(&Selection) -> Result<SelectionMapperReturn, FederationError>,
     ) -> Result<SelectionSet, FederationError> {
         let mut iter = self.selections.values();
@@ -1926,12 +1589,11 @@ impl SelectionSet {
             &self.schema,
             &self.type_position,
             updated_selections.values().map(|v| v.iter()),
-            named_fragments,
         )
     }
 
     pub(crate) fn add_back_typename_in_attachments(&self) -> Result<SelectionSet, FederationError> {
-        self.lazy_map(/*named_fragments*/ &Default::default(), |selection| {
+        self.lazy_map(|selection| {
             let selection_element = selection.element()?;
             let updated = selection
                 .map_selection_set(|ss| ss.add_back_typename_in_attachments().map(Some))?;
@@ -1982,9 +1644,6 @@ impl SelectionSet {
                         .selection_set
                         .as_ref()
                         .map(|s| s.type_position.clone()),
-                    Selection::FragmentSpread(fragment_selection) => {
-                        Some(fragment_selection.spread.type_condition_position.clone())
-                    }
                     Selection::InlineFragment(inline_fragment_selection) => {
                         inline_fragment_selection
                             .inline_fragment
@@ -2078,9 +1737,6 @@ impl SelectionSet {
                     SelectionValue::InlineFragment(fragment) => fragment
                         .get_selection_set_mut()
                         .add_at_path(path, selection_set)?,
-                    SelectionValue::FragmentSpread(_fragment) => {
-                        return Err(FederationError::internal("add_at_path encountered a named fragment spread which should never happen".to_string()));
-                    }
                 };
             }
             // If we have no sub-path, we can add the selection.
@@ -2118,11 +1774,9 @@ impl SelectionSet {
                                 sub_selection_type_pos.clone(),
                             );
                             for selection in selections.iter() {
-                                selection_set.add_local_selection(&selection.rebase_on(
-                                    &sub_selection_type_pos,
-                                    &NamedFragments::default(),
-                                    &self.schema,
-                                )?)?;
+                                selection_set.add_local_selection(
+                                    &selection.rebase_on(&sub_selection_type_pos, &self.schema)?,
+                                )?;
                             }
                             Ok::<_, FederationError>(selection_set)
                         })
@@ -2243,9 +1897,6 @@ impl SelectionSet {
                             .insert(selection.with_updated_selection_set(updated_selection_set)?);
                     }
                 }
-                Selection::FragmentSpread(_) => {
-                    return Err(FederationError::internal("unexpected fragment spread"));
-                }
             }
         }
 
@@ -2267,12 +1918,6 @@ impl SelectionSet {
                     path: Vec::new(),
                     field: field.clone(),
                 }),
-                Selection::FragmentSpread(_fragment) => {
-                    debug_assert!(
-                        false,
-                        "unexpected fragment spreads in expanded fetch operation"
-                    );
-                }
                 Selection::InlineFragment(inline_fragment) => {
                     let condition = inline_fragment
                         .inline_fragment
@@ -2374,7 +2019,7 @@ impl SelectionSet {
     ) -> Result<bool, FederationError> {
         self.selections
             .values()
-            .fallible_any(|selection| selection.any_element(self.type_position.clone(), predicate))
+            .fallible_any(|selection| selection.any_element(predicate))
     }
 }
 
@@ -2604,7 +2249,7 @@ impl FieldSelection {
     pub(crate) fn from_field(
         field: &executable::Field,
         parent_type_position: &CompositeTypeDefinitionPosition,
-        fragments: &NamedFragments,
+        fragments_cache: &FragmentSpreadCache,
         schema: &ValidFederationSchema,
     ) -> Result<Option<FieldSelection>, FederationError> {
         // Skip __schema/__type introspection fields as router takes care of those, and they do not
@@ -2635,7 +2280,7 @@ impl FieldSelection {
             selection_set: if is_composite {
                 Some(SelectionSet::from_selection_set(
                     &field.selection_set,
-                    fragments,
+                    fragments_cache,
                     schema,
                 )?)
             } else {
@@ -2700,7 +2345,7 @@ impl InlineFragmentSelection {
     pub(crate) fn from_inline_fragment(
         inline_fragment: &executable::InlineFragment,
         parent_type_position: &CompositeTypeDefinitionPosition,
-        fragments: &NamedFragments,
+        fragments_cache: &FragmentSpreadCache,
         schema: &ValidFederationSchema,
     ) -> Result<InlineFragmentSelection, FederationError> {
         let type_condition_position: Option<CompositeTypeDefinitionPosition> =
@@ -2709,8 +2354,11 @@ impl InlineFragmentSelection {
             } else {
                 None
             };
-        let new_selection_set =
-            SelectionSet::from_selection_set(&inline_fragment.selection_set, fragments, schema)?;
+        let new_selection_set = SelectionSet::from_selection_set(
+            &inline_fragment.selection_set,
+            fragments_cache,
+            schema,
+        )?;
         let new_inline_fragment = InlineFragment {
             schema: schema.clone(),
             parent_type_position: parent_type_position.clone(),
@@ -2724,14 +2372,27 @@ impl InlineFragmentSelection {
         ))
     }
 
-    pub(crate) fn from_fragment_spread_selection(
-        parent_type_position: CompositeTypeDefinitionPosition,
-        fragment_spread_selection: &Arc<FragmentSpreadSelection>,
-        check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
+    pub(crate) fn from_fragment_spread(
+        parent_type_position: &CompositeTypeDefinitionPosition,
+        fragment_spread: &executable::FragmentSpread,
+        fragments_cache: &FragmentSpreadCache,
+        schema: &ValidFederationSchema,
     ) -> Result<InlineFragmentSelection, FederationError> {
-        let schema = fragment_spread_selection.spread.schema.schema();
-        for directive in fragment_spread_selection.spread.directives.iter() {
-            let Some(definition) = schema.directive_definitions.get(&directive.name) else {
+        let valid_schema = schema.schema();
+        // verify fragment exists
+        let Some(fragment_selection) = fragments_cache.get(&fragment_spread.fragment_name) else {
+            return Err(SingleFederationError::Internal {
+                message: format!(
+                    "Fragment spread referenced non-existent fragment \"{}\"",
+                    fragment_spread.fragment_name,
+                ),
+            }
+            .into());
+        };
+
+        // verify fragment spread directives can be applied on inline fragments
+        for directive in fragment_spread.directives.iter() {
+            let Some(definition) = valid_schema.directive_definitions.get(&directive.name) else {
                 return Err(FederationError::internal(format!(
                     "Undefined directive {}",
                     directive.name
@@ -2748,24 +2409,16 @@ impl InlineFragmentSelection {
             }
         }
 
-        // Note: We assume that fragment_spread_selection.spread.type_condition_position is the same as
-        //       fragment_spread_selection.selection_set.type_position.
+        // Note: We assume that fragment.type_condition() is the same as fragment.selection_set.ty.
         Ok(InlineFragmentSelection::new(
             InlineFragment {
-                schema: fragment_spread_selection.spread.schema.clone(),
-                parent_type_position,
-                type_condition_position: Some(
-                    fragment_spread_selection
-                        .spread
-                        .type_condition_position
-                        .clone(),
-                ),
-                directives: fragment_spread_selection.spread.directives.clone(),
+                schema: schema.clone(),
+                parent_type_position: parent_type_position.clone(),
+                type_condition_position: Some(fragment_selection.type_position.clone()),
+                directives: fragment_spread.directives.clone().into(),
                 selection_id: SelectionId::new(),
             },
-            fragment_spread_selection
-                .selection_set
-                .expand_all_fragments(check_cancellation)?,
+            fragment_selection.clone(),
         ))
     }
 
@@ -2809,127 +2462,6 @@ impl InlineFragmentSelection {
     }
 }
 
-/// This uses internal copy-on-write optimization to make `Clone` cheap.
-/// However a cloned `NamedFragments` still behaves like a deep copy:
-/// unlike in JS where we can have multiple references to a mutable map,
-/// here modifying a cloned map will leave the original unchanged.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub(crate) struct NamedFragments {
-    fragments: Arc<IndexMap<Name, Node<Fragment>>>,
-}
-
-impl NamedFragments {
-    pub(crate) fn new(
-        fragments: &IndexMap<Name, Node<executable::Fragment>>,
-        schema: &ValidFederationSchema,
-    ) -> NamedFragments {
-        // JS PORT - In order to normalize Fragments we need to process them in dependency order.
-        //
-        // In JS implementation mapInDependencyOrder method was called when rebasing/filtering/expanding selection sets.
-        // Since resulting `IndexMap` of `NormalizedFragments` will be already sorted, we only need to map it once
-        // when creating the `NamedFragments`.
-        NamedFragments::initialize_in_dependency_order(fragments, schema)
-    }
-
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &Node<Fragment>> {
-        self.fragments.values()
-    }
-
-    fn insert(&mut self, fragment: Fragment) {
-        Arc::make_mut(&mut self.fragments).insert(fragment.name.clone(), Node::new(fragment));
-    }
-
-    pub(crate) fn get(&self, name: &str) -> Option<&Node<Fragment>> {
-        self.fragments.get(name)
-    }
-
-    pub(crate) fn contains(&self, name: &str) -> bool {
-        self.fragments.contains_key(name)
-    }
-
-    /// JS PORT NOTE: In JS implementation this method was named mapInDependencyOrder and accepted a lambda to
-    /// apply transformation on the fragments. It was called when rebasing/filtering/expanding selection sets.
-    /// JS PORT NOTE: In JS implementation this method was potentially returning `undefined`. In order to simplify the code
-    /// we will always return `NamedFragments` even if they are empty.
-    ///
-    /// We normalize passed in fragments in their dependency order, i.e. if a fragment A uses another fragment B, then we will
-    /// normalize B _before_ attempting to normalize A. Normalized fragments have access to previously normalized fragments.
-    fn initialize_in_dependency_order(
-        fragments: &IndexMap<Name, Node<executable::Fragment>>,
-        schema: &ValidFederationSchema,
-    ) -> NamedFragments {
-        struct FragmentDependencies {
-            fragment: Node<executable::Fragment>,
-            depends_on: Vec<Name>,
-        }
-
-        // Note: We use IndexMap to stabilize the ordering of the result, which influences
-        //       the outcome of `map_to_expanded_selection_sets`.
-        let mut fragments_map: IndexMap<Name, FragmentDependencies> = IndexMap::default();
-        for fragment in fragments.values() {
-            let mut fragment_usages = IndexMap::default();
-            NamedFragments::collect_fragment_usages(&fragment.selection_set, &mut fragment_usages);
-            let usages: Vec<Name> = fragment_usages.keys().cloned().collect::<Vec<Name>>();
-            fragments_map.insert(
-                fragment.name.clone(),
-                FragmentDependencies {
-                    fragment: fragment.clone(),
-                    depends_on: usages,
-                },
-            );
-        }
-
-        let mut removed_fragments: IndexSet<Name> = IndexSet::default();
-        let mut mapped_fragments = NamedFragments::default();
-        while !fragments_map.is_empty() {
-            // Note that graphQL specifies that named fragments cannot have cycles (https://spec.graphql.org/draft/#sec-Fragment-spreads-must-not-form-cycles)
-            // and so we're guaranteed that on every iteration, at least one element of the map is removed (so the `while` loop will terminate).
-            fragments_map.retain(|name, info| {
-                let can_remove = info
-                    .depends_on
-                    .iter()
-                    .all(|n| mapped_fragments.contains(n) || removed_fragments.contains(n));
-                if can_remove {
-                    if let Ok(normalized) =
-                        Fragment::from_fragment(&info.fragment, &mapped_fragments, schema)
-                    {
-                        // TODO this actually throws in JS code -> should we also throw?
-                        // JS code has methods for
-                        // * add and throw exception if entry already there
-                        // * add_if_not_exists
-                        // Rust IndexMap exposes insert (that overwrites) and try_insert (that throws)
-                        mapped_fragments.insert(normalized);
-                    } else {
-                        removed_fragments.insert(name.clone());
-                    }
-                }
-                // keep only the elements that cannot be removed
-                !can_remove
-            });
-        }
-        mapped_fragments
-    }
-
-    /// Just like our `SelectionSet::used_fragments`, but with apollo-compiler types
-    fn collect_fragment_usages(
-        selection_set: &executable::SelectionSet,
-        aggregator: &mut IndexMap<Name, u32>,
-    ) {
-        selection_set.selections.iter().for_each(|s| match s {
-            executable::Selection::Field(f) => {
-                NamedFragments::collect_fragment_usages(&f.selection_set, aggregator);
-            }
-            executable::Selection::InlineFragment(i) => {
-                NamedFragments::collect_fragment_usages(&i.selection_set, aggregator);
-            }
-            executable::Selection::FragmentSpread(f) => {
-                let current_count = aggregator.entry(f.fragment_name.clone()).or_default();
-                *current_count += 1;
-            }
-        })
-    }
-}
-
 // @defer handling: removing and normalization
 
 const DEFER_DIRECTIVE_NAME: Name = name!("defer");
@@ -2938,7 +2470,7 @@ const DEFER_IF_ARGUMENT_NAME: Name = name!("if");
 
 pub(crate) struct NormalizedDefer {
     /// The operation modified to normalize @defer applications.
-    pub(crate) operation: Operation,
+    pub(crate) operation: NormalizedOperation,
     /// True if the operation contains any @defer applications.
     pub(crate) has_defers: bool,
     /// `@defer(label:)` values assigned by normalization.
@@ -2993,76 +2525,11 @@ impl DeferNormalizer {
     }
 }
 
-impl Fragment {
-    /// Returns true if the fragment's selection set contains the @defer directive.
-    fn has_defer(&self) -> bool {
-        self.selection_set.has_defer()
-    }
-
-    /// Create a new fragment without @defer directive applications that have a matching label.
-    fn reduce_defer(
-        &self,
-        defer_labels: &IndexSet<String>,
-        named_fragments: &NamedFragments,
-    ) -> Result<Self, FederationError> {
-        let selection_set = self
-            .selection_set
-            .reduce_defer(defer_labels, named_fragments)?;
-        Ok(Fragment {
-            schema: self.schema.clone(),
-            name: self.name.clone(),
-            type_condition_position: self.type_condition_position.clone(),
-            directives: self.directives.clone(),
-            selection_set,
-        })
-    }
-}
-
-impl NamedFragments {
-    /// Creates new fragment definitions by removing all @defer directives that had a matching label.
-    fn reduce_defer(&self, defer_labels: &IndexSet<String>) -> Result<Self, FederationError> {
-        let mut new_fragments = NamedFragments {
-            fragments: Default::default(),
-        };
-        // The iteration is in dependency order: when we iterate a fragment A that depends on
-        // fragment B, we know that we have already processed fragment B.
-        // This implies that all references to other fragments will already be part of
-        // `new_fragments`. Note that we must process all fragments that depend on each other, even
-        // if a fragment doesn't actually use @defer itself, to make sure that the `.selection_set`
-        // values on each selection are up to date.
-        for fragment in self.iter() {
-            let fragment = fragment.reduce_defer(defer_labels, &new_fragments)?;
-            new_fragments.insert(fragment);
-        }
-        Ok(new_fragments)
-    }
-}
-
 impl FieldSelection {
     /// Returns true if the selection or any of its subselections uses the @defer directive.
     fn has_defer(&self) -> bool {
         // Fields don't have @defer, so we only check the subselection.
         self.selection_set.as_ref().is_some_and(|s| s.has_defer())
-    }
-}
-
-impl FragmentSpread {
-    /// Returns true if the fragment spread has a @defer directive.
-    fn has_defer(&self) -> bool {
-        self.directives.has(&DEFER_DIRECTIVE_NAME)
-    }
-
-    /// Create a new fragment spread without @defer directive applications that have a matching label.
-    fn reduce_defer(&self, defer_labels: &IndexSet<String>) -> Result<Self, FederationError> {
-        let mut reduce_defer = self.clone();
-        reduce_defer.directives.remove_defer(defer_labels);
-        Ok(reduce_defer)
-    }
-}
-
-impl FragmentSpreadSelection {
-    fn has_defer(&self) -> bool {
-        self.spread.has_defer() || self.selection_set.has_defer()
     }
 }
 
@@ -3162,9 +2629,6 @@ impl Selection {
     pub(crate) fn has_defer(&self) -> bool {
         match self {
             Selection::Field(field_selection) => field_selection.has_defer(),
-            Selection::FragmentSpread(fragment_spread_selection) => {
-                fragment_spread_selection.has_defer()
-            }
             Selection::InlineFragment(inline_fragment_selection) => {
                 inline_fragment_selection.has_defer()
             }
@@ -3172,11 +2636,7 @@ impl Selection {
     }
 
     /// Create a new selection without @defer directive applications that have a matching label.
-    fn reduce_defer(
-        &self,
-        defer_labels: &IndexSet<String>,
-        named_fragments: &NamedFragments,
-    ) -> Result<Self, FederationError> {
+    fn reduce_defer(&self, defer_labels: &IndexSet<String>) -> Result<Self, FederationError> {
         match self {
             Selection::Field(field) => {
                 let Some(selection_set) = field
@@ -3188,20 +2648,12 @@ impl Selection {
                 };
 
                 Ok(field
-                    .with_updated_selection_set(Some(
-                        selection_set.reduce_defer(defer_labels, named_fragments)?,
-                    ))
+                    .with_updated_selection_set(Some(selection_set.reduce_defer(defer_labels)?))
                     .into())
-            }
-            Selection::FragmentSpread(frag) => {
-                let spread = frag.spread.reduce_defer(defer_labels)?;
-                Ok(FragmentSpreadSelection::new(spread, named_fragments)?.into())
             }
             Selection::InlineFragment(frag) => {
                 let inline_fragment = frag.inline_fragment.reduce_defer(defer_labels)?;
-                let selection_set = frag
-                    .selection_set
-                    .reduce_defer(defer_labels, named_fragments)?;
+                let selection_set = frag.selection_set.reduce_defer(defer_labels)?;
                 Ok(InlineFragmentSelection::new(inline_fragment, selection_set).into())
             }
         }
@@ -3218,9 +2670,6 @@ impl Selection {
                         .transpose()?,
                 ),
             ))),
-            Selection::FragmentSpread(_spread) => {
-                Err(FederationError::internal("unexpected fragment spread"))
-            }
             Selection::InlineFragment(inline) => inline
                 .with_updated_selection_set(
                     inline.selection_set.clone().normalize_defer(normalizer)?,
@@ -3233,15 +2682,10 @@ impl Selection {
 
 impl SelectionSet {
     /// Create a new selection set without @defer directive applications that have a matching label.
-    fn reduce_defer(
-        &self,
-        defer_labels: &IndexSet<String>,
-        named_fragments: &NamedFragments,
-    ) -> Result<Self, FederationError> {
+    fn reduce_defer(&self, defer_labels: &IndexSet<String>) -> Result<Self, FederationError> {
         let mut reduce_defer = SelectionSet::empty(self.schema.clone(), self.type_position.clone());
         for selection in self.selections.values() {
-            reduce_defer
-                .add_local_selection(&selection.reduce_defer(defer_labels, named_fragments)?)?;
+            reduce_defer.add_local_selection(&selection.reduce_defer(defer_labels)?)?;
         }
         Ok(reduce_defer)
     }
@@ -3268,14 +2712,9 @@ impl SelectionSet {
     }
 }
 
-impl Operation {
+impl NormalizedOperation {
     fn has_defer(&self) -> bool {
         self.selection_set.has_defer()
-            || self
-                .named_fragments
-                .fragments
-                .values()
-                .any(|f| f.has_defer())
     }
 
     /// Create a new operation without specific @defer(label:) directive applications.
@@ -3284,9 +2723,7 @@ impl Operation {
         labels: &IndexSet<String>,
     ) -> Result<Self, FederationError> {
         if self.has_defer() {
-            let named_fragments = self.named_fragments.reduce_defer(labels)?;
-            self.selection_set = self.selection_set.reduce_defer(labels, &named_fragments)?;
-            self.named_fragments = named_fragments;
+            self.selection_set = self.selection_set.reduce_defer(labels)?;
         }
         Ok(self)
     }
@@ -3394,21 +2831,10 @@ impl<'s> VariableCollector<'s> {
         self.visit_selection_set(&selection.selection_set);
     }
 
-    fn visit_fragment_spread(&mut self, fragment: &'s FragmentSpread) {
-        self.visit_directive_list(&fragment.directives);
-        self.visit_directive_list(&fragment.fragment_directives);
-    }
-
-    fn visit_fragment_spread_selection(&mut self, selection: &'s FragmentSpreadSelection) {
-        self.visit_fragment_spread(&selection.spread);
-        self.visit_selection_set(&selection.selection_set);
-    }
-
     fn visit_selection(&mut self, selection: &'s Selection) {
         match selection {
             Selection::Field(field) => self.visit_field_selection(field),
             Selection::InlineFragment(frag) => self.visit_inline_fragment_selection(frag),
-            Selection::FragmentSpread(frag) => self.visit_fragment_spread_selection(frag),
         }
     }
 
@@ -3437,10 +2863,10 @@ impl SelectionSet {
 
 // Conversion between apollo-rs and apollo-federation types.
 
-impl TryFrom<&Operation> for executable::Operation {
+impl TryFrom<&NormalizedOperation> for executable::Operation {
     type Error = FederationError;
 
-    fn try_from(normalized_operation: &Operation) -> Result<Self, Self::Error> {
+    fn try_from(normalized_operation: &NormalizedOperation) -> Result<Self, Self::Error> {
         let operation_type: executable::OperationType = normalized_operation.root_kind.into();
         Ok(Self {
             operation_type,
@@ -3448,18 +2874,6 @@ impl TryFrom<&Operation> for executable::Operation {
             variables: normalized_operation.variables.deref().clone(),
             directives: normalized_operation.directives.iter().cloned().collect(),
             selection_set: (&normalized_operation.selection_set).try_into()?,
-        })
-    }
-}
-
-impl TryFrom<&Fragment> for executable::Fragment {
-    type Error = FederationError;
-
-    fn try_from(normalized_fragment: &Fragment) -> Result<Self, Self::Error> {
-        Ok(Self {
-            name: normalized_fragment.name.clone(),
-            directives: normalized_fragment.directives.iter().cloned().collect(),
-            selection_set: (&normalized_fragment.selection_set).try_into()?,
         })
     }
 }
@@ -3501,11 +2915,6 @@ impl TryFrom<&Selection> for executable::Selection {
             Selection::Field(normalized_field_selection) => executable::Selection::Field(
                 Node::new(normalized_field_selection.deref().try_into()?),
             ),
-            Selection::FragmentSpread(normalized_fragment_spread_selection) => {
-                executable::Selection::FragmentSpread(Node::new(
-                    normalized_fragment_spread_selection.deref().into(),
-                ))
-            }
             Selection::InlineFragment(normalized_inline_fragment_selection) => {
                 executable::Selection::InlineFragment(Node::new(
                     normalized_inline_fragment_selection.deref().try_into()?,
@@ -3591,39 +3000,12 @@ impl TryFrom<&InlineFragmentSelection> for executable::InlineFragment {
     }
 }
 
-impl From<&FragmentSpreadSelection> for executable::FragmentSpread {
-    fn from(val: &FragmentSpreadSelection) -> Self {
-        let normalized_fragment_spread = &val.spread;
-        Self {
-            fragment_name: normalized_fragment_spread.fragment_name.to_owned(),
-            directives: normalized_fragment_spread
-                .directives
-                .iter()
-                .cloned()
-                .collect(),
-        }
-    }
-}
-
-impl TryFrom<Operation> for Valid<executable::ExecutableDocument> {
+impl TryFrom<NormalizedOperation> for Valid<executable::ExecutableDocument> {
     type Error = FederationError;
 
-    fn try_from(value: Operation) -> Result<Self, Self::Error> {
+    fn try_from(value: NormalizedOperation) -> Result<Self, Self::Error> {
         let operation = executable::Operation::try_from(&value)?;
-        let fragments = value
-            .named_fragments
-            .fragments
-            .iter()
-            .map(|(name, fragment)| {
-                Ok((
-                    name.clone(),
-                    Node::new(executable::Fragment::try_from(&**fragment)?),
-                ))
-            })
-            .collect::<Result<IndexMap<_, _>, FederationError>>()?;
-
         let mut document = executable::ExecutableDocument::new();
-        document.fragments = fragments;
         document.operations.insert(operation);
         coerce_executable_values(value.schema.schema(), &mut document);
         Ok(document.validate(value.schema.schema())?)
@@ -3632,27 +3014,13 @@ impl TryFrom<Operation> for Valid<executable::ExecutableDocument> {
 
 // Display implementations for the operation types.
 
-impl Display for Operation {
+impl Display for NormalizedOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let operation: executable::Operation = match self.try_into() {
             Ok(operation) => operation,
             Err(_) => return Err(std::fmt::Error),
         };
-        for fragment_def in self.named_fragments.iter() {
-            fragment_def.fmt(f)?;
-            f.write_str("\n\n")?;
-        }
         operation.serialize().fmt(f)
-    }
-}
-
-impl Display for Fragment {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let fragment: executable::Fragment = match self.try_into() {
-            Ok(fragment) => fragment,
-            Err(_) => return Err(std::fmt::Error),
-        };
-        fragment.serialize().fmt(f)
     }
 }
 
@@ -3696,13 +3064,6 @@ impl Display for InlineFragmentSelection {
     }
 }
 
-impl Display for FragmentSpreadSelection {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let fragment_spread: executable::FragmentSpread = self.into();
-        fragment_spread.serialize().no_indent().fmt(f)
-    }
-}
-
 impl Display for Field {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         // We create a selection with an empty selection set here, relying on `apollo-rs` to skip
@@ -3728,22 +3089,114 @@ impl Display for InlineFragment {
     }
 }
 
-impl Display for FragmentSpread {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let data = self;
-        f.write_str("...")?;
-        f.write_str(&data.fragment_name)?;
-        data.directives.serialize().no_indent().fmt(f)
-    }
-}
-
 impl Display for OperationElement {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             OperationElement::Field(field) => field.fmt(f),
             OperationElement::InlineFragment(inline_fragment) => inline_fragment.fmt(f),
-            OperationElement::FragmentSpread(fragment_spread) => fragment_spread.fmt(f),
         }
+    }
+}
+
+/// Holds normalized selection sets of provided fragments.
+#[derive(Default)]
+pub(crate) struct FragmentSpreadCache {
+    fragment_selection_sets: Arc<HashMap<Name, SelectionSet>>,
+}
+
+impl FragmentSpreadCache {
+    // in order to normalize selection sets, we need to process them in dependency order
+    fn init(fragments: &IndexMap<Name, Node<Fragment>>, schema: &ValidFederationSchema) -> Self {
+        FragmentSpreadCache::normalize_in_dependency_order(fragments, schema)
+    }
+
+    fn insert(&mut self, fragment_name: &Name, selection_set: SelectionSet) {
+        Arc::make_mut(&mut self.fragment_selection_sets)
+            .insert(fragment_name.clone(), selection_set);
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<&SelectionSet> {
+        self.fragment_selection_sets.get(name)
+    }
+
+    pub(crate) fn contains(&self, name: &str) -> bool {
+        self.fragment_selection_sets.contains_key(name)
+    }
+
+    // We normalize passed in fragments in their dependency order, i.e. if a fragment A uses another fragment B, then we will
+    // normalize B _before_ attempting to normalize A. Normalized fragments have access to previously normalized fragments.
+    fn normalize_in_dependency_order(
+        fragments: &IndexMap<Name, Node<Fragment>>,
+        schema: &ValidFederationSchema,
+    ) -> FragmentSpreadCache {
+        struct FragmentDependencies {
+            fragment: Node<Fragment>,
+            depends_on: Vec<Name>,
+        }
+
+        // Note: We use IndexMap to stabilize the ordering of the result so we can
+        // normalize them in order.
+        let mut fragments_map: IndexMap<Name, FragmentDependencies> = IndexMap::default();
+        for fragment in fragments.values() {
+            let mut fragment_usages = IndexMap::default();
+            FragmentSpreadCache::collect_fragment_usages(
+                &fragment.selection_set,
+                &mut fragment_usages,
+            );
+            let usages: Vec<Name> = fragment_usages.keys().cloned().collect::<Vec<Name>>();
+            fragments_map.insert(
+                fragment.name.clone(),
+                FragmentDependencies {
+                    fragment: fragment.clone(),
+                    depends_on: usages,
+                },
+            );
+        }
+
+        let mut removed_fragments: IndexSet<Name> = IndexSet::default();
+        let mut cache = FragmentSpreadCache::default();
+        while !fragments_map.is_empty() {
+            // Note that graphQL specifies that named fragments cannot have cycles (https://spec.graphql.org/draft/#sec-Fragment-spreads-must-not-form-cycles)
+            // and so we're guaranteed that on every iteration, at least one element of the map is removed (so the `while` loop will terminate).
+            fragments_map.retain(|name, info| {
+                let can_remove = info
+                    .depends_on
+                    .iter()
+                    .all(|n| cache.contains(n) || removed_fragments.contains(n));
+                if can_remove {
+                    if let Ok(normalized) = SelectionSet::from_selection_set(
+                        &info.fragment.selection_set,
+                        &cache,
+                        schema,
+                    ) {
+                        cache.insert(&info.fragment.name, normalized);
+                    } else {
+                        removed_fragments.insert(name.clone());
+                    }
+                }
+                // keep only the elements that cannot be removed
+                !can_remove
+            });
+        }
+        cache
+    }
+    /// Just like our `SelectionSet::used_fragments`, but with apollo-compiler types
+    fn collect_fragment_usages(
+        selection_set: &executable::SelectionSet,
+        aggregator: &mut IndexMap<Name, u32>,
+    ) {
+        selection_set.selections.iter().for_each(|s| match s {
+            executable::Selection::Field(f) => {
+                FragmentSpreadCache::collect_fragment_usages(&f.selection_set, aggregator);
+            }
+            executable::Selection::InlineFragment(i) => {
+                FragmentSpreadCache::collect_fragment_usages(&i.selection_set, aggregator);
+            }
+            executable::Selection::FragmentSpread(f) => {
+                let current_count = aggregator.entry(f.fragment_name.clone()).or_default();
+                *current_count += 1;
+            }
+        })
     }
 }
 
@@ -3758,38 +3211,29 @@ impl Display for OperationElement {
 ///   their parent type matches.
 pub(crate) fn normalize_operation(
     operation: &executable::Operation,
-    named_fragments: NamedFragments,
+    fragments: &IndexMap<Name, Node<Fragment>>,
     schema: &ValidFederationSchema,
     interface_types_with_interface_objects: &IndexSet<InterfaceTypeDefinitionPosition>,
-    check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
-) -> Result<Operation, FederationError> {
+) -> Result<NormalizedOperation, FederationError> {
+    let fragment_cache = FragmentSpreadCache::init(fragments, schema);
     let mut normalized_selection_set =
-        SelectionSet::from_selection_set(&operation.selection_set, &named_fragments, schema)?;
-    normalized_selection_set = normalized_selection_set.expand_all_fragments(check_cancellation)?;
+        SelectionSet::from_selection_set(&operation.selection_set, &fragment_cache, schema)?;
     // We clear up the fragments since we've expanded all.
     // Also note that expanding fragment usually generate unnecessary fragments/inefficient
-    // selections, so it basically always make sense to flatten afterwards. Besides, fragment
-    // reuse (done by `optimize`) relies on the fact that its input is normalized to work properly,
-    // so all the more reason to do it here.
+    // selections, so it basically always make sense to flatten afterwards.
     // PORT_NOTE: This was done in `Operation.expandAllFragments`, but it's moved here.
-    normalized_selection_set = normalized_selection_set.flatten_unnecessary_fragments(
-        &normalized_selection_set.type_position,
-        &named_fragments,
-        schema,
-    )?;
+    normalized_selection_set = normalized_selection_set
+        .flatten_unnecessary_fragments(&normalized_selection_set.type_position, schema)?;
     remove_introspection(&mut normalized_selection_set);
     normalized_selection_set.optimize_sibling_typenames(interface_types_with_interface_objects)?;
 
-    let normalized_operation = Operation {
+    let normalized_operation = NormalizedOperation {
         schema: schema.clone(),
         root_kind: operation.operation_type.into(),
         name: operation.name.clone(),
         variables: Arc::new(operation.variables.clone()),
         directives: operation.directives.clone().into(),
         selection_set: normalized_selection_set,
-        // fragments were already expanded into selection sets
-        // new ones will be generated when optimizing the final subgraph fetch operations
-        named_fragments: Default::default(),
     };
     Ok(normalized_operation)
 }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1067,10 +1067,8 @@ impl SelectionSet {
                                     self.parent_type.clone(),
                                     selection,
                                 ));
-                            } else {
-                                if let Some(set) = selection.selection_set().cloned() {
-                                    self.stack.push((selection.element(), Self::new(set)));
-                                }
+                            } else if let Some(set) = selection.selection_set().cloned() {
+                                self.stack.push((selection.element(), Self::new(set)));
                             }
                         }
                         Some((element, top)) => {
@@ -3102,6 +3100,12 @@ impl Display for OperationElement {
 }
 
 /// Holds normalized selection sets of provided fragments.
+///
+/// PORT_NOTE: The JS codebase combined the fragment spread's directives with the fragment
+/// definition's directives. This was invalid GraphQL as those directives may not be applicable
+/// on different locations. Fragment directives are currently ignored. We validate whether
+/// fragment spread directives can be applied to inline fragment and raise an error if they
+/// are not applicable.
 #[derive(Default)]
 pub(crate) struct FragmentSpreadCache {
     fragment_selection_sets: Arc<HashMap<Name, SelectionSet>>,

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -39,6 +39,8 @@ use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::graphql_definition::BooleanOrVariable;
 use crate::link::graphql_definition::DeferDirectiveArguments;
+#[cfg(test)]
+use crate::operation::tests::never_cancel;
 use crate::query_graph::graph_path::OpPathElement;
 use crate::query_plan::FetchDataKeyRenamer;
 use crate::query_plan::FetchDataPathElement;
@@ -224,8 +226,9 @@ impl NormalizedOperation {
             directives: operation.directives.clone().into(),
             selection_set: SelectionSet::from_selection_set(
                 &operation.selection_set,
-                &FragmentSpreadCache::init(&document.fragments, &schema),
+                &FragmentSpreadCache::init(&document.fragments, &schema, &never_cancel),
                 &schema,
+                &never_cancel,
             )?,
         };
         Ok(normalized_operation)

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -39,8 +39,6 @@ use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::graphql_definition::BooleanOrVariable;
 use crate::link::graphql_definition::DeferDirectiveArguments;
-#[cfg(test)]
-use crate::operation::tests::never_cancel;
 use crate::query_graph::graph_path::OpPathElement;
 use crate::query_plan::FetchDataKeyRenamer;
 use crate::query_plan::FetchDataPathElement;
@@ -67,6 +65,8 @@ pub(crate) use contains::*;
 pub(crate) use directive_list::DirectiveList;
 pub(crate) use merging::*;
 pub(crate) use rebase::*;
+#[cfg(test)]
+pub(crate) use tests::never_cancel;
 
 pub(crate) const TYPENAME_FIELD: Name = name!("__typename");
 

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -50,7 +50,7 @@ use apollo_compiler::validation::Valid;
 use super::FieldSelection;
 use super::HasSelectionKey;
 use super::InlineFragmentSelection;
-use super::NormalizedOperation;
+use super::Operation;
 use super::Selection;
 use super::SelectionId;
 use super::SelectionMapperReturn;
@@ -124,7 +124,7 @@ impl From<SelectionOrSet> for SelectionMapperReturn {
     }
 }
 
-impl NormalizedOperation {
+impl Operation {
     /// Optimize the parsed size of the operation by generating fragments from selection sets that
     /// occur multiple times in the operation.
     pub(crate) fn generate_fragments(
@@ -457,11 +457,10 @@ mod tests {
             }
         "#;
 
-        fn operation_without_empty_branches(operation: &NormalizedOperation) -> Option<String> {
+        fn operation_without_empty_branches(operation: &Operation) -> Option<String> {
             operation
                 .selection_set
                 .without_empty_branches()
-                .unwrap()
                 .map(|s| s.to_string())
         }
 

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -3,23 +3,17 @@
 //! Often, the change is between equivalent types from different schemas, but selections can also
 //! be rebased from one type to another in the same schema.
 
-use apollo_compiler::Name;
 use itertools::Itertools;
 
 use super::Field;
 use super::FieldSelection;
-use super::FragmentSpread;
-use super::FragmentSpreadSelection;
 use super::InlineFragment;
 use super::InlineFragmentSelection;
-use super::NamedFragments;
 use super::OperationElement;
 use super::Selection;
-use super::SelectionId;
 use super::SelectionSet;
 use super::TYPENAME_FIELD;
 use super::runtime_types_intersect;
-use crate::ensure;
 use crate::error::FederationError;
 use crate::schema::ValidFederationSchema;
 use crate::schema::position::CompositeTypeDefinitionPosition;
@@ -48,29 +42,22 @@ impl Selection {
     fn rebase_inner(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<Selection, FederationError> {
         match self {
             Selection::Field(field) => field
-                .rebase_inner(parent_type, named_fragments, schema)
+                .rebase_inner(parent_type, schema)
                 .map(|field| field.into()),
-            Selection::FragmentSpread(spread) => {
-                spread.rebase_inner(parent_type, named_fragments, schema)
-            }
-            Selection::InlineFragment(inline) => {
-                inline.rebase_inner(parent_type, named_fragments, schema)
-            }
+            Selection::InlineFragment(inline) => inline.rebase_inner(parent_type, schema),
         }
     }
 
     pub(crate) fn rebase_on(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<Selection, FederationError> {
-        self.rebase_inner(parent_type, named_fragments, schema)
+        self.rebase_inner(parent_type, schema)
     }
 
     fn can_add_to(
@@ -80,10 +67,6 @@ impl Selection {
     ) -> Result<bool, FederationError> {
         match self {
             Selection::Field(field) => field.can_add_to(parent_type, schema),
-            // Since `rebaseOn` never fails, we copy the logic here and always return `true`. But as
-            // mentioned in `rebaseOn`, this leaves it a bit to the caller to know what they're
-            // doing.
-            Selection::FragmentSpread(_) => Ok(true),
             Selection::InlineFragment(inline) => inline.can_add_to(parent_type, schema),
         }
     }
@@ -107,8 +90,6 @@ pub(crate) enum RebaseError {
     },
     #[error("Cannot rebase composite field selection because its subselection is empty")]
     EmptySelectionSet,
-    #[error("Cannot rebase {fragment_name} fragment if it isn't part of the provided fragments")]
-    MissingFragment { fragment_name: Name },
     #[error(
         "Cannot add fragment of condition `{}` (runtimes: [{}]) to parent type `{}` (runtimes: [{}])",
         type_condition.as_ref().map_or_else(Default::default, |t| t.to_string()),
@@ -279,7 +260,6 @@ impl FieldSelection {
     fn rebase_inner(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<FieldSelection, FederationError> {
         if &self.field.schema == schema && &self.field.field_position.parent() == parent_type {
@@ -313,8 +293,7 @@ impl FieldSelection {
             });
         }
 
-        let rebased_selection_set =
-            selection_set.rebase_inner(&rebased_base_type, named_fragments, schema)?;
+        let rebased_selection_set = selection_set.rebase_inner(&rebased_base_type, schema)?;
         if rebased_selection_set.selections.is_empty() {
             Err(RebaseError::EmptySelectionSet.into())
         } else {
@@ -345,146 +324,6 @@ impl FieldSelection {
             }
         }
         Ok(true)
-    }
-}
-
-impl FragmentSpread {
-    /// - `named_fragments`: named fragment definitions that are rebased for the subgraph.
-    // Note: Unlike other `rebase_on`, this method should only be used during fetch operation
-    //       optimization. Thus, it's rebasing within the same subgraph schema.
-    pub(crate) fn rebase_on(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        schema: &ValidFederationSchema,
-        named_fragments: &NamedFragments,
-    ) -> Result<FragmentSpread, FederationError> {
-        let Some(named_fragment) = named_fragments.get(&self.fragment_name) else {
-            return Err(RebaseError::MissingFragment {
-                fragment_name: self.fragment_name.clone(),
-            }
-            .into());
-        };
-        ensure!(
-            *schema == self.schema,
-            "Fragment spread should only be rebased within the same subgraph"
-        );
-        ensure!(
-            *schema == named_fragment.schema,
-            "Referenced named fragment should've been rebased for the subgraph"
-        );
-        if runtime_types_intersect(
-            parent_type,
-            &named_fragment.type_condition_position,
-            &self.schema,
-        ) {
-            Ok(FragmentSpread::from_fragment(
-                named_fragment,
-                &self.directives,
-            ))
-        } else {
-            Err(RebaseError::NonIntersectingCondition {
-                type_condition: named_fragment.type_condition_position.clone().into(),
-                parent_type: parent_type.clone(),
-                schema: schema.clone(),
-            }
-            .into())
-        }
-    }
-}
-
-impl FragmentSpreadSelection {
-    fn rebase_inner(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
-        schema: &ValidFederationSchema,
-    ) -> Result<Selection, FederationError> {
-        // We preserve the parent type here, to make sure we don't lose context, but we actually don't
-        // want to expand the spread as that would compromise the code that optimize subgraph fetches to re-use named
-        // fragments.
-        //
-        // This is a little bit iffy, because the fragment may not apply at this parent type, but we
-        // currently leave it to the caller to ensure this is not a mistake. But most of the
-        // QP code works on selections with fully expanded fragments, so this code (and that of `can_add_to`
-        // on come into play in the code for reusing fragments, and that code calls those methods
-        // appropriately.
-        if self.spread.schema == *schema && self.spread.type_condition_position == *parent_type {
-            return Ok(self.clone().into());
-        }
-
-        let rebase_on_same_schema = self.spread.schema == *schema;
-        let Some(named_fragment) = named_fragments.get(&self.spread.fragment_name) else {
-            // If we're rebasing on another schema (think a subgraph), then named fragments will have been rebased on that, and some
-            // of them may not contain anything that is on that subgraph, in which case they will not have been included at all.
-            // If so, then as long as we're not asked to error if we cannot rebase, then we're happy to skip that spread (since again,
-            // it expands to nothing that applies on the schema).
-            return Err(RebaseError::MissingFragment {
-                fragment_name: self.spread.fragment_name.clone(),
-            }
-            .into());
-        };
-
-        // Lastly, if we rebase on a different schema, it's possible the fragment type does not intersect the
-        // parent type. For instance, the parent type could be some object type T while the fragment is an
-        // interface I, and T may implement I in the supergraph, but not in a particular subgraph (of course,
-        // if I doesn't exist at all in the subgraph, then we'll have exited above, but I may exist in the
-        // subgraph, just not be implemented by T for some reason). In that case, we can't reuse the fragment
-        // as its spread is essentially invalid in that position, so we have to replace it by the expansion
-        // of that fragment, which we rebase on the parentType (which in turn, will remove anythings within
-        // the fragment selection that needs removing, potentially everything).
-        if !rebase_on_same_schema
-            && !runtime_types_intersect(
-                parent_type,
-                &named_fragment.type_condition_position,
-                schema,
-            )
-        {
-            // Note that we've used the rebased `named_fragment` to check the type intersection because we needed to
-            // compare runtime types "for the schema we're rebasing into". But now that we're deciding to not reuse
-            // this rebased fragment, what we rebase is the selection set of the non-rebased fragment. And that's
-            // important because the very logic we're hitting here may need to happen inside the rebase on the
-            // fragment selection, but that logic would not be triggered if we used the rebased `named_fragment` since
-            // `rebase_on_same_schema` would then be 'true'.
-            let expanded_selection_set =
-                self.selection_set
-                    .rebase_inner(parent_type, named_fragments, schema)?;
-            // In theory, we could return the selection set directly, but making `SelectionSet.rebase_on` sometimes
-            // return a `SelectionSet` complicate things quite a bit. So instead, we encapsulate the selection set
-            // in an "empty" inline fragment. This make for non-really-optimal selection sets in the (relatively
-            // rare) case where this is triggered, but in practice this "inefficiency" is removed by future calls
-            // to `flatten_unnecessary_fragments`.
-            return if expanded_selection_set.selections.is_empty() {
-                Err(RebaseError::EmptySelectionSet.into())
-            } else {
-                Ok(InlineFragmentSelection::new(
-                    InlineFragment {
-                        schema: schema.clone(),
-                        parent_type_position: parent_type.clone(),
-                        type_condition_position: None,
-                        directives: Default::default(),
-                        selection_id: SelectionId::new(),
-                    },
-                    expanded_selection_set,
-                )
-                .into())
-            };
-        }
-
-        let spread = FragmentSpread::from_fragment(named_fragment, &self.spread.directives);
-        Ok(FragmentSpreadSelection {
-            spread,
-            selection_set: named_fragment.selection_set.clone(),
-        }
-        .into())
-    }
-
-    pub(crate) fn rebase_on(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
-        schema: &ValidFederationSchema,
-    ) -> Result<Selection, FederationError> {
-        self.rebase_inner(parent_type, named_fragments, schema)
     }
 }
 
@@ -578,7 +417,6 @@ impl InlineFragmentSelection {
     fn rebase_inner(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<Selection, FederationError> {
         if &self.inline_fragment.schema == schema
@@ -596,9 +434,9 @@ impl InlineFragmentSelection {
             // we are within the same schema - selection set does not have to be rebased
             Ok(InlineFragmentSelection::new(rebased_fragment, self.selection_set.clone()).into())
         } else {
-            let rebased_selection_set =
-                self.selection_set
-                    .rebase_inner(&rebased_casted_type, named_fragments, schema)?;
+            let rebased_selection_set = self
+                .selection_set
+                .rebase_inner(&rebased_casted_type, schema)?;
             if rebased_selection_set.selections.is_empty() {
                 // empty selection set
                 Err(RebaseError::EmptySelectionSet.into())
@@ -637,13 +475,9 @@ impl OperationElement {
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,
-        named_fragments: &NamedFragments,
     ) -> Result<OperationElement, FederationError> {
         match self {
             OperationElement::Field(field) => Ok(field.rebase_on(parent_type, schema)?.into()),
-            OperationElement::FragmentSpread(fragment) => Ok(fragment
-                .rebase_on(parent_type, schema, named_fragments)?
-                .into()),
             OperationElement::InlineFragment(inline) => {
                 Ok(inline.rebase_on(parent_type, schema)?.into())
             }
@@ -655,7 +489,6 @@ impl OperationElement {
     ) -> Result<Option<CompositeTypeDefinitionPosition>, FederationError> {
         match self {
             OperationElement::Field(field) => Ok(field.output_base_type()?.try_into().ok()),
-            OperationElement::FragmentSpread(_) => Ok(None), // No sub-selection set
             OperationElement::InlineFragment(inline) => Ok(Some(inline.casted_type())),
         }
     }
@@ -665,13 +498,12 @@ impl SelectionSet {
     fn rebase_inner(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<SelectionSet, FederationError> {
         let rebased_results = self
             .selections
             .values()
-            .map(|selection| selection.rebase_inner(parent_type, named_fragments, schema));
+            .map(|selection| selection.rebase_inner(parent_type, schema));
 
         Ok(SelectionSet {
             schema: schema.clone(),
@@ -688,10 +520,9 @@ impl SelectionSet {
     pub(crate) fn rebase_on(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<SelectionSet, FederationError> {
-        self.rebase_inner(parent_type, named_fragments, schema)
+        self.rebase_inner(parent_type, schema)
     }
 
     /// Returns true if the selection set would select cleanly from the given type in the given

--- a/apollo-federation/src/operation/selection_map.rs
+++ b/apollo-federation/src/operation/selection_map.rs
@@ -414,16 +414,16 @@ impl SelectionMap {
     /// filtering has happened on all the selections of its sub-selection.
     pub(crate) fn filter_recursive_depth_first(
         &self,
-        predicate: &mut dyn FnMut(&Selection) -> Result<bool, FederationError>,
-    ) -> Result<Cow<'_, Self>, FederationError> {
+        predicate: &mut dyn FnMut(&Selection) -> bool,
+    ) -> Cow<'_, Self> {
         fn recur_sub_selections<'sel>(
             selection: &'sel Selection,
-            predicate: &mut dyn FnMut(&Selection) -> Result<bool, FederationError>,
-        ) -> Result<Cow<'sel, Selection>, FederationError> {
-            Ok(match selection {
+            predicate: &mut dyn FnMut(&Selection) -> bool,
+        ) -> Cow<'sel, Selection> {
+            match selection {
                 Selection::Field(field) => {
                     if let Some(sub_selections) = &field.selection_set {
-                        match sub_selections.filter_recursive_depth_first(predicate)? {
+                        match sub_selections.filter_recursive_depth_first(predicate) {
                             Cow::Borrowed(_) => Cow::Borrowed(selection),
                             Cow::Owned(new) => {
                                 Cow::Owned(Selection::from_field(field.field.clone(), Some(new)))
@@ -435,7 +435,7 @@ impl SelectionMap {
                 }
                 Selection::InlineFragment(fragment) => match fragment
                     .selection_set
-                    .filter_recursive_depth_first(predicate)?
+                    .filter_recursive_depth_first(predicate)
                 {
                     Cow::Borrowed(_) => Cow::Borrowed(selection),
                     Cow::Owned(selection_set) => Cow::Owned(Selection::InlineFragment(Arc::new(
@@ -445,17 +445,17 @@ impl SelectionMap {
                         ),
                     ))),
                 },
-            })
+            }
         }
         let mut iter = self.values();
         let mut enumerated = (&mut iter).enumerate();
         let mut new_map: Self;
         loop {
             let Some((index, selection)) = enumerated.next() else {
-                return Ok(Cow::Borrowed(self));
+                return Cow::Borrowed(self);
             };
-            let filtered = recur_sub_selections(selection, predicate)?;
-            let keep = predicate(&filtered)?;
+            let filtered = recur_sub_selections(selection, predicate);
+            let keep = predicate(&filtered);
             if keep && matches!(filtered, Cow::Borrowed(_)) {
                 // Nothing changed so far, continue without cloning
                 continue;
@@ -470,12 +470,12 @@ impl SelectionMap {
             break;
         }
         for selection in iter {
-            let filtered = recur_sub_selections(selection, predicate)?;
-            if predicate(&filtered)? {
+            let filtered = recur_sub_selections(selection, predicate);
+            if predicate(&filtered) {
                 new_map.insert(filtered.into_owned());
             }
         }
-        Ok(Cow::Owned(new_map))
+        Cow::Owned(new_map)
     }
 }
 

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -425,7 +425,7 @@ mod tests {
     use apollo_compiler::Schema;
 
     use super::*;
-    use crate::operation::NormalizedOperation;
+    use crate::operation::Operation;
 
     #[test]
     fn does_not_duplicate_fragments_regression_router782() {
@@ -453,7 +453,7 @@ type Query {
 
         // Below, the second `... on MySpecialNode` is redundant,
         // the same selection is already guaranteed by the first.
-        let operation = NormalizedOperation::parse(
+        let operation = Operation::parse(
             schema.clone(),
             r#"
 {

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -6,14 +6,11 @@ use apollo_compiler::name;
 use super::DirectiveList;
 use super::Field;
 use super::FieldSelection;
-use super::FragmentSpreadSelection;
 use super::InlineFragmentSelection;
-use super::NamedFragments;
 use super::Selection;
 use super::SelectionMap;
 use super::SelectionSet;
 use super::runtime_types_intersect;
-use crate::ensure;
 use crate::error::FederationError;
 use crate::schema::ValidFederationSchema;
 use crate::schema::position::CompositeTypeDefinitionPosition;
@@ -28,18 +25,12 @@ impl Selection {
     fn flatten_unnecessary_fragments(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<Option<SelectionOrSet>, FederationError> {
         match self {
-            Selection::Field(field) => {
-                field.flatten_unnecessary_fragments(parent_type, named_fragments, schema)
-            }
-            Selection::FragmentSpread(spread) => {
-                spread.flatten_unnecessary_fragments(parent_type, named_fragments, schema)
-            }
+            Selection::Field(field) => field.flatten_unnecessary_fragments(parent_type, schema),
             Selection::InlineFragment(inline) => {
-                inline.flatten_unnecessary_fragments(parent_type, named_fragments, schema)
+                inline.flatten_unnecessary_fragments(parent_type, schema)
             }
         }
     }
@@ -49,7 +40,6 @@ impl FieldSelection {
     fn flatten_unnecessary_fragments(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<Option<SelectionOrSet>, FederationError> {
         let field_position =
@@ -71,11 +61,7 @@ impl FieldSelection {
             let field_composite_type_position: CompositeTypeDefinitionPosition =
                 field_element.output_base_type()?.try_into()?;
             let mut normalized_selection: SelectionSet = selection_set
-                .flatten_unnecessary_fragments(
-                    &field_composite_type_position,
-                    named_fragments,
-                    schema,
-                )?;
+                .flatten_unnecessary_fragments(&field_composite_type_position, schema)?;
 
             let mut selection = self.with_updated_element(field_element);
             if normalized_selection.is_empty() {
@@ -116,41 +102,10 @@ impl FieldSelection {
     }
 }
 
-impl FragmentSpreadSelection {
-    fn flatten_unnecessary_fragments(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
-        schema: &ValidFederationSchema,
-    ) -> Result<Option<SelectionOrSet>, FederationError> {
-        let this_condition = self.spread.type_condition_position.clone();
-        // This method assumes by contract that `parent_type` runtimes intersects `self.inline_fragment.parent_type_position`'s,
-        // but `parent_type` runtimes may be a subset. So first check if the selection should not be discarded on that account (that
-        // is, we should not keep the selection if its condition runtimes don't intersect at all with those of
-        // `parent_type` as that would ultimately make an invalid selection set).
-        if (self.spread.schema != *schema || this_condition != *parent_type)
-            && !runtime_types_intersect(&this_condition, parent_type, schema)
-        {
-            return Ok(None);
-        }
-
-        // We must update the spread parent type if necessary since we're not going deeper,
-        // or we'll be fundamentally losing context.
-        ensure!(
-            self.spread.schema == *schema,
-            "Should not try to flatten_unnecessary_fragments using a type from another schema",
-        );
-
-        let rebased_fragment_spread = self.rebase_on(parent_type, named_fragments, schema)?;
-        Ok(Some(SelectionOrSet::Selection(rebased_fragment_spread)))
-    }
-}
-
 impl InlineFragmentSelection {
     fn flatten_unnecessary_fragments(
         self: &Arc<Self>,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<Option<SelectionOrSet>, FederationError> {
         let this_condition = self.inline_fragment.type_condition_position.as_ref();
@@ -181,11 +136,9 @@ impl InlineFragmentSelection {
             if useless_fragment || parent_type.is_object_type() {
                 // Try to skip this fragment and flatten_unnecessary_fragments self.selection_set with `parent_type`,
                 // instead of its original type.
-                let selection_set = self.selection_set.flatten_unnecessary_fragments(
-                    parent_type,
-                    named_fragments,
-                    schema,
-                )?;
+                let selection_set = self
+                    .selection_set
+                    .flatten_unnecessary_fragments(parent_type, schema)?;
                 return if selection_set.is_empty() {
                     Ok(None)
                 } else {
@@ -196,7 +149,7 @@ impl InlineFragmentSelection {
                     let selection_set = if useless_fragment {
                         selection_set.clone()
                     } else {
-                        selection_set.rebase_on(parent_type, named_fragments, schema)?
+                        selection_set.rebase_on(parent_type, schema)?
                     };
                     Ok(Some(SelectionOrSet::SelectionSet(selection_set)))
                 };
@@ -206,7 +159,6 @@ impl InlineFragmentSelection {
         // Note: This selection_set is not rebased here yet. It will be rebased later as necessary.
         let selection_set = self.selection_set.flatten_unnecessary_fragments(
             &self.selection_set.type_position,
-            named_fragments,
             &self.selection_set.schema,
         )?;
         // It could be that nothing was satisfiable.
@@ -261,14 +213,6 @@ impl InlineFragmentSelection {
             let mut liftable_selections = SelectionMap::new();
             for selection in selection_set.selections.values() {
                 match selection {
-                    Selection::FragmentSpread(spread_selection) => {
-                        let type_condition = &spread_selection.spread.type_condition_position;
-                        if type_condition.is_object_type()
-                            && runtime_types_intersect(parent_type, type_condition, schema)
-                        {
-                            liftable_selections.insert(selection.clone());
-                        }
-                    }
                     Selection::InlineFragment(inline_fragment_selection) => {
                         if let Some(type_condition) = &inline_fragment_selection
                             .inline_fragment
@@ -288,8 +232,7 @@ impl InlineFragmentSelection {
             // If we can lift all selections, then that just mean we can get rid of the current fragment altogether
             if liftable_selections.len() == selection_set.selections.len() {
                 // Rebasing is necessary since this normalized sub-selection set changed its parent.
-                let rebased_selection_set =
-                    selection_set.rebase_on(parent_type, named_fragments, schema)?;
+                let rebased_selection_set = selection_set.rebase_on(parent_type, schema)?;
                 return Ok(Some(SelectionOrSet::SelectionSet(rebased_selection_set)));
             }
 
@@ -323,7 +266,7 @@ impl InlineFragmentSelection {
                 // Since liftable_selections are changing their parent, we need to rebase them.
                 liftable_selections = liftable_selections
                     .into_values()
-                    .map(|sel| sel.rebase_on(parent_type, named_fragments, schema))
+                    .map(|sel| sel.rebase_on(parent_type, schema))
                     .collect::<Result<_, _>>()?;
 
                 let mut final_selection_map = SelectionMap::new();
@@ -348,11 +291,8 @@ impl InlineFragmentSelection {
             let rebased_inline_fragment = self.inline_fragment.rebase_on(parent_type, schema)?;
             let rebased_casted_type = rebased_inline_fragment.casted_type();
             // Re-flatten with the rebased casted type, which could further flatten away.
-            let selection_set = selection_set.flatten_unnecessary_fragments(
-                &rebased_casted_type,
-                named_fragments,
-                schema,
-            )?;
+            let selection_set =
+                selection_set.flatten_unnecessary_fragments(&rebased_casted_type, schema)?;
             if selection_set.is_empty() {
                 Ok(None)
             } else {
@@ -361,7 +301,7 @@ impl InlineFragmentSelection {
                 // Note: Rebasing after flattening, since rebasing before that can error out.
                 //       Or, `flatten_unnecessary_fragments` could `rebase` at the same time.
                 let rebased_selection_set =
-                    selection_set.rebase_on(&rebased_casted_type, named_fragments, schema)?;
+                    selection_set.rebase_on(&rebased_casted_type, schema)?;
                 Ok(Some(
                     Selection::InlineFragment(Arc::new(InlineFragmentSelection::new(
                         rebased_inline_fragment,
@@ -453,7 +393,6 @@ impl SelectionSet {
     pub(super) fn flatten_unnecessary_fragments(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<SelectionSet, FederationError> {
         let mut normalized_selections = Self {
@@ -463,7 +402,7 @@ impl SelectionSet {
         };
         for selection in self.selections.values() {
             if let Some(selection_or_set) =
-                selection.flatten_unnecessary_fragments(parent_type, named_fragments, schema)?
+                selection.flatten_unnecessary_fragments(parent_type, schema)?
             {
                 match selection_or_set {
                     SelectionOrSet::Selection(normalized_selection) => {
@@ -471,9 +410,8 @@ impl SelectionSet {
                     }
                     SelectionOrSet::SelectionSet(normalized_set) => {
                         // Since the `selection` has been expanded/lifted, we use
-                        // `add_selection_set_with_fragments` to make sure it's rebased.
-                        normalized_selections
-                            .add_selection_set_with_fragments(&normalized_set, named_fragments)?;
+                        // `add_selection_set` to make sure it's rebased.
+                        normalized_selections.add_selection_set(&normalized_set)?;
                     }
                 }
             }
@@ -487,7 +425,7 @@ mod tests {
     use apollo_compiler::Schema;
 
     use super::*;
-    use crate::operation::Operation;
+    use crate::operation::NormalizedOperation;
 
     #[test]
     fn does_not_duplicate_fragments_regression_router782() {
@@ -515,7 +453,7 @@ type Query {
 
         // Below, the second `... on MySpecialNode` is redundant,
         // the same selection is already guaranteed by the first.
-        let operation = Operation::parse(
+        let operation = NormalizedOperation::parse(
             schema.clone(),
             r#"
 {
@@ -536,17 +474,12 @@ type Query {
 }
         "#,
             "query.graphql",
-            None,
         )
         .unwrap();
 
         let expanded_and_flattened = operation
             .selection_set
-            .flatten_unnecessary_fragments(
-                &operation.selection_set.type_position,
-                &NamedFragments::default(),
-                &schema,
-            )
+            .flatten_unnecessary_fragments(&operation.selection_set.type_position, &schema)
             .unwrap();
 
         // Use apollo-compiler's selection set printer directly instead of the minimized

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -11,6 +11,7 @@ use super::Selection;
 use super::SelectionKey;
 use super::SelectionSet;
 use super::normalize_operation;
+use crate::SingleFederationError;
 use crate::error::FederationError;
 use crate::query_graph::graph_path::OpPathElement;
 use crate::schema::ValidFederationSchema;
@@ -214,6 +215,7 @@ fn can_remove_introspection_selections() {
             &executable_document.fragments,
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
 
@@ -931,6 +933,7 @@ scalar FieldSet
             &executable_document.fragments,
             &schema,
             &interface_objects,
+            &never_cancel,
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -1065,6 +1068,7 @@ mod make_selection_tests {
             &Default::default(),
             &schema,
             &Default::default(),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1163,6 +1167,7 @@ mod lazy_map_tests {
             &Default::default(),
             &schema,
             &Default::default(),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1221,6 +1226,7 @@ mod lazy_map_tests {
             &Default::default(),
             &schema,
             &Default::default(),
+            &never_cancel,
         )
         .unwrap();
 
@@ -1426,6 +1432,7 @@ fn test_expand_all_fragments1() {
             &executable_document.fragments,
             &schema,
             &IndexSet::default(),
+            &never_cancel,
         )
         .unwrap();
         insta::assert_snapshot!(normalized_operation, @r###"

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -87,7 +87,17 @@ pub(super) fn parse_and_expand(
         .next()
         .expect("must have an operation");
 
-    normalize_operation(operation, &doc.fragments, schema, &Default::default())
+    normalize_operation(
+        operation,
+        &doc.fragments,
+        schema,
+        &Default::default(),
+        &never_cancel,
+    )
+}
+
+pub(crate) fn never_cancel() -> Result<(), SingleFederationError> {
+    Ok(())
 }
 
 #[test]

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -6,7 +6,7 @@ use apollo_compiler::schema::Schema;
 
 use super::Field;
 use super::Name;
-use super::NormalizedOperation;
+use super::Operation;
 use super::Selection;
 use super::SelectionKey;
 use super::SelectionSet;
@@ -72,14 +72,14 @@ pub(super) fn parse_schema(schema_doc: &str) -> ValidFederationSchema {
     ValidFederationSchema::new(schema).expect("valid federation schema")
 }
 
-pub(super) fn parse_operation(schema: &ValidFederationSchema, query: &str) -> NormalizedOperation {
-    NormalizedOperation::parse(schema.clone(), query, "query.graphql").expect("valid operation")
+pub(super) fn parse_operation(schema: &ValidFederationSchema, query: &str) -> Operation {
+    Operation::parse(schema.clone(), query, "query.graphql").expect("valid operation")
 }
 
 pub(super) fn parse_and_expand(
     schema: &ValidFederationSchema,
     query: &str,
-) -> Result<NormalizedOperation, FederationError> {
+) -> Result<Operation, FederationError> {
     let doc = ExecutableDocument::parse_and_validate(schema.schema(), query, "query.graphql")?;
 
     let operation = doc
@@ -978,7 +978,7 @@ fn converting_operation_types() {
     )
     .unwrap();
     let schema = ValidFederationSchema::new(schema).unwrap();
-    insta::assert_snapshot!(NormalizedOperation::parse(
+    insta::assert_snapshot!(Operation::parse(
             schema.clone(),
             r#"
         {
@@ -1482,7 +1482,7 @@ fn used_variables() {
     "#;
 
     let valid = parse_schema(schema);
-    let operation = NormalizedOperation::parse(valid, query, "used_variables.graphql").unwrap();
+    let operation = Operation::parse(valid, query, "used_variables.graphql").unwrap();
 
     let mut variables = operation
         .selection_set

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -1084,7 +1084,7 @@ mod make_selection_tests {
                 base_selection_set.type_position.clone(),
                 selection.clone(),
             );
-            Selection::from_element(base.element().unwrap(), Some(subselections)).unwrap()
+            Selection::from_element(base.element(), Some(subselections)).unwrap()
         };
 
         let foo_with_a = clone_selection_at_path(foo, &[name!("a")]);
@@ -1092,7 +1092,7 @@ mod make_selection_tests {
         let foo_with_c = clone_selection_at_path(foo, &[name!("c")]);
         let new_selection = SelectionSet::make_selection(
             &schema,
-            &foo.element().unwrap().parent_type_position(),
+            &foo.element().parent_type_position(),
             [foo_with_c, foo_with_b, foo_with_a].iter(),
         )
         .unwrap();
@@ -1206,7 +1206,7 @@ mod lazy_map_tests {
                 return Ok(updated.into());
             }
 
-            let parent_type_pos = s.element()?.parent_type_position();
+            let parent_type_pos = s.element().parent_type_position();
             // "__typename" field
             let field_element =
                 Field::new_introspection_typename(s.schema(), &parent_type_pos, None);

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -6,14 +6,12 @@ use apollo_compiler::schema::Schema;
 
 use super::Field;
 use super::Name;
-use super::NamedFragments;
-use super::Operation;
+use super::NormalizedOperation;
 use super::Selection;
 use super::SelectionKey;
 use super::SelectionSet;
 use super::normalize_operation;
 use crate::error::FederationError;
-use crate::error::SingleFederationError;
 use crate::query_graph::graph_path::OpPathElement;
 use crate::schema::ValidFederationSchema;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
@@ -44,16 +42,12 @@ macro_rules! assert_normalized_equal {
 }
 
 macro_rules! assert_equal_ops {
-    ($schema: expr, $first: expr, $second: expr) => {
-        let original_document: Valid<ExecutableDocument> =
-            $first.try_into().expect("valid document");
-        let minified_document: Valid<ExecutableDocument> =
-            $second.try_into().expect("valid document");
+    ($schema: expr, $original_document: expr, $minified_document: expr) => {
         // since compare operations just check if a query is subset of another one
         // we verify that both A ⊆ B and B ⊆ A are true which means that A = B
-        compare_operations($schema, &original_document, &minified_document)
+        compare_operations($schema, $original_document, $minified_document)
             .expect("original document is a subset of minified one");
-        compare_operations($schema, &minified_document, &original_document)
+        compare_operations($schema, $minified_document, $original_document)
             .expect("minified document is a subset of original one");
     };
 }
@@ -77,14 +71,14 @@ pub(super) fn parse_schema(schema_doc: &str) -> ValidFederationSchema {
     ValidFederationSchema::new(schema).expect("valid federation schema")
 }
 
-pub(super) fn parse_operation(schema: &ValidFederationSchema, query: &str) -> Operation {
-    Operation::parse(schema.clone(), query, "query.graphql", None).expect("valid operation")
+pub(super) fn parse_operation(schema: &ValidFederationSchema, query: &str) -> NormalizedOperation {
+    NormalizedOperation::parse(schema.clone(), query, "query.graphql").expect("valid operation")
 }
 
 pub(super) fn parse_and_expand(
     schema: &ValidFederationSchema,
     query: &str,
-) -> Result<Operation, FederationError> {
+) -> Result<NormalizedOperation, FederationError> {
     let doc = ExecutableDocument::parse_and_validate(schema.schema(), query, "query.graphql")?;
 
     let operation = doc
@@ -92,21 +86,8 @@ pub(super) fn parse_and_expand(
         .iter()
         .next()
         .expect("must have an operation");
-    let fragments = NamedFragments::new(&doc.fragments, schema);
 
-    normalize_operation(
-        operation,
-        fragments,
-        schema,
-        &Default::default(),
-        &never_cancel,
-    )
-}
-
-/// The `normalize_operation()` function has a `check_cancellation` parameter that we'll want to
-/// configure to never cancel during tests. We create a convenience function here for that purpose.
-pub(crate) fn never_cancel() -> Result<(), SingleFederationError> {
-    Ok(())
+    normalize_operation(operation, &doc.fragments, schema, &Default::default())
 }
 
 #[test]
@@ -220,10 +201,9 @@ fn can_remove_introspection_selections() {
     {
         let normalized_operation = normalize_operation(
             operation,
-            NamedFragments::new(&executable_document.fragments, &schema),
+            &executable_document.fragments,
             &schema,
             &IndexSet::default(),
-            &never_cancel,
         )
         .unwrap();
 
@@ -938,10 +918,9 @@ scalar FieldSet
 
         let normalized_operation = normalize_operation(
             operation,
-            NamedFragments::new(&executable_document.fragments, &schema),
+            &executable_document.fragments,
             &schema,
             &interface_objects,
-            &never_cancel,
         )
         .unwrap();
         let expected = r#"query TestQuery {
@@ -986,7 +965,7 @@ fn converting_operation_types() {
     )
     .unwrap();
     let schema = ValidFederationSchema::new(schema).unwrap();
-    insta::assert_snapshot!(Operation::parse(
+    insta::assert_snapshot!(NormalizedOperation::parse(
             schema.clone(),
             r#"
         {
@@ -998,19 +977,14 @@ fn converting_operation_types() {
         fragment frag on HasA { intfField }
         "#,
             "operation.graphql",
-            None,
         )
         .unwrap(), @r###"
-        fragment frag on HasA {
-          intfField
-        }
-
         {
           intf {
             ... on HasA {
               a
+              intfField
             }
-            ...frag
           }
         }
         "###);
@@ -1078,10 +1052,9 @@ mod make_selection_tests {
         let (schema, executable_document) = parse_schema_and_operation(SAMPLE_OPERATION_DOC);
         let normalized_operation = normalize_operation(
             executable_document.operations.get(None).unwrap(),
-            Default::default(),
+            &Default::default(),
             &schema,
             &Default::default(),
-            &never_cancel,
         )
         .unwrap();
 
@@ -1107,7 +1080,6 @@ mod make_selection_tests {
             &schema,
             &foo.element().unwrap().parent_type_position(),
             [foo_with_c, foo_with_b, foo_with_a].iter(),
-            /*named_fragments*/ &Default::default(),
         )
         .unwrap();
         // Make sure the ordering of c, b and a is preserved.
@@ -1125,7 +1097,7 @@ mod lazy_map_tests {
         ss: &SelectionSet,
         pred: &impl Fn(&Selection) -> bool,
     ) -> Result<SelectionSet, FederationError> {
-        ss.lazy_map(/*named_fragments*/ &Default::default(), |s| {
+        ss.lazy_map(|s| {
             if !pred(s) {
                 return Ok(SelectionMapperReturn::None);
             }
@@ -1178,10 +1150,9 @@ mod lazy_map_tests {
         let (schema, executable_document) = parse_schema_and_operation(SAMPLE_OPERATION_DOC);
         let normalized_operation = normalize_operation(
             executable_document.operations.get(None).unwrap(),
-            Default::default(),
+            &Default::default(),
             &schema,
             &Default::default(),
-            &never_cancel,
         )
         .unwrap();
 
@@ -1213,7 +1184,7 @@ mod lazy_map_tests {
         ss: &SelectionSet,
         pred: &impl Fn(&Selection) -> bool,
     ) -> Result<SelectionSet, FederationError> {
-        ss.lazy_map(/*named_fragments*/ &Default::default(), |s| {
+        ss.lazy_map(|s| {
             let to_add_typename = pred(s);
             let updated = s.map_selection_set(|ss| add_typename_if(ss, pred).map(Some))?;
             if !to_add_typename {
@@ -1237,10 +1208,9 @@ mod lazy_map_tests {
         let (schema, executable_document) = parse_schema_and_operation(SAMPLE_OPERATION_DOC);
         let normalized_operation = normalize_operation(
             executable_document.operations.get(None).unwrap(),
-            Default::default(),
+            &Default::default(),
             &schema,
             &Default::default(),
-            &never_cancel,
         )
         .unwrap();
 
@@ -1441,15 +1411,13 @@ fn test_expand_all_fragments1() {
         "#;
     let (schema, executable_document) = parse_schema_and_operation(operation_with_named_fragment);
     if let Ok(operation) = executable_document.operations.get(None) {
-        let mut normalized_operation = normalize_operation(
+        let normalized_operation = normalize_operation(
             operation,
-            NamedFragments::new(&executable_document.fragments, &schema),
+            &executable_document.fragments,
             &schema,
             &IndexSet::default(),
-            &never_cancel,
         )
         .unwrap();
-        normalized_operation.named_fragments = Default::default();
         insta::assert_snapshot!(normalized_operation, @r###"
             {
               i1 {
@@ -1497,7 +1465,7 @@ fn used_variables() {
     "#;
 
     let valid = parse_schema(schema);
-    let operation = Operation::parse(valid, query, "used_variables.graphql", None).unwrap();
+    let operation = NormalizedOperation::parse(valid, query, "used_variables.graphql").unwrap();
 
     let mut variables = operation
         .selection_set

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -97,6 +97,8 @@ pub(super) fn parse_and_expand(
     )
 }
 
+/// The `normalize_operation()` function has a `check_cancellation` parameter that we'll want to
+/// configure to never cancel during tests. We create a convenience function here for that purpose.
 pub(crate) fn never_cancel() -> Result<(), SingleFederationError> {
     Ok(())
 }

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1923,13 +1923,6 @@ impl FederatedQueryGraphBuilder {
                             stack.push((node, &inline_fragment_selection.selection_set));
                         }
                     }
-                    Selection::FragmentSpread(_) => {
-                        return Err(SingleFederationError::Internal {
-                            message: "Unexpectedly found named fragment in FieldSet scalar"
-                                .to_owned(),
-                        }
-                        .into());
-                    }
                 }
             }
         }

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -581,6 +581,7 @@ mod tests {
 
     use crate::error::FederationError;
     use crate::operation::Field;
+    use crate::operation::never_cancel;
     use crate::operation::normalize_operation;
     use crate::query_graph::QueryGraph;
     use crate::query_graph::QueryGraphEdgeTransition;
@@ -720,9 +721,7 @@ mod tests {
             &Default::default(),
             &schema,
             &Default::default(),
-            &||
-                // never cancel
-                Ok(()),
+            &never_cancel,
         )
         .unwrap();
         let selection_set = Arc::new(normalized_operation.selection_set);

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -581,7 +581,6 @@ mod tests {
 
     use crate::error::FederationError;
     use crate::operation::Field;
-    use crate::operation::never_cancel;
     use crate::operation::normalize_operation;
     use crate::query_graph::QueryGraph;
     use crate::query_graph::QueryGraphEdgeTransition;
@@ -716,14 +715,9 @@ mod tests {
             "Query(Test) --[t]--> T(Test) --[otherId]--> ID(Test)"
         );
 
-        let normalized_operation = normalize_operation(
-            operation,
-            Default::default(),
-            &schema,
-            &Default::default(),
-            &never_cancel,
-        )
-        .unwrap();
+        let normalized_operation =
+            normalize_operation(operation, &Default::default(), &schema, &Default::default())
+                .unwrap();
         let selection_set = Arc::new(normalized_operation.selection_set);
 
         let paths = vec![

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -715,9 +715,16 @@ mod tests {
             "Query(Test) --[t]--> T(Test) --[otherId]--> ID(Test)"
         );
 
-        let normalized_operation =
-            normalize_operation(operation, &Default::default(), &schema, &Default::default())
-                .unwrap();
+        let normalized_operation = normalize_operation(
+            operation,
+            &Default::default(),
+            &schema,
+            &Default::default(),
+            &||
+                // never cancel
+                Ok(()),
+        )
+        .unwrap();
         let selection_set = Arc::new(normalized_operation.selection_set);
 
         let paths = vec![

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -12,7 +12,6 @@ use serde::Serialize;
 use crate::bail;
 use crate::error::FederationError;
 use crate::operation::DirectiveList;
-use crate::operation::NamedFragments;
 use crate::operation::Selection;
 use crate::operation::SelectionMap;
 use crate::operation::SelectionMapperReturn;
@@ -291,7 +290,7 @@ pub(crate) fn remove_conditions_from_selection_set(
             Ok(selection_set.clone())
         }
         Conditions::Variables(variable_conditions) => {
-            selection_set.lazy_map(&NamedFragments::default(), |selection| {
+            selection_set.lazy_map(|selection| {
                 let element = selection.element()?;
                 // We remove any of the conditions on the element and recurse.
                 let updated_element =
@@ -375,10 +374,6 @@ pub(crate) fn remove_unneeded_top_level_fragment_directives(
                         selection_map.insert(Selection::InlineFragment(Arc::new(final_selection)));
                     }
                 }
-            }
-            _ => {
-                // TODO should we apply same logic as for inline_fragment "just in case"?
-                return Err(FederationError::internal("unexpected fragment spread"));
             }
         }
     }

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -291,7 +291,7 @@ pub(crate) fn remove_conditions_from_selection_set(
         }
         Conditions::Variables(variable_conditions) => {
             selection_set.lazy_map(|selection| {
-                let element = selection.element()?;
+                let element = selection.element();
                 // We remove any of the conditions on the element and recurse.
                 let updated_element =
                     remove_conditions_of_element(element.clone(), variable_conditions);

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::AtomicU64;
 
-use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast::Argument;
@@ -17,7 +16,6 @@ use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable;
 use apollo_compiler::executable::VariableDefinition;
 use apollo_compiler::name;
-use apollo_compiler::validation::Valid;
 use itertools::Itertools;
 use multimap::MultiMap;
 use petgraph::stable_graph::EdgeIndex;

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -33,7 +33,6 @@ use crate::bail;
 use crate::display_helpers::DisplayOption;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
-use crate::internal_error;
 use crate::link::graphql_definition::DeferDirectiveArguments;
 use crate::operation::ArgumentList;
 use crate::operation::ContainmentOptions;
@@ -41,7 +40,7 @@ use crate::operation::DirectiveList;
 use crate::operation::Field;
 use crate::operation::InlineFragment;
 use crate::operation::InlineFragmentSelection;
-use crate::operation::Operation;
+use crate::operation::NormalizedOperation;
 use crate::operation::Selection;
 use crate::operation::SelectionId;
 use crate::operation::SelectionMap;
@@ -1341,10 +1340,6 @@ impl FetchDependencyGraph {
         // Some helper functions
 
         let try_get_type_condition = |selection: &Selection| match selection {
-            Selection::FragmentSpread(fragment) => {
-                Some(fragment.spread.type_condition_position.clone())
-            }
-
             Selection::InlineFragment(inline) => {
                 inline.inline_fragment.type_condition_position.clone()
             }
@@ -2660,16 +2655,7 @@ impl FetchDependencyGraphNode {
                 &operation_name,
             )?
         };
-        let operation = operation_compression.compress(operation)?;
-        let operation_document: Valid<ExecutableDocument> =
-            operation.try_into().map_err(|err| match err {
-                FederationError::SingleFederationError(SingleFederationError::InvalidGraphQL {
-                    diagnostics,
-                }) => internal_error!(
-                    "Query planning produced an invalid subgraph operation.\n{diagnostics}"
-                ),
-                _ => err,
-            })?;
+        let operation_document = operation_compression.compress(operation)?;
 
         // this function removes unnecessary pieces of the query plan requires selection set.
         // PORT NOTE: this function was called trimSelectioNodes in the JS implementation
@@ -2993,9 +2979,6 @@ impl FetchDependencyGraphNode {
                         )?;
                     }
                 }
-                Selection::FragmentSpread(_) => {
-                    bail!("Contexts shouldn't contain named fragment spreads");
-                }
                 Selection::InlineFragment(inline_fragment_selection) => {
                     if let Some(type_condition) = &inline_fragment_selection
                         .inline_fragment
@@ -3024,7 +3007,7 @@ fn operation_for_entities_fetch(
     mut variable_definitions: Vec<Node<VariableDefinition>>,
     operation_directives: &DirectiveList,
     operation_name: &Option<Name>,
-) -> Result<Operation, FederationError> {
+) -> Result<NormalizedOperation, FederationError> {
     variable_definitions.insert(0, representations_variable_definition(subgraph_schema)?);
 
     let query_type_name = subgraph_schema.schema().root_operation(OperationType::Query).ok_or_else(||
@@ -3083,14 +3066,13 @@ fn operation_for_entities_fetch(
         selections: Arc::new(map),
     };
 
-    Ok(Operation {
+    Ok(NormalizedOperation {
         schema: subgraph_schema.clone(),
         root_kind: SchemaRootDefinitionKind::Query,
         name: operation_name.clone(),
         variables: Arc::new(variable_definitions),
         directives: operation_directives.clone(),
         selection_set,
-        named_fragments: Default::default(),
     })
 }
 
@@ -3101,15 +3083,14 @@ fn operation_for_query_fetch(
     variable_definitions: Vec<Node<VariableDefinition>>,
     operation_directives: &DirectiveList,
     operation_name: &Option<Name>,
-) -> Result<Operation, FederationError> {
-    Ok(Operation {
+) -> Result<NormalizedOperation, FederationError> {
+    Ok(NormalizedOperation {
         schema: subgraph_schema.clone(),
         root_kind,
         name: operation_name.clone(),
         variables: Arc::new(variable_definitions),
         directives: operation_directives.clone(),
         selection_set,
-        named_fragments: Default::default(),
     })
 }
 
@@ -3145,11 +3126,6 @@ impl SelectionSet {
             let subselections = match selection {
                 Selection::Field(field) => field.selection_set.as_ref(),
                 Selection::InlineFragment(inline) => Some(&inline.selection_set),
-                Selection::FragmentSpread(_) => {
-                    return Err(FederationError::internal(
-                        "unexpected fragment spread in FetchDependencyGraphNode",
-                    ));
-                }
             };
             let subselections_cost = if let Some(selection_set) = subselections {
                 selection_set.cost(depth + 1.0)?

--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -167,7 +167,7 @@ impl FetchDependencyGraphProcessor<QueryPlanCost, QueryPlanCost>
         node: &mut FetchDependencyGraphNode,
         _handled_conditions: &Conditions,
     ) -> Result<QueryPlanCost, FederationError> {
-        Ok(FETCH_COST + node.cost()?)
+        Ok(FETCH_COST + node.cost())
     }
 
     /// We don't take conditions into account in costing for now
@@ -377,7 +377,7 @@ impl FetchDependencyGraphProcessor<Option<PlanNode>, DeferredDeferBlock>
             sub_selection: if defer_info.deferred.is_empty() {
                 defer_info
                     .sub_selection
-                    .without_empty_branches()?
+                    .without_empty_branches()
                     .map(|filtered| executable::SelectionSet::try_from(filtered.as_ref()))
                     .transpose()?
                     .map(|selection_set| selection_set.serialize().no_indent().to_string())
@@ -397,7 +397,7 @@ impl FetchDependencyGraphProcessor<Option<PlanNode>, DeferredDeferBlock>
         Ok(Some(PlanNode::Defer(DeferNode {
             primary: PrimaryDeferBlock {
                 sub_selection: sub_selection
-                    .without_empty_branches()?
+                    .without_empty_branches()
                     .map(|filtered| executable::SelectionSet::try_from(filtered.as_ref()))
                     .transpose()?
                     .map(|selection_set| selection_set.serialize().no_indent().to_string()),

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -368,6 +368,11 @@ impl QueryPlanner {
             &document.fragments,
             &self.api_schema,
             &self.interface_types_with_interface_objects,
+            &|| {
+                QueryPlanningParameters::check_cancellation_with(
+                    &options.check_for_cooperative_cancellation,
+                )
+            },
         )?;
 
         let NormalizedDefer {

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -23,7 +23,7 @@ use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::internal_error;
 use crate::operation::NormalizedDefer;
-use crate::operation::NormalizedOperation;
+use crate::operation::Operation;
 use crate::operation::SelectionSet;
 use crate::operation::normalize_operation;
 use crate::query_graph::QueryGraph;
@@ -781,11 +781,9 @@ fn compute_plan_for_defer_conditionals(
 }
 
 fn generate_condition_nodes<'a>(
-    op: Arc<NormalizedOperation>,
+    op: Arc<Operation>,
     mut conditions: impl Clone + Iterator<Item = (&'a Name, &'a IndexSet<String>)>,
-    on_final_operation: &mut impl FnMut(
-        Arc<NormalizedOperation>,
-    ) -> Result<Option<PlanNode>, FederationError>,
+    on_final_operation: &mut impl FnMut(Arc<Operation>) -> Result<Option<PlanNode>, FederationError>,
 ) -> Result<Option<PlanNode>, FederationError> {
     match conditions.next() {
         None => on_final_operation(op),
@@ -817,7 +815,7 @@ impl SubgraphOperationCompression {
     /// Compress a subgraph operation.
     pub(crate) fn compress(
         &mut self,
-        operation: NormalizedOperation,
+        operation: Operation,
     ) -> Result<Valid<ExecutableDocument>, FederationError> {
         match self {
             Self::GenerateFragments => Ok(operation.generate_fragments()?),

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -21,9 +21,9 @@ use crate::Supergraph;
 use crate::bail;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
-use crate::operation::NamedFragments;
+use crate::internal_error;
 use crate::operation::NormalizedDefer;
-use crate::operation::Operation;
+use crate::operation::NormalizedOperation;
 use crate::operation::SelectionSet;
 use crate::operation::normalize_operation;
 use crate::query_graph::QueryGraph;
@@ -365,14 +365,9 @@ impl QueryPlanner {
 
         let normalized_operation = normalize_operation(
             operation,
-            NamedFragments::new(&document.fragments, &self.api_schema),
+            &document.fragments,
             &self.api_schema,
             &self.interface_types_with_interface_objects,
-            &|| {
-                QueryPlanningParameters::check_cancellation_with(
-                    &options.check_for_cooperative_cancellation,
-                )
-            },
         )?;
 
         let NormalizedDefer {
@@ -781,9 +776,11 @@ fn compute_plan_for_defer_conditionals(
 }
 
 fn generate_condition_nodes<'a>(
-    op: Arc<Operation>,
+    op: Arc<NormalizedOperation>,
     mut conditions: impl Clone + Iterator<Item = (&'a Name, &'a IndexSet<String>)>,
-    on_final_operation: &mut impl FnMut(Arc<Operation>) -> Result<Option<PlanNode>, FederationError>,
+    on_final_operation: &mut impl FnMut(
+        Arc<NormalizedOperation>,
+    ) -> Result<Option<PlanNode>, FederationError>,
 ) -> Result<Option<PlanNode>, FederationError> {
     match conditions.next() {
         None => on_final_operation(op),
@@ -813,14 +810,23 @@ pub(crate) enum SubgraphOperationCompression {
 
 impl SubgraphOperationCompression {
     /// Compress a subgraph operation.
-    pub(crate) fn compress(&mut self, operation: Operation) -> Result<Operation, FederationError> {
+    pub(crate) fn compress(
+        &mut self,
+        operation: NormalizedOperation,
+    ) -> Result<Valid<ExecutableDocument>, FederationError> {
         match self {
-            Self::GenerateFragments => {
-                let mut operation = operation;
-                operation.generate_fragments()?;
-                Ok(operation)
+            Self::GenerateFragments => Ok(operation.generate_fragments()?),
+            Self::Disabled => {
+                let operation_document = operation.try_into().map_err(|err| match err {
+                    FederationError::SingleFederationError(
+                        SingleFederationError::InvalidGraphQL { diagnostics },
+                    ) => internal_error!(
+                        "Query planning produced an invalid subgraph operation.\n{diagnostics}"
+                    ),
+                    _ => err,
+                })?;
+                Ok(operation_document)
             }
-            Self::Disabled => Ok(operation),
         }
     }
 }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -11,7 +11,7 @@ use super::fetch_dependency_graph::FetchIdGenerator;
 use crate::ensure;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
-use crate::operation::NormalizedOperation;
+use crate::operation::Operation;
 use crate::operation::Selection;
 use crate::operation::SelectionSet;
 use crate::query_graph::QueryGraph;
@@ -72,7 +72,7 @@ pub(crate) struct QueryPlanningParameters<'a> {
     /// The federated query graph used for query planning.
     pub(crate) federated_query_graph: Arc<QueryGraph>,
     /// The operation to be query planned.
-    pub(crate) operation: Arc<NormalizedOperation>,
+    pub(crate) operation: Arc<Operation>,
     pub(crate) fetch_id_generator: Arc<FetchIdGenerator>,
     /// The query graph node at which query planning begins.
     pub(crate) head: NodeIndex,

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -11,7 +11,7 @@ use super::fetch_dependency_graph::FetchIdGenerator;
 use crate::ensure;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
-use crate::operation::Operation;
+use crate::operation::NormalizedOperation;
 use crate::operation::Selection;
 use crate::operation::SelectionSet;
 use crate::query_graph::QueryGraph;
@@ -72,7 +72,7 @@ pub(crate) struct QueryPlanningParameters<'a> {
     /// The federated query graph used for query planning.
     pub(crate) federated_query_graph: Arc<QueryGraph>,
     /// The operation to be query planned.
-    pub(crate) operation: Arc<Operation>,
+    pub(crate) operation: Arc<NormalizedOperation>,
     pub(crate) fetch_id_generator: Arc<FetchIdGenerator>,
     /// The query graph node at which query planning begins.
     pub(crate) head: NodeIndex,

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -412,7 +412,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         selection: &Selection,
         options: &mut Vec<SimultaneousPathsWithLazyIndirectPaths>,
     ) -> Result<(bool, Option<OpenBranchAndSelections>), FederationError> {
-        let operation_element = selection.element()?;
+        let operation_element = selection.element();
         let mut new_options = vec![];
         let mut no_followups: bool = false;
 
@@ -636,16 +636,16 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 let check_result = selection.any_element(&mut |element| match element {
                     OpPathElement::InlineFragment(inline_fragment) => {
                         match &inline_fragment.type_condition_position {
-                            Some(type_condition) => Ok(self
+                            Some(type_condition) => self
                                 .parameters
                                 .abstract_types_with_inconsistent_runtime_types
                                 .iter()
-                                .any(|ty| ty.type_name() == type_condition.type_name())),
-                            None => Ok(false),
+                                .any(|ty| ty.type_name() == type_condition.type_name()),
+                            None => false,
                         }
                     }
-                    _ => Ok(false),
-                })?;
+                    _ => false,
+                });
                 has_inconsistent_abstract_types = Some(check_result);
                 Ok(check_result)
             }

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -1,5 +1,4 @@
 use apollo_compiler::Schema;
-use apollo_compiler::collections::IndexMap;
 use apollo_compiler::executable;
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::schema::ExtendedType;
@@ -9,7 +8,6 @@ use apollo_compiler::validation::Valid;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
-use crate::operation::NamedFragments;
 use crate::operation::Selection;
 use crate::operation::SelectionSet;
 use crate::schema::ValidFederationSchema;
@@ -29,11 +27,6 @@ fn check_absence_of_aliases(selection_set: &SelectionSet) -> Result<(), Federati
     ) -> Result<(), FederationError> {
         for selection in selection_set.iter() {
             match selection {
-                Selection::FragmentSpread(_) => {
-                    return Err(FederationError::internal(
-                        "check_absence_of_aliases(): unexpected fragment spread",
-                    ));
-                }
                 Selection::InlineFragment(frag) => check_absence_of_aliases(&frag.selection_set)?,
                 Selection::Field(field) => {
                     if let Some(alias) = &field.field.alias {
@@ -75,9 +68,9 @@ pub(crate) fn parse_field_set(
     )?;
 
     // A field set should not contain any named fragments.
-    let named_fragments = NamedFragments::new(&IndexMap::default(), schema);
+    let fragments = Default::default();
     let selection_set =
-        SelectionSet::from_selection_set(&field_set.selection_set, &named_fragments, schema)?;
+        SelectionSet::from_selection_set(&field_set.selection_set, &fragments, schema)?;
 
     // Validate that the field set has no aliases.
     check_absence_of_aliases(&selection_set)?;
@@ -202,9 +195,9 @@ pub(crate) fn validate_field_value(
     field_value.validate(schema.schema())?;
 
     // A field value should not contain any named fragments.
-    let named_fragments = NamedFragments::new(&IndexMap::default(), schema);
+    let fragments = Default::default();
     let selection_set =
-        SelectionSet::from_selection_set(&field_value.selection_set, &named_fragments, schema)?;
+        SelectionSet::from_selection_set(&field_value.selection_set, &fragments, schema)?;
 
     // Validate that the field value has no aliases.
     check_absence_of_aliases(&selection_set)?;

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -70,7 +70,9 @@ pub(crate) fn parse_field_set(
     // A field set should not contain any named fragments.
     let fragments = Default::default();
     let selection_set =
-        SelectionSet::from_selection_set(&field_set.selection_set, &fragments, schema)?;
+        SelectionSet::from_selection_set(&field_set.selection_set, &fragments, schema, &||
+            // never cancel
+            Ok(()))?;
 
     // Validate that the field set has no aliases.
     check_absence_of_aliases(&selection_set)?;
@@ -197,7 +199,10 @@ pub(crate) fn validate_field_value(
     // A field value should not contain any named fragments.
     let fragments = Default::default();
     let selection_set =
-        SelectionSet::from_selection_set(&field_value.selection_set, &fragments, schema)?;
+        SelectionSet::from_selection_set(&field_value.selection_set, &fragments, schema, &|| {
+            // never cancel
+            Ok(())
+        })?;
 
     // Validate that the field value has no aliases.
     check_absence_of_aliases(&selection_set)?;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/fragment_autogeneration.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/fragment_autogeneration.rs
@@ -450,8 +450,8 @@ fn works_with_key_chains() {
         Fetch(service: "Subgraph1") {
           {
             t {
-              __typename
               id1
+              __typename
             }
           }
         },

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/fragment_autogeneration.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/fragment_autogeneration.rs
@@ -450,8 +450,8 @@ fn works_with_key_chains() {
         Fetch(service: "Subgraph1") {
           {
             t {
-              id1
               __typename
+              id1
             }
           }
         },


### PR DESCRIPTION
In order to simplify the query planning process, we first "normalize" the `apollo-rs` Operation into a form that deduplicates all selections and expands all fragment spreads. As a result, during query planning we only have to handle field selections and inline fragments. This PR refactors federation code to remove all the fragment spread references. Since operations are normalized before query planning, that logic should never be executed anyway. As a side effect fragment generation logic now generates `apollo-rs` Operation instead.

<!-- ROUTER-840 -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
