### PR TITLE
federation/composition: ported `LinkSpecDefinition::add_definitions_to_schema`

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -524,12 +524,16 @@ impl From<FederationSpecError> for FederationError {
     }
 }
 
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error, Default)]
 pub struct MultipleFederationErrors {
     pub errors: Vec<SingleFederationError>,
 }
 
 impl MultipleFederationErrors {
+    pub fn new() -> Self {
+        Self { errors: vec![] }
+    }
+
     pub fn push(&mut self, error: FederationError) {
         match error {
             FederationError::SingleFederationError(error) => {
@@ -643,7 +647,56 @@ impl FederationError {
         }
         .into()
     }
+
+    pub fn merge(self, other: Self) -> Self {
+        let mut result = MultipleFederationErrors::new();
+        result.push(self);
+        result.push(other);
+        result.into()
+    }
 }
+
+// Similar to `multi_try` crate, but with `FederationError` instead of `Vec<E>`.
+pub trait MultiTry<U> {
+    type Output;
+
+    fn and_try(self, other: Result<U, FederationError>) -> Self::Output;
+}
+
+impl<U> MultiTry<U> for Result<(), FederationError> {
+    type Output = Result<U, FederationError>;
+
+    fn and_try(self, other: Result<U, FederationError>) -> Result<U, FederationError> {
+        match (self, other) {
+            (Ok(_a), Ok(b)) => Ok(b),
+            (Ok(_a), Err(b)) => Err(b),
+            (Err(a), Ok(_b)) => Err(a),
+            (Err(a), Err(b)) => Err(a.merge(b)),
+        }
+    }
+}
+
+pub trait MultiTryAll: Sized + Iterator {
+    /// Apply `predicate` on all elements of the iterator, collecting all errors (if any).
+    /// - Returns Ok(()), if all elements are Ok.
+    /// - Otherwise, returns a FederationError with all errors.
+    /// - Note: Not to be confused with `try_for_each`, which stops on the first error.
+    fn try_for_all<F>(self, mut predicate: F) -> Result<(), FederationError>
+    where
+        F: FnMut(Self::Item) -> Result<(), FederationError>,
+    {
+        let mut errors = MultipleFederationErrors::new();
+        for item in self {
+            match predicate(item) {
+                Ok(()) => {}
+                Err(e) => errors.push(e),
+            }
+        }
+        errors.into_result()
+    }
+}
+
+impl<I: Iterator> MultiTryAll for I {}
 
 impl MultipleFederationErrors {
     /// Converts into `Result<(), FederationError>`.

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = r#"MultipleFederationErrors { errors: [Internal { message: "Type Purpose shouldn't be added without being attached to a @link spec" }, Internal { message: "Type Import shouldn't be added without being attached to a @link spec" }] }"#
+        expected = r#"builds subgraph: Internal { message: "Schema definition's directive application \"@link\" does not refer to an existing directive." }"#
     )]
     fn detects_federation_2_subgraphs_correctly() {
         let schema = Schema::parse(


### PR DESCRIPTION
Also specialized `add_elements_to_schema` for `LinkSpecDefinition`.

- This PR changes the error message from the `detects_federation_2_subgraphs_correctly` test.
- Added `MultiTry` and `MultiTryAll` traits for collecting all errors across calls (inspired by `multi_try` crate, but for `FederationError`).

TODO
* port `SchemaDefinition::hasExtensionElements/hasNonExtensionElements`
* port `CoreFeatures.coreItself`