### PR TITLE
Add compute pool metrics (backport #7184)

### DIFF
--- a/.changesets/fix_caroline_compute_pool_metrics.md
+++ b/.changesets/fix_caroline_compute_pool_metrics.md
@@ -1,0 +1,19 @@
+### Add compute pool metrics ([PR #7184](https://github.com/apollographql/router/pull/7184))
+
+The compute job pool is used within the router for compute intensive jobs that should not block the Tokio worker threads.
+When this pool becomes saturated it is difficult for users to see why so that they can take action.
+This change adds new metrics to help users understand how long jobs are waiting to be processed.  
+
+New metrics:
+- `apollo.router.compute_jobs.queue_is_full` - A counter of requests rejected because the queue was full.
+- `apollo.router.compute_jobs.duration` - A histogram of time spent in the compute pipeline by the job, including the queue and query planning.
+  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
+  - `job.outcome`: (`ExecutedOk`, `ExecutedError`, `ChannelError`, `RejectedQueueFull`, `Abandoned`)
+- `apollo.router.compute_jobs.queue.wait.duration` - A histogram of time spent in the compute queue by the job.
+  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
+- `apollo.router.compute_jobs.execution.duration` - A histogram of time spent to execute job (excludes time spent in the queue).
+  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
+- `apollo.router.compute_jobs.active_jobs` - A gauge of the number of compute jobs being processed in parallel.
+  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/7184

--- a/apollo-router/src/compute_job/metrics.rs
+++ b/apollo-router/src/compute_job/metrics.rs
@@ -1,0 +1,168 @@
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::compute_job::ComputeJobType;
+
+#[derive(Copy, Clone, strum_macros::IntoStaticStr)]
+pub(super) enum Outcome {
+    ExecutedOk,
+    ExecutedError,
+    ChannelError,
+    RejectedQueueFull,
+    Abandoned,
+}
+
+impl From<Outcome> for opentelemetry::Value {
+    fn from(outcome: Outcome) -> Self {
+        let s: &'static str = outcome.into();
+        s.into()
+    }
+}
+
+pub(super) struct JobWatcher {
+    queue_start: Instant,
+    compute_job_type: ComputeJobType,
+    pub(super) outcome: Outcome,
+}
+
+impl JobWatcher {
+    pub(super) fn new(compute_job_type: ComputeJobType) -> Self {
+        Self {
+            queue_start: Instant::now(),
+            outcome: Outcome::Abandoned,
+            compute_job_type,
+        }
+    }
+}
+
+impl Drop for JobWatcher {
+    fn drop(&mut self) {
+        let full_duration = self.queue_start.elapsed();
+        f64_histogram!(
+            "apollo.router.compute_jobs.duration",
+            "Total job processing time",
+            full_duration.as_secs_f64(),
+            "job.type" = self.compute_job_type,
+            "job.outcome" = self.outcome
+        );
+    }
+}
+
+pub(super) struct ActiveComputeMetric {
+    compute_job_type: ComputeJobType,
+}
+
+impl ActiveComputeMetric {
+    // create metric (auto-increments and decrements)
+    pub(super) fn register(compute_job_type: ComputeJobType) -> Self {
+        let s = Self { compute_job_type };
+        s.incr(1);
+        s
+    }
+
+    fn incr(&self, value: i64) {
+        i64_up_down_counter!(
+            "apollo.router.compute_jobs.active_jobs",
+            "Number of computation jobs in progress",
+            value,
+            job.type = self.compute_job_type
+        );
+    }
+}
+
+impl Drop for ActiveComputeMetric {
+    fn drop(&mut self) {
+        self.incr(-1);
+    }
+}
+
+pub(super) fn observe_queue_wait_duration(
+    compute_job_type: ComputeJobType,
+    queue_duration: Duration,
+) {
+    f64_histogram!(
+        "apollo.router.compute_jobs.queue.wait.duration",
+        "Time spent by the job in the compute queue",
+        queue_duration.as_secs_f64(),
+        "job.type" = compute_job_type
+    );
+}
+
+pub(super) fn observe_compute_duration(compute_job_type: ComputeJobType, job_duration: Duration) {
+    f64_histogram!(
+        "apollo.router.compute_jobs.execution.duration",
+        "Time to execute the job, after it has been pulled from the queue",
+        job_duration.as_secs_f64(),
+        "job.type" = compute_job_type
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compute_job::ComputeJobType;
+    use crate::compute_job::metrics::ActiveComputeMetric;
+    use crate::compute_job::metrics::JobWatcher;
+    use crate::compute_job::metrics::Outcome;
+
+    #[test]
+    fn test_job_watcher() {
+        let check_histogram_count =
+            |_count: u64, job_type: &'static str, job_outcome: &'static str| {
+                assert_histogram_exists!(
+                    "apollo.router.compute_jobs.duration",
+                    f64,
+                    "job.type" = job_type,
+                    "job.outcome" = job_outcome
+                );
+            };
+
+        {
+            let _job_watcher = JobWatcher::new(ComputeJobType::Introspection);
+        }
+        check_histogram_count(1, "Introspection", Outcome::Abandoned.into());
+
+        {
+            let mut job_watcher = JobWatcher::new(ComputeJobType::QueryParsing);
+            job_watcher.outcome = Outcome::ExecutedOk;
+        }
+        check_histogram_count(1, "QueryParsing", Outcome::ExecutedOk.into());
+
+        for count in 1..5 {
+            {
+                let mut job_watcher = JobWatcher::new(ComputeJobType::QueryPlanning);
+                job_watcher.outcome = Outcome::RejectedQueueFull;
+            }
+            check_histogram_count(count, "QueryPlanning", Outcome::RejectedQueueFull.into());
+        }
+    }
+
+    #[test]
+    fn test_active_compute_metric() {
+        let check_count = |count: i64, job_type: &'static str| {
+            assert_up_down_counter!(
+                "apollo.router.compute_jobs.active_jobs",
+                count,
+                "job.type" = job_type
+            );
+        };
+
+        {
+            let _introspection_1 = ActiveComputeMetric::register(ComputeJobType::Introspection);
+            let _introspection_2 = ActiveComputeMetric::register(ComputeJobType::Introspection);
+            let introspection_3 = ActiveComputeMetric::register(ComputeJobType::Introspection);
+            check_count(3, "Introspection");
+
+            let _planning_1 = ActiveComputeMetric::register(ComputeJobType::QueryPlanning);
+            check_count(3, "Introspection");
+            check_count(1, "QueryPlanning");
+
+            drop(introspection_3);
+            check_count(2, "Introspection");
+            check_count(1, "QueryPlanning");
+        }
+
+        // block ended, so should have no ongoing computation
+        check_count(0, "Introspection");
+        check_count(0, "QueryPlanning");
+    }
+}

--- a/apollo-router/src/compute_job/metrics.rs
+++ b/apollo-router/src/compute_job/metrics.rs
@@ -8,8 +8,10 @@ pub(super) enum Outcome {
     ExecutedOk,
     ExecutedError,
     ChannelError,
-    RejectedQueueFull,
     Abandoned,
+
+    #[allow(dead_code)] // NB: `RejectedQueueFull` is unused for now
+    RejectedQueueFull,
 }
 
 impl From<Outcome> for opentelemetry::Value {

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -8,6 +8,7 @@ use serde_json_bytes::json;
 use crate::Configuration;
 use crate::cache::storage::CacheStorage;
 use crate::compute_job;
+use crate::compute_job::ComputeJobType;
 use crate::graphql;
 use crate::query_planner::QueryKey;
 use crate::services::layers::query_analysis::ParsedDocument;
@@ -137,11 +138,11 @@ impl IntrospectionCache {
         }
         let schema = schema.clone();
         let doc = doc.clone();
-        let priority = compute_job::Priority::P1; // Low priority
-        let response =
-            compute_job::execute(priority, move || Self::execute_introspection(&schema, &doc))
-                .await
-                .expect("Introspection panicked");
+        let response = compute_job::execute(ComputeJobType::Introspection, move || {
+            Self::execute_introspection(&schema, &doc)
+        })
+        .await
+        .expect("Introspection panicked");
         storage.insert(cache_key, response.clone()).await;
         response
     }

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -155,10 +155,10 @@ impl QueryPlannerService {
             compute_job::execute(ComputeJobType::QueryPlanning, move || {
                 let start = Instant::now();
 
-            let query_plan_options = QueryPlanOptions {
-                override_conditions: plan_options.override_conditions,
-                non_local_selections_limit_enabled: non_local_selections_check_enabled(),
-            };
+                let query_plan_options = QueryPlanOptions {
+                    override_conditions: plan_options.override_conditions,
+                    non_local_selections_limit_enabled: non_local_selections_check_enabled(),
+                };
 
                 let result = operation
                     .as_deref()

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -15,9 +15,9 @@ use apollo_federation::error::SingleFederationError;
 use apollo_federation::query_plan::query_planner::QueryPlanOptions;
 use apollo_federation::query_plan::query_planner::QueryPlanner;
 use futures::future::BoxFuture;
-use opentelemetry_api::KeyValue;
-use opentelemetry_api::metrics::MeterProvider as _;
-use opentelemetry_api::metrics::ObservableGauge;
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry::metrics::ObservableGauge;
 use serde_json_bytes::Value;
 use tower::Service;
 
@@ -26,6 +26,7 @@ use super::QueryKey;
 use crate::Configuration;
 use crate::apollo_studio_interop::generate_usage_reporting;
 use crate::compute_job;
+use crate::compute_job::ComputeJobType;
 use crate::error::FederationErrorBridge;
 use crate::error::QueryPlannerError;
 use crate::error::ServiceBuildError;
@@ -150,44 +151,48 @@ impl QueryPlannerService {
     ) -> Result<QueryPlanResult, QueryPlannerError> {
         let doc = doc.clone();
         let rust_planner = self.planner.clone();
-        let priority = compute_job::Priority::P8; // High priority
-        let (plan, mut root_node) = compute_job::execute(priority, move || {
-            let start = Instant::now();
+        let (plan, mut root_node) =
+            compute_job::execute(ComputeJobType::QueryPlanning, move || {
+                let start = Instant::now();
 
             let query_plan_options = QueryPlanOptions {
                 override_conditions: plan_options.override_conditions,
                 non_local_selections_limit_enabled: non_local_selections_check_enabled(),
             };
 
-            let result = operation
-                .as_deref()
-                .map(|n| Name::new(n).map_err(FederationError::from))
-                .transpose()
-                .and_then(|operation| {
-                    rust_planner.build_query_plan(&doc.executable, operation, query_plan_options)
-                });
-            if let Err(FederationError::SingleFederationError(
-                SingleFederationError::InternalUnmergeableFields { .. },
-            )) = &result
-            {
-                u64_counter!(
-                    "apollo.router.operations.query_planner.unmergeable_fields",
-                    "Query planner caught attempting to merge unmergeable fields",
-                    1
-                );
-            }
-            let result = result.map_err(FederationErrorBridge::from);
+                let result = operation
+                    .as_deref()
+                    .map(|n| Name::new(n).map_err(FederationError::from))
+                    .transpose()
+                    .and_then(|operation| {
+                        rust_planner.build_query_plan(
+                            &doc.executable,
+                            operation,
+                            query_plan_options,
+                        )
+                    });
+                if let Err(FederationError::SingleFederationError(
+                    SingleFederationError::InternalUnmergeableFields { .. },
+                )) = &result
+                {
+                    u64_counter!(
+                        "apollo.router.operations.query_planner.unmergeable_fields",
+                        "Query planner caught attempting to merge unmergeable fields",
+                        1
+                    );
+                }
+                let result = result.map_err(FederationErrorBridge::from);
 
-            let elapsed = start.elapsed().as_secs_f64();
-            metric_query_planning_plan_duration(RUST_QP_MODE, elapsed);
+                let elapsed = start.elapsed().as_secs_f64();
+                metric_query_planning_plan_duration(RUST_QP_MODE, elapsed);
 
-            result.map(|plan| {
-                let root_node = convert_root_query_plan_node(&plan);
-                (plan, root_node)
+                result.map(|plan| {
+                    let root_node = convert_root_query_plan_node(&plan);
+                    (plan, root_node)
+                })
             })
-        })
-        .await
-        .expect("query planner panicked")?;
+            .await
+            .expect("query planner panicked")?;
         if let Some(node) = &mut root_node {
             init_query_plan_root_node(node)?;
         }

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -24,6 +24,7 @@ use crate::apollo_studio_interop::ExtendedReferenceStats;
 use crate::apollo_studio_interop::UsageReporting;
 use crate::apollo_studio_interop::generate_extended_references;
 use crate::compute_job;
+use crate::compute_job::ComputeJobType;
 use crate::context::OPERATION_KIND;
 use crate::context::OPERATION_NAME;
 use crate::error::ValidationErrors;
@@ -116,7 +117,6 @@ impl QueryAnalysisLayer {
         // parent
         let span = tracing::info_span!(QUERY_PARSING_SPAN_NAME, "otel.kind" = "INTERNAL");
 
-        let priority = compute_job::Priority::P4; // Medium priority
         let job = move || {
             span.in_scope(|| {
                 Query::parse_document(
@@ -157,7 +157,7 @@ impl QueryAnalysisLayer {
         };
         // TODO: is this correct?
         let job = std::panic::AssertUnwindSafe(job);
-        compute_job::execute(priority, job)
+        compute_job::execute(ComputeJobType::QueryParsing, job)
             .await
             .expect("Query::parse_document panicked")
     }

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -247,6 +247,18 @@ async fn test_graphql_metrics() {
     router
             .assert_metrics_contains(r#"custom_histogram_sum{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 3"#, None)
             .await;
+    router
+        .assert_metrics_contains(r#"apollo_router_compute_jobs_duration_seconds_count{job_outcome="ExecutedOk",job_type="QueryParsing",otel_scope_name="apollo/router"} 1"#, None)
+        .await;
+    router
+        .assert_metrics_contains(r#"apollo_router_compute_jobs_duration_seconds_count{job_outcome="ExecutedOk",job_type="QueryPlanning",otel_scope_name="apollo/router"} 1"#, None)
+        .await;
+    router
+        .assert_metrics_contains(r#"apollo_router_compute_jobs_queue_wait_duration_seconds_count{job_type="QueryParsing",otel_scope_name="apollo/router"} 1"#, None)
+        .await;
+    router
+        .assert_metrics_contains(r#"apollo_router_compute_jobs_execution_duration_seconds_count{job_type="QueryPlanning",otel_scope_name="apollo/router"} 1"#, None)
+        .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -299,5 +311,19 @@ async fn test_gauges_on_reload() {
 
     router
         .assert_metrics_contains(r#"apollo_router_pipelines{config_hash="<any>",schema_id="<any>",otel_scope_name="apollo/router"} 1"#, None)
+        .await;
+
+    router
+        .assert_metrics_contains(
+            r#"apollo_router_compute_jobs_queued{otel_scope_name="apollo/router"} 0"#,
+            None,
+        )
+        .await;
+
+    router
+        .assert_metrics_contains(
+            r#"apollo_router_compute_jobs_active_jobs{job_type="QueryParsing",otel_scope_name="apollo/router"} 0"#,
+            None,
+        )
         .await;
 }

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -248,16 +248,16 @@ async fn test_graphql_metrics() {
             .assert_metrics_contains(r#"custom_histogram_sum{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 3"#, None)
             .await;
     router
-        .assert_metrics_contains(r#"apollo_router_compute_jobs_duration_seconds_count{job_outcome="ExecutedOk",job_type="QueryParsing",otel_scope_name="apollo/router"} 1"#, None)
+        .assert_metrics_contains(r#"apollo_router_compute_jobs_duration_count{job_outcome="ExecutedOk",job_type="QueryParsing",otel_scope_name="apollo/router"} 1"#, None)
         .await;
     router
-        .assert_metrics_contains(r#"apollo_router_compute_jobs_duration_seconds_count{job_outcome="ExecutedOk",job_type="QueryPlanning",otel_scope_name="apollo/router"} 1"#, None)
+        .assert_metrics_contains(r#"apollo_router_compute_jobs_duration_count{job_outcome="ExecutedOk",job_type="QueryPlanning",otel_scope_name="apollo/router"} 1"#, None)
         .await;
     router
-        .assert_metrics_contains(r#"apollo_router_compute_jobs_queue_wait_duration_seconds_count{job_type="QueryParsing",otel_scope_name="apollo/router"} 1"#, None)
+        .assert_metrics_contains(r#"apollo_router_compute_jobs_queue_wait_duration_count{job_type="QueryParsing",otel_scope_name="apollo/router"} 1"#, None)
         .await;
     router
-        .assert_metrics_contains(r#"apollo_router_compute_jobs_execution_duration_seconds_count{job_type="QueryPlanning",otel_scope_name="apollo/router"} 1"#, None)
+        .assert_metrics_contains(r#"apollo_router_compute_jobs_execution_duration_count{job_type="QueryPlanning",otel_scope_name="apollo/router"} 1"#, None)
         .await;
 }
 

--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -65,7 +65,15 @@ The coprocessor operations metric has the following attributes:
 ### Compute jobs
 
 - `apollo.router.compute_jobs.queued` - A gauge of the number of jobs queued for the thread pool dedicated to CPU-heavy components like GraphQL parsing and validation, and the (new) query planner.
-
+- `apollo.router.compute_jobs.duration` - A histogram of time spent in the compute pipeline by the job, including the queue and query planning.
+  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
+  - `job.outcome`: (`ExecutedOk`, `ExecutedError`, `ChannelError`, `RejectedQueueFull`, `Abandoned`)
+- `apollo.router.compute_jobs.queue.wait.duration` - A histogram of time spent in the compute queue by the job.
+  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
+- `apollo.router.compute_jobs.execution.duration` - A histogram of time spent to execute job (excludes time spent in the queue).
+  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
+- `apollo.router.compute_jobs.active_jobs` - A gauge of the number of compute jobs being processed in parallel.
+  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
 ### Uplink
 
 <Tip>


### PR DESCRIPTION
This PR extracts some of the work done in #7111 to make use of those metrics in router `v2.x`. It does not include any of the spans, which I assume will be added in #7124.

There are a few changes and some refactoring, which I can revert if it's not helpful - the main change was to promote `compute_job` to a module and extract the metrics into their own file.

New metrics:
- `apollo.router.compute_jobs.queue_is_full` - A counter of requests rejected because the queue was full.
- `apollo.router.compute_jobs.duration` - A histogram of time spent in the compute pipeline by the job, including the queue and query planning.
  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
  - `job.outcome`: (`ExecutedOk`, `ExecutedError`, `ChannelError`, `RejectedQueueFull`, `Abandoned`)
- `apollo.router.compute_jobs.queue.wait.duration` - A histogram of time spent in the compute queue by the job.
  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
- `apollo.router.compute_jobs.execution.duration` - A histogram of time spent to execute job (excludes time spent in the queue).
  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)
- `apollo.router.compute_jobs.active_jobs` - A gauge of the number of compute jobs being processed in parallel.
  - `job.type`: (`QueryPlanning`, `QueryParsing`, `Introspection`)




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7184 done by [Mergify](https://mergify.com).