### PR TITLE
Split `@connect(http.<METHOD>)` validation into phases.

### DIFF
--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -355,7 +355,7 @@ impl HttpJsonTransport {
 }
 
 /// The HTTP arguments needed for a connect request
-#[derive(Debug, Clone, strum_macros::Display)]
+#[derive(Debug, Clone, Copy)]
 pub enum HTTPMethod {
     Get,
     Post,
@@ -389,6 +389,12 @@ impl FromStr for HTTPMethod {
             "DELETE" => Ok(HTTPMethod::Delete),
             _ => Err(format!("Invalid HTTP method: {s}")),
         }
+    }
+}
+
+impl Display for HTTPMethod {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/apollo-federation/src/sources/connect/spec/schema.rs
+++ b/apollo-federation/src/sources/connect/spec/schema.rs
@@ -10,11 +10,6 @@ use crate::sources::connect::json_selection::JSONSelection;
 
 pub(crate) const CONNECT_DIRECTIVE_NAME_IN_SPEC: Name = name!("connect");
 pub(crate) const CONNECT_SOURCE_ARGUMENT_NAME: Name = name!("source");
-pub(crate) const CONNECT_HTTP_ARGUMENT_GET_METHOD_NAME: Name = name!("GET");
-pub(crate) const CONNECT_HTTP_ARGUMENT_POST_METHOD_NAME: Name = name!("POST");
-pub(crate) const CONNECT_HTTP_ARGUMENT_PUT_METHOD_NAME: Name = name!("PUT");
-pub(crate) const CONNECT_HTTP_ARGUMENT_PATCH_METHOD_NAME: Name = name!("PATCH");
-pub(crate) const CONNECT_HTTP_ARGUMENT_DELETE_METHOD_NAME: Name = name!("DELETE");
 pub(crate) const CONNECT_SELECTION_ARGUMENT_NAME: Name = name!("selection");
 pub(crate) const CONNECT_ENTITY_ARGUMENT_NAME: Name = name!("entity");
 

--- a/apollo-federation/src/sources/connect/validation/connect/http.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/http.rs
@@ -1,21 +1,19 @@
 //! Parsing and validation for `@connect(http:)`
 
 use std::fmt::Display;
+use std::str::FromStr;
 
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast::Value;
 use shape::Shape;
 
+use crate::sources::connect::HTTPMethod;
 use crate::sources::connect::JSONSelection;
 use crate::sources::connect::URLTemplate;
 use crate::sources::connect::spec::schema::CONNECT_BODY_ARGUMENT_NAME;
-use crate::sources::connect::spec::schema::CONNECT_HTTP_ARGUMENT_DELETE_METHOD_NAME;
-use crate::sources::connect::spec::schema::CONNECT_HTTP_ARGUMENT_GET_METHOD_NAME;
-use crate::sources::connect::spec::schema::CONNECT_HTTP_ARGUMENT_PATCH_METHOD_NAME;
-use crate::sources::connect::spec::schema::CONNECT_HTTP_ARGUMENT_POST_METHOD_NAME;
-use crate::sources::connect::spec::schema::CONNECT_HTTP_ARGUMENT_PUT_METHOD_NAME;
 use crate::sources::connect::spec::schema::HTTP_ARGUMENT_NAME;
+use crate::sources::connect::string_template;
 use crate::sources::connect::string_template::Expression;
 use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
@@ -26,10 +24,11 @@ use crate::sources::connect::validation::coordinates::HttpHeadersCoordinate;
 use crate::sources::connect::validation::coordinates::HttpMethodCoordinate;
 use crate::sources::connect::validation::expression;
 use crate::sources::connect::validation::expression::Context;
+use crate::sources::connect::validation::expression::scalars;
 use crate::sources::connect::validation::graphql::GraphQLString;
 use crate::sources::connect::validation::graphql::SchemaInfo;
 use crate::sources::connect::validation::http::headers;
-use crate::sources::connect::validation::http::url::validate_template;
+use crate::sources::connect::validation::http::url::validate_base_url;
 use crate::sources::connect::validation::source::SourceName;
 
 pub(super) fn validate(
@@ -72,18 +71,19 @@ pub(super) fn validate(
         schema,
     ));
 
-    errors.extend(
-        validate_method(
-            http_arg,
-            ConnectHTTPCoordinate::from(coordinate),
-            http_arg_node,
-            source_name,
-            schema,
-        )
-        .err()
-        .into_iter()
-        .flatten(),
-    );
+    // TODO: store transport in parsing phase and type check later
+    match Transport::parse(
+        http_arg,
+        ConnectHTTPCoordinate::from(coordinate),
+        http_arg_node,
+        source_name,
+        schema,
+    ) {
+        Ok(transport) => {
+            errors.extend(transport.type_check(schema));
+        }
+        Err(err) => errors.push(err),
+    }
 
     errors
 }
@@ -193,88 +193,153 @@ impl Display for BodyCoordinate<'_> {
     }
 }
 
-fn validate_method<'schema>(
-    http_arg: &'schema [(Name, Node<Value>)],
-    coordinate: ConnectHTTPCoordinate<'schema>,
-    http_arg_node: &Node<Value>,
-    source_name: Option<&SourceName<'schema>>,
-    schema: &SchemaInfo<'schema>,
-) -> Result<URLTemplate, Vec<Message>> {
-    let source_map = &schema.sources;
-    let mut methods = http_arg
-        .iter()
-        .filter(|(method, _)| {
-            [
-                CONNECT_HTTP_ARGUMENT_GET_METHOD_NAME,
-                CONNECT_HTTP_ARGUMENT_POST_METHOD_NAME,
-                CONNECT_HTTP_ARGUMENT_PUT_METHOD_NAME,
-                CONNECT_HTTP_ARGUMENT_PATCH_METHOD_NAME,
-                CONNECT_HTTP_ARGUMENT_DELETE_METHOD_NAME,
-            ]
-            .contains(method)
+/// The `@connect(http.<METHOD>:)` arg
+struct Transport<'schema> {
+    // TODO: once this is shared with `HttpJsonTransport`, this will be used
+    #[allow(dead_code)]
+    method: HTTPMethod,
+    url: URLTemplate,
+    url_string: GraphQLString<'schema>,
+    coordinate: HttpMethodCoordinate<'schema>,
+}
+
+impl<'schema> Transport<'schema> {
+    fn parse(
+        http_arg: &'schema [(Name, Node<Value>)],
+        coordinate: ConnectHTTPCoordinate<'schema>,
+        http_arg_node: &Node<Value>,
+        source_name: Option<&SourceName<'schema>>,
+        schema: &'schema SchemaInfo<'schema>,
+    ) -> Result<Self, Message> {
+        let source_map = &schema.sources;
+        let mut methods = http_arg
+            .iter()
+            .filter_map(|(method, value)| {
+                HTTPMethod::from_str(method)
+                    .ok()
+                    .map(|method| (method, value))
+            })
+            .peekable();
+
+        let Some((method, method_value)) = methods.next() else {
+            return Err(Message {
+                code: Code::MissingHttpMethod,
+                message: format!("{coordinate} must specify an HTTP method."),
+                locations: http_arg_node
+                    .line_column_range(source_map)
+                    .into_iter()
+                    .collect(),
+            });
+        };
+
+        if methods.peek().is_some() {
+            let locations = method_value
+                .line_column_range(source_map)
+                .into_iter()
+                .chain(methods.filter_map(|(_, node)| node.line_column_range(source_map)))
+                .collect();
+            return Err(Message {
+                code: Code::MultipleHttpMethods,
+                message: format!("{coordinate} cannot specify more than one HTTP method."),
+                locations,
+            });
+        }
+
+        let coordinate = HttpMethodCoordinate {
+            connect: coordinate.connect_directive_coordinate,
+            method,
+            node: method_value,
+        };
+
+        let url_string =
+            GraphQLString::new(coordinate.node, &schema.sources).map_err(|_| Message {
+                code: Code::GraphQLError,
+                message: format!("The value for {coordinate} must be a string."),
+                locations: coordinate
+                    .node
+                    .line_column_range(&schema.sources)
+                    .into_iter()
+                    .collect(),
+            })?;
+        let url = URLTemplate::from_str(url_string.as_str()).map_err(
+            |string_template::Error { message, location }| Message {
+                code: Code::InvalidUrl,
+                message: format!("In {coordinate}: {message}"),
+                locations: url_string
+                    .line_col_for_subslice(location, schema)
+                    .into_iter()
+                    .collect(),
+            },
+        )?;
+
+        if let Some(base) = url.base.as_ref() {
+            validate_base_url(base, coordinate, coordinate.node, url_string, schema)?;
+        }
+
+        if source_name.is_some() && url.base.is_some() {
+            return Err(Message {
+                code: Code::AbsoluteConnectUrlWithSource,
+                message: format!(
+                    "{coordinate} contains the absolute URL {raw_value} while also specifying a `{CONNECT_SOURCE_ARGUMENT_NAME}`. Either remove the `{CONNECT_SOURCE_ARGUMENT_NAME}` argument or change the URL to a path.",
+                    raw_value = coordinate.node
+                ),
+                locations: coordinate
+                    .node
+                    .line_column_range(source_map)
+                    .into_iter()
+                    .collect(),
+            });
+        }
+        if source_name.is_none() && url.base.is_none() {
+            return Err(Message {
+                code: Code::RelativeConnectUrlWithoutSource,
+                message: format!(
+                    "{coordinate} specifies the relative URL {raw_value}, but no `{CONNECT_SOURCE_ARGUMENT_NAME}` is defined. Either use an absolute URL including scheme (e.g. https://), or add a `@{source_directive_name}`.",
+                    raw_value = coordinate.node,
+                    source_directive_name = schema.source_directive_name(),
+                ),
+                locations: coordinate
+                    .node
+                    .line_column_range(source_map)
+                    .into_iter()
+                    .collect(),
+            });
+        }
+        Ok(Self {
+            method,
+            url,
+            url_string,
+            coordinate,
         })
-        .peekable();
-
-    let Some((method_name, method_value)) = methods.next() else {
-        return Err(vec![Message {
-            code: Code::MissingHttpMethod,
-            message: format!("{coordinate} must specify an HTTP method."),
-            locations: http_arg_node
-                .line_column_range(source_map)
-                .into_iter()
-                .collect(),
-        }]);
-    };
-
-    if methods.peek().is_some() {
-        let locations = method_value
-            .line_column_range(source_map)
-            .into_iter()
-            .chain(methods.filter_map(|(_, node)| node.line_column_range(source_map)))
-            .collect();
-        return Err(vec![Message {
-            code: Code::MultipleHttpMethods,
-            message: format!("{coordinate} cannot specify more than one HTTP method."),
-            locations,
-        }]);
     }
 
-    let coordinate = HttpMethodCoordinate {
-        connect: coordinate.connect_directive_coordinate,
-        http_method: method_name,
-        node: method_value,
-    };
+    /// Type-check the `@connect(http:<METHOD>:)` directive.
+    ///
+    /// TODO: get keys here instead of re-parsing later?
+    fn type_check(self, schema: &SchemaInfo) -> Vec<Message> {
+        let expression_context = Context::for_connect_request(
+            schema,
+            self.coordinate.connect,
+            &self.url_string,
+            Code::InvalidUrl,
+        );
 
-    let template = validate_template(coordinate, schema)?;
-
-    if source_name.is_some() && template.base.is_some() {
-        return Err(vec![Message {
-            code: Code::AbsoluteConnectUrlWithSource,
-            message: format!(
-                "{coordinate} contains the absolute URL {raw_value} while also specifying a `{CONNECT_SOURCE_ARGUMENT_NAME}`. Either remove the `{CONNECT_SOURCE_ARGUMENT_NAME}` argument or change the URL to a path.",
-                raw_value = coordinate.node
-            ),
-            locations: coordinate
-                .node
-                .line_column_range(source_map)
-                .into_iter()
-                .collect(),
-        }]);
+        let mut messages = Vec::new();
+        for expression in self.url.expressions() {
+            messages.extend(
+                expression::validate(expression, &expression_context, &scalars())
+                    .err()
+                    .into_iter()
+                    .map(|mut err| {
+                        err.message = format!(
+                            "In {coordinate}: {}",
+                            err.message,
+                            coordinate = self.coordinate
+                        );
+                        err
+                    }),
+            );
+        }
+        messages
     }
-    if source_name.is_none() && template.base.is_none() {
-        return Err(vec![Message {
-            code: Code::RelativeConnectUrlWithoutSource,
-            message: format!(
-                "{coordinate} specifies the relative URL {raw_value}, but no `{CONNECT_SOURCE_ARGUMENT_NAME}` is defined. Either use an absolute URL including scheme (e.g. https://), or add a `@{source_directive_name}`.",
-                raw_value = coordinate.node,
-                source_directive_name = schema.source_directive_name(),
-            ),
-            locations: coordinate
-                .node
-                .line_column_range(source_map)
-                .into_iter()
-                .collect(),
-        }]);
-    }
-    Ok(template)
 }

--- a/apollo-federation/src/sources/connect/validation/connect/http.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/http.rs
@@ -315,7 +315,7 @@ impl<'schema> Transport<'schema> {
 
     /// Type-check the `@connect(http:<METHOD>:)` directive.
     ///
-    /// TODO: get keys here instead of re-parsing later?
+    /// TODO: Return input shapes for keys instead reparsing for `Connector::resolvable_key` later
     fn type_check(self, schema: &SchemaInfo) -> Vec<Message> {
         let expression_context = Context::for_connect_request(
             schema,

--- a/apollo-federation/src/sources/connect/validation/coordinates.rs
+++ b/apollo-federation/src/sources/connect/validation/coordinates.rs
@@ -10,7 +10,6 @@ use apollo_compiler::schema::ObjectType;
 
 use super::DirectiveName;
 use crate::sources::connect::id::ConnectedElement;
-use crate::sources::connect::spec::schema::CONNECT_BODY_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::CONNECT_ENTITY_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::CONNECT_SELECTION_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::CONNECT_SOURCE_ARGUMENT_NAME;
@@ -124,16 +123,6 @@ impl Display for BaseUrlCoordinate<'_> {
             "`@{source_directive_name}({SOURCE_BASE_URL_ARGUMENT_NAME}:)`",
         )
     }
-}
-
-pub(super) fn connect_directive_http_body_coordinate(
-    connect: &ConnectDirectiveCoordinate,
-) -> String {
-    format!(
-        "`@{connect_directive_name}({HTTP_ARGUMENT_NAME}: {{{CONNECT_BODY_ARGUMENT_NAME}:}})` on `{element}`",
-        connect_directive_name = connect.directive.name,
-        element = connect.element
-    )
 }
 
 pub(super) fn source_http_argument_coordinate(source_directive_name: &DirectiveName) -> String {

--- a/apollo-federation/src/sources/connect/validation/coordinates.rs
+++ b/apollo-federation/src/sources/connect/validation/coordinates.rs
@@ -9,6 +9,7 @@ use apollo_compiler::ast::Value;
 use apollo_compiler::schema::ObjectType;
 
 use super::DirectiveName;
+use crate::sources::connect::HTTPMethod;
 use crate::sources::connect::id::ConnectedElement;
 use crate::sources::connect::spec::schema::CONNECT_ENTITY_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::CONNECT_SELECTION_ARGUMENT_NAME;
@@ -88,7 +89,7 @@ impl<'a> From<ConnectDirectiveCoordinate<'a>> for ConnectHTTPCoordinate<'a> {
 #[derive(Clone, Copy)]
 pub(super) struct HttpMethodCoordinate<'a> {
     pub(crate) connect: ConnectDirectiveCoordinate<'a>,
-    pub(crate) http_method: &'a Name,
+    pub(crate) method: HTTPMethod,
     pub(crate) node: &'a Node<Value>,
 }
 
@@ -96,12 +97,12 @@ impl Display for HttpMethodCoordinate<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let Self {
             connect: ConnectDirectiveCoordinate { directive, element },
-            http_method,
+            method,
             node: _node,
         } = self;
         write!(
             f,
-            "`{http_method}` in `@{connect_directive_name}({HTTP_ARGUMENT_NAME}:)` on `{element}`",
+            "`{method}` in `@{connect_directive_name}({HTTP_ARGUMENT_NAME}:)` on `{element}`",
             connect_directive_name = directive.name,
         )
     }

--- a/apollo-federation/src/sources/connect/validation/http/url.rs
+++ b/apollo-federation/src/sources/connect/validation/http/url.rs
@@ -1,84 +1,13 @@
 use std::fmt::Display;
-use std::str::FromStr;
 
 use apollo_compiler::Node;
 use apollo_compiler::ast::Value;
 use url::Url;
 
-use crate::sources::connect::URLTemplate;
-use crate::sources::connect::string_template;
 use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
-use crate::sources::connect::validation::coordinates::HttpMethodCoordinate;
-use crate::sources::connect::validation::expression;
-use crate::sources::connect::validation::expression::scalars;
 use crate::sources::connect::validation::graphql::GraphQLString;
 use crate::sources::connect::validation::graphql::SchemaInfo;
-
-pub(crate) fn validate_template(
-    coordinate: HttpMethodCoordinate,
-    schema: &SchemaInfo,
-) -> Result<URLTemplate, Vec<Message>> {
-    let (template, str_value) = match parse_template(coordinate, schema) {
-        Ok(tuple) => tuple,
-        Err(message) => return Err(vec![message]),
-    };
-    let mut messages = Vec::new();
-    if let Some(base) = template.base.as_ref() {
-        messages
-            .extend(validate_base_url(base, coordinate, coordinate.node, str_value, schema).err());
-    }
-    let expression_context = expression::Context::for_connect_request(
-        schema,
-        coordinate.connect,
-        &str_value,
-        Code::InvalidUrl,
-    );
-
-    for expression in template.expressions() {
-        messages.extend(
-            expression::validate(expression, &expression_context, &scalars())
-                .err()
-                .into_iter()
-                .map(|mut err| {
-                    err.message = format!("In {coordinate}: {}", err.message);
-                    err
-                }),
-        );
-    }
-
-    if messages.is_empty() {
-        Ok(template)
-    } else {
-        Err(messages)
-    }
-}
-
-fn parse_template<'schema>(
-    coordinate: HttpMethodCoordinate<'schema>,
-    schema: &'schema SchemaInfo,
-) -> Result<(URLTemplate, GraphQLString<'schema>), Message> {
-    let str_value = GraphQLString::new(coordinate.node, &schema.sources).map_err(|_| Message {
-        code: Code::GraphQLError,
-        message: format!("The value for {coordinate} must be a string."),
-        locations: coordinate
-            .node
-            .line_column_range(&schema.sources)
-            .into_iter()
-            .collect(),
-    })?;
-    let template = URLTemplate::from_str(str_value.as_str()).map_err(
-        |string_template::Error { message, location }| Message {
-            code: Code::InvalidUrl,
-            message: format!("In {coordinate}: {message}"),
-            locations: str_value
-                .line_col_for_subslice(location, schema)
-                .into_iter()
-                .collect(),
-        },
-    )?;
-    Ok((template, str_value))
-}
 
 pub(crate) fn validate_base_url(
     url: &Url,


### PR DESCRIPTION
Right now parse and type_check are called back-to-back, but once other components are ready, the entire connector can be checked in two phases.

Depends on:

- [x] https://github.com/apollographql/router/pull/7076

<!-- [CNN-612] -->


[CNN-612]: https://apollographql.atlassian.net/browse/CNN-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ