### PR TITLE
Rename metric attribute `state` to `http.connection.state` (backport #7088)

### DIFF
--- a/.changesets/feat_bryn_connection_metrics_2_0.md
+++ b/.changesets/feat_bryn_connection_metrics_2_0.md
@@ -1,0 +1,14 @@
+### Add `apollo.router.open_connections` metric ([PR #7023](https://github.com/apollographql/router/pull/7023))
+
+To help users to diagnose when connections are keeping pipelines hanging around the following metric has been added:
+- `apollo.router.open_connections` - The number of request pipelines active in the router
+    - `schema.id` - The Apollo Studio schema hash associated with the pipeline.
+    - `launch.id` - The Apollo Studio launch id associated with the pipeline (optional).
+    - `config.hash` - The hash of the configuration.
+    - `server.address` - The address that the router is listening on.
+    - `server.port` - The port that the router is listening on if not a unix socket.
+    - `http.connection.state` - Either `active` or `terminating`.
+
+Connections can be held open by clients via keepalive or even just a long-running request, so it's useful to know when this is happening.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/7023

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -963,8 +963,9 @@ impl InstrumentsConfig {
                                 "config.hash",
                                 connection.pipeline_ref.config_hash.clone(),
                             ));
+                            // Technically we need to support `idle` state, but that will have to be a follow-up,
                             attributes.push(KeyValue::new(
-                                "state",
+                                "http.connection.state",
                                 match connection.state {
                                     ConnectionState::Active => "active",
                                     ConnectionState::Terminating => "terminating",

--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -131,6 +131,7 @@ The initial call to Uplink during router startup is not reflected in metrics.
   - `config.hash` - The hash of the configuration.
   - `server.address` - The address that the router is listening on.
   - `server.port` - The port that the router is listening on if not a unix socket.
+<<<<<<< HEAD
   - `state` - Either `active` or `terminating`.
 
 ### Deprecated
@@ -149,3 +150,6 @@ The following metrics have been deprecated and should not be used.
 - `apollo_router_http_request_duration_seconds_bucket` - **Deprecated**: HTTP subgraph request duration (replaced by `http.client.request.duration` metric configured in [instruments](./instruments)), attributes:
   - `subgraph`: (Optional) The subgraph being queried
 
+=======
+  - `http.connection.state` - Either `active` or `terminating`.
+>>>>>>> e59c8084 (Rename metric attribute `state` to `http.connection.state` (#7088))

--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -131,8 +131,7 @@ The initial call to Uplink during router startup is not reflected in metrics.
   - `config.hash` - The hash of the configuration.
   - `server.address` - The address that the router is listening on.
   - `server.port` - The port that the router is listening on if not a unix socket.
-<<<<<<< HEAD
-  - `state` - Either `active` or `terminating`.
+  - `http.connection.state` - Either `active` or `terminating`.
 
 ### Deprecated
 
@@ -149,7 +148,3 @@ The following metrics have been deprecated and should not be used.
 - `apollo_router_http_request_duration_seconds_bucket` - **Deprecated**: HTTP router request duration. It is replaced by `http.server.request.duration` metric configured in [instruments](./instruments).
 - `apollo_router_http_request_duration_seconds_bucket` - **Deprecated**: HTTP subgraph request duration (replaced by `http.client.request.duration` metric configured in [instruments](./instruments)), attributes:
   - `subgraph`: (Optional) The subgraph being queried
-
-=======
-  - `http.connection.state` - Either `active` or `terminating`.
->>>>>>> e59c8084 (Rename metric attribute `state` to `http.connection.state` (#7088))


### PR DESCRIPTION
In this PR we rename the `state` attribute on `apollo.router.open_connections` to `http.connection.state`

This enables us to use the [Otel convention] (https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-connection-state)

Technically this attribute is on a custom instrument, so there is no requirement to call it the same as the convention, but it's probably better from the user perspective to reuse a well known attribute.

Note that we don't support `idle` as a value yet, but we should add this in future.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7088 done by [Mergify](https://mergify.com).