### PR TITLE
fix(federation): return internal errors for invalid query plans (backport #7214) (backport #7219)

### DIFF
--- a/.changesets/fix_renee_bail_invalid_query_plans.md
+++ b/.changesets/fix_renee_bail_invalid_query_plans.md
@@ -1,0 +1,7 @@
+### Fix crash when an invalid query plan is generated ([PR #7214](https://github.com/apollographql/router/pull/7214))
+
+When an invalid query plan is generated, the router could panic and crash.
+This could happen if there are gaps in the GraphQL validation implementation.
+Now, even if there are unresolved gaps, the router will handle it gracefully and reject the request.
+
+By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/7214

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -266,3 +266,17 @@ pub enum QueryPathElement {
     #[serde(serialize_with = "crate::utils::serde_bridge::serialize_exe_inline_fragment")]
     InlineFragment(executable::InlineFragment),
 }
+
+impl PlanNode {
+    /// Returns the kind of plan node this is as a human-readable string. Exact output not guaranteed.
+    fn node_kind(&self) -> &'static str {
+        match self {
+            Self::Fetch(_) => "Fetch",
+            Self::Sequence(_) => "Sequence",
+            Self::Parallel(_) => "Parallel",
+            Self::Flatten(_) => "Flatten",
+            Self::Defer(_) => "Defer",
+            Self::Condition(_) => "Condition",
+        }
+    }
+}

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -462,10 +462,11 @@ impl QueryPlanner {
             ),
             Some(PlanNode::Sequence(root_node)) if is_subscription => {
                 let Some((primary, rest)) = root_node.nodes.split_first() else {
-                    unreachable!("Sequence must have at least one node");
+                    // TODO(@goto-bus-stop): We could probably guarantee this in the type system
+                    bail!("Invalid query plan: Sequence must have at least one node");
                 };
                 let PlanNode::Fetch(primary) = primary.clone() else {
-                    unreachable!("Primary node of a subscription is not a Fetch");
+                    bail!("Invalid query plan: Primary node of a subscription is not a Fetch");
                 };
                 let rest = PlanNode::Sequence(SequenceNode {
                     nodes: rest.to_vec(),
@@ -478,9 +479,10 @@ impl QueryPlanner {
                 ))
             }
             Some(node) if is_subscription => {
-                unreachable!(
-                    "Unexpected top level PlanNode: '{node:?}' when processing subscription"
-                )
+                bail!(
+                    "Invalid query plan for subscription: unexpected {} at root",
+                    node.node_kind()
+                );
             }
             Some(PlanNode::Fetch(inner)) => Some(TopLevelPlanNode::Fetch(inner)),
             Some(PlanNode::Sequence(inner)) => Some(TopLevelPlanNode::Sequence(inner)),

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/subscriptions.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/subscriptions.rs
@@ -1,5 +1,6 @@
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::name;
+use apollo_compiler::validation::Valid;
 use apollo_federation::query_plan::query_planner::QueryPlanIncrementalDeliveryConfig;
 use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
 
@@ -186,6 +187,102 @@ fn trying_to_use_defer_with_a_subcription_results_in_an_error() {
         "trying_to_use_defer_with_a_subcription_results_in_an_error.graphql",
     )
     .unwrap();
+
+    planner
+        .build_query_plan(&document, Some(name!(MySubscription)), Default::default())
+        .expect_err("should return an error");
+}
+
+#[test]
+fn trying_to_use_skip_with_a_subscription_results_in_an_error() {
+    let (api_schema, planner) = planner!(
+    SubgraphA: r#"
+            type Query {
+                me: User!
+            }
+
+            type Subscription {
+                onNewUser: User!
+            }
+
+            type User @key(fields: "id") {
+                id: ID!
+                name: String!
+            }
+        "#,
+    SubgraphB: r#"
+            type Query {
+                foo: Int
+            }
+
+            type User @key(fields: "id") {
+                id: ID!
+                address: String!
+            }
+        "#,
+    );
+
+    // This is invalid per https://github.com/graphql/graphql-spec/pull/860
+    let document = Valid::assume_valid(
+        ExecutableDocument::parse(
+            api_schema.schema(),
+            r#"
+        subscription MySubscription($v: Boolean!) {
+          onNewUser @skip(if: $v) { id name }
+        }
+        "#,
+            "trying_to_use_skip_with_a_subcription_results_in_an_error.graphql",
+        )
+        .unwrap(),
+    );
+
+    planner
+        .build_query_plan(&document, Some(name!(MySubscription)), Default::default())
+        .expect_err("should return an error");
+}
+
+#[test]
+fn trying_to_use_include_with_a_subscription_results_in_an_error() {
+    let (api_schema, planner) = planner!(
+    SubgraphA: r#"
+            type Query {
+                me: User!
+            }
+
+            type Subscription {
+                onNewUser: User!
+            }
+
+            type User @key(fields: "id") {
+                id: ID!
+                name: String!
+            }
+        "#,
+    SubgraphB: r#"
+            type Query {
+                foo: Int
+            }
+
+            type User @key(fields: "id") {
+                id: ID!
+                address: String!
+            }
+        "#,
+    );
+
+    // This is invalid per https://github.com/graphql/graphql-spec/pull/860
+    let document = Valid::assume_valid(
+        ExecutableDocument::parse(
+            api_schema.schema(),
+            r#"
+        subscription MySubscription($v: Boolean!) {
+          onNewUser @include(if: $v) { id name }
+        }
+        "#,
+            "trying_to_use_include_with_a_subcription_results_in_an_error.graphql",
+        )
+        .unwrap(),
+    );
 
     planner
         .build_query_plan(&document, Some(name!(MySubscription)), Default::default())

--- a/apollo-federation/tests/query_plan/supergraphs/trying_to_use_include_with_a_subscription_results_in_an_error.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/trying_to_use_include_with_a_subscription_results_in_an_error.graphql
@@ -1,0 +1,79 @@
+# Composed from subgraphs with hash: c8a41e00d374bc7c77184e0ffa9fae7d65868f14
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+  subscription: Subscription
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")
+  SUBGRAPHB @join__graph(name: "SubgraphB", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+{
+  me: User! @join__field(graph: SUBGRAPHA)
+  foo: Int @join__field(graph: SUBGRAPHB)
+}
+
+type Subscription
+  @join__type(graph: SUBGRAPHA)
+{
+  onNewUser: User!
+}
+
+type User
+  @join__type(graph: SUBGRAPHA, key: "id")
+  @join__type(graph: SUBGRAPHB, key: "id")
+{
+  id: ID!
+  name: String! @join__field(graph: SUBGRAPHA)
+  address: String! @join__field(graph: SUBGRAPHB)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/trying_to_use_skip_with_a_subscription_results_in_an_error.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/trying_to_use_skip_with_a_subscription_results_in_an_error.graphql
@@ -1,0 +1,79 @@
+# Composed from subgraphs with hash: c8a41e00d374bc7c77184e0ffa9fae7d65868f14
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+  subscription: Subscription
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")
+  SUBGRAPHB @join__graph(name: "SubgraphB", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+{
+  me: User! @join__field(graph: SUBGRAPHA)
+  foo: Int @join__field(graph: SUBGRAPHB)
+}
+
+type Subscription
+  @join__type(graph: SUBGRAPHA)
+{
+  onNewUser: User!
+}
+
+type User
+  @join__type(graph: SUBGRAPHA, key: "id")
+  @join__type(graph: SUBGRAPHB, key: "id")
+{
+  id: ID!
+  name: String! @join__field(graph: SUBGRAPHA)
+  address: String! @join__field(graph: SUBGRAPHB)
+}


### PR DESCRIPTION
When an invalid query plan is generated, we may panic and crash the
router. This was probably introduced before we had the short error
macros :)

Let's use the `bail!()` macro for all these cases and return internal
errors. None of these cases should happen unless there is a bug.





<hr>

This is an automatic backport of pull request #7214 done by [Mergify](https://mergify.com).

[ROUTER-1230]: https://apollographql.atlassian.net/browse/ROUTER-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #7219 done by [Mergify](https://mergify.com).