### PR TITLE
Fix helm template syntax for virtualservice `Hosts` list

### DIFF
--- a/helm/chart/router/templates/virtualservice.yaml
+++ b/helm/chart/router/templates/virtualservice.yaml
@@ -20,13 +20,13 @@ metadata:
   {{- end }}
 spec:
   hosts:
-  { { if .Values.virtualservice.Hosts } }
-  { { - range .Values.virtualservice.Hosts } }
-  - { { . | quote } }
-  { { - end } }
-  { { - else } }
+  {{ if .Values.virtualservice.Hosts }}
+  {{ - range .Values.virtualservice.Hosts }}
+  - {{ . | quote }}
+  {{ - end }}
+  {{ - else }}
   - "*"
-  { { - end } }
+  {{ - end }}
   {{- if .Values.virtualservice.gatewayName }}
   gateways:
   - {{ .Values.virtualservice.gatewayName }}

--- a/helm/chart/router/templates/virtualservice.yaml
+++ b/helm/chart/router/templates/virtualservice.yaml
@@ -21,12 +21,12 @@ metadata:
 spec:
   hosts:
   {{ if .Values.virtualservice.Hosts }}
-  {{ - range .Values.virtualservice.Hosts }}
-  - {{ . | quote }}
-  {{ - end }}
-  {{ - else }}
+  {{- range .Values.virtualservice.Hosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- else }}
   - "*"
-  {{ - end }}
+  {{- end }}
   {{- if .Values.virtualservice.gatewayName }}
   gateways:
   - {{ .Values.virtualservice.gatewayName }}


### PR DESCRIPTION
Closes https://github.com/apollographql/router/pull/7268
Fixes https://github.com/apollographql/router/issues/7267

#7268 as a branch so CI can run.