### PR TITLE
Add no-cache and no-store to cache example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "cache-control"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "apollo-router",

--- a/examples/cache-control/rhai/Cargo.toml
+++ b/examples/cache-control/rhai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-control"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/cache-control/rhai/src/cache_control.rhai
+++ b/examples/cache-control/rhai/src/cache_control.rhai
@@ -10,6 +10,18 @@ fn subgraph_service(service, subgraph) {
       return;
     }
 
+    // if a subgraph needs revalidation, the whole response needs revalidation
+    if cache_control == "no-cache" {
+        response.context.cache_control_no_cache = true;
+        return;
+    }
+
+    // if a subgraph does not allow cache, the whole response is not allowed to be stored
+    if cache_control == "no-store" {
+        response.context.cache_control_no_store = true;
+        return;
+    }
+
     let max_age = get_max_age(cache_control);
 
     // use the smallest max age
@@ -48,10 +60,16 @@ fn supergraph_service(service) {
     // https://www.apollographql.com/docs/router/customizations/rhai-api/#response-interface
     if response.is_primary() {
       let uncacheable = response.context.cache_control_uncacheable;
+      let no_cache = response.context.cache_control_no_cache;
+      let no_store = response.context.cache_control_no_store;
       let max_age = response.context.cache_control_max_age;
       let scope = response.context.cache_control_scope;
-  
-      if uncacheable != true && max_age != () && scope != () {
+
+      if no_cache == true {
+        response.headers["cache-control"] = "no-cache";
+      } else if no_store == true {
+        response.headers["cache-control"] = "no-store";
+      } else if uncacheable != true && max_age != () && scope != () {
         response.headers["cache-control"] = `max-age=${max_age}, ${scope}`;
       }
   }

--- a/examples/cache-control/rhai/src/main.rs
+++ b/examples/cache-control/rhai/src/main.rs
@@ -150,4 +150,20 @@ mod tests {
             None
         );
     }
+
+    #[tokio::test]
+    async fn test_subgraph_cache_no_cache() {
+        assert_eq!(
+            cache_control_header(Some("max-age=100, private".to_string()), Some("no-cache".to_string())).await,
+            Some("no-cache".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subgraph_cache_no_store() {
+        assert_eq!(
+            cache_control_header(Some("max-age=100, private".to_string()), Some("no-store".to_string())).await,
+            Some("no-store".to_string())
+        );
+    }
 }


### PR DESCRIPTION
This adds support for `no-cache` and `no-store` values to the cache control example. 


Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [*] Changes are compatible[^1]
- [*] Documentation[^2] completed
- [*] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [*] Unit Tests
    - [*] Integration Tests
    - [*] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
