### PR TITLE
Add apollo.router.pipelines metrics (backport #6967)

### DIFF
--- a/.changesets/feat_pipeline_metrics.md
+++ b/.changesets/feat_pipeline_metrics.md
@@ -1,0 +1,14 @@
+### Add apollo.router.pipelines metrics ([PR #6967](https://github.com/apollographql/router/pull/6967))
+
+When the Router reloads either via schema change or config change a new request pipeline is created.
+Existing request pipelines are closed once their requests finish. However, this may not happen if there are ongoing long requests 
+such as Subscriptions that do not finish.
+
+To enable debugging when request pipelines are being kept around a new gauge metric has been added:
+
+- `apollo.router.pipelines` - The number of request pipelines active in the router
+    - `schema.id` - The Apollo Studio schema hash associated with the pipeline.
+    - `launch.id` - The Apollo Studio launch id associated with the pipeline (optional).
+    - `config.hash` - The hash of the configuration
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/6967

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -1,5 +1,6 @@
 //! Logic for loading configuration in to an object model
 use std::fmt;
+use std::hash::Hash;
 use std::io;
 use std::io::BufReader;
 use std::iter;
@@ -36,6 +37,7 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde_json::Map;
 use serde_json::Value;
+use sha2::Digest;
 use thiserror::Error;
 
 use self::cors::Cors;
@@ -118,7 +120,7 @@ pub enum ConfigurationError {
 #[derivative(Debug)]
 // We can't put a global #[serde(default)] here because of the Default implementation using `from_str` which use deserialize
 pub struct Configuration {
-    /// The raw configuration string.
+    /// The raw configuration value.
     #[serde(skip)]
     pub(crate) validated_yaml: Option<Value>,
 
@@ -323,6 +325,18 @@ impl Configuration {
 }
 
 impl Configuration {
+    pub(crate) fn hash(&self) -> String {
+        let mut hasher = sha2::Sha256::new();
+        let defaulted_raw = self
+            .validated_yaml
+            .as_ref()
+            .map(|s| serde_yaml::to_string(s).expect("config was not serializable"))
+            .unwrap_or_default();
+        hasher.update(defaulted_raw);
+        let hash: String = format!("{:x}", hasher.finalize());
+        hash
+    }
+
     fn notify(
         apollo_plugins: &Map<String, Value>,
     ) -> Result<Notify<String, graphql::Response>, ConfigurationError> {

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -3,12 +3,21 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+<<<<<<< HEAD
 use opentelemetry::metrics::Unit;
 use opentelemetry_api::metrics::Counter;
 use opentelemetry_api::metrics::Histogram;
 use opentelemetry_api::metrics::MeterProvider;
 use opentelemetry_api::metrics::UpDownCounter;
 use opentelemetry_api::KeyValue;
+=======
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Counter;
+use opentelemetry::metrics::Histogram;
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry::metrics::ObservableGauge;
+use opentelemetry::metrics::UpDownCounter;
+>>>>>>> 71e5fe45 (Add apollo.router.pipelines metrics (#6967))
 use opentelemetry_semantic_conventions::trace::HTTP_REQUEST_METHOD;
 use opentelemetry_semantic_conventions::trace::SERVER_ADDRESS;
 use opentelemetry_semantic_conventions::trace::SERVER_PORT;
@@ -33,6 +42,11 @@ use super::selectors::CacheKind;
 use super::DefaultForLevel;
 use super::Selector;
 use crate::metrics;
+<<<<<<< HEAD
+=======
+use crate::metrics::meter_provider;
+use crate::plugins::telemetry::config_new::Selectors;
+>>>>>>> 71e5fe45 (Add apollo.router.pipelines metrics (#6967))
 use crate::plugins::telemetry::config_new::attributes::DefaultAttributeRequirementLevel;
 use crate::plugins::telemetry::config_new::attributes::RouterAttributes;
 use crate::plugins::telemetry::config_new::attributes::SubgraphAttributes;
@@ -54,6 +68,8 @@ use crate::plugins::telemetry::config_new::selectors::SupergraphValue;
 use crate::plugins::telemetry::config_new::Selectors;
 use crate::plugins::telemetry::otlp::TelemetryDataKind;
 use crate::services::router;
+use crate::services::router::pipeline_handle::PIPELINE_METRIC;
+use crate::services::router::pipeline_handle::pipelines;
 use crate::services::subgraph;
 use crate::services::supergraph;
 use crate::Context;
@@ -319,8 +335,8 @@ impl InstrumentsConfig {
                                     )
                                     .as_histogram()
                                     .cloned().expect(
-                                "cannot convert instrument to histogram for router; this should not happen",
-                            )
+                                    "cannot convert instrument to histogram for router; this should not happen",
+                                )
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
                             selector: Some(Arc::new(RouterSelector::RequestHeader {
@@ -363,7 +379,7 @@ impl InstrumentsConfig {
                                     .as_histogram()
                                     .cloned()
                                     .expect(
-                                    "cannot convert instrument to histogram for router; this should not happen",
+                                        "cannot convert instrument to histogram for router; this should not happen",
                                     )
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
@@ -771,16 +787,16 @@ impl InstrumentsConfig {
                         increment: Increment::FieldCustom(None),
                         condition: Condition::True,
                         histogram: Some(static_instruments
-                                .get(FIELD_LENGTH)
-                                .expect(
-                                    "cannot get static instrument for graphql; this should not happen",
-                                )
-                                .as_histogram()
-                                .cloned()
-                                .expect(
-                                    "cannot convert instrument to counter for graphql; this should not happen",
-                                )
-                            ),
+                            .get(FIELD_LENGTH)
+                            .expect(
+                                "cannot get static instrument for graphql; this should not happen",
+                            )
+                            .as_histogram()
+                            .cloned()
+                            .expect(
+                                "cannot convert instrument to counter for graphql; this should not happen",
+                            )
+                        ),
                         attributes: Vec::with_capacity(nb_attributes),
                         selector: Some(Arc::new(GraphQLSelector::ListLength {
                             list_length: ListLength::Value,
@@ -873,16 +889,16 @@ impl InstrumentsConfig {
                         increment: Increment::Custom(None),
                         condition: Condition::True,
                         counter: Some(static_instruments
-                                .get(CACHE_METRIC)
-                                .expect(
-                                    "cannot get static instrument for cache; this should not happen",
-                                )
-                                .as_counter_f64()
-                                .cloned()
-                                .expect(
-                                    "cannot convert instrument to counter for cache; this should not happen",
-                                )
-                            ),
+                            .get(CACHE_METRIC)
+                            .expect(
+                                "cannot get static instrument for cache; this should not happen",
+                            )
+                            .as_counter_f64()
+                            .cloned()
+                            .expect(
+                                "cannot convert instrument to counter for cache; this should not happen",
+                            )
+                        ),
                         attributes: Vec::with_capacity(nb_attributes),
                         selector: Some(Arc::new(SubgraphSelector::Cache {
                             cache: CacheKind::Hit,
@@ -896,6 +912,34 @@ impl InstrumentsConfig {
             }),
         }
     }
+
+    pub(crate) fn new_pipeline_instruments(&self) -> HashMap<String, StaticInstrument> {
+        let meter = meter_provider().meter("apollo/router");
+        let mut instruments = HashMap::new();
+        instruments.insert(
+            PIPELINE_METRIC.to_string(),
+            StaticInstrument::GaugeU64(
+                meter
+                    .u64_observable_gauge(PIPELINE_METRIC)
+                    .with_description("The number of request pipelines active in the router")
+                    .with_callback(|i| {
+                        for (pipeline, count) in &*pipelines() {
+                            let mut attributes = Vec::with_capacity(3);
+                            attributes.push(KeyValue::new("schema.id", pipeline.schema_id.clone()));
+                            if let Some(launch_id) = &pipeline.launch_id {
+                                attributes.push(KeyValue::new("launch.id", launch_id.clone()));
+                            }
+                            attributes
+                                .push(KeyValue::new("config.hash", pipeline.config_hash.clone()));
+
+                            i.observe(*count, &attributes);
+                        }
+                    })
+                    .init(),
+            ),
+        );
+        instruments
+    }
 }
 
 #[derive(Debug)]
@@ -903,6 +947,9 @@ pub(crate) enum StaticInstrument {
     CounterF64(Counter<f64>),
     UpDownCounterI64(UpDownCounter<i64>),
     Histogram(Histogram<f64>),
+    // Gauges are never read
+    #[allow(dead_code)]
+    GaugeU64(ObservableGauge<u64>),
 }
 
 impl StaticInstrument {

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -40,6 +40,7 @@ pub type Body = hyper::Body;
 pub type Error = hyper::Error;
 
 pub mod body;
+pub(crate) mod pipeline_handle;
 pub(crate) mod service;
 #[cfg(test)]
 mod tests;

--- a/apollo-router/src/services/router/pipeline_handle.rs
+++ b/apollo-router/src/services/router/pipeline_handle.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use parking_lot::Mutex;
+use parking_lot::MutexGuard;
+
+/// A pipeline is used to keep track of how many pipelines we have active. It's associated with an instance of RouterCreator
+/// The telemetry plugin has a gauge to expose this data
+/// Pipeline ref represents a unique pipeline
+#[derive(Clone, Hash, Eq, PartialEq, Debug)]
+pub(crate) struct PipelineRef {
+    pub(crate) schema_id: String,
+    pub(crate) launch_id: Option<String>,
+    pub(crate) config_hash: String,
+}
+
+/// A pipeline handle does the actual tracking of pipelines
+/// Creating a new pipeline handle will insert a PipelineRef into a static map.
+/// Dropping all pipeline handles associated with the internal ref will remove the PipelineRef
+/// Clone MUST NOT be implemented for this type. Cloning will make extra copies that when dropped will throw off the global count.
+pub(crate) struct PipelineHandle {
+    pipeline_ref: PipelineRef,
+}
+
+static PIPELINES: OnceLock<Mutex<HashMap<PipelineRef, u64>>> = OnceLock::new();
+pub(crate) fn pipelines() -> MutexGuard<'static, HashMap<PipelineRef, u64>> {
+    PIPELINES.get_or_init(Default::default).lock()
+}
+
+impl PipelineHandle {
+    pub(crate) fn new(schema_id: String, launch_id: Option<String>, config_hash: String) -> Self {
+        let pipeline_ref = PipelineRef {
+            schema_id,
+            launch_id,
+            config_hash,
+        };
+        pipelines()
+            .entry(pipeline_ref.clone())
+            .and_modify(|p| *p += 1)
+            .or_insert(1);
+        PipelineHandle { pipeline_ref }
+    }
+}
+
+impl Drop for PipelineHandle {
+    fn drop(&mut self) {
+        let mut pipelines = pipelines();
+        let value = pipelines
+            .get_mut(&self.pipeline_ref)
+            .expect("pipeline_ref MUST be greater than zero");
+        *value -= 1;
+        if *value == 0 {
+            pipelines.remove(&self.pipeline_ref);
+        }
+    }
+}
+
+pub(crate) const PIPELINE_METRIC: &str = "apollo.router.pipelines";

--- a/apollo-router/tests/integration/telemetry/fixtures/prometheus_updated.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/prometheus_updated.router.yaml
@@ -1,0 +1,53 @@
+limits:
+  http_max_request_bytes: 200
+telemetry:
+  instrumentation:
+    instruments:
+      default_requirement_level: required
+      router:
+        http.server.request.duration:
+          attributes:
+            server.port: false
+            server.address: false
+            http.response.status_code:
+              alias: status
+            error:
+              error: reason
+  exporters:
+    metrics:
+      prometheus:
+        listen: 127.0.0.1:4000
+        enabled: true
+        path: /metrics
+      common:
+        views:
+          - name: apollo_router_http_request_duration_seconds
+            aggregation:
+              histogram:
+                buckets:
+                  - 0.1
+                  - 0.5
+                  - 1
+                  - 2
+                  - 3
+                  - 4
+                  - 5
+                  - 100
+                  - 1000
+headers:
+  all:
+    request:
+      - insert:
+          name: "x-custom-header"
+          value: "test_custom"
+override_subgraph_url:
+  products: http://localhost:4005
+include_subgraph_errors:
+  all: true
+supergraph:
+  introspection: true
+apq:
+  router:
+    cache:
+      in_memory:
+        limit: 1000

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
+use regex::Regex;
 use serde_json::json;
+use wiremock::ResponseTemplate;
 
 use crate::integration::common::graph_os_enabled;
 use crate::integration::common::Query;
@@ -296,4 +298,46 @@ async fn test_gauges_on_reload() {
             None,
         )
         .await;
+
+    router
+        .assert_metrics_contains(r#"apollo_router_pipelines{config_hash="<any>",schema_id="<any>",otel_scope_name="apollo/router"} 1"#, None)
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multi_pipelines() {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return;
+    }
+    let mut router = IntegrationTest::builder()
+        .config(PROMETHEUS_CONFIG)
+        .responder(ResponseTemplate::new(500).set_delay(Duration::from_secs(10)))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let query = router.execute_default_query();
+    // Long running request 1
+    let _h1 = tokio::task::spawn(query);
+    router
+        .update_config(include_str!("fixtures/prometheus_updated.router.yaml"))
+        .await;
+
+    router.assert_reloaded().await;
+    // Long running request 2
+    let query = router.execute_default_query();
+    let _h2 = tokio::task::spawn(query);
+    let metrics = router
+        .get_metrics_response()
+        .await
+        .expect("metrics")
+        .text()
+        .await
+        .expect("metrics");
+    // There should be two instances of the pipeline metrics
+    let regex = Regex::new(r#"(?m)^apollo_router_pipelines[{].+[}] 1"#).expect("regex");
+    assert_eq!(regex.captures_iter(&metrics).count(), 2);
 }

--- a/apollo-router/tests/integration/telemetry/otlp.rs
+++ b/apollo-router/tests/integration/telemetry/otlp.rs
@@ -49,7 +49,7 @@ async fn test_trace_error() -> Result<(), BoxError> {
 
     router.start().await;
     router.assert_started().await;
-    router.assert_log_contained("OpenTelemetry trace error occurred: cannot send message to batch processor 'otlp-tracing' as the channel is full").await;
+    router.assert_log_contained("OpenTelemetry trace error occurred: cannot send message to batch processor 'otlp-tracing' as the channel is full");
     router.assert_metrics_contains(r#"apollo_router_telemetry_batch_processor_errors_total{error="channel full",name="otlp-tracing",otel_scope_name="apollo/router"}"#, None).await;
     router.graceful_shutdown().await;
 

--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -116,6 +116,7 @@ The initial call to Uplink during router startup is not reflected in metrics.
 ### Telemetry
 - `apollo.router.telemetry.batch_processor.errors` - The number of errors encountered by exporter batch processors.
   - `name`: One of `apollo-tracing`, `datadog-tracing`, `jaeger-collector`, `otlp-tracing`, `zipkin-tracing`.
+<<<<<<< HEAD
   - `error` = One of `channel closed`, `channel full`.
 
 ### Deprecated
@@ -133,3 +134,12 @@ The following metrics have been deprecated and should not be used.
 - `apollo_router_http_request_duration_seconds_bucket` - **Deprecated**: HTTP router request duration. It is replaced by `http.server.request.duration` metric configured in [instruments](./instruments).
 - `apollo_router_http_request_duration_seconds_bucket` - **Deprecated**: HTTP subgraph request duration (replaced by `http.client.request.duration` metric configured in [instruments](./instruments)), attributes:
   - `subgraph`: (Optional) The subgraph being queried
+=======
+  - `error`: One of `channel closed`, `channel full`.
+
+### Internals
+- `apollo.router.pipelines` - The number of request pipelines active in the router
+    - `schema.id` - The Apollo Studio schema hash associated with the pipeline.
+    - `launch.id` - The Apollo Studio launch id associated with the pipeline (optional).
+    - `config.hash` - The hash of the configuration
+>>>>>>> 71e5fe45 (Add apollo.router.pipelines metrics (#6967))


### PR DESCRIPTION
To enable debugging when request pipelines are being kept around a new gauge metric has been added:

- `apollo.router.pipelines` - The number of request pipelines active in the router
    - `schema.id` - The Apollo Studio schema hash associated with the pipeline.
    - `launch.id` - The Apollo Studio launch id associated with the pipeline (optional).
    - `config.hash` - The hash of the configuration


Backport: https://github.com/apollographql/router/pull/6953



---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6967 done by [Mergify](https://mergify.com).