### PR TITLE
remove argument when adding contextArguments (backport #7132)

### DIFF
--- a/.changesets/fix_heap_tail_paper_bunk.md
+++ b/.changesets/fix_heap_tail_paper_bunk.md
@@ -1,0 +1,5 @@
+### Support @context/@fromContext when using Connectors ([PR #7132](https://github.com/apollographql/router/pull/7132))
+
+This fixes a bug that dropped the `@context` and `@fromContext` directives when introducing a connector.
+
+By [@lennyburdette](https://github.com/lennyburdette) in https://github.com/apollographql/router/pull/7132

--- a/apollo-federation/src/sources/connect/expand/snapshots/apollo_federation__sources__connect__expand__carryover__tests__carryover.snap
+++ b/apollo-federation/src/sources/connect/expand/snapshots/apollo_federation__sources__connect__expand__carryover__tests__carryover.snap
@@ -94,7 +94,7 @@ type T @join__type(graph: ONE) @custom2 {
 
 type X @join__type(graph: TWO, key: "id") {
   id: ID! @join__field(graph: TWO, type: "ID!")
-  w(z: String): String @join__field(graph: TWO, type: "String", contextArguments: [{context: "two__ctx", name: "z", type: "String", selection: " { y }"}])
+  w: String @join__field(graph: TWO, type: "String", contextArguments: [{context: "two__ctx", name: "z", type: "String", selection: " { y }"}])
 }
 
 type Z @join__type(graph: TWO, key: "id") @context(name: "two__ctx") {

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@carryover.graphql-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@carryover.graphql-3.snap
@@ -93,7 +93,7 @@ type R @join__type(graph: ONE_T_R_0) {
 
 type X @join__type(graph: TWO, key: "id") {
   id: ID! @join__field(graph: TWO, type: "ID!")
-  w(z: String): String @join__field(graph: TWO, type: "String", contextArguments: [{context: "two__ctx", name: "z", type: "String", selection: " { y }"}])
+  w: String @join__field(graph: TWO, type: "String", contextArguments: [{context: "two__ctx", name: "z", type: "String", selection: " { y }"}])
 }
 
 type Z @join__type(graph: TWO, key: "id") @context(name: "two__ctx") {


### PR DESCRIPTION


I didn't notice that the actual argument is removed from the supergraph. I tested this end-to-end and it's working


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7132 done by [Mergify](https://mergify.com).