### PR TITLE
[DRAFT] Set hard bound on compute queue size

### DIFF
--- a/apollo-router/src/ageing_priority_queue.rs
+++ b/apollo-router/src/ageing_priority_queue.rs
@@ -14,6 +14,12 @@ pub(crate) enum Priority {
     P8,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum SendError {
+    QueueIsFull,
+    Disconnected,
+}
+
 const INNER_QUEUES_COUNT: usize = Priority::P8 as usize - Priority::P1 as usize + 1;
 
 /// Indices start at 0 for highest priority
@@ -34,7 +40,7 @@ where
     inner_queues:
         [(crossbeam_channel::Sender<T>, crossbeam_channel::Receiver<T>); INNER_QUEUES_COUNT],
     queued_count: AtomicUsize,
-    soft_capacity: usize,
+    capacity: usize,
 }
 
 pub(crate) struct Receiver<'a, T>
@@ -49,12 +55,12 @@ impl<T> AgeingPriorityQueue<T>
 where
     T: Send + 'static,
 {
-    pub(crate) fn soft_bounded(soft_capacity: usize) -> Self {
+    pub(crate) fn bounded(capacity: usize) -> Self {
         Self {
             // Using unbounded channels: callers must use `is_full` to implement backpressure
             inner_queues: std::array::from_fn(|_| crossbeam_channel::unbounded()),
             queued_count: AtomicUsize::new(0),
-            soft_capacity,
+            capacity,
         }
     }
 
@@ -63,14 +69,20 @@ where
     }
 
     pub(crate) fn is_full(&self) -> bool {
-        self.queued_count() >= self.soft_capacity
+        self.queued_count() >= self.capacity
     }
 
     /// Panics if `priority` is not in `AVAILABLE_PRIORITIES`
-    pub(crate) fn send(&self, priority: Priority, message: T) {
-        self.queued_count.fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn send(&self, priority: Priority, message: T) -> Result<(), SendError> {
+        self.queued_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |previous_count| {
+                (previous_count < self.capacity).then_some(previous_count + 1)
+            })
+            .map_err(|_| SendError::QueueIsFull)?;
         let (inner_sender, _) = &self.inner_queues[index_from_priority(priority)];
-        inner_sender.send(message).expect("disconnected channel")
+        inner_sender
+            .send(message)
+            .map_err(|crossbeam_channel::SendError(_)| SendError::Disconnected)
     }
 
     pub(crate) fn receiver(&self) -> Receiver<'_, T> {
@@ -121,17 +133,19 @@ where
 
 #[test]
 fn test_priorities() {
-    let queue = AgeingPriorityQueue::soft_bounded(3);
+    let queue = AgeingPriorityQueue::bounded(4);
     assert_eq!(queue.queued_count(), 0);
     assert!(!queue.is_full());
-    queue.send(Priority::P1, "p1");
+    queue.send(Priority::P1, "p1").unwrap();
     assert!(!queue.is_full());
-    queue.send(Priority::P2, "p2");
+    queue.send(Priority::P2, "p2").unwrap();
     assert!(!queue.is_full());
-    queue.send(Priority::P3, "p3");
-    // The queue is now "full" but sending still works, it’s up to the caller to stop sending
+    queue.send(Priority::P3, "p3").unwrap();
+    assert!(!queue.is_full());
+    queue.send(Priority::P2, "p2 again").unwrap();
+    // The queue is now "full" so sending will fail
     assert!(queue.is_full());
-    queue.send(Priority::P2, "p2 again");
+    queue.send(Priority::P2, "p2 fails").unwrap_err();
     assert_eq!(queue.queued_count(), 4);
 
     let mut receiver = queue.receiver();

--- a/apollo-router/src/compute_job/metrics.rs
+++ b/apollo-router/src/compute_job/metrics.rs
@@ -9,8 +9,6 @@ pub(super) enum Outcome {
     ExecutedError,
     ChannelError,
     Abandoned,
-
-    #[allow(dead_code)] // NB: `RejectedQueueFull` is unused for now
     RejectedQueueFull,
 }
 


### PR DESCRIPTION
Rather than using a soft bound and relying on callers to check that the compute queue is not full, verify that the queue is not full when `send` is called.

This also allows us to make use of the `RejectedQueueFull` outcome added in #7216.

TODO: This will currently panic as soon as the queue is full, as callers of `execute` unwrap any errors. I'm trying to find a balance between a complete backport of #6761 and a minimal set of changes, but need to continue work on it.

<!-- start metadata -->
<!-- ROUTER-1245 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
