### PR TITLE
Add changelog for `state`->`http.connection.state` rename

### DIFF
--- a/.changesets/bug_bryn_connection_metrics_rename.md
+++ b/.changesets/bug_bryn_connection_metrics_rename.md
@@ -1,4 +1,4 @@
-### Add `apollo.router.open_connections` metric `state` attribute rename ([PR #7091](https://github.com/apollographql/router/pull/7023))
+### Add `apollo.router.open_connections` metric `state` attribute rename ([PR #7091](https://github.com/apollographql/router/pull/7091))
 
 The `state` attribute on `apollo.router.open_connections` has been renamed to `http.connection.state`.
 

--- a/.changesets/bug_bryn_connection_metrics_rename.md
+++ b/.changesets/bug_bryn_connection_metrics_rename.md
@@ -1,0 +1,9 @@
+### Add `apollo.router.open_connections` metric `state` attribute rename ([PR #7091](https://github.com/apollographql/router/pull/7023))
+
+The `state` attribute on `apollo.router.open_connections` has been renamed to `http.connection.state`.
+
+This enables us to use the [Otel convention] (https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-connection-state) and provide better consistency for users.
+
+Note that `idle` state is not yet supported.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/7091


### PR DESCRIPTION
In the 2.1.0 release we added a metric `apollo.router.open-connections`.

This had an attribute `state` which should have been `http.connection.state`. However the rename PRs missed the cut for the release.

The actual PRs for the rename did get merged, but they updated the original changelog items which will be zapped once the release happens.

It was deemed better to fix this now before many people start relying on this metric.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
