### PR TITLE
fix: poll pending compute jobs hang request

### DIFF
--- a/.changesets/fix_bryn_poll_pending_compute_jobs.md
+++ b/.changesets/fix_bryn_poll_pending_compute_jobs.md
@@ -1,0 +1,10 @@
+### Poll pending compute jobs hang request ([PR #7273](https://github.com/apollographql/router/pull/7273))
+
+Compute jobs in the router are used to execute CPU intensive work outside of the main io worker threads, in particular for QueryParsing, QueryPlanning and Introspection.
+
+We currently check in the pipeline if the compute job is full and if it is then it will return `Poll::Pending` in the tower services.
+However, this will cause requests to hang until timeout.
+
+This PR shifts the logic into `call` and will immediately return a `SERVICE_UNAVAILABLE` response to the user.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/7273

--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -29,14 +29,10 @@ use crate::metrics::meter_provider;
 /// a sizable backlog during spikes.
 fn queue_capacity() -> usize {
     // This environment variable is intentionally undocumented.
-    if let Some(threads) = std::env::var("APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD")
+    std::env::var("APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
-    {
-        threads
-    } else {
-        1000
-    }
+        .unwrap_or(1000)
 }
 
 /// By default, let this thread pool use all available resources if it can.

--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -20,12 +20,24 @@ use crate::ageing_priority_queue::Priority;
 use crate::metrics::meter_provider;
 
 /// We generate backpressure in tower `poll_ready` when the number of queued jobs
-/// reaches `QUEUE_SOFT_CAPACITY_PER_THREAD * thread_pool_size()`
+/// reaches `APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD * thread_pool_size()`
+///
+/// The default for APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD is 1000
 ///
 /// This number is somewhat arbitrary and subject to change. Most compute jobs
 /// don't take a long time, so by making the queue quite big, it's capable of eating
 /// a sizable backlog during spikes.
-const QUEUE_SOFT_CAPACITY_PER_THREAD: usize = 1_000;
+fn queue_capacity() -> usize {
+    // This environment variable is intentionally undocumented.
+    if let Some(threads) = std::env::var("APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+    {
+        threads
+    } else {
+        1000
+    }
+}
 
 /// By default, let this thread pool use all available resources if it can.
 /// In the worst case, we’ll have moderate context switching cost
@@ -98,7 +110,7 @@ fn queue() -> &'static AgeingPriorityQueue<Job> {
                 }
             });
         }
-        AgeingPriorityQueue::soft_bounded(QUEUE_SOFT_CAPACITY_PER_THREAD * pool_size)
+        AgeingPriorityQueue::soft_bounded(queue_capacity() * pool_size)
     })
 }
 

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -378,11 +378,7 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if crate::compute_job::is_full() {
-            Poll::Pending
-        } else {
-            Poll::Ready(Ok(()))
-        }
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: QueryPlannerRequest) -> Self::Future {

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -9,6 +9,7 @@ use axum::response::*;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
+use futures::FutureExt;
 use futures::TryFutureExt;
 use futures::future::BoxFuture;
 use futures::future::join_all;
@@ -215,15 +216,31 @@ impl Service<RouterRequest> for RouterService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // This service eventually calls `QueryAnalysisLayer::parse_document()`
-        // which calls `compute_job::execute()`
-        if crate::compute_job::is_full() {
-            return Poll::Pending;
-        }
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: RouterRequest) -> Self::Future {
+        // Report early to the user if the compute job queue is full
+        // This is not how it is done in Router 2.0 as backpressure is fixed, and we correctly deal with it
+        // in poll_ready. However, in router 1.0 where we do not use load_shed this is a compromise that is not invasive
+        // If the compute job queue is full then it will immediately return an error that the service is unavailable.
+        if crate::compute_job::is_full() {
+            let context = req.context.clone();
+            return async {
+                Ok(router::Response::error_builder()
+                    .error(
+                        graphql::Error::builder()
+                            .message("Overloaded")
+                            .extension_code("SERVICE_UNAVAILABLE")
+                            .build(),
+                    )
+                    .status_code(StatusCode::SERVICE_UNAVAILABLE)
+                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                    .context(context)
+                    .build()?)
+            }
+            .boxed();
+        }
         let clone = self.clone();
 
         let this = std::mem::replace(self, clone);

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -227,7 +227,7 @@ impl Service<RouterRequest> for RouterService {
         if crate::compute_job::is_full() {
             let context = req.context.clone();
             return async {
-                Ok(router::Response::error_builder()
+                router::Response::error_builder()
                     .error(
                         graphql::Error::builder()
                             .message("Overloaded")
@@ -237,7 +237,7 @@ impl Service<RouterRequest> for RouterService {
                     .status_code(StatusCode::SERVICE_UNAVAILABLE)
                     .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                     .context(context)
-                    .build()?)
+                    .build()
             }
             .boxed();
         }

--- a/apollo-router/tests/integration/fixtures/rust_query_planner.router.yaml
+++ b/apollo-router/tests/integration/fixtures/rust_query_planner.router.yaml
@@ -1,1 +1,0 @@
-experimental_query_planner_mode: new

--- a/apollo-router/tests/integration/fixtures/rust_query_planner.router.yaml
+++ b/apollo-router/tests/integration/fixtures/rust_query_planner.router.yaml
@@ -1,0 +1,1 @@
+experimental_query_planner_mode: new

--- a/apollo-router/tests/integration/query_planner.rs
+++ b/apollo-router/tests/integration/query_planner.rs
@@ -111,7 +111,7 @@ async fn overloaded_compute_job_pool() {
     let mut router = IntegrationTest::builder()
         .env_entry("APOLLO_ROUTER_COMPUTE_THREADS", "1")
         .env_entry("APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD", "1")
-        .config(include_str!("fixtures/rust_query_planner.router.yaml"))
+        .config(include_str!("fixtures/happy.router.yaml"))
         .build()
         .await;
     router.start().await;

--- a/apollo-router/tests/integration/query_planner.rs
+++ b/apollo-router/tests/integration/query_planner.rs
@@ -117,7 +117,7 @@ async fn overloaded_compute_job_pool() {
     router.start().await;
     router.assert_started().await;
     // Fire off 100 concurrent requests
-    let requests = (0..1000).map(|i| {
+    let requests = (0..100).map(|i| {
         let mut body = json!({"query":"query ExampleQuery {topProducts{name}}","variables":{}});
         // Replace the query nameAlias with a new query that has an alias based on i
         body["query"] = format!(r#"query ExampleQuery{} {{topProducts{{name}}}}"#, i).into();

--- a/apollo-router/tests/integration/query_planner.rs
+++ b/apollo-router/tests/integration/query_planner.rs
@@ -110,7 +110,7 @@ async fn valid_schema_with_new_qp_change_to_broken_schema_keeps_old_config() {
 async fn overloaded_compute_job_pool() {
     let mut router = IntegrationTest::builder()
         .env_entry("APOLLO_ROUTER_COMPUTE_THREADS", "1")
-        .env_entry("APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD", "2")
+        .env_entry("APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD", "1")
         .config(include_str!("fixtures/rust_query_planner.router.yaml"))
         .build()
         .await;

--- a/apollo-router/tests/integration/query_planner.rs
+++ b/apollo-router/tests/integration/query_planner.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
+use serde_json::json;
+
 use crate::integration::IntegrationTest;
+use crate::integration::common::Query;
 use crate::integration::common::graph_os_enabled;
 
 mod max_evaluated_plans;
@@ -100,5 +103,37 @@ async fn valid_schema_with_new_qp_change_to_broken_schema_keeps_old_config() {
         .wait_for_log_message("error while reloading, continuing with previous configuration")
         .await;
     router.execute_default_query().await;
+    router.graceful_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn overloaded_compute_job_pool() {
+    let mut router = IntegrationTest::builder()
+        .env_entry("APOLLO_ROUTER_COMPUTE_THREADS", "1")
+        .env_entry("APOLLO_ROUTER_COMPUTE_QUEUE_CAPACITY_PER_THREAD", "2")
+        .config(include_str!("fixtures/rust_query_planner.router.yaml"))
+        .build()
+        .await;
+    router.start().await;
+    router.assert_started().await;
+    // Fire off 100 concurrent requests
+    let requests = (0..100).map(|i| {
+        let mut body =
+            json!({"query":"query ExampleQuery {topProducts{nameAlias: name}}","variables":{}});
+        body["variables"]["nameAlias"] = format!("name-{}", i).into();
+        router.execute_query(Query::builder().body(body).build())
+    });
+    let responses = futures::future::join_all(requests).await;
+
+    // Assert that at least one response indicates "overloaded"
+    let overloaded_count = responses
+        .iter()
+        .filter(|response| response.1.status() == 503)
+        .count();
+
+    assert!(
+        overloaded_count > 0,
+        "Expected at least one request to be overloaded, but none were."
+    );
     router.graceful_shutdown().await;
 }

--- a/apollo-router/tests/integration/query_planner.rs
+++ b/apollo-router/tests/integration/query_planner.rs
@@ -117,10 +117,11 @@ async fn overloaded_compute_job_pool() {
     router.start().await;
     router.assert_started().await;
     // Fire off 100 concurrent requests
-    let requests = (0..100).map(|i| {
-        let mut body =
-            json!({"query":"query ExampleQuery {topProducts{nameAlias: name}}","variables":{}});
-        body["variables"]["nameAlias"] = format!("name-{}", i).into();
+    let requests = (0..1000).map(|i| {
+        let mut body = json!({"query":"query ExampleQuery {topProducts{name}}","variables":{}});
+        // Replace the query nameAlias with a new query that has an alias based on i
+        body["query"] = format!(r#"query ExampleQuery{} {{topProducts{{name}}}}"#, i).into();
+
         router.execute_query(Query::builder().body(body).build())
     });
     let responses = futures::future::join_all(requests).await;


### PR DESCRIPTION
Compute jobs in the router are used to execute CPU intensive work outside of the main io worker threads, in particular for QueryParsing, QueryPlanning and Introspection.

We currently check in the pipeline if the compute job is full and if it is then it will return `Poll::Pending` in the tower services.
However this will cause requests to hang until timeout.

This PR shifts the logic into `call` and will immediately return a `SERVICE_UNAVAILABLE` response to the user.


<!-- start metadata -->
<!--ROUTER-1238-->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

No new docs

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
