### PR TITLE
Add units to metric descriptions

### DIFF
--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -187,7 +187,7 @@ impl Invalidation {
 
                 f64_histogram!(
                     "apollo.router.cache.invalidation.duration",
-                    "Duration of the invalidation event execution.",
+                    "Duration of the invalidation event execution, in seconds.",
                     start.elapsed().as_secs_f64()
                 );
                 res

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -437,7 +437,7 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
 
             f64_histogram!(
                 "apollo.router.query_planning.total.duration",
-                "Duration of the time the router waited for a query plan, including both the queue time and planning time.",
+                "Duration of the time the router waited for a query plan, including both the queue time and planning time, in seconds.",
                 start.elapsed().as_secs_f64()
             );
 
@@ -593,7 +593,7 @@ pub(crate) struct QueryPlanResult {
 pub(crate) fn metric_query_planning_plan_duration(planner: &'static str, elapsed: f64) {
     f64_histogram!(
         "apollo.router.query_planning.plan.duration",
-        "Duration of the query planning.",
+        "Duration of the query planning, in seconds.",
         elapsed,
         "planner" = planner
     );

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -148,7 +148,7 @@ impl Schema {
 
         f64_histogram!(
             "apollo.router.schema.load.duration",
-            "Time spent loading the supergraph schema.",
+            "Time spent loading the supergraph schema, in seconds.",
             start.elapsed().as_secs_f64()
         );
 


### PR DESCRIPTION
This PR adds units to several 'duration' metrics' descriptions.

Per #7034, we are not able to actually modify the metrics' units - doing so would change the name of the metrics in Prometheus.

The metrics in question:
* `apollo.router.cache.invalidation.duration`
* `apollo.router.query_planning.plan.duration`
* `apollo.router.query_planning.total.duration`
* `apollo.router.schema.load.duration`

<!-- start metadata -->
<!-- ROUTER-714 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
