### PR TITLE
De-prioritize query parsing during warmup process

### DIFF
--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -109,14 +109,16 @@ pub(crate) enum ComputeJobType {
     QueryParsing,
     QueryPlanning,
     Introspection,
+    QueryParsingWarmup,
 }
 
 impl From<ComputeJobType> for Priority {
     fn from(job_type: ComputeJobType) -> Self {
         match job_type {
-            ComputeJobType::QueryPlanning => Self::P8, // high
-            ComputeJobType::QueryParsing => Self::P4,  // medium
-            ComputeJobType::Introspection => Self::P1, // low
+            ComputeJobType::QueryPlanning => Self::P8,      // high
+            ComputeJobType::QueryParsing => Self::P4,       // medium
+            ComputeJobType::Introspection => Self::P1,      // low
+            ComputeJobType::QueryParsingWarmup => Self::P1, // low
         }
     }
 }

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -316,26 +316,6 @@ where
                 })
                 .await;
             if entry.is_first() {
-                let doc = loop {
-                    match query_analysis
-                        .parse_document(&query, operation_name.as_deref())
-                        .await
-                    {
-                        Ok(doc) => break doc,
-                        Err(MaybeBackPressureError::PermanentError(error)) => {
-                            let e = Arc::new(QueryPlannerError::SpecError(error));
-                            tokio::spawn(async move {
-                                entry.insert(Err(e)).await;
-                            });
-                            continue 'all_cache_keys_loop;
-                        }
-                        Err(MaybeBackPressureError::TemporaryError(ComputeBackPressureError)) => {
-                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                            // try again
-                        }
-                    }
-                };
-
                 loop {
                     let request = QueryPlannerRequest {
                         query: query.clone(),

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -24,6 +24,7 @@ use crate::cache::estimate_size;
 use crate::cache::storage::InMemoryCache;
 use crate::cache::storage::ValueType;
 use crate::compute_job::ComputeBackPressureError;
+use crate::compute_job::ComputeJobType;
 use crate::compute_job::MaybeBackPressureError;
 use crate::configuration::PersistedQueriesPrewarmQueryPlanCache;
 use crate::error::CacheResolverError;
@@ -274,7 +275,11 @@ where
         } in all_cache_keys
         {
             let doc = match query_analysis
-                .parse_document(&query, operation_name.as_deref())
+                .parse_document(
+                    &query,
+                    operation_name.as_deref(),
+                    ComputeJobType::QueryParsingWarmup,
+                )
                 .await
             {
                 Ok(doc) => doc,

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -274,6 +274,9 @@ where
             config_mode_hash: _,
         } in all_cache_keys
         {
+            // NB: warmup query parsing has a very low priority so that real requests are
+            // prioritized. However, warmup query planning maintains its normal priority so
+            // that warmup doesn't take an excessively long time.
             let doc = loop {
                 match query_analysis
                     .parse_document(

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -116,6 +116,7 @@ impl QueryAnalysisLayer {
         &self,
         query: &str,
         operation_name: Option<&str>,
+        compute_job_type: ComputeJobType,
     ) -> Result<ParsedDocument, MaybeBackPressureError<SpecError>> {
         let query = query.to_string();
         let operation_name = operation_name.map(|o| o.to_string());
@@ -125,7 +126,7 @@ impl QueryAnalysisLayer {
         // Must be created *outside* of the compute_job or the span is not connected to the parent
         let span = tracing::info_span!(QUERY_PARSING_SPAN_NAME, "otel.kind" = "INTERNAL");
 
-        compute_job::execute(ComputeJobType::QueryParsing, move |_| {
+        compute_job::execute(compute_job_type, move |_| {
             span.in_scope(|| {
                 Query::parse_document(
                     &query,
@@ -281,7 +282,10 @@ impl QueryAnalysisLayer {
             .cloned();
 
         let res = match entry {
-            None => match self.parse_document(&query, op_name.as_deref()).await {
+            None => match self
+                .parse_document(&query, op_name.as_deref(), ComputeJobType::QueryParsing)
+                .await
+            {
                 Err(e) => {
                     if let MaybeBackPressureError::PermanentError(errors) = &e {
                         (*self.cache.lock().await).put(


### PR DESCRIPTION
This PR lowers the priority of query parsing during the warmup process. This will help reduce the impact of warmup on serving requests.

Open considerations:
- [ ] I only changed the priority of parsing (not planning). This was for a few reasons - (1) changing the priority of planning will be much more complicated, and (2) I was worried that lowering the planning priority would excessively throttle the warmup and it would take way too long to complete. I'm happy to work on the planning side as well if desired.
- [ ] I noticed that parsing was happening twice, so I removed the second instance. The downside of doing that is that if the parsing fails with a `SpecError`, that error will not be inserted into the cache. My suspicion is that skipping the second parsing for all cached queries will outperform the benefit of having the `SpecError` cached, but I'm happy to revert that if desired.

<!-- start metadata -->
<!-- ROUTER-1242 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
