### PR TITLE
Add spans for compute jobs

### DIFF
--- a/.changesets/feat_bryn_compute_job_spans.md
+++ b/.changesets/feat_bryn_compute_job_spans.md
@@ -1,0 +1,17 @@
+### Compute job spans ([PR #7236](https://github.com/apollographql/router/pull/7236))
+
+The router uses a separate thread pool called "compute jobs" to ensure that requests do not block tokio io worker threads.
+This PR adds spans to jobs that are on this pool to allow users to see when latency is introduced due to 
+resource contention within the compute job pool.
+
+* `compute_job`:
+  - `job.type`: (`QueryParsing`|`QueryParsing`|`Introspection`)
+* `compute_job.execution`
+  - `job.age`: `P1`-`P8`
+  - `job.type`: (`QueryParsing`|`QueryParsing`|`Introspection`)
+
+Jobs are executed highest priority (`P8`) first. Jobs that are low priority (`P1`) age over time, eventually executing 
+at highest priority. The age of a job is can be used to diagnose if a job was waiting in the queue due to other higher 
+priority jobs also in the queue.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/7236

--- a/apollo-router/src/ageing_priority_queue.rs
+++ b/apollo-router/src/ageing_priority_queue.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::Ordering;
 
 /// Items with higher priority value get handled sooner
 #[allow(unused)]
+#[derive(strum_macros::IntoStaticStr)]
 pub(crate) enum Priority {
     P1 = 1,
     P2,
@@ -27,9 +28,28 @@ const fn index_from_priority(priority: Priority) -> usize {
     Priority::P8 as usize - priority as usize
 }
 
+/// Indices start at 0 for highest priority
+const fn priority_from_index(idx: usize) -> Priority {
+    match idx {
+        0 => Priority::P8,
+        1 => Priority::P7,
+        2 => Priority::P6,
+        3 => Priority::P5,
+        4 => Priority::P4,
+        5 => Priority::P3,
+        6 => Priority::P2,
+        7 => Priority::P1,
+        _ => {
+            panic!("invalid index")
+        }
+    }
+}
+
 const _: () = {
     assert!(index_from_priority(Priority::P1) == 7);
     assert!(index_from_priority(Priority::P8) == 0);
+    assert!(index_from_priority(priority_from_index(7)) == 7);
+    assert!(index_from_priority(priority_from_index(0)) == 0);
 };
 
 pub(crate) struct AgeingPriorityQueue<T>
@@ -97,7 +117,7 @@ impl<T> Receiver<'_, T>
 where
     T: Send + 'static,
 {
-    pub(crate) fn blocking_recv(&mut self) -> T {
+    pub(crate) fn blocking_recv(&mut self) -> (T, Priority) {
         // Because we used `Select::new_biased` above,
         // `select()` will not shuffle receivers as it would with `Select::new` (for fairness)
         // but instead will try each one in priority order.
@@ -109,7 +129,7 @@ where
         let item = selected.recv(rx).expect("disconnected channel");
         self.shared.queued_count.fetch_sub(1, Ordering::Relaxed);
         self.age(index);
-        item
+        (item, priority_from_index(index))
     }
 
     // Promote some messages from priorities lower (higher indices) than `message_consumed_at_index`
@@ -146,9 +166,9 @@ fn test_priorities() {
     assert_eq!(queue.queued_count(), 4);
 
     let mut receiver = queue.receiver();
-    assert_eq!(receiver.blocking_recv(), "p3");
-    assert_eq!(receiver.blocking_recv(), "p2");
-    assert_eq!(receiver.blocking_recv(), "p2 again");
-    assert_eq!(receiver.blocking_recv(), "p1");
+    assert_eq!(receiver.blocking_recv().0, "p3");
+    assert_eq!(receiver.blocking_recv().0, "p2");
+    assert_eq!(receiver.blocking_recv().0, "p2 again");
+    assert_eq!(receiver.blocking_recv().0, "p1");
     assert_eq!(queue.queued_count(), 0);
 }

--- a/apollo-router/src/compute_job/metrics.rs
+++ b/apollo-router/src/compute_job/metrics.rs
@@ -1,7 +1,12 @@
 use std::time::Duration;
 use std::time::Instant;
 
+use tracing::Span;
+
 use crate::compute_job::ComputeJobType;
+use crate::plugins::telemetry::consts::OTEL_STATUS_CODE;
+use crate::plugins::telemetry::consts::OTEL_STATUS_CODE_ERROR;
+use crate::plugins::telemetry::consts::OTEL_STATUS_CODE_OK;
 
 #[derive(Copy, Clone, strum_macros::IntoStaticStr)]
 pub(super) enum Outcome {
@@ -20,6 +25,7 @@ impl From<Outcome> for opentelemetry::Value {
 }
 
 pub(super) struct JobWatcher {
+    span: Span,
     queue_start: Instant,
     compute_job_type: ComputeJobType,
     pub(super) outcome: Outcome,
@@ -28,6 +34,7 @@ pub(super) struct JobWatcher {
 impl JobWatcher {
     pub(super) fn new(compute_job_type: ComputeJobType) -> Self {
         Self {
+            span: Span::current(),
             queue_start: Instant::now(),
             outcome: Outcome::Abandoned,
             compute_job_type,
@@ -37,6 +44,18 @@ impl JobWatcher {
 
 impl Drop for JobWatcher {
     fn drop(&mut self) {
+        let outcome: &'static str = self.outcome.into();
+        self.span.record("job.outcome", outcome);
+
+        match &self.outcome {
+            Outcome::ExecutedOk => {
+                self.span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_OK);
+            }
+            Outcome::ExecutedError | Outcome::ChannelError | Outcome::RejectedQueueFull => {
+                self.span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
+            }
+            _ => {}
+        }
         let full_duration = self.queue_start.elapsed();
         f64_histogram_with_unit!(
             "apollo.router.compute_jobs.duration",
@@ -44,7 +63,7 @@ impl Drop for JobWatcher {
             "s",
             full_duration.as_secs_f64(),
             "job.type" = self.compute_job_type,
-            "job.outcome" = self.outcome
+            "job.outcome" = outcome
         );
     }
 }

--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -8,6 +8,11 @@ use std::time::Instant;
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::metrics::ObservableGauge;
 use tokio::sync::oneshot;
+use tracing::Instrument;
+use tracing::Span;
+use tracing::info_span;
+use tracing_core::Dispatch;
+use tracing_subscriber::util::SubscriberInitExt;
 
 use self::metrics::ActiveComputeMetric;
 use self::metrics::JobWatcher;
@@ -18,6 +23,8 @@ use crate::ageing_priority_queue::AgeingPriorityQueue;
 use crate::ageing_priority_queue::Priority;
 use crate::ageing_priority_queue::SendError;
 use crate::metrics::meter_provider;
+use crate::plugins::telemetry::consts::COMPUTE_JOB_EXECUTION_SPAN_NAME;
+use crate::plugins::telemetry::consts::COMPUTE_JOB_SPAN_NAME;
 
 /// We generate backpressure in tower `poll_ready` when the number of queued jobs
 /// reaches `QUEUE_SOFT_CAPACITY_PER_THREAD * thread_pool_size()`
@@ -129,6 +136,8 @@ impl From<ComputeJobType> for opentelemetry::Value {
 }
 
 pub(crate) struct Job {
+    subscriber: Dispatch,
+    span: Span,
     ty: ComputeJobType,
     queue_start: Instant,
     job_fn: Box<dyn FnOnce() + Send + 'static>,
@@ -148,13 +157,25 @@ pub(crate) fn queue() -> &'static AgeingPriorityQueue<Job> {
 
                 let mut receiver = queue.receiver();
                 loop {
-                    let job = receiver.blocking_recv();
-                    observe_queue_wait_duration(job.ty, job.queue_start.elapsed());
+                    let (job, age) = receiver.blocking_recv();
+                    let job_type: &'static str = job.ty.into();
+                    let age: &'static str = age.into();
+                    let _subscriber = job.subscriber.set_default();
+                    job.span.in_scope(|| {
+                        let span = info_span!(
+                            COMPUTE_JOB_EXECUTION_SPAN_NAME,
+                            "job.type" = job_type,
+                            "job.age" = age
+                        );
+                        span.in_scope(|| {
+                            observe_queue_wait_duration(job.ty, job.queue_start.elapsed());
 
-                    let _active_metric = ActiveComputeMetric::register(job.ty);
-                    let job_start = Instant::now();
-                    (job.job_fn)();
-                    observe_compute_duration(job.ty, job_start.elapsed());
+                            let _active_metric = ActiveComputeMetric::register(job.ty);
+                            let job_start = Instant::now();
+                            (job.job_fn)();
+                            observe_compute_duration(job.ty, job_start.elapsed());
+                        })
+                    })
                 }
             });
         }
@@ -171,91 +192,102 @@ where
     F: FnOnce(JobStatus<'_, T>) -> T + Send + 'static,
     T: Send + 'static,
 {
-    let mut job_watcher = JobWatcher::new(compute_job_type);
-
-    let (tx, rx) = oneshot::channel();
-    let wrapped_job_fn = Box::new(move || {
-        let status = JobStatus { result_sender: &tx };
-        // `AssertUnwindSafe` here is correct because this `catch_unwind`
-        // is paired with `resume_unwind` below, so the overall effect on unwind safety
-        // is the same as if the caller had executed `job` directly without a thread pool.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || job(status)));
-        match tx.send(result) {
-            Ok(()) => {}
-            Err(_) => {
-                // `rx` was dropped: `result` is no longer needed and we can safely drop it
+    let compute_job_type_str: &'static str = compute_job_type.into();
+    let span = info_span!(
+        COMPUTE_JOB_SPAN_NAME,
+        "job.type" = compute_job_type_str,
+        "job.outcome" = tracing::field::Empty
+    );
+    span.in_scope(|| {
+        let mut job_watcher = JobWatcher::new(compute_job_type);
+        let (tx, rx) = oneshot::channel();
+        let wrapped_job_fn = Box::new(move || {
+            let status = JobStatus { result_sender: &tx };
+            // `AssertUnwindSafe` here is correct because this `catch_unwind`
+            // is paired with `resume_unwind` below, so the overall effect on unwind safety
+            // is the same as if the caller had executed `job` directly without a thread pool.
+            let result =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || job(status)));
+            match tx.send(result) {
+                Ok(()) => {}
+                Err(_) => {
+                    // `rx` was dropped: `result` is no longer needed and we can safely drop it
+                }
             }
-        }
-    });
+        });
 
-    let queue = queue();
-    let job = Job {
-        ty: compute_job_type,
-        job_fn: wrapped_job_fn,
-        queue_start: Instant::now(),
-    };
-
-    queue
-        .send(Priority::from(compute_job_type), job)
-        .map_err(|e| match e {
-            SendError::QueueIsFull => {
-                u64_counter!(
-                    "apollo.router.compute_jobs.queue_is_full",
-                    "Number of requests rejected because the queue for compute jobs is full",
-                    1u64
-                );
-                job_watcher.outcome = Outcome::RejectedQueueFull;
-                ComputeBackPressureError
-            }
-            SendError::Disconnected => {
-                // This never panics because this channel can never be disconnect:
-                // the receiver is owned by `queue` which we can access here:
-                let _proof_of_life: &'static AgeingPriorityQueue<_> = queue;
-                unreachable!("compute thread pool queue is disconnected")
-            }
-        })?;
-
-    Ok(async move {
-        let result = rx.await;
-
-        // This local variable MUST exist. Otherwise, only the field from the JobWatcher struct is moved and drop will occur before the outcome is set.
-        // This is predicated on all the fields in the struct being Copy!!!
-        let mut local_job_watcher = job_watcher;
-        local_job_watcher.outcome = match &result {
-            Ok(Ok(_)) => Outcome::ExecutedOk,
-            // We don't know what the cardinality of errors are so we just say there was a response error
-            Ok(Err(_)) => Outcome::ExecutedError,
-            // We got an error reading the response from the channel
-            Err(_) => Outcome::ChannelError,
+        let queue = queue();
+        let job = Job {
+            subscriber: Dispatch::default(),
+            span: Span::current(),
+            ty: compute_job_type,
+            job_fn: wrapped_job_fn,
+            queue_start: Instant::now(),
         };
 
-        match result {
-            Ok(Ok(value)) => value,
-            Ok(Err(panic_payload)) => {
-                // The `job` callback panicked.
-                //
-                // We try to to avoid this (by returning errors instead) and consider this a bug.
-                // But if it does happen, propagating the panic to the caller from here
-                // has the same effect as if they had executed `job` directly
-                // without a thread pool.
-                //
-                // Additionally we have a panic handler in `apollo-router/src/executable.rs`
-                // that exits the process,
-                // so in practice a Router thread should never start unwinding
-                // an this code path should be unreachable.
-                std::panic::resume_unwind(panic_payload)
-            }
-            Err(e) => {
-                let _: tokio::sync::oneshot::error::RecvError = e;
-                // This should never happen because this oneshot channel can never be disconnect:
-                // the sender is owned by `job` which, if we reach here,
-                // was successfully sent to the queue.
-                // The queue or thread pool never drop a job without executing it.
-                // When executing, `catch_unwind` ensures that
-                // the sender cannot be dropped without sending.
-                unreachable!("compute result oneshot channel is disconnected")
+        queue
+            .send(Priority::from(compute_job_type), job)
+            .map_err(|e| match e {
+                SendError::QueueIsFull => {
+                    u64_counter!(
+                        "apollo.router.compute_jobs.queue_is_full",
+                        "Number of requests rejected because the queue for compute jobs is full",
+                        1u64
+                    );
+                    job_watcher.outcome = Outcome::RejectedQueueFull;
+                    ComputeBackPressureError
+                }
+                SendError::Disconnected => {
+                    // This never panics because this channel can never be disconnect:
+                    // the receiver is owned by `queue` which we can access here:
+                    let _proof_of_life: &'static AgeingPriorityQueue<_> = queue;
+                    unreachable!("compute thread pool queue is disconnected")
+                }
+            })?;
+
+        Ok(async move {
+            let result = rx.await;
+
+            // This local variable MUST exist. Otherwise, only the field from the JobWatcher struct is moved and drop will occur before the outcome is set.
+            // This is predicated on all the fields in the struct being Copy!!!
+            let mut local_job_watcher = job_watcher;
+            local_job_watcher.outcome = match &result {
+                Ok(Ok(_)) => Outcome::ExecutedOk,
+                // We don't know what the cardinality of errors are so we just say there was a response error
+                Ok(Err(_)) => Outcome::ExecutedError,
+                // We got an error reading the response from the channel
+                Err(_) => Outcome::ChannelError,
+            };
+
+            match result {
+                Ok(Ok(value)) => value,
+                Ok(Err(panic_payload)) => {
+                    // The `job` callback panicked.
+                    //
+                    // We try to to avoid this (by returning errors instead) and consider this a bug.
+                    // But if it does happen, propagating the panic to the caller from here
+                    // has the same effect as if they had executed `job` directly
+                    // without a thread pool.
+                    //
+                    // Additionally we have a panic handler in `apollo-router/src/executable.rs`
+                    // that exits the process,
+                    // so in practice a Router thread should never start unwinding
+                    // an this code path should be unreachable.
+                    std::panic::resume_unwind(panic_payload)
+                }
+                Err(e) => {
+                    let _: tokio::sync::oneshot::error::RecvError = e;
+                    // This should never happen because this oneshot channel can never be disconnect:
+                    // the sender is owned by `job` which, if we reach here,
+                    // was successfully sent to the queue.
+                    // The queue or thread pool never drop a job without executing it.
+                    // When executing, `catch_unwind` ensures that
+                    // the sender cannot be dropped without sending.
+                    unreachable!("compute result oneshot channel is disconnected")
+                }
             }
         }
+        .in_current_span())
     })
 }
 
@@ -275,7 +307,31 @@ mod tests {
     use std::time::Duration;
     use std::time::Instant;
 
+    use tracing_futures::WithSubscriber;
+
     use super::*;
+    use crate::assert_snapshot_subscriber;
+
+    #[tokio::test]
+    async fn test_observability() {
+        // In this test we expect the logged message to have
+
+        async {
+            let span = info_span!("test_observability");
+            let job = span.in_scope(|| {
+                tracing::info!("Outer");
+                execute(ComputeJobType::QueryParsing, |_| {
+                    tracing::info!("Inner");
+                    1
+                })
+                .unwrap()
+            });
+            let result = job.await;
+            assert_eq!(result, 1);
+        }
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await;
+    }
 
     #[tokio::test]
     async fn test_executes_on_different_thread() {

--- a/apollo-router/src/compute_job/snapshots/apollo_router__compute_job__tests__observability@logs.snap
+++ b/apollo-router/src/compute_job/snapshots/apollo_router__compute_job__tests__observability@logs.snap
@@ -1,0 +1,25 @@
+---
+source: apollo-router/src/compute_job/mod.rs
+expression: yaml
+---
+- fields: {}
+  level: INFO
+  message: Outer
+  span:
+    name: test_observability
+  spans:
+    - name: test_observability
+- fields: {}
+  level: INFO
+  message: Inner
+  span:
+    job.age: P4
+    job.type: QueryParsing
+    name: compute_job.execution
+  spans:
+    - name: test_observability
+    - job.type: QueryParsing
+      name: compute_job
+    - job.age: P4
+      job.type: QueryParsing
+      name: compute_job.execution

--- a/apollo-router/src/plugins/telemetry/consts.rs
+++ b/apollo-router/src/plugins/telemetry/consts.rs
@@ -22,6 +22,8 @@ pub(crate) const SUBGRAPH_REQUEST_SPAN_NAME: &str = "subgraph_request";
 pub(crate) const QUERY_PARSING_SPAN_NAME: &str = "parse_query";
 pub(crate) const CONNECT_SPAN_NAME: &str = "connect";
 pub(crate) const CONNECT_REQUEST_SPAN_NAME: &str = "connect_request";
+pub(crate) const COMPUTE_JOB_SPAN_NAME: &str = "compute_job";
+pub(crate) const COMPUTE_JOB_EXECUTION_SPAN_NAME: &str = "compute_job.execution";
 
 pub(crate) const BUILT_IN_SPAN_NAMES: [&str; 11] = [
     REQUEST_SPAN_NAME,

--- a/apollo-router/tests/snapshots/apollo_otel_traces__batch_send_header-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__batch_send_header-2.snap
@@ -114,7 +114,79 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: parse_query
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"
@@ -187,6 +259,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"
@@ -673,6 +781,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__batch_send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__batch_send_header.snap
@@ -114,7 +114,79 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: parse_query
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"
@@ -187,6 +259,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"
@@ -673,6 +781,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__batch_trace_id-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__batch_trace_id-2.snap
@@ -114,7 +114,79 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: parse_query
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"
@@ -187,6 +259,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"
@@ -673,6 +781,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__batch_trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__batch_trace_id.snap
@@ -114,7 +114,79 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: parse_query
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"
@@ -187,6 +259,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"
@@ -673,6 +781,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__client_name-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__client_name-2.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__client_name.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__client_name.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__client_version-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__client_version-2.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__client_version.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__client_version.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__condition_else-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__condition_else-2.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__condition_else.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__condition_else.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__condition_if-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__condition_if-2.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__condition_if.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__condition_if.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__non_defer-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__non_defer-2.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__non_defer.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__non_defer.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__send_header-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__send_header-2.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__send_header.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__send_variable_value-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__send_variable_value-2.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__send_variable_value.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__send_variable_value.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__trace_id-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__trace_id-2.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"

--- a/apollo-router/tests/snapshots/apollo_otel_traces__trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__trace_id.snap
@@ -141,6 +141,42 @@ resourceSpans:
             traceState: ""
             parentSpanId: "[span_id]"
             flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
             name: supergraph
             kind: 1
             startTimeUnixNano: "[start_time]"
@@ -196,6 +232,42 @@ resourceSpans:
             parentSpanId: "[span_id]"
             flags: 1
             name: query_planning
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job
+            kind: 1
+            startTimeUnixNano: "[start_time]"
+            endTimeUnixNano: "[end_time]"
+            attributes: []
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              message: ""
+              code: 0
+          - traceId: "[trace_id]"
+            spanId: "[span_id]"
+            traceState: ""
+            parentSpanId: "[span_id]"
+            flags: 1
+            name: compute_job.execution
             kind: 1
             startTimeUnixNano: "[start_time]"
             endTimeUnixNano: "[end_time]"


### PR DESCRIPTION
The router uses a separate thread pool called "compute jobs" to ensure that requests do not block tokio io worker threads.
This PR adds spans to jobs that are on this pool to allow users to see when latency is introduced due to 
resource contention within the compute job pool.

* `compute_job`:
  - `job.type`: (`QueryParsing`|`QueryParsing`|`Introspection`)
* `compute_job.execution`
  - `job.age`: `P1`-`P8`
  - `job.type`: (`QueryParsing`|`QueryParsing`|`Introspection`)

Jobs are executed highest priority (`P8`) first. Jobs that are low priority (`P1`) age over time, eventually executing 
at highest priority. The age of a job is can be used to diagnose if a job was waiting in the queue due to other higher 
priority jobs also in the queue.

As the result of compute jobs are generally cached these extra spans are OK.

<!-- start metadata -->
---
<!--ROUTER-1237-->
**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

We don't currently document spans. This needs to be tackled separately.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

