### PR TITLE
feat(federation/correctness): implemented the soundness part of the correctness checker

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -310,10 +310,7 @@ fn cmd_plan(
     match result {
         Ok(_) => Ok(()),
         Err(CorrectnessError::FederationError(e)) => Err(e),
-        Err(CorrectnessError::ComparisonError(e)) => Err(internal_error!(
-            "Response shape from query plan does not match response shape from input operation:\n{}",
-            e.description()
-        )),
+        Err(CorrectnessError::ComparisonError(e)) => Err(internal_error!("{}", e.description())),
     }
 }
 

--- a/apollo-federation/src/correctness/mod.rs
+++ b/apollo-federation/src/correctness/mod.rs
@@ -2,6 +2,8 @@ pub mod query_plan_analysis;
 #[cfg(test)]
 pub mod query_plan_analysis_test;
 mod query_plan_soundness;
+#[cfg(test)]
+pub mod query_plan_soundness_test;
 pub mod response_shape;
 pub mod response_shape_compare;
 #[cfg(test)]

--- a/apollo-federation/src/correctness/mod.rs
+++ b/apollo-federation/src/correctness/mod.rs
@@ -1,6 +1,7 @@
 pub mod query_plan_analysis;
 #[cfg(test)]
 pub mod query_plan_analysis_test;
+mod query_plan_soundness;
 pub mod response_shape;
 pub mod response_shape_compare;
 #[cfg(test)]
@@ -83,6 +84,10 @@ pub fn check_plan(
 
     let path_constraint = subgraph_constraint::SubgraphConstraint::at_root(subgraphs_by_name);
     let assumption = response_shape::Clause::default(); // empty assumption at the top level
-    compare_response_shapes_with_constraint(&path_constraint, &assumption, &op_rs, &plan_rs)?;
+    compare_response_shapes_with_constraint(&path_constraint, &assumption, &op_rs, &plan_rs).map_err(|e| {
+        ComparisonError::new(format!(
+            "Response shape from query plan does not match response shape from input operation:\n{e}"
+        ))
+    })?;
     Ok(())
 }

--- a/apollo-federation/src/correctness/mod.rs
+++ b/apollo-federation/src/correctness/mod.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::validation::Valid;
+use query_plan_analysis::AnalysisContext;
 
 use crate::FederationError;
 use crate::compat::coerce_executable_values;
@@ -69,8 +70,9 @@ pub fn check_plan(
 
     let op_rs = response_shape::compute_response_shape_for_operation(&operation_doc, api_schema)?;
     let root_type = response_shape::compute_the_root_type_condition_for_operation(&operation_doc)?;
-    let plan_rs = query_plan_analysis::interpret_query_plan(supergraph_schema, &root_type, plan)
-        .map_err(|e| {
+    let context = AnalysisContext::new(supergraph_schema.clone(), subgraphs_by_name);
+    let plan_rs =
+        query_plan_analysis::interpret_query_plan(&context, &root_type, plan).map_err(|e| {
             ComparisonError::new(format!(
                 "Failed to compute the response shape from query plan:\n{e}"
             ))

--- a/apollo-federation/src/correctness/query_plan_analysis.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis.rs
@@ -131,6 +131,8 @@ impl ResponseShape {
 // - They take the `state` parameter that represents everything that has been fetched so far,
 //   which is used to check the soundness property of the query plan.
 
+/// The common data used by `interpret_query_plan` function and its subroutines.
+/// - Contains the supergraph schema and all subgraph schemas.
 pub struct AnalysisContext<'a> {
     supergraph_schema: ValidFederationSchema,
     subgraphs_by_name: &'a IndexMap<Arc<str>, ValidFederationSchema>,
@@ -170,6 +172,8 @@ fn format_federation_error(e: FederationError) -> String {
     }
 }
 
+/// Computes the overall ResponseShape of the query plan while checking the soundness of each
+/// entity fetch.
 pub fn interpret_query_plan(
     context: &AnalysisContext,
     root_type: &Name,
@@ -233,10 +237,10 @@ fn interpret_plan_node(
     }
 }
 
-// `type_filter`: The type condition to apply to the response shape.
-// - This is from the previous path elements.
-// - It can be empty if there is no type conditions.
-// - Also, multiple type conditions can be accumulated (meaning the conjunction of them).
+/// `type_filter`: The type condition to apply to the response shape.
+/// - This is from the previous path elements.
+/// - It can be empty if there is no type conditions.
+/// - Also, multiple type conditions can be accumulated (meaning the conjunction of them).
 fn rename_at_path(
     schema: &ValidFederationSchema,
     response: &ResponseShape,
@@ -426,6 +430,7 @@ fn interpret_fetch_node(
             )?;
 
         // Soundness check
+        // TODO: also check `context_rewrites` requirements.
         let subgraph_name = &fetch.subgraph_name;
         let Some(subgraph_schema) = context.get_subgraph_schema(subgraph_name) else {
             return Err(format!(

--- a/apollo-federation/src/correctness/query_plan_analysis_test.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis_test.rs
@@ -1,5 +1,6 @@
 use apollo_compiler::ExecutableDocument;
 
+use super::query_plan_analysis::AnalysisContext;
 use super::query_plan_analysis::interpret_query_plan;
 use super::response_shape::ResponseShape;
 use super::*;
@@ -127,13 +128,15 @@ fn plan_response_shape(op_str: &str) -> ResponseShape {
     // Compare response shapes
     let op_rs = response_shape::compute_response_shape_for_operation(&op, api_schema).unwrap();
     let root_type = response_shape::compute_the_root_type_condition_for_operation(&op).unwrap();
-    let plan_rs = interpret_query_plan(&supergraph.schema, &root_type, &query_plan).unwrap();
+    let supergraph_schema = planner.supergraph_schema();
     let subgraphs_by_name = supergraph
         .extract_subgraphs()
         .unwrap()
         .into_iter()
         .map(|(name, subgraph)| (name, subgraph.schema))
         .collect();
+    let context = AnalysisContext::new(supergraph_schema.clone(), &subgraphs_by_name);
+    let plan_rs = interpret_query_plan(&context, &root_type, &query_plan).unwrap();
     let path_constraint = subgraph_constraint::SubgraphConstraint::at_root(&subgraphs_by_name);
     let assumption = response_shape::Clause::default(); // empty assumption at the top level
     assert!(

--- a/apollo-federation/src/correctness/query_plan_analysis_test.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis_test.rs
@@ -102,7 +102,7 @@ type T implements I
 }
 "#;
 
-fn plan_response_shape(op_str: &str) -> ResponseShape {
+pub(crate) fn plan_response_shape_with_schema(schema_str: &str, op_str: &str) -> ResponseShape {
     // Initialization
     let config = query_planner::QueryPlannerConfig {
         generate_query_fragments: false,
@@ -112,7 +112,7 @@ fn plan_response_shape(op_str: &str) -> ResponseShape {
         },
         ..Default::default()
     };
-    let supergraph = crate::Supergraph::new(SCHEMA_STR).unwrap();
+    let supergraph = crate::Supergraph::new(schema_str).unwrap();
     let planner = query_planner::QueryPlanner::new(&supergraph, config).unwrap();
 
     // Parse the schema and operation
@@ -145,6 +145,10 @@ fn plan_response_shape(op_str: &str) -> ResponseShape {
     );
 
     plan_rs
+}
+
+fn plan_response_shape(op_str: &str) -> ResponseShape {
+    plan_response_shape_with_schema(SCHEMA_STR, op_str)
 }
 
 //=================================================================================================

--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -1,0 +1,661 @@
+use std::fmt;
+
+use apollo_compiler::Node;
+use apollo_compiler::ast;
+use apollo_compiler::executable;
+use apollo_compiler::executable::FieldSet;
+use apollo_compiler::executable::Name;
+use itertools::Itertools;
+
+use super::query_plan_analysis::AnalysisContext;
+use super::response_shape::Clause;
+use super::response_shape::PossibleDefinitions;
+use super::response_shape::ResponseShape;
+use super::response_shape::compute_response_shape_for_selection_set;
+use super::response_shape_compare::compare_representative_field;
+use super::response_shape_compare::compare_response_shapes_with_constraint;
+use super::subgraph_constraint::SubgraphConstraint;
+use crate::FederationError;
+use crate::bail;
+use crate::internal_error;
+use crate::link::federation_spec_definition::FederationSpecDefinition;
+use crate::link::federation_spec_definition::KeyDirectiveArguments;
+use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
+use crate::query_plan::requires_selection;
+use crate::schema::ValidFederationSchema;
+use crate::schema::position::INTROSPECTION_TYPENAME_FIELD_NAME;
+use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
+use crate::schema::position::TypeDefinitionPosition;
+use crate::utils::FallibleIterator;
+
+/// Query plan analysis error enum
+#[derive(Debug, derive_more::From)]
+pub(crate) enum AnalysisErrorMessage {
+    /// Correctness checker's internal error
+    FederationError(FederationError),
+    /// Error in the input query plan
+    QueryPlanError(String),
+}
+
+pub(crate) struct AnalysisError {
+    message: AnalysisErrorMessage,
+    context: Vec<String>,
+}
+
+impl AnalysisError {
+    pub(crate) fn with_context(mut self, context: impl Into<String>) -> Self {
+        self.context.push(context.into());
+        self
+    }
+}
+
+impl fmt::Display for AnalysisErrorMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AnalysisErrorMessage::FederationError(err) => write!(f, "{}", err),
+            AnalysisErrorMessage::QueryPlanError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl fmt::Display for AnalysisError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", self.message)?;
+        let num_contexts = self.context.len();
+        for (i, ctx) in self.context.iter().enumerate() {
+            writeln!(f, "[{index}/{num_contexts}] {ctx}", index = i + 1)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<FederationError> for AnalysisError {
+    fn from(err: FederationError) -> Self {
+        AnalysisError {
+            message: AnalysisErrorMessage::FederationError(err),
+            context: vec![],
+        }
+    }
+}
+
+impl From<String> for AnalysisError {
+    fn from(err: String) -> Self {
+        AnalysisError {
+            message: AnalysisErrorMessage::QueryPlanError(err),
+            context: vec![],
+        }
+    }
+}
+
+//==================================================================================================
+// Checking subgraph fetch requirements
+
+fn compute_response_shape_for_field_set(
+    schema: &ValidFederationSchema,
+    parent_type: Name,
+    field_set: &str,
+) -> Result<ResponseShape, FederationError> {
+    // Similar to `crate::schema::field_set::parse_field_set` function.
+    let field_set =
+        FieldSet::parse_and_validate(schema.schema(), parent_type, field_set, "field_set.graphql")?;
+    compute_response_shape_for_selection_set(schema, &field_set.selection_set)
+}
+
+fn compute_response_shape_for_field_set_with_typename(
+    schema: &ValidFederationSchema,
+    parent_type: Name,
+    field_set: &str,
+) -> Result<ResponseShape, FederationError> {
+    // Similar to `crate::schema::field_set::parse_field_set` function.
+    let field_set =
+        FieldSet::parse_and_validate(schema.schema(), parent_type, field_set, "field_set.graphql")?;
+    let mut selection_set = field_set.into_inner().selection_set;
+    let typename = selection_set
+        .new_field(schema.schema(), INTROSPECTION_TYPENAME_FIELD_NAME.clone())
+        .map_err(|_| {
+            internal_error!(
+                "Unexpected error: {} not found in schema",
+                INTROSPECTION_TYPENAME_FIELD_NAME
+            )
+        })?;
+    selection_set.push(typename);
+    compute_response_shape_for_selection_set(schema, &selection_set)
+}
+
+/// Used for FetchNode's `requires` field values
+/// - The `requires` items are a single inline fragment.
+/// - Computes a response shape of the inline fragment and returns it.
+fn compute_response_shape_for_require_selection(
+    schema: &ValidFederationSchema,
+    require: &requires_selection::Selection,
+) -> Result<ResponseShape, FederationError> {
+    let requires_selection::Selection::InlineFragment(inline) = require else {
+        bail!("Expected require selection to be an inline fragment, but got: {require:#?}")
+    };
+    let Some(type_condition) = &inline.type_condition else {
+        bail!("Expected a type condition on require inline fragment")
+    };
+    // Convert the `inline`'s selection set into the `executable::SelectionSet` type,
+    // so we can use `compute_response_shape_for_selection_set` function.
+    let selections = convert_requires_selections(schema, type_condition, &inline.selections)?;
+    let mut selection_set = executable::SelectionSet::new(type_condition.clone());
+    selection_set.extend(selections);
+    compute_response_shape_for_selection_set(schema, &selection_set)
+}
+
+/// Converts a `requires_selection::Selection` array into a Vec of `executable::Selection`.
+fn convert_requires_selections(
+    schema: &ValidFederationSchema,
+    ty: &Name,
+    selections: &[requires_selection::Selection],
+) -> Result<Vec<executable::Selection>, FederationError> {
+    let mut result = Vec::new();
+    for selection in selections {
+        match selection {
+            requires_selection::Selection::Field(field) => {
+                let field_def = get_field_definition(schema, ty, &field.name)?;
+                // Note: `field` has no arguments nor directive applications.
+                let converted = executable::Field::new(field.name.clone(), field_def)
+                    .with_opt_alias(field.alias.clone());
+                let converted = if field.selections.is_empty() {
+                    converted
+                } else {
+                    let sub_ty = converted.ty().inner_named_type().clone();
+                    let sub_selections =
+                        convert_requires_selections(schema, &sub_ty, &field.selections)?;
+                    converted.with_selections(sub_selections)
+                };
+                result.push(converted.into());
+            }
+            requires_selection::Selection::InlineFragment(inline) => {
+                let converted = if let Some(type_condition) = &inline.type_condition {
+                    executable::InlineFragment::with_type_condition(type_condition.clone())
+                } else {
+                    executable::InlineFragment::without_type_condition(ty.clone())
+                };
+                let sub_ty = converted.selection_set.ty.clone();
+                let sub_selections =
+                    convert_requires_selections(schema, &sub_ty, &inline.selections)?;
+                result.push(converted.with_selections(sub_selections).into());
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Get the `ast::FieldDefinition` for the given type and field name from the schema.
+fn get_field_definition(
+    schema: &ValidFederationSchema,
+    parent_type: &Name,
+    field_name: &Name,
+) -> Result<Node<ast::FieldDefinition>, FederationError> {
+    let parent_type_pos: ObjectOrInterfaceTypeDefinitionPosition =
+        schema.get_type(parent_type.clone())?.try_into()?;
+    let field_def_pos = parent_type_pos.field(field_name.clone());
+    field_def_pos
+        .get(schema.schema())
+        .map(|component| component.node.clone())
+        .map_err(|err| err.into())
+}
+
+/// Collect `@requires` conditions from the fields used in the fetch response shape based on their
+/// definitions in the subgraph schema.
+/// - `response_shape`: the fetch response shape for the entity
+/// - Only consider the fields at the root level of the response shape.
+/// - The fields may have Boolean conditions. Then, the computed conditions will inherit them.
+/// - The collected conditions are merged into a single response shape.
+fn collect_require_condition(
+    supergraph_schema: &ValidFederationSchema,
+    subgraph_schema: &ValidFederationSchema,
+    federation_spec_definition: &FederationSpecDefinition,
+    response_shape: &ResponseShape,
+) -> Result<ResponseShape, FederationError> {
+    let requires_directive_definition =
+        federation_spec_definition.requires_directive_definition(subgraph_schema)?;
+    let parent_type = response_shape.default_type_condition();
+    let mut result = ResponseShape::new(parent_type.clone());
+    for (_key, defs) in response_shape.iter() {
+        for (_type_cond, defs_per_type_cond) in defs.iter() {
+            for variant in defs_per_type_cond.conditional_variants() {
+                let field_def = &variant.representative_field().definition;
+                for directive in field_def
+                    .directives
+                    .get_all(&requires_directive_definition.name)
+                {
+                    let requires_application =
+                        federation_spec_definition.requires_directive_arguments(directive)?;
+                    let rs = compute_response_shape_for_field_set(
+                        supergraph_schema,
+                        parent_type.clone(),
+                        requires_application.fields,
+                    )?;
+                    result.merge_with(&rs.add_boolean_conditions(variant.boolean_clause()))?;
+                }
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Check if the `@requires` and `@key` conditions match a `requires` item & the current state.
+/// - `type_condition`: the type condition for the entity fetch
+/// - `boolean_clause`: the Boolean condition on the fetch node
+/// - `entity_require_shape`: the response shape of the `requires` item specified on the fetch node
+/// - `require_condition`: the response shape of the computed require condition (from `@requires`).
+/// - Note: `entity_require_shape`'s type condition only needs to be a subset of the
+///          `type_condition`. So, they don't have to be the same. It happens when the entity's
+///          subgraph type is an interface object type.
+/// - The key directive and `require_condition` put together must have the same set of response
+///   keys as the `entity_require_shape`.
+fn key_directive_matches(
+    context: &AnalysisContext,
+    state: &ResponseShape,
+    boolean_clause: &Clause,
+    entity_require_shape: &ResponseShape,
+    require_condition: &ResponseShape,
+    key_directive_application: &KeyDirectiveArguments<'_>,
+) -> Result<(), AnalysisError> {
+    // Note: We use the `entity_require_shape`'s type to interpret the `@key` directive's field
+    //       set, instead of the entity's actual type, since the fetch node's `requires` item may
+    //       be on a more specific type than the entity's type in subgraph.
+    let key_type_condition = entity_require_shape.default_type_condition();
+    let key_condition = compute_response_shape_for_field_set_with_typename(
+        context.supergraph_schema(),
+        key_type_condition.clone(),
+        key_directive_application.fields,
+    )?;
+    // `condition`: the whole condition computed from the fetch query & subgraph schema.
+    let mut condition = key_condition.clone();
+    condition.merge_with(require_condition)?;
+    // Check if `entity_require_shape` is a subset of `condition` in terms of response keys.
+    if !key_only_compare_response_shapes(entity_require_shape, &condition) {
+        return Err(format!(
+            "The `requires` item does not match the subgraph schema\n\
+             * @key field set: {key_condition}\n\
+             * @requires field set: {require_condition}"
+        )
+        .into());
+    }
+    let final_require_shape = condition.add_boolean_conditions(boolean_clause);
+    let path_constraint = SubgraphConstraint::at_root(context.subgraphs_by_name());
+    let assumption = Clause::default(); // empty assumption at the top level
+    compare_response_shapes_with_constraint(
+        &path_constraint,
+        &assumption,
+        &final_require_shape,
+        state,
+    )
+    .map_err(|e| {
+        format!(
+            "The state does not satisfy the subgraph schema requirements:\n\
+                 * schema requires: ({condition_type}) {condition}\n\
+                 * Comparison error:\n{e}\n\
+                 * state: ({state_type}) {state}",
+            condition_type = condition.default_type_condition(),
+            state_type = state.default_type_condition(),
+        )
+        .into()
+    })
+}
+
+/// Check if the entity's `@key`/`@requires` conditions are satisfied in the current `state`.
+/// Also, checks if the fetch node's `requires` item for the entity matches the `@key`/`@requires`
+/// conditions.
+/// - `state`: the input state
+/// - `boolean_clause`: the fetch node's Boolean conditions
+/// - `entity_response_shape`: the fetch node's response shape for the entity
+/// - `entity_require`: the fetch node's `requires` array item for the entity
+fn check_require(
+    context: &AnalysisContext,
+    subgraph_schema: &ValidFederationSchema,
+    state: &ResponseShape,
+    boolean_clause: &Clause,
+    entity_response_shape: &ResponseShape,
+    entity_require: &requires_selection::Selection,
+) -> Result<(), AnalysisError> {
+    let subgraph_entity_type_name = entity_response_shape.default_type_condition();
+    let subgraph_entity_type_pos = subgraph_schema.get_type(subgraph_entity_type_name.clone())?;
+    let directives = match &subgraph_entity_type_pos {
+        TypeDefinitionPosition::Object(type_pos) => {
+            let type_def = type_pos
+                .get(subgraph_schema.schema())
+                .map_err(FederationError::from)?;
+            &type_def.directives
+        }
+        TypeDefinitionPosition::Interface(type_pos) => {
+            let type_def = type_pos
+                .get(subgraph_schema.schema())
+                .map_err(FederationError::from)?;
+            &type_def.directives
+        }
+        _ => bail!("check_require: unexpected kind of entity type: {subgraph_entity_type_name}"),
+    };
+
+    let entity_require_shape =
+        compute_response_shape_for_require_selection(context.supergraph_schema(), entity_require)
+            .map_err(|err| {
+            format!(
+                "check_require: failed to compute response shape:\n{err}\n\
+                    require selection: {entity_require}"
+            )
+        })?;
+
+    let federation_spec_definition = get_federation_spec_definition_from_subgraph(subgraph_schema)?;
+    // Collect all applicable `@requires` field sets and put them in a response shape.
+    let require_condition = collect_require_condition(
+        context.supergraph_schema(),
+        subgraph_schema,
+        federation_spec_definition,
+        entity_response_shape,
+    )
+    .map_err(|err| {
+        format!(
+            "check_require: failed to collect require conditions from the subgraph schema:\n\
+                {err}\n\
+                entity_response_shape: {entity_response_shape}"
+        )
+    })?;
+
+    // Find the matching `@key` directive
+    // - Note: The type condition may have multiple `@key` directives. Try find one that works.
+    let key_directive_definition =
+        federation_spec_definition.key_directive_definition(subgraph_schema)?;
+    let mut mismatch_cases = Vec::new();
+    let mut unresolvable_cases = Vec::new();
+    let found = directives
+        .get_all(&key_directive_definition.name)
+        .map(|directive| federation_spec_definition.key_directive_arguments(directive))
+        .ok_and_any(|ref key_directive_application| {
+            match key_directive_matches(
+                context,
+                state,
+                boolean_clause,
+                &entity_require_shape,
+                &require_condition,
+                key_directive_application,
+            ) {
+                Ok(_) => {
+                    if key_directive_application.resolvable {
+                        true
+                    } else {
+                        unresolvable_cases.push(format!(
+                            "The matched @key directive is not resolvable.\n\
+                             * @key field set: {key_field_set}",
+                            key_field_set = key_directive_application.fields
+                        ));
+                        false
+                    }
+                }
+                Err(e) => {
+                    mismatch_cases.push(e);
+                    false
+                }
+            }
+        })?;
+    if found {
+        Ok(())
+    } else {
+        // soundness error
+        if unresolvable_cases.is_empty() {
+            if mismatch_cases.len() == 1 {
+                Err(format!(
+                    "check_require: no matching require condition found (@key didn't match)\n\
+                     * plan requires: {entity_require_shape}\n\
+                     Mismatch description:\n{mismatch_cases}",
+                    mismatch_cases = mismatch_cases.iter().map(|e| e.to_string()).join("\n")
+                )
+                .into())
+            } else {
+                Err(format!(
+                    "check_require: no matching require condition found (all @key directives failed to match)\n\
+                     * plan requires: {entity_require_shape}\n\
+                     Mismatches:\n{mismatch_cases}",
+                     mismatch_cases = mismatch_cases.iter().enumerate().map(|(i, e)|
+                        format!("[{index}/{bound}] {e}", index=i+1, bound=mismatch_cases.len())
+                    ).join("\n")
+                ).into())
+            }
+        } else {
+            Err(format!(
+                "check_require: @key matched, but none of them are resolvable.\n\
+                    * plan requires: {entity_require_shape}\n\
+                    Unresolvable cases:\n{unresolvable_cases}",
+                unresolvable_cases = unresolvable_cases
+                    .iter()
+                    .enumerate()
+                    .map(|(i, e)| format!(
+                        "[{index}/{bound}] {e}",
+                        index = i + 1,
+                        bound = unresolvable_cases.len()
+                    ))
+                    .join("\n")
+            )
+            .into())
+        }
+    }
+}
+
+/// Check subgraph requirements for all entity fetches
+/// - `state`: the input state
+/// - `boolean_clause`: the fetch node's Boolean conditions
+/// - `response_shapes`: the fetch node's response shape for entities
+/// - `requires`: the fetch node's `requires` field value for entities
+pub(crate) fn check_requires(
+    context: &AnalysisContext,
+    subgraph_schema: &ValidFederationSchema,
+    state: &ResponseShape,
+    boolean_clause: &Clause,
+    response_shapes: &[ResponseShape],
+    requires: &[requires_selection::Selection],
+) -> Result<(), AnalysisError> {
+    // The `requires` array and `response_shape` array should match. So, usually they are 1:1.
+    // However, the entity fetch operation may be simplified by merging identical entity fetches.
+    // In that case, the `requires` array may have more items than the `response_shape` array and
+    // we need to find a corresponding entity response shape item for each `requires` item.
+    match requires.len().cmp(&response_shapes.len()) {
+        std::cmp::Ordering::Less => Err(
+            "check_requires: Fewer number of requires items than entity fetch cases"
+                .to_string()
+                .into(),
+        ),
+        std::cmp::Ordering::Equal => {
+            // 1:1 match
+            for (rs, require) in response_shapes.iter().zip(requires.iter()) {
+                check_require(
+                    context,
+                    subgraph_schema,
+                    state,
+                    boolean_clause,
+                    rs,
+                    require,
+                )
+                .map_err(|e| {
+                    e.with_context(format!(
+                        "check_requires: Subgraph require check failed for type condition: {type_condition}",
+                        type_condition = rs.default_type_condition()
+                    ))
+                })?;
+            }
+            Ok(())
+        }
+        std::cmp::Ordering::Greater => {
+            // 1:many => check if each `requires` item has a matching entity fetch case
+            requires.iter().try_for_each(|require| {
+                let mut errors = Vec::new();
+                let has_any = response_shapes.iter().any(|rs| {
+                    match check_require(
+                        context,
+                        subgraph_schema,
+                        state,
+                        boolean_clause,
+                        rs,
+                        require,
+                    ) {
+                        Ok(_) => true,
+                        Err(e) => { errors.push(e); false }
+                    }
+                });
+                if has_any {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "check_requires: Subgraph require check failed to find a matching entity fetch for the requires item: {require}\nErrors:\n{errors}",
+                        errors = errors.iter().enumerate().map(|(i, e)|
+                            format!("[{index}/{bound}] {e}", index=i+1, bound=errors.len())
+                        ).join("\n"),
+                    ).into())
+                }
+            })
+        }
+    }
+}
+
+//==================================================================================================
+// Key-only ResponseShape comparison
+// - This is used to verify that each `requires` item on the fetch node represents the actual
+//   subgraph constraints specified in the subgraph schema's `@key/@requires` directives.
+// - The `requires` items on FetchNode only have the response key name (field name) without
+//   arguments, directives nor aliases.
+//   * Thus, their definitions (and response shapes) won't have Boolean conditions.
+// - `@key/@requires` directive's field set selections can't have aliases nor directives.
+//   * Note: `@requires` response shape inherits the Boolean condition from their individual entity
+//           fetch selections. Thus, Boolean conditions can be different and one response key
+//           may have multiple Boolean variants.
+// - `requires` items and `@key/@requires` directive's field set selections have this common
+//   property: Their response keys will always be the same as their definition's field name.
+//   * Even though the field arguments are missing in the `requires` items, since aliasing is not
+//     allowed, we can still match them just by their their response keys.
+// - Note: The type condition on `requires` item can be different from its corresponding entity
+//   type. The entity type can be a superset of the `requires` item's type condition, when the
+//   entity type in the subgraph is an interface object type.
+// - Argument convention: For each comparison function,
+//   * `this` is the response shape of the `requires` item.
+//   * `other` is the response shape of the `@key/@requires` directives from the subgraph schema.
+// - Essentially, this module is a simplified version of the `response_shape_compare` module.
+//
+// Example fetch node:
+//   FetchNode(service_name: "supply") {
+//     ... on Movie { # suppose `Movie` implements the `Product` interface.
+//       id # from a `@key` directive
+//       data # from a `@requires` directive (but the argument is missing)
+//     }
+//   } => {
+//     ... on Product { # `Product` is an interface object type in this subgraph.
+//       name
+//       sku @include(if: $includeSku)
+//           # The `@requires` response shape inherits this Boolean condition.
+//     }
+//   }
+//
+// Suppose the `Product` type is defined in the subgraph schema as following,
+//   type Product @key(fields: "id") {
+//      id: ID!
+//      name: String!
+//      sku: String! @requires(fields: "data(arg: 42)")
+//   }
+
+mod key_only_response_shape_compare {
+    use super::super::response_shape::DefinitionVariant;
+    use super::super::response_shape::PossibleDefinitionsPerTypeCondition;
+    use super::*;
+
+    /// Check if the key set of `this` is the same as that of `other` (ignoring their definitions)
+    pub(super) fn key_only_compare_response_shapes(
+        this: &ResponseShape,
+        other: &ResponseShape,
+    ) -> bool {
+        // Should have the exact same set of response keys.
+        this.len() == other.len()
+            && this.iter().all(|(key, this_def)| {
+                let Some(other_def) = other.get(key) else {
+                    return false;
+                };
+                key_only_compare_possible_definitions(this_def, other_def)
+            })
+    }
+
+    fn key_only_compare_possible_definitions(
+        this: &PossibleDefinitions,
+        other: &PossibleDefinitions,
+    ) -> bool {
+        // Should have the exact same set of type conditions.
+        this.len() == other.len()
+            && this.iter().all(|(this_cond, this_def)| {
+                let Some(other_def) = other.get(this_cond) else {
+                    return false;
+                };
+                key_only_compare_possible_definitions_per_type_condition(this_def, other_def)
+            })
+    }
+
+    fn key_only_compare_possible_definitions_per_type_condition(
+        this: &PossibleDefinitionsPerTypeCondition,
+        other: &PossibleDefinitionsPerTypeCondition,
+    ) -> bool {
+        // The `this` should have exactly one variant with no Boolean conditions, since the
+        // `requires` item won't have this detail.
+        // On the other hand, the `other` can have variants with Boolean conditions. But, the
+        // variants are merged since their Boolean conditions are ignored.
+        if this.conditional_variants().len() != 1 {
+            return false;
+        }
+        this.conditional_variants().iter().all(|this_def| {
+            let Some(merged_def) = merge_variants_ignoring_boolean_conditions(other) else {
+                return false;
+            };
+            key_only_compare_definition_variant(this_def, &merged_def)
+        })
+    }
+
+    fn merge_variants_ignoring_boolean_conditions(
+        other: &PossibleDefinitionsPerTypeCondition,
+    ) -> Option<DefinitionVariant> {
+        // Note: Similar to `collect_variants_for_boolean_condition`'s implementation.
+        let mut iter = other.conditional_variants().iter();
+        let first = iter.next()?;
+        let mut result_sub = first.sub_selection_response_shape().cloned();
+        for variant in iter {
+            if compare_representative_field(
+                variant.representative_field(),
+                first.representative_field(),
+            )
+            .is_err()
+            {
+                // Unexpected: GraphQL invariant violation
+                return None;
+            }
+            match (&mut result_sub, variant.sub_selection_response_shape()) {
+                (None, None) => {}
+                (Some(result_sub), Some(variant_sub)) => {
+                    let result = result_sub.merge_with(variant_sub);
+                    if result.is_err() {
+                        return None;
+                    }
+                }
+                _ => {
+                    return None;
+                }
+            }
+        }
+        Some(first.with_updated_fields(Clause::default(), result_sub))
+    }
+
+    fn key_only_compare_definition_variant(
+        this: &DefinitionVariant,
+        other: &DefinitionVariant,
+    ) -> bool {
+        // Note: The `boolean_clause` of DefinitionVariant is ignored.
+        match (
+            this.sub_selection_response_shape(),
+            other.sub_selection_response_shape(),
+        ) {
+            (None, None) => true,
+            (Some(this_sub), Some(other_sub)) => {
+                key_only_compare_response_shapes(this_sub, other_sub)
+            }
+            _ => false,
+        }
+    }
+}
+
+use key_only_response_shape_compare::key_only_compare_response_shapes;

--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -154,9 +154,8 @@ fn convert_requires_selections(
         match selection {
             requires_selection::Selection::Field(field) => {
                 let field_def = get_field_definition(schema, ty, &field.name)?;
-                // Note: `field` has no arguments nor directive applications.
-                let converted = executable::Field::new(field.name.clone(), field_def)
-                    .with_opt_alias(field.alias.clone());
+                // Note: `field` has no alias, arguments nor directive applications.
+                let converted = executable::Field::new(field.name.clone(), field_def);
                 let converted = if field.selections.is_empty() {
                     converted
                 } else {

--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -23,8 +23,8 @@ use crate::link::federation_spec_definition::KeyDirectiveArguments;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::query_plan::requires_selection;
 use crate::schema::ValidFederationSchema;
+use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::INTROSPECTION_TYPENAME_FIELD_NAME;
-use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::utils::FallibleIterator;
 
@@ -189,9 +189,9 @@ fn get_field_definition(
     parent_type: &Name,
     field_name: &Name,
 ) -> Result<Node<ast::FieldDefinition>, FederationError> {
-    let parent_type_pos: ObjectOrInterfaceTypeDefinitionPosition =
+    let parent_type_pos: CompositeTypeDefinitionPosition =
         schema.get_type(parent_type.clone())?.try_into()?;
-    let field_def_pos = parent_type_pos.field(field_name.clone());
+    let field_def_pos = parent_type_pos.field(field_name.clone())?;
     field_def_pos
         .get(schema.schema())
         .map(|component| component.node.clone())

--- a/apollo-federation/src/correctness/query_plan_soundness_test.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness_test.rs
@@ -1,0 +1,189 @@
+use super::query_plan_analysis_test::plan_response_shape_with_schema;
+use super::response_shape::ResponseShape;
+
+// The schema used in these tests.
+const SCHEMA_STR: &str = r#"
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "A", url: "test-template.graphql?subgraph=A")
+  S @join__graph(name: "S", url: "test-template.graphql?subgraph=S")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type P
+  @join__type(graph: A)
+  @join__type(graph: S, key: "id")
+{
+  id: ID!
+  p_data(arg: Int!): Int! @join__field(graph: A, external: true) @join__field(graph: S)
+}
+
+type Query
+  @join__type(graph: A)
+  @join__type(graph: S)
+{
+  start_t: T! @join__field(graph: S)
+}
+
+type T
+  @join__type(graph: A, key: "id")
+  @join__type(graph: S, key: "id")
+{
+  id: ID!
+  data: Int! @join__field(graph: A, requires: "pre(arg: 0)")
+  data2: Int! @join__field(graph: A, requires: "pre2(arg: 2)")
+  data3: Int! @join__field(graph: A, requires: "p { p_data(arg: 1) }")
+  pre(arg: Int!): Int! @join__field(graph: A, external: true) @join__field(graph: S)
+  pre2(arg: Int!): Int! @join__field(graph: A, external: true) @join__field(graph: S)
+  p: P! @join__field(graph: A)
+}
+"#;
+
+fn plan_response_shape(op_str: &str) -> ResponseShape {
+    plan_response_shape_with_schema(SCHEMA_STR, op_str)
+}
+
+//=================================================================================================
+// Basic tests
+
+#[test]
+fn test_requires_basic() {
+    let op_str = r#"
+        query {
+            start_t {
+                data
+                data2
+                data3
+            }
+        }
+    "#;
+    insta::assert_snapshot!(plan_response_shape(op_str), @r###"
+    {
+      start_t -----> start_t {
+        __typename -----> __typename
+        id -----> id
+        pre2 -----> pre2(arg: 2)
+        pre -----> pre(arg: 0)
+        p -----> p {
+          __typename -----> __typename
+          id -----> id
+          p_data -----> p_data(arg: 1)
+        }
+        data -----> data
+        data2 -----> data2
+        data3 -----> data3
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_requires_conditional() {
+    let op_str = r#"
+        query($v0: Boolean!) {
+            start_t {
+                data
+                data2 @include(if: $v0)
+            }
+        }
+    "#;
+    // Note: `pre2` is conditional just like `data2` is conditional.
+    insta::assert_snapshot!(plan_response_shape(op_str), @r###"
+    {
+      start_t -----> start_t {
+        __typename -----> __typename
+        id -----> id
+        pre2 -may-> pre2(arg: 2) if v0
+        pre -----> pre(arg: 0)
+        data -----> data
+        data2 -may-> data2 if v0
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_requires_conditional_multiple_variants() {
+    let op_str = r#"
+        query($v0: Boolean!) {
+            start_t {
+                data
+                data @include(if: $v0) # creates multi variant requires
+            }
+        }
+    "#;
+    // Note: `pre` has two conditional variants just like the `data`.
+    insta::assert_snapshot!(plan_response_shape(op_str), @r###"
+    {
+      start_t -----> start_t {
+        __typename -----> __typename
+        id -----> id
+        pre -may-> pre(arg: 0) if v0
+        pre -may-> pre(arg: 0)
+        data -may-> data
+        data -may-> data if v0
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_requires_external_under_non_external() {
+    let op_str = r#"
+        query {
+            start_t {
+                data3
+            }
+        }
+    "#;
+    // Note: `p` is a nested selection set from a `@requires` directive.
+    insta::assert_snapshot!(plan_response_shape(op_str), @r###"
+    {
+      start_t -----> start_t {
+        __typename -----> __typename
+        id -----> id
+        p -----> p {
+          __typename -----> __typename
+          id -----> id
+          p_data -----> p_data(arg: 1)
+        }
+        data3 -----> data3
+      }
+    }
+    "###);
+}

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -1273,6 +1273,29 @@ fn get_fragment_type_condition(
     })
 }
 
+/// Used for field sets like `@key`/`@requires` fields.
+pub fn compute_response_shape_for_selection_set(
+    schema: &ValidFederationSchema,
+    selection_set: &SelectionSet,
+) -> Result<ResponseShape, FederationError> {
+    let type_condition = &selection_set.ty;
+    let Some(normalized_type_condition) =
+        NormalizedTypeCondition::from_type_name(type_condition.clone(), schema)?
+    else {
+        bail!("Unexpected empty type condition for field set: {type_condition}")
+    };
+    let context = ResponseShapeContext {
+        schema: schema.clone(),
+        fragment_defs: Default::default(), // empty
+        parent_type: type_condition.clone(),
+        type_condition: normalized_type_condition,
+        inherited_clause: Clause::default(), // empty
+        current_clause: Clause::default(),   // empty
+        skip_introspection: false,           // false by default
+    };
+    context.process_selection_set(selection_set)
+}
+
 //==================================================================================================
 // ResponseShape display
 // - This section is only for display and thus untrusted.

--- a/apollo-federation/src/correctness/response_shape_compare.rs
+++ b/apollo-federation/src/correctness/response_shape_compare.rs
@@ -127,7 +127,7 @@ pub(crate) fn compare_response_shapes_with_constraint<T: PathConstraint>(
 
 /// Collect and merge all definitions applicable to the given type condition.
 /// Returns `None` if no definitions are applicable.
-fn collect_definitions_for_type_condition(
+pub(crate) fn collect_definitions_for_type_condition(
     defs: &PossibleDefinitions,
     filter_cond: &NormalizedTypeCondition,
 ) -> Result<Option<PossibleDefinitionsPerTypeCondition>, ComparisonError> {
@@ -409,7 +409,7 @@ fn generate_clauses(vars: &[Name]) -> Vec<Clause> {
 
 /// Collect all variants implied by the Boolean condition and merge them into one.
 /// Returns `None` if no variants are applicable.
-fn collect_variants_for_boolean_condition(
+pub(crate) fn collect_variants_for_boolean_condition(
     defs: &PossibleDefinitionsPerTypeCondition,
     filter_cond: &Clause,
 ) -> Result<Option<DefinitionVariant>, ComparisonError> {

--- a/apollo-federation/src/correctness/response_shape_compare.rs
+++ b/apollo-federation/src/correctness/response_shape_compare.rs
@@ -31,7 +31,7 @@ impl ComparisonError {
         ComparisonError { description }
     }
 
-    fn add_description(self: ComparisonError, description: &str) -> ComparisonError {
+    pub fn add_description(self: ComparisonError, description: &str) -> ComparisonError {
         ComparisonError {
             description: format!("{}\n{}", self.description, description),
         }
@@ -495,7 +495,10 @@ fn compare_field_selection_key(
     Ok(())
 }
 
-fn compare_representative_field(this: &Field, other: &Field) -> Result<(), ComparisonError> {
+pub(crate) fn compare_representative_field(
+    this: &Field,
+    other: &Field,
+) -> Result<(), ComparisonError> {
     check_match_eq!(this.name, other.name);
     // Note: Arguments and directives are NOT normalized.
     if !same_ast_arguments(&this.arguments, &other.arguments) {

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -415,6 +415,12 @@ fn write_requires_selection(
     Ok(())
 }
 
+impl fmt::Display for requires_selection::Selection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_requires_selection(&mut State::new(f), self)
+    }
+}
+
 /// PORT_NOTE: Corresponds to `GroupPath.updatedResponsePath` in `buildPlan.ts`
 impl fmt::Display for FetchDataPathElement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -801,6 +801,8 @@ fn handles_types_with_no_common_supertype_at_the_same_merge_at() {
         }
         "#,
     );
+    // Note: This plan is ambiguous without type-conditioned fetching (FED-515).
+    //       So, correctness check is disabled.
     assert_plan!(
         validate_correctness = false,
         &planner,


### PR DESCRIPTION
This PR contains 4 commits with the first 2 commits being just a refactoring and a minor fix:

* refactor: added `AnalysisContext` struct to pass `subgraphs_by_name` around.
* fix: improved `interpret_plan_node_at_path` to compute the merged states
* feat: implemented the soundness part of the correctness checker
* tests

It will be easier to review commit by commit, since the refactoring is widespread.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

This is an internal testing feature.
The corpus result looked reasonable.