### PR TITLE
Fix JWT metrics discrepancy

### DIFF
--- a/.changesets/fix_simon_jwt_metrics.md
+++ b/.changesets/fix_simon_jwt_metrics.md
@@ -1,0 +1,9 @@
+### Fix JWT metrics discrepancy ([PR #7258](https://github.com/apollographql/router/pull/7258))
+
+This fixes the `apollo.router.operations.authentication.jwt` counter metric to behave [as documented](https://www.apollographql.com/docs/graphos/routing/security/jwt#observability): emitted for every request that uses JWT, with the `authentication.jwt.failed` attribute set to true or false for failed or successful authentication.
+
+Previously, it was only used for failed authentication.
+
+The attribute-less and accidentally-differently-named `apollo.router.operations.jwt` counter was and is only emitted for successful authentication, but is deprecated now.
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/7258

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -449,12 +449,9 @@ fn authenticate(
         source: Option<&Source>,
     ) -> ControlFlow<router::Response, router::Request> {
         // This is a metric and will not appear in the logs
-        u64_counter!(
-            "apollo.router.operations.authentication.jwt",
-            "Number of requests with JWT authentication",
-            1,
-            authentication.jwt.failed = true
-        );
+        let failed = true;
+        increment_jwt_counter_metric(failed);
+
         tracing::error!(message = %error, "jwt authentication failure");
 
         let _ = request.context.insert_json_value(
@@ -479,6 +476,16 @@ fn authenticate(
         } else {
             ControlFlow::Continue(request)
         }
+    }
+
+    /// This is the documented metric
+    fn increment_jwt_counter_metric(failed: bool) {
+        u64_counter!(
+            "apollo.router.operations.authentication.jwt",
+            "Number of requests with JWT authentication",
+            1,
+            authentication.jwt.failed = failed
+        );
     }
 
     let mut jwt = None;
@@ -588,11 +595,19 @@ fn authenticate(
             );
         }
         // This is a metric and will not appear in the logs
+        //
+        // Apparently intended to be `apollo.router.operations.authentication.jwt` like above,
+        // but has existed for two years with a buggy name. Keep it for now.
         u64_counter!(
             "apollo.router.operations.jwt",
-            "Number of requests with JWT authentication",
+            "Number of requests with JWT successful authentication (deprecated, \
+                use `apollo.router.operations.authentication.jwt` \
+                with `authentication.jwt.failed = false` instead)",
             1
         );
+        // Use the fixed name too:
+        let failed = false;
+        increment_jwt_counter_metric(failed);
 
         let _ = request.context.insert_json_value(
             JWT_CONTEXT_KEY,


### PR DESCRIPTION
This fixes the `apollo.router.operations.authentication.jwt` counter metric to behave [as documented](https://www.apollographql.com/docs/graphos/routing/security/jwt#observability): emitted for every request that uses JWT, with the `authentication.jwt.failed` attribute set to true or false for failed or successful authentication.

Previously, it was only used for failed authentication.

The attribute-less and accidentally-differently-named `apollo.router.operations.jwt` counter was and is only emitted for successful authentication, but is deprecated now.
<!-- ROUTER-1250 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
