### PR TITLE
Remove the cancellation changeset

### DIFF
--- a/.changesets/fix_stance_intercom_body_director.md
+++ b/.changesets/fix_stance_intercom_body_director.md
@@ -1,5 +1,0 @@
-### Ensure query planning exits when its request times out ([PR #6840](https://github.com/apollographql/router/pull/6840))
-
-When a request times out/is cancelled, resources allocated to that request should be released. Previously, query planning could potentially keep running after the request is cancelled. After this fix, query planning now exits shortly after the request is cancelled. If you need query planning to run longer, you can [increase the request timeout](https://www.apollographql.com/docs/graphos/routing/performance/traffic-shaping#timeouts).
-
-By [@SimonSapin](https://github.com/SimonSapin) and [@sachindshinde](https://github.com/sachindshinde) in https://github.com/apollographql/router/pull/6840


### PR DESCRIPTION
Per #6949, this feature doesn't yet work fully. We also need significantly more design and testing time in order to release it without breaking customers.

The part of the feature that's already implemented doesn't hurt, so I'm keeping the existing implementation and its tests. It's not a problem to release it, it just won't do much.

But we shouldn't advertise it in the changelog for 2.1.