### PR TITLE
Consolidate `@connect(http.method)` checks

### DIFF
--- a/apollo-federation/src/sources/connect/validation/http.rs
+++ b/apollo-federation/src/sources/connect/validation/http.rs
@@ -1,3 +1,2 @@
 pub(super) mod headers;
-pub(super) mod method;
 pub(super) mod url;


### PR DESCRIPTION
The check is only for `@connect`, so it lives in the `connect` module now. You also can't get a `URLTemplate` out of it unless the template is valid (so moving all related validations into the same place).

This is basically prep for a `ConnectHttp` struct or similar that we will build up containing the entire successfully parsed `http` arg—which we will then type check at a later stage (once that's extracted).