### PR TITLE
Error categorization: make feature flag non-experimental

### DIFF
--- a/.changesets/config_meryl_pulsr_1463.md
+++ b/.changesets/config_meryl_pulsr_1463.md
@@ -1,5 +1,5 @@
 ### Make experimental otlp error metrics feature flag non-experimental ([PR #7033](https://github.com/apollographql/router/pull/7033))
 
-Because the otlp error metrics feature is being promoted to `preview` from `experimental`, this change updates its feature flag name from `experimental_otlp_error_metrics` to `preview_otlp_error_metrics`.
+Because the otlp error metrics feature is being promoted to `preview` from `experimental`, this change updates its feature flag name from `experimental_otlp_error_metrics` to `preview_extended_error_metrics`.
 
 By [@merylc](https://github.com/merylc) in https://github.com/apollographql/router/pull/7033

--- a/.changesets/config_meryl_pulsr_1463.md
+++ b/.changesets/config_meryl_pulsr_1463.md
@@ -1,5 +1,5 @@
-### Brief but complete sentence that stands on its own ([Issue #ISSUE_NUMBER](https://github.com/apollographql/router/issues/ISSUE_NUMBER))
+### Make experimental otlp error metrics feature flag non-experimental ([PR #7033](https://github.com/apollographql/router/pull/7033))
 
-Because the otlp metrics error metrics feature is being promoted to `preview` from `experimental`, this change updates its feature flag name from `experimental_otlp_error_metrics` to `preview_otlp_error_metrics`.
+Because the otlp error metrics feature is being promoted to `preview` from `experimental`, this change updates its feature flag name from `experimental_otlp_error_metrics` to `preview_otlp_error_metrics`.
 
-By [@merylc](https://github.com/merylc) in https://github.com/apollographql/router/pull/PULL_NUMBER
+By [@merylc](https://github.com/merylc) in https://github.com/apollographql/router/pull/7033

--- a/.changesets/config_meryl_pulsr_1463.md
+++ b/.changesets/config_meryl_pulsr_1463.md
@@ -1,5 +1,5 @@
-### Make experimental otlp error metrics feature flag non-experimental ([PR #7033](https://github.com/apollographql/router/pull/7033))
+### Make experimental OTLP error metrics feature flag non-experimental ([PR #7033](https://github.com/apollographql/router/pull/7033))
 
-Because the otlp error metrics feature is being promoted to `preview` from `experimental`, this change updates its feature flag name from `experimental_otlp_error_metrics` to `preview_extended_error_metrics`.
+Because the OTLP error metrics feature is being promoted to `preview` from `experimental`, this change updates its feature flag name from `experimental_otlp_error_metrics` to `preview_extended_error_metrics`.
 
 By [@merylc](https://github.com/merylc) in https://github.com/apollographql/router/pull/7033

--- a/.changesets/config_meryl_pulsr_1463.md
+++ b/.changesets/config_meryl_pulsr_1463.md
@@ -1,0 +1,5 @@
+### Brief but complete sentence that stands on its own ([Issue #ISSUE_NUMBER](https://github.com/apollographql/router/issues/ISSUE_NUMBER))
+
+Because the otlp metrics error metrics feature is being promoted to `preview` from `experimental`, this change updates its feature flag name from `experimental_otlp_error_metrics` to `preview_otlp_error_metrics`.
+
+By [@merylc](https://github.com/merylc) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/apollo-router/src/configuration/migrations/0037-preview_otlp_error_metrics.yaml
+++ b/apollo-router/src/configuration/migrations/0037-preview_otlp_error_metrics.yaml
@@ -3,4 +3,4 @@ actions:
 
   - type: move
     from: telemetry.apollo.experimental_otlp_error_metrics
-    to: telemetry.apollo.preview_otlp_error_metrics
+    to: telemetry.apollo.preview_extended_error_metrics

--- a/apollo-router/src/configuration/migrations/0037-preview_otlp_error_metrics.yaml
+++ b/apollo-router/src/configuration/migrations/0037-preview_otlp_error_metrics.yaml
@@ -1,4 +1,4 @@
-description: The otlp error metrics option is now in the preview release stage
+description: The OTLP error metrics option is now in the preview release stage
 actions:
 
   - type: move

--- a/apollo-router/src/configuration/migrations/0037-preview_otlp_error_metrics.yaml
+++ b/apollo-router/src/configuration/migrations/0037-preview_otlp_error_metrics.yaml
@@ -1,0 +1,6 @@
+description: The otlp error metrics option is now in the preview release stage
+actions:
+
+  - type: move
+    from: telemetry.apollo.experimental_otlp_error_metrics
+    to: telemetry.apollo.preview_otlp_error_metrics

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2752,7 +2752,7 @@ expression: "&schema"
     "ErrorsConfiguration": {
       "additionalProperties": false,
       "properties": {
-        "preview_otlp_error_metrics": {
+        "preview_extended_error_metrics": {
           "$ref": "#/definitions/OtlpErrorMetricsMode",
           "description": "#/definitions/OtlpErrorMetricsMode"
         },

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/tests.rs
-assertion_line: 26
 expression: "&schema"
 ---
 {
@@ -2753,7 +2752,7 @@ expression: "&schema"
     "ErrorsConfiguration": {
       "additionalProperties": false,
       "properties": {
-        "experimental_otlp_error_metrics": {
+        "preview_otlp_error_metrics": {
           "$ref": "#/definitions/OtlpErrorMetricsMode",
           "description": "#/definitions/OtlpErrorMetricsMode"
         },

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2753,8 +2753,8 @@ expression: "&schema"
       "additionalProperties": false,
       "properties": {
         "preview_extended_error_metrics": {
-          "$ref": "#/definitions/OtlpErrorMetricsMode",
-          "description": "#/definitions/OtlpErrorMetricsMode"
+          "$ref": "#/definitions/ExtendedErrorMetricsMode",
+          "description": "#/definitions/ExtendedErrorMetricsMode"
         },
         "subgraph": {
           "$ref": "#/definitions/SubgraphErrorConfig",
@@ -3106,6 +3106,25 @@ expression: "&schema"
         }
       },
       "type": "object"
+    },
+    "ExtendedErrorMetricsMode": {
+      "description": "Extended Open Telemetry error metrics mode",
+      "oneOf": [
+        {
+          "description": "Do not send extended OTLP error metrics",
+          "enum": [
+            "disabled"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Send extended OTLP error metrics to Apollo Studio with additional dimensions [`extensions.service`, `extensions.code`]. If enabled, it's also recommended to enable `redaction_policy: extended` on subgraphs to send the `extensions.code` for subgraph errors.",
+          "enum": [
+            "enabled"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "FieldName": {
       "oneOf": [
@@ -4495,25 +4514,6 @@ expression: "&schema"
           "description": "A hash of the operation name.",
           "enum": [
             "hash"
-          ],
-          "type": "string"
-        }
-      ]
-    },
-    "OtlpErrorMetricsMode": {
-      "description": "Extended Open Telemetry error metrics mode",
-      "oneOf": [
-        {
-          "description": "Do not send extended OTLP error metrics",
-          "enum": [
-            "disabled"
-          ],
-          "type": "string"
-        },
-        {
-          "description": "Send extended OTLP error metrics to Apollo Studio with additional dimensions [`extensions.service`, `extensions.code`]. If enabled, it's also recommended to enable `redaction_policy: extended` on subgraphs to send the `extensions.code` for subgraph errors.",
-          "enum": [
-            "enabled"
           ],
           "type": "string"
         }

--- a/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
@@ -23,7 +23,7 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
         self.config.subgraph.all.send
             // When OtlpErrorMetricsMode is enabled, this plugin supports reporting connector errors
             && !matches!(
-                self.config.experimental_otlp_error_metrics,
+                self.config.preview_otlp_error_metrics,
                 apollo::OtlpErrorMetricsMode::Enabled
             )
     }
@@ -39,7 +39,7 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
                 .partition_map(|(name, sub)| {
                     if sub.send
                         && !matches!(
-                            self.config.experimental_otlp_error_metrics,
+                            self.config.preview_otlp_error_metrics,
                             apollo::OtlpErrorMetricsMode::Enabled
                         )
                     {
@@ -61,13 +61,13 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
             if self.config.subgraph.subgraphs.contains_key(subgraph) {
                 tracing::warn!(
                     subgraph = subgraph,
-                    message = "plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `experimental_otlp_error_metrics` is enabled",
+                    message = "plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `preview_otlp_error_metrics` is enabled",
                     see = "https://go.apollo.dev/connectors/incompat",
                 );
             } else {
                 tracing::info!(
                     subgraph = subgraph,
-                    message = "plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `experimental_otlp_error_metrics` is enabled",
+                    message = "plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `preview_otlp_error_metrics` is enabled",
                     see = "https://go.apollo.dev/connectors/incompat",
                 );
             }

--- a/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
@@ -21,10 +21,10 @@ impl TelemetryIncompatPlugin {
 impl IncompatiblePlugin for TelemetryIncompatPlugin {
     fn is_applied_to_all(&self) -> bool {
         self.config.subgraph.all.send
-            // When OtlpErrorMetricsMode is enabled, this plugin supports reporting connector errors
+            // When ExtendedErrorMetricsMode is enabled, this plugin supports reporting connector errors
             && !matches!(
                 self.config.preview_extended_error_metrics,
-                apollo::OtlpErrorMetricsMode::Enabled
+                apollo::ExtendedErrorMetricsMode::Enabled
             )
     }
 
@@ -40,7 +40,7 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
                     if sub.send
                         && !matches!(
                             self.config.preview_extended_error_metrics,
-                            apollo::OtlpErrorMetricsMode::Enabled
+                            apollo::ExtendedErrorMetricsMode::Enabled
                         )
                     {
                         Either::Left(name)

--- a/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
@@ -23,7 +23,7 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
         self.config.subgraph.all.send
             // When OtlpErrorMetricsMode is enabled, this plugin supports reporting connector errors
             && !matches!(
-                self.config.preview_otlp_error_metrics,
+                self.config.preview_extended_error_metrics,
                 apollo::OtlpErrorMetricsMode::Enabled
             )
     }
@@ -39,7 +39,7 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
                 .partition_map(|(name, sub)| {
                     if sub.send
                         && !matches!(
-                            self.config.preview_otlp_error_metrics,
+                            self.config.preview_extended_error_metrics,
                             apollo::OtlpErrorMetricsMode::Enabled
                         )
                     {
@@ -61,13 +61,13 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
             if self.config.subgraph.subgraphs.contains_key(subgraph) {
                 tracing::warn!(
                     subgraph = subgraph,
-                    message = "plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `preview_otlp_error_metrics` is enabled",
+                    message = "plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `preview_extended_error_metrics` is enabled",
                     see = "https://go.apollo.dev/connectors/incompat",
                 );
             } else {
                 tracing::info!(
                     subgraph = subgraph,
-                    message = "plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `preview_otlp_error_metrics` is enabled",
+                    message = "plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `preview_extended_error_metrics` is enabled",
                     see = "https://go.apollo.dev/connectors/incompat",
                 );
             }

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -123,7 +123,7 @@ pub(crate) struct ErrorsConfiguration {
     pub(crate) subgraph: SubgraphErrorConfig,
 
     /// Send error metrics via OTLP with additional dimensions [`extensions.service`, `extensions.code`]
-    pub(crate) preview_extended_error_metrics: OtlpErrorMetricsMode,
+    pub(crate) preview_extended_error_metrics: ExtendedErrorMetricsMode,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
@@ -170,7 +170,7 @@ impl SubgraphErrorConfig {
 /// Extended Open Telemetry error metrics mode
 #[derive(Clone, Default, Debug, Deserialize, JsonSchema, Copy)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
-pub(crate) enum OtlpErrorMetricsMode {
+pub(crate) enum ExtendedErrorMetricsMode {
     /// Do not send extended OTLP error metrics
     #[default]
     Disabled,

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -123,7 +123,7 @@ pub(crate) struct ErrorsConfiguration {
     pub(crate) subgraph: SubgraphErrorConfig,
 
     /// Send error metrics via OTLP with additional dimensions [`extensions.service`, `extensions.code`]
-    pub(crate) preview_otlp_error_metrics: OtlpErrorMetricsMode,
+    pub(crate) preview_extended_error_metrics: OtlpErrorMetricsMode,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -123,7 +123,7 @@ pub(crate) struct ErrorsConfiguration {
     pub(crate) subgraph: SubgraphErrorConfig,
 
     /// Send error metrics via OTLP with additional dimensions [`extensions.service`, `extensions.code`]
-    pub(crate) experimental_otlp_error_metrics: OtlpErrorMetricsMode,
+    pub(crate) preview_otlp_error_metrics: OtlpErrorMetricsMode,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]

--- a/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
+++ b/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
@@ -2,19 +2,6 @@
 source: apollo-router/src/services/layers/persisted_queries/mod.rs
 expression: yaml
 ---
-- fields:
-    operation_body: "query SomeQuery { me { id } }"
-  level: WARN
-  message: unknown operation
-- fields:
-    operation_body: "query SomeQuery { me { id } }"
-  level: WARN
-  message: unknown operation
-- fields:
-    operation_body: "fragment A on Query { me { id } }    query SomeOp { ...A ...B }    fragment,,, B on Query{me{username,name}  } # yeah"
-  level: WARN
-  message: unknown operation
-- fields:
-    operation_body: "fragment F on Query { __typename foo: __schema { __typename } me { id } } query Q { __type(name: \"foo\") { name } ...F }"
-  level: WARN
-  message: unknown operation
+- fields: {}
+  level: INFO
+  message: Loaded 2 persisted queries.

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -900,14 +900,14 @@ impl RouterService {
 
             let send_otlp_errors = if service.is_empty() {
                 matches!(
-                    errors_config.experimental_otlp_error_metrics,
+                    errors_config.preview_otlp_error_metrics,
                     OtlpErrorMetricsMode::Enabled
                 )
             } else {
                 let subgraph_error_config = errors_config.subgraph.get_error_config(&service);
                 subgraph_error_config.send
                     && matches!(
-                        errors_config.experimental_otlp_error_metrics,
+                        errors_config.preview_otlp_error_metrics,
                         OtlpErrorMetricsMode::Enabled
                     )
             };

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -61,7 +61,7 @@ use crate::plugins::telemetry::CLIENT_NAME;
 use crate::plugins::telemetry::CLIENT_VERSION;
 use crate::plugins::telemetry::apollo::Config as ApolloTelemetryConfig;
 use crate::plugins::telemetry::apollo::ErrorsConfiguration;
-use crate::plugins::telemetry::apollo::OtlpErrorMetricsMode;
+use crate::plugins::telemetry::apollo::ExtendedErrorMetricsMode;
 use crate::plugins::telemetry::config::Conf as TelemetryConfig;
 use crate::plugins::telemetry::config_new::attributes::HTTP_REQUEST_BODY;
 use crate::plugins::telemetry::config_new::attributes::HTTP_REQUEST_HEADERS;
@@ -901,14 +901,14 @@ impl RouterService {
             let send_otlp_errors = if service.is_empty() {
                 matches!(
                     errors_config.preview_extended_error_metrics,
-                    OtlpErrorMetricsMode::Enabled
+                    ExtendedErrorMetricsMode::Enabled
                 )
             } else {
                 let subgraph_error_config = errors_config.subgraph.get_error_config(&service);
                 subgraph_error_config.send
                     && matches!(
                         errors_config.preview_extended_error_metrics,
-                        OtlpErrorMetricsMode::Enabled
+                        ExtendedErrorMetricsMode::Enabled
                     )
             };
 

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -900,14 +900,14 @@ impl RouterService {
 
             let send_otlp_errors = if service.is_empty() {
                 matches!(
-                    errors_config.preview_otlp_error_metrics,
+                    errors_config.preview_extended_error_metrics,
                     OtlpErrorMetricsMode::Enabled
                 )
             } else {
                 let subgraph_error_config = errors_config.subgraph.get_error_config(&service);
                 subgraph_error_config.send
                     && matches!(
-                        errors_config.preview_otlp_error_metrics,
+                        errors_config.preview_extended_error_metrics,
                         OtlpErrorMetricsMode::Enabled
                     )
             };

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -627,7 +627,7 @@ async fn it_stores_operation_error_when_config_is_enabled() {
             serde_json::json!({
                 "apollo": {
                     "errors": {
-                        "preview_otlp_error_metrics": "enabled",
+                        "preview_extended_error_metrics": "enabled",
                         "subgraph": {
                             "subgraphs": {
                                 "myIgnoredSubgraph": {

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -627,7 +627,7 @@ async fn it_stores_operation_error_when_config_is_enabled() {
             serde_json::json!({
                 "apollo": {
                     "errors": {
-                        "experimental_otlp_error_metrics": "enabled",
+                        "preview_otlp_error_metrics": "enabled",
                         "subgraph": {
                             "subgraphs": {
                                 "myIgnoredSubgraph": {

--- a/apollo-router/tests/integration/connectors.rs
+++ b/apollo-router/tests/integration/connectors.rs
@@ -843,7 +843,7 @@ mod telemetry {
 
         router.start().await;
         router
-        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `preview_otlp_error_metrics` is enabled"#)
+        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `preview_extended_error_metrics` is enabled"#)
         .await;
 
         Ok(())
@@ -885,7 +885,7 @@ mod telemetry {
 
         router.start().await;
         router
-        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `preview_otlp_error_metrics` is enabled"#)
+        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `preview_extended_error_metrics` is enabled"#)
         .await;
 
         Ok(())
@@ -950,7 +950,7 @@ mod telemetry {
                 telemetry:
                   apollo:
                     errors:
-                      preview_otlp_error_metrics: enabled
+                      preview_extended_error_metrics: enabled
                       subgraph:
                         all:
                           send: true

--- a/apollo-router/tests/integration/connectors.rs
+++ b/apollo-router/tests/integration/connectors.rs
@@ -843,7 +843,7 @@ mod telemetry {
 
         router.start().await;
         router
-        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `experimental_otlp_error_metrics` is enabled"#)
+        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `preview_otlp_error_metrics` is enabled"#)
         .await;
 
         Ok(())
@@ -885,7 +885,7 @@ mod telemetry {
 
         router.start().await;
         router
-        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `experimental_otlp_error_metrics` is enabled"#)
+        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `preview_otlp_error_metrics` is enabled"#)
         .await;
 
         Ok(())
@@ -950,7 +950,7 @@ mod telemetry {
                 telemetry:
                   apollo:
                     errors:
-                      experimental_otlp_error_metrics: enabled
+                      preview_otlp_error_metrics: enabled
                       subgraph:
                         all:
                           send: true


### PR DESCRIPTION
Make the feature flag `experimental_otlp_error_metrics` non-experimental

Implements #PULSR-1463

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
