### PR TITLE
support preserving key fields in connector response mapping

### DIFF
--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -314,11 +314,11 @@ fn root_fields(
 
                 let response_key = ResponseKey::RootField {
                     name: response_name,
-                    selection: Arc::new(
-                        connector
-                            .selection
-                            .apply_selection_set(&request.operation, &field.selection_set),
-                    ),
+                    selection: Arc::new(connector.selection.apply_selection_set(
+                        &request.operation,
+                        &field.selection_set,
+                        None,
+                    )),
                     inputs: request_inputs,
                 };
 
@@ -373,11 +373,11 @@ fn entities_from_request(
 
     let (entities_field, _) = graphql_utils::get_entity_fields(&request.operation, op)?;
 
-    let selection = Arc::new(
-        connector
-            .selection
-            .apply_selection_set(&request.operation, &entities_field.selection_set),
-    );
+    let selection = Arc::new(connector.selection.apply_selection_set(
+        &request.operation,
+        &entities_field.selection_set,
+        None,
+    ));
 
     representations
         .as_array()
@@ -528,11 +528,11 @@ fn entities_with_fields_from_request(
         .into_iter()
         .flatten()
         .flat_map(|(typename, field)| {
-            let selection = Arc::new(
-                connector
-                    .selection
-                    .apply_selection_set(&request.operation, &field.selection_set),
-            );
+            let selection = Arc::new(connector.selection.apply_selection_set(
+                &request.operation,
+                &field.selection_set,
+                None,
+            ));
 
             representations.iter().map(move |(i, representation)| {
                 let args = graphql_utils::field_arguments_map(field, &request.variables.variables)


### PR DESCRIPTION
the query planner doesn't ask for key fields when it makes a batch entity request (because it already has them). but we'll need key fields in order to match the response objects with the entity references and ensure that the batch result is consistent with the request

<!-- https://apollographql.atlassian.net/browse/CNN-633 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
