### PR TITLE
Remove `fed-core` from `apollo-router/` owner list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 /.changesets/ @apollographql/docs
 /apollo-federation/ @apollographql/fed-core @apollographql/rust-platform
 /apollo-federation/src/sources/connect @apollographql/connectors
-/apollo-router/ @apollographql/router-core @apollographql/fed-core
+/apollo-router/ @apollographql/router-core
 /apollo-router/src/plugins/connectors @apollographql/connectors
 /apollo-router-benchmarks/ @apollographql/router-core @apollographql/fed-core
 /examples/ @apollographql/router-core @apollographql/fed-core


### PR DESCRIPTION
The federation and router teams have distinct focuses, and the fed-core team doesn't typically need to review changes to the `apollo-router` directory.
Hopefully this will reduce notification fatigue and make it easier to understand which teams' reviews are blocking the merging of a PR. However, if we find it blocks PRs from being merged, we should revert this change.

NB: This should in no way preclude fed-core from reviewing `apollo-router` changes! All feedback is welcome :)