### PR TITLE
Coprocessor httprequest span (backport #6856)

### DIFF
--- a/.changesets/feat_coprocessorhttprequestspan.md
+++ b/.changesets/feat_coprocessorhttprequestspan.md
@@ -1,0 +1,15 @@
+### Instrument coprocessor request with http_request span ([Issue #6739](https://github.com/apollographql/router/issues/6739))
+
+Coprocessor requests will now emit an `http_request` span. This span can help to gain
+insight into latency that may be introduced over the network stack when communicating with coprocessor. 
+
+Coprocessor span attributes are:
+* `otel.kind`: `CLIENT`
+* `http.request.method`: `POST`
+* `server.address`: `<target address>`
+* `server.port`: `<target port>`
+* `url.full`: `<url.full>`
+* `otel.name`: `<method> <url.full>`
+* `otel.original_name`: `http_request`
+
+By [Jon Christiansen](https://github.com/theJC) in https://github.com/apollographql/router/pull/6776

--- a/apollo-router/src/services/snapshots/apollo_router__services__external__test__it_will_create_an_http_request_span@logs.snap
+++ b/apollo-router/src/services/snapshots/apollo_router__services__external__test__it_will_create_an_http_request_span@logs.snap
@@ -1,0 +1,25 @@
+---
+source: apollo-router/src/services/external.rs
+expression: yaml
+---
+- fields: {}
+  level: INFO
+  message: got request
+  span:
+    http.request.method: POST
+    name: http_request
+    otel.kind: CLIENT
+    otel.name: "POST http://example.com/test"
+    otel.original_name: http_request
+    server.address: example.com
+    server.port: "80"
+    url.full: "http://example.com/test"
+  spans:
+    - http.request.method: POST
+      name: http_request
+      otel.kind: CLIENT
+      otel.name: "POST http://example.com/test"
+      otel.original_name: http_request
+      server.address: example.com
+      server.port: "80"
+      url.full: "http://example.com/test"


### PR DESCRIPTION
Brings in PR #6776 that adds a span to coprocessor requests.

Coprocessor requests will now emit an `http_request` span. This span can help to gain
insight into latency that may be introduced over the network stack when communicating with coprocessor. 

Coprocessor span attributes are:
* `otel.kind`: `CLIENT`
* `http.request.method`: `POST`
* `server.address`: `<target address>`
* `server.port`: `<target port>`
* `url.full`: `<url.full>`
* `otel.name`: `<method> <url.full>`
* `otel.original_name`: `http_request`


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #6856 done by [Mergify](https://mergify.com).