### PR TITLE
Add exemption for RUSTSEC-2024-0437 and prevent adding new vulnerable dependencies (backport #6962)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -100,7 +100,6 @@ highlight = "all"
 
 # List of crates to deny
 deny = [
-<<<<<<< HEAD
   # `cargo-scaffold` uses `git2` which uses `libssh2-sys` and `libgit2-sys`.
   # Both require `openssl-sys`. Adding this rule in this way is sufficient to
   # allow those to use `openssl-sys` (not a runtime dependency), leveraging the
@@ -120,14 +119,11 @@ deny = [
   { name = "libgit2-sys", wrappers = ["git2"] },
   # Note! This line is required to support the above exception.
   { name = "libssh2-sys", wrappers = ["libgit2-sys"] },
-=======
-  { crate = "openssl-sys" },
   # Prevent adding new dependencies on protobuf that may use code with
   # a security advisory in it (see `[advisories]`).
   # If you *must* add a new crate to the "wrappers" here, carefully audit
   # that it is *not* affected by any of the advisories above.
   { crate = "protobuf:<3.7.2", wrappers = ["prometheus", "opentelemetry-prometheus"] },
->>>>>>> 5384ede6 (Add exemption for RUSTSEC-2024-0437 and prevent adding new vulnerable dependencies (#6962))
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -30,7 +30,12 @@ git-fetch-with-cli = true
 ignore = [
     "RUSTSEC-2023-0071",
     "RUSTSEC-2024-0376", # we do not use tonic::transport::Server
-    "RUSTSEC-2024-0421" # we only resolve trusted subgraphs
+    "RUSTSEC-2024-0421", # we only resolve trusted subgraphs
+
+    # protobuf is used only through prometheus crates, enforced by
+    # a `[bans]` entry below. in the prometheus crates, only the protobuf
+    # encoder is used, while only the decoder is affected by this advisory.
+    "RUSTSEC-2024-0437",
 ]
 
 # This section is considered when running `cargo deny check licenses`
@@ -95,6 +100,7 @@ highlight = "all"
 
 # List of crates to deny
 deny = [
+<<<<<<< HEAD
   # `cargo-scaffold` uses `git2` which uses `libssh2-sys` and `libgit2-sys`.
   # Both require `openssl-sys`. Adding this rule in this way is sufficient to
   # allow those to use `openssl-sys` (not a runtime dependency), leveraging the
@@ -114,6 +120,14 @@ deny = [
   { name = "libgit2-sys", wrappers = ["git2"] },
   # Note! This line is required to support the above exception.
   { name = "libssh2-sys", wrappers = ["libgit2-sys"] },
+=======
+  { crate = "openssl-sys" },
+  # Prevent adding new dependencies on protobuf that may use code with
+  # a security advisory in it (see `[advisories]`).
+  # If you *must* add a new crate to the "wrappers" here, carefully audit
+  # that it is *not* affected by any of the advisories above.
+  { crate = "protobuf:<3.7.2", wrappers = ["prometheus", "opentelemetry-prometheus"] },
+>>>>>>> 5384ede6 (Add exemption for RUSTSEC-2024-0437 and prevent adding new vulnerable dependencies (#6962))
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
[RUSTSEC-2024-0437](https://rustsec.org/advisories/RUSTSEC-2024-0437) shows a vulnerability in the `protobuf` crate's decoder implementation.

We use protobuf 2.x through the `prometheus` and `opentelemetry-prometheus` crates. A patch is only available for protobuf 3.x.
We basically cannot update to a patched version of `protobuf`, especially since we are also using an older version of opentelemetry.

Luckily, the prometheus crates only use the protobuf *encoder* implementation, not the decoder implementation. So we are not actually affected by the advisory.

This patch adds an exemption for the vulnerability, and disallows adding any *new* dependency on the vulnerable protobuf crates, so we can not silently add a dependency that *does* use the decoder implementation.
<hr>This is an automatic backport of pull request #6962 done by [Mergify](https://mergify.com).