### PR TITLE
feat(configuration): enable auto migration for minor version bumps

### DIFF
--- a/.changesets/feat_bnjjj_config_auto_migration.md
+++ b/.changesets/feat_bnjjj_config_auto_migration.md
@@ -1,0 +1,6 @@
+### Enable configuation auto migration for minor version bumps ([PR #7162](https://github.com/apollographql/router/pull/7162))
+
+Enable configuration auto migration when running the Router, only when it's migration written for the related version.
+Example: if you're running on Router 2.x, only migrations named `2xxx_*.yaml` will be automatically applied. Previous migrations will have to be applied using `router upgrade` command. 
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/7162

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -25,6 +25,7 @@ use regex::Regex;
 use rustls::ServerConfig;
 use rustls::pki_types::CertificateDer;
 use rustls::pki_types::PrivateKeyDer;
+use schema::Mode;
 use schemars::JsonSchema;
 use schemars::r#gen::SchemaGenerator;
 use schemars::schema::ObjectValidation;
@@ -65,7 +66,7 @@ pub(crate) mod expansion;
 mod experimental;
 pub(crate) mod metrics;
 mod persisted_queries;
-mod schema;
+pub(crate) mod schema;
 pub(crate) mod shared;
 pub(crate) mod subgraph;
 #[cfg(test)]
@@ -559,7 +560,7 @@ impl FromStr for Configuration {
     type Err = ConfigurationError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        schema::validate_yaml_configuration(s, Expansion::default()?)?.validate()
+        schema::validate_yaml_configuration(s, Expansion::default()?, Mode::Upgrade)?.validate()
     }
 }
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@minor__health_check.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@minor__health_check.yaml.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+health_check:
+  enabled: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_major_configuration@apollo_extended_errors.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_major_configuration@apollo_extended_errors.yaml.snap
@@ -1,0 +1,9 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+telemetry:
+  apollo:
+    errors:
+      preview_extended_error_metrics: enabled

--- a/apollo-router/src/configuration/testdata/migrations/defer_support_ga.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/defer_support_ga.router.yaml
@@ -1,2 +1,0 @@
-supergraph:
-  defer_support: true

--- a/apollo-router/src/configuration/testdata/migrations/minor/health_check.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/minor/health_check.yaml
@@ -1,0 +1,2 @@
+health-check:
+  enabled: true

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -144,10 +144,10 @@ subgraphs:
     assert_eq!(
         error.to_string(),
         String::from(
-            r#"configuration had errors:
+            r#"configuration had errors: 
 1. at line 4
 
-
+  
   supergraph:
     path: /
 ┌ subgraphs:
@@ -173,10 +173,10 @@ unknown:
     assert_eq!(
         error.to_string(),
         String::from(
-            r#"configuration had errors:
+            r#"configuration had errors: 
 1. at line 2
 
-
+  
 ┌ unknown:
 |   foo: true
 └-----> Additional properties are not allowed ('unknown' was unexpected)

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -144,10 +144,10 @@ subgraphs:
     assert_eq!(
         error.to_string(),
         String::from(
-            r#"configuration had errors: 
+            r#"configuration had errors:
 1. at line 4
 
-  
+
   supergraph:
     path: /
 ┌ subgraphs:
@@ -173,10 +173,10 @@ unknown:
     assert_eq!(
         error.to_string(),
         String::from(
-            r#"configuration had errors: 
+            r#"configuration had errors:
 1. at line 2
 
-  
+
 ┌ unknown:
 |   foo: true
 └-----> Additional properties are not allowed ('unknown' was unexpected)
@@ -611,7 +611,7 @@ supergraph:
 struct Asset;
 
 #[test]
-fn upgrade_old_major_configuration() {
+fn upgrade_old_configuration() {
     for file_name in Asset::iter() {
         if file_name.ends_with(".yaml") {
             let source = Asset::get(&file_name).expect("test file must exist");

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -144,9 +144,10 @@ subgraphs:
     assert_eq!(
         error.to_string(),
         String::from(
-            r#"configuration had errors:
+            r#"configuration had errors: 
 1. at line 4
 
+  
   supergraph:
     path: /
 ┌ subgraphs:
@@ -172,10 +173,10 @@ unknown:
     assert_eq!(
         error.to_string(),
         String::from(
-            r#"configuration had errors:
+            r#"configuration had errors: 
 1. at line 2
 
-
+  
 ┌ unknown:
 |   foo: true
 └-----> Additional properties are not allowed ('unknown' was unexpected)

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -57,13 +57,31 @@ enum Action {
 const REMOVAL_VALUE: &str = "__PLEASE_DELETE_ME";
 const REMOVAL_EXPRESSION: &str = r#"const("__PLEASE_DELETE_ME")"#;
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum UpgradeMode {
+    /// Upgrade using migrations for major version (eg: from router 1.x to router 2.x)
+    Major,
+    /// Upgrade using migrations for minor version (eg: from router 2.x to router 2.y)
+    Minor,
+}
+
 pub(crate) fn upgrade_configuration(
     config: &serde_json::Value,
     log_warnings: bool,
+    upgrade_mode: UpgradeMode,
 ) -> Result<serde_json::Value, super::ConfigurationError> {
+    const CURRENT_MAJOR_VERSION: &str = env!("CARGO_PKG_VERSION_MAJOR");
+    dbg!(CURRENT_MAJOR_VERSION);
     // Transformers are loaded from a file and applied in order
     let mut migrations: Vec<Migration> = Vec::new();
-    for filename in Asset::iter().sorted().filter(|f| f.ends_with(".yaml")) {
+    let files = Asset::iter().sorted().filter(|f| {
+        if matches!(upgrade_mode, UpgradeMode::Major) {
+            f.ends_with(".yaml")
+        } else {
+            f.ends_with(".yaml") && f.starts_with(CURRENT_MAJOR_VERSION)
+        }
+    });
+    for filename in files {
         if let Some(migration) = Asset::get(&filename) {
             let parsed_migration = serde_yaml::from_slice(&migration.data).map_err(|error| {
                 ConfigurationError::MigrationFailure {
@@ -186,12 +204,13 @@ fn apply_migration(config: &Value, migration: &Migration) -> Result<Value, Confi
     Ok(new_config)
 }
 
+/// Used for upgrade command
 pub(crate) fn generate_upgrade(config: &str, diff: bool) -> Result<String, ConfigurationError> {
     let parsed_config =
         serde_yaml::from_str(config).map_err(|error| ConfigurationError::MigrationFailure {
             error: format!("Failed to parse config: {}", error),
         })?;
-    let upgraded_config = upgrade_configuration(&parsed_config, true)?;
+    let upgraded_config = upgrade_configuration(&parsed_config, true, UpgradeMode::Major)?;
     let upgraded_config = serde_yaml::to_string(&upgraded_config).map_err(|error| {
         ConfigurationError::MigrationFailure {
             error: format!("Failed to serialize upgraded config: {}", error),

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -29,6 +29,7 @@ use crate::configuration::Discussed;
 use crate::configuration::expansion::Expansion;
 use crate::configuration::generate_config_schema;
 use crate::configuration::generate_upgrade;
+use crate::configuration::schema::Mode;
 use crate::configuration::validate_yaml_configuration;
 use crate::metrics::meter_provider_internal;
 use crate::plugin::plugins;
@@ -444,7 +445,12 @@ impl Executable {
                 command: ConfigSubcommand::Validate { config_path },
             })) => {
                 let config_string = std::fs::read_to_string(config_path)?;
-                validate_yaml_configuration(&config_string, Expansion::default()?)?.validate()?;
+                validate_yaml_configuration(
+                    &config_string,
+                    Expansion::default()?,
+                    Mode::NoUpgrade,
+                )?
+                .validate()?;
 
                 println!("Configuration at path {:?} is valid!", config_path);
 


### PR DESCRIPTION
Enable configuration auto migration when running the Router, only when it's migration written for the related version.
Example: if you're running on Router 2.x, only migrations named `2xxx_*.yaml` will be automatically applied. Previous migrations will have to be applied using `router upgrade` command. 

<!-- [ROUTER-1225] -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1064]: https://apollographql.atlassian.net/browse/ROUTER-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ROUTER-1225]: https://apollographql.atlassian.net/browse/ROUTER-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ