### PR TITLE
Implement backpressure with `load_shed` and `Poll::Pending`

### DIFF
--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -385,8 +385,10 @@ where
     type Error = CacheResolverError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
-        task::Poll::Ready(Ok(()))
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.delegate
+            .poll_ready(cx)
+            .map_err(|err| CacheResolverError::RetrievalError(Arc::new(err)))
     }
 
     fn call(&mut self, request: query_planner::CachingRequest) -> Self::Future {

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -921,6 +921,10 @@ impl SupergraphCreator {
             .notify(self.config.notify.clone())
             .build();
 
+        let supergraph_service = ServiceBuilder::new()
+            .load_shed()
+            .service(supergraph_service);
+
         let shaping = self
             .plugins
             .iter()


### PR DESCRIPTION
This PR ensures that when the compute queue is full, incoming work is rejected via `load_shed`.

Actually figuring this out took me much longer than I'd like, for what ended up being such a small code change - I initially thought I'd need to add the load shedding directly in the `CachingQueryPlanner` to avoid caching rejected responses, but with proper use of `poll_ready` the queries never make it to the cache.

A few notes:
* This approach works because the queue is 'soft' bounded - we reject work at the `poll_ready` stage but anything that makes it to the `call` stage is allowed through. If we want the queue to be strictly bounded, we'll need to return an `Overloaded` error through a different path.
* I'd originally hoped to only need to use load shedding on the supergraph stage, but it turns out the router stage does the query parsing and the supergraph stage does the query planning - so they both needed the load shed layer and queue size check in `poll_ready`.

TODO:
- [ ] Query warmup will not respect the back-pressure - it'll just add to the queue regardless of whether it's full. There's a part of me that thinks that might be okay, given that the queue size is some multiple of a thousand and the warmup happens sequentially... but it certainly would require discussion and team buy-in.
- [ ] Add proper tests. I tested manually with `vegeta` and made sure the rejected query count math made sense, but we need to do this with integration tests.
- [ ] Change error response type. Right now the load shed layer returns a 500 error (`ERROR router{otel.status_code=ERROR,http.route=/,...,error.type=Internal Server Error,http.response.status_code=500,}  code="INTERNAL_SERVER_ERROR" err=service overloaded` in the logs), but we should make it a 503.
- [ ] Remove my errant sadness comment (didn't realize I'd committed it).
- [ ] Add documentation for how this works.
- [ ] <future> Discuss whether this approach is something we'd like to forward-port to 2.x - I appreciate the simplicity of it, but there's a different backpressure solution there already!

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
