### PR TITLE
Fix JWT metrics discrepancy (backport #7258)

### DIFF
--- a/.changesets/fix_simon_jwt_metrics.md
+++ b/.changesets/fix_simon_jwt_metrics.md
@@ -1,0 +1,9 @@
+### Fix JWT metrics discrepancy ([PR #7258](https://github.com/apollographql/router/pull/7258))
+
+This fixes the `apollo.router.operations.authentication.jwt` counter metric to behave [as documented](https://www.apollographql.com/docs/graphos/routing/security/jwt#observability): emitted for every request that uses JWT, with the `authentication.jwt.failed` attribute set to true or false for failed or successful authentication.
+
+Previously, it was only used for failed authentication.
+
+The attribute-less and accidentally-differently-named `apollo.router.operations.jwt` counter was and is only emitted for successful authentication, but is deprecated now.
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/7258

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -545,19 +545,14 @@ fn authenticate(
         status: StatusCode,
     ) -> ControlFlow<router::Response, router::Request> {
         // This is a metric and will not appear in the logs
-<<<<<<< HEAD
         u64_counter!(
             "apollo_authentication_failure_count",
             "Number of requests with failed JWT authentication (deprecated)",
             1,
             kind = "JWT"
         );
-        u64_counter!(
-            "apollo.router.operations.authentication.jwt",
-            "Number of requests with JWT authentication",
-            1,
-            authentication.jwt.failed = true
-        );
+        let failed = true;
+        increment_jwt_counter_metric(failed);
         tracing::info!(message = %error, "jwt authentication failure");
         let response = router::Response::infallible_builder()
             .error(
@@ -571,35 +566,6 @@ fn authenticate(
             .context(context)
             .build();
         ControlFlow::Break(response)
-=======
-        let failed = true;
-        increment_jwt_counter_metric(failed);
-
-        tracing::error!(message = %error, "jwt authentication failure");
-
-        let _ = request.context.insert_json_value(
-            JWT_CONTEXT_KEY,
-            serde_json_bytes::json!(JwtStatus::new_failure(source, error.as_context_object())),
-        );
-
-        if config.on_error == OnError::Error {
-            let response = router::Response::infallible_builder()
-                .error(
-                    graphql::Error::builder()
-                        .message(error.to_string())
-                        .extension_code("AUTH_ERROR")
-                        .build(),
-                )
-                .status_code(status)
-                .header(header::CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone())
-                .context(request.context)
-                .build();
-
-            ControlFlow::Break(response)
-        } else {
-            ControlFlow::Continue(request)
-        }
->>>>>>> f57b2079 (Fix JWT metrics discrepancy (#7258))
     }
 
     /// This is the documented metric
@@ -697,15 +663,14 @@ fn authenticate(
             );
         }
         // This is a metric and will not appear in the logs
-        //
-        // Apparently intended to be `apollo.router.operations.authentication.jwt` like above,
-        // but has existed for two years with a buggy name. Keep it for now.
         u64_counter!(
             "apollo_authentication_success_count",
             "Number of requests with successful JWT authentication (deprecated)",
             1,
             kind = "JWT"
         );
+        // Apparently intended to be `apollo.router.operations.authentication.jwt` like above,
+        // but has existed for two years with a buggy name. Keep it for now.
         u64_counter!(
             "apollo.router.operations.jwt",
             "Number of requests with JWT successful authentication (deprecated, \
@@ -713,18 +678,10 @@ fn authenticate(
                 with `authentication.jwt.failed = false` instead)",
             1
         );
-<<<<<<< HEAD
-=======
         // Use the fixed name too:
         let failed = false;
         increment_jwt_counter_metric(failed);
 
-        let _ = request.context.insert_json_value(
-            JWT_CONTEXT_KEY,
-            serde_json_bytes::json!(JwtStatus::new_success(source_of_extracted_jwt)),
-        );
-
->>>>>>> f57b2079 (Fix JWT metrics discrepancy (#7258))
         return ControlFlow::Continue(request);
     }
 


### PR DESCRIPTION
This fixes the `apollo.router.operations.authentication.jwt` counter metric to behave [as documented](https://www.apollographql.com/docs/graphos/routing/security/jwt#observability): emitted for every request that uses JWT, with the `authentication.jwt.failed` attribute set to true or false for failed or successful authentication.

Previously, it was only used for failed authentication.

The attribute-less and accidentally-differently-named `apollo.router.operations.jwt` counter was and is only emitted for successful authentication, but is deprecated now.



---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7258 done by [Mergify](https://mergify.com).