### PR TITLE
docs: all event instrumentation config requires a GraphOS plan (backport #7199)

### DIFF
--- a/docs/source/routing/observability/telemetry/instrumentation/events.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/events.mdx
@@ -15,6 +15,8 @@ You can configure events for each service in `router.yaml`. Events can be standa
 
 ## Event configuration
 
+<PremiumFeature />
+
 ### Router request lifecycle services
 
 <RouterServices />
@@ -91,8 +93,6 @@ telemetry:
 
 
 ### Custom events
-
-<PremiumFeature />
 
 For each service you can also configure custom events.
 


### PR DESCRIPTION
https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events#standard-events

The notice was under the "Custom events" section, but also applies to
the "Standard events" section. This moves the notice to (near) the top
of the page.

https://github.com/apollographql/router/blob/def63abda4e447d36aebc67d7029fcccc59985ea/apollo-router/src/uplink/license_enforcement.rs#L355-L358




[RH-830]: https://apollographql.atlassian.net/browse/RH-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #7199 done by [Mergify](https://mergify.com).