### PR TITLE
Fix/docker image fix for cloudrun

### DIFF
--- a/.changesets/fix_fix_docker_image_fix_for_cloudrun.md
+++ b/.changesets/fix_fix_docker_image_fix_for_cloudrun.md
@@ -1,0 +1,11 @@
+### Update Dockerfile exec script to use `#!/bin/bash` instead of `#!/usr/bin/env bash` ([Issue #3517](https://github.com/apollographql/router/issues/3517))
+
+For users of Google Cloud Platform (GCP) Cloud Run platform, using the router's default Docker image was not possible due to an error that would occur during startup: 
+
+```sh
+"/usr/bin/env: 'bash ': No such file or directory"
+```
+
+To avoid this issue, we've changed the script to use `#!/bin/bash` instead of `#!/usr/bin/env bash`, as we use a fixed Linux distribution in Docker which has the Bash binary located there. 
+
+By [@lleadbet](https://github.com/lleadbet) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -61,7 +61,7 @@ ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 
 # Create a wrapper script to run the router, use exec to ensure signals are handled correctly
 RUN \
-  echo '#!/usr/bin/env bash \
+  echo '#!/bin/bash \
 \nset -e \
 \n \
 \nif [ -f "/usr/bin/heaptrack" ]; then \


### PR DESCRIPTION
*Description*

Fixes #3517. 

This PR changes the shebang used in the default Dockerfile to `#!/bin/bash` as we use `debian:bookworm-slim` as our basis. Within that image, `bash` will be located at `/bin/bash`, so we don't need to use `env` to locate it. Cloud Run, for some reason, wasn't able to use `env`, hence the issue in #3517. 

This change is relatively minor, but worth testing. Locally it works fine, however, using a Mac (M1/arm64). 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests
