### PR TITLE
docs: use `context: all` for coprocessor in 2.x docs

### DIFF
--- a/docs/source/routing/security/authorization.mdx
+++ b/docs/source/routing/security/authorization.mdx
@@ -578,7 +578,7 @@ coprocessor:
   url: http://127.0.0.1:8081
   supergraph:
     request:
-      context: true
+      context: all
 ```
 
 A coprocessor can then receive a request with this format:

--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -411,7 +411,7 @@ coprocessor:
   url: http://127.0.0.1:8081
   router:
     request:
-      context: true
+      context: all
 ```
 
 The router sends requests to the coprocessor with this format:


### PR DESCRIPTION
In 2.x, you can specify different values for the
`coprocessor.**.context` keys.

- `context: deprecated` uses the 1.x names for context keys.
- `context: all` uses the 2.x names for context keys.
- `context: true` uses the **1.x** names for context keys.

We should not recommend `context: true` anywhere in our docs, except in
the upgrade guide, and should potentially start logging a warning for it.

This updates two mentions of `context: true` are actually _buggy_.

(even better might be to use an allowlist of only the necessary extension
keys here, but I'm just solving the bugs first ;) )