### PR TITLE
Remove specialization of missing `@connect` on Mutation/Query

### DIFF
--- a/apollo-federation/src/sources/connect/validation/connect.rs
+++ b/apollo-federation/src/sources/connect/validation/connect.rs
@@ -4,7 +4,6 @@ use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::FieldDefinition;
-use apollo_compiler::parser::SourceMap;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::ObjectType;
@@ -141,26 +140,8 @@ fn fields_seen_by_connector(
         .collect_vec();
 
     if connect_directives.is_empty() {
-        match category {
-            ObjectCategory::Query => errors.push(get_missing_connect_directive_message(
-                Code::QueryFieldMissingConnect,
-                field,
-                object,
-                source_map,
-                schema.connect_directive_name(),
-            )),
-            ObjectCategory::Mutation => errors.push(get_missing_connect_directive_message(
-                Code::MutationFieldMissingConnect,
-                field,
-                object,
-                source_map,
-                schema.connect_directive_name(),
-            )),
-            _ => (),
-        }
-
-        return Err(errors);
-    };
+        return Ok(Vec::new());
+    }
 
     // mark the field with a @connect directive as seen
     let mut seen_fields = vec![(object.name.clone(), field.name.clone())];
@@ -293,24 +274,6 @@ fn fields_seen_by_connector(
         Ok(seen_fields)
     } else {
         Err(errors)
-    }
-}
-
-fn get_missing_connect_directive_message(
-    code: Code,
-    field: &Component<FieldDefinition>,
-    object: &Node<ObjectType>,
-    source_map: &SourceMap,
-    connect_directive_name: &Name,
-) -> Message {
-    Message {
-        code,
-        message: format!(
-            "The field `{object_name}.{field}` has no `@{connect_directive_name}` directive.",
-            field = field.name,
-            object_name = object.name,
-        ),
-        locations: field.line_column_range(source_map).into_iter().collect(),
     }
 }
 

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -203,10 +203,6 @@ pub enum Code {
     SourceNameMismatch,
     /// Connectors currently don't support subscription operations.
     SubscriptionInConnectors,
-    /// A query field is missing the `@connect` directive.
-    QueryFieldMissingConnect,
-    /// A mutation field is missing the `@connect` directive.
-    MutationFieldMissingConnect,
     /// The `@connect` is using a `source`, but the URL is absolute. This is not allowed because
     /// the `@source` URL will be joined with the `@connect` URL, so the `@connect` URL should
     /// only be a path.

--- a/apollo-federation/src/sources/connect/validation/schema.rs
+++ b/apollo-federation/src/sources/connect/validation/schema.rs
@@ -3,7 +3,6 @@
 use apollo_compiler::Name;
 use apollo_compiler::Schema;
 use apollo_compiler::ast::Directive;
-use apollo_compiler::ast::OperationType;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::executable::Selection;
@@ -141,13 +140,6 @@ fn check_seen_fields(
         .values()
         .filter_map(|extended_type| {
             if extended_type.is_built_in() {
-                return None;
-            }
-            // ignore root fields, we have different validations for them
-            if schema.root_operation(OperationType::Query) == Some(extended_type.name())
-                || schema.root_operation(OperationType::Mutation) == Some(extended_type.name())
-                || schema.root_operation(OperationType::Subscription) == Some(extended_type.name())
-            {
                 return None;
             }
             let coord = |(name, _): (&Name, _)| (extended_type.name().clone(), name.clone());

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@missing_connect_on_mutation_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@missing_connect_on_mutation_field.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/sources/connect/validation/mod.rs
-expression: "format!(\"{:#?}\", errors)"
+expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/sources/connect/validation/test_data/missing_connect_on_mutation_field.graphql
 ---
 [
     Message {
-        code: MutationFieldMissingConnect,
-        message: "The field `Mutation.setMessage` has no `@connect` directive.",
+        code: ConnectorsUnresolvedField,
+        message: "No connector resolves field `Mutation.setMessage`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
             9:3..9:38,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@missing_connect_on_query_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@missing_connect_on_query_field.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/sources/connect/validation/mod.rs
-expression: "format!(\"{:#?}\", errors)"
+expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/sources/connect/validation/test_data/missing_connect_on_query_field.graphql
 ---
 [
     Message {
-        code: QueryFieldMissingConnect,
-        message: "The field `Query.resources` has no `@connect` directive.",
+        code: ConnectorsUnresolvedField,
+        message: "No connector resolves field `Query.resources`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
             9:5..9:26,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@renamed_connect_directive.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@renamed_connect_directive.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/sources/connect/validation/mod.rs
-expression: "format!(\"{:#?}\", errors)"
+expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/sources/connect/validation/test_data/renamed_connect_directive.graphql
 ---
 [
     Message {
-        code: QueryFieldMissingConnect,
-        message: "The field `Query.resources` has no `@data` directive.",
+        code: ConnectorsUnresolvedField,
+        message: "No connector resolves field `Query.resources`. It must have a `@data` directive or appear in `@data(selection:)`.",
         locations: [
             9:5..9:26,
         ],


### PR DESCRIPTION
Our seen field validation is capable of detecting this already, and this makes more sense to live in the schema-wide checks.

Two user-facing changes:

1. This check will now only happen when the other seen field validations happen—so only after all `@connect` are verified to be accurate
2. The error message and code are different, see the snapshot for details

<!-- [CNN-612] -->


[CNN-612]: https://apollographql.atlassian.net/browse/CNN-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ