### PR TITLE
deps: remove unused dependency `async-channel`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,6 @@ dependencies = [
  "apollo-compiler",
  "apollo-environment-detector",
  "apollo-federation",
- "async-channel 1.9.0",
  "async-compression",
  "async-trait",
  "aws-config",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -59,7 +59,6 @@ snapshot = ["axum-server", "serde_regex"]
 anyhow = "1.0.86"
 apollo-compiler.workspace = true
 apollo-federation = { path = "../apollo-federation", version = "=2.0.0" }
-async-channel = "1.9.0"
 async-compression = { version = "0.4.6", features = [
     "tokio",
     "brotli",


### PR DESCRIPTION
Closes https://github.com/apollographql/router/pull/6923

async-channel is used elsewhere in our dep tree but not by the router directly.