### PR TITLE
Add compute pool metrics

### DIFF
--- a/apollo-router/src/compute_job/metrics.rs
+++ b/apollo-router/src/compute_job/metrics.rs
@@ -1,0 +1,82 @@
+use std::time::Instant;
+
+use crate::compute_job::ComputeJobType;
+use crate::plugins::telemetry::consts::OTEL_STATUS_CODE_ERROR;
+use crate::plugins::telemetry::consts::OTEL_STATUS_CODE_OK;
+
+#[derive(strum_macros::Display)]
+pub(super) enum Outcome {
+    Executed,
+    ExecutedError,
+    RejectedQueueFull,
+    Abandoned,
+}
+
+pub(super) struct JobWatcher {
+    queue_start: Instant,
+    compute_job_type: ComputeJobType,
+    pub(super) outcome: Outcome,
+}
+
+impl JobWatcher {
+    pub(super) fn new(compute_job_type: ComputeJobType) -> Self {
+        Self {
+            queue_start: Instant::now(),
+            outcome: Outcome::Abandoned,
+            compute_job_type,
+        }
+    }
+}
+
+impl Drop for JobWatcher {
+    fn drop(&mut self) {
+        let otel_status = match self.outcome {
+            Outcome::Executed => OTEL_STATUS_CODE_OK,
+            Outcome::Abandoned | Outcome::ExecutedError | Outcome::RejectedQueueFull => {
+                OTEL_STATUS_CODE_ERROR
+            }
+        };
+
+        let current_span = tracing::Span::current();
+        current_span.record("job.outcome", self.outcome.to_string());
+        current_span.record("otel.status_code", otel_status);
+
+        let queue_duration = self.queue_start.elapsed();
+        f64_histogram!(
+            "apollo.router.compute_jobs.queue.jobs",
+            "Information about the jobs",
+            queue_duration.as_secs_f64(),
+            "job.type" = self.compute_job_type.to_string(),
+            "job.outcome" = self.outcome.to_string()
+        );
+    }
+}
+
+pub(super) struct QueueActiveMetric {
+    compute_job_type: ComputeJobType,
+}
+
+impl QueueActiveMetric {
+    // create metric (auto-increments and decrements)
+    pub(super) fn register(compute_job_type: ComputeJobType) -> Self {
+        let s = Self { compute_job_type };
+        s.incr(1);
+        s
+    }
+
+    fn incr(&self, value: i64) {
+        i64_up_down_counter_with_unit!(
+            "apollo.router.compute_jobs.active",
+            "Number of computation jobs in progress",
+            "s",
+            value,
+            job.type = self.compute_job_type.to_string()
+        );
+    }
+}
+
+impl Drop for QueueActiveMetric {
+    fn drop(&mut self) {
+        self.incr(-1);
+    }
+}

--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -12,11 +12,11 @@ use tokio::sync::oneshot;
 use self::metrics::ActiveComputeMetric;
 use self::metrics::JobWatcher;
 use self::metrics::Outcome;
+use self::metrics::observe_compute_duration;
+use self::metrics::observe_queue_wait_duration;
 use crate::ageing_priority_queue::AgeingPriorityQueue;
 pub(crate) use crate::ageing_priority_queue::Priority;
 use crate::ageing_priority_queue::SendError;
-use crate::compute_job::metrics::observe_compute_duration;
-use crate::compute_job::metrics::observe_queue_wait_duration;
 use crate::metrics::meter_provider;
 
 /// We generate backpressure in tower `poll_ready` when the number of queued jobs

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -9,6 +9,7 @@ use crate::Configuration;
 use crate::cache::storage::CacheStorage;
 use crate::compute_job;
 use crate::compute_job::ComputeBackPressureError;
+use crate::compute_job::ComputeJobType;
 use crate::graphql;
 use crate::query_planner::QueryKey;
 use crate::services::layers::query_analysis::ParsedDocument;
@@ -159,8 +160,7 @@ impl IntrospectionCache {
         }
         let schema = schema.clone();
         let doc = doc.clone();
-        let priority = compute_job::Priority::P1; // Low priority
-        let response = compute_job::execute(priority, move |_| {
+        let response = compute_job::execute(ComputeJobType::Introspection, move |_| {
             Self::execute_introspection(max_depth, &schema, &doc)
         })?
         // `expect()` propagates any panic that potentially happens in the closure, but:

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -188,10 +188,9 @@ impl QueryPlannerService {
             let root_node = convert_root_query_plan_node(&plan);
             Ok((plan, root_node))
         };
-        let (plan, mut root_node) =
-            compute_job::execute(ComputeJobType::QueryPlanning, job)
-                .map_err(MaybeBackPressureError::TemporaryError)?
-                .await?;
+        let (plan, mut root_node) = compute_job::execute(ComputeJobType::QueryPlanning, job)
+            .map_err(MaybeBackPressureError::TemporaryError)?
+            .await?;
         if let Some(node) = &mut root_node {
             init_query_plan_root_node(node).map_err(QueryPlannerError::from)?;
         }

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -27,6 +27,7 @@ use crate::apollo_studio_interop::ExtendedReferenceStats;
 use crate::apollo_studio_interop::UsageReporting;
 use crate::apollo_studio_interop::generate_extended_references;
 use crate::compute_job;
+use crate::compute_job::ComputeJobType;
 use crate::compute_job::MaybeBackPressureError;
 use crate::context::OPERATION_KIND;
 use crate::context::OPERATION_NAME;
@@ -124,8 +125,7 @@ impl QueryAnalysisLayer {
         // Must be created *outside* of the compute_job or the span is not connected to the parent
         let span = tracing::info_span!(QUERY_PARSING_SPAN_NAME, "otel.kind" = "INTERNAL");
 
-        let priority = compute_job::Priority::P4; // Medium priority
-        compute_job::execute(priority, move |_| {
+        compute_job::execute(ComputeJobType::QueryParsing, move |_| {
             span.in_scope(|| {
                 Query::parse_document(
                     &query,


### PR DESCRIPTION
This PR extracts some of the work done in #7111 to make use of those metrics in router `v2.x`. It does not include any of the spans, which I assume will be added in #7124.

There are a few changes and some refactoring, which I can revert if it's not helpful - the main change was to promote `compute_job` to a module and extract the metrics into their own file.

New metrics:
* `apollo.router.compute_jobs.duration`: total duration spent by the job in the computation pipeline (including the compute queue and the actual computation time).
  dimensions: job type, job outcome
* `apollo.router.compute_jobs.queue.wait.duration`: time the job spent waiting in the queue.
   dimensions: job type
* `apollo.router.compute_jobs.execution.duration`: time it took to actually execute the job.
   dimensions: job type
* `apollo.router.compute_jobs.execution.active_count`: number of jobs being actively processed (gauge).
   dimensions: job type

Dimensions:
* job type: `QueryParsing`, `QueryPlanning`, `Introspection`
* job outcome: `Executed` (success), `ExecutedError`, `RejectedQueueFull`, `Abandoned`

<!-- start metadata -->
<!-- RH-802 -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
