### PR TITLE
Docs: Expand GraphQL error codes

### DIFF
--- a/.changesets/docs_timbotnik_pulsr_1484_graphos_error_docs.md
+++ b/.changesets/docs_timbotnik_pulsr_1484_graphos_error_docs.md
@@ -1,0 +1,5 @@
+### Added documentation for more GraphQL error codes that can occur during Router execution. ([PR #7160](https://github.com/apollographql/router/issues/7160))
+
+Added documentation for more GraphQL error codes that can occur during Router execution, including better differentiation between HTTP status codes and GraphQL error extensions codes.
+
+By [@timbotnik](https://github.com/timbotnik) in https://github.com/apollographql/router/pull/7160

--- a/.changesets/docs_timbotnik_pulsr_1484_graphos_error_docs.md
+++ b/.changesets/docs_timbotnik_pulsr_1484_graphos_error_docs.md
@@ -1,5 +1,5 @@
-### Added documentation for more GraphQL error codes that can occur during Router execution. ([PR #7160](https://github.com/apollographql/router/issues/7160))
+### Added documentation for more GraphQL error codes that can occur during router execution. ([PR #7160](https://github.com/apollographql/router/issues/7160))
 
-Added documentation for more GraphQL error codes that can occur during Router execution, including better differentiation between HTTP status codes and GraphQL error extensions codes.
+Added documentation for more GraphQL error codes that can occur during router execution, including better differentiation between HTTP status codes and GraphQL error extensions codes.
 
 By [@timbotnik](https://github.com/timbotnik) in https://github.com/apollographql/router/pull/7160

--- a/docs/source/routing/errors.mdx
+++ b/docs/source/routing/errors.mdx
@@ -161,6 +161,23 @@ safelist.
 The operation could not be parsed as GraphQL.
 
 </Property>
+<Property name="PERSISTED_QUERY_HASH_MISMATCH">
+
+The operation was not executed due to a mismatch with the automatic persisted query (APQ) protocol.
+There was an attempt to store this operation in the APQ cache, but the provided hash did not match the operation.
+
+</Property>
+<Property name="PERSISTED_QUERY_NOT_FOUND">
+
+The operation was not executed since it was not found in the automatic persisted query (APQ) cache.  
+This is an expected behavior when using the APQ protocol.
+
+</Property>
+<Property name="PERSISTED_QUERY_NOT_SUPPORTED">
+
+An operation attempted to use automatic persisted queries, but the feature was not enabled.
+
+</Property>
 <Property name="PERSISTED_QUERY_NOT_IN_LIST">
 
 The operation was not executed because it was not found in the persisted query
@@ -182,6 +199,12 @@ schema.
 <Property name="SUBREQUEST_HTTP_ERROR">
 
 There was an error at the HTTP transport layer when fetching data from a subgraph service.
+
+</Property>
+<Property name="UNAUTHORIZED_FIELD_OR_TYPE">
+
+The operation was not fully executed because it attempted to use a field
+or type was unauthorized.
 
 </Property>
 </PropertyList>

--- a/docs/source/routing/errors.mdx
+++ b/docs/source/routing/errors.mdx
@@ -6,7 +6,7 @@ description: Reference of error codes and HTTP status codes returned by Apollo G
 
 Learn about error codes and HTTP response status codes returned by GraphOS Router and Apollo Router Core.
 
-## HTTP Status codes
+## HTTP status codes
 
 <PropertyList kind="errCodes">
 <Property name="400" short="Bad request">
@@ -71,7 +71,7 @@ You can create Rhai scripts that throw custom status codes. See [Terminating cli
 
 </Note>
 
-## GraphQL Error codes
+## GraphQL error codes
 
 GraphQL error codes can appear in client responses under `errors[].extensions.code`, which is an established convention found in [GraphQL error extensions](https://spec.graphql.org/October2021/#sec-Errors.Error-result-format). Learn how to see these error codes in Studio via [extended error metrics](/graphos/routing/graphos-reporting#enabling-extended-error-reporting).
 
@@ -79,7 +79,7 @@ GraphQL error codes can appear in client responses under `errors[].extensions.co
 
 <Property name="CANNOT_SEND_PQ_ID_AND_BODY">
 
-The operation could not be executed because sending a persisted query ID and a
+The operation was not executed because sending a persisted query ID and a
 body in the same request is disallowed.
 
 </Property>
@@ -110,7 +110,7 @@ The response from a subgraph did not match the GraphQL schema.
 </Property>
 <Property name="GATEWAY_TIMEOUT">
 
-There request timed out when fetching data from a connector service.
+The request timed out when fetching data from a connector service.
 
 </Property>
 <Property name="GRAPHQL_VALIDATION_FAILED">
@@ -132,22 +132,22 @@ connector service.
 </Property>
 <Property name="MAX_ALIASES_LIMIT">
 
-The operation was not executed due to exceeding the max_aliases limit.
+The operation was not executed due to exceeding the `max_aliases` limit.
 
 </Property>
 <Property name="MAX_DEPTH_LIMIT">
 
-The operation was not executed due to exceeding the max_depth limit.
+The operation was not executed due to exceeding the `max_depth` limit.
 
 </Property>
 <Property name="MAX_HEIGHT_LIMIT">
 
-The operation was not executed due to exceeding the max_height limit.
+The operation was not executed due to exceeding the `max_height` limit.
 
 </Property>
 <Property name="MAX_ROOT_FIELDS_LIMIT">
 
-The operation was not executed due to exceeding the max_root_fields limit.
+The operation was not executed due to exceeding the `max_root_fields` limit.
 
 </Property>
 <Property name="QUERY_NOT_IN_SAFELIST">
@@ -169,7 +169,7 @@ There was an attempt to store this operation in the APQ cache, but the provided 
 </Property>
 <Property name="PERSISTED_QUERY_NOT_FOUND">
 
-The operation was not executed since it was not found in the automatic persisted query (APQ) cache.  
+The operation was not executed because it was not found in the automatic persisted query (APQ) cache.  
 This is an expected behavior when using the APQ protocol.
 
 </Property>

--- a/docs/source/routing/errors.mdx
+++ b/docs/source/routing/errors.mdx
@@ -6,7 +6,7 @@ description: Reference of error codes and HTTP status codes returned by Apollo G
 
 Learn about error codes and HTTP response status codes returned by GraphOS Router and Apollo Router Core.
 
-## Status codes
+## HTTP Status codes
 
 <PropertyList kind="errCodes">
 <Property name="400" short="Bad request">
@@ -24,8 +24,7 @@ Requests may receive this response in two cases:
 </Property>
 <Property name="405" short="Method not allowed">
 
-
-<Note> 
+<Note>
 
 Both mutations and subscriptions must use POST.
 
@@ -34,7 +33,8 @@ Both mutations and subscriptions must use POST.
 </Property>
 <Property name="406" short="Not acceptable">
 
-A request's HTTP `Accept` header didn't contain any of the router's supported mime-types: 
+A request's HTTP `Accept` header didn't contain any of the router's supported mime-types:
+
 - `application/json`
 - `application/graphql-response+json`
 - `multipart/mixed;deferSpec=20220824`
@@ -60,7 +60,7 @@ The router encountered an unexpected issue. [Report](https://github.com/apollogr
 
 <Property name="504" short="Request timed out">
 
-The request was not able to complete within a configured amount of time.  See [client side traffic shaping timeouts](/router/configuration/traffic-shaping/#timeouts).
+The request was not able to complete within a configured amount of time. See [client side traffic shaping timeouts](/router/configuration/traffic-shaping/#timeouts).
 
 </Property>
 </PropertyList>
@@ -71,13 +71,23 @@ You can create Rhai scripts that throw custom status codes. See [Terminating cli
 
 </Note>
 
-## Error codes
+## GraphQL Error codes
 
-### Demand control
-
-Errors returned by the router when [demand control](/router/executing-operations/demand-control) is enabled.
+GraphQL error codes can appear in client responses under `errors[].extensions.code`, which is an established convention found in [GraphQL error extensions](https://spec.graphql.org/October2021/#sec-Errors.Error-result-format). Learn how to see these error codes in Studio via [extended error metrics](/graphos/routing/graphos-reporting#enabling-extended-error-reporting).
 
 <PropertyList kind="errCodes">
+
+<Property name="CANNOT_SEND_PQ_ID_AND_BODY">
+
+The operation could not be executed because sending a persisted query ID and a
+body in the same request is disallowed.
+
+</Property>
+<Property name="CONNECTOR_FETCH">
+
+There was an error fetching data from a connector service.
+
+</Property>
 <Property name="COST_ESTIMATED_TOO_EXPENSIVE">
 
 The estimated cost of the query was greater than the configured maximum cost.
@@ -96,6 +106,82 @@ The query could not be parsed.
 <Property name="COST_RESPONSE_TYPING_FAILURE">
 
 The response from a subgraph did not match the GraphQL schema.
+
+</Property>
+<Property name="GATEWAY_TIMEOUT">
+
+There request timed out when fetching data from a connector service.
+
+</Property>
+<Property name="GRAPHQL_VALIDATION_FAILED">
+
+The operation failed during GraphQL validation.
+
+</Property>
+<Property name="GRAPHQL_UNKNOWN_OPERATION_NAME">
+
+The operation could not be executed because the operation name was invalid or
+did not match an operation in the query document.
+
+</Property>
+<Property name="HTTP_CLIENT_ERROR">
+
+There was an error at the HTTP transport layer when fetching data from a
+connector service.
+
+</Property>
+<Property name="MAX_ALIASES_LIMIT">
+
+The operation was not executed due to exceeding the max_aliases limit.
+
+</Property>
+<Property name="MAX_DEPTH_LIMIT">
+
+The operation was not executed due to exceeding the max_depth limit.
+
+</Property>
+<Property name="MAX_HEIGHT_LIMIT">
+
+The operation was not executed due to exceeding the max_height limit.
+
+</Property>
+<Property name="MAX_ROOT_FIELDS_LIMIT">
+
+The operation was not executed due to exceeding the max_root_fields limit.
+
+</Property>
+<Property name="QUERY_NOT_IN_SAFELIST">
+
+The operation was not executed because it was not found in the persisted query
+safelist.
+
+</Property>
+<Property name="PARSING_ERROR">
+
+The operation could not be parsed as GraphQL.
+
+</Property>
+<Property name="PERSISTED_QUERY_NOT_IN_LIST">
+
+The operation was not executed because it was not found in the persisted query
+safelist.
+
+</Property>
+<Property name="REQUEST_LIMIT_EXCEEDED">
+
+There was an error due to exceeding the max requests configuration for a
+connector service.
+
+</Property>
+<Property name="RESPONSE_VALIDATION_FAILED">
+
+The response returned from a subgraph failed validation for the supergraph
+schema.
+
+</Property>
+<Property name="SUBREQUEST_HTTP_ERROR">
+
+There was an error at the HTTP transport layer when fetching data from a subgraph service.
 
 </Property>
 </PropertyList>


### PR DESCRIPTION
Provides additional documentation for error codes from Router.  Also better differentiates between HTTP status codes and GraphQL error extensions codes that can occur during Router execution.

https://www.apollographql.com/docs/deploy-preview/bd4351dc12913e9308f58b27/graphos/routing/errors

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
