### PR TITLE
refactor: remove `alias` field from `requires_selection::Field`

### DIFF
--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -383,15 +383,7 @@ fn write_requires_selection(
     selection: &requires_selection::Selection,
 ) -> fmt::Result {
     match selection {
-        requires_selection::Selection::Field(requires_selection::Field {
-            alias,
-            name,
-            selections,
-        }) => {
-            if let Some(alias) = alias {
-                state.write(alias)?;
-                state.write(": ")?;
-            }
+        requires_selection::Selection::Field(requires_selection::Field { name, selections }) => {
             state.write(name)?;
             if !selections.is_empty() {
                 state.write(" ")?;

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2666,7 +2666,6 @@ impl FetchDependencyGraphNode {
                 .filter_map(|s| match s {
                     executable::Selection::Field(field) => Some(
                         requires_selection::Selection::Field(requires_selection::Field {
-                            alias: None,
                             name: field.name.clone(),
                             selections: trim_requires_selection_set(&field.selection_set),
                         }),

--- a/apollo-federation/src/query_plan/requires_selection.rs
+++ b/apollo-federation/src/query_plan/requires_selection.rs
@@ -17,8 +17,6 @@ pub enum Selection {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Field {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub alias: Option<Name>,
     pub name: Name,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -30,12 +30,8 @@ pub(crate) fn execute_selection_set<'a>(
     let mut output = Object::with_capacity(selections.len());
     for selection in selections {
         match selection {
-            Selection::Field(Field {
-                alias,
-                name,
-                selections,
-            }) => {
-                let selection_name = alias.as_ref().map(|a| a.as_str()).unwrap_or(name.as_str());
+            Selection::Field(Field { name, selections }) => {
+                let selection_name = name.as_str();
                 let field_type = current_type.and_then(|t| {
                     schema
                         .supergraph_schema()
@@ -43,10 +39,10 @@ pub(crate) fn execute_selection_set<'a>(
                         .get(t)
                         .and_then(|ty| match ty {
                             apollo_compiler::schema::ExtendedType::Object(o) => {
-                                o.fields.get(name.as_str()).map(|f| &f.ty)
+                                o.fields.get(name).map(|f| &f.ty)
                             }
                             apollo_compiler::schema::ExtendedType::Interface(i) => {
-                                i.fields.get(name.as_str()).map(|f| &f.ty)
+                                i.fields.get(name).map(|f| &f.ty)
                             }
                             _ => None,
                         })

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__query_plan_from_json.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__query_plan_from_json.snap
@@ -57,14 +57,12 @@ Sequence {
                                                     selections: [
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "__typename",
                                                                 selections: [],
                                                             },
                                                         ),
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "isbn",
                                                                 selections: [],
                                                             },
@@ -120,28 +118,24 @@ Sequence {
                                                     selections: [
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "__typename",
                                                                 selections: [],
                                                             },
                                                         ),
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "isbn",
                                                                 selections: [],
                                                             },
                                                         ),
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "title",
                                                                 selections: [],
                                                             },
                                                         ),
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "year",
                                                                 selections: [],
                                                             },
@@ -196,14 +190,12 @@ Sequence {
                                                     selections: [
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "__typename",
                                                                 selections: [],
                                                             },
                                                         ),
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "isbn",
                                                                 selections: [],
                                                             },
@@ -254,28 +246,24 @@ Sequence {
                                                     selections: [
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "__typename",
                                                                 selections: [],
                                                             },
                                                         ),
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "isbn",
                                                                 selections: [],
                                                             },
                                                         ),
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "title",
                                                                 selections: [],
                                                             },
                                                         ),
                                                         Field(
                                                             Field {
-                                                                alias: None,
                                                                 name: "year",
                                                                 selections: [],
                                                             },

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -321,14 +321,12 @@ async fn defer() {
                                     selections: vec![
                                         requires_selection::Selection::Field(
                                             requires_selection::Field {
-                                                alias: None,
                                                 name: name!("id"),
                                                 selections: Vec::new(),
                                             },
                                         ),
                                         requires_selection::Selection::Field(
                                             requires_selection::Field {
-                                                alias: None,
                                                 name: name!("__typename"),
                                                 selections: Vec::new(),
                                             },


### PR DESCRIPTION
* The `alias` field is never used (always set `None`). This PR removes it.
* This is a follow-up of the de-serializable `QueryPlan` PR (#6861).

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

This is a pure refactoring.