### PR TITLE
chore: remove empty matchPackageNames from renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -79,7 +79,6 @@
       groupName: 'all non-major packages >= 1.0',
       groupSlug: 'all-non-major-gte-1.0',
       automerge: true,
-      matchPackageNames: [],
     },
     // We're currently constrained in our ability to update the `tracing`
     // packages to the latest versions because of our usage.  As an extension


### PR DESCRIPTION
Not sure if it hurts, but it surely doesn't help to have it.
