### PR TITLE
Move no subscriptions check into schema-wide checks

### DIFF
--- a/apollo-federation/src/sources/connect/validation/connect.rs
+++ b/apollo-federation/src/sources/connect/validation/connect.rs
@@ -75,23 +75,6 @@ fn fields_seen_by_object_connectors(
     schema: &SchemaInfo,
     source_names: &[SourceName],
 ) -> Result<Vec<(Name, Name)>, Vec<Message>> {
-    let source_map = &schema.sources;
-    let is_subscription = schema
-        .schema_definition
-        .subscription
-        .as_ref()
-        .is_some_and(|sub| sub.name == object.name);
-    if is_subscription {
-        return Err(vec![Message {
-            code: Code::SubscriptionInConnectors,
-            message: format!(
-                "A subscription root type is not supported when using `@{connect_directive_name}`.",
-                connect_directive_name = schema.connect_directive_name(),
-            ),
-            locations: object.line_column_range(source_map).into_iter().collect(),
-        }]);
-    }
-
     let object_category = if schema
         .schema_definition
         .query

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@subscriptions_with_connectors.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@subscriptions_with_connectors.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/sources/connect/validation/mod.rs
-expression: "format!(\"{:#?}\", errors)"
+expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/sources/connect/validation/test_data/subscriptions_with_connectors.graphql
 ---
 [
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/subscript
         code: SubscriptionInConnectors,
         message: "A subscription root type is not supported when using `@connect`.",
         locations: [
-            13:1..15:2,
+            13:6..13:18,
         ],
     },
 ]


### PR DESCRIPTION
Same deal as previous ones, this doesn't have to do with `@connect` specifically, so I've moved it into the schema-wide checks. Which means it won't trigger if there are errors in individual `@connect`s.

Does make me wonder if in the future we want to run _some_ schema-wide checks, just not all to reduce surprises.

<!-- [CNN-612] -->


[CNN-612]: https://apollographql.atlassian.net/browse/CNN-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ