### PR TITLE
Port schema upgrader tests

### DIFF
--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -44,7 +44,7 @@ pub(crate) fn upgrade_subgraphs_if_necessary(
         .iter()
         .all(|subgraph| subgraph.metadata().is_fed_2_schema())
     {
-        return Ok(Default::default());
+        return Ok(());
     }
 
     let mut object_type_map: HashMap<Name, HashMap<String, TypeInfo>> = Default::default();

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -518,7 +518,7 @@ mod tests {
             &r#"Removed @provides directive on field "Random.x" as it is of non-composite type "Int": while not rejected by federation 0.x, such @provide is nonsensical and was ignored"#.to_string()
         ));
 
-        assert_eq!(
+        insta::assert_snapshot!(
             s1.schema().schema().to_string(),
             r#"
             schema
@@ -596,7 +596,7 @@ mod tests {
             ]
         );
 
-        assert_eq!(
+        insta::assert_snapshot!(
             s.schema().schema().to_string(),
             r#"
             schema
@@ -831,7 +831,7 @@ mod tests {
         // router that supports the build pipeline they're upgrading to, but that
         // mechanism isn't in place yet.
         // - Trevor
-        assert_eq!(
+        insta::assert_snapshot!(
             subgraph.schema().schema().to_string(),
             r#"
             schema
@@ -842,7 +842,6 @@ mod tests {
             }
         "#
         );
-        // TODO: Check if SDL assertions are better done with assert_snapshot
     }
 
     #[ignore = "not yet implemented"]


### PR DESCRIPTION
Ports all tests from [schemaUpgrader.test.ts](https://github.com/apollographql/federation/blob/main/internals-js/src/__tests__/schemaUpgrader.test.ts). Tests are currently ignored and can be selectively enabled as we implement the schema upgrader.

<!-- FED-526 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
