### PR TITLE
Align accepted licenses in `about.toml` with `deny.toml`

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -10,8 +10,10 @@ accepted = [
     "MIT",
     "MPL-2.0",
     "Unicode-3.0",
+    "OpenSSL", # required by aws-lc-sys
     "Unicode-DFS-2016",
-    "Zlib"
+    "Zlib",
+    "NCSA", # similar to MIT/BSD-3-Clause, used by libfuzzer
 ]
 
 # See https://github.com/EmbarkStudios/cargo-about/pull/216


### PR DESCRIPTION
https://github.com/apollographql/router/pull/6972 updated `deny.toml`, but we only run `cargo about` during a release process so the need to update `about.toml` was not visible when merging the PR, only when making a Nightly release:

https://app.circleci.com/pipelines/github/apollographql/router/33528/workflows/9a2cdf3d-e398-48c9-9b2c-aa147117a073/jobs/247848?invite=true#step-117-23403_48

CI for this PR again won’t check it, but I could reproduce the release error locally by running `cargo xtask licenses` and this PR fixes it.