### PR TITLE
Add support for $request.headers and $response.headers to connectors mapping

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@batch.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@batch.graphql.snap
@@ -86,6 +86,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ba
         spec: V0_2,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_User_0": Connector {
         id: ConnectId {
@@ -261,5 +263,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ba
             $batch,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@carryover.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@carryover.graphql.snap
@@ -168,6 +168,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ca
         spec: V0_1,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_Query_t_0": Connector {
         id: ConnectId {
@@ -384,6 +386,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ca
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_T_r_0": Connector {
         id: ConnectId {
@@ -526,5 +530,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ca
             $this,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@interface-object.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@interface-object.graphql.snap
@@ -149,6 +149,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/in
             $this,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_Query_itfs_0": Connector {
         id: ConnectId {
@@ -244,6 +246,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/in
         spec: V0_1,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_Query_itf_0": Connector {
         id: ConnectId {
@@ -402,5 +406,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/in
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@keys.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@keys.graphql.snap
@@ -157,6 +157,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_Query_t2_0": Connector {
         id: ConnectId {
@@ -371,6 +373,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_Query_unselected_0": Connector {
         id: ConnectId {
@@ -525,6 +529,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_T_r1_0": Connector {
         id: ConnectId {
@@ -667,6 +673,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
             $this,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_T_r2_0": Connector {
         id: ConnectId {
@@ -869,6 +877,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
             $this,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_T_r3_0": Connector {
         id: ConnectId {
@@ -1055,6 +1065,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
         response_variables: {
             $this,
         },
+        request_headers: {},
+        response_headers: {},
     },
     "one_T_r4_0": Connector {
         id: ConnectId {
@@ -1214,6 +1226,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
             $this,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "one_T_r5_0": Connector {
         id: ConnectId {
@@ -1417,5 +1431,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
         response_variables: {
             $this,
         },
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@nested_inputs.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@nested_inputs.graphql.snap
@@ -264,5 +264,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ne
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@normalize_names.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@normalize_names.graphql.snap
@@ -85,6 +85,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/no
         spec: V0_1,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors-subgraph_Query_user_0": Connector {
         id: ConnectId {
@@ -231,5 +233,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/no
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@realistic.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@realistic.graphql.snap
@@ -303,6 +303,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_Query_filterUsersByEmailDomain_0": Connector {
         id: ConnectId {
@@ -472,6 +474,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_Query_usersByCompany_0": Connector {
         id: ConnectId {
@@ -685,6 +689,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_Query_user_0": Connector {
         id: ConnectId {
@@ -1047,5 +1053,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@sibling_fields.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@sibling_fields.graphql.snap
@@ -102,6 +102,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
         spec: V0_1,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_T_b_0": Connector {
         id: ConnectId {
@@ -247,5 +249,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
             $this,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@simple.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@simple.graphql.snap
@@ -85,6 +85,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
         spec: V0_1,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_Query_user_0": Connector {
         id: ConnectId {
@@ -231,6 +233,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_User_d_1": Connector {
         id: ConnectId {
@@ -429,5 +433,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
             $this,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@steelthread.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@steelthread.graphql.snap
@@ -96,6 +96,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/st
         spec: V0_1,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_Query_user_0": Connector {
         id: ConnectId {
@@ -252,6 +254,8 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/st
             $args,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     "connectors_User_d_1": Connector {
         id: ConnectId {
@@ -401,5 +405,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/st
             $this,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
@@ -145,5 +145,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ty
         spec: V0_1,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -29,6 +29,7 @@ use super::location::WithRange;
 use super::location::merge_ranges;
 use super::location::new_span;
 use super::location::ranged_span;
+use crate::sources::connect::Namespace;
 use crate::sources::connect::variable::VariableNamespace;
 use crate::sources::connect::variable::VariablePathPart;
 use crate::sources::connect::variable::VariableReference;
@@ -231,11 +232,10 @@ impl JSONSelection {
         }
     }
 
-    pub fn external_variables<N: FromStr + ToString>(&self) -> impl Iterator<Item = N> {
+    pub fn variable_references(&self) -> impl Iterator<Item = VariableReference<Namespace>> + '_ {
         self.external_var_paths()
             .into_iter()
             .flat_map(|var_path| var_path.variable_reference())
-            .map(|var_ref| var_ref.namespace.namespace)
     }
 }
 

--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -65,6 +65,11 @@ pub struct Connector {
 
     pub request_variables: HashSet<Namespace>,
     pub response_variables: HashSet<Namespace>,
+
+    /// The request headers referenced in the connectors request mapping
+    pub request_headers: HashSet<String>,
+    /// The request or response headers referenced in the connectors response mapping
+    pub response_headers: HashSet<String>,
 }
 
 pub type CustomConfiguration = Arc<HashMap<String, Value>>;
@@ -141,8 +146,18 @@ impl Connector {
         let source_http = source.map(|s| &s.http);
 
         let transport = HttpJsonTransport::from_directive(connect_http, source_http)?;
-        let request_variables = transport.variables().collect();
-        let response_variables = connect.selection.external_variables().collect();
+        let request_variables: HashSet<Namespace> = transport
+            .variable_references()
+            .map(|var_ref| var_ref.namespace.namespace)
+            .collect();
+        let request_headers = extract_header_references(transport.variable_references());
+
+        let response_variables: HashSet<Namespace> = connect
+            .selection
+            .variable_references()
+            .map(|var_ref| var_ref.namespace.namespace)
+            .collect();
+        let response_headers = extract_header_references(connect.selection.variable_references());
         let entity_resolver = determine_entity_resolver(&connect, schema, &request_variables);
 
         let id = ConnectId {
@@ -162,6 +177,8 @@ impl Connector {
             spec,
             request_variables,
             response_variables,
+            request_headers,
+            response_headers,
         };
 
         Ok((id, connector))
@@ -274,6 +291,34 @@ fn determine_entity_resolver(
     }
 }
 
+/// Get any headers referenced in the variable references by looking at both Request and Response namespaces.
+fn extract_header_references<'a>(
+    variable_references: impl Iterator<Item = VariableReference<'a, Namespace>> + 'a,
+) -> HashSet<String> {
+    let headers: HashSet<String> = variable_references
+        .filter_map(|var_ref| {
+            if var_ref.namespace.namespace != Namespace::Request
+                && var_ref.namespace.namespace != Namespace::Response
+            {
+                return None;
+            }
+
+            // We only care if the path references starts with "headers"
+            if var_ref
+                .path
+                .first()
+                .is_none_or(|path| path.part != "headers")
+            {
+                return None;
+            }
+
+            // Grab the name of the header from the path
+            var_ref.path.get(1).map(|path| path.part.to_string())
+        })
+        .collect();
+    headers
+}
+
 // --- HTTP JSON ---------------------------------------------------------------
 #[derive(Clone, Debug)]
 pub struct HttpJsonTransport {
@@ -330,11 +375,6 @@ impl HttpJsonTransport {
 
     fn label(&self) -> String {
         format!("http: {} {}", self.method.as_str(), self.connect_template)
-    }
-
-    fn variables(&self) -> impl Iterator<Item = Namespace> {
-        self.variable_references()
-            .map(|var_ref| var_ref.namespace.namespace)
     }
 
     fn variable_references(&self) -> impl Iterator<Item = VariableReference<Namespace>> {
@@ -723,6 +763,8 @@ mod tests {
                 spec: V0_1,
                 request_variables: {},
                 response_variables: {},
+                request_headers: {},
+                response_headers: {},
             },
             ConnectId {
                 label: "connectors.json http: GET /posts",
@@ -859,6 +901,8 @@ mod tests {
                 spec: V0_1,
                 request_variables: {},
                 response_variables: {},
+                request_headers: {},
+                response_headers: {},
             },
         }
         "#);

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__models__tests__from_schema_v0_2.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__models__tests__from_schema_v0_2.snap
@@ -138,6 +138,8 @@ expression: "&connectors"
         spec: V0_2,
         request_variables: {},
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
     ConnectId {
         label: "connectors.json http: POST /posts",
@@ -342,5 +344,7 @@ expression: "&connectors"
             $batch,
         },
         response_variables: {},
+        request_headers: {},
+        response_headers: {},
     },
 }

--- a/apollo-federation/src/sources/connect/validation/connect/http.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/http.rs
@@ -133,9 +133,16 @@ impl<'schema> Http<'schema> {
         self.transport
             .url
             .expressions()
-            .map(|e| e.expression.external_variables())
-            .chain(self.body.as_ref().map(|b| b.selection.external_variables()))
-            .flatten()
+            .flat_map(|e| {
+                e.expression
+                    .variable_references()
+                    .map(|var_ref| var_ref.namespace.namespace)
+            })
+            .chain(self.body.as_ref().into_iter().flat_map(|b| {
+                b.selection
+                    .variable_references()
+                    .map(|var_ref| var_ref.namespace.namespace)
+            }))
     }
 }
 

--- a/apollo-federation/src/sources/connect/validation/connect/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/selection.rs
@@ -170,7 +170,9 @@ impl<'schema> Selection<'schema> {
     }
 
     pub(super) fn variables(&self) -> impl Iterator<Item = Namespace> + '_ {
-        self.parsed.external_variables()
+        self.parsed
+            .variable_references()
+            .map(|var_ref| var_ref.namespace.namespace)
     }
 }
 

--- a/apollo-federation/src/sources/connect/validation/expression.rs
+++ b/apollo-federation/src/sources/connect/validation/expression.rs
@@ -3,6 +3,7 @@
 
 use std::ops::Range;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::parser::LineColumn;
@@ -23,6 +24,17 @@ use crate::sources::connect::validation::Message;
 use crate::sources::connect::validation::coordinates::ConnectDirectiveCoordinate;
 use crate::sources::connect::validation::graphql::GraphQLString;
 use crate::sources::connect::validation::graphql::SchemaInfo;
+
+static REQUEST_SHAPE: LazyLock<Shape> = LazyLock::new(|| {
+    Shape::record(
+        [(
+            "headers".to_string(),
+            Shape::dict(Shape::list(Shape::string([]), []), []),
+        )]
+        .into(),
+        [],
+    )
+});
 
 /// Details about the available variables and shapes for the current expression.
 /// These should be consistent for all pieces of a connector in the request phase.
@@ -53,7 +65,7 @@ impl<'schema> Context<'schema> {
                     (Namespace::Args, shape_for_arguments(field_def)),
                     (Namespace::Config, Shape::unknown([])),
                     (Namespace::Context, Shape::unknown([])),
-                    (Namespace::Request, Shape::unknown([])),
+                    (Namespace::Request, REQUEST_SHAPE.clone()),
                 ]
                 .into_iter()
                 .collect();
@@ -75,7 +87,7 @@ impl<'schema> Context<'schema> {
                     (Namespace::Batch, Shape::list(Shape::from(type_def), [])),
                     (Namespace::Config, Shape::unknown([])),
                     (Namespace::Context, Shape::unknown([])),
-                    (Namespace::Request, Shape::unknown([])),
+                    (Namespace::Request, REQUEST_SHAPE.clone()),
                 ]
                 .into_iter()
                 .collect();
@@ -99,6 +111,7 @@ impl<'schema> Context<'schema> {
         let var_lookup: IndexMap<Namespace, Shape> = [
             (Namespace::Config, Shape::unknown([])),
             (Namespace::Context, Shape::unknown([])),
+            (Namespace::Request, REQUEST_SHAPE.clone()),
         ]
         .into_iter()
         .collect();

--- a/apollo-federation/src/sources/connect/validation/expression.rs
+++ b/apollo-federation/src/sources/connect/validation/expression.rs
@@ -53,6 +53,7 @@ impl<'schema> Context<'schema> {
                     (Namespace::Args, shape_for_arguments(field_def)),
                     (Namespace::Config, Shape::unknown([])),
                     (Namespace::Context, Shape::unknown([])),
+                    (Namespace::Request, Shape::unknown([])),
                 ]
                 .into_iter()
                 .collect();
@@ -74,6 +75,7 @@ impl<'schema> Context<'schema> {
                     (Namespace::Batch, Shape::list(Shape::from(type_def), [])),
                     (Namespace::Config, Shape::unknown([])),
                     (Namespace::Context, Shape::unknown([])),
+                    (Namespace::Request, Shape::unknown([])),
                 ]
                 .into_iter()
                 .collect();

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch.graphql.snap
@@ -27,21 +27,21 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch.gra
     },
     Message {
         code: InvalidBody,
-        message: "In `@connect(http: {body:})` on `Query.ts`: $batch is not valid here, must be one of $args, $config, $context",
+        message: "In `@connect(http: {body:})` on `Query.ts`: $batch is not valid here, must be one of $args, $config, $context, $request",
         locations: [
             14:40..14:46,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `POST` in `@connect(http:)` on `Query.ts`: $batch is not valid here, must be one of $args, $config, $context",
+        message: "In `POST` in `@connect(http:)` on `Query.ts`: $batch is not valid here, must be one of $args, $config, $context, $request",
         locations: [
             19:31..19:37,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `T`: $args is not valid here, must be one of $this, $batch, $config, $context",
+        message: "In `GET` in `@connect(http:)` on `T`: $args is not valid here, must be one of $this, $batch, $config, $context, $request",
         locations: [
             37:29..37:34,
         ],
@@ -70,7 +70,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch.gra
     },
     Message {
         code: InvalidSelection,
-        message: "In `@connect(selection:)` on `T`: variable `$batch` is not valid at this location, must be one of $args, $config, $context, $status, $this",
+        message: "In `@connect(selection:)` on `T`: variable `$batch` is not valid at this location, must be one of $args, $config, $context, $request, $response, $status, $this",
         locations: [
             64:35..64:41,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@body_selection.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@body_selection.graphql.snap
@@ -6,14 +6,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/body_sele
 [
     Message {
         code: InvalidBody,
-        message: "In `@connect(http: {body:})` on `Query.dollar`: must start with one of $args, $config, $context",
+        message: "In `@connect(http: {body:})` on `Query.dollar`: must start with one of $args, $config, $context, $request",
         locations: [
             12:20..12:21,
         ],
     },
     Message {
         code: InvalidBody,
-        message: "In `@connect(http: {body:})` on `Query.dollarField`: `foo` must start with one of $args, $config, $context",
+        message: "In `@connect(http: {body:})` on `Query.dollarField`: `foo` must start with one of $args, $config, $context, $request",
         locations: [
             20:22..20:25,
         ],
@@ -27,7 +27,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/body_sele
     },
     Message {
         code: InvalidBody,
-        message: "In `@connect(http: {body:})` on `Query.invalidVariable`: unknown variable `$nosuchvariable`, must be one of $args, $config, $context",
+        message: "In `@connect(http: {body:})` on `Query.invalidVariable`: unknown variable `$nosuchvariable`, must be one of $args, $config, $context, $request",
         locations: [
             52:32..52:47,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@headers__invalid_namespace_in_header_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@headers__invalid_namespace_in_header_variables.graphql.snap
@@ -27,28 +27,28 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/headers/i
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.scalar`: unknown variable `$foo`, must be one of $args, $config, $context",
+        message: "In `@connect(http.headers:)` on `Query.scalar`: unknown variable `$foo`, must be one of $args, $config, $context, $request",
         locations: [
             24:49..24:53,
         ],
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.scalar`: $status is not valid here, must be one of $args, $config, $context",
+        message: "In `@connect(http.headers:)` on `Query.scalar`: $status is not valid here, must be one of $args, $config, $context, $request",
         locations: [
             25:62..25:69,
         ],
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.scalar`: $this is not valid here, must be one of $args, $config, $context",
+        message: "In `@connect(http.headers:)` on `Query.scalar`: $this is not valid here, must be one of $args, $config, $context, $request",
         locations: [
             26:47..26:52,
         ],
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.scalar`: `config.bar` must start with one of $args, $config, $context",
+        message: "In `@connect(http.headers:)` on `Query.scalar`: `config.bar` must start with one of $args, $config, $context, $request",
         locations: [
             27:56..27:62,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@headers__invalid_namespace_in_header_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@headers__invalid_namespace_in_header_variables.graphql.snap
@@ -6,21 +6,21 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/headers/i
 [
     Message {
         code: InvalidHeader,
-        message: "In `@source(http.headers:)`: unknown variable `$foo`, must be one of $config, $context",
+        message: "In `@source(http.headers:)`: unknown variable `$foo`, must be one of $config, $context, $request",
         locations: [
             11:49..11:53,
         ],
     },
     Message {
         code: InvalidHeader,
-        message: "In `@source(http.headers:)`: $this is not valid here, must be one of $config, $context",
+        message: "In `@source(http.headers:)`: $this is not valid here, must be one of $config, $context, $request",
         locations: [
             12:62..12:67,
         ],
     },
     Message {
         code: InvalidHeader,
-        message: "In `@source(http.headers:)`: `config.bar` must start with one of $config, $context",
+        message: "In `@source(http.headers:)`: `config.bar` must start with one of $config, $context, $request",
         locations: [
             13:56..13:62,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_body_selection.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_namespace_in_body_selection.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_n
 [
     Message {
         code: InvalidBody,
-        message: "In `@connect(http: {body:})` on `Mutation.createUser`: $status is not valid here, must be one of $args, $config, $context",
+        message: "In `@connect(http: {body:})` on `Mutation.createUser`: $status is not valid here, must be one of $args, $config, $context, $request",
         locations: [
             21:17..21:24,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@request_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@request_headers.graphql.snap
@@ -1,0 +1,31 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", result.errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/request_headers.graphql
+---
+[
+    Message {
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)`: array values aren't valid here",
+        locations: [
+            5:101..5:111,
+            5:101..5:111,
+        ],
+    },
+    Message {
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.failOnArray`: array values aren't valid here",
+        locations: [
+            28:68..28:78,
+            28:68..28:78,
+        ],
+    },
+    Message {
+        code: InvalidUrl,
+        message: "In `GET` in `@connect(http:)` on `Query.failOnArray`: array values aren't valid here",
+        locations: [
+            27:61..27:71,
+            27:61..27:71,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@request_headers.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@request_headers.graphql.snap
@@ -28,4 +28,32 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/request_h
             27:61..27:71,
         ],
     },
+    Message {
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.failOnInvalidRequestProperty`: `$request` doesn't have a field named `x`",
+        locations: [
+            36:60..36:61,
+        ],
+    },
+    Message {
+        code: InvalidUrl,
+        message: "In `GET` in `@connect(http:)` on `Query.failOnInvalidRequestProperty`: `$request` doesn't have a field named `x`",
+        locations: [
+            35:53..35:54,
+        ],
+    },
+    Message {
+        code: InvalidHeader,
+        message: "In `@connect(http.headers:)` on `Query.failOnInvalidObject`: object values aren't valid here",
+        locations: [
+            44:60..44:67,
+        ],
+    },
+    Message {
+        code: InvalidUrl,
+        message: "In `GET` in `@connect(http:)` on `Query.failOnInvalidObject`: object values aren't valid here",
+        locations: [
+            43:53..43:60,
+        ],
+    },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@uri_templates__invalid-path-parameter.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@uri_templates__invalid-path-parameter.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/uri_templ
 [
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.resources`: unknown variable `$blah`, must be one of $args, $config, $context",
+        message: "In `GET` in `@connect(http:)` on `Query.resources`: unknown variable `$blah`, must be one of $args, $config, $context, $request",
         locations: [
             12:23..12:28,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@uri_templates__invalid_namespace_in_url_template_variables.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@uri_templates__invalid_namespace_in_url_template_variables.graphql.snap
@@ -6,21 +6,21 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/uri_templ
 [
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.unknown`: unknown variable `$foo`, must be one of $args, $config, $context",
+        message: "In `GET` in `@connect(http:)` on `Query.unknown`: unknown variable `$foo`, must be one of $args, $config, $context, $request",
         locations: [
             11:31..11:35,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.invalid`: $status is not valid here, must be one of $args, $config, $context",
+        message: "In `GET` in `@connect(http:)` on `Query.invalid`: $status is not valid here, must be one of $args, $config, $context, $request",
         locations: [
             18:31..18:38,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.nodollar`: `config.bar` must start with one of $args, $config, $context",
+        message: "In `GET` in `@connect(http:)` on `Query.nodollar`: `config.bar` must start with one of $args, $config, $context, $request",
         locations: [
             25:31..25:37,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@uri_templates__this_on_root_types.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@uri_templates__this_on_root_types.graphql.snap
@@ -6,14 +6,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/uri_templ
 [
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.requiresThis`: $this is not valid here, must be one of $args, $config, $context",
+        message: "In `GET` in `@connect(http:)` on `Query.requiresThis`: $this is not valid here, must be one of $args, $config, $context, $request",
         locations: [
             11:39..11:44,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Mutation.requiresThis`: $this is not valid here, must be one of $args, $config, $context",
+        message: "In `GET` in `@connect(http:)` on `Mutation.requiresThis`: $this is not valid here, must be one of $args, $config, $context, $request",
         locations: [
             20:37..20:42,
         ],

--- a/apollo-federation/src/sources/connect/validation/test_data/request_headers.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/request_headers.graphql
@@ -29,4 +29,20 @@ type Query {
       }
       selection: "$"
     )
+  failOnInvalidRequestProperty: [String!]!
+    @connect(
+      http: {
+        GET: "http://127.0.0.1/?something={$request.x}"
+        headers: [{ name: "x-my-header", value: "{$request.x}" }]
+      }
+      selection: "$"
+    )
+  failOnInvalidObject: [String!]!
+    @connect(
+      http: {
+        GET: "http://127.0.0.1/?something={$request.headers}"
+        headers: [{ name: "x-my-header", value: "{$request.headers}" }]
+      }
+      selection: "$"
+    )
 }

--- a/apollo-federation/src/sources/connect/validation/test_data/request_headers.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/request_headers.graphql
@@ -1,0 +1,32 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"])
+  @source(
+    name: "invalid_api"
+    http: { baseURL: "http://127.0.0.1", headers: [{ name: "x-my-header", value: "{$request.headers.someheader}" }] }
+  )
+  @source(
+    name: "awesome_api"
+    http: {
+      baseURL: "http://127.0.0.1"
+      headers: [{ name: "x-my-header", value: "{$request.headers.someheader->first}" }]
+    }
+  )
+
+type Query {
+  pass: [String!]!
+    @connect(
+      http: {
+        GET: "http://127.0.0.1/?something={$request.headers.someheader->first}"
+        headers: [{ name: "x-my-header", value: "{$request.headers.someheader->first}" }]
+      }
+      selection: "$"
+    )
+  failOnArray: [String!]!
+    @connect(
+      http: {
+        GET: "http://127.0.0.1/?something={$request.headers.someheader}"
+        headers: [{ name: "x-my-header", value: "{$request.headers.someheader}" }]
+      }
+      selection: "$"
+    )
+}

--- a/apollo-federation/src/sources/connect/variable.rs
+++ b/apollo-federation/src/sources/connect/variable.rs
@@ -44,6 +44,8 @@ impl<'schema> VariableContext<'schema> {
                     Namespace::Context,
                     Namespace::Status,
                     Namespace::This,
+                    Namespace::Request,
+                    Namespace::Response,
                 ]
             }
         }
@@ -90,6 +92,8 @@ pub enum Namespace {
     Status,
     This,
     Batch,
+    Request,
+    Response,
 }
 
 impl Namespace {
@@ -101,6 +105,8 @@ impl Namespace {
             Self::Status => "$status",
             Self::This => "$this",
             Self::Batch => "$batch",
+            Self::Request => "$request",
+            Self::Response => "$response",
         }
     }
 }
@@ -116,6 +122,8 @@ impl FromStr for Namespace {
             "$status" => Ok(Self::Status),
             "$this" => Ok(Self::This),
             "$batch" => Ok(Self::Batch),
+            "$request" => Ok(Self::Request),
+            "$response" => Ok(Self::Response),
             _ => Err(()),
         }
     }
@@ -136,9 +144,9 @@ impl Display for Namespace {
 /// A variable reference. Consists of a namespace starting with a `$` and an optional path
 /// separated by '.' characters.
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
-pub(crate) struct VariableReference<'a, N: FromStr + ToString> {
+pub struct VariableReference<'a, N: FromStr + ToString> {
     /// The namespace of the variable - `$this`, `$args`, `$status`, etc.
-    pub(crate) namespace: VariableNamespace<N>,
+    pub namespace: VariableNamespace<N>,
 
     /// The path elements of this reference. For example, the reference `$this.a.b.c`
     /// has path elements `a`, `b`, `c`. May be empty in some cases, as in the reference `$status`.
@@ -161,8 +169,8 @@ impl<N: FromStr + ToString> Display for VariableReference<'_, N> {
 
 /// A namespace in a variable reference, like `$this` in `$this.a.b.c`
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
-pub(crate) struct VariableNamespace<N: FromStr + ToString> {
-    pub(crate) namespace: N,
+pub struct VariableNamespace<N: FromStr + ToString> {
+    pub namespace: N,
     pub(crate) location: Range<usize>,
 }
 

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -81,6 +81,7 @@ impl RawResponse {
         connector: Arc<Connector>,
         context: &Context,
         debug_context: &Option<Arc<Mutex<ConnectorContext>>>,
+        supergraph_request: Arc<http::Request<crate::graphql::Request>>,
     ) -> connector::request_service::Response {
         let mapped_response = match self {
             RawResponse::Error { error, key } => MappedResponse::Error { error, key },
@@ -92,9 +93,12 @@ impl RawResponse {
             } => {
                 let inputs = key.inputs().merge(
                     &connector.response_variables,
+                    &connector.response_headers,
                     connector.config.as_ref(),
                     context,
                     Some(parts.status.as_u16()),
+                    supergraph_request,
+                    Some(&parts),
                 );
 
                 let (res, apply_to_errors) = key.selection().apply_with_vars(&data, &inputs);
@@ -344,6 +348,7 @@ pub(crate) async fn process_response<T: HttpBody>(
     context: &Context,
     debug_request: Option<ConnectorDebugHttpRequest>,
     debug_context: &Option<Arc<Mutex<ConnectorContext>>>,
+    supergraph_request: Arc<http::Request<crate::graphql::Request>>,
 ) -> connector::request_service::Response {
     match result {
         // This occurs when we short-circuit the request when over the limit
@@ -393,7 +398,13 @@ pub(crate) async fn process_response<T: HttpBody>(
             };
             if is_success {
                 Span::current().record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_OK);
-                raw.map_response(result, connector, context, debug_context)
+                raw.map_response(
+                    result,
+                    connector,
+                    context,
+                    debug_context,
+                    supergraph_request,
+                )
             } else {
                 Span::current().record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                 raw.map_error(result, connector, context, debug_context)
@@ -611,6 +622,7 @@ mod tests {
     use url::Url;
 
     use crate::Context;
+    use crate::graphql;
     use crate::plugins::connectors::handle_responses::process_response;
     use crate::plugins::connectors::make_requests::RequestInputs;
     use crate::plugins::connectors::make_requests::ResponseKey;
@@ -642,6 +654,8 @@ mod tests {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         });
 
         let response1: http::Response<RouterBody> = http::Response::builder()
@@ -662,6 +676,12 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
+        let supergraph_request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
+                .unwrap(),
+        );
+
         let res = super::aggregate_responses(vec![
             process_response(
                 Ok(response1),
@@ -670,6 +690,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request.clone(),
             )
             .await
             .mapped_response,
@@ -680,6 +701,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request,
             )
             .await
             .mapped_response,
@@ -742,6 +764,8 @@ mod tests {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         });
 
         let response1: http::Response<RouterBody> = http::Response::builder()
@@ -762,6 +786,12 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
+        let supergraph_request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
+                .unwrap(),
+        );
+
         let res = super::aggregate_responses(vec![
             process_response(
                 Ok(response1),
@@ -770,6 +800,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request.clone(),
             )
             .await
             .mapped_response,
@@ -780,6 +811,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request,
             )
             .await
             .mapped_response,
@@ -847,6 +879,8 @@ mod tests {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         });
 
         let keys = connector
@@ -880,6 +914,12 @@ mod tests {
             inputs,
         };
 
+        let supergraph_request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
+                .unwrap(),
+        );
+
         let res = super::aggregate_responses(vec![
             process_response(
                 Ok(response1),
@@ -888,6 +928,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request,
             )
             .await
             .mapped_response,
@@ -962,6 +1003,8 @@ mod tests {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         });
 
         let response1: http::Response<RouterBody> = http::Response::builder()
@@ -986,6 +1029,12 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
+        let supergraph_request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
+                .unwrap(),
+        );
+
         let res = super::aggregate_responses(vec![
             process_response(
                 Ok(response1),
@@ -994,6 +1043,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request.clone(),
             )
             .await
             .mapped_response,
@@ -1004,6 +1054,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request,
             )
             .await
             .mapped_response,
@@ -1078,6 +1129,8 @@ mod tests {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         });
 
         let response_plaintext: http::Response<RouterBody> = http::Response::builder()
@@ -1118,6 +1171,12 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
         };
 
+        let supergraph_request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
+                .unwrap(),
+        );
+
         let res = super::aggregate_responses(vec![
             process_response(
                 Ok(response_plaintext),
@@ -1126,6 +1185,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request.clone(),
             )
             .await
             .mapped_response,
@@ -1136,6 +1196,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request.clone(),
             )
             .await
             .mapped_response,
@@ -1146,6 +1207,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request.clone(),
             )
             .await
             .mapped_response,
@@ -1156,6 +1218,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request,
             )
             .await
             .mapped_response,
@@ -1331,7 +1394,12 @@ mod tests {
             config: Default::default(),
             max_requests: None,
             request_variables: Default::default(),
-            response_variables: selection.external_variables().collect(),
+            response_variables: selection
+                .variable_references()
+                .map(|var_ref| var_ref.namespace.namespace)
+                .collect(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         });
 
         let response1: http::Response<RouterBody> = http::Response::builder()
@@ -1344,6 +1412,12 @@ mod tests {
             selection: Arc::new(JSONSelection::parse("$status").unwrap()),
         };
 
+        let supergraph_request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
+                .unwrap(),
+        );
+
         let res = super::aggregate_responses(vec![
             process_response(
                 Ok(response1),
@@ -1352,6 +1426,7 @@ mod tests {
                 &Context::default(),
                 None,
                 &None,
+                supergraph_request,
             )
             .await
             .mapped_response,

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -116,17 +116,13 @@ impl RequestInputs {
                 .unwrap_or_default()
                 .iter()
                 .filter_map(|(key, value)| {
-                    if headers_used.contains(key.as_str()) {
-                        return Some((
-                            key.as_str().into(),
-                            value
-                                .iter()
-                                .map(|s| Value::String(s.as_str().into()))
-                                .collect(),
-                        ));
-                    }
-
-                    None
+                    headers_used.contains(key.as_str()).then_some((
+                        key.as_str().into(),
+                        value
+                            .iter()
+                            .map(|s| Value::String(s.as_str().into()))
+                            .collect(),
+                    ))
                 })
                 .collect();
             let request_object = json!({
@@ -144,17 +140,13 @@ impl RequestInputs {
                         .unwrap_or_default()
                         .iter()
                         .filter_map(|(key, value)| {
-                            if headers_used.contains(key.as_str()) {
-                                return Some((
-                                    key.as_str().into(),
-                                    value
-                                        .iter()
-                                        .map(|s| Value::String(s.as_str().into()))
-                                        .collect(),
-                                ));
-                            }
-
-                            None
+                            headers_used.contains(key.as_str()).then_some((
+                                key.as_str().into(),
+                                value
+                                    .iter()
+                                    .map(|s| Value::String(s.as_str().into()))
+                                    .collect(),
+                            ))
                         })
                         .collect();
                 let response_object = json!({

--- a/apollo-router/src/plugins/connectors/testdata/variables-subgraph.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/variables-subgraph.graphql
@@ -1,9 +1,6 @@
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.10")
-  @link(
-    url: "https://specs.apollo.dev/connect/v0.1"
-    import: ["@connect", "@source"]
-  )
+  @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"])
   @source(
     name: "v1"
     http: {
@@ -20,7 +17,7 @@ type Query {
     @connect(
       source: "v1"
       http: {
-        POST: "/f?arg={$args.arg->slice(1)}&context={$context.value}&config={$config.value}"
+        POST: "/f?arg={$args.arg->slice(1)}&context={$context.value}&config={$config.value}&header={$request.headers.value->first}"
         headers: [
           { name: "x-connect-context", value: "{$context.value}" }
           { name: "x-connect-config", value: "{$config.value}" }
@@ -30,6 +27,7 @@ type Query {
         arg: $args.arg
         context: $context.value
         config: $config.value
+        request: $request.headers.value->first
         """
       }
       selection: """
@@ -39,6 +37,8 @@ type Query {
       status: $status
       sibling: $("D")
       extra: $->echo({ arg: $args.arg, context: $context.value, config: $config.value, status: $status })
+      request: $request.headers.value->first
+      response: $response.headers.value->first
       """
     )
 }
@@ -50,6 +50,8 @@ type T {
   status: Int
   sibling: String
   extra: JSON
+  request: String
+  response: String
   f(arg: String): U
     @connect(
       source: "v1"

--- a/apollo-router/src/plugins/connectors/testdata/variables.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/variables.graphql
@@ -61,7 +61,7 @@ enum link__Purpose {
 type Query
   @join__type(graph: CONNECTORS)
 {
-  f(arg: String!): T @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {POST: "/f?arg={$args.arg->slice(1)}&context={$context.value}&config={$config.value}", headers: [{name: "x-connect-context", value: "{$context.value}"}, {name: "x-connect-config", value: "{$config.value}"}, {name: "x-connect-arg", value: "{$args.arg->last}"}], body: "arg: $args.arg\ncontext: $context.value\nconfig: $config.value"}, selection: "arg: $args.arg\ncontext: $context.value\nconfig: $config.value\nstatus: $status\nsibling: $(\"D\")\nextra: $->echo({ arg: $args.arg, context: $context.value, config: $config.value, status: $status })"})
+  f(arg: String!): T @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {POST: "/f?arg={$args.arg->slice(1)}&context={$context.value}&config={$config.value}&header={$request.headers.value->first}", headers: [{name: "x-connect-context", value: "{$context.value}"}, {name: "x-connect-config", value: "{$config.value}"}, {name: "x-connect-arg", value: "{$args.arg->last}"}], body: "arg: $args.arg\ncontext: $context.value\nconfig: $config.value\nrequest: $request.headers.value->first"}, selection: "arg: $args.arg\ncontext: $context.value\nconfig: $config.value\nstatus: $status\nsibling: $(\"D\")\nextra: $->echo({ arg: $args.arg, context: $context.value, config: $config.value, status: $status })\nrequest: $request.headers.value->first\nresponse: $response.headers.value->first"})
 }
 
 type T
@@ -73,6 +73,8 @@ type T
   status: Int
   sibling: String
   extra: JSON
+  request: String
+  response: String
   f(arg: String): U @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {POST: "/f?arg={$args.arg->slice(2)}&context={$context.value}&config={$config.value}&sibling={$this.sibling}", headers: [{name: "x-connect-context", value: "{$context.value}"}, {name: "x-connect-config", value: "{$config.value}"}, {name: "x-connect-arg", value: "{$args.arg->first}"}, {name: "x-connect-sibling", value: "{$this.sibling}"}], body: "arg: $args.arg\ncontext: $context.value\nconfig: $config.value\nsibling: $this.sibling"}, selection: "arg: $args.arg\ncontext: $context.value\nconfig: $config.value\nsibling: $this.sibling\nstatus: $status"})
 }
 

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -1638,7 +1638,11 @@ async fn test_variables() {
         .await;
     Mock::given(method("POST"))
         .and(path("/f"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({}))
+                .insert_header("value", "myothercoolheader"),
+        )
         .mount(&mock_server)
         .await;
     let uri = mock_server.uri();
@@ -1646,7 +1650,7 @@ async fn test_variables() {
     let response = execute(
         &VARIABLES_SCHEMA.replace("http://localhost:4001/", &mock_server.uri()),
         &uri,
-        "{ f(arg: \"arg\") { arg context config sibling status extra f(arg: \"arg\") { arg context config sibling status } } }",
+        "{ f(arg: \"arg\") { arg context config sibling status extra request response f(arg: \"arg\") { arg context config sibling status } } }",
         Default::default(),
         Some(json!({
           "connectors": {
@@ -1667,7 +1671,10 @@ async fn test_variables() {
             }
           }
         })),
-        |_| {},
+        |request| {
+          let headers = request.router_request.headers_mut();
+          headers.insert("value", "coolheader".parse().unwrap());
+        },
     )
     .await;
 
@@ -1686,6 +1693,8 @@ async fn test_variables() {
             "config": "C",
             "status": 200
           },
+          "request": "coolheader",
+          "response": "myothercoolheader",
           "f": {
             "arg": "arg",
             "context": "B",
@@ -1705,13 +1714,13 @@ async fn test_variables() {
             Matcher::new()
                 .method("POST")
                 .path("/f")
-                .query("arg=rg&context=B&config=C")
+                .query("arg=rg&context=B&config=C&header=coolheader")
                 .header("x-source-context".into(), "B".try_into().unwrap())
                 .header("x-source-config".into(), "C".try_into().unwrap())
                 .header("x-connect-arg".into(), "g".try_into().unwrap())
                 .header("x-connect-context".into(), "B".try_into().unwrap())
                 .header("x-connect-config".into(), "C".try_into().unwrap())
-                .body(serde_json::json!({ "arg": "arg", "context": "B", "config": "C" }))
+                .body(serde_json::json!({ "arg": "arg", "context": "B", "config": "C", "request": "coolheader" }))
                 ,
             Matcher::new()
                 .method("POST")

--- a/apollo-router/src/plugins/connectors/tracing.rs
+++ b/apollo-router/src/plugins/connectors/tracing.rs
@@ -87,6 +87,8 @@ mod tests {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         };
 
         let connectors = Connectors {

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -1525,6 +1525,8 @@ mod test {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         };
         let key = ResponseKey::RootField {
             name: "hello".to_string(),
@@ -1611,6 +1613,8 @@ mod test {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         };
         let key = ResponseKey::RootField {
             name: "hello".to_string(),

--- a/apollo-router/src/plugins/telemetry/config_new/connector/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/selectors.rs
@@ -361,6 +361,8 @@ mod tests {
             spec: ConnectSpec::V0_1,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         }
     }
 

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -1232,6 +1232,8 @@ mod tests {
                 spec: ConnectSpec::V0_1,
                 request_variables: Default::default(),
                 response_variables: Default::default(),
+                request_headers: Default::default(),
+                response_headers: Default::default(),
             };
             let response_key = ResponseKey::RootField {
                 name: "hello".to_string(),
@@ -1315,6 +1317,8 @@ mod tests {
                 spec: ConnectSpec::V0_1,
                 request_variables: Default::default(),
                 response_variables: Default::default(),
+                request_headers: Default::default(),
+                response_headers: Default::default(),
             };
             let response_key = ResponseKey::RootField {
                 name: "hello".to_string(),

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -3378,6 +3378,8 @@ mod tests {
                                         spec: ConnectSpec::V0_1,
                                         request_variables: Default::default(),
                                         response_variables: Default::default(),
+                                        request_headers: Default::default(),
+                                        response_headers: Default::default(),
                                     };
                                     let response_key = ResponseKey::RootField {
                                         name: "hello".to_string(),
@@ -3441,6 +3443,8 @@ mod tests {
                                         spec: ConnectSpec::V0_1,
                                         request_variables: Default::default(),
                                         response_variables: Default::default(),
+                                        request_headers: Default::default(),
+                                        response_headers: Default::default(),
                                     };
                                     let response_key = ResponseKey::RootField {
                                         name: "hello".to_string(),

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -843,6 +843,8 @@ connector:
                     spec: ConnectSpec::V0_1,
                     request_variables: Default::default(),
                     response_variables: Default::default(),
+                    request_headers: Default::default(),
+                    response_headers: Default::default(),
                 });
                 let response_key = ResponseKey::RootField {
                     name: "hello".to_string(),
@@ -1195,6 +1197,8 @@ subgraph:
                     spec: ConnectSpec::V0_1,
                     request_variables: Default::default(),
                     response_variables: Default::default(),
+                    request_headers: Default::default(),
+                    response_headers: Default::default(),
                 });
                 let response_key = ResponseKey::RootField {
                     name: "hello".to_string(),

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -788,6 +788,8 @@ mod test {
             max_requests: None,
             request_variables: Default::default(),
             response_variables: Default::default(),
+            request_headers: Default::default(),
+            response_headers: Default::default(),
         });
         let key = ResponseKey::RootField {
             name: "hello".to_string(),

--- a/apollo-router/src/services/connect.rs
+++ b/apollo-router/src/services/connect.rs
@@ -1,5 +1,6 @@
 //! Connect service request and response types.
 
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use apollo_compiler::ExecutableDocument;
@@ -23,6 +24,18 @@ pub(crate) struct Request {
     pub(crate) supergraph_request: Arc<http::Request<GraphQLRequest>>,
     pub(crate) variables: Variables,
     pub(crate) keys: Option<Valid<FieldSet>>,
+}
+
+impl Debug for Request {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Request")
+            .field("service_name", &self.service_name)
+            .field("context", &self.context)
+            .field("operation", &self.operation)
+            .field("supergraph_request", &self.supergraph_request)
+            .field("variables", &self.variables.variables)
+            .finish()
+    }
 }
 
 assert_impl_all!(Response: Send);

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -407,6 +407,7 @@ impl tower::Service<Request> for ConnectorRequestService {
                 &request.context,
                 debug_request,
                 &debug,
+                request.supergraph_request,
             )
             .await)
         })


### PR DESCRIPTION
Add support for `$request.headers` and `$response.headers` to connectors mapping

TODO: Shape validation, versioning

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
