### PR TITLE
Implement schema upgrader functions

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -176,8 +176,10 @@ pub enum SingleFederationError {
     RequiresDirectiveInFieldsArgs { message: String },
     #[error("{message}")]
     ExternalUnused { message: String },
-    #[error("{message}")]
-    TypeWithOnlyUnusedExternal { message: String },
+    #[error(
+        "Type {type_name} contains only external fields and all those fields are all unused (they do not appear in any @key, @provides or @requires)."
+    )]
+    TypeWithOnlyUnusedExternal { type_name: Name },
     #[error("{message}")]
     ProvidesOnNonObjectField { message: String },
     #[error("{message}")]

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -11,6 +11,7 @@ use apollo_compiler::ast::Argument;
 use apollo_compiler::name;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ComponentName;
+use apollo_compiler::schema::ComponentOrigin;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::DirectiveDefinition;
 use apollo_compiler::schema::EnumType;
@@ -263,6 +264,20 @@ impl TypeDefinitionPosition {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn remove_extensions(
+        &self,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
+        match self {
+            TypeDefinitionPosition::Scalar(type_) => type_.remove_extensions(schema),
+            TypeDefinitionPosition::Object(type_) => type_.remove_extensions(schema),
+            TypeDefinitionPosition::Interface(type_) => type_.remove_extensions(schema),
+            TypeDefinitionPosition::Union(type_) => type_.remove_extensions(schema),
+            TypeDefinitionPosition::Enum(type_) => type_.remove_extensions(schema),
+            TypeDefinitionPosition::InputObject(type_) => type_.remove_extensions(schema),
+        }
     }
 }
 
@@ -545,6 +560,18 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
             )),
         }
     }
+
+    pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        match self {
+            ObjectOrInterfaceTypeDefinitionPosition::Object(type_) => {
+                let _ = type_.remove(schema);
+            }
+            ObjectOrInterfaceTypeDefinitionPosition::Interface(type_) => {
+                let _ = type_.remove(schema);
+            }
+        }
+        Ok(())
+    }
 }
 
 fallible_conversions!(ObjectOrInterfaceTypeDefinitionPosition::Object -> ObjectTypeDefinitionPosition);
@@ -675,6 +702,13 @@ impl ObjectOrInterfaceFieldDefinitionPosition {
         schema: &'schema Schema,
     ) -> Option<&'schema Component<FieldDefinition>> {
         self.get(schema).ok()
+    }
+
+    pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        match self {
+            ObjectOrInterfaceFieldDefinitionPosition::Object(field) => field.remove(schema),
+            ObjectOrInterfaceFieldDefinitionPosition::Interface(field) => field.remove(schema),
+        }
     }
 
     pub(crate) fn insert_directive(
@@ -1388,6 +1422,18 @@ impl ScalarTypeDefinitionPosition {
 
         Ok(())
     }
+
+    fn remove_extensions(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        for directive in self
+            .make_mut(&mut schema.schema)?
+            .make_mut()
+            .directives
+            .iter_mut()
+        {
+            directive.origin = ComponentOrigin::Definition;
+        }
+        Ok(())
+    }
 }
 
 impl Display for ScalarTypeDefinitionPosition {
@@ -1880,6 +1926,26 @@ impl ObjectTypeDefinitionPosition {
         let type_ = self.make_mut(&mut schema.schema)?.make_mut();
         type_.implements_interfaces.swap_remove(old_name);
         type_.implements_interfaces.insert(new_name.into());
+        Ok(())
+    }
+
+    fn remove_extensions(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        let type_ = self.make_mut(&mut schema.schema)?.make_mut();
+        for directive in type_.directives.iter_mut() {
+            directive.origin = ComponentOrigin::Definition;
+        }
+        type_.implements_interfaces = type_
+            .implements_interfaces
+            .iter()
+            .map(|i| {
+                let mut i = i.clone();
+                i.origin = ComponentOrigin::Definition;
+                i
+            })
+            .collect();
+        for (_, field) in type_.fields.iter_mut() {
+            field.origin = ComponentOrigin::Definition;
+        }
         Ok(())
     }
 }
@@ -3001,6 +3067,26 @@ impl InterfaceTypeDefinitionPosition {
         type_.implements_interfaces.insert(new_name.into());
         Ok(())
     }
+
+    fn remove_extensions(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        let type_ = self.make_mut(&mut schema.schema)?.make_mut();
+        for directive in type_.directives.iter_mut() {
+            directive.origin = ComponentOrigin::Definition;
+        }
+        type_.implements_interfaces = type_
+            .implements_interfaces
+            .iter()
+            .map(|i| {
+                let mut i = i.clone();
+                i.origin = ComponentOrigin::Definition;
+                i
+            })
+            .collect();
+        for (_, field) in type_.fields.iter_mut() {
+            field.origin = ComponentOrigin::Definition;
+        }
+        Ok(())
+    }
 }
 
 impl Display for InterfaceTypeDefinitionPosition {
@@ -3983,6 +4069,23 @@ impl UnionTypeDefinitionPosition {
 
         Ok(())
     }
+
+    fn remove_extensions(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        let type_ = self.make_mut(&mut schema.schema)?.make_mut();
+        for directive in type_.directives.iter_mut() {
+            directive.origin = ComponentOrigin::Definition;
+        }
+        type_.members = type_
+            .members
+            .iter()
+            .map(|m| {
+                let mut m = m.clone();
+                m.origin = ComponentOrigin::Definition;
+                m
+            })
+            .collect();
+        Ok(())
+    }
 }
 
 impl Display for UnionTypeDefinitionPosition {
@@ -4344,6 +4447,17 @@ impl EnumTypeDefinitionPosition {
                 .insert(new_name, enum_type_referencers);
         }
 
+        Ok(())
+    }
+
+    fn remove_extensions(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        let type_ = self.make_mut(&mut schema.schema)?.make_mut();
+        for directive in type_.directives.iter_mut() {
+            directive.origin = ComponentOrigin::Definition;
+        }
+        for (_, v) in type_.values.iter_mut() {
+            v.origin = ComponentOrigin::Definition;
+        }
         Ok(())
     }
 }
@@ -4843,6 +4957,17 @@ impl InputObjectTypeDefinitionPosition {
                 .insert(new_name, input_object_type_referencers);
         }
 
+        Ok(())
+    }
+
+    fn remove_extensions(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        let type_ = self.make_mut(&mut schema.schema)?.make_mut();
+        for directive in type_.directives.iter_mut() {
+            directive.origin = ComponentOrigin::Definition;
+        }
+        for (_, field) in type_.fields.iter_mut() {
+            field.origin = ComponentOrigin::Definition;
+        }
         Ok(())
     }
 }

--- a/apollo-federation/src/schema/referencer.rs
+++ b/apollo-federation/src/schema/referencer.rs
@@ -84,12 +84,30 @@ pub(crate) struct ObjectTypeReferencers {
     pub(crate) union_types: IndexSet<UnionTypeDefinitionPosition>,
 }
 
+impl ObjectTypeReferencers {
+    pub(crate) fn len(&self) -> usize {
+        self.schema_roots.len()
+            + self.object_fields.len()
+            + self.interface_fields.len()
+            + self.union_types.len()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct InterfaceTypeReferencers {
     pub(crate) object_types: IndexSet<ObjectTypeDefinitionPosition>,
     pub(crate) object_fields: IndexSet<ObjectFieldDefinitionPosition>,
     pub(crate) interface_types: IndexSet<InterfaceTypeDefinitionPosition>,
     pub(crate) interface_fields: IndexSet<InterfaceFieldDefinitionPosition>,
+}
+
+impl InterfaceTypeReferencers {
+    pub(crate) fn len(&self) -> usize {
+        self.object_types.len()
+            + self.object_fields.len()
+            + self.interface_types.len()
+            + self.interface_fields.len()
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast::Directive;
@@ -12,9 +14,14 @@ use super::position::InterfaceTypeDefinitionPosition;
 use super::position::ObjectFieldDefinitionPosition;
 use super::position::ObjectTypeDefinitionPosition;
 use crate::error::FederationError;
+use crate::error::MultipleFederationErrors;
+use crate::error::SingleFederationError;
 use crate::schema::SubgraphMetadata;
+use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
+use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
 use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Subgraph;
+use crate::supergraph::remove_inactive_requires_and_provides_from_subgraph;
 use crate::utils::FallibleIterator;
 
 #[derive(Clone, Debug)]
@@ -207,33 +214,140 @@ impl<'a> SchemaUpgrader<'a> {
         todo!();
     }
 
-    fn fix_inactive_provides_and_requires(&self) {
-        todo!();
+    fn fix_inactive_provides_and_requires(&mut self) -> Result<(), FederationError> {
+        remove_inactive_requires_and_provides_from_subgraph(
+            self.original_subgraph.schema(),
+            &mut self.schema,
+        )
     }
 
-    fn remove_type_extensions(&self) {
-        todo!();
+    fn remove_type_extensions(&mut self) -> Result<(), FederationError> {
+        let types: Vec<_> = self.schema.get_types().collect();
+        for ty in types {
+            if !self.is_federation_type_extension(&ty)? && !self.is_root_type_extension(&ty) {
+                continue;
+            }
+            ty.remove_extensions(&mut self.schema)?;
+        }
+        Ok(())
+    }
+
+    /// Whether the type represents a type extension in the sense of federation 1.
+    /// That is, type extensions are a thing in GraphQL, but federation 1 overloads the notion for entities. This method
+    /// returns true if the type is used in the federation 1 sense of an extension.
+    /// We recognize federation 1 type extensions as type extensions that:
+    ///  1. are on object types or interface types (note that federation 1 doesn't really handle interface type extensions properly but it "accepts" them
+    ///     so we do it here too).
+    ///  2. do not have a definition for the same type in the same subgraph (this is a GraphQL extension otherwise).
+    ///
+    /// Not that type extensions in federation 1 generally have a @key, but in reality the code considers something a type extension even without
+    /// it (which one could argue is an unintended bug of fed1 since this leads to various problems). So, we don't check for the presence of @key here.
+    fn is_federation_type_extension(
+        &self,
+        ty: &TypeDefinitionPosition,
+    ) -> Result<bool, FederationError> {
+        let type_ = ty.get(self.schema.schema())?;
+        let has_extend = self
+            .original_subgraph
+            .extends_directive_name()?
+            .is_some_and(|extends| type_.directives().has(extends.as_str()));
+        Ok((Self::has_extension_elements(type_) || has_extend)
+            && (type_.is_object() || type_.is_interface())
+            && (has_extend || !Self::has_non_extension_elements(type_)))
+    }
+
+    fn has_extension_elements(ty: &ExtendedType) -> bool {
+        match ty {
+            ExtendedType::Object(obj) => !obj.extensions().is_empty(),
+            ExtendedType::Interface(itf) => !itf.extensions().is_empty(),
+            ExtendedType::Union(u) => !u.extensions().is_empty(),
+            ExtendedType::Enum(e) => !e.extensions().is_empty(),
+            ExtendedType::InputObject(io) => !io.extensions().is_empty(),
+            ExtendedType::Scalar(s) => !s.extensions().is_empty(),
+        }
+    }
+
+    fn has_non_extension_elements(ty: &ExtendedType) -> bool {
+        ty.directives()
+            .iter()
+            .any(|d| d.origin.extension_id().is_none())
+            || Self::has_non_extension_inner_elements(ty)
+    }
+
+    fn has_non_extension_inner_elements(ty: &ExtendedType) -> bool {
+        match ty {
+            ExtendedType::Scalar(_) => false,
+            ExtendedType::Object(t) => {
+                t.implements_interfaces
+                    .iter()
+                    .any(|itf| itf.origin.extension_id().is_none())
+                    || t.fields.values().any(|f| f.origin.extension_id().is_none())
+            }
+            ExtendedType::Interface(t) => {
+                t.implements_interfaces
+                    .iter()
+                    .any(|itf| itf.origin.extension_id().is_none())
+                    || t.fields.values().any(|f| f.origin.extension_id().is_none())
+            }
+            ExtendedType::Union(t) => t.members.iter().any(|m| m.origin.extension_id().is_none()),
+            ExtendedType::Enum(t) => t.values.values().any(|v| v.origin.extension_id().is_none()),
+            ExtendedType::InputObject(t) => {
+                t.fields.values().any(|f| f.origin.extension_id().is_none())
+            }
+        }
+    }
+
+    /// Whether the type is a root type but is declared only as an extension, which federation 1 actually accepts.
+    fn is_root_type_extension(&self, pos: &TypeDefinitionPosition) -> bool {
+        if !matches!(pos, TypeDefinitionPosition::Object(_)) || !self.is_root_type(pos) {
+            return false;
+        }
+        let Ok(ty) = pos.get(self.schema.schema()) else {
+            return false;
+        };
+        let has_extends_directive = self
+            .original_subgraph
+            .extends_directive_name()
+            .ok()
+            .flatten()
+            .is_some_and(|extends| ty.directives().has(extends.as_str()));
+
+        has_extends_directive
+            || (Self::has_extension_elements(ty) && !Self::has_non_extension_elements(ty))
+    }
+
+    fn is_root_type(&self, ty: &TypeDefinitionPosition) -> bool {
+        self.schema
+            .schema()
+            .schema_definition
+            .iter_root_operations()
+            .any(|op| op.1.as_str() == ty.type_name().as_str())
     }
 
     fn remove_directives_on_interface(&mut self) -> Result<(), FederationError> {
-        let schema = &mut self.schema;
-        let Some(metadata) = &schema.subgraph_metadata else {
-            return Ok(());
-        };
+        if let Some(key) = self.original_subgraph.key_directive_name()? {
+            for pos in &self
+                .schema
+                .referencers()
+                .get_directive(&key)?
+                .interface_types
+                .clone()
+            {
+                pos.remove_directive_name(&mut self.schema, &key);
 
-        let _provides_directive = metadata
-            .federation_spec_definition()
-            .provides_directive_definition(schema)?;
+                let fields: Vec<_> = pos.fields(self.schema.schema())?.collect();
+                for field in fields {
+                    if let Some(provides) = self.original_subgraph.provides_directive_name()? {
+                        field.remove_directive_name(&mut self.schema, &provides);
+                    }
+                    if let Some(requires) = self.original_subgraph.requires_directive_name()? {
+                        field.remove_directive_name(&mut self.schema, &requires);
+                    }
+                }
+            }
+        }
 
-        let _requires_directive = metadata
-            .federation_spec_definition()
-            .requires_directive_definition(schema)?;
-
-        let _key_directive = metadata
-            .federation_spec_definition()
-            .key_directive_definition(schema)?;
-
-        todo!();
+        Ok(())
     }
 
     fn remove_provides_on_non_composite(&mut self) -> Result<(), FederationError> {
@@ -266,8 +380,61 @@ impl<'a> SchemaUpgrader<'a> {
         Ok(())
     }
 
-    fn remove_unused_externals(&self) {
-        todo!();
+    fn remove_unused_externals(&mut self) -> Result<(), FederationError> {
+        let mut error = MultipleFederationErrors::new();
+        let mut fields_to_remove: HashSet<ObjectOrInterfaceFieldDefinitionPosition> =
+            HashSet::new();
+        let mut types_to_remove: HashSet<ObjectOrInterfaceTypeDefinitionPosition> = HashSet::new();
+        for type_ in self.schema.get_types() {
+            if let Ok(pos) = ObjectOrInterfaceTypeDefinitionPosition::try_from(type_) {
+                let mut has_fields = false;
+                for field in pos.fields(self.schema.schema())? {
+                    has_fields = true;
+                    let field_def = FieldDefinitionPosition::from(field.clone());
+                    if self
+                        .original_subgraph
+                        .metadata()
+                        .is_field_external(&field_def)
+                        && !self.original_subgraph.metadata().is_field_used(&field_def)
+                    {
+                        fields_to_remove.insert(field);
+                    }
+                }
+                if !has_fields {
+                    let is_referenced = match &pos {
+                        ObjectOrInterfaceTypeDefinitionPosition::Object(obj_pos) => self
+                            .schema
+                            .referencers()
+                            .object_types
+                            .get(&obj_pos.type_name)
+                            .is_some_and(|r| r.len() > 0),
+                        ObjectOrInterfaceTypeDefinitionPosition::Interface(itf_pos) => self
+                            .schema
+                            .referencers()
+                            .interface_types
+                            .get(&itf_pos.type_name)
+                            .is_some_and(|r| r.len() > 0),
+                    };
+                    if is_referenced {
+                        error
+                            .errors
+                            .push(SingleFederationError::TypeWithOnlyUnusedExternal {
+                                type_name: pos.type_name().clone(),
+                            });
+                    } else {
+                        types_to_remove.insert(pos);
+                    }
+                }
+            }
+        }
+
+        for field in fields_to_remove {
+            field.remove(&mut self.schema)?;
+        }
+        for type_ in types_to_remove {
+            type_.remove(&mut self.schema)?;
+        }
+        error.into_result()
     }
 
     fn add_shareable(&self) {

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -1,3 +1,4 @@
+use apollo_compiler::Name;
 use apollo_compiler::Schema;
 use apollo_compiler::name;
 
@@ -5,7 +6,12 @@ use crate::LinkSpecDefinition;
 use crate::ValidFederationSchema;
 use crate::error::FederationError;
 use crate::internal_error;
+use crate::link::federation_spec_definition::FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::federation_spec_definition::FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::federation_spec_definition::FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::federation_spec_definition::FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::add_fed1_link_to_schema;
+use crate::link::spec_definition::SpecDefinition;
 use crate::schema::FederationSchema;
 use crate::schema::KeyDirective;
 use crate::schema::blueprint::FederationBlueprint;
@@ -233,6 +239,30 @@ impl<S: HasMetadata> Subgraph<S> {
 
     pub(crate) fn schema(&self) -> &FederationSchema {
         self.state.schema()
+    }
+
+    pub(crate) fn extends_directive_name(&self) -> Result<Option<Name>, FederationError> {
+        self.metadata()
+            .federation_spec_definition()
+            .directive_name_in_schema(self.schema(), &FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC)
+    }
+
+    pub(crate) fn key_directive_name(&self) -> Result<Option<Name>, FederationError> {
+        self.metadata()
+            .federation_spec_definition()
+            .directive_name_in_schema(self.schema(), &FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC)
+    }
+
+    pub(crate) fn provides_directive_name(&self) -> Result<Option<Name>, FederationError> {
+        self.metadata()
+            .federation_spec_definition()
+            .directive_name_in_schema(self.schema(), &FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC)
+    }
+
+    pub(crate) fn requires_directive_name(&self) -> Result<Option<Name>, FederationError> {
+        self.metadata()
+            .federation_spec_definition()
+            .directive_name_in_schema(self.schema(), &FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC)
     }
 }
 

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -1798,7 +1798,7 @@ fn add_federation_operations(
 /// impact on later query planning, because it sometimes make us try type-exploding some interfaces
 /// unnecessarily. Besides, if a usage adds something useless, there is a chance it hasn't fully
 /// understood something, and warning about that fact through an error is more helpful.
-fn remove_inactive_requires_and_provides_from_subgraph(
+pub(crate) fn remove_inactive_requires_and_provides_from_subgraph(
     supergraph_schema: &FederationSchema,
     schema: &mut FederationSchema,
 ) -> Result<(), FederationError> {


### PR DESCRIPTION
Ports the following functions from the JS SchemaUpgrader:

- `fix_inactive_provides_and_requires`
- `remove_type_extensions`
- `remove_directives_on_interface`
- `remove_unused_externals`

The bulk of the source for these functions is [here](https://github.com/apollographql/federation/blob/main/internals-js/src/schemaUpgrader.ts#L550-L676).

<!-- FED-520 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
