### PR TITLE
Split `@connect(selection:)` parsing & type checking.

### DIFF
--- a/apollo-federation/src/sources/connect/validation/connect.rs
+++ b/apollo-federation/src/sources/connect/validation/connect.rs
@@ -10,7 +10,7 @@ use apollo_compiler::schema::ObjectType;
 use itertools::Itertools;
 
 use self::entity::validate_entity_arg;
-use self::selection::get_seen_fields_from_selection;
+use self::selection::Selection;
 use super::Code;
 use super::Message;
 use super::coordinates::ConnectDirectiveCoordinate;
@@ -178,7 +178,14 @@ fn fields_seen_by_connector(
             },
         };
 
-        match get_seen_fields_from_selection(coordinate, schema) {
+        let selection = match Selection::parse(coordinate, schema) {
+            Ok(selection) => selection,
+            Err(err) => {
+                errors.push(err);
+                continue;
+            }
+        };
+        match selection.type_check(schema) {
             Ok(seen) => seen_fields.extend(seen),
             Err(error) => errors.push(error),
         }

--- a/apollo-federation/src/sources/connect/validation/coordinates.rs
+++ b/apollo-federation/src/sources/connect/validation/coordinates.rs
@@ -38,12 +38,12 @@ impl Display for ConnectDirectiveCoordinate<'_> {
 
 #[derive(Clone, Copy)]
 pub(super) struct SelectionCoordinate<'a> {
-    pub(crate) connect_directive_coordinate: ConnectDirectiveCoordinate<'a>,
+    pub(crate) connect: ConnectDirectiveCoordinate<'a>,
 }
 
 impl Display for SelectionCoordinate<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let ConnectDirectiveCoordinate { directive, element } = self.connect_directive_coordinate;
+        let ConnectDirectiveCoordinate { directive, element } = self.connect;
         write!(
             f,
             "`@{connect_directive_name}({CONNECT_SELECTION_ARGUMENT_NAME}:)` on `{element}`",
@@ -55,7 +55,7 @@ impl Display for SelectionCoordinate<'_> {
 impl<'a> From<ConnectDirectiveCoordinate<'a>> for SelectionCoordinate<'a> {
     fn from(connect_directive_coordinate: ConnectDirectiveCoordinate<'a>) -> Self {
         Self {
-            connect_directive_coordinate,
+            connect: connect_directive_coordinate,
         }
     }
 }

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@empty_selection.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@empty_selection.graphql.snap
@@ -6,16 +6,16 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/empty_sel
 [
     Message {
         code: InvalidSelection,
-        message: "`@connect(selection:)` on `Query.resources` is empty",
+        message: "`@connect(selection:)` on `Query.emptySelection` is empty",
         locations: [
             13:18..13:29,
         ],
     },
     Message {
         code: InvalidBody,
-        message: "`@connect(http: {body:})` on `Query.resources` is empty",
+        message: "`@connect(http: {body:})` on `Query.emptyBody` is empty",
         locations: [
-            12:41..12:45,
+            18:41..18:45,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/test_data/empty_selection.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/empty_selection.graphql
@@ -6,10 +6,16 @@ extend schema
   @source(name: "v2", http: { baseURL: "http://127.0.0.1" })
 
 type Query {
-  resources: [String!]!
+  emptySelection: [String!]!
+    @connect(
+      source: "v2"
+      http: { POST: "/resources" }
+      selection: "# comment"
+    )
+  emptyBody: [String!]!
     @connect(
       source: "v2"
       http: { POST: "/resources", body: "  " }
-      selection: "# comment"
+      selection: "$"
     )
 }


### PR DESCRIPTION
Basically, `get_json_selection` became `Selection::parse` and `get_seen_fields_from_selection` became `Selection::type_check`.

One thing we lose by splitting out parsing and type-checking is some ability to keep going after encountering an error. Because we need to keep the success result around (e.g., `Selection` in this case) for later type checking, it's much less ergonomic to collect errors. We'll have to decide if this is acceptable or worth the code complexity cost of working around.

<!-- [CNN-612] -->


[CNN-612]: https://apollographql.atlassian.net/browse/CNN-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ