### PR TITLE
Prevent composition of 0.2.

### DIFF
--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -17,6 +17,7 @@ autotests = false                                      # Integration tests are m
 snapshot_tracing = ["ron"]
 # `correctness` feature enables the `correctness` module.
 correctness = []
+connect_v02 = []
 
 [dependencies]
 apollo-compiler.workspace = true

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -17,7 +17,7 @@ autotests = false                                      # Integration tests are m
 snapshot_tracing = ["ron"]
 # `correctness` feature enables the `correctness` module.
 correctness = []
-connect_v02 = []
+"connect_v0.2" = []
 
 [dependencies]
 apollo-compiler.workspace = true

--- a/apollo-federation/src/sources/connect/spec/mod.rs
+++ b/apollo-federation/src/sources/connect/spec/mod.rs
@@ -156,6 +156,14 @@ impl ConnectSpec {
             ConnectSpec::V0_2 => CONNECT_V0_2_LOCATIONS,
         }
     }
+
+    pub(crate) const fn available() -> &'static [ConnectSpec] {
+        if cfg!(any(feature = "connect_v02", test)) {
+            &[ConnectSpec::V0_1, ConnectSpec::V0_2]
+        } else {
+            &[ConnectSpec::V0_1]
+        }
+    }
 }
 
 impl TryFrom<&Version> for ConnectSpec {
@@ -163,6 +171,7 @@ impl TryFrom<&Version> for ConnectSpec {
     fn try_from(version: &Version) -> Result<Self, Self::Error> {
         match (version.major, version.minor) {
             (0, 1) => Ok(Self::V0_1),
+            #[cfg(any(feature = "connect_v02", test))]
             (0, 2) => Ok(Self::V0_2),
             _ => Err(SingleFederationError::UnknownLinkVersion {
                 message: format!("Unknown connect version: {version}"),

--- a/apollo-federation/src/sources/connect/spec/mod.rs
+++ b/apollo-federation/src/sources/connect/spec/mod.rs
@@ -158,7 +158,7 @@ impl ConnectSpec {
     }
 
     pub(crate) const fn available() -> &'static [ConnectSpec] {
-        if cfg!(any(feature = "connect_v02", test)) {
+        if cfg!(any(feature = "connect_v0.2", test)) {
             &[ConnectSpec::V0_1, ConnectSpec::V0_2]
         } else {
             &[ConnectSpec::V0_1]
@@ -171,7 +171,7 @@ impl TryFrom<&Version> for ConnectSpec {
     fn try_from(version: &Version) -> Result<Self, Self::Error> {
         match (version.major, version.minor) {
             (0, 1) => Ok(Self::V0_1),
-            #[cfg(any(feature = "connect_v02", test))]
+            #[cfg(any(feature = "connect_v0.2", test))]
             (0, 2) => Ok(Self::V0_2),
             _ => Err(SingleFederationError::UnknownLinkVersion {
                 message: format!("Unknown connect version: {version}"),

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -58,7 +58,7 @@ snapshot = ["axum-server", "serde_regex"]
 [dependencies]
 anyhow = "1.0.86"
 apollo-compiler.workspace = true
-apollo-federation = { path = "../apollo-federation", version = "=2.0.0" }
+apollo-federation = { path = "../apollo-federation", version = "=2.0.0", features = ["connect_v0.2"] }
 async-compression = { version = "0.4.6", features = [
     "tokio",
     "brotli",
@@ -67,8 +67,8 @@ async-compression = { version = "0.4.6", features = [
 ] }
 async-trait.workspace = true
 axum = { version = "0.8.1", features = ["http2"] }
-axum-extra = { version = "0.10.0", features = [ "typed-header" ] }
-axum-server = {  version = "0.7.1", optional = true }
+axum-extra = { version = "0.10.0", features = ["typed-header"] }
+axum-server = { version = "0.7.1", optional = true }
 base64 = "0.22.0"
 bloomfilter = "1.0.13"
 buildstructor = "0.6.0"
@@ -99,7 +99,7 @@ hex.workspace = true
 http.workspace = true
 http-0_2 = { version = "0.2.12", package = "http" }
 http-body = "1.0.1"
-http-body-util = {version = "0.1.2" }
+http-body-util = { version = "0.1.2" }
 heck = "0.5.0"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"


### PR DESCRIPTION
Unless a build of composition specifically opts in to the unstable 0.2 feature now, composition will reject 0.2 versions.