### PR TITLE
fix(entity_caching): do not include other fields from representation variable than the entity keys (backport #6888)

### DIFF
--- a/.changesets/fix_bnjjj_fix_entity_caching_entity_key.md
+++ b/.changesets/fix_bnjjj_fix_entity_caching_entity_key.md
@@ -1,0 +1,11 @@
+### Do not include other fields from representation variable than the entity keys for entity cache([Issue #6673](https://github.com/apollographql/router/issues/6673))
+
+Separate entity keys and representation variable value in the cache key to avoid issues with `@requires` for example.
+
+close #6673
+
+> [!IMPORTANT]
+>
+> If you have enabled [Distributed query plan caching](https://www.apollographql.com/docs/router/configuration/distributed-caching/#distributed-query-plan-caching), this release contains changes which necessarily alter the hashing algorithm used for the cache keys.  On account of this, you should anticipate additional cache regeneration cost when updating between these versions while the new hashing algorithm comes into service.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/6888

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.25.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d810db7b42773a4082426bcd58658cb9b311c5b74febd255130a9dcfc13109d"
+checksum = "1bb8a0d8a54b31d8a9efcc25d4be3d949d823e8105a710861d6d4a4ef811b5f2"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -188,7 +188,6 @@ dependencies = [
  "thiserror",
  "triomphe",
  "typed-arena",
- "uuid",
 ]
 
 [[package]]
@@ -3296,7 +3295,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "smallvec",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -7195,7 +7194,6 @@ checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,11 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
+<<<<<<< HEAD
 apollo-compiler = "1.25.0"
+=======
+apollo-compiler = "1.27.0"
+>>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
 apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,7 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-<<<<<<< HEAD
-apollo-compiler = "1.25.0"
-=======
 apollo-compiler = "1.27.0"
->>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
 apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"

--- a/apollo-router/src/plugin/test/mock/subgraph.rs
+++ b/apollo-router/src/plugin/test/mock/subgraph.rs
@@ -199,7 +199,6 @@ impl Service<SubgraphRequest> for MockSubgraph {
         }
 
         normalize(body);
-
         let response = if let Some(response) = self.mocks.get(body) {
             // Build an http Response
             let mut http_response_builder = http::Response::builder().status(StatusCode::OK);

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -5,11 +5,11 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Duration;
 
-use apollo_compiler::Name;
-use apollo_compiler::Schema;
 use apollo_compiler::ast::NamedType;
 use apollo_compiler::parser::Parser;
 use apollo_compiler::validation::Valid;
+use apollo_compiler::Name;
+use apollo_compiler::Schema;
 use http::header;
 use http::header::CACHE_CONTROL;
 use indexmap::IndexMap;
@@ -411,13 +411,9 @@ impl Plugin for EntityCache {
                     private_id,
                     invalidation: self.invalidation.clone(),
                     expose_keys_in_context: self.expose_keys_in_context,
-<<<<<<< HEAD
-                })));
-=======
                     supergraph_schema: self.supergraph_schema.clone(),
                     subgraph_enums: self.subgraph_enums.clone(),
-                });
->>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
+                })));
             tower::util::BoxService::new(inner)
         } else {
             ServiceBuilder::new()
@@ -462,7 +458,9 @@ impl Plugin for EntityCache {
                     map.insert(endpoint_config.listen.clone(), endpoint);
                 }
                 None => {
-                    tracing::warn!("Cannot start entity caching invalidation endpoint because the listen address and endpoint is not configured");
+                    tracing::warn!(
+                        "Cannot start entity caching invalidation endpoint because the listen address and endpoint is not configured"
+                    );
                 }
             }
         }
@@ -518,11 +516,6 @@ impl EntityCache {
     }
 }
 
-<<<<<<< HEAD
-struct CacheService(Option<InnerCacheService>);
-struct InnerCacheService {
-    service: subgraph::BoxService,
-=======
 /// Get the map of subgraph enum variant mapped with subgraph name
 fn get_subgraph_enums(supergraph_schema: &Valid<Schema>) -> HashMap<String, String> {
     let mut subgraph_enums = HashMap::new();
@@ -544,10 +537,9 @@ fn get_subgraph_enums(supergraph_schema: &Valid<Schema>) -> HashMap<String, Stri
     subgraph_enums
 }
 
-#[derive(Clone)]
-struct CacheService {
-    service: subgraph::BoxCloneService,
->>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
+struct CacheService(Option<InnerCacheService>);
+struct InnerCacheService {
+    service: subgraph::BoxService,
     name: String,
     entity_type: Option<String>,
     storage: RedisCacheStorage,
@@ -1438,14 +1430,9 @@ fn extract_cache_keys(
         // - entity key: invalidate a specific entity
         // - query hash: invalidate the entry for a specific query and operation name
         // - additional data: separate cache entries depending on info like authorization status
-<<<<<<< HEAD
-        let mut key = String::new();
-        let _ = write!(&mut key, "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph_name}:type:{typename}:entity:{hashed_entity_key}:hash:{query_hash}:data:{additional_data_hash}");
-=======
         let mut key = format!(
             "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph_name}:type:{typename}:entity:{hashed_entity_key}:representation:{hashed_representation}:hash:{query_hash}:data:{additional_data_hash}"
         );
->>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
         if is_known_private {
             if let Some(id) = private_id {
                 let _ = write!(&mut key, ":{id}");
@@ -1463,12 +1450,12 @@ fn extract_cache_keys(
     Ok(res)
 }
 
-fn get_entity_keys_from_supergraph_schema(
-    typename: &str,
-    subgraph_name: &str,
-    supergraph_schema: &Valid<Schema>,
-    subgraph_enums: &HashMap<String, String>,
-) -> Result<impl Iterator<Item = Name>, BoxError> {
+fn get_entity_keys_from_supergraph_schema<'a, 'b>(
+    typename: &'b str,
+    subgraph_name: &'b str,
+    supergraph_schema: &'a Valid<Schema>,
+    subgraph_enums: &'a HashMap<String, String>,
+) -> Result<impl Iterator<Item = Name> + use<'a, 'b>, BoxError> {
     let entity_keys = supergraph_schema
         .types
         .get(typename)

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -5,8 +5,14 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Duration;
 
+use apollo_compiler::Name;
+use apollo_compiler::Schema;
+use apollo_compiler::ast::NamedType;
+use apollo_compiler::parser::Parser;
+use apollo_compiler::validation::Valid;
 use http::header;
 use http::header::CACHE_CONTROL;
+use indexmap::IndexMap;
 use multimap::MultiMap;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -79,6 +85,9 @@ pub(crate) struct EntityCache {
     expose_keys_in_context: bool,
     private_queries: Arc<RwLock<HashSet<String>>>,
     pub(crate) invalidation: Invalidation,
+    supergraph_schema: Arc<Valid<Schema>>,
+    /// map containing the enum GRAPH
+    subgraph_enums: Arc<HashMap<String, String>>,
 }
 
 pub(crate) struct Storage {
@@ -311,6 +320,8 @@ impl Plugin for EntityCache {
             metrics: init.config.metrics,
             private_queries: Arc::new(RwLock::new(HashSet::new())),
             invalidation,
+            subgraph_enums: Arc::new(get_subgraph_enums(&init.supergraph_schema)),
+            supergraph_schema: init.supergraph_schema,
         })
     }
 
@@ -400,7 +411,13 @@ impl Plugin for EntityCache {
                     private_id,
                     invalidation: self.invalidation.clone(),
                     expose_keys_in_context: self.expose_keys_in_context,
+<<<<<<< HEAD
                 })));
+=======
+                    supergraph_schema: self.supergraph_schema.clone(),
+                    subgraph_enums: self.subgraph_enums.clone(),
+                });
+>>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
             tower::util::BoxService::new(inner)
         } else {
             ServiceBuilder::new()
@@ -459,6 +476,7 @@ impl EntityCache {
     pub(crate) async fn with_mocks(
         storage: RedisCacheStorage,
         subgraphs: HashMap<String, Subgraph>,
+        supergraph_schema: Arc<Valid<Schema>>,
     ) -> Result<Self, BoxError>
     where
         Self: Sized,
@@ -494,13 +512,42 @@ impl EntityCache {
                 concurrent_requests: 10,
             })),
             invalidation,
+            subgraph_enums: Arc::new(get_subgraph_enums(&supergraph_schema)),
+            supergraph_schema,
         })
     }
 }
 
+<<<<<<< HEAD
 struct CacheService(Option<InnerCacheService>);
 struct InnerCacheService {
     service: subgraph::BoxService,
+=======
+/// Get the map of subgraph enum variant mapped with subgraph name
+fn get_subgraph_enums(supergraph_schema: &Valid<Schema>) -> HashMap<String, String> {
+    let mut subgraph_enums = HashMap::new();
+    if let Some(graph_enum) = supergraph_schema.get_enum("join__Graph") {
+        subgraph_enums.extend(graph_enum.values.iter().filter_map(
+            |(enum_name, enum_value_def)| {
+                let subgraph_name = enum_value_def
+                    .directives
+                    .get("join__graph")?
+                    .specified_argument_by_name("name")?
+                    .as_str()?
+                    .to_string();
+
+                Some((enum_name.to_string(), subgraph_name))
+            },
+        ));
+    }
+
+    subgraph_enums
+}
+
+#[derive(Clone)]
+struct CacheService {
+    service: subgraph::BoxCloneService,
+>>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
     name: String,
     entity_type: Option<String>,
     storage: RedisCacheStorage,
@@ -509,6 +556,8 @@ struct InnerCacheService {
     private_id: Option<String>,
     expose_keys_in_context: bool,
     invalidation: Invalidation,
+    supergraph_schema: Arc<Valid<Schema>>,
+    subgraph_enums: Arc<HashMap<String, String>>,
 }
 
 impl Service<subgraph::Request> for CacheService {
@@ -681,6 +730,8 @@ impl InnerCacheService {
             let request_id = request.id.clone();
             match cache_lookup_entities(
                 self.name.clone(),
+                self.supergraph_schema.clone(),
+                &self.subgraph_enums,
                 self.storage.clone(),
                 is_known_private,
                 private_id.as_deref(),
@@ -926,8 +977,11 @@ async fn cache_lookup_root(
 
 struct EntityCacheResults(Vec<IntermediateResult>, Option<CacheControl>);
 
+#[allow(clippy::too_many_arguments)]
 async fn cache_lookup_entities(
     name: String,
+    supergraph_schema: Arc<Valid<Schema>>,
+    subgraph_enums: &HashMap<String, String>,
     cache: RedisCacheStorage,
     is_known_private: bool,
     private_id: Option<&str>,
@@ -935,9 +989,10 @@ async fn cache_lookup_entities(
     expose_keys_in_context: bool,
 ) -> Result<ControlFlow<subgraph::Response, (subgraph::Request, EntityCacheResults)>, BoxError> {
     let body = request.subgraph_request.body_mut();
-
     let keys = extract_cache_keys(
         &name,
+        supergraph_schema,
+        subgraph_enums,
         &request.query_hash,
         body,
         &request.context,
@@ -1306,8 +1361,11 @@ fn extract_cache_key_root(
 }
 
 // build a list of keys to get from the cache in one query
+#[allow(clippy::too_many_arguments)]
 fn extract_cache_keys(
     subgraph_name: &str,
+    supergraph_schema: Arc<Valid<Schema>>,
+    subgraph_enums: &HashMap<String, String>,
     query_hash: &QueryHash,
     body: &mut graphql::Request,
     context: &Context,
@@ -1326,18 +1384,52 @@ fn extract_cache_keys(
         .and_then(|value| value.as_array_mut())
         .expect("we already checked that representations exist");
 
+    // Get entity key to only get the right fields in representations
+
     let mut res = Vec::new();
     for representation in representations {
-        let opt_type = representation
-            .as_object_mut()
-            .and_then(|o| o.remove(TYPENAME))
+        let representation =
+            representation
+                .as_object_mut()
+                .ok_or_else(|| FetchError::MalformedRequest {
+                    reason: "representation variable should be an array of object".to_string(),
+                })?;
+        let typename_value =
+            representation
+                .remove(TYPENAME)
+                .ok_or_else(|| FetchError::MalformedRequest {
+                    reason: "missing __typename in representation".to_string(),
+                })?;
+
+        let typename = typename_value
+            .as_str()
             .ok_or_else(|| FetchError::MalformedRequest {
-                reason: "missing __typename in representation".to_string(),
+                reason: "__typename in representation is not a string".to_string(),
             })?;
+        let entity_keys = get_entity_keys_from_supergraph_schema(
+            typename,
+            subgraph_name,
+            &supergraph_schema,
+            subgraph_enums,
+        )?;
 
-        let typename = opt_type.as_str().unwrap_or("-");
+        let mut representation_entity_keys = IndexMap::new();
+        for entity_key in entity_keys {
+            // We remove it from original representation to not hash it both in entity_hash_key and representation_hash_key
+            let (key, value) = representation
+                .remove_entry(entity_key.as_str())
+                .ok_or_else(|| FetchError::MalformedRequest {
+                    reason: format!("can't get entity key {entity_key:?} in representations"),
+                })?;
+            representation_entity_keys.insert(key, value);
+        }
 
-        let hashed_entity_key = hash_entity_key(representation);
+        let hashed_representation = if representation.is_empty() {
+            String::new()
+        } else {
+            hash_other_representation(representation)
+        };
+        let hashed_entity_key = hash_entity_key(&representation_entity_keys);
 
         // the cache key is written to easily find keys matching a prefix for deletion:
         // - entity cache version: current version of the hash
@@ -1346,27 +1438,98 @@ fn extract_cache_keys(
         // - entity key: invalidate a specific entity
         // - query hash: invalidate the entry for a specific query and operation name
         // - additional data: separate cache entries depending on info like authorization status
+<<<<<<< HEAD
         let mut key = String::new();
         let _ = write!(&mut key, "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph_name}:type:{typename}:entity:{hashed_entity_key}:hash:{query_hash}:data:{additional_data_hash}");
+=======
+        let mut key = format!(
+            "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph_name}:type:{typename}:entity:{hashed_entity_key}:representation:{hashed_representation}:hash:{query_hash}:data:{additional_data_hash}"
+        );
+>>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
         if is_known_private {
             if let Some(id) = private_id {
                 let _ = write!(&mut key, ":{id}");
             }
         }
 
-        representation
-            .as_object_mut()
-            .map(|o| o.insert(TYPENAME, opt_type));
+        representation.insert(TYPENAME, typename_value);
+        representation_entity_keys
+            .into_iter()
+            .for_each(|(key, val)| {
+                representation.insert(key, val);
+            });
         res.push(key);
     }
     Ok(res)
 }
 
-/// Returns a hash for the given representation, independent of field order. Destructively sorts any objects in the input.
-pub(crate) fn hash_entity_key(representation: &mut Value) -> String {
+fn get_entity_keys_from_supergraph_schema(
+    typename: &str,
+    subgraph_name: &str,
+    supergraph_schema: &Valid<Schema>,
+    subgraph_enums: &HashMap<String, String>,
+) -> Result<impl Iterator<Item = Name>, BoxError> {
+    let entity_keys = supergraph_schema
+        .types
+        .get(typename)
+        .ok_or_else(|| FetchError::MalformedRequest {
+            reason: format!("unknown typename {typename:?} in representations"),
+        })?
+        .directives()
+        .get_all("join__type")
+        .filter_map(move |directive| {
+            let schema_subgraph_name = directive
+                .specified_argument_by_name("graph")
+                .and_then(|arg| arg.as_enum())
+                .and_then(|arg| subgraph_enums.get(arg.as_str()))?;
+
+            if schema_subgraph_name == subgraph_name {
+                let mut parser = Parser::new();
+                directive
+                    .specified_argument_by_name("key")
+                    .and_then(|arg| arg.as_str())
+                    .and_then(|arg| {
+                        parser
+                            .parse_field_set(
+                                supergraph_schema,
+                                NamedType::new(typename).ok()?,
+                                arg,
+                                "entity_caching.graphql",
+                            )
+                            .ok()
+                    })
+            } else {
+                None
+            }
+        })
+        .flat_map(|field_set| {
+            field_set
+                .selection_set
+                .root_fields(&Default::default())
+                .map(|f| f.name.clone())
+                .collect::<Vec<Name>>()
+        });
+
+    Ok(entity_keys)
+}
+
+// Only hash the list of entity keys
+pub(crate) fn hash_entity_key(
+    entity_keys: &IndexMap<ByteString, serde_json_bytes::Value>,
+) -> String {
     // We have to hash the representation because it can contains PII
     let mut digest = Sha256::new();
-    representation.sort_all_objects();
+    digest.update(serde_json::to_string(&entity_keys).unwrap().as_bytes());
+    hex::encode(digest.finalize().as_slice())
+}
+
+// Hash other representation variables except __typename and entity keys
+fn hash_other_representation(
+    representation: &mut serde_json_bytes::Map<ByteString, Value>,
+) -> String {
+    // We had to sort it to be deterministic
+    representation.sort_keys();
+    let mut digest = Sha256::new();
     digest.update(serde_json::to_string(&representation).unwrap().as_bytes());
     hex::encode(digest.finalize().as_slice())
 }
@@ -1615,29 +1778,5 @@ impl Ord for CacheKeyStatus {
             (CacheKeyStatus::Cached, CacheKeyStatus::New) => std::cmp::Ordering::Less,
             (CacheKeyStatus::Cached, CacheKeyStatus::Cached) => std::cmp::Ordering::Equal,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_hash_entity_key_ordering() {
-        let mut representations = serde_json_bytes::json!([{
-            "id1": "test",
-            "id2": "test2"
-        }]);
-        let first_hash_key = hash_entity_key(&mut representations);
-        let mut representations = serde_json_bytes::json!([{
-            "id2": "test2",
-            "id1": "test"
-        }]);
-        let second_hash_key = hash_entity_key(&mut representations);
-
-        assert_eq!(
-            first_hash_key, second_hash_key,
-            "these 2 hashes should be equals because ordering doesn't matter"
-        );
     }
 }

--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -4,11 +4,8 @@ use std::time::Instant;
 use fred::error::RedisError;
 use fred::types::Scanner;
 use futures::stream;
-<<<<<<< HEAD
 use futures::StreamExt;
-=======
 use indexmap::IndexMap;
->>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;

--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -4,10 +4,15 @@ use std::time::Instant;
 use fred::error::RedisError;
 use fred::types::Scanner;
 use futures::stream;
+<<<<<<< HEAD
 use futures::StreamExt;
+=======
+use indexmap::IndexMap;
+>>>>>>> d0db5d84 (fix(entity_caching): do not include other fields from representation variable than the entity keys (#6888))
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_json_bytes::ByteString;
 use serde_json_bytes::Value;
 use thiserror::Error;
 use tokio::sync::Semaphore;
@@ -225,7 +230,7 @@ pub(crate) enum InvalidationRequest {
     Entity {
         subgraph: String,
         r#type: String,
-        key: Value,
+        key: IndexMap<ByteString, Value>,
     },
 }
 

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert-5.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/plugins/cache/tests.rs
 expression: cache_keys
-snapshot_kind: text
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/plugins/cache/tests.rs
 expression: cache_keys
-snapshot_kind: text
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-2.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-2.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response.response.headers().get(CACHE_CONTROL)
+---
+Some(
+    "public",
+)

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-3.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response
+---
+{
+  "data": {
+    "topProducts": [
+      {
+        "name": "Test",
+        "shippingEstimate": 15,
+        "price": 150
+      }
+    ]
+  }
+}

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-4.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-4.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response.response.headers().get(CACHE_CONTROL)
+---
+Some(
+    "public",
+)

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-5.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: cache_keys
+---
+[
+  {
+    "key": "version:1.0:subgraph:inventory:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation:7ae1cf67d5c484b3430662edab68bf613043333264470c8f5834fea277b4e060:hash:a7b76558fe61b2f89ee9ea8bac8eee0b702ba1f319eaace576ab6ccdd19cdc80:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "status": "cached",
+    "cache_control": "public"
+  },
+  {
+    "key": "version:1.0:subgraph:products:type:Query:hash:0a9c11d2f86fae30d5fdfe748e0be34c3d69dd26fa6520ee683d4d002e36e62a:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "status": "cached",
+    "cache_control": "public"
+  }
+]

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-6.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-6.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response
+---
+{
+  "data": {
+    "topProducts": [
+      {
+        "name": "Test",
+        "shippingEstimate": 15,
+        "price": 150
+      }
+    ]
+  }
+}

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: cache_keys
+---
+[
+  {
+    "key": "version:1.0:subgraph:inventory:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation:7ae1cf67d5c484b3430662edab68bf613043333264470c8f5834fea277b4e060:hash:a7b76558fe61b2f89ee9ea8bac8eee0b702ba1f319eaace576ab6ccdd19cdc80:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "status": "new",
+    "cache_control": "public"
+  },
+  {
+    "key": "version:1.0:subgraph:products:type:Query:hash:0a9c11d2f86fae30d5fdfe748e0be34c3d69dd26fa6520ee683d4d002e36e62a:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "status": "new",
+    "cache_control": "public"
+  }
+]

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-3.snap
@@ -1,16 +1,15 @@
 ---
 source: apollo-router/src/plugins/cache/tests.rs
 expression: cache_keys
-snapshot_kind: text
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "[REDACTED]"
   },
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "[REDACTED]"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
@@ -1,16 +1,15 @@
 ---
 source: apollo-router/src/plugins/cache/tests.rs
 expression: cache_keys
-snapshot_kind: text
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "[REDACTED]"
   },
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "[REDACTED]"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-3.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/plugins/cache/tests.rs
 expression: cache_keys
-snapshot_kind: text
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-5.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/plugins/cache/tests.rs
 expression: cache_keys
-snapshot_kind: text
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/plugins/cache/tests.rs
 expression: cache_keys
-snapshot_kind: text
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "private"
   },

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -17,7 +17,7 @@ mod labeler;
 mod plan;
 pub(crate) mod query_planner_service;
 pub(crate) mod rewrites;
-mod selection;
+pub(crate) mod selection;
 mod subgraph_context;
 pub(crate) mod subscription;
 

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -729,9 +729,9 @@ mod tests {
           @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
           query: Query
         }
-        
+
         directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
-        
+
         directive @join__field(
           graph: join__Graph
           requires: join__FieldSet
@@ -741,14 +741,14 @@ mod tests {
           override: String
           usedOverridden: Boolean
         ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-        
+
         directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-        
+
         directive @join__implements(
           graph: join__Graph!
           interface: String!
         ) repeatable on OBJECT | INTERFACE
-        
+
         directive @join__type(
           graph: join__Graph!
           key: join__FieldSet
@@ -756,27 +756,27 @@ mod tests {
           resolvable: Boolean! = true
           isInterfaceObject: Boolean! = false
         ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-        
+
         directive @join__unionMember(
           graph: join__Graph!
           member: String!
         ) repeatable on UNION
-        
+
         directive @link(
           url: String
           as: String
           for: link__Purpose
           import: [link__Import]
         ) repeatable on SCHEMA
-        
+
         scalar join__FieldSet
-        
+
         enum join__Graph {
             TEST @join__graph(name: "test", url: "http://localhost:4001/graphql")
         }
-        
+
         scalar link__Import
-        
+
         enum link__Purpose {
           SECURITY
           EXECUTION

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -459,7 +459,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
     let v: Value = serde_json::from_str(&s).unwrap();
     insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
 
-    let s: String = client.get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c").await.unwrap();
+    let s: String = client.get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c").await.unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
     insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
 
@@ -571,7 +571,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
     insta::assert_json_snapshot!(response);
 
     let s:String = client
-        .get("version:1.0:subgraph:reviews:type:Product:entity:d9a4cd73308dd13ca136390c10340823f94c335b9da198d2339c886c738abf0d:hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+        .get("version:1.0:subgraph:reviews:type:Product:entity:d9a4cd73308dd13ca136390c10340823f94c335b9da198d2339c886c738abf0d:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -821,7 +821,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
     );
 
     let s: String = client
-        .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+        .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -865,7 +865,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
     insta::assert_json_snapshot!(response);
 
     let s:String = client
-          .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:hash:572a2cdde770584306cd0def24555773323b1738e9a303c7abc1721b6f9f2ec4:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+          .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation::hash:572a2cdde770584306cd0def24555773323b1738e9a303c7abc1721b6f9f2ec4:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -875,6 +875,30 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
             "reviews": [{
                 "body": "I can sit on it",
                 "author": {"__typename": "User", "id": "1"}
+            }]
+        }}
+    );
+    let s:String = client
+          .get("version:1.0:subgraph:reviews:type:Product:entity:4e48855987eae27208b466b941ecda5fb9b88abc03301afef6e4099a981889e9:representation::hash:572a2cdde770584306cd0def24555773323b1738e9a303c7abc1721b6f9f2ec4:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+          .await
+          .unwrap();
+    let v: Value = serde_json::from_str(&s).unwrap();
+    assert_eq!(
+        v.as_object().unwrap().get("data").unwrap(),
+        &json! {{
+            "reviews": [{
+                "body": "I can sit on it",
+                "author": {
+                    "__typename": "User",
+                    "id": "1"
+                }
+            },
+            {
+                "body": "I can eat on it",
+                "author": {
+                    "__typename": "User",
+                    "id": "2"
+                }
             }]
         }}
     );


### PR DESCRIPTION
Separate entity keys and representation variable value in the cache key to avoid issues with `@requires` for example.

close #6673 

 <hr>This is an automatic backport of pull request #6888 done by [Mergify](https://mergify.com).