### PR TITLE
Add router config validate command

### DIFF
--- a/.changesets/feat_feature_configvalidatesubcommand.md
+++ b/.changesets/feat_feature_configvalidatesubcommand.md
@@ -1,0 +1,9 @@
+### Add router config validate subcommand ([PR #6131](https://github.com/apollographql/router/pull/6131))
+
+Added new `router config validate` subcommand to allow validation of a Router config file without fully starting up the Router.
+
+```
+./router config validate <path-to-config-file.yaml>
+```
+
+By [@andrewmcgivery](https://github.com/andrewmcgivery) in https://github.com/apollographql/router/pull/6131

--- a/.changesets/feat_feature_configvalidatesubcommand.md
+++ b/.changesets/feat_feature_configvalidatesubcommand.md
@@ -1,4 +1,4 @@
-### Add router config validate subcommand ([PR #6131](https://github.com/apollographql/router/pull/6131))
+### Add router config validate subcommand ([PR #7016](https://github.com/apollographql/router/pull/7016))
 
 Added new `router config validate` subcommand to allow validation of a Router config file without fully starting up the Router.
 
@@ -6,4 +6,4 @@ Added new `router config validate` subcommand to allow validation of a Router co
 ./router config validate <path-to-config-file.yaml>
 ```
 
-By [@andrewmcgivery](https://github.com/andrewmcgivery) in https://github.com/apollographql/router/pull/6131
+By [@andrewmcgivery](https://github.com/andrewmcgivery) in https://github.com/apollographql/router/pull/7016

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -43,6 +43,7 @@ use self::expansion::Expansion;
 pub(crate) use self::experimental::Discussed;
 pub(crate) use self::schema::generate_config_schema;
 pub(crate) use self::schema::generate_upgrade;
+pub(crate) use self::schema::validate_yaml_configuration;
 use self::subgraph::SubgraphConfiguration;
 use crate::ApolloRouterError;
 use crate::cache::DEFAULT_CACHE_CAPACITY;

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -26,8 +26,10 @@ use url::Url;
 
 use crate::LicenseSource;
 use crate::configuration::Discussed;
+use crate::configuration::expansion::Expansion;
 use crate::configuration::generate_config_schema;
 use crate::configuration::generate_upgrade;
+use crate::configuration::validate_yaml_configuration;
 use crate::metrics::meter_provider_internal;
 use crate::plugin::plugins;
 use crate::plugins::telemetry::reload::init_telemetry;
@@ -145,6 +147,12 @@ enum ConfigSubcommand {
         /// Print a diff.
         #[clap(action = ArgAction::SetTrue, long)]
         diff: bool,
+    },
+    /// Validate existing Router configuration file
+    Validate {
+        /// The location of the config to validate.
+        #[clap(value_parser, env = "APOLLO_ROUTER_CONFIG_PATH")]
+        config_path: PathBuf,
     },
     /// List all the available experimental configurations with related GitHub discussion
     Experimental,
@@ -430,6 +438,16 @@ impl Executable {
             })) => {
                 let schema = generate_config_schema();
                 println!("{}", serde_json::to_string_pretty(&schema)?);
+                Ok(())
+            }
+            Some(Commands::Config(ConfigSubcommandArgs {
+                command: ConfigSubcommand::Validate { config_path },
+            })) => {
+                let config_string = std::fs::read_to_string(config_path)?;
+                validate_yaml_configuration(&config_string, Expansion::default()?)?.validate()?;
+
+                println!("Configuration at path {:?} is valid!", config_path);
+
                 Ok(())
             }
             Some(Commands::Config(ConfigSubcommandArgs {

--- a/docs/source/reference/router/configuration.mdx
+++ b/docs/source/reference/router/configuration.mdx
@@ -301,7 +301,6 @@ If set, the router prints its version number, then exits.
 </tbody>
 </table>
 
-
 ### Dev mode defaults
 
 <Caution>
@@ -348,7 +347,7 @@ After you generate the schema, configure your text editor. Here are the instruct
 
 New releases of the router might introduce breaking changes to the [YAML config file's](#yaml-config-file) expected format, usually to extend existing functionality or improve usability.
 
-**If you run a new version of your router with a configuration file that it no longer supports, it emits a warning on startup and terminates.** 
+**If you run a new version of your router with a configuration file that it no longer supports, it emits a warning on startup and terminates.**
 
 If you encounter this warning, you can use the `router config upgrade` command to see the new expected format for your existing configuration file:
 
@@ -361,6 +360,22 @@ You can also view a diff of exactly which changes are necessary to upgrade your 
 ```bash
 ./router config upgrade --diff <path_to_config.yaml>
 ```
+
+## Validating your Router configuration
+
+The Router can be used to validate an existing configuration file. This can be useful if you want to have a validate step as part of your CI pipeline.
+
+```
+./router config validate <path-to-config-file.yaml>
+```
+
+This command takes a config file and validates it against the router's full supported configuration format.
+
+<Note>
+
+This is a static validation that checks if it is syntactically correct using the JSON schema. The router does additional logical checks on startup against the config that this command does not capture.
+
+<Note>
 
 ## YAML config file
 

--- a/docs/source/reference/router/configuration.mdx
+++ b/docs/source/reference/router/configuration.mdx
@@ -375,7 +375,7 @@ This command takes a config file and validates it against the router's full supp
 
 This is a static validation that checks if it is syntactically correct using the JSON schema. The router does additional logical checks on startup against the config that this command does not capture.
 
-<Note>
+</Note>
 
 ## YAML config file
 


### PR DESCRIPTION
Add router config validate subcommand to allow validation of a Router config file without fully starting up the Router.

```
./router config validate <path-to-config-file.yaml>
```

Note this is a port of https://github.com/apollographql/router/pull/6131 to a new PR to be on a fresh branch against Router 2.0. The implementation is otherwise identical.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
