### PR TITLE
add custom tag via tracing.datadog.tags

### DIFF
--- a/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
@@ -84,6 +84,10 @@ pub(crate) struct Config {
     #[serde(default = "default_true")]
     enable_span_mapping: bool,
 
+    /// Custom host tags to be sent as part of the host metadata
+    #[serde(default)]
+    tags: Vec<String>,
+
     /// Fixes the span names, this means that the APM view will show the original span names in the operation dropdown.
     #[serde(default = "default_true")]
     fixed_span_names: bool,
@@ -214,6 +218,7 @@ impl TracingConfigurator for Config {
                     .pool_idle_timeout(Duration::from_millis(1))
                     .build()?,
             )
+            .with_tags(self.tags.clone())
             .with_trace_config(common)
             .build_exporter()?;
 

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/model/unified_tags.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/model/unified_tags.rs
@@ -4,6 +4,7 @@ pub struct UnifiedTags {
     pub service: UnifiedTagField,
     pub env: UnifiedTagField,
     pub version: UnifiedTagField,
+    pub custom_tags: Vec<(String, String)>,
 }
 
 impl UnifiedTags {
@@ -12,6 +13,7 @@ impl UnifiedTags {
             service: UnifiedTagField::new(UnifiedTagEnum::Service),
             env: UnifiedTagField::new(UnifiedTagEnum::Env),
             version: UnifiedTagField::new(UnifiedTagEnum::Version),
+            custom_tags: Vec::new(),
         }
     }
     pub fn set_service(&mut self, service: Option<String>) {
@@ -27,7 +29,19 @@ impl UnifiedTags {
         self.service.value.clone()
     }
     pub fn compute_attribute_size(&self) -> u32 {
-        self.service.len() + self.env.len() + self.version.len()
+        self.service.len() + self.env.len() + self.version.len() + self.custom_tags.len() as u32
+    }
+
+    /// Add custom tags as the Second Primary tag(custom unified tags)
+    pub fn add_custom_tags(&mut self, tags: Vec<String>) {
+        for tag in tags {
+            if let Some(idx) = tag.find(':') {
+                let (key, value) = tag.split_at(idx);
+                // Skip the ':' character
+                let value = &value[1..];
+                self.custom_tags.push((key.to_string(), value.to_string()));
+            }
+        }
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/model/v05.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/model/v05.rs
@@ -118,6 +118,12 @@ fn write_unified_tags<'a>(
     write_unified_tag(encoded, interner, &unified_tags.service)?;
     write_unified_tag(encoded, interner, &unified_tags.env)?;
     write_unified_tag(encoded, interner, &unified_tags.version)?;
+
+    for (key, value) in &unified_tags.custom_tags {
+        rmp::encode::write_u32(encoded, interner.intern(key))?;
+        rmp::encode::write_u32(encoded, interner.intern(value))?;
+    }
+
     Ok(())
 }
 
@@ -230,13 +236,10 @@ where
             )?;
             rmp::encode::write_i64(&mut encoded, start)?;
             rmp::encode::write_i64(&mut encoded, duration)?;
-            rmp::encode::write_i32(
-                &mut encoded,
-                match span.status {
-                    Status::Error { .. } => 1,
-                    _ => 0,
-                },
-            )?;
+            rmp::encode::write_i32(&mut encoded, match span.status {
+                Status::Error { .. } => 1,
+                _ => 0,
+            })?;
 
             rmp::encode::write_map_len(
                 &mut encoded,


### PR DESCRIPTION
it's same as `OTEL_RESOURCE_ATTRIBUTES` that custom tag from this PR only added as an attribute but not as a dd tag. 
Looks like the only way to add custom tag is utilize `datadog.host.tag` and `datadog.container.tag` via [OTEL collector mentioned here](https://docs.datadoghq.com/opentelemetry/config/hostname_tagging/?tab=host#custom-host-tags), but Rust OTEL collector doesn't have transform processor. And our DD agent doesn't have env var to explicitly accept `host` and `container` tags. In addition, our dd needs to support `OTLP`. 