### PR TITLE
Improve the invocation of rhai service methods (backport #7112)

### DIFF
--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -1751,8 +1751,9 @@ impl Rhai {
         // change and one that requires more thought in the future.
         match subgraph {
             Some(name) => {
-                self.engine
-                    .call_fn(
+                let _ = self
+                    .engine
+                    .call_fn::<Dynamic>(
                         &mut guard,
                         &self.ast,
                         function_name,
@@ -1761,8 +1762,9 @@ impl Rhai {
                     .map_err(|err| err.to_string())?;
             }
             None => {
-                self.engine
-                    .call_fn(&mut guard, &self.ast, function_name, (rhai_service,))
+                let _ = self
+                    .engine
+                    .call_fn::<Dynamic>(&mut guard, &self.ast, function_name, (rhai_service,))
                     .map_err(|err| err.to_string())?;
             }
         }

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -119,7 +119,10 @@ impl Plugin for Rhai {
             ServiceStep::Router(shared_service.clone()),
             self.scope.clone(),
         ) {
-            tracing::error!("service callback failed: {error}");
+            tracing::error!(
+                service = "RouterService",
+                "service callback failed: {error}"
+            );
         }
         shared_service.take_unwrap()
     }
@@ -137,7 +140,10 @@ impl Plugin for Rhai {
             ServiceStep::Supergraph(shared_service.clone()),
             self.scope.clone(),
         ) {
-            tracing::error!("service callback failed: {error}");
+            tracing::error!(
+                service = "SupergraphService",
+                "service callback failed: {error}"
+            );
         }
         shared_service.take_unwrap()
     }
@@ -155,7 +161,10 @@ impl Plugin for Rhai {
             ServiceStep::Execution(shared_service.clone()),
             self.scope.clone(),
         ) {
-            tracing::error!("service callback failed: {error}");
+            tracing::error!(
+                service = "ExecutionService",
+                "service callback failed: {error}"
+            );
         }
         shared_service.take_unwrap()
     }
@@ -173,7 +182,11 @@ impl Plugin for Rhai {
             ServiceStep::Subgraph(shared_service.clone()),
             self.scope.clone(),
         ) {
-            tracing::error!("service callback failed: {error}");
+            tracing::error!(
+                service = "SubgraphService",
+                subgraph = name,
+                "service callback failed: {error}"
+            );
         }
         shared_service.take_unwrap()
     }

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__rhai_plugin_execution_service_error@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__rhai_plugin_execution_service_error@logs.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "[message]"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "execution :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "execution :: Request"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__rhai_plugin_supergraph_service@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__rhai_plugin_supergraph_service@logs.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+[]


### PR DESCRIPTION
Update the `call_fn` to indicate that the expected return type is `Dynamic` and improve the logging of errors so it's clear which service is failing.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7112 done by [Mergify](https://mergify.com).