### PR TITLE
Improve error message for invalid JWT Header values

### DIFF
--- a/.changesets/fix_improve_jwt_errors.md
+++ b/.changesets/fix_improve_jwt_errors.md
@@ -1,0 +1,16 @@
+### Improve Error Message for Invalid JWT Header Values ([PR #7121](https://github.com/apollographql/router/pull/7121))
+
+Enhanced parsing error messages for JWT Authorization header values now provide developers with clear, actionable feedback while ensuring that no sensitive data is exposed.
+
+Examples of the updated error messages:
+```diff
+-         Header Value: '<invalid value>' is not correctly formatted. prefix should be 'Bearer'
++         Value of 'authorization' JWT header should be prefixed with 'Bearer'
+```
+
+```diff
+-         Header Value: 'Bearer' is not correctly formatted. Missing JWT
++         Value of 'authorization' JWT header has only 'Bearer' prefix but no JWT token
+```
+
+By [@IvanGoncharov](https://github.com/IvanGoncharov) in https://github.com/apollographql/router/pull/7121

--- a/apollo-router/src/plugins/authentication/error.rs
+++ b/apollo-router/src/plugins/authentication/error.rs
@@ -13,11 +13,11 @@ pub(crate) enum AuthenticationError {
     /// Configured header is not convertible to a string
     CannotConvertToString,
 
-    /// Header Value: '{0}' is not correctly formatted. prefix should be '{1}'
-    InvalidPrefix(String, String),
+    /// Value of '{0}' JWT header should be prefixed with '{1}'
+    InvalidJWTPrefix(String, String),
 
-    /// Header Value: '{0}' is not correctly formatted. Missing JWT
-    MissingJWT(String),
+    /// Value of '{0}' JWT header has only '{1}' prefix but no JWT token
+    MissingJWTToken(String, String),
 
     /// '{0}' is not a valid JWT header: {1}
     InvalidHeader(String, JWTError),
@@ -78,8 +78,8 @@ impl AuthenticationError {
     pub(crate) fn as_context_object(&self) -> ErrorContext {
         let (code, reason) = match self {
             AuthenticationError::CannotConvertToString => ("CANNOT_CONVERT_TO_STRING", None),
-            AuthenticationError::InvalidPrefix(_, _) => ("INVALID_PREFIX", None),
-            AuthenticationError::MissingJWT(_) => ("MISSING_JWT", None),
+            AuthenticationError::InvalidJWTPrefix(_, _) => ("INVALID_PREFIX", None),
+            AuthenticationError::MissingJWTToken(_, _) => ("MISSING_JWT", None),
             AuthenticationError::InvalidHeader(_, jwt_err) => {
                 ("INVALID_HEADER", Some(jwt_error_to_reason(jwt_err).into()))
             }

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -485,8 +485,8 @@ pub(super) fn extract_jwt<'a, 'b: 'a>(
                 return if ignore_other_prefixes {
                     None
                 } else {
-                    Some(Err(AuthenticationError::InvalidPrefix(
-                        jwt_value_untrimmed.to_owned(),
+                    Some(Err(AuthenticationError::InvalidJWTPrefix(
+                        name.to_owned(),
                         value_prefix.to_owned(),
                     )))
                 };
@@ -496,8 +496,8 @@ pub(super) fn extract_jwt<'a, 'b: 'a>(
                 // check for whitespace — we've already trimmed, so this means the request has a
                 // prefix that shouldn't exist
                 if jwt_value.contains(' ') {
-                    return Some(Err(AuthenticationError::InvalidPrefix(
-                        jwt_value_untrimmed.to_owned(),
+                    return Some(Err(AuthenticationError::InvalidJWTPrefix(
+                        name.to_owned(),
                         value_prefix.to_owned(),
                     )));
                 }
@@ -508,7 +508,10 @@ pub(super) fn extract_jwt<'a, 'b: 'a>(
                 // Otherwise, we need to split our string in (at most 2) sections.
                 let jwt_parts: Vec<&str> = jwt_value.splitn(2, ' ').collect();
                 if jwt_parts.len() != 2 {
-                    return Some(Err(AuthenticationError::MissingJWT(jwt_value.to_owned())));
+                    return Some(Err(AuthenticationError::MissingJWTToken(
+                        name.to_owned(),
+                        value_prefix.to_owned(),
+                    )));
                 }
 
                 // We have our jwt

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -264,7 +264,10 @@ async fn it_rejects_when_auth_prefix_is_missing() {
     .unwrap();
 
     let expected_error = graphql::Error::builder()
-        .message("Header Value: 'invalid' is not correctly formatted. prefix should be 'Bearer'")
+        .message(format!(
+            "Value of '{0}' JWT header should be prefixed with 'Bearer'",
+            http::header::AUTHORIZATION,
+        ))
         .extension_code("AUTH_ERROR")
         .build();
 
@@ -274,7 +277,7 @@ async fn it_rejects_when_auth_prefix_is_missing() {
 }
 
 #[tokio::test]
-async fn it_rejects_when_auth_prefix_has_no_jwt() {
+async fn it_rejects_when_auth_prefix_has_no_jwt_token() {
     let test_harness = build_a_default_test_harness().await;
 
     // Let's create a request with our operation name
@@ -300,7 +303,10 @@ async fn it_rejects_when_auth_prefix_has_no_jwt() {
     .unwrap();
 
     let expected_error = graphql::Error::builder()
-        .message("Header Value: 'Bearer' is not correctly formatted. Missing JWT")
+        .message(format!(
+            "Value of '{0}' JWT header has only 'Bearer' prefix but no JWT token",
+            http::header::AUTHORIZATION,
+        ))
         .extension_code("AUTH_ERROR")
         .build();
 


### PR DESCRIPTION
Enhanced parsing error messages for JWT Authorization header values now provide developers with clear, actionable feedback while ensuring that no sensitive data is exposed.

Examples of the updated error messages:
```diff
-         Header Value: '<invalid value>' is not correctly formatted. prefix should be 'Bearer'
+         Value of 'authorization' JWT header should be prefixed with 'Bearer'
```

```diff
-         Header Value: 'Bearer' is not correctly formatted. Missing JWT
+         Value of 'authorization' JWT header has only 'Bearer' prefix but no JWT token
```

Fixes #**issue_number**

<!-- start metadata -->
<!-- [ROUTER-1212] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1212]: https://apollographql.atlassian.net/browse/ROUTER-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ