### PR TITLE
Inject federation definitions when building test schemas

### DIFF
--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -645,7 +645,7 @@ impl FederationSpecDefinition {
         DirectiveSpecification::new(
             FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC,
             &[],
-            self.version().gt(&Version { major: 2, minor: 1 }), // repeatable in Fed 2.2 or later
+            self.version().ge(&Version { major: 2, minor: 2 }),
             &[
                 DirectiveLocation::FieldDefinition,
                 DirectiveLocation::Object,

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -551,6 +551,93 @@ impl FederationSpecDefinition {
             )?,
         })
     }
+
+    fn key_directive_specification() -> DirectiveSpecification {
+        DirectiveSpecification::new(
+            FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC,
+            &vec![
+                Self::fields_argument_specification(),
+                Self::resolvable_argument_specification(),
+            ],
+            true,
+            &[DirectiveLocation::Object, DirectiveLocation::Interface],
+            false,
+            None,
+        )
+    }
+
+    fn fields_argument_specification() -> DirectiveArgumentSpecification {
+        DirectiveArgumentSpecification {
+            base_spec: ArgumentSpecification {
+                name: FEDERATION_FIELDS_ARGUMENT_NAME,
+                get_type: |_| Ok(Type::Named(FIELDSET_SCALAR_NAME)),
+                default_value: None,
+            },
+            composition_strategy: None,
+        }
+    }
+
+    fn resolvable_argument_specification() -> DirectiveArgumentSpecification {
+        DirectiveArgumentSpecification {
+            base_spec: ArgumentSpecification {
+                name: FEDERATION_RESOLVABLE_ARGUMENT_NAME,
+                get_type: |_| Ok(ty!(Boolean)),
+                default_value: Some(Value::Boolean(true)),
+            },
+            composition_strategy: None,
+        }
+    }
+
+    fn requires_directive_specification() -> DirectiveSpecification {
+        DirectiveSpecification::new(
+            FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC,
+            &vec![Self::fields_argument_specification()],
+            false,
+            &[DirectiveLocation::FieldDefinition],
+            false,
+            None,
+        )
+    }
+
+    fn provides_directive_specification() -> DirectiveSpecification {
+        DirectiveSpecification::new(
+            FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC,
+            &vec![Self::fields_argument_specification()],
+            false,
+            &[DirectiveLocation::FieldDefinition],
+            false,
+            None,
+        )
+    }
+
+    fn external_directive_specification() -> DirectiveSpecification {
+        DirectiveSpecification::new(
+            FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC,
+            &vec![DirectiveArgumentSpecification {
+                base_spec: ArgumentSpecification {
+                    name: FEDERATION_REASON_ARGUMENT_NAME,
+                    get_type: |_| Ok(ty!(String)),
+                    default_value: None,
+                },
+                composition_strategy: None,
+            }],
+            false,
+            &[DirectiveLocation::FieldDefinition],
+            false,
+            None,
+        )
+    }
+
+    fn extends_directive_specification() -> DirectiveSpecification {
+        DirectiveSpecification::new(
+            FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC,
+            &[],
+            false,
+            &[DirectiveLocation::Object, DirectiveLocation::Interface],
+            false,
+            None,
+        )
+    }
 }
 
 impl SpecDefinition for FederationSpecDefinition {
@@ -559,31 +646,16 @@ impl SpecDefinition for FederationSpecDefinition {
     }
 
     fn directive_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
-        vec![Box::new(DirectiveSpecification::new(
-            FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC,
-            &vec![
-                DirectiveArgumentSpecification {
-                    base_spec: ArgumentSpecification {
-                        name: FEDERATION_FIELDS_ARGUMENT_NAME,
-                        get_type: |_| Ok(Type::Named(FIELDSET_SCALAR_NAME)),
-                        default_value: None,
-                    },
-                    composition_strategy: None,
-                },
-                DirectiveArgumentSpecification {
-                    base_spec: ArgumentSpecification {
-                        name: FEDERATION_RESOLVABLE_ARGUMENT_NAME,
-                        get_type: |_| Ok(ty!(Boolean)),
-                        default_value: Some(Value::Boolean(true)),
-                    },
-                    composition_strategy: None,
-                },
-            ],
-            true,
-            &[DirectiveLocation::Object, DirectiveLocation::Interface],
-            false,
-            None,
-        ))]
+        let mut specs: Vec<Box<dyn TypeAndDirectiveSpecification>> = vec![
+            Box::new(Self::key_directive_specification()),
+            Box::new(Self::requires_directive_specification()),
+            Box::new(Self::provides_directive_specification()),
+            Box::new(Self::external_directive_specification()),
+        ];
+        if self.is_fed1() {
+            specs.push(Box::new(Self::extends_directive_specification()));
+        }
+        specs
     }
 
     fn type_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -557,7 +557,7 @@ impl FederationSpecDefinition {
     fn key_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC,
-            &vec![
+            &[
                 Self::fields_argument_specification(),
                 Self::resolvable_argument_specification(),
             ],
@@ -593,7 +593,7 @@ impl FederationSpecDefinition {
     fn requires_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC,
-            &vec![Self::fields_argument_specification()],
+            &[Self::fields_argument_specification()],
             false,
             &[DirectiveLocation::FieldDefinition],
             false,
@@ -604,7 +604,7 @@ impl FederationSpecDefinition {
     fn provides_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC,
-            &vec![Self::fields_argument_specification()],
+            &[Self::fields_argument_specification()],
             false,
             &[DirectiveLocation::FieldDefinition],
             false,
@@ -615,7 +615,7 @@ impl FederationSpecDefinition {
     fn external_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC,
-            &vec![DirectiveArgumentSpecification {
+            &[DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: FEDERATION_REASON_ARGUMENT_NAME,
                     get_type: |_| Ok(ty!(String)),
@@ -655,7 +655,7 @@ impl FederationSpecDefinition {
     fn override_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC,
-            &vec![
+            &[
                 DirectiveArgumentSpecification {
                     base_spec: ArgumentSpecification {
                         name: FEDERATION_FROM_ARGUMENT_NAME,
@@ -683,7 +683,7 @@ impl FederationSpecDefinition {
     fn progressive_override_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC,
-            &vec![
+            &[
                 DirectiveArgumentSpecification {
                     base_spec: ArgumentSpecification {
                         name: FEDERATION_FROM_ARGUMENT_NAME,
@@ -711,7 +711,7 @@ impl FederationSpecDefinition {
     fn compose_directive_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             FEDERATION_COMPOSEDIRECTIVE_DIRECTIVE_NAME_IN_SPEC,
-            &vec![DirectiveArgumentSpecification {
+            &[DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: FEDERATION_NAME_ARGUMENT_NAME,
                     get_type: |_| Ok(ty!(String!)),

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -117,7 +117,7 @@ impl FederationBlueprint {
         ] {
             if let Some(pos) = schema.get_directive_definition(directive_name) {
                 let directive = pos.get(schema.schema())?;
-                if directive.arguments.len() == 0
+                if directive.arguments.is_empty()
                     || (directive.arguments.len() == 1
                         && directive
                             .argument_by_name(&FEDERATION_FIELDS_ARGUMENT_NAME)

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -134,7 +134,7 @@ impl FederationBlueprint {
                 // definition to re-add the "correct" version, we'd have to re-attach existing applications (doable but not
                 // done). This assert is so we notice it quickly if that ever happens (again, unlikely, because fed1 schema
                 // is a backward compatibility thing and there is no reason to expand that too much in the future).
-                if schema.referencers().get_directive(&directive_name)?.len() > 0 {
+                if schema.referencers().get_directive(directive_name)?.len() > 0 {
                     bail!(
                         "Subgraph has applications of @{directive_name} but we are trying to remove the definition."
                     );

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -226,7 +226,7 @@ mod tests {
                 name!("provides"),
                 name!("requires"),
                 name!("skip"),
-                name!("specifiedBy")
+                name!("specifiedBy"),
             ]
         );
     }
@@ -261,8 +261,51 @@ mod tests {
                 name!("include"),
                 name!("key"),
                 name!("link"),
+                name!("override"),
                 name!("provides"),
                 name!("requires"),
+                name!("shareable"),
+                name!("skip"),
+                name!("specifiedBy"),
+            ]
+        );
+    }
+
+    #[test]
+    fn injects_missing_directive_definitions_fed_2_1() {
+        let schema = Schema::parse(
+            r#"
+                extend schema @link(url: "https://specs.apollo.dev/federation/v2.1")
+
+                type Query {
+                    s: String
+                }"#,
+            "empty-fed2-schema.graphqls",
+        )
+        .expect("valid schema");
+        let subgraph = build_subgraph(&schema, true).expect("builds subgraph");
+
+        let mut defined_directive_names = subgraph
+            .schema()
+            .directive_definitions
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        defined_directive_names.sort();
+
+        assert_eq!(
+            defined_directive_names,
+            vec![
+                name!("composeDirective"),
+                name!("deprecated"),
+                name!("external"),
+                name!("include"),
+                name!("key"),
+                name!("link"),
+                name!("override"),
+                name!("provides"),
+                name!("requires"),
+                name!("shareable"),
                 name!("skip"),
                 name!("specifiedBy"),
             ]

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -207,7 +207,28 @@ mod tests {
         .expect("valid schema");
         let subgraph = build_subgraph(&schema, true).expect("builds subgraph");
 
-        assert!(subgraph.get_directive_definition(&name!("key")).is_some());
+        let mut defined_directive_names = subgraph
+            .schema()
+            .directive_definitions
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        defined_directive_names.sort();
+
+        assert_eq!(
+            defined_directive_names,
+            vec![
+                name!("deprecated"),
+                name!("extends"),
+                name!("external"),
+                name!("include"),
+                name!("key"),
+                name!("provides"),
+                name!("requires"),
+                name!("skip"),
+                name!("specifiedBy")
+            ]
+        );
     }
 
     #[test]
@@ -224,8 +245,28 @@ mod tests {
         .expect("valid schema");
         let subgraph = build_subgraph(&schema, true).expect("builds subgraph");
 
-        assert!(subgraph.get_directive_definition(&name!("link")).is_some());
-        assert!(subgraph.get_directive_definition(&name!("key")).is_some());
+        let mut defined_directive_names = subgraph
+            .schema()
+            .directive_definitions
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        defined_directive_names.sort();
+
+        assert_eq!(
+            defined_directive_names,
+            vec![
+                name!("deprecated"),
+                name!("external"),
+                name!("include"),
+                name!("key"),
+                name!("link"),
+                name!("provides"),
+                name!("requires"),
+                name!("skip"),
+                name!("specifiedBy"),
+            ]
+        );
     }
 
     fn build_subgraph(

--- a/apollo-federation/src/sources/connect/expand/carryover.rs
+++ b/apollo-federation/src/sources/connect/expand/carryover.rs
@@ -443,7 +443,7 @@ impl_copy_directive! {
 }
 
 impl DirectiveReferencers {
-    fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.schema.as_ref().map(|_| 1).unwrap_or_default()
             + self.scalar_types.len()
             + self.object_types.len()


### PR DESCRIPTION
The `build_subgraph` utility takes in a partial schema and expands it to include definitions for `@link` as well as federation directives. Note that this utility is still private to the blueprint tests, but it will soon be ready to use widely in composition tests. After collecting links metadata for the schema, it now applies the blueprint's `on_directive_definition_and_schema_parsed` hook, which ultimately uses the federation spec's `add_elements_to_schema` functionality.

JS source for blueprint hook in [federation.ts](https://github.com/apollographql/federation/blob/3566777b82cc7a5e011a096764f8ee2884524658/internals-js/src/federation.ts#L2113-L2240)

Some notes on the blueprint:
As we go along, we'll probably find that the code in the blueprint is either misnamed or obsolete. This PR also removes the base trait for `SchemaBlueprint` because the only nontrivial implementation in the JS base class is handling `graphql-js` error messages which won't apply in Rust. This code now uses `FederationBlueprint` directly, which removes some unnecessary self references previously needed for dispatch. Additionally, the hook names sometimes refer to the "parsing" that was done to convert from `graphql-js` ASTs into usable object formats, which is done for us by `apollo-compiler`. I have left the names as-is for now, but I have created a follow-up ticket for us to make these more declarative later on.

<!-- FED-540 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
