### PR TITLE
Revert: chore: Delegate setting "latest" to RELEASE_CHECKLIST.md, rather than CI. (backport #7125)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -937,10 +937,17 @@ jobs:
                   cd artifacts && sha1sum *.tar.gz > sha1sums.txt
             - run:
                 name: Create GitHub Release
-                # We always create the version as a "pre-release" version.
-                # It is promoted to latest in a separate step in RELEASE_CHECKLIST.md
                 command: >
-                  gh release create $VERSION --prerelease --notes-file /dev/null --title $VERSION artifacts/*
+                  case "$VERSION" in
+
+                    # If the VERSION contains a dash, consider it a pre-release version.
+                    # This is in-line with SemVer's expectations/designations!
+                    *-*) gh release create $VERSION --prerelease --notes-file /dev/null --title $VERSION artifacts/* ;;
+
+                    # In all other cases, publish it as the latest version.
+                    *) gh release create $VERSION --notes-file /dev/null --title $VERSION artifacts/* ;;
+
+                  esac
             - run:
                 name: Docker build
                 command: |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -440,15 +440,7 @@ Start following the steps below to start a release PR.  The process is **not ful
     gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" release edit v"${APOLLO_ROUTER_RELEASE_VERSION}" -F ./this_release.md
     ```
 
-18. (Conditional) If this is meant to be marked as the latest version, edit the release and add the "Latest" label:
-
-    > Note: As of this writing, we will only mark 1.x versions as Latest.
-
-    ```
-    gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" release edit v"${APOLLO_ROUTER_RELEASE_VERSION}" --latest
-    ```
-
-19. Finally, publish the Crates (`apollo-federation` followed by `apollo-router`) from your local computer from the `main` branch (this also needs to be moved to CI, but requires changing the release containers to be Rust-enabled and to restore the caches):
+18. Finally, publish the Crates (`apollo-federation` followed by `apollo-router`) from your local computer from the `main` branch (this also needs to be moved to CI, but requires changing the release containers to be Rust-enabled and to restore the caches):
 
     > Note: This command may appear unnecessarily specific, but it will help avoid publishing a version to Crates.io that doesn't match what you're currently releasing. (e.g., in the event that you've changed branches in another window) 
 
@@ -457,7 +449,7 @@ Start following the steps below to start a release PR.  The process is **not ful
       cargo publish -p apollo-router@"${APOLLO_ROUTER_RELEASE_VERSION}"
     ```
 
-20. (Optional) To have a "social banner" for this release, run [this `htmlq` command](https://crates.io/crates/htmlq) (`cargo install htmlq`, or on MacOS `brew install htmlq`; its `jq` for HTML), open the link it produces, copy the image to your clipboard:
+19. (Optional) To have a "social banner" for this release, run [this `htmlq` command](https://crates.io/crates/htmlq) (`cargo install htmlq`, or on MacOS `brew install htmlq`; its `jq` for HTML), open the link it produces, copy the image to your clipboard:
 
     ```
     curl -s "https://github.com/apollographql/router/releases/tag/v${APOLLO_ROUTER_RELEASE_VERSION}" | htmlq 'meta[property="og:image"]' --attribute content


### PR DESCRIPTION
This reverts the change introduced in:

- https://github.com/apollographql/router/pull/6809

This will also need to be backported to 1.x to revert the similarly applied
https://github.com/apollographql/router/pull/6811.

It turns out that this change, while precautionarily a great idea, is not
necessary! This is only noted very very discreetly in this part of the
easily missed [GitHub documentation].

[GitHub documentation]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#about-release-management:~:text=Optionally%2C%20select%20Set%20as%20latest%20release.%20If%20you%20do%20not%20select%20this%20option%2C%20the%20latest%20release%20label%20will%20automatically%20be%20assigned%20based%20on%20semantic%20versioning.
<hr>This is an automatic backport of pull request #7125 done by [Mergify](https://mergify.com).