### PR TITLE
Report thread pool size and queue length during startup

### DIFF
--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -158,6 +158,11 @@ pub(crate) fn queue() -> &'static AgeingPriorityQueue<Job> {
                 }
             });
         }
+        tracing::info!(
+                "ComputeJob thread pool created.  threads:{} queue capacity:{}",
+                pool_size,
+                QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size
+            );
         AgeingPriorityQueue::bounded(QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size)
     })
 }

--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -159,10 +159,10 @@ pub(crate) fn queue() -> &'static AgeingPriorityQueue<Job> {
             });
         }
         tracing::info!(
-                "ComputeJob thread pool created.  threads:{} queue capacity:{}",
-                pool_size,
-                QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size
-            );
+            threads = pool_size,
+            queue_capacity = QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size,
+            "ComputeJob thread pool created",
+        );
         AgeingPriorityQueue::bounded(QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size)
     })
 }

--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -161,7 +161,7 @@ pub(crate) fn queue() -> &'static AgeingPriorityQueue<Job> {
         tracing::info!(
             threads = pool_size,
             queue_capacity = QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size,
-            "ComputeJob thread pool created",
+            "compute job thread pool created",
         );
         AgeingPriorityQueue::bounded(QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size)
     })


### PR DESCRIPTION
Pulls in #6663 by @theJC. Adds a log message at `info` level to report the number of threads used by the compute pool as well as the total queue capacity.

Fixes #6662, #6663

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
