### PR TITLE
Add configuration option to limit maximum batch size (backport #7005)

### DIFF
--- a/.changesets/feat_limit_client_batch_size.md
+++ b/.changesets/feat_limit_client_batch_size.md
@@ -1,0 +1,25 @@
+### Add configuration option to limit maximum batch size ([PR #7005](https://github.com/apollographql/router/pull/7005))
+
+Add an optional `maximum_size` parameter to the batching configuration.
+
+* When specified, the router will reject requests which contain more than `maximum_size` queries in the client batch.
+* When unspecified, the router performs no size checking (the current behavior).
+
+If the number of queries provided exceeds the maximum batch size, the entire batch fails with error code 422 (
+`Unprocessable Content`). For example:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Invalid GraphQL request",
+      "extensions": {
+        "details": "Batch limits exceeded: you provided a batch with 3 entries, but the configured maximum router batch size is 2",
+        "code": "BATCH_LIMIT_EXCEEDED"
+      }
+    }
+  ]
+}
+```
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/7005

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -1473,6 +1473,10 @@ pub(crate) struct Batching {
 
     /// Subgraph options for batching
     pub(crate) subgraph: Option<SubgraphConfiguration<CommonBatchingConfig>>,
+
+    /// Maximum size for a batch
+    #[serde(default)]
+    pub(crate) maximum_size: Option<usize>,
 }
 
 /// Common options for configuring subgraph batching
@@ -1505,6 +1509,13 @@ impl Batching {
                         .is_some_and(|x| x.enabled)
                 }
             }
+            None => false,
+        }
+    }
+
+    pub(crate) fn exceeds_batch_size<T>(&self, batch: &[T]) -> bool {
+        match self.maximum_size {
+            Some(maximum_size) => batch.len() > maximum_size,
             None => false,
         }
     }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -359,6 +359,14 @@ expression: "&schema"
           "description": "Activates Batching (disabled by default)",
           "type": "boolean"
         },
+        "maximum_size": {
+          "default": null,
+          "description": "Maximum size for a batch",
+          "format": "uint",
+          "minimum": 0.0,
+          "nullable": true,
+          "type": "integer"
+        },
         "mode": {
           "$ref": "#/definitions/BatchingMode",
           "description": "#/definitions/BatchingMode"

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -1091,6 +1091,31 @@ fn it_processes_batching_subgraph_accounts_override_enabled_correctly() {
     assert!(config.batch_include("accounts"));
 }
 
+#[test]
+fn it_processes_unspecified_maximum_batch_limit_correctly() {
+    let json_config = json!({
+        "enabled": true,
+        "mode": "batch_http_link",
+    });
+
+    let config: Batching = serde_json::from_value(json_config).unwrap();
+
+    assert_eq!(config.maximum_size, None);
+}
+
+#[test]
+fn it_processes_specified_maximum_batch_limit_correctly() {
+    let json_config = json!({
+        "enabled": true,
+        "mode": "batch_http_link",
+        "maximum_size": 10
+    });
+
+    let config: Batching = serde_json::from_value(json_config).unwrap();
+
+    assert_eq!(config.maximum_size, Some(10));
+}
+
 fn has_field_level_serde_defaults(lines: &[&str], line_number: usize) -> bool {
     let serde_field_default = Regex::new(
         r#"^\s*#[\s\n]*\[serde\s*\((.*,)?\s*default\s*=\s*"[a-zA-Z0-9_:]+"\s*(,.*)?\)\s*\]\s*$"#,

--- a/apollo-router/src/services/query_batching/testdata/batch_exceeds_maximum_size_response.json
+++ b/apollo-router/src/services/query_batching/testdata/batch_exceeds_maximum_size_response.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "message": "Invalid GraphQL request",
+      "extensions": {
+        "details": "Batch limits exceeded: you provided a batch with 2 entries, but the configured maximum router batch size is 1",
+        "code": "BATCH_LIMIT_EXCEEDED"
+      }
+    }
+  ]
+}

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -658,7 +658,8 @@ impl RouterService {
         if is_batch && self.batching.exceeds_batch_size(&result) {
             return Err(TranslateError {
                 status: StatusCode::UNPROCESSABLE_ENTITY,
-                extension_code: "BATCH_LIMIT_EXCEEDED".to_string(),
+                error: "batch limits exceeded",
+                extension_code: "BATCH_LIMIT_EXCEEDED",
                 extension_details: format!(
                     "Batch limits exceeded: you provided a batch with {} entries, but the configured maximum router batch size is {}",
                     result.len(),

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -654,6 +654,19 @@ impl RouterService {
                 }
             }
         };
+
+        if is_batch && self.batching.exceeds_batch_size(&result) {
+            return Err(TranslateError {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                extension_code: "BATCH_LIMIT_EXCEEDED".to_string(),
+                extension_details: format!(
+                    "Batch limits exceeded: you provided a batch with {} entries, but the configured maximum router batch size is {}",
+                    result.len(),
+                    self.batching.maximum_size.unwrap_or_default()
+                ),
+            });
+        }
+
         Ok((result, is_batch))
     }
 

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -20,7 +20,6 @@ use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 use crate::services::router;
-use crate::services::router::body::RouterBody;
 use crate::services::router::body::get_body_bytes;
 use crate::services::router::service::from_supergraph_mock_callback;
 use crate::services::router::service::process_vary_header;

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -20,11 +20,8 @@ use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 use crate::services::router;
-<<<<<<< HEAD
-use crate::services::router::body::get_body_bytes;
-=======
 use crate::services::router::body::RouterBody;
->>>>>>> dfa3aa0a (Add configuration option to limit maximum batch size (#7005))
+use crate::services::router::body::get_body_bytes;
 use crate::services::router::service::from_supergraph_mock_callback;
 use crate::services::router::service::process_vary_header;
 use crate::services::subgraph;
@@ -277,34 +274,7 @@ async fn it_processes_a_valid_query_batch() {
     .unwrap();
 
     async fn with_config() -> router::Response {
-<<<<<<< HEAD
-        let http_request = supergraph::Request::canned_builder()
-            .build()
-            .unwrap()
-            .supergraph_request
-            .map(|req_2: graphql::Request| {
-                // Create clones of our standard query and update it to have 3 unique queries
-                let mut req_1 = req_2.clone();
-                let mut req_3 = req_2.clone();
-                req_1.query = req_2.query.clone().map(|x| x.replace("upc\n", ""));
-                req_3.query = req_2.query.clone().map(|x| x.replace("id name", "name"));
-
-                // Modify the request so that it is a valid array of 3 requests.
-                let mut json_bytes_1 = serde_json::to_vec(&req_1).unwrap();
-                let mut json_bytes_2 = serde_json::to_vec(&req_2).unwrap();
-                let mut json_bytes_3 = serde_json::to_vec(&req_3).unwrap();
-                let mut result = vec![b'['];
-                result.append(&mut json_bytes_1);
-                result.push(b',');
-                result.append(&mut json_bytes_2);
-                result.push(b',');
-                result.append(&mut json_bytes_3);
-                result.push(b']');
-                hyper::Body::from(result)
-            });
-=======
         let http_request = batch_with_three_unique_queries();
->>>>>>> dfa3aa0a (Add configuration option to limit maximum batch size (#7005))
         let config = serde_json::json!({
             "batching": {
                 "enabled": true,
@@ -580,168 +550,6 @@ async fn escaped_quotes_in_string_literal() {
     // The string literal made it through unchanged:
     assert!(subgraph_query.contains(r#"reviewsForAuthor(authorID: "\"1\"")"#));
 }
-<<<<<<< HEAD
-=======
-
-#[tokio::test]
-async fn it_stores_operation_error_when_config_is_enabled() {
-    async {
-        let query = "query operationName { __typename }";
-        let operation_name = "operationName";
-        let operation_type = "query";
-        let operation_id = "opId";
-        let client_name = "client";
-        let client_version = "version";
-
-        let mut config = Configuration::default();
-        config.apollo_plugins.plugins.insert(
-            "telemetry".to_string(),
-            serde_json::json!({
-                "apollo": {
-                    "errors": {
-                        "preview_extended_error_metrics": "enabled",
-                        "subgraph": {
-                            "subgraphs": {
-                                "myIgnoredSubgraph": {
-                                    "send": false,
-                                }
-                            }
-                        }
-                    }
-                }
-            }),
-        );
-
-        let mut router_service = from_supergraph_mock_callback_and_configuration(
-            move |req| {
-                let example_response = graphql::Response::builder()
-                    .data(json!({"data": null}))
-                    .extension(EXTENSIONS_VALUE_COMPLETION_KEY, json!([{
-                        "message": "Cannot return null for non-nullable field SomeType.someField",
-                        "path": Path::from("someType/someField")
-                    }]))
-                    .errors(vec![
-                        graphql::Error::builder()
-                            .message("some error")
-                            .extension_code("SOME_ERROR_CODE")
-                            .extension("service", "mySubgraph")
-                            .path(Path::from("obj/field"))
-                            .build(),
-                        graphql::Error::builder()
-                            .message("some other error")
-                            .extension_code("SOME_OTHER_ERROR_CODE")
-                            .extension("service", "myOtherSubgraph")
-                            .path(Path::from("obj/arr/@/firstElementField"))
-                            .build(),
-                        graphql::Error::builder()
-                            .message("some ignored error")
-                            .extension_code("SOME_IGNORED_ERROR_CODE")
-                            .extension("service", "myIgnoredSubgraph")
-                            .path(Path::from("obj/arr/@/firstElementField"))
-                            .build(),
-                    ])
-                    .build();
-                Ok(SupergraphResponse::new_from_graphql_response(
-                    example_response,
-                    req.context,
-                ))
-            },
-            Arc::new(config),
-        )
-        .await;
-
-        let context = Context::new();
-        context.insert_json_value(APOLLO_OPERATION_ID, operation_id.into());
-        context.insert_json_value(OPERATION_NAME, operation_name.into());
-        context.insert_json_value(OPERATION_KIND, query.into());
-        context.insert_json_value(CLIENT_NAME, client_name.into());
-        context.insert_json_value(CLIENT_VERSION, client_version.into());
-
-        let post_request = supergraph::Request::builder()
-            .query(query)
-            .operation_name(operation_name)
-            .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-            .uri(Uri::from_static("/"))
-            .method(Method::POST)
-            .context(context)
-            .build()
-            .unwrap();
-
-        router_service
-            .ready()
-            .await
-            .unwrap()
-            .call(post_request.try_into().unwrap())
-            .await
-            .unwrap();
-
-        assert_counter!(
-            "apollo.router.operations.error",
-            1,
-            &[
-                KeyValue::new("apollo.operation.id", operation_id),
-                KeyValue::new("graphql.operation.name", operation_name),
-                KeyValue::new("graphql.operation.type", operation_type),
-                KeyValue::new("apollo.client.name", client_name),
-                KeyValue::new("apollo.client.version", client_version),
-                KeyValue::new("graphql.error.extensions.code", "SOME_ERROR_CODE"),
-                KeyValue::new("graphql.error.extensions.severity", "ERROR"),
-                KeyValue::new("graphql.error.path", "/obj/field"),
-                KeyValue::new("apollo.router.error.service", "mySubgraph"),
-            ]
-        );
-        assert_counter!(
-            "apollo.router.operations.error",
-            1,
-            &[
-                KeyValue::new("apollo.operation.id", operation_id),
-                KeyValue::new("graphql.operation.name", operation_name),
-                KeyValue::new("graphql.operation.type", operation_type),
-                KeyValue::new("apollo.client.name", client_name),
-                KeyValue::new("apollo.client.version", client_version),
-                KeyValue::new("graphql.error.extensions.code", "SOME_OTHER_ERROR_CODE"),
-                KeyValue::new("graphql.error.extensions.severity", "ERROR"),
-                KeyValue::new("graphql.error.path", "/obj/arr/@/firstElementField"),
-                KeyValue::new("apollo.router.error.service", "myOtherSubgraph"),
-            ]
-        );
-        assert_counter!(
-            "apollo.router.operations.error",
-            1,
-            &[
-                KeyValue::new("apollo.operation.id", operation_id),
-                KeyValue::new("graphql.operation.name", operation_name),
-                KeyValue::new("graphql.operation.type", operation_type),
-                KeyValue::new("apollo.client.name", client_name),
-                KeyValue::new("apollo.client.version", client_version),
-                KeyValue::new(
-                    "graphql.error.extensions.code",
-                    "RESPONSE_VALIDATION_FAILED"
-                ),
-                KeyValue::new("graphql.error.extensions.severity", "WARN"),
-                KeyValue::new("graphql.error.path", "/someType/someField"),
-                KeyValue::new("apollo.router.error.service", ""),
-            ]
-        );
-        assert_counter_not_exists!(
-            "apollo.router.operations.error",
-            u64,
-            &[
-                KeyValue::new("apollo.operation.id", operation_id),
-                KeyValue::new("graphql.operation.name", operation_name),
-                KeyValue::new("graphql.operation.type", operation_type),
-                KeyValue::new("apollo.client.name", client_name),
-                KeyValue::new("apollo.client.version", client_version),
-                KeyValue::new("graphql.error.extensions.code", "SOME_IGNORED_ERROR_CODE"),
-                KeyValue::new("graphql.error.extensions.severity", "ERROR"),
-                KeyValue::new("graphql.error.path", "/obj/arr/@/firstElementField"),
-                KeyValue::new("apollo.router.error.service", "myIgnoredSubgraph"),
-            ]
-        );
-    }
-    .with_metrics()
-    .await;
-}
 
 #[tokio::test]
 async fn it_processes_a_valid_query_batch_with_maximum_size() {
@@ -763,12 +571,8 @@ async fn it_processes_a_valid_query_batch_with_maximum_size() {
     let response = oneshot_request(http_request, config).await.response;
     assert_eq!(response.status(), http::StatusCode::OK);
 
-    let data: serde_json::Value = serde_json::from_slice(
-        &router::body::into_bytes(response.into_body())
-            .await
-            .unwrap(),
-    )
-    .unwrap();
+    let data: serde_json::Value =
+        serde_json::from_slice(&get_body_bytes(response.into_body()).await.unwrap()).unwrap();
     assert_eq!(expected_response, data);
 }
 
@@ -799,17 +603,13 @@ async fn it_will_not_process_a_batch_that_exceeds_the_maximum_size() {
     let response = oneshot_request(http_request, config).await.response;
     assert_eq!(response.status(), http::StatusCode::UNPROCESSABLE_ENTITY);
 
-    let data: serde_json::Value = serde_json::from_slice(
-        &router::body::into_bytes(response.into_body())
-            .await
-            .unwrap(),
-    )
-    .unwrap();
+    let data: serde_json::Value =
+        serde_json::from_slice(&get_body_bytes(response.into_body()).await.unwrap()).unwrap();
     assert_eq!(expected_response, data);
 }
 
 async fn oneshot_request(
-    http_request: Request<RouterBody>,
+    http_request: Request<hyper::Body>,
     config: serde_json::Value,
 ) -> router::Response {
     crate::TestHarness::builder()
@@ -823,7 +623,7 @@ async fn oneshot_request(
         .unwrap()
 }
 
-fn batch_with_three_unique_queries() -> Request<RouterBody> {
+fn batch_with_three_unique_queries() -> Request<hyper::Body> {
     supergraph::Request::canned_builder()
         .build()
         .unwrap()
@@ -846,7 +646,6 @@ fn batch_with_three_unique_queries() -> Request<RouterBody> {
             result.push(b',');
             result.append(&mut json_bytes_3);
             result.push(b']');
-            router::body::from_bytes(result)
+            hyper::Body::from(result)
         })
 }
->>>>>>> dfa3aa0a (Add configuration option to limit maximum batch size (#7005))

--- a/docs/source/routing/performance/query-batching.mdx
+++ b/docs/source/routing/performance/query-batching.mdx
@@ -62,6 +62,7 @@ batching:
 | :-- | :-- | :-- | :-- |
 | `enabled` | Flag to enable reception of client query batches | boolean | `false` |
 | `mode` | Supported client batching mode | `batch_http_link`:  the client uses Apollo Link and its [`BatchHttpLink`](/react/api/link/apollo-link-batch-http) link. | No Default |
+| `maximum_size` | Maximum number of queries in a client batch (optional) | integer | `null` (no limit on number of queries) |
 
 #### Subgraph query batching
 
@@ -320,6 +321,53 @@ As a result, the router returns an invalid batch error:
 {"errors":
   [
     {"message":"Invalid GraphQL request","extensions":{"details":"failed to deserialize the request body into JSON: expected value at line 1 column 54","code":"INVALID_GRAPHQL_REQUEST"}}
+  ]
+}
+```
+
+### Excessive queries batch error
+
+If the number of queries provided exceeds the maximum batch size, the entire batch fails.
+
+For example, this configuration sets a batch size limit of 2, but three queries are provided:
+```yaml
+batching:
+  enabled: true
+  mode: batch_http_link
+  maximum_size: 2
+```
+
+```graphql
+[
+  query MyFirstQuery {
+    me {
+      id
+    }
+  },
+  query MySecondQuery {
+    me {
+      name
+    }
+  },
+  query MyThirdQuery {
+    me {
+      name
+    }
+  }
+]
+```
+
+As a result, the router returns an error:
+```json
+{
+  "errors": [
+    {
+      "message": "Invalid GraphQL request",
+      "extensions": {
+        "details": "Batch limits exceeded: you provided a batch with 3 entries, but the configured maximum router batch size is 2",
+        "code": "BATCH_LIMIT_EXCEEDED"
+      }
+    }
   ]
 }
 ```


### PR DESCRIPTION
Add an optional `maximum_size` parameter to the batching configuration. 
* When specified, the router will reject requests which contain more than `maximum_size` queries in the client batch.
* When unspecified, the router performs no size checking (the current behavior).

I've also added tests for the configuration and router, and updated the documentation to reflect the new parameter.

NB: I ended up using HTTP code 422 (`Unprocessable Content`) as the error code when a batch is rejected due to the maximum size limit. My original plan was to use 413 (`Content Too Large`), but the error ended up being mangled by the `limit` plugin.




---
<!-- [ROUTER-1096](https://apollographql.atlassian.net/browse/ROUTER-1096) -->
**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1096]: https://apollographql.atlassian.net/browse/ROUTER-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #7005 done by [Mergify](https://mergify.com).