### PR TITLE
Add subgraph validation for interface objects

### DIFF
--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1170,6 +1170,7 @@ impl FederatedQueryGraphBuilder {
                     schema,
                     type_pos.type_name().clone(),
                     application.fields,
+                    true,
                 )?);
 
                 // Note that each subgraph has a key edge to itself (when head == tail below).
@@ -1295,6 +1296,7 @@ impl FederatedQueryGraphBuilder {
                                     .type_name()
                                     .clone(),
                                 application.fields,
+                                true,
                             ) else {
                                 // Ignored on purpose: it just means the key is not usable on this
                                 // subgraph.
@@ -1361,6 +1363,7 @@ impl FederatedQueryGraphBuilder {
                     &self.supergraph_schema,
                     field_definition_position.parent().type_name().clone(),
                     application.fields,
+                    true,
                 )?;
                 all_conditions.push(conditions);
             }
@@ -1709,6 +1712,7 @@ impl FederatedQueryGraphBuilder {
                     schema,
                     field_type_pos.type_name().clone(),
                     application.fields,
+                    true,
                 )?;
                 all_conditions.push(conditions);
             }
@@ -2127,6 +2131,7 @@ impl FederatedQueryGraphBuilder {
                     schema,
                     type_in_supergraph_pos.type_name.clone(),
                     "__typename",
+                    false,
                 )?);
                 for implementation_type_in_supergraph_pos in self
                     .supergraph_schema

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -2131,6 +2131,9 @@ impl FederatedQueryGraphBuilder {
                     schema,
                     type_in_supergraph_pos.type_name.clone(),
                     "__typename",
+                    // We don't validate here because __typename queried against a composite type is
+                    // guaranteed to be valid. If the field set becomes non-trivial in the future,
+                    // this should be updated accordingly.
                     false,
                 )?);
                 for implementation_type_in_supergraph_pos in self

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -742,6 +742,7 @@ impl QueryGraph {
                     subgraph_schema,
                     composite_type_position.type_name().clone(),
                     key_value.fields,
+                    true,
                 )
             })
             .find_ok(|selection| !external_metadata.selects_any_external_field(selection))
@@ -979,7 +980,7 @@ impl QueryGraph {
                 key.specified_argument_by_name("fields")
                     .and_then(|arg| arg.as_str())
             })
-            .map(|value| parse_field_set(schema, ty.name().clone(), value))
+            .map(|value| parse_field_set(schema, ty.name().clone(), value, true))
             .find_ok(|selection| {
                 !metadata
                     .external_metadata()

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -23,14 +23,21 @@ use crate::link::link_spec_definition::LinkSpecDefinition;
 use crate::link::spec::Url;
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::FederationSchema;
+use crate::schema::ValidFederationSchema;
 use crate::schema::compute_subgraph_metadata;
+use crate::schema::field_set::parse_field_set;
 use crate::schema::position::DirectiveDefinitionPosition;
+use crate::schema::position::InterfaceTypeDefinitionPosition;
+use crate::schema::subgraph_metadata::SubgraphMetadata;
 use crate::schema::validators::key::validate_key_directives;
 use crate::schema::validators::provides::validate_provides_directives;
 use crate::schema::validators::requires::validate_requires_directives;
 use crate::supergraph::GRAPHQL_MUTATION_TYPE_NAME;
 use crate::supergraph::GRAPHQL_QUERY_TYPE_NAME;
 use crate::supergraph::GRAPHQL_SUBSCRIPTION_TYPE_NAME;
+use crate::utils::human_readable::HumanReadableListOptions;
+use crate::utils::human_readable::HumanReadableListPrefix;
+use crate::utils::human_readable::human_readable_list;
 
 #[allow(dead_code)]
 struct CoreFeature {
@@ -98,8 +105,8 @@ impl FederationBlueprint {
 
     pub(crate) fn on_validation(
         &self,
-        schema: &mut FederationSchema,
-    ) -> Result<(), FederationError> {
+        mut schema: FederationSchema,
+    ) -> Result<ValidFederationSchema, FederationError> {
         let mut error_collector = MultipleFederationErrors { errors: Vec::new() };
         if self.with_root_type_renaming {
             let mut operation_types_to_rename = HashMap::new();
@@ -120,10 +127,13 @@ impl FederationBlueprint {
                 }
             }
             for (current_name, new_name) in operation_types_to_rename {
-                schema.get_type(current_name)?.rename(schema, new_name)?;
+                schema
+                    .get_type(current_name)?
+                    .rename(&mut schema, new_name)?;
             }
         }
 
+        let schema = schema.validate_or_return_self().map_err(|e| e.1)?;
         let Some(meta) = schema.subgraph_metadata() else {
             bail!("Federation schema should have had its metadata set on construction");
         };
@@ -131,16 +141,22 @@ impl FederationBlueprint {
         // accepted, and some of those issues are fixed by `SchemaUpgrader`. So insofar as any fed 1 schma is ultimately converted
         // to a fed 2 one before composition, then skipping some validation on fed 1 schema is fine.
         if !meta.is_fed_2_schema() {
-            return error_collector.into_result();
+            return error_collector.into_result().map(|_| schema);
         }
 
-        validate_key_directives(schema, &mut error_collector)?;
-        validate_provides_directives(schema, meta, &mut error_collector)?;
-        validate_requires_directives(schema, meta, &mut error_collector)?;
+        validate_key_directives(&schema, &mut error_collector)?;
+        validate_provides_directives(&schema, meta, &mut error_collector)?;
+        validate_requires_directives(&schema, meta, &mut error_collector)?;
 
         // TODO: Remaining validations
+        Self::validate_keys_on_interfaces_are_also_on_all_implementations(
+            &schema,
+            meta,
+            &mut error_collector,
+        )?;
+        Self::validate_interface_objects_are_on_entities(&schema, meta, &mut error_collector)?;
 
-        error_collector.into_result()
+        error_collector.into_result().map(|_| schema)
     }
 
     fn on_apollo_rs_validation_error(
@@ -230,6 +246,154 @@ impl FederationBlueprint {
         for _link in links_metadata.links.clone() {
             // TODO: Pick out known features by link identity and call `add_elements_to_schema`.
             // JS calls coreFeatureDefinitionIfKnown here, but we don't have a feature registry yet.
+        }
+        Ok(())
+    }
+
+    fn validate_keys_on_interfaces_are_also_on_all_implementations(
+        schema: &ValidFederationSchema,
+        metadata: &SubgraphMetadata,
+        error_collector: &mut MultipleFederationErrors,
+    ) -> Result<(), FederationError> {
+        let key_directive_definition_name = &metadata
+            .federation_spec_definition()
+            .key_directive_definition(schema)?
+            .name;
+        for type_pos in schema.get_types() {
+            let Ok(type_pos): Result<InterfaceTypeDefinitionPosition, _> = type_pos.try_into()
+            else {
+                continue;
+            };
+            let implementation_types = schema.possible_runtime_types(type_pos.clone().into())?;
+            let type_ = type_pos.get(schema.schema())?;
+            for application in type_.directives.get_all(key_directive_definition_name) {
+                let arguments = metadata
+                    .federation_spec_definition()
+                    .key_directive_arguments(application)?;
+                // Note that we will have validated all @key field sets by this point, so we skip
+                // re-validating here.
+                let fields = parse_field_set(schema, type_.name.clone(), arguments.fields, false)?;
+                let mut implementations_with_non_resolvable_keys = vec![];
+                let mut implementations_with_missing_keys = vec![];
+                for implementation_type_pos in &implementation_types {
+                    let implementation_type = implementation_type_pos.get(schema.schema())?;
+                    let mut matching_application_arguments = None;
+                    for implementation_application in implementation_type
+                        .directives
+                        .get_all(key_directive_definition_name)
+                    {
+                        let implementation_arguments = metadata
+                            .federation_spec_definition()
+                            .key_directive_arguments(implementation_application)?;
+                        let implementation_fields = parse_field_set(
+                            schema,
+                            implementation_type.name.clone(),
+                            implementation_arguments.fields,
+                            false,
+                        )?;
+                        if implementation_fields == fields {
+                            matching_application_arguments = Some(implementation_arguments);
+                            break;
+                        }
+                    }
+                    if let Some(matching_application_arguments) = matching_application_arguments {
+                        // TODO: This code assumes there's at most one matching application for a
+                        // given fieldset, but I'm not sure whether other validation code guarantees
+                        // this.
+                        if arguments.resolvable && !matching_application_arguments.resolvable {
+                            implementations_with_non_resolvable_keys.push(implementation_type_pos);
+                        }
+                    } else {
+                        implementations_with_missing_keys.push(implementation_type_pos);
+                    }
+
+                    if !implementations_with_missing_keys.is_empty() {
+                        let types_list = human_readable_list(
+                            implementations_with_missing_keys
+                                .iter()
+                                .map(|pos| format!("\"{}\"", pos)),
+                            HumanReadableListOptions {
+                                prefix: Some(HumanReadableListPrefix {
+                                    singular: "type",
+                                    plural: "types",
+                                }),
+                                ..Default::default()
+                            },
+                        );
+                        error_collector.errors.push(
+                            SingleFederationError::InterfaceKeyNotOnImplementation {
+                                message: format!(
+                                    "Key {} on interface type \"{}\" is missing on implementation {}",
+                                    application.serialize(),
+                                    type_pos,
+                                    types_list,
+                                )
+                            }
+                        )
+                    } else if !implementations_with_non_resolvable_keys.is_empty() {
+                        let types_list = human_readable_list(
+                            implementations_with_non_resolvable_keys
+                                .iter()
+                                .map(|pos| format!("\"{}\"", pos)),
+                            HumanReadableListOptions {
+                                prefix: Some(HumanReadableListPrefix {
+                                    singular: "type",
+                                    plural: "types",
+                                }),
+                                ..Default::default()
+                            },
+                        );
+                        error_collector.errors.push(
+                            SingleFederationError::InterfaceKeyNotOnImplementation {
+                                message: format!(
+                                    "Key {} on interface type \"{}\" should be resolvable on all implementation types, but is declared with argument \"@key(resolvable:)\" set to false in {}",
+                                    application.serialize(),
+                                    type_pos,
+                                    types_list,
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_interface_objects_are_on_entities(
+        schema: &ValidFederationSchema,
+        metadata: &SubgraphMetadata,
+        error_collector: &mut MultipleFederationErrors,
+    ) -> Result<(), FederationError> {
+        let Some(interface_object_directive_definition) = &metadata
+            .federation_spec_definition()
+            .interface_object_directive_definition(schema)?
+        else {
+            return Ok(());
+        };
+        let key_directive_definition_name = &metadata
+            .federation_spec_definition()
+            .key_directive_definition(schema)?
+            .name;
+        for type_pos in &schema
+            .referencers
+            .get_directive(&interface_object_directive_definition.name)?
+            .object_types
+        {
+            if !type_pos
+                .get(schema.schema())?
+                .directives
+                .has(key_directive_definition_name)
+            {
+                error_collector.errors.push(
+                    SingleFederationError::InterfaceObjectUsageError {
+                        message: format!(
+                            "The @interfaceObject directive can only be applied to entity types but type \"{}\" has no @key in this subgraph.",
+                            type_pos
+                        )
+                    }
+                )
+            }
         }
         Ok(())
     }

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -100,10 +100,6 @@ impl FederationSchema {
         &self.referencers
     }
 
-    pub(crate) fn subgraph_metadata(&self) -> Option<&SubgraphMetadata> {
-        self.subgraph_metadata.as_deref()
-    }
-
     /// Returns all the types in the schema, minus builtins.
     pub(crate) fn get_types(&self) -> impl Iterator<Item = TypeDefinitionPosition> {
         self.schema

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -254,19 +254,11 @@ impl Subgraph<Expanded> {
         todo!("Implement upgrade logic for expanded subgraphs");
     }
 
-    pub fn validate(
-        mut self,
-        rename_root_types: bool,
-    ) -> Result<Subgraph<Validated>, SubgraphError> {
+    pub fn validate(self, rename_root_types: bool) -> Result<Subgraph<Validated>, SubgraphError> {
         let blueprint = FederationBlueprint::new(rename_root_types);
-        blueprint
-            .on_validation(&mut self.state.schema)
+        let schema = blueprint
+            .on_validation(self.state.schema)
             .map_err(|e| SubgraphError::new(self.name.clone(), e))?;
-        let schema = self
-            .state
-            .schema
-            .validate_or_return_self()
-            .map_err(|t| SubgraphError::new(self.name.clone(), t.1))?;
 
         Ok(Subgraph {
             name: self.name,

--- a/apollo-federation/src/utils/human_readable.rs
+++ b/apollo-federation/src/utils/human_readable.rs
@@ -1,0 +1,150 @@
+pub(crate) struct JoinStringsOptions<'a> {
+    pub(crate) separator: &'a str,
+    pub(crate) first_separator: Option<&'a str>,
+    pub(crate) last_separator: Option<&'a str>,
+    /// When displaying a list of something in a human-readable form, after what size (in number of
+    /// characters) we start displaying only a subset of the list. Note this only counts characters
+    /// in list elements, and ignores separators.
+    pub(crate) output_length_limit: Option<usize>,
+}
+
+impl Default for JoinStringsOptions<'_> {
+    fn default() -> Self {
+        Self {
+            separator: ", ",
+            first_separator: None,
+            last_separator: Some(" and "),
+            output_length_limit: None,
+        }
+    }
+}
+
+/// Joins an iterator of strings, but with the ability to use a specific different separator for the
+/// first and/or last occurrence (if both are given and the list is size two, the first separator is
+/// used). Optionally, if the resulting list to print is "too long", it can display a subset of the
+/// elements and uses an ellipsis (...) for the rest.
+///
+/// The goal is to make the reading flow slightly better. For instance, if you have a vector of
+/// subgraphs `s = ["A", "B", "C"]`, then `join_strings(s.iter(), Default::default())` will yield
+/// "A, B and C".
+pub(crate) fn join_strings(
+    mut iter: impl Iterator<Item = impl AsRef<str>>,
+    options: JoinStringsOptions,
+) -> String {
+    let mut output = String::new();
+    let Some(first) = iter.next() else {
+        return output;
+    };
+    output.push_str(first.as_ref());
+    let Some(second) = iter.next() else {
+        return output;
+    };
+    // PORT_NOTE: The analogous JS code in `printHumanReadableList()` was only tracking the length
+    // of elements getting added to the list and ignored separators, so we do the same here.
+    let mut element_length = first.as_ref().chars().count();
+    // Returns true if push would exceed limit, and instead pushes default separator and "...".
+    let mut push_sep_and_element = |sep: &str, element: &str| {
+        if let Some(output_length_limit) = options.output_length_limit {
+            // PORT_NOTE: The analogous JS code in `printHumanReadableList()` has a bug where it
+            // doesn't early exit when the length would be too long, and later small elements in the
+            // list may erroneously extend the printed subset. That bug is fixed here.
+            let new_element_length = element_length + element.chars().count();
+            return if new_element_length <= output_length_limit {
+                element_length = new_element_length;
+                output.push_str(sep);
+                output.push_str(element);
+                false
+            } else {
+                output.push_str(options.separator);
+                output.push_str("...");
+                true
+            };
+        }
+        output.push_str(sep);
+        output.push_str(element);
+        false
+    };
+    let last_sep = options.last_separator.unwrap_or(options.separator);
+    let Some(mut current) = iter.next() else {
+        push_sep_and_element(options.first_separator.unwrap_or(last_sep), second.as_ref());
+        return output;
+    };
+    if push_sep_and_element(
+        options.first_separator.unwrap_or(options.separator),
+        second.as_ref(),
+    ) {
+        return output;
+    }
+    for next in iter {
+        if push_sep_and_element(options.separator, current.as_ref()) {
+            return output;
+        }
+        current = next;
+    }
+    push_sep_and_element(last_sep, current.as_ref());
+    output
+}
+
+pub(crate) struct HumanReadableListOptions<'a> {
+    pub(crate) prefix: Option<HumanReadableListPrefix<'a>>,
+    pub(crate) last_separator: Option<&'a str>,
+    /// When displaying a list of something in a human-readable form, after what size (in number of
+    /// characters) we start displaying only a subset of the list.
+    pub(crate) output_length_limit: usize,
+}
+
+pub(crate) struct HumanReadableListPrefix<'a> {
+    pub(crate) singular: &'a str,
+    pub(crate) plural: &'a str,
+}
+
+impl Default for HumanReadableListOptions<'_> {
+    fn default() -> Self {
+        Self {
+            prefix: None,
+            last_separator: Some(" and "),
+            output_length_limit: 100,
+        }
+    }
+}
+
+// PORT_NOTE: Named `printHumanReadableList` in the JS codebase, but "print" in Rust has the
+// implication it prints to stdout/stderr, so we remove it here. Also, the "emptyValue" option is
+// never used, so it's not ported.
+/// Like [join_strings], joins an iterator of strings, but with a few differences, namely:
+/// - It allows prefixing the whole list, and to use a different prefix if there's only a single
+///   element in the list.
+/// - It forces the use of ", " as separator, but allows a different last separator.
+/// - It forces an output length limit to be specified. In other words, this function assumes it's
+///   more useful to avoid flooding the output than printing everything when the list is too long.
+pub(crate) fn human_readable_list(
+    mut iter: impl Iterator<Item = impl AsRef<str>>,
+    options: HumanReadableListOptions,
+) -> String {
+    let Some(first) = iter.next() else {
+        // TODO: The JS code returns an empty string here, which we've ported accordingly. However,
+        // this probably isn't want the caller wants, and something like e.g. "no types" for prefix
+        // type/types may be better.
+        return "".to_owned();
+    };
+    let Some(second) = iter.next() else {
+        return if let Some(prefix) = options.prefix {
+            format!("{} {}", prefix.singular, first.as_ref())
+        } else {
+            first.as_ref().to_owned()
+        };
+    };
+    let joined_strings = join_strings(
+        [first, second].into_iter().chain(iter),
+        JoinStringsOptions {
+            last_separator: options.last_separator,
+            output_length_limit: Some(options.output_length_limit),
+            ..Default::default()
+        },
+    );
+    if let Some(prefix) = options.prefix {
+        format!("{} {}", prefix.plural, joined_strings)
+    } else {
+        joined_strings
+    }
+}

--- a/apollo-federation/src/utils/mod.rs
+++ b/apollo-federation/src/utils/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains various tools that help the ergonomics of this crate.
 
 mod fallible_iterator;
+pub(crate) mod human_readable;
 pub(crate) mod logging;
 pub(crate) mod serde_bridge;
 


### PR DESCRIPTION
Port `validateKeyOnInterfacesAreAlsoOnAllImplementations()` and `validateInterfaceObjectsAreOnEntities()` from the JS composition code, i.e. the per-subgraph validations for interface objects. Note that as part of this, `printHumanReadableList()` and `joinStrings()`, were also ported.

<!-- FED-499 -->