### PR TITLE
Move connect `@link` validations into their own type/module

### DIFF
--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -59,7 +59,7 @@ impl From<LinkError> for FederationError {
     }
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum Purpose {
     SECURITY,
     EXECUTION,
@@ -255,7 +255,7 @@ impl fmt::Display for Import {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Link {
     pub url: Url,
     pub spec_alias: Option<Name>,

--- a/apollo-federation/src/sources/connect/validation/connect.rs
+++ b/apollo-federation/src/sources/connect/validation/connect.rs
@@ -87,7 +87,7 @@ fn fields_seen_by_object_connectors(
             code: Code::SubscriptionInConnectors,
             message: format!(
                 "A subscription root type is not supported when using `@{connect_directive_name}`.",
-                connect_directive_name = schema.connect_directive_name,
+                connect_directive_name = schema.connect_directive_name(),
             ),
             locations: object.line_column_range(source_map).into_iter().collect(),
         }]);
@@ -137,7 +137,7 @@ fn fields_seen_by_connector(
     let connect_directives = field
         .directives
         .iter()
-        .filter(|directive| directive.name == *schema.connect_directive_name)
+        .filter(|directive| directive.name == *schema.connect_directive_name())
         .collect_vec();
 
     if connect_directives.is_empty() {
@@ -147,14 +147,14 @@ fn fields_seen_by_connector(
                 field,
                 object,
                 source_map,
-                schema.connect_directive_name,
+                schema.connect_directive_name(),
             )),
             ObjectCategory::Mutation => errors.push(get_missing_connect_directive_message(
                 Code::MutationFieldMissingConnect,
                 field,
                 object,
                 source_map,
-                schema.connect_directive_name,
+                schema.connect_directive_name(),
             )),
             _ => (),
         }
@@ -272,7 +272,7 @@ fn fields_seen_by_connector(
                     message: format!(
                         "{coordinate} specifies the relative URL {raw_value}, but no `{CONNECT_SOURCE_ARGUMENT_NAME}` is defined. Either use an absolute URL including scheme (e.g. https://), or add a `@{source_directive_name}`.",
                         raw_value = coordinate.node,
-                        source_directive_name = schema.source_directive_name,
+                        source_directive_name = schema.source_directive_name(),
                     ),
                     locations: coordinate.node.line_column_range(source_map).into_iter().collect()
                 })
@@ -326,7 +326,7 @@ pub(super) fn validate_source_name_arg(
     if source_names.iter().all(|name| name != &source_name.value) {
         // TODO: Pick a suggestion that's not just the first defined source
         let qualified_directive = connect_directive_name_coordinate(
-            schema.connect_directive_name,
+            schema.connect_directive_name(),
             &source_name.value,
             object_name,
             field_name,
@@ -347,7 +347,7 @@ pub(super) fn validate_source_name_arg(
                 code: Code::NoSourcesDefined,
                 message: format!(
                     "{qualified_directive} specifies a source, but none are defined. Try adding {coordinate} to the schema.",
-                    coordinate = source_name_value_coordinate(schema.source_directive_name, &source_name.value),
+                    coordinate = source_name_value_coordinate(schema.source_directive_name(), &source_name.value),
                 ),
                 locations: source_name.line_column_range(&schema.sources)
                     .into_iter()

--- a/apollo-federation/src/sources/connect/validation/connect/entity.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/entity.rs
@@ -228,7 +228,7 @@ impl<'schema> FieldVisitor<Field<'schema>> for ArgumentVisitor<'schema> {
                 message: format!(
                     "{coordinate} has invalid arguments. Mismatched type on field `{field_name}` - expected `{entity_type}` but found `{input_type}`.",
                     coordinate = field_with_connect_directive_entity_true_coordinate(
-                        self.schema.connect_directive_name,
+                        self.schema.connect_directive_name(),
                         self.entity_arg_value.as_ref(),
                         self.object,
                         self.field,
@@ -276,7 +276,7 @@ impl<'schema> ArgumentVisitor<'schema> {
                         message: format!(
                             "{coordinate} has invalid arguments. Argument `{arg_name}` does not have a matching field `{arg_name}` on type `{entity_type}`.",
                             coordinate = field_with_connect_directive_entity_true_coordinate(
-                                self.schema.connect_directive_name,
+                                self.schema.connect_directive_name(),
                                 self.entity_arg_value.as_ref(),
                                 self.object,
                                 &field.name
@@ -330,7 +330,7 @@ impl<'schema> ArgumentVisitor<'schema> {
                     message: format!(
                         "{coordinate} has invalid arguments. Field `{name}` on `{input_type}` does not have a matching field `{name}` on `{entity_type}`.",
                         coordinate = field_with_connect_directive_entity_true_coordinate(
-                            self.schema.connect_directive_name,
+                            self.schema.connect_directive_name(),
                             self.entity_arg_value.as_ref(),
                             self.object,
                             self.field,

--- a/apollo-federation/src/sources/connect/validation/expression.rs
+++ b/apollo-federation/src/sources/connect/validation/expression.rs
@@ -335,14 +335,13 @@ fn shape_name(shape: &Shape) -> &'static str {
 #[cfg(test)]
 mod tests {
     use apollo_compiler::Schema;
-    use apollo_compiler::name;
     use line_col::LineColLookup;
     use rstest::rstest;
 
     use super::*;
-    use crate::sources::connect::ConnectSpec;
     use crate::sources::connect::JSONSelection;
     use crate::sources::connect::validation::coordinates::FieldCoordinate;
+    use crate::sources::connect::validation::link::ConnectLink;
 
     fn expression(selection: &str) -> Expression {
         Expression {
@@ -400,14 +399,8 @@ mod tests {
         let object = schema.get_object("Query").unwrap();
         let field = &object.fields["aField"];
         let directive = field.directives.get("connect").unwrap();
-        let source_directive = name!("source");
-        let schema_info = SchemaInfo::new(
-            &schema,
-            ConnectSpec::V0_1,
-            &schema_str,
-            &directive.name,
-            &source_directive,
-        );
+        let schema_info =
+            SchemaInfo::new(&schema, &schema_str, ConnectLink::new(&schema).unwrap()?);
         let expr_string = GraphQLString::new(
             &directive
                 .argument_by_name("http", &schema)

--- a/apollo-federation/src/sources/connect/validation/graphql.rs
+++ b/apollo-federation/src/sources/connect/validation/graphql.rs
@@ -11,15 +11,13 @@ mod strings;
 
 pub(super) use strings::GraphQLString;
 
-use crate::sources::connect::ConnectSpec;
+use crate::sources::connect::validation::link::ConnectLink;
 
 pub(super) struct SchemaInfo<'schema> {
     pub(crate) schema: &'schema Schema,
-    pub(crate) connect_spec: ConnectSpec,
     len: usize,
     lookup: LineColLookup<'schema>,
-    pub(crate) connect_directive_name: &'schema Name,
-    pub(crate) source_directive_name: &'schema Name,
+    pub(crate) connect_link: ConnectLink<'schema>,
     /// A lookup map for the Shapes computed from GraphQL types.
     pub(crate) shape_lookup: IndexMap<&'schema str, Shape>,
 }
@@ -27,18 +25,14 @@ pub(super) struct SchemaInfo<'schema> {
 impl<'schema> SchemaInfo<'schema> {
     pub(crate) fn new(
         schema: &'schema Schema,
-        connect_spec: ConnectSpec,
         src: &'schema str,
-        connect_directive_name: &'schema Name,
-        source_directive_name: &'schema Name,
+        connect_link: ConnectLink<'schema>,
     ) -> Self {
         Self {
             schema,
-            connect_spec,
             len: src.len(),
             lookup: LineColLookup::new(src),
-            connect_directive_name,
-            source_directive_name,
+            connect_link,
             shape_lookup: shape::graphql::shapes_for_schema(schema),
         }
     }
@@ -53,6 +47,16 @@ impl<'schema> SchemaInfo<'schema> {
         } else {
             Some(self.lookup.get(offset))
         }
+    }
+
+    #[inline]
+    pub(crate) fn source_directive_name(&self) -> &Name {
+        &self.connect_link.source_directive_name
+    }
+
+    #[inline]
+    pub(crate) fn connect_directive_name(&self) -> &Name {
+        &self.connect_link.connect_directive_name
     }
 }
 
@@ -71,14 +75,15 @@ mod tests {
     #[test]
     fn line_col_lookup() {
         let src = r#"
+            extend schema @link(url: "https://specs.apollo.dev/connect/v0.1")
             type Query {
                 foo: String
             }
         "#;
         let schema = Schema::parse(src, "testSchema").unwrap();
 
-        let name = "unused".try_into().unwrap();
-        let schema_info = SchemaInfo::new(&schema, ConnectSpec::V0_1, src, &name, &name);
+        let schema_info =
+            SchemaInfo::new(&schema, src, ConnectLink::new(&schema).unwrap().unwrap());
 
         assert_eq!(schema_info.line_col(0), Some((1, 1)));
         assert_eq!(schema_info.line_col(4), Some((2, 4)));

--- a/apollo-federation/src/sources/connect/validation/graphql/strings.rs
+++ b/apollo-federation/src/sources/connect/validation/graphql/strings.rs
@@ -219,11 +219,11 @@ mod tests {
     use apollo_compiler::schema::ExtendedType;
     use pretty_assertions::assert_eq;
 
-    use crate::sources::connect::ConnectSpec;
+    use crate::sources::connect::validation::ConnectLink;
     use crate::sources::connect::validation::graphql::GraphQLString;
     use crate::sources::connect::validation::graphql::SchemaInfo;
 
-    const SCHEMA: &str = r#"
+    const SCHEMA: &str = r#"extend schema @link(url: "https://specs.apollo.dev/connect/v0.1")
         type Query {
           field: String @connect(
             http: {
@@ -256,8 +256,8 @@ mod tests {
 
         let string = GraphQLString::new(value, &schema.sources).unwrap();
         assert_eq!(string.as_str(), "https://example.com");
-        let name = "unused".try_into().unwrap();
-        let schema_info = SchemaInfo::new(&schema, ConnectSpec::V0_1, SCHEMA, &name, &name);
+        let schema_info =
+            SchemaInfo::new(&schema, SCHEMA, ConnectLink::new(&schema).unwrap().unwrap());
         assert_eq!(
             string.line_col_for_subslice(2..5, &schema_info),
             Some(
@@ -279,8 +279,8 @@ mod tests {
 
         let string = GraphQLString::new(value, &schema.sources).unwrap();
         assert_eq!(string.as_str(), "something\nsomethingElse {\n  nested\n}");
-        let name = "unused".try_into().unwrap();
-        let schema_info = SchemaInfo::new(&schema, ConnectSpec::V0_1, SCHEMA, &name, &name);
+        let schema_info =
+            SchemaInfo::new(&schema, SCHEMA, ConnectLink::new(&schema).unwrap().unwrap());
         assert_eq!("nested", &string.as_str()[28..34]);
         assert_eq!(
             string.line_col_for_subslice(28..34, &schema_info),

--- a/apollo-federation/src/sources/connect/validation/link.rs
+++ b/apollo-federation/src/sources/connect/validation/link.rs
@@ -1,0 +1,77 @@
+//! Validations for `@link(url: "https://specs.apollo.dev/connect")`
+
+use std::fmt::Display;
+
+use apollo_compiler::Name;
+use apollo_compiler::Schema;
+use apollo_compiler::schema::Component;
+use apollo_compiler::schema::Directive;
+use strum::IntoEnumIterator;
+
+use crate::link::Link;
+use crate::sources::connect::ConnectSpec;
+use crate::sources::connect::validation::Code;
+use crate::sources::connect::validation::Message;
+
+/// The `@link` in a subgraph which enables connectors
+#[derive(Clone, Debug)]
+pub(super) struct ConnectLink<'schema> {
+    pub(crate) spec: ConnectSpec,
+    pub(crate) source_directive_name: Name,
+    pub(crate) connect_directive_name: Name,
+    pub(crate) directive: &'schema Component<Directive>,
+    link: Link,
+}
+
+impl<'schema> ConnectLink<'schema> {
+    /// Find the connect link, if any, and validate it.
+    /// Returns `None` if this is not a connectors subgraph.
+    ///
+    /// # Errors
+    /// - Unknown spec version
+    pub(super) fn new(schema: &'schema Schema) -> Option<Result<Self, Message>> {
+        let connect_identity = ConnectSpec::identity();
+        let (link, directive) = Link::for_identity(schema, &connect_identity)?;
+
+        let spec = match ConnectSpec::try_from(&link.url.version) {
+            Err(err) => {
+                let available_versions: Vec<_> =
+                    ConnectSpec::iter().map(ConnectSpec::as_str).collect();
+                let message = if available_versions.len() == 1 {
+                    // TODO: No need to branch here once multiple spec versions are available
+                    format!("{err}; should be {version}.", version = ConnectSpec::V0_1)
+                } else {
+                    // This won't happen today, but it's prepping for 0.2 so we don't forget
+                    format!(
+                        "{err}; should be one of {available_versions}.",
+                        available_versions = available_versions.join(", "),
+                    )
+                };
+                return Some(Err(Message {
+                    code: Code::UnknownConnectorsVersion,
+                    message,
+                    locations: directive
+                        .line_column_range(&schema.sources)
+                        .into_iter()
+                        .collect(),
+                }));
+            }
+            Ok(spec) => spec,
+        };
+        let source_directive_name = ConnectSpec::source_directive_name(&link);
+        let connect_directive_name = ConnectSpec::connect_directive_name(&link);
+        Some(Ok(Self {
+            spec,
+            source_directive_name,
+            connect_directive_name,
+            directive,
+            link,
+        }))
+    }
+}
+
+impl Display for ConnectLink<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "@link(url: \"{}\")", self.link.url)
+    }
+}

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -19,6 +19,7 @@ mod coordinates;
 mod expression;
 mod graphql;
 mod http;
+mod link;
 mod schema;
 mod source;
 mod variable;
@@ -34,7 +35,6 @@ use apollo_compiler::name;
 use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::SchemaBuilder;
 use itertools::Itertools;
-use strum::IntoEnumIterator;
 use strum_macros::Display;
 use strum_macros::IntoStaticStr;
 use url::Url;
@@ -42,22 +42,22 @@ use url::Url;
 use crate::link::Import;
 use crate::link::Link;
 use crate::link::spec::Identity;
-use crate::sources::connect::ConnectSpec;
 use crate::sources::connect::spec::schema::SOURCE_DIRECTIVE_NAME_IN_SPEC;
 use crate::sources::connect::validation::connect::fields_seen_by_all_connects;
 use crate::sources::connect::validation::graphql::GraphQLString;
 use crate::sources::connect::validation::graphql::SchemaInfo;
+use crate::sources::connect::validation::link::ConnectLink;
 use crate::sources::connect::validation::source::SourceDirective;
 use crate::subgraph::spec::CONTEXT_DIRECTIVE_NAME;
 use crate::subgraph::spec::FROM_CONTEXT_DIRECTIVE_NAME;
 
-// The result of a validation pass on a subgraph
+/// The result of a validation pass on a subgraph
 #[derive(Debug)]
 pub struct ValidationResult {
     /// All validation errors encountered.
     pub errors: Vec<Message>,
 
-    /// Whether or not the validated subgraph contained connector directives
+    /// Whether the validated subgraph contained connector directives
     pub has_connectors: bool,
 
     /// The parsed (and potentially invalid) schema of the subgraph
@@ -76,56 +76,26 @@ pub fn validate(source_text: &str, file_name: &str) -> ValidationResult {
         .parse(source_text, file_name)
         .build()
         .unwrap_or_else(|schema_with_errors| schema_with_errors.partial);
-    let connect_identity = ConnectSpec::identity();
-    let Some((link, link_directive)) = Link::for_identity(&schema, &connect_identity) else {
-        // There are no connectors-related directives to validate
-        return ValidationResult {
-            errors: Vec::new(),
-            has_connectors: false,
-            schema,
-        };
-    };
-
-    let spec = match ConnectSpec::try_from(&link.url.version) {
-        Err(err) => {
-            let available_versions = ConnectSpec::iter().map(ConnectSpec::as_str).collect_vec();
-            let message = if available_versions.len() == 1 {
-                // TODO: No need to branch here once multiple spec versions are available
-                format!("{err}; should be {version}.", version = ConnectSpec::V0_1)
-            } else {
-                // This won't happen today, but it's prepping for 0.2 so we don't forget
-                format!(
-                    "{err}; should be one of {available_versions}.",
-                    available_versions = available_versions.join(", "),
-                )
-            };
+    let link = match ConnectLink::new(&schema) {
+        None => {
             return ValidationResult {
-                errors: vec![Message {
-                    code: Code::UnknownConnectorsVersion,
-                    message,
-                    locations: link_directive
-                        .line_column_range(&schema.sources)
-                        .into_iter()
-                        .collect(),
-                }],
+                errors: Vec::new(),
+                has_connectors: false,
+                schema,
+            };
+        }
+        Some(Err(err)) => {
+            return ValidationResult {
+                errors: vec![err],
                 has_connectors: true,
                 schema,
             };
         }
-        Ok(spec) => spec,
+        Some(Ok(link)) => link,
     };
-
     let mut messages = check_conflicting_directives(&schema);
 
-    let source_directive_name = ConnectSpec::source_directive_name(&link);
-    let connect_directive_name = ConnectSpec::connect_directive_name(&link);
-    let schema_info = SchemaInfo::new(
-        &schema,
-        spec,
-        source_text,
-        &connect_directive_name,
-        &source_directive_name,
-    );
+    let schema_info = SchemaInfo::new(&schema, source_text, link);
 
     let (source_directives, source_messages) = SourceDirective::find(&schema_info);
     messages.extend(source_messages);
@@ -148,15 +118,15 @@ pub fn validate(source_text: &str, file_name: &str) -> ValidationResult {
         }
     }
 
-    if source_directive_name == DEFAULT_SOURCE_DIRECTIVE_NAME
+    if schema_info.connect_link.source_directive_name == DEFAULT_SOURCE_DIRECTIVE_NAME
         && messages
             .iter()
             .any(|error| error.code == Code::NoSourcesDefined)
     {
         messages.push(Message {
             code: Code::NoSourceImport,
-            message: format!("The `@{SOURCE_DIRECTIVE_NAME_IN_SPEC}` directive is not imported. Try adding `@{SOURCE_DIRECTIVE_NAME_IN_SPEC}` to `import` for `@{link_name}(url: \"{connect_identity}\")`", link_name=link_directive.name),
-            locations: link_directive.line_column_range(&schema.sources)
+            message: format!("The `@{SOURCE_DIRECTIVE_NAME_IN_SPEC}` directive is not imported. Try adding `@{SOURCE_DIRECTIVE_NAME_IN_SPEC}` to `import` for `{link}`", link=schema_info.connect_link),
+            locations: schema_info.connect_link.directive.line_column_range(&schema.sources)
                 .into_iter()
                 .collect(),
         });

--- a/apollo-federation/src/sources/connect/validation/schema.rs
+++ b/apollo-federation/src/sources/connect/validation/schema.rs
@@ -151,7 +151,7 @@ fn check_seen_fields(
             code: Code::ConnectorsUnresolvedField,
             message: format!(
                 "No connector resolves field `{parent_type}.{field_name}`. It must have a `@{connect_directive_name}` directive or appear in `@{connect_directive_name}(selection:)`.",
-                connect_directive_name = schema.connect_directive_name
+                connect_directive_name = schema.connect_directive_name()
             ),
             locations: field_def.line_column_range(&schema.sources).into_iter().collect(),
         }
@@ -237,7 +237,8 @@ fn resolvable_key_fields<'a>(
 fn advanced_validations(schema: &SchemaInfo, subgraph_name: &str) -> Vec<Message> {
     let mut messages = Vec::new();
 
-    let Ok(connectors) = Connector::from_schema(schema, subgraph_name, schema.connect_spec) else {
+    let Ok(connectors) = Connector::from_schema(schema, subgraph_name, schema.connect_link.spec)
+    else {
         return messages;
     };
 

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@missing_source_import.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@missing_source_import.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/sources/connect/validation/mod.rs
-expression: "format!(\"{:#?}\", errors)"
+expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/sources/connect/validation/test_data/missing_source_import.graphql
 ---
 [
@@ -13,7 +13,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/missing_s
     },
     Message {
         code: NoSourceImport,
-        message: "The `@source` directive is not imported. Try adding `@source` to `import` for `@link(url: \"https://specs.apollo.dev/connect\")`",
+        message: "The `@source` directive is not imported. Try adding `@source` to `import` for `@link(url: \"https://specs.apollo.dev/connect/v0.1\")`",
         locations: [
             2:3..2:76,
         ],

--- a/apollo-federation/src/sources/connect/validation/source.rs
+++ b/apollo-federation/src/sources/connect/validation/source.rs
@@ -29,7 +29,7 @@ pub(super) struct SourceDirective<'schema> {
 
 impl<'schema> SourceDirective<'schema> {
     pub(super) fn find(schema: &'schema SchemaInfo) -> (Vec<Self>, Vec<Message>) {
-        let source_directive_name = schema.source_directive_name;
+        let source_directive_name = schema.source_directive_name();
         let mut directives = Vec::new();
         let mut messages = Vec::new();
         for directive in &schema.schema_definition.directives {


### PR DESCRIPTION
Only user facing change is a slight tweak to an error message (see snapshot).

Moves the validations of `@link` for connectors out of `mod.rs` and into a new `ConnectLink` struct—so we "parse" the details of the link to use later, rather than validate their components. Because the spec version and imported names of `@source` and `@connect` come from that link, they are grouped into that struct as well, which causes some code changes elsewhere where they're used.

<!-- [CNN-612]-->

[CNN-612]: https://apollographql.atlassian.net/browse/CNN-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ