### PR TITLE
Remove `UnwindSafe` bound and panic `Result` from `compute_job::execute`

### DIFF
--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -168,8 +168,7 @@ impl IntrospectionCache {
         // * We try to avoid such panics in the first place and consider them bugs
         // * The panic handler in `apollo-router/src/executable.rs` exits the process
         //   so this error case should never be reached.
-        .await
-        .expect("Introspection panicked");
+        .await;
         storage.insert(cache_key, response.clone()).await;
         Ok(response)
     }

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -169,13 +169,7 @@ impl QueryPlannerService {
         };
         let (plan, mut root_node) = compute_job::execute(priority, job)
             .map_err(MaybeBackPressureError::TemporaryError)?
-            .await
-            // `expect()` propagates any panic that potentially happens in the closure, but:
-            //
-            // * We try to avoid such panics in the first place and consider them bugs
-            // * The panic handler in `apollo-router/src/executable.rs` exits the process
-            //   so this error case should never be reached.
-            .expect("query planner panicked")?;
+            .await?;
         if let Some(node) = &mut root_node {
             init_query_plan_root_node(node).map_err(QueryPlannerError::from)?;
         }


### PR DESCRIPTION
This PR is expected to not change any run-time behavior, but makes it easier to use the “compute” thread pool:

* The return type no longer includes a `Result` related to the callback having panicked. Instead `resume_unwind` is used to propagate any panic to the caller. This is not a behavior change because every single caller was using `.expect()` on that `Result`, and because we also install a panic hook that exits the process so unwinding never starts this whole code path is unreachable.

* The callback no longer needs to implement `UnwindSafe`. With the above change, `compute_job::execute(job)` is effectively the same as `job()` regarding unwind safety.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
