### PR TITLE
Allow disabling subgraphs during query planning

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -318,6 +318,8 @@ pub enum SingleFederationError {
     QueryPlanComplexityExceeded { message: String },
     #[error("the caller requested cancellation")]
     PlanningCancelled,
+    #[error("No plan was found when subgraphs were disabled")]
+    NoPlanFoundWithDisabledSubgraphs,
 }
 
 impl SingleFederationError {
@@ -513,6 +515,9 @@ impl SingleFederationError {
                 ErrorCode::QueryPlanComplexityExceededError
             }
             SingleFederationError::PlanningCancelled => ErrorCode::Internal,
+            SingleFederationError::NoPlanFoundWithDisabledSubgraphs => {
+                ErrorCode::NoPlanFoundWithDisabledSubgraphs
+            }
         }
     }
 
@@ -1577,6 +1582,15 @@ static QUERY_PLAN_COMPLEXITY_EXCEEDED: LazyLock<ErrorCodeDefinition> = LazyLock:
     )
 });
 
+static NO_PLAN_FOUND_WITH_DISABLED_SUBGRAPHS: LazyLock<ErrorCodeDefinition> = LazyLock::new(|| {
+    ErrorCodeDefinition::new(
+        "NO_PLAN_FOUND_WITH_DISABLED_SUBGRAPHS".to_owned(),
+        "Indicates that the provided query could not be query planned due to subgraphs being disabled"
+            .to_owned(),
+        None,
+    )
+});
+
 #[derive(Debug, strum_macros::EnumIter)]
 pub enum ErrorCode {
     Internal,
@@ -1659,6 +1673,7 @@ pub enum ErrorCode {
     UnsupportedFederationVersion,
     UnsupportedFederationDirective,
     QueryPlanComplexityExceededError,
+    NoPlanFoundWithDisabledSubgraphs,
 }
 
 impl ErrorCode {
@@ -1759,6 +1774,7 @@ impl ErrorCode {
             ErrorCode::UnsupportedFederationVersion => &UNSUPPORTED_FEDERATION_VERSION,
             ErrorCode::UnsupportedFederationDirective => &UNSUPPORTED_FEDERATION_DIRECTIVE,
             ErrorCode::QueryPlanComplexityExceededError => &QUERY_PLAN_COMPLEXITY_EXCEEDED,
+            ErrorCode::NoPlanFoundWithDisabledSubgraphs => &NO_PLAN_FOUND_WITH_DISABLED_SUBGRAPHS,
         }
     }
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -35,6 +35,7 @@ mod cancel;
 mod context;
 mod debug_max_evaluated_plans_configuration;
 mod defer;
+mod disable_subgraphs;
 mod entities;
 mod fetch_operation_names;
 mod field_merging_with_skip_and_include;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/disable_subgraphs.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/disable_subgraphs.rs
@@ -1,0 +1,161 @@
+use apollo_federation::error::FederationError;
+use apollo_federation::error::SingleFederationError;
+use apollo_federation::query_plan::query_planner::QueryPlanOptions;
+
+const SUBGRAPH_A: &str = r#"
+  type Query {
+    foo: Foo
+  }
+
+  type Foo {
+    idA: ID! @shareable
+    idB: ID! @shareable
+  }
+"#;
+
+const SUBGRAPH_B: &str = r#"
+  type Foo @key(fields: "idA idB") {
+    idA: ID!
+    idB: ID!
+    bar: String! @shareable
+  }
+"#;
+
+const SUBGRAPH_C: &str = r#"
+  type Foo @key(fields: "idA") {
+    idA: ID!
+    bar: String! @shareable
+  }
+"#;
+
+const OPERATION: &str = r#"
+  query {
+    foo {
+      bar
+    }
+  }
+"#;
+
+#[test]
+fn test_if_less_expensive_subgraph_jump_is_used() {
+    let planner = planner!(
+        subgraphA: SUBGRAPH_A,
+        subgraphB: SUBGRAPH_B,
+        subgraphC: SUBGRAPH_C,
+    );
+    assert_plan!(
+      &planner,
+      OPERATION,
+      @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "subgraphA") {
+            {
+              foo {
+                __typename
+                idA
+              }
+            }
+          },
+          Flatten(path: "foo") {
+            Fetch(service: "subgraphC") {
+              {
+                ... on Foo {
+                  __typename
+                  idA
+                }
+              } =>
+              {
+                ... on Foo {
+                  bar
+                }
+              }
+            },
+          },
+        },
+      }
+      "###
+    );
+}
+
+#[test]
+fn test_if_disabling_less_expensive_subgraph_jump_causes_other_to_be_used() {
+    // setup_tracing_subscriber().expect("Failed to setup tracing");
+    let planner = planner!(
+        subgraphA: SUBGRAPH_A,
+        subgraphB: SUBGRAPH_B,
+        subgraphC: SUBGRAPH_C,
+    );
+    assert_plan!(
+      &planner,
+      OPERATION,
+      QueryPlanOptions {
+          disabled_subgraph_names: vec!["subgraphC".to_string()].into_iter().collect(),
+          ..Default::default()
+      },
+      @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "subgraphA") {
+            {
+              foo {
+                __typename
+                idA
+                idB
+              }
+            }
+          },
+          Flatten(path: "foo") {
+            Fetch(service: "subgraphB") {
+              {
+                ... on Foo {
+                  __typename
+                  idA
+                  idB
+                }
+              } =>
+              {
+                ... on Foo {
+                  bar
+                }
+              }
+            },
+          },
+        },
+      }
+      "###
+    );
+}
+
+#[test]
+fn test_if_disabling_all_subgraph_jumps_causes_error() {
+    let planner = planner!(
+        subgraphA: SUBGRAPH_A,
+        subgraphB: SUBGRAPH_B,
+        subgraphC: SUBGRAPH_C,
+    );
+    let api_schema = planner.api_schema();
+    let document = apollo_compiler::ExecutableDocument::parse_and_validate(
+        api_schema.schema(),
+        OPERATION,
+        "operation.graphql",
+    )
+    .expect("valid graphql document");
+    assert!(matches!(
+        planner
+            .build_query_plan(
+                &document,
+                None,
+                QueryPlanOptions {
+                    disabled_subgraph_names: vec!["subgraphB".to_string(), "subgraphC".to_string()]
+                        .into_iter()
+                        .collect(),
+                    ..Default::default()
+                },
+            )
+            .err(),
+        Some(FederationError::SingleFederationError(
+            SingleFederationError::NoPlanFoundWithDisabledSubgraphs
+        ))
+    ))
+}

--- a/apollo-federation/tests/query_plan/supergraphs/test_if_disabling_all_subgraph_jumps_causes_error.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_if_disabling_all_subgraph_jumps_causes_error.graphql
@@ -1,0 +1,74 @@
+# Composed from subgraphs with hash: 440d3c4bdff8acf74c9ca72961ae2f7bbb9f2223
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Foo
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB, key: "idA idB")
+  @join__type(graph: SUBGRAPHC, key: "idA")
+{
+  idA: ID!
+  idB: ID! @join__field(graph: SUBGRAPHA) @join__field(graph: SUBGRAPHB)
+  bar: String! @join__field(graph: SUBGRAPHB) @join__field(graph: SUBGRAPHC)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "subgraphA", url: "none")
+  SUBGRAPHB @join__graph(name: "subgraphB", url: "none")
+  SUBGRAPHC @join__graph(name: "subgraphC", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+  @join__type(graph: SUBGRAPHC)
+{
+  foo: Foo @join__field(graph: SUBGRAPHA)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/test_if_disabling_less_expensive_subgraph_jump_causes_other_to_be_used.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_if_disabling_less_expensive_subgraph_jump_causes_other_to_be_used.graphql
@@ -1,0 +1,74 @@
+# Composed from subgraphs with hash: 440d3c4bdff8acf74c9ca72961ae2f7bbb9f2223
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Foo
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB, key: "idA idB")
+  @join__type(graph: SUBGRAPHC, key: "idA")
+{
+  idA: ID!
+  idB: ID! @join__field(graph: SUBGRAPHA) @join__field(graph: SUBGRAPHB)
+  bar: String! @join__field(graph: SUBGRAPHB) @join__field(graph: SUBGRAPHC)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "subgraphA", url: "none")
+  SUBGRAPHB @join__graph(name: "subgraphB", url: "none")
+  SUBGRAPHC @join__graph(name: "subgraphC", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+  @join__type(graph: SUBGRAPHC)
+{
+  foo: Foo @join__field(graph: SUBGRAPHA)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/test_if_less_expensive_subgraph_jump_is_used.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_if_less_expensive_subgraph_jump_is_used.graphql
@@ -1,0 +1,74 @@
+# Composed from subgraphs with hash: 440d3c4bdff8acf74c9ca72961ae2f7bbb9f2223
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Foo
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB, key: "idA idB")
+  @join__type(graph: SUBGRAPHC, key: "idA")
+{
+  idA: ID!
+  idB: ID! @join__field(graph: SUBGRAPHA) @join__field(graph: SUBGRAPHB)
+  bar: String! @join__field(graph: SUBGRAPHB) @join__field(graph: SUBGRAPHC)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "subgraphA", url: "none")
+  SUBGRAPHB @join__graph(name: "subgraphB", url: "none")
+  SUBGRAPHC @join__graph(name: "subgraphC", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+  @join__type(graph: SUBGRAPHC)
+{
+  foo: Foo @join__field(graph: SUBGRAPHA)
+}

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -160,6 +160,7 @@ impl QueryPlannerService {
                 override_conditions: plan_options.override_conditions,
                 check_for_cooperative_cancellation: Some(&check),
                 non_local_selections_limit_enabled: non_local_selections_check_enabled(),
+                disabled_subgraph_names: Default::default(),
             };
 
             let result = operation


### PR DESCRIPTION
This PR updates `build_query_plan()` to optionally accept a set of subgraphs that shouldn't be used for query planning. This may result in no query plan being found; if it does, the `SingleFederationError::NoPlanFoundWithDisabledSubgraphs` error is emitted (normally, composition's satisfiability check guarantees that a plan is always found).

<!-- [FED-586] -->

[FED-586]: https://apollographql.atlassian.net/browse/FED-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ