### PR TITLE
remove lambda note from the API Gateway docs

### DIFF
--- a/docs/source/routing/operations/subscriptions/api-gateway.mdx
+++ b/docs/source/routing/operations/subscriptions/api-gateway.mdx
@@ -95,6 +95,4 @@ Streaming of HTTP multipart is supported out of the box with no additional confi
 
 ## AWS API Gateway
 
-AWS API Gateway doesn't support streaming of HTTP data.
-
-A possible workaround is to use a Lambda expression which does support streaming. To learn more, see [AWS Lambda response streaming](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/).
+AWS API Gateway currently doesn't support streaming of HTTP data.


### PR DESCRIPTION
This just removes a misleading note in the API Gateway docs page that implied that Lambda may be a workaround for using subscriptions; given the router cannot run as a lambda, it is not possible unless it fronts the router, which is not best practice. 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

