### PR TITLE
Improve our Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -99,15 +99,6 @@
       "groupSlug": "rust-apollo-rs-updates",
       "matchManagers": ["cargo"],
       "automerge": false
-    },
-    // We'll review these in a PR of their own since it has the most direct runtime
-    // implications on users that we'd like to be very intentional about.
-    {
-      "matchPackageNames": ["router-bridge"],
-      "groupName": "router-bridge updates (including federation)",
-      "groupSlug": "rust-router-bridge-updates",
-      "matchManagers": ["cargo"],
-      "automerge": false
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -55,26 +55,10 @@
       "groupName": "rustc",
       "branchName": "{{{branchPrefix}}}rustc"
     },
-    // Bunch up all non-major npm dependencies into a single PR.  In the common case
+    // Bunch up all non-major dependencies into a single PR.  In the common case
     // where the upgrades apply cleanly, this causes less noise and is resolved faster
     // than starting a bunch of upgrades in parallel for what may turn out to be
     // a suite of related packages all released at once.
-    //
-    // Since too much in the Rust ecosystem is pre-1.0, we make an exception here.
-    {
-      "matchCurrentVersion": "< 1.0.0",
-      "separateMinorPatch": true,
-      "matchManagers": [ "cargo" ],
-      "minor": {
-        "groupName": "cargo pre-1.0 packages",
-        "groupSlug": "cargo-all-pre-1.0",
-      },
-      "patch": {
-        "groupName": "cargo pre-1.0 packages",
-        "groupSlug": "cargo-all-pre-1.0",
-        "automerge": true,
-      }
-    },
     {
       "matchCurrentVersion": ">= 1.0.0",
       "matchManagers": [ "cargo", "npm" ],


### PR DESCRIPTION
**Remove renovate grouping of < 1.0 packages**  
A pre 1.0 minor package update can be a breaking change. We have many
pre 1.0 dependencies that are totally independent, so the grouped up PR
can almost never be merged, and actually functions more as a garbage bin
for us to forget about these dependencies altogether.

This change will cause more renovate PRs to be opened, and also more PRs
that we can't merge at all. But we'll also be much more able to stay up
to date on the dependencies that we *can* upgrade.

**Remove router-bridge update config**  
We no longer have this dependency 🎉 