### PR TITLE
Adjust compute job worker pool queue size (backport #7205)

### DIFF
--- a/apollo-router/src/compute_job.rs
+++ b/apollo-router/src/compute_job.rs
@@ -12,7 +12,11 @@ use crate::metrics::meter_provider;
 
 /// We generate backpressure in tower `poll_ready` when the number of queued jobs
 /// reaches `QUEUE_SOFT_CAPACITY_PER_THREAD * thread_pool_size()`
-const QUEUE_SOFT_CAPACITY_PER_THREAD: usize = 20;
+///
+/// This number is somewhat arbitrary and subject to change. Most compute jobs
+/// don't take a long time, so by making the queue quite big, it's capable of eating
+/// a sizable backlog during spikes.
+const QUEUE_SOFT_CAPACITY_PER_THREAD: usize = 1_000;
 
 /// By default, let this thread pool use all available resources if it can.
 /// In the worst case, we’ll have moderate context switching cost


### PR DESCRIPTION
The compute job worker pool is used for CPU-bound tasks, like GraphQL parsing, validation, and query planning. When there are too many jobs to handle in parallel, jobs enter a queue.

We previously set this queue size to 20 (per thread) somewhat arbitrarily. We got some signals that this may be too little. Actually, most jobs complete very quickly.

This patch increases the queue size to 1 000 jobs per thread. For reference, in older router versions that were based on the JavaScript query planner, the equivalent queue size was _10 000_.

The number is still a bit arbitrary, and subject to more changes in the future as we understand its effects better. Along with some other tweaks to job priorities we expect this to give better behaviour and reject fewer requests needlessly.




[ROUTER-1236]: https://apollographql.atlassian.net/browse/ROUTER-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #7205 done by [Mergify](https://mergify.com).