### PR TITLE
Split `@connect(http.body)` validations into two phases.

### DIFF
--- a/apollo-federation/src/sources/connect/validation/coordinates.rs
+++ b/apollo-federation/src/sources/connect/validation/coordinates.rs
@@ -10,7 +10,6 @@ use apollo_compiler::schema::ObjectType;
 
 use super::DirectiveName;
 use crate::sources::connect::id::ConnectedElement;
-use crate::sources::connect::spec::schema::CONNECT_BODY_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::CONNECT_ENTITY_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::CONNECT_SELECTION_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::CONNECT_SOURCE_ARGUMENT_NAME;
@@ -124,16 +123,6 @@ impl Display for BaseUrlCoordinate<'_> {
             "`@{source_directive_name}({SOURCE_BASE_URL_ARGUMENT_NAME}:)`",
         )
     }
-}
-
-pub(super) fn connect_directive_http_body_coordinate(
-    connect: &ConnectDirectiveCoordinate,
-) -> String {
-    format!(
-        "`@{connect_directive_name}({HTTP_ARGUMENT_NAME}: {{{CONNECT_BODY_ARGUMENT_NAME}:}})` on `{element}`",
-        connect_directive_name = connect.directive.name,
-        element = connect.element
-    )
 }
 
 pub(super) fn source_http_argument_coordinate(source_directive_name: &DirectiveName) -> String {


### PR DESCRIPTION
Right now parse and type_check are called back-to-back, but once other components are ready, the entire connector can be checked in two phases.

Also swapped the body coordinate to the lazy "don't allocate a string unless we need to" style we use elsewhere, but I put the coordinate right in `http` since I'm hopeful we won't _need_ a top-level `coordinates` module when this is all over.

There's also an open question of whether when we do the type-checking work for the body here if it'd be worth extracting info about keys for use later (rather than re-parsing & extracting as we do today).

<!-- [CNN-612] -->


[CNN-612]: https://apollographql.atlassian.net/browse/CNN-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ