### PR TITLE
Reduce Brotli compression level

### DIFF
--- a/.changesets/fix_brotli_compression_level.md
+++ b/.changesets/fix_brotli_compression_level.md
@@ -1,0 +1,8 @@
+### Reduce Brotli compression level ([Issue #6857](https://github.com/apollographql/router/issues/6857))
+
+The current Brotli compression level used is `11`, which is the highest quality (and slowest). The value has been
+changed to `4`
+to mimic the other compression algorithms' `fast` setting; it is also a much more reasonable value for dynamic
+workloads.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/7007

--- a/apollo-router/src/axum_factory/compression/mod.rs
+++ b/apollo-router/src/axum_factory/compression/mod.rs
@@ -44,10 +44,14 @@ impl Compressor {
                         DeflateEncoder::new(Compression::fast()),
                     ));
                 }
-                // FIXME: find the "fast" brotli encoder params
                 "br" => {
                     return Some(Compressor::Brotli(Box::new(BrotliEncoder::new(
-                        BrotliEncoderParams::default(),
+                        BrotliEncoderParams {
+                            // '4' is a reasonable setting for 'fast'
+                            // https://github.com/dropbox/rust-brotli/issues/93
+                            quality: 4,
+                            ..BrotliEncoderParams::default()
+                        },
                     ))));
                 }
                 "zstd" => {

--- a/apollo-router/src/axum_factory/compression/mod.rs
+++ b/apollo-router/src/axum_factory/compression/mod.rs
@@ -85,7 +85,7 @@ where {
                 while let Some(data) = stream.next().await {
                     match data {
                         Err(e) => {
-                            if tx.send(Err(e.into())).await.is_err() {
+                            if (tx.send(Err(e.into())).await).is_err() {
                                 return;
                             }
                         }
@@ -132,7 +132,7 @@ where {
                                     let _ = partial_output.into_inner();
                                     buf.resize(len, 0);
 
-                                    if tx.send(Ok(buf.freeze())).await.is_err() {
+                                    if (tx.send(Ok(buf.freeze())).await).is_err() {
                                         return;
                                     }
                                     break;
@@ -156,7 +156,7 @@ where {
 
                             let mut buf = partial_output.into_inner();
                             buf.resize(len, 0);
-                            if tx.send(Ok(buf.freeze())).await.is_err() {
+                            if (tx.send(Ok(buf.freeze())).await).is_err() {
                                 return;
                             }
                             if is_flushed {
@@ -219,6 +219,7 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     use super::*;
+    use crate::services::router;
     use crate::services::router::body::{self};
 
     #[tokio::test]
@@ -295,7 +296,7 @@ content-type: application/json
 "#;
         let compressor = Compressor::new(["gzip"].into_iter()).unwrap();
 
-        let body: RouterBody = body::from_result_stream(stream::iter(vec![
+        let body: RouterBody = router::body::from_result_stream(stream::iter(vec![
             Ok::<_, BoxError>(Bytes::from(primary_response)),
             Ok(Bytes::from(deferred_response)),
         ]));

--- a/apollo-router/src/axum_factory/compression/mod.rs
+++ b/apollo-router/src/axum_factory/compression/mod.rs
@@ -85,7 +85,7 @@ where {
                 while let Some(data) = stream.next().await {
                     match data {
                         Err(e) => {
-                            if (tx.send(Err(e.into())).await).is_err() {
+                            if tx.send(Err(e.into())).await.is_err() {
                                 return;
                             }
                         }
@@ -132,7 +132,7 @@ where {
                                     let _ = partial_output.into_inner();
                                     buf.resize(len, 0);
 
-                                    if (tx.send(Ok(buf.freeze())).await).is_err() {
+                                    if tx.send(Ok(buf.freeze())).await.is_err() {
                                         return;
                                     }
                                     break;
@@ -156,7 +156,7 @@ where {
 
                             let mut buf = partial_output.into_inner();
                             buf.resize(len, 0);
-                            if (tx.send(Ok(buf.freeze())).await).is_err() {
+                            if tx.send(Ok(buf.freeze())).await.is_err() {
                                 return;
                             }
                             if is_flushed {
@@ -219,7 +219,6 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     use super::*;
-    use crate::services::router;
     use crate::services::router::body::{self};
 
     #[tokio::test]
@@ -296,7 +295,7 @@ content-type: application/json
 "#;
         let compressor = Compressor::new(["gzip"].into_iter()).unwrap();
 
-        let body: RouterBody = router::body::from_result_stream(stream::iter(vec![
+        let body: RouterBody = body::from_result_stream(stream::iter(vec![
             Ok::<_, BoxError>(Bytes::from(primary_response)),
             Ok(Bytes::from(deferred_response)),
         ]));


### PR DESCRIPTION
Per the discussion in #6857, the current Brotli compression level is set to `11` which is the highest quality. A setting of `4` is a much more reasonable value for dynamic workloads, and aligns with Koa' & Cloudflare's practice.

Fixes #6857

<!-- start metadata -->
<!-- [ROUTER-1137] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1137]: https://apollographql.atlassian.net/browse/ROUTER-1137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ