### PR TITLE
chore: warn about pushing changes to Github Actions automatic update PRs

### DIFF
--- a/.github/workflows/update_apollo_protobuf.yaml
+++ b/.github/workflows/update_apollo_protobuf.yaml
@@ -29,3 +29,7 @@ jobs:
           title: 'chore: Update Apollo Protobuf'
           body: |
             This updates the copy of `reports.proto` which this repository relies on with the latest copy fetched via our public endpoint.
+
+            > [!IMPORTANT]
+            > This PR will be continuously force-pushed with the new `reports.proto` copy. If the update requires code changes, apply them
+            > in a separate PR. This PR will be automatically closed if it is no longer necessary.

--- a/.github/workflows/update_uplink_schema.yml
+++ b/.github/workflows/update_uplink_schema.yml
@@ -31,3 +31,7 @@ jobs:
           title: 'chore: Update Uplink schema'
           body: |
             This updates the copy of `uplink.graphql` which this repository relies on with the latest copy fetched via `rover graph introspect`.
+
+            > [!IMPORTANT]
+            > This PR will be continuously force-pushed with the new `uplink.graphql` copy. If the update requires code changes, apply them
+            > in a separate PR. This PR will be automatically closed if it is no longer necessary.


### PR DESCRIPTION
I tried to apply some fixes to
https://github.com/apollographql/router/pull/6958 and ended up in an
existential struggle, force-pushing back and forth with Github Actions.
