### PR TITLE
fix(subscription): check if jwt claims is part of the context before getting the jwt expiration

### DIFF
--- a/.changesets/fix_bnjjj_fix_log_with_subs_jwt.md
+++ b/.changesets/fix_bnjjj_fix_log_with_subs_jwt.md
@@ -1,0 +1,6 @@
+### Check if jwt claims is part of the context before getting the jwt expiration with subscriptions ([PR #7069](https://github.com/apollographql/router/pull/7069))
+
+In https://github.com/apollographql/router/pull/6930 we introduced [logs](https://github.com/apollographql/router/pull/6930/files#diff-7597092ab9d509e0ffcb328691f1dded20f69d849f142628095f0455aa49880cR648) in `jwt_expires_in` function which causes a lot of logs when using subscriptions. 
+It also unveils a bug in the subscription implementation with JWT. Indeed if there was not JWT claims in the context, before we set a timeout set at `Duration::MAX`. Now it's always pending and there's no timeout anymore.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/7069

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::Ordering;
 use std::task::Poll;
 use std::time::Instant;
 
+use futures::FutureExt;
 use futures::TryFutureExt;
 use futures::future::BoxFuture;
 use futures::stream::StreamExt;
@@ -40,6 +41,7 @@ use crate::graphql::Response;
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::DynPlugin;
+use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
 use crate::plugins::connectors::query_plans::store_connectors;
 use crate::plugins::connectors::query_plans::store_connectors_labels;
 use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN;
@@ -559,9 +561,17 @@ async fn subscription_task(
     let mut configuration_updated_rx = notify.subscribe_configuration();
     let mut schema_updated_rx = notify.subscribe_schema();
 
-    let expires_in = crate::plugins::authentication::jwks::jwt_expires_in(&supergraph_req.context);
-
-    let mut timeout = Box::pin(tokio::time::sleep(expires_in));
+    let mut timeout = if supergraph_req
+        .context
+        .get_json_value(APOLLO_AUTHENTICATION_JWT_CLAIMS)
+        .is_some()
+    {
+        let expires_in =
+            crate::plugins::authentication::jwks::jwt_expires_in(&supergraph_req.context);
+        tokio::time::sleep(expires_in).boxed()
+    } else {
+        futures::future::pending().boxed()
+    };
 
     loop {
         tokio::select! {


### PR DESCRIPTION
In https://github.com/apollographql/router/pull/6930 we introduced [logs](https://github.com/apollographql/router/pull/6930/files#diff-7597092ab9d509e0ffcb328691f1dded20f69d849f142628095f0455aa49880cR648) in `jwt_expires_in` function which causes a lot of logs when using subscriptions. 
Thanks to this unexpected behavior it unveils a bug in the subscription implementation with JWT. Indeed if there was not JWT claims in the context, before we set a timeout set at `Duration::MAX`. Now it's always pending and there's no timeout anymore