### PR TITLE
fix: update tokio to address unsoundness issue (backport #7174)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6569,9 +6569,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
This addresses [RUSTSEC-2025-0023](https://rustsec.org/advisories/RUSTSEC-2025-0023).

I don't have a reason to assume that we're affected by this issue (you have to have an unusual `Clone` implementation), so the update is just to unblock our CI, and a changeset is unnecessary.

This is a manual backport of #7174, only increasing the patch version of tokio and not the minor.