### PR TITLE
Revert "Error categorization: make feature flag non-experimental"

### DIFF
--- a/.changesets/config_meryl_pulsr_1463.md
+++ b/.changesets/config_meryl_pulsr_1463.md
@@ -1,5 +1,0 @@
-### Make experimental OTLP error metrics feature flag non-experimental ([PR #7033](https://github.com/apollographql/router/pull/7033))
-
-Because the OTLP error metrics feature is being promoted to `preview` from `experimental`, this change updates its feature flag name from `experimental_otlp_error_metrics` to `preview_extended_error_metrics`.
-
-By [@merylc](https://github.com/merylc) in https://github.com/apollographql/router/pull/7033

--- a/apollo-router/src/configuration/migrations/0037-preview_otlp_error_metrics.yaml
+++ b/apollo-router/src/configuration/migrations/0037-preview_otlp_error_metrics.yaml
@@ -1,6 +1,0 @@
-description: The OTLP error metrics option is now in the preview release stage
-actions:
-
-  - type: move
-    from: telemetry.apollo.experimental_otlp_error_metrics
-    to: telemetry.apollo.preview_extended_error_metrics

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/src/configuration/tests.rs
+assertion_line: 26
 expression: "&schema"
 ---
 {
@@ -2752,9 +2753,9 @@ expression: "&schema"
     "ErrorsConfiguration": {
       "additionalProperties": false,
       "properties": {
-        "preview_extended_error_metrics": {
-          "$ref": "#/definitions/ExtendedErrorMetricsMode",
-          "description": "#/definitions/ExtendedErrorMetricsMode"
+        "experimental_otlp_error_metrics": {
+          "$ref": "#/definitions/OtlpErrorMetricsMode",
+          "description": "#/definitions/OtlpErrorMetricsMode"
         },
         "subgraph": {
           "$ref": "#/definitions/SubgraphErrorConfig",
@@ -3106,25 +3107,6 @@ expression: "&schema"
         }
       },
       "type": "object"
-    },
-    "ExtendedErrorMetricsMode": {
-      "description": "Extended Open Telemetry error metrics mode",
-      "oneOf": [
-        {
-          "description": "Do not send extended OTLP error metrics",
-          "enum": [
-            "disabled"
-          ],
-          "type": "string"
-        },
-        {
-          "description": "Send extended OTLP error metrics to Apollo Studio with additional dimensions [`extensions.service`, `extensions.code`]. If enabled, it's also recommended to enable `redaction_policy: extended` on subgraphs to send the `extensions.code` for subgraph errors.",
-          "enum": [
-            "enabled"
-          ],
-          "type": "string"
-        }
-      ]
     },
     "FieldName": {
       "oneOf": [
@@ -4514,6 +4496,25 @@ expression: "&schema"
           "description": "A hash of the operation name.",
           "enum": [
             "hash"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "OtlpErrorMetricsMode": {
+      "description": "Extended Open Telemetry error metrics mode",
+      "oneOf": [
+        {
+          "description": "Do not send extended OTLP error metrics",
+          "enum": [
+            "disabled"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Send extended OTLP error metrics to Apollo Studio with additional dimensions [`extensions.service`, `extensions.code`]. If enabled, it's also recommended to enable `redaction_policy: extended` on subgraphs to send the `extensions.code` for subgraph errors.",
+          "enum": [
+            "enabled"
           ],
           "type": "string"
         }

--- a/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/telemetry.rs
@@ -21,10 +21,10 @@ impl TelemetryIncompatPlugin {
 impl IncompatiblePlugin for TelemetryIncompatPlugin {
     fn is_applied_to_all(&self) -> bool {
         self.config.subgraph.all.send
-            // When ExtendedErrorMetricsMode is enabled, this plugin supports reporting connector errors
+            // When OtlpErrorMetricsMode is enabled, this plugin supports reporting connector errors
             && !matches!(
-                self.config.preview_extended_error_metrics,
-                apollo::ExtendedErrorMetricsMode::Enabled
+                self.config.experimental_otlp_error_metrics,
+                apollo::OtlpErrorMetricsMode::Enabled
             )
     }
 
@@ -39,8 +39,8 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
                 .partition_map(|(name, sub)| {
                     if sub.send
                         && !matches!(
-                            self.config.preview_extended_error_metrics,
-                            apollo::ExtendedErrorMetricsMode::Enabled
+                            self.config.experimental_otlp_error_metrics,
+                            apollo::OtlpErrorMetricsMode::Enabled
                         )
                     {
                         Either::Left(name)
@@ -61,13 +61,13 @@ impl IncompatiblePlugin for TelemetryIncompatPlugin {
             if self.config.subgraph.subgraphs.contains_key(subgraph) {
                 tracing::warn!(
                     subgraph = subgraph,
-                    message = "plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `preview_extended_error_metrics` is enabled",
+                    message = "plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `experimental_otlp_error_metrics` is enabled",
                     see = "https://go.apollo.dev/connectors/incompat",
                 );
             } else {
                 tracing::info!(
                     subgraph = subgraph,
-                    message = "plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `preview_extended_error_metrics` is enabled",
+                    message = "plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `experimental_otlp_error_metrics` is enabled",
                     see = "https://go.apollo.dev/connectors/incompat",
                 );
             }

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -123,7 +123,7 @@ pub(crate) struct ErrorsConfiguration {
     pub(crate) subgraph: SubgraphErrorConfig,
 
     /// Send error metrics via OTLP with additional dimensions [`extensions.service`, `extensions.code`]
-    pub(crate) preview_extended_error_metrics: ExtendedErrorMetricsMode,
+    pub(crate) experimental_otlp_error_metrics: OtlpErrorMetricsMode,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
@@ -170,7 +170,7 @@ impl SubgraphErrorConfig {
 /// Extended Open Telemetry error metrics mode
 #[derive(Clone, Default, Debug, Deserialize, JsonSchema, Copy)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
-pub(crate) enum ExtendedErrorMetricsMode {
+pub(crate) enum OtlpErrorMetricsMode {
     /// Do not send extended OTLP error metrics
     #[default]
     Disabled,

--- a/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
+++ b/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
@@ -2,6 +2,19 @@
 source: apollo-router/src/services/layers/persisted_queries/mod.rs
 expression: yaml
 ---
-- fields: {}
-  level: INFO
-  message: Loaded 2 persisted queries.
+- fields:
+    operation_body: "query SomeQuery { me { id } }"
+  level: WARN
+  message: unknown operation
+- fields:
+    operation_body: "query SomeQuery { me { id } }"
+  level: WARN
+  message: unknown operation
+- fields:
+    operation_body: "fragment A on Query { me { id } }    query SomeOp { ...A ...B }    fragment,,, B on Query{me{username,name}  } # yeah"
+  level: WARN
+  message: unknown operation
+- fields:
+    operation_body: "fragment F on Query { __typename foo: __schema { __typename } me { id } } query Q { __type(name: \"foo\") { name } ...F }"
+  level: WARN
+  message: unknown operation

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -61,7 +61,7 @@ use crate::plugins::telemetry::CLIENT_NAME;
 use crate::plugins::telemetry::CLIENT_VERSION;
 use crate::plugins::telemetry::apollo::Config as ApolloTelemetryConfig;
 use crate::plugins::telemetry::apollo::ErrorsConfiguration;
-use crate::plugins::telemetry::apollo::ExtendedErrorMetricsMode;
+use crate::plugins::telemetry::apollo::OtlpErrorMetricsMode;
 use crate::plugins::telemetry::config::Conf as TelemetryConfig;
 use crate::plugins::telemetry::config_new::attributes::HTTP_REQUEST_BODY;
 use crate::plugins::telemetry::config_new::attributes::HTTP_REQUEST_HEADERS;
@@ -900,15 +900,15 @@ impl RouterService {
 
             let send_otlp_errors = if service.is_empty() {
                 matches!(
-                    errors_config.preview_extended_error_metrics,
-                    ExtendedErrorMetricsMode::Enabled
+                    errors_config.experimental_otlp_error_metrics,
+                    OtlpErrorMetricsMode::Enabled
                 )
             } else {
                 let subgraph_error_config = errors_config.subgraph.get_error_config(&service);
                 subgraph_error_config.send
                     && matches!(
-                        errors_config.preview_extended_error_metrics,
-                        ExtendedErrorMetricsMode::Enabled
+                        errors_config.experimental_otlp_error_metrics,
+                        OtlpErrorMetricsMode::Enabled
                     )
             };
 

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -627,7 +627,7 @@ async fn it_stores_operation_error_when_config_is_enabled() {
             serde_json::json!({
                 "apollo": {
                     "errors": {
-                        "preview_extended_error_metrics": "enabled",
+                        "experimental_otlp_error_metrics": "enabled",
                         "subgraph": {
                             "subgraphs": {
                                 "myIgnoredSubgraph": {

--- a/apollo-router/tests/integration/connectors.rs
+++ b/apollo-router/tests/integration/connectors.rs
@@ -843,7 +843,7 @@ mod telemetry {
 
         router.start().await;
         router
-        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `preview_extended_error_metrics` is enabled"#)
+        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is indirectly configured to send errors to Apollo studio for a connector-enabled subgraph, which is only supported when `experimental_otlp_error_metrics` is enabled"#)
         .await;
 
         Ok(())
@@ -885,7 +885,7 @@ mod telemetry {
 
         router.start().await;
         router
-        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `preview_extended_error_metrics` is enabled"#)
+        .wait_for_log_message(r#""subgraph":"connectors","message":"plugin `telemetry` is explicitly configured to send errors to Apollo studio for connector-enabled subgraph, which is only supported when `experimental_otlp_error_metrics` is enabled"#)
         .await;
 
         Ok(())
@@ -950,7 +950,7 @@ mod telemetry {
                 telemetry:
                   apollo:
                     errors:
-                      preview_extended_error_metrics: enabled
+                      experimental_otlp_error_metrics: enabled
                       subgraph:
                         all:
                           send: true


### PR DESCRIPTION
Reverts apollographql/router#7033

Some issues found with the snapshot and migration might not be working.