### PR TITLE
deps: update crossbeam-channel (backport #7209) (backport #7215)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -82,7 +82,7 @@ clap = { version = "4.5.8", default-features = false, features = [
     "help",
 ] }
 cookie = { version = "0.18.0", default-features = false }
-crossbeam-channel = "0.5.14"
+crossbeam-channel = "0.5.15"
 ci_info = { version = "0.14.14", features = ["serde-1"] }
 dashmap = { version = "5.5.3", features = ["serde"] }
 derivative = "2.2.0"


### PR DESCRIPTION
There is a potential double-free in crossbeam-channel 0.5.14.

https://github.com/crossbeam-rs/crossbeam/releases/tag/crossbeam-channel-0.5.15<hr>This is an automatic backport of pull request #7209 done by [Mergify](https://mergify.com).<hr>This is an automatic backport of pull request #7215 done by [Mergify](https://mergify.com).