### PR TITLE
Remove "setting resource attributes is not allowed" warning

### DIFF
--- a/.changesets/fix_simon_unwarn_resource_attr.md
+++ b/.changesets/fix_simon_unwarn_resource_attr.md
@@ -1,0 +1,17 @@
+### Remove "setting resource attributes is not allowed" warning ([PR #7272](https://github.com/apollographql/router/pull/7272))
+
+If Uplink is enabled, Router 2.1.x emits this warning at startup event though no user configuration or other choice is responsible for it:
+
+```
+WARN  setting resource attributes is not allowed for Apollo telemetry
+```
+
+This removes the warning entirely as it’s not particularly helpful.
+
+Reproduction:
+
+```
+APOLLO_KEY=secret APOLLO_GRAPH_REF=starstuff@current cargo run
+```
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/7272

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -1283,7 +1283,6 @@ impl SpanExporter for Exporter {
     fn set_resource(&mut self, _resource: &Resource) {
         // This is intentionally a NOOP. The reason for this is that we do not allow users to set the resource attributes
         // for telemetry that is sent to Apollo. To do so would expose potential private information that the user did not intend for us.
-        tracing::warn!("setting resource attributes is not allowed for Apollo telemetry");
     }
 }
 


### PR DESCRIPTION
If Uplink is enabled, Router 2.1.x emits this warning at startup event though no user configuration or other choice is responsible for it:

```
WARN  setting resource attributes is not allowed for Apollo telemetry
```

This removes the warning entirely as it’s not particularly helpful.

Reproduction:

```
APOLLO_KEY=secret APOLLO_GRAPH_REF=starstuff@current cargo run
```

<!-- ROUTER-1253 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
