### PR TITLE
Revert "Use batch_processor Config for Apollo Metrics PerodicReader"

### DIFF
--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -1,6 +1,7 @@
 //! Apollo metrics
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::MetricsExporterBuilder;
@@ -129,8 +130,7 @@ impl Config {
             ),
         )?;
         let reader = PeriodicReader::builder(exporter, runtime::Tokio)
-            .with_interval(batch_processor.scheduled_delay)
-            .with_timeout(batch_processor.max_export_timeout)
+            .with_interval(Duration::from_secs(60))
             .build();
 
         builder.apollo_meter_provider_builder = builder


### PR DESCRIPTION
Reverts apollographql/router#7024

We're reverting this because:
1. It reused the configuration for exporting traces. These are very different things. We need to actually have different config for tracing and metrics as exporting should have different periods.
2. The default export period has gone from 60 seconds to 5 seconds for metrics. This vastly increases the metrics we ingest.
3. There are no lower bounds on export frequency. Tracing and metrics should have different lower bounds. This needs to implemented on both tracing and metrics.
