### PR TITLE
Change `source_url` to be an `http::Uri`

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@batch.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@batch.graphql.snap
@@ -21,23 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ba
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "localhost",
-                        ),
-                    ),
-                    port: Some(
-                        4001,
-                    ),
-                    path: "/api",
-                    query: None,
-                    fragment: None,
-                },
+                http://localhost:4001/api,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -111,23 +95,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ba
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "localhost",
-                        ),
-                    ),
-                    port: Some(
-                        4001,
-                    ),
-                    path: "/api",
-                    query: None,
-                    fragment: None,
-                },
+                http://localhost:4001/api,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@carryover.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@carryover.graphql.snap
@@ -21,21 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ca
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -193,21 +179,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ca
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -416,21 +388,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ca
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@interface-object.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@interface-object.graphql.snap
@@ -21,23 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/in
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "localhost",
-                        ),
-                    ),
-                    port: Some(
-                        4001,
-                    ),
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://localhost:4001/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -174,23 +158,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/in
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "localhost",
-                        ),
-                    ),
-                    port: Some(
-                        4001,
-                    ),
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://localhost:4001/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -276,23 +244,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/in
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "localhost",
-                        ),
-                    ),
-                    port: Some(
-                        4001,
-                    ),
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://localhost:4001/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@nested_inputs.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@nested_inputs.graphql.snap
@@ -21,21 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ne
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@normalize_names.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@normalize_names.graphql.snap
@@ -21,21 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/no
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -110,21 +96,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/no
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@realistic.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@realistic.graphql.snap
@@ -21,21 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -328,21 +314,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -504,21 +476,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -724,21 +682,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@simple.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@simple.graphql.snap
@@ -21,21 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -110,21 +96,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -263,21 +235,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@steelthread.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@steelthread.graphql.snap
@@ -21,21 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/st
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "https",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "jsonplaceholder.typicode.com",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                https://jsonplaceholder.typicode.com/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -121,21 +107,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/st
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "https",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "jsonplaceholder.typicode.com",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                https://jsonplaceholder.typicode.com/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -284,21 +256,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/st
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "https",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "jsonplaceholder.typicode.com",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                https://jsonplaceholder.typicode.com/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
@@ -21,21 +21,7 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ty
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "http",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "example",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                http://example/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -17,9 +17,9 @@ use apollo_compiler::parser::SourceSpan;
 use apollo_compiler::validation::Valid;
 use either::Either;
 use http::HeaderName;
+use http::Uri;
 use keys::make_key_field_set_from_variables;
 use serde_json::Value;
-use url::Url;
 
 use super::ConnectId;
 use super::JSONSelection;
@@ -339,7 +339,7 @@ fn extract_header_references<'a>(
 // --- HTTP JSON ---------------------------------------------------------------
 #[derive(Clone, Debug)]
 pub struct HttpJsonTransport {
-    pub source_url: Option<Url>,
+    pub source_url: Option<Uri>,
     pub connect_template: URLTemplate,
     pub method: HTTPMethod,
     pub headers: IndexMap<HeaderName, HeaderSource>,
@@ -655,7 +655,7 @@ mod tests {
         let connectors =
             Connector::from_schema(subgraph.schema.schema(), "connectors", ConnectSpec::V0_1)
                 .unwrap();
-        assert_debug_snapshot!(&connectors, @r#"
+        assert_debug_snapshot!(&connectors, @r###"
         {
             ConnectId {
                 label: "connectors.json http: GET /users",
@@ -687,21 +687,7 @@ mod tests {
                 },
                 transport: HttpJsonTransport {
                     source_url: Some(
-                        Url {
-                            scheme: "https",
-                            cannot_be_a_base: false,
-                            username: "",
-                            password: None,
-                            host: Some(
-                                Domain(
-                                    "jsonplaceholder.typicode.com",
-                                ),
-                            ),
-                            port: None,
-                            path: "/",
-                            query: None,
-                            fragment: None,
-                        },
+                        https://jsonplaceholder.typicode.com/,
                     ),
                     connect_template: URLTemplate {
                         base: None,
@@ -818,21 +804,7 @@ mod tests {
                 },
                 transport: HttpJsonTransport {
                     source_url: Some(
-                        Url {
-                            scheme: "https",
-                            cannot_be_a_base: false,
-                            username: "",
-                            password: None,
-                            host: Some(
-                                Domain(
-                                    "jsonplaceholder.typicode.com",
-                                ),
-                            ),
-                            port: None,
-                            path: "/",
-                            query: None,
-                            fragment: None,
-                        },
+                        https://jsonplaceholder.typicode.com/,
                     ),
                     connect_template: URLTemplate {
                         base: None,
@@ -932,7 +904,7 @@ mod tests {
                 ),
             },
         }
-        "#);
+        "###);
     }
 
     #[test]

--- a/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__models__tests__from_schema_v0_2.snap
+++ b/apollo-federation/src/sources/connect/snapshots/apollo_federation__sources__connect__models__tests__from_schema_v0_2.snap
@@ -33,21 +33,7 @@ expression: "&connectors"
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "https",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "jsonplaceholder.typicode.com",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                https://jsonplaceholder.typicode.com/,
             ),
             connect_template: URLTemplate {
                 base: None,
@@ -176,21 +162,7 @@ expression: "&connectors"
         },
         transport: HttpJsonTransport {
             source_url: Some(
-                Url {
-                    scheme: "https",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: Some(
-                        Domain(
-                            "jsonplaceholder.typicode.com",
-                        ),
-                    ),
-                    port: None,
-                    path: "/",
-                    query: None,
-                    fragment: None,
-                },
+                https://jsonplaceholder.typicode.com/,
             ),
             connect_template: URLTemplate {
                 base: None,

--- a/apollo-federation/src/sources/connect/spec/directives.rs
+++ b/apollo-federation/src/sources/connect/spec/directives.rs
@@ -501,21 +501,7 @@ mod tests {
             SourceDirectiveArguments {
                 name: "json",
                 http: SourceHTTPArguments {
-                    base_url: Url {
-                        scheme: "https",
-                        cannot_be_a_base: false,
-                        username: "",
-                        password: None,
-                        host: Some(
-                            Domain(
-                                "jsonplaceholder.typicode.com",
-                            ),
-                        ),
-                        port: None,
-                        path: "/",
-                        query: None,
-                        fragment: None,
-                    },
+                    base_url: https://jsonplaceholder.typicode.com/,
                     headers: {
                         "authtoken": From(
                             "x-auth-token",

--- a/apollo-federation/src/sources/connect/spec/schema.rs
+++ b/apollo-federation/src/sources/connect/spec/schema.rs
@@ -2,7 +2,7 @@ use apollo_compiler::Name;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::name;
 use http::HeaderName;
-use url::Url;
+use http::Uri;
 
 use crate::sources::connect::ConnectorPosition;
 use crate::sources::connect::HeaderSource;
@@ -50,7 +50,7 @@ pub(crate) struct SourceDirectiveArguments {
 #[cfg_attr(test, derive(Debug))]
 pub(crate) struct SourceHTTPArguments {
     /// The base URL containing all sub API endpoints
-    pub(crate) base_url: Url,
+    pub(crate) base_url: Uri,
 
     /// HTTP headers used when requesting resources from the upstream source.
     /// Can be overridden by name with headers in a @connect directive.

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -616,6 +616,7 @@ async fn deserialize_response<T: HttpBody>(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
     use std::sync::Arc;
 
     use apollo_compiler::Schema;
@@ -627,9 +628,9 @@ mod tests {
     use apollo_federation::sources::connect::HTTPMethod;
     use apollo_federation::sources::connect::HttpJsonTransport;
     use apollo_federation::sources::connect::JSONSelection;
+    use http::Uri;
     use insta::assert_debug_snapshot;
     use itertools::Itertools;
-    use url::Url;
 
     use crate::Context;
     use crate::graphql;
@@ -652,7 +653,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -763,7 +764,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -879,7 +880,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Post,
                 headers: Default::default(),
@@ -1004,7 +1005,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1131,7 +1132,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1398,7 +1399,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -805,6 +805,7 @@ fn batch_entities_from_request(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
     use std::sync::Arc;
 
     use apollo_compiler::ExecutableDocument;
@@ -818,8 +819,8 @@ mod tests {
     use apollo_federation::sources::connect::HTTPMethod;
     use apollo_federation::sources::connect::HttpJsonTransport;
     use apollo_federation::sources::connect::JSONSelection;
+    use http::Uri;
     use insta::assert_debug_snapshot;
-    use url::Url;
 
     use crate::Context;
     use crate::graphql;
@@ -866,7 +867,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -952,7 +953,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1064,7 +1065,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1188,7 +1189,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1311,7 +1312,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1415,7 +1416,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1541,7 +1542,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1702,7 +1703,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1860,7 +1861,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1989,7 +1990,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -2105,7 +2106,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -2226,7 +2227,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -2351,7 +2352,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path?id={$this.id}".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -2430,7 +2431,7 @@ mod tests {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),

--- a/apollo-router/src/plugins/connectors/tracing.rs
+++ b/apollo-router/src/plugins/connectors/tracing.rs
@@ -45,6 +45,7 @@ fn connect_spec_counts(connectors: &Connectors) -> HashMap<String, u64> {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
     use std::sync::Arc;
 
     use apollo_compiler::name;
@@ -55,7 +56,7 @@ mod tests {
     use apollo_federation::sources::connect::HttpJsonTransport;
     use apollo_federation::sources::connect::JSONSelection;
     use apollo_federation::sources::connect::expand::Connectors;
-    use url::Url;
+    use http::Uri;
 
     use crate::metrics::FutureMetricsExt as _;
     use crate::plugins::connectors::tracing::connect_spec_counts;
@@ -75,7 +76,7 @@ mod tests {
                 "label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -597,10 +597,10 @@ mod test {
     use apollo_federation::sources::connect::HTTPMethod;
     use apollo_federation::sources::connect::HttpJsonTransport;
     use apollo_federation::sources::connect::JSONSelection;
+    use http::Uri;
     use serde_json::json;
     use subgraph::SubgraphRequestId;
     use tower::BoxError;
-    use url::Url;
 
     use super::*;
     use crate::Context;
@@ -1513,7 +1513,7 @@ mod test {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),
@@ -1602,7 +1602,7 @@ mod test {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -573,6 +573,7 @@ register_private_plugin!("apollo", "traffic_shaping", TrafficShaping);
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
     use std::sync::Arc;
 
     use apollo_compiler::name;
@@ -584,13 +585,13 @@ mod test {
     use apollo_federation::sources::connect::JSONSelection;
     use bytes::Bytes;
     use http::HeaderMap;
+    use http::Uri;
     use maplit::hashmap;
     use once_cell::sync::Lazy;
     use serde_json_bytes::ByteString;
     use serde_json_bytes::Value;
     use serde_json_bytes::json;
     use tower::Service;
-    use url::Url;
 
     use super::*;
     use crate::Configuration;
@@ -776,7 +777,7 @@ mod test {
                 "test label",
             ),
             transport: HttpJsonTransport {
-                source_url: Some(Url::parse("http://localhost/api").unwrap()),
+                source_url: Some(Uri::from_str("http://localhost/api").unwrap()),
                 connect_template: "/path".parse().unwrap(),
                 method: HTTPMethod::Get,
                 headers: Default::default(),

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -167,9 +167,9 @@ impl tower::Service<ConnectRequest> for ConnectorService {
             }
             if let Some(source_name) = connector.id.source_name.as_ref() {
                 span.record("apollo.connector.source.name", source_name);
-                if let Ok(detail) =
-                    serde_json::to_string(&serde_json::json!({ "baseURL": transport.source_url }))
-                {
+                if let Ok(detail) = serde_json::to_string(
+                    &serde_json::json!({ "baseURL": transport.source_url.as_ref().map(|uri| uri.to_string()) }),
+                ) {
                     span.record("apollo.connector.source.detail", detail);
                 }
             }


### PR DESCRIPTION
This doesn't do much right now other than simplify snapshots, but it's part of #7220 and makes that PR easier to review by doing this separately.