### PR TITLE
Fix flakey connectors test

### DIFF
--- a/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
+++ b/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
@@ -5,6 +5,7 @@ use wiremock::matchers::method;
 use wiremock::matchers::path;
 
 use super::req_asserts::Matcher;
+use super::req_asserts::Plan;
 
 #[tokio::test]
 async fn basic_batch() {
@@ -160,13 +161,13 @@ async fn connect_on_type() {
     }
     "#);
 
-    super::req_asserts::matches(
-        &mock_server.received_requests().await.unwrap(),
-        vec![
-            Matcher::new().method("GET").path("/users"),
-            Matcher::new().method("GET").path("/users/3"),
+    Plan::Sequence(vec![
+        Plan::Fetch(Matcher::new().method("GET").path("/users")),
+        Plan::Parallel(vec![
             Matcher::new().method("GET").path("/users/1"),
             Matcher::new().method("GET").path("/users/2"),
-        ],
-    );
+            Matcher::new().method("GET").path("/users/3"),
+        ]),
+    ])
+    .assert_matches(&mock_server.received_requests().await.unwrap());
 }

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -29,6 +29,7 @@ use wiremock::matchers::path;
 use crate::Configuration;
 use crate::json_ext::ValueExt;
 use crate::metrics::FutureMetricsExt;
+use crate::plugins::connectors::tests::req_asserts::Plan;
 use crate::plugins::telemetry::consts::CONNECT_SPAN_NAME;
 use crate::plugins::telemetry::consts::OTEL_STATUS_CODE;
 use crate::router_factory::RouterSuperServiceFactory;
@@ -41,7 +42,6 @@ use crate::uplink::license_enforcement::LicenseState;
 mod connect_on_type;
 mod mock_api;
 mod quickstart;
-#[allow(dead_code)]
 mod req_asserts;
 
 const STEEL_THREAD_SCHEMA: &str = include_str!("../testdata/steelthread.graphql");
@@ -343,17 +343,20 @@ async fn test_root_field_plus_entity_plus_requires() {
     }
     "###);
 
-    req_asserts::matches(
-        &mock_server.received_requests().await.unwrap(),
-        vec![
-            Matcher::new().method("GET").path("/users"),
+    let plan = Plan::Sequence(vec![
+        Plan::Fetch(Matcher::new().method("GET").path("/users")),
+        Plan::Parallel(vec![
             Matcher::new().method("GET").path("/users/1"),
             Matcher::new().method("GET").path("/users/2"),
             Matcher::new().method("POST").path("/graphql"),
+        ]),
+        Plan::Parallel(vec![
             Matcher::new().method("GET").path("/users/1"),
             Matcher::new().method("GET").path("/users/2"),
-        ],
-    );
+        ]),
+    ]);
+
+    plan.assert_matches(&mock_server.received_requests().await.unwrap())
 }
 
 /// Tests that a connector can vend an entity reference like `user: { id: userId }`

--- a/apollo-router/src/plugins/connectors/tests/req_asserts.rs
+++ b/apollo-router/src/plugins/connectors/tests/req_asserts.rs
@@ -52,47 +52,38 @@ impl Matcher {
         self
     }
 
-    fn matches(&self, request: &wiremock::Request, index: usize) {
+    fn matches(&self, request: &wiremock::Request, index: usize) -> Result<(), String> {
         if let Some(method) = self.method.as_ref() {
-            assert_eq!(
-                method,
-                &request.method.to_string(),
-                "[Request {}]: Expected method {}, got {}",
-                index,
-                method,
-                request.method
-            )
+            if method != &request.method.to_string() {
+                return Err(format!(
+                    "[Request {index}]: Expected method {method}, got {}",
+                    request.method
+                ));
+            }
         }
 
         if let Some(path) = self.path.as_ref() {
-            assert_eq!(
-                path,
-                request.url.path(),
-                "[Request {}]: Expected path {}, got {}",
-                index,
-                path,
-                request.url.path()
-            )
+            if path != request.url.path() {
+                return Err(format!(
+                    "[Request {index}]: Expected path {path}, got {}",
+                    request.url.path()
+                ));
+            }
         }
 
         if let Some(query) = self.query.as_ref() {
-            assert_eq!(
-                query,
-                request.url.query().unwrap_or_default(),
-                "[Request {}]: Expected query {}, got {}",
-                index,
-                query,
-                request.url.query().unwrap_or_default()
-            )
+            if query != request.url.query().unwrap_or_default() {
+                return Err(format!(
+                    "[Request {index}]: Expected query {query}, got {}",
+                    request.url.query().unwrap_or_default()
+                ));
+            }
         }
 
         if let Some(body) = self.body.as_ref() {
-            assert_eq!(
-                body,
-                &request.body_json::<serde_json::Value>().unwrap(),
-                "[Request {}]: incorrect body",
-                index,
-            )
+            if body != &request.body_json::<serde_json::Value>().unwrap() {
+                return Err(format!("[Request {index}]: incorrect body"));
+            }
         }
 
         for (name, expected) in self.headers.iter() {
@@ -102,21 +93,22 @@ impl Matcher {
                         expected.iter().map(|v| v.as_str().to_owned()).collect();
                     let actual: HashSet<String> =
                         actual.iter().map(|v| v.as_str().to_owned()).collect();
-                    assert_eq!(
-                        expected,
-                        actual,
-                        "[Request {}]: expected header {} to be [{}], was [{}]",
-                        index,
-                        name,
-                        expected.iter().join(", "),
-                        actual.iter().join(", ")
-                    );
+                    if expected != actual {
+                        return Err(format!(
+                            "[Request {index}]: expected header {name} to be [{}], was [{}]",
+                            expected.iter().join(", "),
+                            actual.iter().join(", ")
+                        ));
+                    }
                 }
                 None => {
-                    panic!("[Request {}]: expected header {}, was missing", index, name);
+                    return Err(format!(
+                        "[Request {index}]: expected header {name}, was missing"
+                    ));
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -129,6 +121,68 @@ pub(crate) fn matches(received: &[wiremock::Request], matchers: Vec<Matcher>) {
         received.len()
     );
     for (i, (request, matcher)) in received.iter().zip(matchers.iter()).enumerate() {
-        matcher.matches(request, i);
+        matcher.matches(request, i).unwrap();
+    }
+}
+
+/// Basically a [`crate::query_planner::PlanNode`], but specialized for testing connectors.
+pub(crate) enum Plan {
+    Fetch(Matcher),
+    Sequence(Vec<Plan>),
+    /// Fetches that can run in any order.
+    /// TODO: support nesting plans if we need it some day
+    Parallel(Vec<Matcher>),
+}
+
+impl Plan {
+    fn len(&self) -> usize {
+        match self {
+            Plan::Fetch(_) => 1,
+            Plan::Sequence(plans) => plans.iter().map(Plan::len).sum(),
+            Plan::Parallel(matchers) => matchers.len(),
+        }
+    }
+
+    pub(crate) fn assert_matches(self, received: &[wiremock::Request]) {
+        assert_eq!(
+            received.len(),
+            self.len(),
+            "Expected {} requests, recorded {}",
+            self.len(),
+            received.len()
+        );
+        self.matches(received, 0);
+    }
+
+    fn matches(self, received: &[wiremock::Request], index_offset: usize) {
+        match self {
+            Plan::Fetch(matcher) => {
+                matcher.matches(&received[0], index_offset).unwrap();
+            }
+            Plan::Sequence(plans) => {
+                let mut index = 0;
+                for plan in plans {
+                    let len = plan.len();
+                    plan.matches(&received[index..index + len], index_offset + index);
+                    index += len;
+                }
+            }
+            Plan::Parallel(mut matchers) => {
+                // These can be received in any order, so we need to make sure _one_ of the sub-plans
+                // matches each request.
+                'requests: for (request_index, request) in received.iter().enumerate() {
+                    for (matcher_index, matcher) in matchers.iter().enumerate() {
+                        if matcher
+                            .matches(request, request_index + index_offset)
+                            .is_ok()
+                        {
+                            matchers.remove(matcher_index);
+                            continue 'requests;
+                        }
+                    }
+                    panic!("No plan matched request {:?}", request);
+                }
+            }
+        }
     }
 }

--- a/apollo-router/src/plugins/connectors/tests/req_asserts.rs
+++ b/apollo-router/src/plugins/connectors/tests/req_asserts.rs
@@ -168,7 +168,7 @@ impl Plan {
                 }
             }
             Plan::Parallel(mut matchers) => {
-                // These can be received in any order, so we need to make sure _one_ of the sub-plans
+                // These can be received in any order, so we need to make sure _one_ of the matchers
                 // matches each request.
                 'requests: for (request_index, request) in received.iter().enumerate() {
                     for (matcher_index, matcher) in matchers.iter().enumerate() {


### PR DESCRIPTION
Connectors assertions weren't properly handling parallel requests, which can technically happen in any order.