### PR TITLE
telemetry: correctly apply conditions on events

### DIFF
--- a/.changesets/fix_events_conditions.md
+++ b/.changesets/fix_events_conditions.md
@@ -1,0 +1,30 @@
+### telemetry: correctly apply conditions on events ([PR #7325](https://github.com/apollographql/router/pull/7325))
+
+Fixed a issue where conditional telemetry events weren't being properly evaluated.
+This affected both standard events (`response`, `error`) and custom telemetry events.
+
+For example in config like this:
+```yaml
+telemetry:
+  instrumentation:
+    events:
+      supergraph:
+        request:
+          level: info
+          condition:
+            eq:
+            - request_header: apollo-router-log-request
+            - testing
+        response:
+          level: info
+          condition:
+            eq:
+            - request_header: apollo-router-log-request
+            - testing
+```
+
+The Router would emit the `request` event when the header matched, but never emit the `response` event - even with the same matching header.
+
+This fix ensures that all event conditions are properly evaluated, restoring expected telemetry behavior and making conditional logging work correctly throughout the entire request lifecycle.
+
+By [@IvanGoncharov](https://github.com/IvanGoncharov) in https://github.com/apollographql/router/pull/7325

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -824,7 +824,11 @@ mod tests {
                 .expect("expecting successful response");
         }
         .with_subscriber(
-            assert_snapshot_subscriber!({r#"[].span["apollo_private.duration_ns"]"# => "[duration]", r#"[].spans[]["apollo_private.duration_ns"]"# => "[duration]", "[].fields.attributes" => insta::sorted_redaction()}),
+            assert_snapshot_subscriber!({
+                r#"[].span["apollo_private.duration_ns"]"# => "[duration]",
+                r#"[].spans[]["apollo_private.duration_ns"]"# => "[duration]",
+                "[].fields.attributes" => insta::sorted_redaction()
+            }),
         )
         .await
     }

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -801,35 +801,31 @@ mod tests {
 
         async {
             test_harness
-                .router_service(
-                    |_r|async  {
-                        Ok(router::Response::fake_builder()
-                            .header("custom-header", "val1")
-                            .header(CONTENT_LENGTH, "25")
-                            .header("x-log-request", HeaderValue::from_static("log"))
-                            .data(serde_json_bytes::json!({"data": "res"}))
-                            .build()
-                            .expect("expecting valid response"))
-                    },
-                )
+                .router_service(|_r| async {
+                    Ok(router::Response::fake_builder()
+                        .header("custom-header", "val1")
+                        .header(CONTENT_LENGTH, "25")
+                        .header("x-log-request", HeaderValue::from_static("log"))
+                        .data(serde_json_bytes::json!({"data": "res"}))
+                        .build()
+                        .expect("expecting valid response"))
+                })
                 .call(
                     router::Request::fake_builder()
                         .header(CONTENT_LENGTH, "0")
                         .header("custom-header", "val1")
                         .header("x-log-request", HeaderValue::from_static("log"))
                         .build()
-                        .unwrap()
+                        .unwrap(),
                 )
                 .await
                 .expect("expecting successful response");
         }
-        .with_subscriber(
-            assert_snapshot_subscriber!({
-                r#"[].span["apollo_private.duration_ns"]"# => "[duration]",
-                r#"[].spans[]["apollo_private.duration_ns"]"# => "[duration]",
-                "[].fields.attributes" => insta::sorted_redaction()
-            }),
-        )
+        .with_subscriber(assert_snapshot_subscriber!({
+            r#"[].span["apollo_private.duration_ns"]"# => "[duration]",
+            r#"[].spans[]["apollo_private.duration_ns"]"# => "[duration]",
+            "[].fields.attributes" => insta::sorted_redaction()
+        }))
         .await
     }
 

--- a/apollo-router/src/plugins/telemetry/config_new/snapshots/apollo_router__plugins__telemetry__config_new__events__tests__router_events@logs.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/snapshots/apollo_router__plugins__telemetry__config_new__events__tests__router_events@logs.snap
@@ -1,8 +1,13 @@
 ---
 source: apollo-router/src/plugins/telemetry/config_new/events.rs
 expression: yaml
+snapshot_kind: text
 ---
 - fields:
     kind: my.request_event
   level: INFO
   message: my event message
+- fields:
+    kind: my.response_event
+  level: INFO
+  message: my response event message

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -838,7 +838,7 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn pid(&mut self) -> i32 {
+    pub(crate) fn pid(&self) -> i32 {
         self.router
             .as_ref()
             .expect("router must have been started")
@@ -882,7 +882,7 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
-    pub fn print_logs(&mut self) {
+    pub fn print_logs(&self) {
         for line in &self.logs {
             println!("{}", line);
         }
@@ -891,12 +891,23 @@ impl IntegrationTest {
     #[allow(dead_code)]
     pub fn read_logs(&mut self) {
         while let Ok(line) = self.stdio_rx.try_recv() {
-            self.logs.push(line.to_string());
+            self.logs.push(line);
         }
     }
 
     #[allow(dead_code)]
-    pub fn assert_log_contained(&mut self, msg: &str) {
+    pub fn capture_logs<T>(&mut self, try_match_line: impl Fn(String) -> Option<T>) -> Vec<T> {
+        let mut logs = Vec::new();
+        while let Ok(line) = self.stdio_rx.try_recv() {
+            if let Some(log) = try_match_line(line) {
+                logs.push(log);
+            }
+        }
+        logs
+    }
+
+    #[allow(dead_code)]
+    pub fn assert_log_contained(&self, msg: &str) {
         for line in &self.logs {
             if line.contains(msg) {
                 return;
@@ -927,7 +938,7 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
-    pub async fn assert_log_not_contained(&mut self, msg: &str) {
+    pub async fn assert_log_not_contained(&self, msg: &str) {
         for line in &self.logs {
             if line.contains(msg) {
                 panic!(
@@ -1046,7 +1057,7 @@ impl IntegrationTest {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn dump_stack_traces(&mut self) {
+    pub fn dump_stack_traces(&self) {
         if let Ok(trace) = rstack::TraceOptions::new()
             .symbols(true)
             .thread_names(true)
@@ -1072,7 +1083,7 @@ impl IntegrationTest {
         }
     }
     #[cfg(not(target_os = "linux"))]
-    pub fn dump_stack_traces(&mut self) {}
+    pub fn dump_stack_traces(&self) {}
 
     #[allow(dead_code)]
     pub(crate) fn force_flush(&self) {

--- a/apollo-router/tests/integration/telemetry/events.rs
+++ b/apollo-router/tests/integration/telemetry/events.rs
@@ -1,0 +1,350 @@
+use insta::assert_yaml_snapshot;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::json;
+use tower::BoxError;
+
+use crate::integration::common::IntegrationTest;
+use crate::integration::common::Query;
+use crate::integration::common::graph_os_enabled;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_standard_events() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+
+    let mut router = EventTest::new(json!({
+      "router": { "request": "info", "response": "info" },
+      "supergraph": { "request": "info", "response": "info" },
+      "subgraph": { "request": "info", "response": "info" }
+    }))
+    .await;
+
+    assert_yaml_snapshot!(router.execute_default_query().await?, @r"
+    - kind: router.request
+      level: INFO
+    - kind: supergraph.request
+      level: INFO
+    - kind: subgraph.request
+      level: INFO
+    - kind: subgraph.response
+      level: INFO
+    - kind: supergraph.response
+      level: INFO
+    - kind: router.response
+      level: INFO
+    ");
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_custom_events() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+
+    let mut router = EventTest::new(json!({
+      "router": {
+        "custom.router.request": {
+          "on": "request",
+          "message": "Custom router request",
+          "level": "info"
+        },
+        "custom.router.response": {
+          "on": "response",
+          "message": "Custom router response",
+          "level": "info"
+        }
+      },
+      "supergraph": {
+        "custom.supergraph.request": {
+          "on": "request",
+          "message": "Custom supergraph request",
+          "level": "info"
+        },
+        "custom.supergraph.response": {
+          "on": "response",
+          "message": "Custom supergraph response",
+          "level": "info"
+        }
+      },
+      "subgraph": {
+        "custom.subgraph.request": {
+          "on": "request",
+          "message": "Custom subgraph request",
+          "level": "info"
+        },
+        "custom.subgraph.response": {
+          "on": "response",
+          "message": "Custom subgraph response",
+          "level": "info"
+        }
+      }
+    }))
+    .await;
+
+    assert_yaml_snapshot!(router.execute_default_query().await?, @r"
+    - kind: custom.router.request
+      level: INFO
+    - kind: custom.supergraph.request
+      level: INFO
+    - kind: custom.subgraph.request
+      level: INFO
+    - kind: custom.subgraph.response
+      level: INFO
+    - kind: custom.supergraph.response
+      level: INFO
+    - kind: custom.router.response
+      level: INFO
+    ");
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_events_with_request_header_condition() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+
+    let x_log_request = String::from("x-log-request");
+    let x_log_response = String::from("x-log-response");
+    let x_log_custom_request = String::from("x-log-custom-request");
+    let x_log_custom_response = String::from("x-log-custom-response");
+
+    let mut router = EventTest::new(json!({
+      "router": {
+        "request": {
+          "level": "info",
+          "condition": { "exists": { "request_header": x_log_request } }
+        },
+        "response": {
+          "level": "info",
+          "condition": { "exists": { "request_header": x_log_response } }
+        },
+        "custom.router.request": {
+          "on": "request",
+          "message": "Custom router request",
+          "level": "info",
+          "condition": { "exists": { "request_header": x_log_custom_request } }
+        },
+        "custom.router.response": {
+          "on": "response",
+          "message": "Custom router response",
+          "level": "info",
+          "condition": { "exists": { "request_header": x_log_custom_response } }
+        }
+      },
+      "supergraph": {
+        "request": {
+          "level": "info",
+          "condition": { "exists": { "request_header": x_log_request } }
+        },
+        "response": {
+          "level": "info",
+          "condition": { "exists": { "request_header": x_log_response } }
+        },
+        "custom.supergraph.request": {
+          "on": "request",
+          "message": "Custom supergraph request",
+          "level": "info",
+          "condition": { "exists": { "request_header": x_log_custom_request } }
+        },
+        "custom.supergraph.response": {
+          "on": "response",
+          "message": "Custom supergraph response",
+          "level": "info",
+          "condition": { "exists": { "request_header": x_log_custom_response } }
+        }
+      },
+      "subgraph": {
+        "request": {
+          "level": "info",
+          "condition": { "exists": { "subgraph_request_header": x_log_request } }
+        },
+        "response": {
+          "level": "info",
+          "condition": { "exists": { "subgraph_request_header": x_log_response } }
+        },
+        "custom.subgraph.request": {
+          "on": "request",
+          "message": "Custom subgraph request",
+          "level": "info",
+          "condition": { "exists": { "subgraph_request_header": x_log_custom_request } }
+        },
+        "custom.subgraph.response": {
+          "on": "response",
+          "message": "Custom subgraph response",
+          "level": "info",
+          "condition": { "exists": { "subgraph_request_header": x_log_custom_response } }
+        }
+      }
+    }))
+    .await;
+
+    assert_yaml_snapshot!(router.execute_default_query().await?, @r"[]");
+
+    let query = Query::builder()
+        .header(x_log_request.clone(), "enabled".to_owned())
+        .build();
+    assert_yaml_snapshot!(router.execute_query(query).await?, @r"
+    - kind: router.request
+      level: INFO
+    - kind: supergraph.request
+      level: INFO
+    - kind: subgraph.request
+      level: INFO
+    ");
+
+    let query = Query::builder()
+        .header(x_log_response.clone(), "enabled".to_owned())
+        .build();
+    assert_yaml_snapshot!(router.execute_query(query).await?, @r"
+    - kind: subgraph.response
+      level: INFO
+    - kind: supergraph.response
+      level: INFO
+    - kind: router.response
+      level: INFO
+    ");
+
+    let query = Query::builder()
+        .header(x_log_custom_request.clone(), "enabled".to_owned())
+        .build();
+    assert_yaml_snapshot!(router.execute_query(query).await?, @r"
+    - kind: custom.router.request
+      level: INFO
+    - kind: custom.supergraph.request
+      level: INFO
+    - kind: custom.subgraph.request
+      level: INFO
+    ");
+
+    let query = Query::builder()
+        .header(x_log_custom_response.clone(), "enabled".to_owned())
+        .build();
+    assert_yaml_snapshot!(router.execute_query(query).await?, @r"
+    - kind: custom.subgraph.response
+      level: INFO
+    - kind: custom.supergraph.response
+      level: INFO
+    - kind: custom.router.response
+      level: INFO
+    ");
+
+    let query = Query::builder()
+        .header(x_log_request.clone(), "enabled".to_owned())
+        .header(x_log_response.clone(), "enabled".to_owned())
+        .header(x_log_custom_request.clone(), "enabled".to_owned())
+        .header(x_log_custom_response.clone(), "enabled".to_owned())
+        .build();
+    assert_yaml_snapshot!(router.execute_query(query).await?, @r"
+    - kind: custom.router.request
+      level: INFO
+    - kind: router.request
+      level: INFO
+    - kind: supergraph.request
+      level: INFO
+    - kind: custom.supergraph.request
+      level: INFO
+    - kind: custom.subgraph.request
+      level: INFO
+    - kind: subgraph.request
+      level: INFO
+    - kind: subgraph.response
+      level: INFO
+    - kind: custom.subgraph.response
+      level: INFO
+    - kind: custom.supergraph.response
+      level: INFO
+    - kind: supergraph.response
+      level: INFO
+    - kind: router.response
+      level: INFO
+    - kind: custom.router.response
+      level: INFO
+    ");
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+struct EventLog {
+    kind: String,
+    level: String,
+}
+
+struct EventTest {
+    router: IntegrationTest,
+}
+
+impl EventTest {
+    async fn new(events_config: serde_json::Value) -> Self {
+        let config = json!({
+            "headers": {
+              "all": {
+                "request": [{ "propagate": { "matching": "x-log-.*" } }]
+              }
+            },
+            "telemetry": {
+                "instrumentation": {
+                    "events": events_config
+                },
+                "exporters": {
+                    "logging": {
+                        "stdout": {
+                            "enabled": true,
+                        }
+                    }
+                }
+            }
+        });
+        let mut router = IntegrationTest::builder()
+            .config(serde_yaml::to_string(&config).expect("valid yaml"))
+            .build()
+            .await;
+        router.start().await;
+        router.assert_started().await;
+
+        Self { router }
+    }
+
+    async fn execute_default_query(&mut self) -> Result<Vec<EventLog>, BoxError> {
+        self.router.read_logs();
+
+        let (_, response) = self.router.execute_default_query().await;
+        response.error_for_status()?;
+
+        Ok(self.capture_logged_events())
+    }
+
+    async fn execute_query(&mut self, query: Query) -> Result<Vec<EventLog>, BoxError> {
+        self.router.read_logs();
+
+        let (_, response) = self.router.execute_query(query).await;
+        response.error_for_status()?;
+
+        Ok(self.capture_logged_events())
+    }
+
+    fn capture_logged_events(&mut self) -> Vec<EventLog> {
+        self.router
+            .capture_logs(|s| serde_json::from_str::<EventLog>(&s).ok())
+    }
+
+    async fn graceful_shutdown(&mut self) {
+        self.router.graceful_shutdown().await
+    }
+}
+
+impl Drop for EventTest {
+    fn drop(&mut self) {}
+}

--- a/apollo-router/tests/integration/telemetry/mod.rs
+++ b/apollo-router/tests/integration/telemetry/mod.rs
@@ -5,6 +5,7 @@ use opentelemetry::trace::TraceId;
 
 #[cfg(any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux")))]
 mod datadog;
+mod events;
 mod logging;
 mod metrics;
 mod otlp;
@@ -12,7 +13,6 @@ mod propagation;
 mod verifier;
 #[cfg(any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux")))]
 mod zipkin;
-mod events;
 
 struct TraceSpec {
     operation_name: Option<String>,

--- a/apollo-router/tests/integration/telemetry/mod.rs
+++ b/apollo-router/tests/integration/telemetry/mod.rs
@@ -12,6 +12,7 @@ mod propagation;
 mod verifier;
 #[cfg(any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux")))]
 mod zipkin;
+mod events;
 
 struct TraceSpec {
     operation_name: Option<String>,


### PR DESCRIPTION
The core issue is that currently, some `on_request`/`on_response` functions exit earlier:
https://github.com/apollographql/router/blob/3ae5f3f2e02464f6208f078a6611ec9f2b002ba8/apollo-router/src/plugins/telemetry/config_new/events.rs#L261-L264

And because of it, bypass `response` and custom events:
https://github.com/apollographql/router/blob/3ae5f3f2e02464f6208f078a6611ec9f2b002ba8/apollo-router/src/plugins/telemetry/config_new/events.rs#L273-L281

<!-- start metadata -->
<!-- [ROUTER-1246] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1246]: https://apollographql.atlassian.net/browse/ROUTER-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ