### PR TITLE
fix(federation/composition): fixed a few directive spec definition discrepancies

### DIFF
--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -715,7 +715,10 @@ impl FederationSpecDefinition {
                 composition_strategy: None,
             }],
             false,
-            &[DirectiveLocation::FieldDefinition],
+            &[
+                DirectiveLocation::Object,
+                DirectiveLocation::FieldDefinition,
+            ],
             false,
             None,
             None,
@@ -740,8 +743,8 @@ impl FederationSpecDefinition {
             &[],
             self.version().ge(&Version { major: 2, minor: 2 }),
             &[
-                DirectiveLocation::FieldDefinition,
                 DirectiveLocation::Object,
+                DirectiveLocation::FieldDefinition,
             ],
             false,
             None,

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -581,14 +581,14 @@ impl TypeAndDirectiveSpecification for DirectiveSpecification {
         }
 
         let directive_pos = DirectiveDefinitionPosition {
-            directive_name: actual_name,
+            directive_name: actual_name.clone(),
         };
         directive_pos.pre_insert(schema)?;
         directive_pos.insert(
             schema,
             Node::new(DirectiveDefinition {
                 description: None,
-                name: self.name.clone(),
+                name: actual_name,
                 arguments: resolved_args
                     .iter()
                     .map(|arg| Node::new(arg.into()))


### PR DESCRIPTION
I've reviewed the federated schema outputs and compared against JS output and documentation.
I found a few discrepancies and fixed them.

<!-- FED-503 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests
