### PR TITLE
Use batch_processor Config for Apollo Metrics PerodicReader

### DIFF
--- a/.changesets/fix_rreg_use_batch_config_for_apollo_metrics.md
+++ b/.changesets/fix_rreg_use_batch_config_for_apollo_metrics.md
@@ -1,0 +1,5 @@
+### Use batch_processor config for Apollo metrics PeriodicReader ([PR #7024](https://github.com/apollographql/router/pull/7024))
+
+The Apollo otlp `batch_processor` configurations `telemetry.apollo.batch_processor.scheduled_delay` and `telemetry.apollo.batch_processor.max_export_timeout` now also control the Apollo otlp `PeriodicReader` export interval and timeout respectively. This brings parity between Apollo otlp metrics and [non-Apollo otlp Exporter metrics](https://github.com/apollographql/router/blob/0f88850e0b164d12c14b1f05b0043076f21a3b28/apollo-router/src/plugins/telemetry/metrics/otlp.rs#L37-L40)
+
+By [@rregitsky](https://github.com/rregitsky) in https://github.com/apollographql/router/pull/7024

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -1,7 +1,6 @@
 //! Apollo metrics
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::MetricsExporterBuilder;

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -130,7 +130,8 @@ impl Config {
             ),
         )?;
         let reader = PeriodicReader::builder(exporter, runtime::Tokio)
-            .with_interval(Duration::from_secs(60))
+            .with_interval(batch_processor.scheduled_delay)
+            .with_timeout(batch_processor.max_export_timeout)
             .build();
 
         builder.apollo_meter_provider_builder = builder


### PR DESCRIPTION
This fix allows users to control Apollo otlp metrics' `PeriodicReader`with the `telemetry.apollo.batch_processor.scheduled_delay` and `telemetry.apollo.batch_processor.max_export_timeout` configs. This brings parity between Apollo otlp metrics and [non-Apollo otlp Exporter metrics](https://github.com/apollographql/router/blob/0f88850e0b164d12c14b1f05b0043076f21a3b28/apollo-router/src/plugins/telemetry/metrics/otlp.rs#L37-L40)

<!-- https://apollographql.atlassian.net/browse/ROUTER-1196 -->
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
