### PR TITLE
Simplify `->` method tail handling, ensuring left associativity

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/methods.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods.rs
@@ -5,7 +5,6 @@ use shape::location::SourceId;
 
 use super::ApplyToError;
 use super::MethodArgs;
-use super::PathList;
 use super::VarsWithPathsMap;
 use super::immutable::InputPath;
 use super::location::WithRange;
@@ -68,9 +67,8 @@ macro_rules! impl_arrow_method {
                 data: &JSON,
                 vars: &VarsWithPathsMap,
                 input_path: &InputPath<JSON>,
-                tail: &WithRange<PathList>,
             ) -> (Option<JSON>, Vec<ApplyToError>) {
-                $impl_fn_name(method_name, method_args, data, vars, input_path, tail)
+                $impl_fn_name(method_name, method_args, data, vars, input_path)
             }
 
             fn shape(
@@ -104,7 +102,6 @@ pub(super) trait ArrowMethodImpl {
         data: &JSON,
         vars: &VarsWithPathsMap,
         input_path: &InputPath<JSON>,
-        tail: &WithRange<PathList>,
     ) -> (Option<JSON>, Vec<ApplyToError>);
 
     fn shape(

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/and.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/and.rs
@@ -8,9 +8,7 @@ use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
-use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
@@ -30,7 +28,6 @@ fn and_method(
     data: &JSON,
     vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args {
         let mut result = is_truthy(data);
@@ -45,8 +42,7 @@ fn and_method(
             result = value_opt.map(|value| is_truthy(&value)).unwrap_or(false);
         }
 
-        tail.apply_to_path(&JSON::Bool(result), vars, input_path)
-            .prepend_errors(errors)
+        (Some(JSON::Bool(result)), errors)
     } else {
         (
             None,

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/arithmetic.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/arithmetic.rs
@@ -8,9 +8,7 @@ use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
-use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::helpers::vec_push;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
@@ -159,10 +157,8 @@ macro_rules! infix_math_method {
             data: &JSON,
             vars: &VarsWithPathsMap,
             input_path: &InputPath<JSON>,
-            tail: &WithRange<PathList>,
         ) -> (Option<JSON>, Vec<ApplyToError>) {
             arithmetic_method(method_name, method_args, $op, data, vars, input_path)
-                .and_then_collecting_errors(|result| tail.apply_to_path(&result, vars, input_path))
         }
     };
 }

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/eq.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/eq.rs
@@ -7,9 +7,7 @@ use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
-use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
@@ -26,7 +24,6 @@ fn eq_method(
     data: &JSON,
     vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args {
         if args.len() == 1 {
@@ -36,9 +33,7 @@ fn eq_method(
             } else {
                 false
             };
-            return tail
-                .apply_to_path(&JSON::Bool(matches), vars, input_path)
-                .prepend_errors(arg_errors);
+            return (Some(JSON::Bool(matches)), arg_errors);
         }
     }
     (

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/get.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/get.rs
@@ -10,9 +10,7 @@ use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
-use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::helpers::json_type_name;
 use crate::sources::connect::json_selection::helpers::vec_push;
 use crate::sources::connect::json_selection::immutable::InputPath;
@@ -35,7 +33,6 @@ fn get_method(
     data: &JSON,
     vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args {
         if let Some(index_literal) = args.first() {
@@ -48,8 +45,7 @@ fn get_method(
                         } else {
                             i as usize
                         }) {
-                            tail.apply_to_path(element, vars, input_path)
-                                .prepend_errors(index_errors)
+                            (Some(element.clone()), index_errors)
                         } else {
                             (
                                 None,
@@ -77,12 +73,7 @@ fn get_method(
                         if index >= 0 && index < ilen {
                             let uindex = index as usize;
                             let single_char_string = s_str[uindex..uindex + 1].to_string();
-                            tail.apply_to_path(
-                                &JSON::String(single_char_string.into()),
-                                vars,
-                                input_path,
-                            )
-                            .prepend_errors(index_errors)
+                            (Some(JSON::String(single_char_string.into())), index_errors)
                         } else {
                             (
                                 None,
@@ -135,8 +126,7 @@ fn get_method(
                 (Some(ref key @ JSON::String(ref s)), index_errors) => match data {
                     JSON::Object(map) => {
                         if let Some(value) = map.get(s.as_str()) {
-                            tail.apply_to_path(value, vars, input_path)
-                                .prepend_errors(index_errors)
+                            (Some(value.clone()), index_errors)
                         } else {
                             (
                                 None,

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/keys.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/keys.rs
@@ -8,9 +8,7 @@ use shape::location::SourceId;
 
 use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
-use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::helpers::json_type_name;
 use crate::sources::connect::json_selection::immutable::InputPath;
@@ -26,9 +24,8 @@ fn keys_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
-    vars: &VarsWithPathsMap,
+    _vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if method_args.is_some() {
         return (
@@ -47,7 +44,7 @@ fn keys_method(
     match data {
         JSON::Object(map) => {
             let keys = map.keys().map(|key| JSON::String(key.clone())).collect();
-            tail.apply_to_path(&JSON::Array(keys), vars, input_path)
+            (Some(JSON::Array(keys)), vec![])
         }
         _ => (
             None,

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/match_if.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/match_if.rs
@@ -7,7 +7,6 @@ use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::helpers::vec_push;
@@ -34,7 +33,6 @@ fn match_if_method(
     data: &JSON,
     vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     let mut errors = Vec::new();
 
@@ -49,9 +47,6 @@ fn match_if_method(
                     if let Some(JSON::Bool(true)) = condition_opt {
                         return pair[1]
                             .apply_to_path(data, vars, input_path)
-                            .and_then_collecting_errors(|value| {
-                                tail.apply_to_path(value, vars, input_path)
-                            })
                             .prepend_errors(errors);
                     };
                 }

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/not.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/not.rs
@@ -6,9 +6,7 @@ use shape::location::SourceId;
 
 use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
-use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
@@ -26,9 +24,8 @@ fn not_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
-    vars: &VarsWithPathsMap,
+    _vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if method_args.is_some() {
         (
@@ -43,7 +40,7 @@ fn not_method(
             )],
         )
     } else {
-        tail.apply_to_path(&JSON::Bool(!is_truthy(data)), vars, input_path)
+        (Some(JSON::Bool(!is_truthy(data))), vec![])
     }
 }
 #[allow(dead_code)] // method type-checking disabled until we add name resolution

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/or.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/or.rs
@@ -8,9 +8,7 @@ use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
-use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
@@ -30,7 +28,6 @@ fn or_method(
     data: &JSON,
     vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args {
         let mut result = is_truthy(data);
@@ -45,8 +42,7 @@ fn or_method(
             result = value_opt.map(|value| is_truthy(&value)).unwrap_or(false);
         }
 
-        tail.apply_to_path(&JSON::Bool(result), vars, input_path)
-            .prepend_errors(errors)
+        (Some(JSON::Bool(result)), errors)
     } else {
         (
             None,

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/typeof.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/typeof.rs
@@ -5,9 +5,7 @@ use shape::location::SourceId;
 
 use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
-use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::helpers::json_type_name;
 use crate::sources::connect::json_selection::immutable::InputPath;
@@ -26,9 +24,8 @@ fn typeof_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
-    vars: &VarsWithPathsMap,
+    _vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if method_args.is_some() {
         (
@@ -44,7 +41,7 @@ fn typeof_method(
         )
     } else {
         let typeof_string = JSON::String(json_type_name(data).to_string().into());
-        tail.apply_to_path(&typeof_string, vars, input_path)
+        (Some(typeof_string), vec![])
     }
 }
 #[allow(dead_code)] // method type-checking disabled until we add name resolution

--- a/apollo-federation/src/sources/connect/json_selection/methods/future/values.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/future/values.rs
@@ -8,9 +8,7 @@ use shape::location::SourceId;
 
 use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
-use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::helpers::json_type_name;
 use crate::sources::connect::json_selection::immutable::InputPath;
@@ -26,9 +24,8 @@ fn values_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
-    vars: &VarsWithPathsMap,
+    _vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if method_args.is_some() {
         return (
@@ -47,7 +44,7 @@ fn values_method(
     match data {
         JSON::Object(map) => {
             let values = map.values().cloned().collect();
-            tail.apply_to_path(&JSON::Array(values), vars, input_path)
+            (Some(JSON::Array(values)), vec![])
         }
         _ => (
             None,

--- a/apollo-federation/src/sources/connect/json_selection/methods/public/echo.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public/echo.rs
@@ -7,9 +7,7 @@ use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
-use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
@@ -34,13 +32,10 @@ fn echo_method(
     data: &JSON,
     vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args {
         if let Some(arg) = args.first() {
-            return arg
-                .apply_to_path(data, vars, input_path)
-                .and_then_collecting_errors(|value| tail.apply_to_path(value, vars, input_path));
+            return arg.apply_to_path(data, vars, input_path);
         }
     }
     (

--- a/apollo-federation/src/sources/connect/json_selection/methods/public/entries.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public/entries.rs
@@ -8,9 +8,7 @@ use shape::location::SourceId;
 
 use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
-use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::helpers::json_type_name;
 use crate::sources::connect::json_selection::immutable::InputPath;
@@ -36,9 +34,8 @@ fn entries_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
-    vars: &VarsWithPathsMap,
+    _vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if method_args.is_some() {
         return (
@@ -65,7 +62,7 @@ fn entries_method(
                     JSON::Object(key_value_pair)
                 })
                 .collect();
-            tail.apply_to_path(&JSON::Array(entries), vars, input_path)
+            (Some(JSON::Array(entries)), vec![])
         }
         _ => (
             None,

--- a/apollo-federation/src/sources/connect/json_selection/methods/public/first.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public/first.rs
@@ -6,9 +6,7 @@ use shape::location::SourceId;
 
 use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
-use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
@@ -25,9 +23,8 @@ fn first_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
-    vars: &VarsWithPathsMap,
+    _vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if method_args.is_some() {
         return (
@@ -44,23 +41,25 @@ fn first_method(
     }
 
     match data {
-        JSON::Array(array) => {
-            if let Some(first) = array.first() {
-                tail.apply_to_path(first, vars, input_path)
-            } else {
-                (None, vec![])
-            }
-        }
-
+        JSON::Array(array) => (array.first().cloned(), vec![]),
         JSON::String(s) => {
             if let Some(first) = s.as_str().chars().next() {
-                tail.apply_to_path(&JSON::String(first.to_string().into()), vars, input_path)
+                (Some(JSON::String(first.to_string().into())), vec![])
             } else {
                 (None, vec![])
             }
         }
-
-        _ => tail.apply_to_path(data, vars, input_path),
+        _ => (
+            Some(data.clone()),
+            vec![ApplyToError::new(
+                format!(
+                    "Method ->{} requires an array or string input",
+                    method_name.as_ref()
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+            )],
+        ),
     }
 }
 #[allow(dead_code)] // method type-checking disabled until we add name resolution
@@ -99,9 +98,17 @@ fn first_shape(
             }
         }
         ShapeCase::Name(_, _) => input_shape.item(0, locations),
+        ShapeCase::Unknown => Shape::unknown(locations),
         // When there is no obvious first element, ->first gives us the input
         // value itself, which has input_shape.
-        _ => input_shape.clone(),
+        _ => Shape::error_with_partial(
+            format!(
+                "Method ->{} requires an array or string input",
+                method_name.as_ref()
+            ),
+            input_shape.clone(),
+            locations,
+        ),
     }
 }
 

--- a/apollo-federation/src/sources/connect/json_selection/methods/public/json_stringify.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public/json_stringify.rs
@@ -6,7 +6,6 @@ use shape::location::SourceId;
 use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
@@ -28,7 +27,6 @@ fn json_stringify_method(
     data: &JSON,
     _vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    _tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if method_args.is_some() {
         return (

--- a/apollo-federation/src/sources/connect/json_selection/methods/public/match.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public/match.rs
@@ -36,7 +36,6 @@ fn match_method(
     data: &JSON,
     vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     let mut errors = Vec::new();
 
@@ -52,9 +51,6 @@ fn match_method(
                         if candidate == *data {
                             return pair[1]
                                 .apply_to_path(data, vars, input_path)
-                                .and_then_collecting_errors(|value| {
-                                    tail.apply_to_path(value, vars, input_path)
-                                })
                                 .prepend_errors(errors);
                         }
                     };

--- a/apollo-federation/src/sources/connect/json_selection/methods/public/size.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public/size.rs
@@ -6,9 +6,7 @@ use shape::location::SourceId;
 
 use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
-use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
 use crate::sources::connect::json_selection::helpers::json_type_name;
 use crate::sources::connect::json_selection::immutable::InputPath;
@@ -26,9 +24,8 @@ fn size_method(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,
     data: &JSON,
-    vars: &VarsWithPathsMap,
+    _vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if method_args.is_some() {
         return (
@@ -47,17 +44,17 @@ fn size_method(
     match data {
         JSON::Array(array) => {
             let size = array.len() as i64;
-            tail.apply_to_path(&JSON::Number(size.into()), vars, input_path)
+            (Some(JSON::Number(size.into())), vec![])
         }
         JSON::String(s) => {
             let size = s.as_str().len() as i64;
-            tail.apply_to_path(&JSON::Number(size.into()), vars, input_path)
+            (Some(JSON::Number(size.into())), vec![])
         }
         // Though we can't ask for ->first or ->last or ->at(n) on an object, we
         // can safely return how many properties the object has for ->size.
         JSON::Object(map) => {
             let size = map.len() as i64;
-            tail.apply_to_path(&JSON::Number(size.into()), vars, input_path)
+            (Some(JSON::Number(size.into())), vec![])
         }
         _ => (
             None,

--- a/apollo-federation/src/sources/connect/json_selection/methods/public/slice.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/public/slice.rs
@@ -10,9 +10,7 @@ use crate::impl_arrow_method;
 use crate::sources::connect::json_selection::ApplyToError;
 use crate::sources::connect::json_selection::ApplyToInternal;
 use crate::sources::connect::json_selection::MethodArgs;
-use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::VarsWithPathsMap;
-use crate::sources::connect::json_selection::apply_to::ApplyToResultMethods;
 use crate::sources::connect::json_selection::immutable::InputPath;
 use crate::sources::connect::json_selection::location::Ranged;
 use crate::sources::connect::json_selection::location::WithRange;
@@ -30,7 +28,6 @@ fn slice_method(
     data: &JSON,
     vars: &VarsWithPathsMap,
     input_path: &InputPath<JSON>,
-    tail: &WithRange<PathList>,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     let length = if let JSON::Array(array) = data {
         array.len() as i64
@@ -104,8 +101,7 @@ fn slice_method(
             _ => unreachable!(),
         };
 
-        tail.apply_to_path(&array, vars, input_path)
-            .prepend_errors(errors)
+        (Some(array), errors)
     } else {
         // TODO Should calling ->slice or ->slice() without arguments be an
         // error? In JavaScript, array->slice() copies the array, but that's not


### PR DESCRIPTION
This PR removes the `tail: &WithRange<PathList>` parameter from the `ArrowMethodImpl::apply` trait method that each arrow method must implement, which is a significant simplification because arrow method implementations are now responsible for returning only their immediate value, not also invoking the rest of the path (the `tail`) to return a final value recursively.

For reference, the `tail` of an arrow method invocation is `input->method(arg).THIS.PART`, so it's a little strange that the implementation of each `->method` was previously responsible for continuing to evaluate its own tail. Instead, the runtime code that invokes methods will now call `tail.apply_to_path` automatically on behalf of any method that returns a non-`None` value, enforcing the same protocol for every method. Theoretically, this slightly reduces the power of arrow methods, since they can no longer evaluate their own tails in exotic ways. We do not have any use cases for that today, and arrow methods are not developer-extensible, so this doesn't seem like much of a loss.

As part of these changes, I changed the handling of `PathList::Key` items when mapped over input arrays. Previously, if `array.key` had a `->method` after it (so `array.key->method`), the `->method` would be applied to each individual `key` value, rather than receiving the entire array as a whole. After this PR, path evaluation is reliably _left associative_, so everything preceding the `->` will be evaluated before invoking the method, and the method will be invoked only once, rather than participating in the mapping of `array.key`. This is generally more predictable and convenient, since (for example) it allows you to guarantee a final string by slapping `->jsonStringify` at the end of any path, without having to worry it may be mapped over individual values and recomposed into a larger (non-string) array.

It may be possible to gate these changes so they work the old way(s) in `connect/v0.1`, but it would be ugly. For now, I'm waiting on the team to decide if we need to preserve old behavior for a change like this (where the old behavior was buggy).