### PR TITLE
Add support of ignored_headers for subscription deduplication

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2338,6 +2338,27 @@ expression: "&schema"
         }
       ]
     },
+    "DeduplicationConfig": {
+      "additionalProperties": false,
+      "description": "Deduplication configuration",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "Enable the deduplication of subscriptions (for example if we detect the exact same request to subgraph we won't open a new websocket to the subgraph in passthrough mode) (default: true)",
+          "type": "boolean"
+        },
+        "ignored_headers": {
+          "default": [],
+          "description": "List of headers to ignore for deduplication, for example if you forward 'user-agent' header but doesn't interfere with data returned by the subscription we can just ignore it to not create a new subscription connection",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
     "DefaultAttributeRequirementLevel": {
       "oneOf": [
         {
@@ -6994,10 +7015,9 @@ expression: "&schema"
       "additionalProperties": false,
       "description": "Subscriptions configuration",
       "properties": {
-        "enable_deduplication": {
-          "default": true,
-          "description": "Enable the deduplication of subscription (for example if we detect the exact same request to subgraph we won't open a new websocket to the subgraph in passthrough mode) (default: true)",
-          "type": "boolean"
+        "deduplication": {
+          "$ref": "#/definitions/DeduplicationConfig",
+          "description": "#/definitions/DeduplicationConfig"
         },
         "enabled": {
           "default": true,

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)] // FIXME
 
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -375,8 +376,7 @@ impl Response {
 }
 
 impl Request {
-    #[allow(dead_code)]
-    pub(crate) fn to_sha256(&self) -> String {
+    pub(crate) fn to_sha256(&self, ignored_headers: &HashSet<String>) -> String {
         let mut hasher = Sha256::new();
         let http_req = &self.subgraph_request;
         hasher.update(http_req.method().as_str().as_bytes());
@@ -403,7 +403,11 @@ impl Request {
         }
 
         // this assumes headers are in the same order
-        for (name, value) in http_req.headers() {
+        for (name, value) in http_req
+            .headers()
+            .iter()
+            .filter(|(name, _)| !ignored_headers.contains(name.as_str()))
+        {
             hasher.update(name.as_str().as_bytes());
             hasher.update(value.to_str().unwrap_or("ERROR").as_bytes());
         }
@@ -422,15 +426,71 @@ impl Request {
         }
         for (var_name, var_value) in &body.variables {
             hasher.update(var_name.inner());
-            // TODO implement to_bytes() for value in serde_json_bytes
-            hasher.update(var_value.to_string().as_bytes());
+            hasher.update(var_value.to_bytes());
         }
         for (name, val) in &body.extensions {
             hasher.update(name.inner());
             // TODO implement to_bytes() for value in serde_json_bytes
-            hasher.update(val.to_string().as_bytes());
+            hasher.update(val.to_bytes());
         }
 
         hex::encode(hasher.finalize())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subgraph_request_hash() {
+        let subgraph_req_1 = Request::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .header("public_header", "value")
+                    .header("auth", "my_token")
+                    .body(graphql::Request::default())
+                    .unwrap(),
+            )
+            .build();
+        let subgraph_req_2 = Request::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .header("public_header", "value_bis")
+                    .header("auth", "my_token")
+                    .body(graphql::Request::default())
+                    .unwrap(),
+            )
+            .build();
+        let mut ignored_headers = HashSet::new();
+        ignored_headers.insert("public_header".to_string());
+        assert_eq!(
+            subgraph_req_1.to_sha256(&ignored_headers),
+            subgraph_req_2.to_sha256(&ignored_headers)
+        );
+
+        let subgraph_req_1 = Request::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .header("public_header", "value")
+                    .header("auth", "my_token")
+                    .body(graphql::Request::default())
+                    .unwrap(),
+            )
+            .build();
+        let subgraph_req_2 = Request::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .header("public_header", "value_bis")
+                    .header("auth", "my_token")
+                    .body(graphql::Request::default())
+                    .unwrap(),
+            )
+            .build();
+        let ignored_headers = HashSet::new();
+        assert_ne!(
+            subgraph_req_1.to_sha256(&ignored_headers),
+            subgraph_req_2.to_sha256(&ignored_headers)
+        );
     }
 }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -235,8 +235,8 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                     });
                 }
             };
-            if subscription_config.enable_deduplication {
-                request.to_sha256()
+            if subscription_config.deduplication.enabled {
+                request.to_sha256(&subscription_config.deduplication.ignored_headers)
             } else {
                 Uuid::new_v4().to_string()
             }
@@ -1686,6 +1686,7 @@ mod tests {
     use crate::graphql::Error;
     use crate::graphql::Request;
     use crate::graphql::Response;
+    use crate::plugins::subscription::DeduplicationConfig;
     use crate::plugins::subscription::HeartbeatInterval;
     use crate::plugins::subscription::SUBSCRIPTION_CALLBACK_HMAC_KEY;
     use crate::plugins::subscription::SubgraphPassthroughMode;
@@ -2347,7 +2348,7 @@ mod tests {
                     .into(),
                 }),
             },
-            enable_deduplication: true,
+            deduplication: DeduplicationConfig::default(),
             max_opened_subscriptions: None,
             queue_capacity: None,
         }


### PR DESCRIPTION
Add support for `ignored_headers` for subscription deduplication which is a way to ignore some specific headers in deduplication because for example if you include some transaction ID in headers or so , then you can’t benefit from subscription dedup even if it doesn't change the data returned by susbscription.



Here is an example of configuration:

```yaml
subscription:
  enabled: true
  deduplication:
    enabled: true # optional, default: true
    ignored_headers: # (optional) List of ignored headers when deduplicating subscriptions
    - x-transaction-id
    - custom_header_name
```

<!-- [ROUTER-409] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
