### PR TITLE
Tracing deadlock investigation (backport #7142)

### DIFF
--- a/.changesets/fix_caroline_deadlock.md
+++ b/.changesets/fix_caroline_deadlock.md
@@ -1,0 +1,20 @@
+### Fix potential telemetry deadlock ([PR #7142](https://github.com/apollographql/router/pull/7142))
+
+The `tracing_subscriber` crate uses `RwLock`s to manage access to a `Span`'s `Extensions`. Deadlocks are possible when
+multiple threads access this lock, including with reentrant locks:
+```
+// Thread 1              |  // Thread 2
+let _rg1 = lock.read();  |
+                         |  // will block
+                         |  let _wg = lock.write();
+// may deadlock          |
+let _rg2 = lock.read();  |
+```
+
+This fix removes an opportunity for reentrant locking while extracting a Datadog identifier.
+
+There is also a potential for deadlocks when the root and active spans' `Extensions` are acquired at the same time, if
+multiple threads are attempting to access those `Extensions` but in a different order. This fix removes a few cases
+where multiple spans' `Extensions` are acquired at the same time.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/7142

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -353,7 +353,7 @@ fn extract_dd_trace_id<'a, 'b, T: LookupSpan<'a>>(span: &SpanRef<'a, T>) -> Opti
     if let Some(root_span) = root.next() {
         let ext = root_span.extensions();
         // Extract dd_trace_id, this could be in otel data or log attributes
-        if let Some(otel_data) = root_span.extensions().get::<OtelData>() {
+        if let Some(otel_data) = ext.get::<OtelData>() {
             if let Some(attributes) = otel_data.builder.attributes.as_ref() {
                 if let Some((_k, v)) = attributes
                     .iter()


### PR DESCRIPTION
I've been trying to look into a deadlock on `tracing-subscriber::registry::Extensions`. The function `extract_dd_trace_id` is a relatively good candidate for the lock trigger due to the fact that it's looking at the root span extensions, rather than those of the current span.

For more information about when reentrant locking may cause a deadlock see: https://doc.rust-lang.org/std/sync/struct.RwLock.html

```
// Thread 1              |  // Thread 2
let _rg1 = lock.read();  |
                         |  // will block
                         |  let _wg = lock.write();
// may deadlock          |
let _rg2 = lock.read();  |
```

To test this we ran an instrumented version of the router that would log out if re-entrant locking of span extensions was detected.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7142 done by [Mergify](https://mergify.com).