### PR TITLE
Add apollo.router.pipelines metrics

### DIFF
--- a/.changesets/feat_pipeline_metrics.md
+++ b/.changesets/feat_pipeline_metrics.md
@@ -1,0 +1,14 @@
+### Add apollo.router.pipelines metrics ([PR #6967](https://github.com/apollographql/router/pull/6967))
+
+When the Router reloads either via schema change or config change a new request pipeline is created.
+Existing request pipelines are closed once their requests finish. However, this may not happen if there are ongoing long requests 
+such as Subscriptions that do not finish.
+
+To enable debugging when request pipelines are being kept around a new gauge metric has been added:
+
+- `apollo.router.pipelines` - The number of request pipelines active in the router
+    - `schema.id` - The Apollo Studio schema hash associated with the pipeline.
+    - `launch.id` - The Apollo Studio launch id associated with the pipeline (optional).
+    - `config.hash` - The hash of the configuration
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/6967

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -1,5 +1,7 @@
 //! Logic for loading configuration in to an object model
 use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::io;
 use std::io::BufReader;
 use std::iter;
@@ -337,6 +339,12 @@ impl Configuration {
 }
 
 impl Configuration {
+    pub(crate) fn hash(&self) -> String {
+        let mut hasher = std::hash::DefaultHasher::default();
+        self.validated_yaml.hash(&mut hasher);
+        hasher.finish().to_string()
+    }
+
     fn notify(
         apollo_plugins: &Map<String, Value>,
     ) -> Result<Notify<String, graphql::Response>, ConfigurationError> {

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -7,6 +7,7 @@ use opentelemetry::KeyValue;
 use opentelemetry::metrics::Counter;
 use opentelemetry::metrics::Histogram;
 use opentelemetry::metrics::MeterProvider;
+use opentelemetry::metrics::ObservableGauge;
 use opentelemetry::metrics::UpDownCounter;
 use opentelemetry_semantic_conventions::trace::HTTP_REQUEST_METHOD;
 use opentelemetry_semantic_conventions::trace::SERVER_ADDRESS;
@@ -33,6 +34,7 @@ use super::graphql::selectors::ListLength;
 use super::selectors::CacheKind;
 use crate::Context;
 use crate::metrics;
+use crate::metrics::meter_provider;
 use crate::plugins::telemetry::config_new::Selectors;
 use crate::plugins::telemetry::config_new::attributes::DefaultAttributeRequirementLevel;
 use crate::plugins::telemetry::config_new::attributes::RouterAttributes;
@@ -59,6 +61,8 @@ use crate::plugins::telemetry::config_new::selectors::SupergraphSelector;
 use crate::plugins::telemetry::config_new::selectors::SupergraphValue;
 use crate::plugins::telemetry::otlp::TelemetryDataKind;
 use crate::services::router;
+use crate::services::router::pipeline_handle::PIPELINE_METRIC;
+use crate::services::router::pipeline_handle::pipelines;
 use crate::services::subgraph;
 use crate::services::supergraph;
 
@@ -335,8 +339,8 @@ impl InstrumentsConfig {
                                     )
                                     .as_histogram()
                                     .cloned().expect(
-                                "cannot convert instrument to histogram for router; this should not happen",
-                            )
+                                    "cannot convert instrument to histogram for router; this should not happen",
+                                )
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
                             selector: Some(Arc::new(RouterSelector::RequestHeader {
@@ -379,7 +383,7 @@ impl InstrumentsConfig {
                                     .as_histogram()
                                     .cloned()
                                     .expect(
-                                    "cannot convert instrument to histogram for router; this should not happen",
+                                        "cannot convert instrument to histogram for router; this should not happen",
                                     )
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
@@ -830,16 +834,16 @@ impl InstrumentsConfig {
                         increment: Increment::FieldCustom(None),
                         condition: Condition::True,
                         histogram: Some(static_instruments
-                                .get(FIELD_LENGTH)
-                                .expect(
-                                    "cannot get static instrument for graphql; this should not happen",
-                                )
-                                .as_histogram()
-                                .cloned()
-                                .expect(
-                                    "cannot convert instrument to counter for graphql; this should not happen",
-                                )
-                            ),
+                            .get(FIELD_LENGTH)
+                            .expect(
+                                "cannot get static instrument for graphql; this should not happen",
+                            )
+                            .as_histogram()
+                            .cloned()
+                            .expect(
+                                "cannot convert instrument to counter for graphql; this should not happen",
+                            )
+                        ),
                         attributes: Vec::with_capacity(nb_attributes),
                         selector: Some(Arc::new(GraphQLSelector::ListLength {
                             list_length: ListLength::Value,
@@ -932,16 +936,16 @@ impl InstrumentsConfig {
                         increment: Increment::Custom(None),
                         condition: Condition::True,
                         counter: Some(static_instruments
-                                .get(CACHE_METRIC)
-                                .expect(
-                                    "cannot get static instrument for cache; this should not happen",
-                                )
-                                .as_counter_f64()
-                                .cloned()
-                                .expect(
-                                    "cannot convert instrument to counter for cache; this should not happen",
-                                )
-                            ),
+                            .get(CACHE_METRIC)
+                            .expect(
+                                "cannot get static instrument for cache; this should not happen",
+                            )
+                            .as_counter_f64()
+                            .cloned()
+                            .expect(
+                                "cannot convert instrument to counter for cache; this should not happen",
+                            )
+                        ),
                         attributes: Vec::with_capacity(nb_attributes),
                         selector: Some(Arc::new(SubgraphSelector::Cache {
                             cache: CacheKind::Hit,
@@ -955,6 +959,34 @@ impl InstrumentsConfig {
             }),
         }
     }
+
+    pub(crate) fn new_pipeline_instruments(&self) -> HashMap<String, StaticInstrument> {
+        let meter = meter_provider().meter("apollo/router");
+        let mut instruments = HashMap::new();
+        instruments.insert(
+            PIPELINE_METRIC.to_string(),
+            StaticInstrument::GaugeU64(
+                meter
+                    .u64_observable_gauge(PIPELINE_METRIC)
+                    .with_description("The number of request pipelines active in the router")
+                    .with_callback(|i| {
+                        for (pipeline, count) in &*pipelines() {
+                            let mut attributes = Vec::with_capacity(3);
+                            attributes.push(KeyValue::new("schema.id", pipeline.schema_id.clone()));
+                            if let Some(launch_id) = &pipeline.launch_id {
+                                attributes.push(KeyValue::new("launch.id", launch_id.clone()));
+                            }
+                            attributes
+                                .push(KeyValue::new("config.hash", pipeline.config_hash.clone()));
+
+                            i.observe(*count, &attributes);
+                        }
+                    })
+                    .init(),
+            ),
+        );
+        instruments
+    }
 }
 
 #[derive(Debug)]
@@ -962,6 +994,9 @@ pub(crate) enum StaticInstrument {
     CounterF64(Counter<f64>),
     UpDownCounterI64(UpDownCounter<i64>),
     Histogram(Histogram<f64>),
+    // Gauges are never read
+    #[allow(dead_code)]
+    GaugeU64(ObservableGauge<u64>),
 }
 
 impl StaticInstrument {

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -30,7 +30,9 @@ use once_cell::sync::OnceCell;
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use opentelemetry::global::GlobalTracerProvider;
+use opentelemetry::metrics::MeterProvider;
 use opentelemetry::metrics::MetricsError;
+use opentelemetry::metrics::ObservableGauge;
 use opentelemetry::propagation::Extractor;
 use opentelemetry::propagation::Injector;
 use opentelemetry::propagation::TextMapCompositePropagator;
@@ -92,6 +94,7 @@ use crate::layers::ServiceBuilderExt;
 use crate::layers::instrument::InstrumentLayer;
 use crate::metrics::aggregation::MeterProviderType;
 use crate::metrics::filter::FilterMeterProvider;
+use crate::metrics::meter_provider;
 use crate::metrics::meter_provider_internal;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
@@ -143,6 +146,7 @@ use crate::services::connector;
 use crate::services::execution;
 use crate::services::layers::apq::PERSISTED_QUERY_CACHE_HIT;
 use crate::services::router;
+use crate::services::router::pipeline_handle::pipelines;
 use crate::services::subgraph;
 use crate::services::supergraph;
 use crate::spec::operation_limits::OperationLimits;
@@ -201,12 +205,7 @@ pub(crate) struct Telemetry {
     custom_endpoints: MultiMap<ListenAddr, Endpoint>,
     apollo_metrics_sender: apollo_exporter::Sender,
     field_level_instrumentation_ratio: f64,
-    pub(crate) graphql_custom_instruments: RwLock<Arc<HashMap<String, StaticInstrument>>>,
-    router_custom_instruments: RwLock<Arc<HashMap<String, StaticInstrument>>>,
-    supergraph_custom_instruments: RwLock<Arc<HashMap<String, StaticInstrument>>>,
-    subgraph_custom_instruments: RwLock<Arc<HashMap<String, StaticInstrument>>>,
-    connector_custom_instruments: RwLock<Arc<HashMap<String, StaticInstrument>>>,
-    cache_custom_instruments: RwLock<Arc<HashMap<String, StaticInstrument>>>,
+    builtin_instruments: RwLock<BuiltinInstruments>,
     activation: Mutex<TelemetryActivation>,
 }
 
@@ -267,9 +266,30 @@ struct BuiltinInstruments {
     subgraph_custom_instruments: Arc<HashMap<String, StaticInstrument>>,
     connector_custom_instruments: Arc<HashMap<String, StaticInstrument>>,
     cache_custom_instruments: Arc<HashMap<String, StaticInstrument>>,
+    _gauges: Vec<ObservableGauge<u64>>,
 }
 
 fn create_builtin_instruments(config: &InstrumentsConfig) -> BuiltinInstruments {
+    let mut gauges = Vec::new();
+    let meter = meter_provider().meter("apollo/router");
+    gauges.push(
+        meter
+            .u64_observable_gauge("apollo.router.pipelines")
+            .with_description("The number of request pipelines active in the router")
+            .with_callback(|i| {
+                for (pipeline, count) in &*pipelines() {
+                    let mut attributes = Vec::with_capacity(3);
+                    attributes.push(KeyValue::new("schema.id", pipeline.schema_id.clone()));
+                    if let Some(launch_id) = &pipeline.launch_id {
+                        attributes.push(KeyValue::new("launch.id", launch_id.clone()));
+                    }
+                    attributes.push(KeyValue::new("config.hash", pipeline.config_hash.clone()));
+
+                    i.observe(*count, &attributes);
+                }
+            })
+            .init(),
+    );
     BuiltinInstruments {
         graphql_custom_instruments: Arc::new(config.new_builtin_graphql_instruments()),
         router_custom_instruments: Arc::new(config.new_builtin_router_instruments()),
@@ -277,6 +297,7 @@ fn create_builtin_instruments(config: &InstrumentsConfig) -> BuiltinInstruments 
         subgraph_custom_instruments: Arc::new(config.new_builtin_subgraph_instruments()),
         connector_custom_instruments: Arc::new(config.new_builtin_connector_instruments()),
         cache_custom_instruments: Arc::new(config.new_builtin_cache_instruments()),
+        _gauges: gauges,
     }
 }
 
@@ -308,15 +329,6 @@ impl PluginPrivate for Telemetry {
             );
         }
 
-        let BuiltinInstruments {
-            graphql_custom_instruments,
-            router_custom_instruments,
-            supergraph_custom_instruments,
-            subgraph_custom_instruments,
-            connector_custom_instruments,
-            cache_custom_instruments,
-        } = create_builtin_instruments(&config.instrumentation.instruments);
-
         Ok(Telemetry {
             custom_endpoints: metrics_builder.custom_endpoints,
             apollo_metrics_sender: metrics_builder.apollo_metrics_sender,
@@ -335,12 +347,9 @@ impl PluginPrivate for Telemetry {
                     .map(FilterMeterProvider::public),
                 is_active: false,
             }),
-            graphql_custom_instruments: RwLock::new(graphql_custom_instruments),
-            router_custom_instruments: RwLock::new(router_custom_instruments),
-            supergraph_custom_instruments: RwLock::new(supergraph_custom_instruments),
-            subgraph_custom_instruments: RwLock::new(subgraph_custom_instruments),
-            connector_custom_instruments: RwLock::new(connector_custom_instruments),
-            cache_custom_instruments: RwLock::new(cache_custom_instruments),
+            builtin_instruments: RwLock::new(create_builtin_instruments(
+                &config.instrumentation.instruments,
+            )),
             config: Arc::new(config),
         })
     }
@@ -355,7 +364,11 @@ impl PluginPrivate for Telemetry {
             matches!(config.instrumentation.spans.mode, SpanMode::Deprecated);
         let field_level_instrumentation_ratio = self.field_level_instrumentation_ratio;
         let metrics_sender = self.apollo_metrics_sender.clone();
-        let static_router_instruments = self.router_custom_instruments.read().clone();
+        let static_router_instruments = self
+            .builtin_instruments
+            .read()
+            .router_custom_instruments
+            .clone();
 
         ServiceBuilder::new()
             .map_response(move |response: router::Response| {
@@ -583,8 +596,16 @@ impl PluginPrivate for Telemetry {
         let config_map_res_first = config.clone();
         let config_map_res = config.clone();
         let field_level_instrumentation_ratio = self.field_level_instrumentation_ratio;
-        let static_supergraph_instruments = self.supergraph_custom_instruments.read().clone();
-        let static_graphql_instruments = self.graphql_custom_instruments.read().clone();
+        let static_supergraph_instruments = self
+            .builtin_instruments
+            .read()
+            .supergraph_custom_instruments
+            .clone();
+        let static_graphql_instruments = self
+            .builtin_instruments
+            .read()
+            .graphql_custom_instruments
+            .clone();
         ServiceBuilder::new()
             .instrument(move |supergraph_req: &SupergraphRequest| {
                 span_mode.create_supergraph(
@@ -778,8 +799,16 @@ impl PluginPrivate for Telemetry {
         let conf = self.config.clone();
         let subgraph_name = ByteString::from(name);
         let name = name.to_owned();
-        let static_subgraph_instruments = self.subgraph_custom_instruments.read().clone();
-        let static_cache_instruments = self.cache_custom_instruments.read().clone();
+        let static_subgraph_instruments = self
+            .builtin_instruments
+            .read()
+            .subgraph_custom_instruments
+            .clone();
+        let static_cache_instruments = self
+            .builtin_instruments
+            .read()
+            .cache_custom_instruments
+            .clone();
         ServiceBuilder::new()
             .instrument(move |req: &SubgraphRequest| span_mode.create_subgraph(name.as_str(), req))
             .map_request(move |req: SubgraphRequest| request_ftv1(req))
@@ -882,7 +911,11 @@ impl PluginPrivate for Telemetry {
     ) -> connector::request_service::BoxService {
         let req_fn_config = self.config.clone();
         let res_fn_config = self.config.clone();
-        let static_connector_instruments = self.connector_custom_instruments.read().clone();
+        let static_connector_instruments = self
+            .builtin_instruments
+            .read()
+            .connector_custom_instruments
+            .clone();
         ServiceBuilder::new()
             .map_future_with_request_data(
                 move |request: &connector::request_service::Request| {
@@ -995,22 +1028,8 @@ impl PluginPrivate for Telemetry {
 
         activation.reload_metrics();
 
-        let BuiltinInstruments {
-            graphql_custom_instruments,
-            router_custom_instruments,
-            supergraph_custom_instruments,
-            subgraph_custom_instruments,
-            connector_custom_instruments,
-            cache_custom_instruments,
-        } = create_builtin_instruments(&self.config.instrumentation.instruments);
-
-        *self.graphql_custom_instruments.write() = graphql_custom_instruments;
-        *self.router_custom_instruments.write() = router_custom_instruments;
-        *self.supergraph_custom_instruments.write() = supergraph_custom_instruments;
-        *self.subgraph_custom_instruments.write() = subgraph_custom_instruments;
-        *self.connector_custom_instruments.write() = connector_custom_instruments;
-        *self.cache_custom_instruments.write() = cache_custom_instruments;
-
+        *self.builtin_instruments.write() =
+            create_builtin_instruments(&self.config.instrumentation.instruments);
         reload_fmt(create_fmt_layer(&self.config));
         activation.is_active = true;
     }

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -40,6 +40,7 @@ pub type Body = RouterBody;
 pub type Error = hyper::Error;
 
 pub mod body;
+pub(crate) mod pipeline_handle;
 pub(crate) mod service;
 #[cfg(test)]
 mod tests;

--- a/apollo-router/src/services/router/pipeline_handle.rs
+++ b/apollo-router/src/services/router/pipeline_handle.rs
@@ -42,18 +42,6 @@ impl PipelineHandle {
     }
 }
 
-impl Clone for PipelineHandle {
-    fn clone(&self) -> Self {
-        pipelines()
-            .entry(self.pipeline_ref.clone())
-            .and_modify(|p| *p += 1)
-            .or_insert(1);
-        PipelineHandle {
-            pipeline_ref: self.pipeline_ref.clone(),
-        }
-    }
-}
-
 impl Drop for PipelineHandle {
     fn drop(&mut self) {
         let mut pipelines = pipelines();

--- a/apollo-router/src/services/router/pipeline_handle.rs
+++ b/apollo-router/src/services/router/pipeline_handle.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
-use std::sync::MutexGuard;
 use std::sync::OnceLock;
+
+use parking_lot::Mutex;
+use parking_lot::MutexGuard;
 
 /// A pipeline is used to keep track of how many pipelines we have active. It's associated with an instance of RouterCreator
 /// The telemetry plugin has a gauge to expose this data
@@ -23,10 +24,7 @@ pub(crate) struct PipelineHandle {
 
 static PIPELINES: OnceLock<Mutex<HashMap<PipelineRef, u64>>> = OnceLock::new();
 pub(crate) fn pipelines() -> MutexGuard<'static, HashMap<PipelineRef, u64>> {
-    PIPELINES
-        .get_or_init(Default::default)
-        .lock()
-        .expect("poisoned")
+    PIPELINES.get_or_init(Default::default).lock()
 }
 
 impl PipelineHandle {

--- a/apollo-router/src/services/router/pipeline_handle.rs
+++ b/apollo-router/src/services/router/pipeline_handle.rs
@@ -54,3 +54,5 @@ impl Drop for PipelineHandle {
         }
     }
 }
+
+pub(crate) const PIPELINE_METRIC: &str = "apollo.router.pipelines";

--- a/apollo-router/src/services/router/pipeline_handle.rs
+++ b/apollo-router/src/services/router/pipeline_handle.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+use std::sync::OnceLock;
+
+/// A pipeline is used to keep track of how many pipelines we have active. It's associated with an instance of RouterCreator
+/// The telemetry plugin has a gauge to expose this data
+/// Pipeline ref represents a unique pipeline
+#[derive(Clone, Hash, Eq, PartialEq, Debug)]
+pub(crate) struct PipelineRef {
+    pub(crate) schema_id: String,
+    pub(crate) launch_id: Option<String>,
+    pub(crate) config_hash: String,
+}
+
+/// A pipeline handle does the actual tracking of pipelines
+/// Creating a new pipeline handle will insert a PipelineRef into a static map.
+/// Dropping all pipeline handles associated with the internal ref will remove the PipelineRef
+/// Clone MUST NOT be implemented for this type. Cloning will make extra copies that when dropped will throw off the global count.
+pub(crate) struct PipelineHandle {
+    pipeline_ref: PipelineRef,
+}
+
+static PIPELINES: OnceLock<Mutex<HashMap<PipelineRef, u64>>> = OnceLock::new();
+pub(crate) fn pipelines() -> MutexGuard<'static, HashMap<PipelineRef, u64>> {
+    PIPELINES
+        .get_or_init(Default::default)
+        .lock()
+        .expect("poisoned")
+}
+
+impl PipelineHandle {
+    pub(crate) fn new(schema_id: String, launch_id: Option<String>, config_hash: String) -> Self {
+        let pipeline_ref = PipelineRef {
+            schema_id: schema_id.to_string(),
+            launch_id,
+            config_hash: config_hash.to_string(),
+        };
+        pipelines()
+            .entry(pipeline_ref.clone())
+            .and_modify(|p| *p += 1)
+            .or_insert(1);
+        PipelineHandle { pipeline_ref }
+    }
+}
+
+impl Clone for PipelineHandle {
+    fn clone(&self) -> Self {
+        pipelines()
+            .entry(self.pipeline_ref.clone())
+            .and_modify(|p| *p += 1)
+            .or_insert(1);
+        PipelineHandle {
+            pipeline_ref: self.pipeline_ref.clone(),
+        }
+    }
+}
+
+impl Drop for PipelineHandle {
+    fn drop(&mut self) {
+        let mut pipelines = pipelines();
+        let value = pipelines
+            .get_mut(&self.pipeline_ref)
+            .expect("pipeline_ref MUST be greater than zero");
+        *value -= 1;
+        if *value == 0 {
+            pipelines.remove(&self.pipeline_ref);
+        }
+    }
+}

--- a/apollo-router/src/services/router/pipeline_handle.rs
+++ b/apollo-router/src/services/router/pipeline_handle.rs
@@ -30,9 +30,9 @@ pub(crate) fn pipelines() -> MutexGuard<'static, HashMap<PipelineRef, u64>> {
 impl PipelineHandle {
     pub(crate) fn new(schema_id: String, launch_id: Option<String>, config_hash: String) -> Self {
         let pipeline_ref = PipelineRef {
-            schema_id: schema_id.to_string(),
+            schema_id,
             launch_id,
-            config_hash: config_hash.to_string(),
+            config_hash,
         };
         pipelines()
             .entry(pipeline_ref.clone())

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -1004,14 +1004,14 @@ impl RouterCreator {
 
         // Create a handle that will help us keep track of this pipeline.
         // A metric is exposed that allows the use to see if pipelines are being hung onto.
-        let schema_id = supergraph_creator.schema().schema_id.clone();
-        let launch_id = supergraph_creator.schema().launch_id.clone();
+        let schema_id = supergraph_creator.schema().schema_id.to_string();
+        let launch_id = supergraph_creator
+            .schema()
+            .launch_id
+            .as_ref()
+            .map(|launch_id| launch_id.to_string());
         let config_hash = configuration.hash();
-        let pipeline_handle = PipelineHandle::new(
-            schema_id.to_string(),
-            launch_id.map(|id| id.to_string()),
-            config_hash,
-        );
+        let pipeline_handle = PipelineHandle::new(schema_id, launch_id, config_hash);
 
         let oltp_error_metrics_mode: OtlpErrorMetricsMode =
             match configuration.apollo_plugins.plugins.get("telemetry") {

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -882,7 +882,18 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
-    pub async fn assert_log_contained(&self, msg: &str) {
+    pub fn print_logs(&mut self) {
+        while let Ok(line) = self.stdio_rx.try_recv() {
+            self.logs.push(line.to_string());
+        }
+
+        for line in &self.logs {
+            println!("{}", line);
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn assert_log_contained(&self, msg: &str) {
         for line in &self.logs {
             if line.contains(msg) {
                 return;

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -925,6 +925,13 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
+    /// Checks the metrics contain the supplied string in prometheus format.
+    /// To allow checking of metrics where the value is not stable the magic tag `<any>` can be used.
+    /// For example:
+    /// ```rust,ignore
+    /// router.assert_metrics_contains(r#"apollo_router_pipelines{config_hash="<any>",schema_id="<any>",otel_scope_name="apollo/router"} 1"#, None)
+    /// ```
+    /// Will allow the metric to be checked even if the config hash and schema id are fluid.
     pub async fn assert_metrics_contains(&self, text: &str, duration: Option<Duration>) {
         let now = Instant::now();
         let mut last_metrics = String::new();

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -913,6 +913,8 @@ impl IntegrationTest {
     pub async fn assert_metrics_contains(&self, text: &str, duration: Option<Duration>) {
         let now = Instant::now();
         let mut last_metrics = String::new();
+        let text = regex::escape(text).replace("<any>", ".+");
+        let re = Regex::new(&format!("(?m)^{}", text)).expect("Invalid regex");
         while now.elapsed() < duration.unwrap_or_else(|| Duration::from_secs(15)) {
             if let Ok(metrics) = self
                 .get_metrics_response()
@@ -921,7 +923,7 @@ impl IntegrationTest {
                 .text()
                 .await
             {
-                if metrics.contains(text) {
+                if re.is_match(&metrics) {
                     return;
                 }
                 last_metrics = metrics;

--- a/apollo-router/tests/integration/telemetry/fixtures/prometheus_updated.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/prometheus_updated.router.yaml
@@ -1,0 +1,53 @@
+limits:
+  http_max_request_bytes: 200
+telemetry:
+  instrumentation:
+    instruments:
+      default_requirement_level: required
+      router:
+        http.server.request.duration:
+          attributes:
+            server.port: false
+            server.address: false
+            http.response.status_code:
+              alias: status
+            error:
+              error: reason
+  exporters:
+    metrics:
+      prometheus:
+        listen: 127.0.0.1:4000
+        enabled: true
+        path: /metrics
+      common:
+        views:
+          - name: apollo_router_http_request_duration_seconds
+            aggregation:
+              histogram:
+                buckets:
+                  - 0.1
+                  - 0.5
+                  - 1
+                  - 2
+                  - 3
+                  - 4
+                  - 5
+                  - 100
+                  - 1000
+headers:
+  all:
+    request:
+      - insert:
+          name: "x-custom-header"
+          value: "test_custom"
+override_subgraph_url:
+  products: http://localhost:4005
+include_subgraph_errors:
+  all: true
+supergraph:
+  introspection: true
+apq:
+  router:
+    cache:
+      in_memory:
+        limit: 1000

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -318,4 +318,8 @@ async fn test_gauges_on_reload() {
             None,
         )
         .await;
+
+    router
+        .assert_metrics_contains(r#"apollo_router_pipelines{config_hash="<any>",schema_id="<any>",otel_scope_name="apollo/router"} 1"#, None)
+        .await;
 }

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
+use regex::Regex;
 use serde_json::json;
+use wiremock::ResponseTemplate;
 
 use crate::integration::IntegrationTest;
 use crate::integration::common::Query;
@@ -322,4 +324,42 @@ async fn test_gauges_on_reload() {
     router
         .assert_metrics_contains(r#"apollo_router_pipelines{config_hash="<any>",schema_id="<any>",otel_scope_name="apollo/router"} 1"#, None)
         .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multi_pipelines() {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return;
+    }
+    let mut router = IntegrationTest::builder()
+        .config(PROMETHEUS_CONFIG)
+        .responder(ResponseTemplate::new(500).set_delay(Duration::from_secs(10)))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let query = router.execute_default_query();
+    // Long running request 1
+    let _h1 = tokio::task::spawn(query);
+    router
+        .update_config(include_str!("fixtures/prometheus_updated.router.yaml"))
+        .await;
+
+    router.assert_reloaded().await;
+    // Long running request 2
+    let query = router.execute_default_query();
+    let _h2 = tokio::task::spawn(query);
+    let metrics = router
+        .get_metrics_response()
+        .await
+        .expect("metrics")
+        .text()
+        .await
+        .expect("metrics");
+    // There should be two instances of the pipeline metrics
+    let regex = Regex::new(r#"(?m)^apollo_router_pipelines[{].+[}] 1"#).expect("regex");
+    assert_eq!(regex.captures_iter(&metrics).count(), 2);
 }

--- a/apollo-router/tests/integration/telemetry/otlp.rs
+++ b/apollo-router/tests/integration/telemetry/otlp.rs
@@ -47,7 +47,7 @@ async fn test_trace_error() -> Result<(), BoxError> {
 
     router.start().await;
     router.assert_started().await;
-    router.assert_log_contained("OpenTelemetry trace error occurred: cannot send message to batch processor 'otlp-tracing' as the channel is full").await;
+    router.assert_log_contained("OpenTelemetry trace error occurred: cannot send message to batch processor 'otlp-tracing' as the channel is full");
     router.assert_metrics_contains(r#"apollo_router_telemetry_batch_processor_errors_total{error="channel full",name="otlp-tracing",otel_scope_name="apollo/router"}"#, None).await;
     router.graceful_shutdown().await;
 

--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -120,4 +120,10 @@ The initial call to Uplink during router startup is not reflected in metrics.
 
 - `apollo.router.telemetry.batch_processor.errors` - The number of errors encountered by exporter batch processors.
   - `name`: One of `apollo-tracing`, `datadog-tracing`, `jaeger-collector`, `otlp-tracing`, `zipkin-tracing`.
-  - `error` = One of `channel closed`, `channel full`.
+  - `error`: One of `channel closed`, `channel full`.
+
+### Internals
+- `apollo.router.pipelines` - The number of request pipelines active in the router
+    - `schema.id` - The Apollo Studio schema hash associated with the pipeline.
+    - `launch.id` - The Apollo Studio launch id associated with the pipeline (optional).
+    - `config.hash` - The hash of the configuration


### PR DESCRIPTION
To enable debugging when request pipelines are being kept around a new gauge metric has been added:

- `apollo.router.pipelines` - The number of request pipelines active in the router
    - `schema.id` - The Apollo Studio schema hash associated with the pipeline.
    - `launch.id` - The Apollo Studio launch id associated with the pipeline (optional).
    - `config.hash` - The hash of the configuration


Backport: https://github.com/apollographql/router/pull/6953

<!-- start metadata -->
<!-- ROUTER-1129 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
