### PR TITLE
Fix panic error message when building elapsed response: overloaded -> elapsed

### DIFF
--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -280,7 +280,7 @@ impl PluginPrivate for TrafficShaping {
                                     .error(error)
                                     .context(ctx)
                                     .build()
-                                    .expect("should build overloaded response"))
+                                    .expect("should build elapsed response"))
                             }
                             Err(err) => Err(err),
                         }


### PR DESCRIPTION
*Description here*

Fixes panic error message

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
