### PR TITLE
Fix helm template syntax for virtualservice `Hosts` list (backport #7284)

### DIFF
--- a/helm/chart/router/templates/virtualservice.yaml
+++ b/helm/chart/router/templates/virtualservice.yaml
@@ -20,13 +20,13 @@ metadata:
   {{- end }}
 spec:
   hosts:
-  { { if .Values.virtualservice.Hosts } }
-  { { - range .Values.virtualservice.Hosts } }
-  - { { . | quote } }
-  { { - end } }
-  { { - else } }
+  {{ if .Values.virtualservice.Hosts }}
+  {{- range .Values.virtualservice.Hosts }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- else }}
   - "*"
-  { { - end } }
+  {{- end }}
   {{- if .Values.virtualservice.gatewayName }}
   gateways:
   - {{ .Values.virtualservice.gatewayName }}


### PR DESCRIPTION
Closes https://github.com/apollographql/router/pull/7268
Fixes https://github.com/apollographql/router/issues/7267

#7268 as a branch so CI can run.<hr>This is an automatic backport of pull request #7284 done by [Mergify](https://mergify.com).