### PR TITLE
fix(entity-cache): handle multiple key directives

### DIFF
--- a/.changesets/fix_duckki_entity_cache_matching_key.md
+++ b/.changesets/fix_duckki_entity_cache_matching_key.md
@@ -1,6 +1,6 @@
 ### Entity-cache: handle multiple key directives ([PR #7228](https://github.com/apollographql/router/pull/7228))
 
-This PR fixes a bug in entity caching introduced by the fix in https://github.com/apollographql/router/pull/6888 for cases where several `@key` directives with different fields were declared on a type as documented [here](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#managing-types). 
+This PR fixes a bug in entity caching introduced by the fix in https://github.com/apollographql/router/pull/6888 for cases where several `@key` directives with different fields were declared on a type as documented [here](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#managing-types).
 
 For example if you have this kind of entity in your schema:
 
@@ -11,9 +11,5 @@ type Product @key(fields: "upc") @key(fields: "sku") {
   name: String
 }
 ```
-
-<!-- [ROUTER-1244] -->
-
-[ROUTER-1244]: https://apollographql.atlassian.net/browse/ROUTER-1244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
 
 By [@duckki](https://github.com/duckki) & [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/7228

--- a/.changesets/fix_duckki_entity_cache_matching_key.md
+++ b/.changesets/fix_duckki_entity_cache_matching_key.md
@@ -1,0 +1,19 @@
+### Entity-cache: handle multiple key directives ([PR #7228](https://github.com/apollographql/router/pull/7228))
+
+This PR fixes a bug in entity caching introduced by the fix in https://github.com/apollographql/router/pull/6888 for cases where several `@key` directives with different fields were declared on a type as documented [here](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#managing-types). 
+
+For example if you have this kind of entity in your schema:
+
+```graphql
+type Product @key(fields: "upc") @key(fields: "sku") {
+  upc: ID!
+  sku: ID!
+  name: String
+}
+```
+
+<!-- [ROUTER-1244] -->
+
+[ROUTER-1244]: https://apollographql.atlassian.net/browse/ROUTER-1244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
+
+By [@duckki](https://github.com/duckki) & [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/7228

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -663,7 +663,6 @@ impl CacheService {
                         );
 
                         let mut response = self.service.call(request).await?;
-
                         let cache_control =
                             if response.response.headers().contains_key(CACHE_CONTROL) {
                                 CacheControl::new(response.response.headers(), self.storage.ttl)?
@@ -771,6 +770,7 @@ impl CacheService {
                                     reason: e.to_string(),
                                 },
                             };
+                            println!("errrooooor !!!! {e:?}");
 
                             let graphql_error = e.to_graphql_error(None);
 
@@ -1616,18 +1616,21 @@ pub(crate) fn hash_representation(
 ) -> String {
     let mut digest = Sha256::new();
     fn hash(state: &mut Sha256, fields: &serde_json_bytes::Map<ByteString, Value>) {
-        fields.iter().sorted_by(|a, b| a.0.cmp(&b.0)).for_each(|(k, v)| {
-            state.update(serde_json::to_string(k).unwrap().as_bytes());
-            state.update(":".as_bytes());
-            match v {
-                serde_json_bytes::Value::Object(obj) => {
-                    state.update("{".as_bytes());
-                    hash(state, obj);
-                    state.update("}".as_bytes());
+        fields
+            .iter()
+            .sorted_by(|a, b| a.0.cmp(b.0))
+            .for_each(|(k, v)| {
+                state.update(serde_json::to_string(k).unwrap().as_bytes());
+                state.update(":".as_bytes());
+                match v {
+                    serde_json_bytes::Value::Object(obj) => {
+                        state.update("{".as_bytes());
+                        hash(state, obj);
+                        state.update("}".as_bytes());
+                    }
+                    _ => state.update(serde_json::to_string(v).unwrap().as_bytes()),
                 }
-                _ => state.update(serde_json::to_string(v).unwrap().as_bytes()),
-            }
-        });
+            });
     }
     hash(&mut digest, representation);
     hex::encode(digest.finalize().as_slice())
@@ -1637,6 +1640,8 @@ pub(crate) fn hash_representation(
 pub(crate) fn hash_entity_key(
     entity_keys: &serde_json_bytes::Map<ByteString, serde_json_bytes::Value>,
 ) -> String {
+    #[cfg(test)]
+    dbg!(&entity_keys);
     // We have to hash the representation because it can contains PII
     hash_representation(entity_keys)
 }
@@ -1861,9 +1866,9 @@ pub(crate) type CacheKeysContext = HashMap<SubgraphRequestId, Vec<CacheKeyContex
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(test, derive(PartialEq, Eq, Hash, PartialOrd, Ord))]
 pub(crate) struct CacheKeyContext {
-    key: String,
-    status: CacheKeyStatus,
-    cache_control: String,
+    pub(super) key: String,
+    pub(super) status: CacheKeyStatus,
+    pub(super) cache_control: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -1464,12 +1464,8 @@ fn take_matching_key_field_set(
     supergraph_schema: &Valid<Schema>,
     subgraph_enums: &HashMap<String, String>,
 ) -> Result<serde_json_bytes::Map<ByteString, Value>, FetchError> {
-    let key_field_sets = collect_key_field_sets(
-        typename,
-        subgraph_name,
-        &supergraph_schema,
-        subgraph_enums,
-    )?;
+    let key_field_sets =
+        collect_key_field_sets(typename, subgraph_name, &supergraph_schema, subgraph_enums)?;
     let matched_key_field_set = find_matching_field_set(
         representation,
         &key_field_sets,
@@ -1477,12 +1473,10 @@ fn take_matching_key_field_set(
     .ok_or_else(|| FetchError::MalformedRequest {
         reason: format!("representation does not match any key field set for typename {typename} in subgraph {subgraph_name}"),
     })?;
-    take_selection_set(
-        representation,
-        &matched_key_field_set.selection_set,
-    )
-    .ok_or_else(|| FetchError::MalformedRequest {
-        reason: format!("representation does not match the field set {matched_key_field_set}"),
+    take_selection_set(representation, &matched_key_field_set.selection_set).ok_or_else(|| {
+        FetchError::MalformedRequest {
+            reason: format!("representation does not match the field set {matched_key_field_set}"),
+        }
     })
 }
 
@@ -1533,7 +1527,7 @@ fn collect_key_field_sets(
 fn find_matching_field_set<'a>(
     representation: &serde_json_bytes::Map<ByteString, Value>,
     field_sets: &'a [apollo_compiler::executable::FieldSet],
-) -> Option<&'a apollo_compiler::executable::FieldSet>{
+) -> Option<&'a apollo_compiler::executable::FieldSet> {
     // find an entry in the `key_field_sets` that matches the `representation`.
     field_sets.iter().find(|field_set| {
         // Check if the representation matches the selection set.
@@ -1602,7 +1596,10 @@ fn take_selection_set(
             let Some(taken_part) = take_selection_set(sub_value, &field.selection_set) else {
                 return None;
             };
-            result.insert(ByteString::from(field.name.as_str()), Value::Object(taken_part));
+            result.insert(
+                ByteString::from(field.name.as_str()),
+                Value::Object(taken_part),
+            );
         }
     }
     Some(result)
@@ -1621,8 +1618,9 @@ fn merge_representation(
         };
 
         // Overlapping fields must be objects.
-        if let (Value::Object(dest_sub_value), Value::Object(src_sub_value))
-        = (dest_value, src_value) {
+        if let (Value::Object(dest_sub_value), Value::Object(src_sub_value)) =
+            (dest_value, src_value)
+        {
             // Merge sub-values
             merge_representation(dest_sub_value, src_sub_value);
         }

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -770,7 +770,6 @@ impl CacheService {
                                     reason: e.to_string(),
                                 },
                             };
-                            println!("errrooooor !!!! {e:?}");
 
                             let graphql_error = e.to_graphql_error(None);
 

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -1470,8 +1470,11 @@ fn take_matching_key_field_set(
         .find(|field_set| {
             matches_selection_set(representation, &field_set.selection_set)
         })
-        .ok_or_else(|| FetchError::MalformedRequest {
-            reason: format!("representation does not match any key field set for typename {typename} in subgraph {subgraph_name}"),
+        .ok_or_else(|| {
+            tracing::trace!("representation does not match any key field set for typename {typename} in subgraph {subgraph_name}");
+            FetchError::MalformedRequest {
+                reason: format!("unexpected critical internal error for typename {typename} in subgraph {subgraph_name}"),
+            }
         })?;
     take_selection_set(representation, &matched_key_field_set.selection_set).ok_or_else(|| {
         FetchError::MalformedRequest {
@@ -1639,8 +1642,7 @@ pub(crate) fn hash_representation(
 pub(crate) fn hash_entity_key(
     entity_keys: &serde_json_bytes::Map<ByteString, serde_json_bytes::Value>,
 ) -> String {
-    #[cfg(test)]
-    dbg!(&entity_keys);
+    tracing::trace!("entity keys: {entity_keys:?}");
     // We have to hash the representation because it can contains PII
     hash_representation(entity_keys)
 }

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -5,14 +5,12 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Duration;
 
-use apollo_compiler::Name;
 use apollo_compiler::Schema;
 use apollo_compiler::ast::NamedType;
 use apollo_compiler::parser::Parser;
 use apollo_compiler::validation::Valid;
 use http::header;
 use http::header::CACHE_CONTROL;
-use indexmap::IndexMap;
 use multimap::MultiMap;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -1417,30 +1415,22 @@ fn extract_cache_keys(
             .ok_or_else(|| FetchError::MalformedRequest {
                 reason: "__typename in representation is not a string".to_string(),
             })?;
-        let entity_keys = get_entity_keys_from_supergraph_schema(
+
+        // Split `representation` into two parts: the entity key part and the rest.
+        let representation_entity_key = take_matching_key_field_set(
+            representation,
             typename,
             subgraph_name,
             &supergraph_schema,
             subgraph_enums,
         )?;
 
-        let mut representation_entity_keys = IndexMap::new();
-        for entity_key in entity_keys {
-            // We remove it from original representation to not hash it both in entity_hash_key and representation_hash_key
-            let (key, value) = representation
-                .remove_entry(entity_key.as_str())
-                .ok_or_else(|| FetchError::MalformedRequest {
-                    reason: format!("can't get entity key {entity_key:?} in representations"),
-                })?;
-            representation_entity_keys.insert(key, value);
-        }
-
         let hashed_representation = if representation.is_empty() {
             String::new()
         } else {
             hash_other_representation(representation)
         };
-        let hashed_entity_key = hash_entity_key(&representation_entity_keys);
+        let hashed_entity_key = hash_entity_key(&representation_entity_key);
 
         // the cache key is written to easily find keys matching a prefix for deletion:
         // - entity cache version: current version of the hash
@@ -1458,24 +1448,53 @@ fn extract_cache_keys(
             }
         }
 
+        // Restore the `representation` back whole again
         representation.insert(TYPENAME, typename_value);
-        representation_entity_keys
-            .into_iter()
-            .for_each(|(key, val)| {
-                representation.insert(key, val);
-            });
+        merge_representation(representation, representation_entity_key);
+
         res.push(key);
     }
     Ok(res)
 }
 
-fn get_entity_keys_from_supergraph_schema(
+fn take_matching_key_field_set(
+    representation: &mut serde_json_bytes::Map<ByteString, Value>,
     typename: &str,
     subgraph_name: &str,
     supergraph_schema: &Valid<Schema>,
     subgraph_enums: &HashMap<String, String>,
-) -> Result<impl Iterator<Item = Name>, BoxError> {
-    let entity_keys = supergraph_schema
+) -> Result<serde_json_bytes::Map<ByteString, Value>, FetchError> {
+    let key_field_sets = collect_key_field_sets(
+        typename,
+        subgraph_name,
+        &supergraph_schema,
+        subgraph_enums,
+    )?;
+    let matched_key_field_set = find_matching_field_set(
+        representation,
+        &key_field_sets,
+    )
+    .ok_or_else(|| FetchError::MalformedRequest {
+        reason: format!("representation does not match any key field set for typename {typename} in subgraph {subgraph_name}"),
+    })?;
+    take_selection_set(
+        representation,
+        &matched_key_field_set.selection_set,
+    )
+    .ok_or_else(|| FetchError::MalformedRequest {
+        reason: format!("representation does not match the field set {matched_key_field_set}"),
+    })
+}
+
+// Collect `@key` field sets on a `typename` in a `subgraph_name`.
+// - Returns a Vec of FieldSet, since there may be more than one @key directives in the subgraph.
+fn collect_key_field_sets(
+    typename: &str,
+    subgraph_name: &str,
+    supergraph_schema: &Valid<Schema>,
+    subgraph_enums: &HashMap<String, String>,
+) -> Result<Vec<apollo_compiler::executable::FieldSet>, FetchError> {
+    Ok(supergraph_schema
         .types
         .get(typename)
         .ok_or_else(|| FetchError::MalformedRequest {
@@ -1508,20 +1527,111 @@ fn get_entity_keys_from_supergraph_schema(
                 None
             }
         })
-        .flat_map(|field_set| {
-            field_set
-                .selection_set
-                .root_fields(&Default::default())
-                .map(|f| f.name.clone())
-                .collect::<Vec<Name>>()
-        });
+        .collect())
+}
 
-    Ok(entity_keys)
+fn find_matching_field_set<'a>(
+    representation: &serde_json_bytes::Map<ByteString, Value>,
+    field_sets: &'a [apollo_compiler::executable::FieldSet],
+) -> Option<&'a apollo_compiler::executable::FieldSet>{
+    // find an entry in the `key_field_sets` that matches the `representation`.
+    field_sets.iter().find(|field_set| {
+        // Check if the representation matches the selection set.
+        matches_selection_set(representation, &field_set.selection_set)
+    })
+}
+
+// Does the shape of `representation`  match the `selection_set`?
+fn matches_selection_set(
+    representation: &serde_json_bytes::Map<ByteString, Value>,
+    selection_set: &apollo_compiler::executable::SelectionSet,
+) -> bool {
+    for field in selection_set.root_fields(&Default::default()) {
+        // Note: field sets can't have aliases.
+        let Some(value) = representation.get(field.name.as_str()) else {
+            return false;
+        };
+
+        if field.selection_set.is_empty() {
+            // `value` must be a scalar.
+            if matches!(value, Value::Object(_)) {
+                return false;
+            }
+            continue;
+        }
+
+        // Check the sub-selection set.
+        let Value::Object(sub_value) = value else {
+            return false;
+        };
+        if !matches_selection_set(sub_value, &field.selection_set) {
+            return false;
+        }
+    }
+    true
+}
+
+// Removes the selection set from `representation` and returns the value corresponding to it.
+// - Returns None if the representation doesn't match the selection set.
+fn take_selection_set(
+    representation: &mut serde_json_bytes::Map<ByteString, Value>,
+    selection_set: &apollo_compiler::executable::SelectionSet,
+) -> Option<serde_json_bytes::Map<ByteString, Value>> {
+    let mut result = serde_json_bytes::Map::new();
+    for field in selection_set.root_fields(&Default::default()) {
+        // Note: field sets can't have aliases.
+        if field.selection_set.is_empty() {
+            let Some(value) = representation.remove(field.name.as_str()) else {
+                return None;
+            };
+            // `value` must be a scalar.
+            if matches!(value, Value::Object(_)) {
+                return None;
+            }
+            // Move the scalar field to the `result`.
+            result.insert(ByteString::from(field.name.as_str()), value);
+            continue;
+        } else {
+            let Some(value) = representation.get_mut(field.name.as_str()) else {
+                return None;
+            };
+            // Update the sub-selection set.
+            let Value::Object(sub_value) = value else {
+                return None;
+            };
+            let Some(taken_part) = take_selection_set(sub_value, &field.selection_set) else {
+                return None;
+            };
+            result.insert(ByteString::from(field.name.as_str()), Value::Object(taken_part));
+        }
+    }
+    Some(result)
+}
+
+// The inverse of `take_selection_set`.
+fn merge_representation(
+    dest: &mut serde_json_bytes::Map<ByteString, Value>,
+    source: serde_json_bytes::Map<ByteString, Value>,
+) {
+    source.into_iter().for_each(|(key, src_value)| {
+        // Note: field sets can't have aliases.
+        let Some(dest_value) = dest.get_mut(&key) else {
+            dest.insert(key, src_value);
+            return;
+        };
+
+        // Overlapping fields must be objects.
+        if let (Value::Object(dest_sub_value), Value::Object(src_sub_value))
+        = (dest_value, src_value) {
+            // Merge sub-values
+            merge_representation(dest_sub_value, src_sub_value);
+        }
+    });
 }
 
 // Only hash the list of entity keys
 pub(crate) fn hash_entity_key(
-    entity_keys: &IndexMap<ByteString, serde_json_bytes::Value>,
+    entity_keys: &serde_json_bytes::Map<ByteString, serde_json_bytes::Value>,
 ) -> String {
     // We have to hash the representation because it can contains PII
     let mut digest = Sha256::new();

--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -5,7 +5,6 @@ use fred::error::RedisError;
 use fred::types::Scanner;
 use futures::StreamExt;
 use futures::stream;
-use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
@@ -225,7 +224,7 @@ pub(crate) enum InvalidationRequest {
     Entity {
         subgraph: String,
         r#type: String,
-        key: IndexMap<ByteString, Value>,
+        key: serde_json_bytes::Map<ByteString, Value>,
     },
 }
 

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert-5.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-2.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-2.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response.response.headers().get(CACHE_CONTROL)
+---
+Some(
+    "public",
+)

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-3.snap
@@ -1,0 +1,19 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response
+---
+{
+  "data": {
+    "allProducts": [
+      {
+        "name": "Test",
+        "createdBy": {
+          "name": "test",
+          "country": {
+            "a": "France"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-4.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-4.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response.response.headers().get(CACHE_CONTROL)
+---
+Some(
+    "public",
+)

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-5.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: cache_keys
+---
+[
+  {
+    "key": "version:1.0:subgraph:products:type:Query:hash:bead1beb068f19990b462d5d7c17974a33b822f4b3439407a9f820ce1cb47de9:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "status": "cached",
+    "cache_control": "public"
+  },
+  {
+    "key": "version:1.0:subgraph:users:type:User:entity:210e26346d676046faa9fb55d459273a43e5b5397a1a056f179a3521dc5643aa:representation:7cd02a08f4ea96f0affa123d5d3f56abca20e6014e060fe5594d210c00f64b27:hash:cfc5f467f767710804724ff6a05c3f63297328cd8283316adb25f5642e1439ad:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "status": "cached",
+    "cache_control": "public"
+  }
+]

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-6.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-6.snap
@@ -1,0 +1,19 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response
+---
+{
+  "data": {
+    "allProducts": [
+      {
+        "name": "Test",
+        "createdBy": {
+          "name": "test",
+          "country": {
+            "a": "France"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: cache_keys
+---
+[
+  {
+    "key": "version:1.0:subgraph:products:type:Query:hash:bead1beb068f19990b462d5d7c17974a33b822f4b3439407a9f820ce1cb47de9:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "status": "new",
+    "cache_control": "public"
+  },
+  {
+    "key": "version:1.0:subgraph:users:type:User:entity:210e26346d676046faa9fb55d459273a43e5b5397a1a056f179a3521dc5643aa:representation:7cd02a08f4ea96f0affa123d5d3f56abca20e6014e060fe5594d210c00f64b27:hash:cfc5f467f767710804724ff6a05c3f63297328cd8283316adb25f5642e1439ad:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "status": "new",
+    "cache_control": "public"
+  }
+]

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-5.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:inventory:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation:7ae1cf67d5c484b3430662edab68bf613043333264470c8f5834fea277b4e060:hash:a7b76558fe61b2f89ee9ea8bac8eee0b702ba1f319eaace576ab6ccdd19cdc80:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:inventory:type:Product:entity:72bafad9ffe61307806863b13856470e429e0cf332c99e5b735224fb0b1436f7:representation:7a26bc9b6cfab31cd9278921710167eaf9cde6c17d5f86102c898a04a06aeb6c:hash:a7b76558fe61b2f89ee9ea8bac8eee0b702ba1f319eaace576ab6ccdd19cdc80:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:inventory:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation:7ae1cf67d5c484b3430662edab68bf613043333264470c8f5834fea277b4e060:hash:a7b76558fe61b2f89ee9ea8bac8eee0b702ba1f319eaace576ab6ccdd19cdc80:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:inventory:type:Product:entity:72bafad9ffe61307806863b13856470e429e0cf332c99e5b735224fb0b1436f7:representation:7a26bc9b6cfab31cd9278921710167eaf9cde6c17d5f86102c898a04a06aeb6c:hash:a7b76558fe61b2f89ee9ea8bac8eee0b702ba1f319eaace576ab6ccdd19cdc80:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-3.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:2a66208010218056832ffcb8e3e26c636cb2a57e71fc62b424909e2ab2246145:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "[REDACTED]"
   },
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "[REDACTED]"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5221ff42b311b757445c096c023cee4fefab5de49735e421c494f1119326317b:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:2a66208010218056832ffcb8e3e26c636cb2a57e71fc62b424909e2ab2246145:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "[REDACTED]"
   },
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:5f460b74668616b2388b1afed7af6557ee4a0d60fbca18f3b4c59b8027035f32:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "[REDACTED]"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-3.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-5.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   },

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:5811967f540d300d249ab30ae681359a7815fdb5d3dc71a94be1d491006a6b27:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:4db0b6e27a228df592ab8ae4e6c776bb048cb4d82d191a9eb49c182705781e78:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "private"
   },

--- a/apollo-router/src/plugins/cache/tests.rs
+++ b/apollo-router/src/plugins/cache/tests.rs
@@ -11,6 +11,7 @@ use fred::prelude::RedisValue;
 use http::HeaderValue;
 use http::header::CACHE_CONTROL;
 use parking_lot::Mutex;
+use serde_json_bytes::ByteString;
 use tower::Service;
 use tower::ServiceExt;
 
@@ -25,6 +26,7 @@ use crate::plugins::cache::entity::CONTEXT_CACHE_KEYS;
 use crate::plugins::cache::entity::CacheKeyContext;
 use crate::plugins::cache::entity::CacheKeysContext;
 use crate::plugins::cache::entity::Subgraph;
+use crate::plugins::cache::entity::hash_representation;
 use crate::services::subgraph;
 use crate::services::supergraph;
 
@@ -299,8 +301,8 @@ async fn insert_with_requires() {
                 "variables": {
                     "representations": [
                         {
-                            "price": 150,
                             "weight": 5,
+                            "price": 150,
                             "upc": "1",
                             "__typename": "Product"
                         }
@@ -364,6 +366,19 @@ async fn insert_with_requires() {
     let cache_keys: CacheKeysContext = response.context.get(CONTEXT_CACHE_KEYS).unwrap().unwrap();
     let mut cache_keys: Vec<CacheKeyContext> = cache_keys.into_values().flatten().collect();
     cache_keys.sort();
+    let mut entity_key = serde_json_bytes::Map::new();
+    entity_key.insert(
+        ByteString::from("upc"),
+        serde_json_bytes::Value::String(ByteString::from("1")),
+    );
+    let hashed_entity_key = hash_representation(&entity_key);
+    let prefix_key =
+        format!("version:1.0:subgraph:inventory:type:Product:entity:{hashed_entity_key}");
+    assert!(
+        cache_keys
+            .iter()
+            .any(|cache_key| cache_key.key.starts_with(&prefix_key))
+    );
     insta::assert_json_snapshot!(cache_keys);
 
     insta::assert_debug_snapshot!(response.response.headers().get(CACHE_CONTROL));

--- a/apollo-router/src/plugins/cache/tests.rs
+++ b/apollo-router/src/plugins/cache/tests.rs
@@ -32,6 +32,7 @@ use crate::services::supergraph;
 
 pub(super) const SCHEMA: &str = include_str!("../../testdata/orga_supergraph.graphql");
 const SCHEMA_REQUIRES: &str = include_str!("../../testdata/supergraph.graphql");
+const SCHEMA_NESTED_KEYS: &str = include_str!("../../testdata/supergraph_nested_fields.graphql");
 #[derive(Debug)]
 pub(crate) struct MockStore {
     map: Arc<Mutex<HashMap<Bytes, Bytes>>>,
@@ -239,6 +240,19 @@ async fn insert() {
     let mut cache_keys: Vec<CacheKeyContext> = cache_keys.into_values().flatten().collect();
     cache_keys.sort();
     insta::assert_json_snapshot!(cache_keys);
+    let mut entity_key = serde_json_bytes::Map::new();
+    entity_key.insert(
+        ByteString::from("id"),
+        serde_json_bytes::Value::String(ByteString::from("1")),
+    );
+    let hashed_entity_key = hash_representation(&entity_key);
+    let prefix_key =
+        format!("version:1.0:subgraph:orga:type:Organization:entity:{hashed_entity_key}");
+    assert!(
+        cache_keys
+            .iter()
+            .any(|cache_key| cache_key.key.starts_with(&prefix_key))
+    );
 
     insta::assert_debug_snapshot!(response.response.headers().get(CACHE_CONTROL));
     let response = response.next_response().await.unwrap();
@@ -396,6 +410,143 @@ async fn insert_with_requires() {
         .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
         .unwrap()
         .schema(SCHEMA_REQUIRES)
+        .extra_plugin(entity_cache)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .context(Context::new())
+        .build()
+        .unwrap();
+    let mut response = service.oneshot(request).await.unwrap();
+
+    insta::assert_debug_snapshot!(response.response.headers().get(CACHE_CONTROL));
+    let cache_keys: CacheKeysContext = response.context.get(CONTEXT_CACHE_KEYS).unwrap().unwrap();
+    let mut cache_keys: Vec<CacheKeyContext> = cache_keys.into_values().flatten().collect();
+    cache_keys.sort();
+    insta::assert_json_snapshot!(cache_keys);
+
+    let response = response.next_response().await.unwrap();
+
+    insta::assert_json_snapshot!(response);
+}
+
+#[tokio::test]
+async fn insert_with_nested_field_set() {
+    let valid_schema =
+        Arc::new(Schema::parse_and_validate(SCHEMA_NESTED_KEYS, "test.graphql").unwrap());
+    let query = "query { allProducts { name createdBy { name country { a } } } }";
+
+    let subgraphs = serde_json::json!({
+        "products": {
+            "query": {"allProducts": [{
+                "id": "1",
+                "name": "Test",
+                "sku": "150",
+                "createdBy": { "__typename": "User", "email": "test@test.com", "country": {"a": "France"} }
+            }]},
+            "headers": {"cache-control": "public"},
+        },
+        "users": {
+            "entities": [{
+                "__typename": "User",
+                "email": "test@test.com",
+                "name": "test",
+                "country": {
+                    "a": "France"
+                }
+            }],
+            "headers": {"cache-control": "public"},
+        }
+    });
+
+    let redis_cache = RedisCacheStorage::from_mocks(Arc::new(MockStore::new()))
+        .await
+        .unwrap();
+    let map = [
+        (
+            "products".to_string(),
+            Subgraph {
+                redis: None,
+                private_id: Some("sub".to_string()),
+                enabled: true.into(),
+                ttl: None,
+                ..Default::default()
+            },
+        ),
+        (
+            "users".to_string(),
+            Subgraph {
+                redis: None,
+                private_id: Some("sub".to_string()),
+                enabled: true.into(),
+                ttl: None,
+                ..Default::default()
+            },
+        ),
+    ]
+    .into_iter()
+    .collect();
+    let entity_cache = EntityCache::with_mocks(redis_cache.clone(), map, valid_schema.clone())
+        .await
+        .unwrap();
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true }, "experimental_mock_subgraphs": subgraphs.clone() }))
+        .unwrap()
+        .schema(SCHEMA_NESTED_KEYS)
+        .extra_plugin(entity_cache)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .context(Context::new())
+        .build()
+        .unwrap();
+    let mut response = service.oneshot(request).await.unwrap();
+    let cache_keys: CacheKeysContext = response.context.get(CONTEXT_CACHE_KEYS).unwrap().unwrap();
+    let mut cache_keys: Vec<CacheKeyContext> = cache_keys.into_values().flatten().collect();
+    cache_keys.sort();
+    let mut entity_key = serde_json_bytes::Map::new();
+    entity_key.insert(
+        ByteString::from("email"),
+        serde_json_bytes::Value::String(ByteString::from("test@test.com")),
+    );
+    entity_key.insert(
+        ByteString::from("country"),
+        serde_json_bytes::json!({"a": "France"}),
+    );
+
+    let hashed_entity_key = hash_representation(&entity_key);
+    let prefix_key = format!("version:1.0:subgraph:users:type:User:entity:{hashed_entity_key}");
+    assert!(
+        cache_keys
+            .iter()
+            .any(|cache_key| cache_key.key.starts_with(&prefix_key))
+    );
+
+    insta::assert_json_snapshot!(cache_keys);
+
+    insta::assert_debug_snapshot!(response.response.headers().get(CACHE_CONTROL));
+
+    let response = response.next_response().await.unwrap();
+
+    insta::assert_json_snapshot!(response);
+
+    // Now testing without any mock subgraphs, all the data should come from the cache
+    let entity_cache =
+        EntityCache::with_mocks(redis_cache.clone(), HashMap::new(), valid_schema.clone())
+            .await
+            .unwrap();
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true }, "experimental_mock_subgraphs": subgraphs.clone() }))
+        .unwrap()
+        .schema(SCHEMA_NESTED_KEYS)
         .extra_plugin(entity_cache)
         .build_supergraph()
         .await

--- a/apollo-router/src/testdata/supergraph_nested_fields.graphql
+++ b/apollo-router/src/testdata/supergraph_nested_fields.graphql
@@ -1,0 +1,82 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Country
+  @join__type(graph: PRODUCTS, key: "a")
+  @join__type(graph: USERS, key: "a")
+{
+  a: String
+  b: String
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  PRODUCTS @join__graph(name: "products", url: "http://localhost:4001/graphql")
+  USERS @join__graph(name: "users", url: "http://localhost:4003/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Product
+  @join__type(graph: PRODUCTS, key: "id")
+  @join__type(graph: PRODUCTS, key: "sku")
+{
+  id: ID!
+  sku: String
+  name: String
+  createdBy: User
+}
+
+type Query
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: USERS)
+{
+  allProducts: [Product] @join__field(graph: PRODUCTS)
+  product(id: ID!): Product @join__field(graph: PRODUCTS)
+}
+
+type User
+  @join__type(graph: PRODUCTS, key: "email country { a }")
+  @join__type(graph: PRODUCTS, key: "email country { b }")
+  @join__type(graph: USERS, key: "email country { a }")
+  @join__type(graph: USERS, key: "email country { b }")
+{
+  email: ID!
+  country: Country
+  name: String @join__field(graph: USERS)
+}

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -461,7 +461,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
     let v: Value = serde_json::from_str(&s).unwrap();
     insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
 
-    let s: String = client.get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c").await.unwrap();
+    let s: String = client.get("version:1.0:subgraph:reviews:type:Product:entity:72bafad9ffe61307806863b13856470e429e0cf332c99e5b735224fb0b1436f7:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c").await.unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
     insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
 
@@ -573,7 +573,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
     insta::assert_json_snapshot!(response);
 
     let s:String = client
-        .get("version:1.0:subgraph:reviews:type:Product:entity:d9a4cd73308dd13ca136390c10340823f94c335b9da198d2339c886c738abf0d:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+        .get("version:1.0:subgraph:reviews:type:Product:entity:080fc430afd3fb953a05525a6a00999226c34436466eff7ace1d33d004adaae3:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -823,7 +823,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
     );
 
     let s: String = client
-        .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+        .get("version:1.0:subgraph:reviews:type:Product:entity:72bafad9ffe61307806863b13856470e429e0cf332c99e5b735224fb0b1436f7:representation::hash:b9b8a9c94830cf56329ec2db7d7728881a6ba19cc1587710473e732e775a5870:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -867,7 +867,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
     insta::assert_json_snapshot!(response);
 
     let s:String = client
-          .get("version:1.0:subgraph:reviews:type:Product:entity:4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66:representation::hash:572a2cdde770584306cd0def24555773323b1738e9a303c7abc1721b6f9f2ec4:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+          .get("version:1.0:subgraph:reviews:type:Product:entity:72bafad9ffe61307806863b13856470e429e0cf332c99e5b735224fb0b1436f7:representation::hash:572a2cdde770584306cd0def24555773323b1738e9a303c7abc1721b6f9f2ec4:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -881,7 +881,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
         }}
     );
     let s:String = client
-          .get("version:1.0:subgraph:reviews:type:Product:entity:4e48855987eae27208b466b941ecda5fb9b88abc03301afef6e4099a981889e9:representation::hash:572a2cdde770584306cd0def24555773323b1738e9a303c7abc1721b6f9f2ec4:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+          .get("version:1.0:subgraph:reviews:type:Product:entity:472484d4df9e800bbb846447c4c077787860c4c9ec59579d50009bfcba275c3b:representation::hash:572a2cdde770584306cd0def24555773323b1738e9a303c7abc1721b6f9f2ec4:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
     let v: Value = serde_json::from_str(&s).unwrap();


### PR DESCRIPTION
This is my suggestion for PR https://github.com/apollographql/router/pull/7207.

This PR fixes a bug in entity caching introduced by the fix in https://github.com/apollographql/router/pull/6888 for cases where several `@key` directives with different fields were declared on a type as documented [here](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#managing-types). 

For example if you have this kind of entity in your schema:

```graphql
type Product @key(fields: "upc") @key(fields: "sku") {
  upc: ID!
  sku: ID!
  name: String
}
```

<!-- [ROUTER-1244] -->

[ROUTER-1244]: https://apollographql.atlassian.net/browse/ROUTER-1244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ