### PR TITLE
docs: add missing slash in the config path

### DIFF
--- a/docs/source/routing/self-hosted/containerization/index.mdx
+++ b/docs/source/routing/self-hosted/containerization/index.mdx
@@ -19,7 +19,7 @@ Each release of the router includes both default (production) and debug images. 
 A router image has the following layout:
 
 * A `/dist` directory containing the router executable and licensing details
-* A `dist/config` directory containing a default configuration file, `router.yaml`
+* A `/dist/config` directory containing a default configuration file, `router.yaml`
 * A `/dist/schema` directory for conveniently mounting a locally defined supergraph schema
 
 ## Next steps


### PR DESCRIPTION
Noticed `/` is missing in the config path

Closes https://github.com/apollographql/router/pull/6107

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
