### PR TITLE
fix(federation/correctness): remove context arguments from entity fetch response shapes

### DIFF
--- a/apollo-federation/src/correctness/query_plan_analysis.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis.rs
@@ -1,12 +1,18 @@
 // Analyze a QueryPlan and compute its overall response shape
 
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use apollo_compiler::executable::Field;
 use apollo_compiler::executable::Name;
 use itertools::Itertools;
 
 use super::response_shape::Clause;
+use super::response_shape::DefinitionVariant;
 use super::response_shape::Literal;
 use super::response_shape::NormalizedTypeCondition;
 use super::response_shape::PossibleDefinitions;
+use super::response_shape::PossibleDefinitionsPerTypeCondition;
 use super::response_shape::ResponseShape;
 use super::response_shape::compute_response_shape_for_entity_fetch_operation;
 use super::response_shape::compute_response_shape_for_operation;
@@ -386,6 +392,9 @@ fn interpret_fetch_node(
     for rewrite in &fetch.output_rewrites {
         result = apply_rewrites(schema, &result, rewrite)?;
     }
+    if !fetch.context_rewrites.is_empty() {
+        result = remove_context_arguments(&fetch.context_rewrites, &result)?;
+    }
     Ok(result)
 }
 
@@ -400,6 +409,87 @@ fn merge_response_shapes<'a>(
         result.merge_with(rs)?;
     }
     Ok(result)
+}
+
+/// Remove context arguments that are added to fetch operations.
+/// Returns a new response shape with all field arguments referencing a context variable removed.
+fn remove_context_arguments(
+    context_rewrites: &[Arc<FetchDataRewrite>],
+    response: &ResponseShape,
+) -> Result<ResponseShape, String> {
+    let context_variables: Result<HashSet<Name>, _> = context_rewrites
+        .iter()
+        .map(|rewrite| match rewrite.as_ref() {
+            FetchDataRewrite::KeyRenamer(renamer) => Ok(renamer.rename_key_to.clone()),
+            FetchDataRewrite::ValueSetter(_) => {
+                Err("unexpected value setter in context rewrites".to_string())
+            }
+        })
+        .collect();
+    Ok(remove_context_arguments_in_response_shape(
+        &context_variables?,
+        response,
+    ))
+}
+
+/// `context_variables`: the set of context variable names
+fn remove_context_arguments_in_response_shape(
+    context_variables: &HashSet<Name>,
+    response_shape: &ResponseShape,
+) -> ResponseShape {
+    let mut result = ResponseShape::new(response_shape.default_type_condition().clone());
+    for (key, defs) in response_shape.iter() {
+        let mut updated_defs = PossibleDefinitions::default();
+        for (type_cond, defs_per_type_cond) in defs.iter() {
+            let updated_selection_key = remove_context_arguments_in_field(
+                context_variables,
+                defs_per_type_cond.field_selection_key(),
+            );
+            let updated_variants =
+                defs_per_type_cond
+                    .conditional_variants()
+                    .iter()
+                    .map(|variant| {
+                        let updated_representative_field = remove_context_arguments_in_field(
+                            context_variables,
+                            variant.representative_field(),
+                        );
+                        let sub_rs = variant.sub_selection_response_shape().as_ref().map(|rs| {
+                            remove_context_arguments_in_response_shape(context_variables, rs)
+                        });
+                        DefinitionVariant::new(
+                            variant.boolean_clause().clone(),
+                            updated_representative_field,
+                            sub_rs,
+                        )
+                    });
+            let updated_variants: Vec<_> = updated_variants.collect();
+            let updated_defs_per_type_cond =
+                PossibleDefinitionsPerTypeCondition::new(updated_selection_key, updated_variants);
+            updated_defs.insert(type_cond.clone(), updated_defs_per_type_cond);
+        }
+        result.insert(key.clone(), updated_defs);
+    }
+    result
+}
+
+/// `context_variables`: the set of context variable names
+fn remove_context_arguments_in_field(context_variables: &HashSet<Name>, field: &Field) -> Field {
+    let arguments = field
+        .arguments
+        .iter()
+        .filter_map(|arg| {
+            // see if the argument value is one of the context variables
+            match arg.value.as_variable() {
+                Some(var) if context_variables.contains(var) => None,
+                _ => Some(arg.clone()),
+            }
+        })
+        .collect();
+    Field {
+        arguments,
+        ..field.clone()
+    }
 }
 
 /// Add a literal to the conditions

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -661,6 +661,18 @@ impl DefinitionVariant {
             representative_field: self.representative_field.clone(),
         }
     }
+
+    pub fn new(
+        boolean_clause: Clause,
+        representative_field: Field,
+        sub_selection_response_shape: Option<ResponseShape>,
+    ) -> Self {
+        DefinitionVariant {
+            boolean_clause,
+            representative_field,
+            sub_selection_response_shape,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -688,6 +700,16 @@ impl PossibleDefinitionsPerTypeCondition {
         PossibleDefinitionsPerTypeCondition {
             field_selection_key: self.field_selection_key.clone(),
             conditional_variants: new_variants,
+        }
+    }
+
+    pub fn new(
+        field_selection_key: FieldSelectionKey,
+        conditional_variants: Vec<DefinitionVariant>,
+    ) -> Self {
+        PossibleDefinitionsPerTypeCondition {
+            field_selection_key,
+            conditional_variants,
         }
     }
 

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -859,7 +859,7 @@ fn removes_sibling_typename() {
         }
       }
     "#;
-    // unnecessary __typename is removed
+    // The __typename selection is hidden (attached to its sibling).
     assert_normalized!(schema, operation_with_typename, @r###"
       query TestQuery {
         foo {
@@ -889,6 +889,7 @@ fn keeps_typename_if_no_other_selection() {
         }
       }
     "#;
+    // The __typename selection is kept because it's the only selection.
     assert_normalized_equal!(
         schema,
         operation_with_single_typename,
@@ -1794,7 +1795,7 @@ fn off_by_1_error() {
       }
     "#;
 
-    // unnecessary __typename selections are dropped
+    // The __typename selections are hidden (attached to their siblings).
     assert_normalized!(schema, query,@r###"
       {
         t {
@@ -1899,6 +1900,7 @@ fn fragments_with_directive_on_typename() {
         }
     "#;
 
+    // The __typename selections are kept since they have directive applications.
     assert_normalized_equal!(
         schema,
         query,
@@ -1963,7 +1965,7 @@ fn fragments_with_non_intersecting_types() {
         }
     "#;
 
-    // dropping unnecessary __typename selection from fragment
+    // The __typename selection is hidden (attached to its sibling).
     assert_normalized!(schema, query, @r###"
         query($if: Boolean!) {
           t {

--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -71,7 +71,7 @@ macro_rules! assert_plan {
         .expect("valid graphql document");
         let plan = $planner.build_query_plan(&document, None, $options).expect("query plan generated");
         insta::assert_snapshot!(plan, @$expected);
-        // temporary workaround for correctness errors such as FED-509 and FED-515
+        // temporary workaround for correctness errors such as FED-515
         if $validate_correctness {
             apollo_federation::correctness::check_plan($planner.api_schema(), $planner.supergraph_schema(), $planner.subgraph_schemas(), &document, &plan).expect("generated correct plan");
         }

--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -58,6 +58,9 @@ macro_rules! subgraph_name {
 /// formatted query plan string.
 /// Run `cargo insta review` to diff and accept changes to the generated query plan.
 macro_rules! assert_plan {
+    (validate_correctness = $validate_correctness: expr, $api_schema_and_planner: expr, $operation: expr, @$expected: literal) => {{
+        assert_plan!($api_schema_and_planner, $operation, Default::default(), $validate_correctness, @$expected)
+    }};
     ($planner: expr, $operation: expr, $options: expr, $validate_correctness: expr, @$expected: literal) => {{
         let api_schema = $planner.api_schema();
         let document = apollo_compiler::ExecutableDocument::parse_and_validate(
@@ -68,7 +71,7 @@ macro_rules! assert_plan {
         .expect("valid graphql document");
         let plan = $planner.build_query_plan(&document, None, $options).expect("query plan generated");
         insta::assert_snapshot!(plan, @$expected);
-        // temporary workaround for FED-508 and FED-509
+        // temporary workaround for correctness errors such as FED-509 and FED-515
         if $validate_correctness {
             apollo_federation::correctness::check_plan($planner.api_schema(), $planner.supergraph_schema(), $planner.subgraph_schemas(), &document, &plan).expect("generated correct plan");
         }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/context.rs
@@ -35,7 +35,6 @@ use apollo_federation::query_plan::FetchDataPathElement;
 use apollo_federation::query_plan::FetchDataRewrite;
 use apollo_federation::query_plan::PlanNode;
 use apollo_federation::query_plan::TopLevelPlanNode;
-use apollo_federation::query_plan::query_planner::QueryPlanOptions;
 
 fn parse_fetch_data_path_element(value: &str) -> FetchDataPathElement {
     if value == ".." {
@@ -118,8 +117,6 @@ fn set_context_test_variable_is_from_same_subgraph() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
            QueryPlan {
              Sequence {
@@ -205,8 +202,6 @@ fn set_context_test_variable_is_from_different_subgraph() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
            QueryPlan {
              Sequence {
@@ -308,8 +303,6 @@ fn set_context_test_variable_is_already_in_a_different_fetch_group() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
                QueryPlan {
                  Sequence {
@@ -410,8 +403,6 @@ fn set_context_test_variable_is_a_list() {
           }
         }
       "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
                QueryPlan {
                  Sequence {
@@ -514,8 +505,6 @@ fn set_context_test_fetched_as_a_list() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
                QueryPlan {
                  Sequence {
@@ -613,8 +602,6 @@ fn set_context_test_impacts_on_query_planning() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
                QueryPlan {
                  Sequence {
@@ -723,8 +710,6 @@ fn set_context_test_with_type_conditions_for_union() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
            QueryPlan {
              Sequence {
@@ -824,8 +809,6 @@ fn set_context_test_accesses_a_different_top_level_query() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
                QueryPlan {
                  Sequence {
@@ -899,8 +882,6 @@ fn set_context_one_subgraph() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
                QueryPlan {
                  Sequence {
@@ -1006,8 +987,6 @@ fn set_context_required_field_is_several_levels_deep_going_back_and_forth_betwee
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
                QueryPlan {
                  Sequence {
@@ -1144,8 +1123,6 @@ fn set_context_test_before_key_resolution_transition() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
     QueryPlan {
       Sequence {
@@ -1279,8 +1256,6 @@ fn set_context_test_efficiently_merge_fetch_groups() {
           }
         }
         "#,
-        QueryPlanOptions::default(),
-        /* verify_correctness FED-508 */ false,
         @r###"
     QueryPlan {
       Sequence {

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -802,6 +802,7 @@ fn handles_types_with_no_common_supertype_at_the_same_merge_at() {
         "#,
     );
     assert_plan!(
+        validate_correctness = false,
         &planner,
         r#"
         {


### PR DESCRIPTION
This PR removes `@context` arguments from the response shapes computed from query plan's fetch nodes.
- Context arguments are only added in query plans and not present in input query.
- They should be removed from query plan response shape for apples-to-apples comparison.

<!-- FED-508 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

This is about internal testing. No impact on public features.