### PR TITLE
test(federation/composition): ported the rest of "@core/@link handling" tests 

### DIFF
--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -921,7 +921,6 @@ pub(crate) fn get_federation_spec_definition_from_subgraph(
 }
 
 /// Adds a bootstrap fed 1 link directive to the schema.
-#[allow(dead_code)]
 pub(crate) fn add_fed1_link_to_schema(
     schema: &mut FederationSchema,
 ) -> Result<(), FederationError> {

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -127,7 +127,6 @@ impl LinkSpecDefinition {
     /// Add `self` (the @link spec definition) and a directive application of it to the schema.
     // Note: we may want to allow some `import` as argument to this method. When we do, we need to
     // watch for imports of `Purpose` and `Import` and add the types under their imported name.
-    #[allow(dead_code)]
     pub(crate) fn add_to_schema(
         &self,
         schema: &mut FederationSchema,
@@ -221,7 +220,6 @@ impl LinkSpecDefinition {
             )
     }
 
-    #[allow(dead_code)]
     pub(crate) fn fed1_latest() -> &'static Self {
         // Note: The `unwrap()` calls won't panic, since `CORE_VERSIONS` will always have at
         // least one version.

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -368,7 +368,7 @@ pub struct SubgraphError {
 }
 
 impl SubgraphError {
-    pub(crate) fn new(subgraph: impl Into<String>, error: impl Into<FederationError>) -> Self {
+    pub fn new(subgraph: impl Into<String>, error: impl Into<FederationError>) -> Self {
         SubgraphError {
             subgraph: subgraph.into(),
             error: error.into(),
@@ -377,6 +377,24 @@ impl SubgraphError {
 
     pub fn error(&self) -> &FederationError {
         &self.error
+    }
+
+    // Format subgraph errors in the same way as `Rover` does.
+    // And return them as a vector of (error_code, error_message) tuples
+    // - Gather associated errors from the validation error.
+    // - Split each error into its code and message.
+    // - Add the subgraph name prefix to FederationError message.
+    pub fn format_errors(&self) -> Vec<(String, String)> {
+        self.error
+            .errors()
+            .iter()
+            .map(|e| {
+                (
+                    e.code_string(),
+                    format!("[{subgraph}] {e}", subgraph = self.subgraph),
+                )
+            })
+            .collect()
     }
 }
 

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -303,6 +303,11 @@ impl<S: HasMetadata> Subgraph<S> {
         self.state.schema()
     }
 
+    /// Returns the schema as a string. Mainly for testing purposes.
+    pub fn schema_string(&self) -> String {
+        self.schema().schema().to_string()
+    }
+
     pub(crate) fn extends_directive_name(&self) -> Result<Option<Name>, FederationError> {
         self.metadata()
             .federation_spec_definition()
@@ -829,156 +834,5 @@ mod tests {
                 .root_operation(OperationType::Subscription),
             Some(name!("MySubscription")).as_ref()
         );
-    }
-}
-
-// PORT_NOTE: Corresponds to '@core/@link handling' tests in JS
-#[cfg(test)]
-mod link_handling_tests {
-    use super::*;
-
-    // TODO(FED-543): Remaining directive definitions should be added to the schema
-    #[allow(dead_code)]
-    const EXPECTED_FULL_SCHEMA: &str = r#"
-    schema
-      @link(url: "https://specs.apollo.dev/link/v1.0")
-      @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
-    {
-      query: Query
-    }
-
-    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-
-    directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
-
-    directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
-
-    directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
-
-    directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
-
-    directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
-    directive @federation__extends on OBJECT | INTERFACE
-
-    directive @federation__shareable on OBJECT | FIELD_DEFINITION
-
-    directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
-    directive @federation__override(from: String!) on FIELD_DEFINITION
-
-    type T
-      @key(fields: "k")
-    {
-      k: ID!
-    }
-
-    enum link__Purpose {
-      """
-      \`SECURITY\` features provide metadata necessary to securely resolve fields.
-      """
-      SECURITY
-
-      """
-      \`EXECUTION\` features provide metadata necessary for operation execution.
-      """
-      EXECUTION
-    }
-
-    scalar link__Import
-
-    scalar federation__FieldSet
-
-    scalar _Any
-
-    type _Service {
-      sdl: String
-    }
-
-    union _Entity = T
-
-    type Query {
-      _entities(representations: [_Any!]!): [_Entity]!
-      _service: _Service!
-    }
-    "#;
-
-    #[test]
-    fn expands_everything_if_only_the_federation_spec_is_linked() {
-        let subgraph = Subgraph::parse(
-            "S",
-            "",
-            r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
-
-            type T @key(fields: "k") {
-                k: ID!
-            }
-            "#,
-        )
-        .expect("valid schema")
-        .expand_links()
-        .expect("expands subgraph")
-        .validate(true)
-        .expect("expanded subgraph to be valid");
-
-        // TODO(FED-543): `subgraph` is supposed to be compared against `EXPECTED_FULL_SCHEMA`, but
-        //                it's failing due to missing directive definitions. So, we use
-        //                `insta::assert_snapshot` for now.
-        // assert_eq!(subgraph.schema().schema().to_string(), EXPECTED_FULL_SCHEMA);
-        insta::assert_snapshot!(subgraph.schema().schema().to_string(), @r###"
-        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
-          query: Query
-        }
-
-        extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
-
-        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-
-        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
-
-        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
-
-        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
-
-        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
-
-        directive @federation__shareable on OBJECT | FIELD_DEFINITION
-
-        directive @federation__override(from: String!) on FIELD_DEFINITION
-
-        type T @key(fields: "k") {
-          k: ID!
-        }
-
-        enum link__Purpose {
-          """
-          `SECURITY` features provide metadata necessary to securely resolve fields.
-          """
-          SECURITY
-          """
-          `EXECUTION` features provide metadata necessary for operation execution.
-          """
-          EXECUTION
-        }
-
-        scalar link__Import
-
-        scalar federation__FieldSet
-
-        scalar _Any
-
-        type _Service {
-          sdl: String
-        }
-
-        union _Entity = T
-
-        type Query {
-          _entities(representations: [_Any!]!): [_Entity]!
-          _service: _Service!
-        }
-        "###);
     }
 }

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -1,31 +1,104 @@
+use apollo_federation::subgraph::SubgraphError;
 use apollo_federation::subgraph::typestate::Subgraph;
+use apollo_federation::subgraph::typestate::Validated;
 
-fn build_for_errors(schema: &str) -> Vec<(String, String)> {
-    let err = Subgraph::parse("S", "", schema)
-        .expect("parses schema")
+fn build_inner(schema_str: &str) -> Result<Subgraph<Validated>, SubgraphError> {
+    let name = "S";
+    Subgraph::parse(name, &format!("http://{name}"), schema_str)
+        .expect("valid schema")
         .expand_links()
-        .expect("expands links")
+        .map_err(|e| SubgraphError::new(name, e))?
         .validate(true)
-        .expect_err("subgraph error was expected");
-
-    // Gather associated errors from the validation error
-    // and format them as a vector of (error_code, error_message) tuples
-    err.error()
-        .errors()
-        .into_iter()
-        .map(|e| (e.code_string(), e.to_string()))
-        .collect()
 }
 
-// True if a and b contain the same error messages
-fn errors_eq(a: &[(String, String)], b: &[(&str, &str)]) -> bool {
+fn build_and_validate(schema_str: &str) -> Subgraph<Validated> {
+    build_inner(schema_str).expect("expanded subgraph to be valid")
+}
+
+fn build_for_errors(schema: &str) -> Vec<(String, String)> {
+    build_inner(schema)
+        .expect_err("subgraph error was expected")
+        .format_errors()
+}
+
+fn remove_indentation(s: &str) -> String {
+    // count the last lines that are space-only
+    let first_empty_lines = s.lines().take_while(|line| line.trim().is_empty()).count();
+    let last_empty_lines = s
+        .lines()
+        .rev()
+        .take_while(|line| line.trim().is_empty())
+        .count();
+
+    // lines without the space-only first/last lines
+    let lines = s
+        .lines()
+        .skip(first_empty_lines)
+        .take(s.lines().count() - first_empty_lines - last_empty_lines);
+
+    // compute the indentation
+    let indentation = lines
+        .clone()
+        .map(|line| line.chars().take_while(|c| *c == ' ').count())
+        .min()
+        .unwrap_or(0);
+
+    // remove the indentation
+    lines
+        .map(|line| {
+            line.trim_end()
+                .chars()
+                .skip(indentation)
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// True if a and b contain the same error messages
+fn check_errors(a: &[(String, String)], b: &[(&str, &str)]) -> Result<(), String> {
     if a.len() != b.len() {
-        return false;
+        return Err(format!(
+            "Mismatched error counts: {} != {}",
+            a.len(),
+            b.len()
+        ));
     }
 
-    a.iter()
-        .zip(b.iter())
-        .all(|(a_i, b_i)| a_i.0.as_str() == b_i.0 && a_i.1.as_str() == b_i.1)
+    // remove indentations from messages to ignore indentation differences
+    let b_iter = b
+        .iter()
+        .map(|(code, message)| (*code, remove_indentation(message)));
+    let diff: Vec<_> = a
+        .iter()
+        .map(|(code, message)| (code.as_str(), remove_indentation(message)))
+        .zip(b_iter)
+        .filter(|(a_i, b_i)| a_i.0 != b_i.0 || a_i.1 != b_i.1)
+        .collect();
+    if diff.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Mismatched errors:\n{}\n",
+            diff.iter()
+                .map(|(a_i, b_i)| { format!("- {}: {}\n+ {}: {}", b_i.0, b_i.1, a_i.0, a_i.1) })
+                .collect::<Vec<_>>()
+                .join("\n")
+        ))
+    }
+}
+
+macro_rules! assert_errors {
+    ($a:expr, $b:expr) => {
+        match check_errors(&$a, &$b) {
+            Ok(()) => {
+                // Success
+            }
+            Err(e) => {
+                panic!("{e}")
+            }
+        }
+    };
 }
 
 mod fieldset_based_directives {
@@ -44,13 +117,13 @@ mod fieldset_based_directives {
         "#;
         let err = build_for_errors(schema_str);
 
-        assert!(errors_eq(
-            &err,
-            &[(
+        assert_errors!(
+            err,
+            [(
                 "KEY_FIELDS_HAS_ARGS",
                 r#"[S] On type "T", for @key(fields: "f"): field T.f cannot be included because it has arguments (fields with argument are not allowed in @key)"#,
             )]
-        ));
+        );
     }
 
     #[test]
@@ -67,13 +140,13 @@ mod fieldset_based_directives {
         "#;
         let err = build_for_errors(schema_str);
 
-        assert!(errors_eq(
-            &err,
-            &[(
+        assert_errors!(
+            err,
+            [(
                 "PROVIDES_FIELDS_HAS_ARGS",
                 r#"[S] On field "Query.t", for @provides(fields: "f"): field T.f cannot be included because it has arguments (fields with argument are not allowed in @provides)"#,
             )]
-        ));
+        );
     }
 
     #[test]
@@ -90,13 +163,13 @@ mod fieldset_based_directives {
         "#;
         let err = build_for_errors(schema_str);
 
-        assert!(errors_eq(
-            &err,
-            &[(
+        assert_errors!(
+            err,
+            [(
                 "PROVIDES_FIELDS_MISSING_EXTERNAL",
                 r#"[S] On field "Query.t", for @provides(fields: "f"): field "T.f" should not be part of a @provides since it is already provided by this subgraph (it is not marked @external)"#,
             )]
-        ));
+        );
     }
 
     #[test]
@@ -114,13 +187,13 @@ mod fieldset_based_directives {
         "#;
         let err = build_for_errors(schema_str);
 
-        assert!(errors_eq(
-            &err,
-            &[(
+        assert_errors!(
+            err,
+            [(
                 "REQUIRES_FIELDS_MISSING_EXTERNAL",
                 r#"[S] On field "T.g", for @requires(fields: "f"): field "T.f" should not be part of a @requires since it is already provided by this subgraph (it is not marked @external)"#,
             )]
-        ));
+        );
     }
 
     #[test]
@@ -144,13 +217,13 @@ mod fieldset_based_directives {
             );
             let err = build_for_errors(&schema_str);
 
-            assert!(errors_eq(
-                &err,
-                &[(
+            assert_errors!(
+                err,
+                [(
                     "KEY_UNSUPPORTED_ON_INTERFACE",
                     r#"[S] Cannot use @key on interface "T": @key is not yet supported on interfaces"#,
                 )]
-            ));
+            );
         }
     }
 
@@ -172,13 +245,13 @@ mod fieldset_based_directives {
         "#;
         let err = build_for_errors(schema_str);
 
-        assert!(errors_eq(
-            &err,
-            &[(
+        assert_errors!(
+            err,
+            [(
                 "PROVIDES_UNSUPPORTED_ON_INTERFACE",
                 r#"[S] Cannot use @provides on field "T.f" of parent type "T": @provides is not yet supported within interfaces"#,
             )]
-        ));
+        );
     }
 
     #[test]
@@ -196,9 +269,9 @@ mod fieldset_based_directives {
         "#;
         let err = build_for_errors(schema_str);
 
-        assert!(errors_eq(
-            &err,
-            &[
+        assert_errors!(
+            err,
+            [
                 (
                     "REQUIRES_UNSUPPORTED_ON_INTERFACE",
                     r#"[S] Cannot use @requires on field "T.g" of parent type "T": @requires is not yet supported within interfaces"#,
@@ -208,7 +281,7 @@ mod fieldset_based_directives {
                     r#"[S] Interface type field "T.f" is marked @external but @external is not allowed on interface fields (it is nonsensical)."#,
                 ),
             ]
-        ));
+        );
     }
 
     #[test]
@@ -225,13 +298,13 @@ mod fieldset_based_directives {
         "#;
         let err = build_for_errors(schema_str);
 
-        assert!(errors_eq(
-            &err,
-            &[(
+        assert_errors!(
+            err,
+            [(
                 "EXTERNAL_UNUSED",
                 r#"[S] Field "T.f" is marked @external but is not used in any federation directive (@key, @provides, @requires) or to satisfy an interface; the field declaration has no use and should be removed (or the field should not be @external)."#,
             )]
-        ));
+        );
     }
 
     #[test]
@@ -248,12 +321,600 @@ mod fieldset_based_directives {
         "#;
         let err = build_for_errors(schema_str);
 
-        assert!(errors_eq(
-            &err,
-            &[(
+        assert_errors!(
+            err,
+            [(
                 "PROVIDES_ON_NON_OBJECT_FIELD",
                 r#"[S] Invalid @provides directive on field "Query.t": field has type "Int" which is not a Composite Type"#,
             )]
-        ));
+        );
+    }
+}
+
+// PORT_NOTE: Corresponds to '@core/@link handling' tests in JS
+#[cfg(test)]
+mod link_handling_tests {
+    use super::*;
+
+    // TODO(FED-543): Remaining directive definitions should be added to the schema
+    #[allow(dead_code)]
+    const EXPECTED_FULL_SCHEMA: &str = r#"
+    schema
+      @link(url: "https://specs.apollo.dev/link/v1.0")
+      @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+    {
+      query: Query
+    }
+
+    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+    directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+    directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+    directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+    directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+    directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+    directive @federation__extends on OBJECT | INTERFACE
+
+    directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+    directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+    directive @federation__override(from: String!) on FIELD_DEFINITION
+
+    type T
+      @key(fields: "k")
+    {
+      k: ID!
+    }
+
+    enum link__Purpose {
+      """
+      \`SECURITY\` features provide metadata necessary to securely resolve fields.
+      """
+      SECURITY
+
+      """
+      \`EXECUTION\` features provide metadata necessary for operation execution.
+      """
+      EXECUTION
+    }
+
+    scalar link__Import
+
+    scalar federation__FieldSet
+
+    scalar _Any
+
+    type _Service {
+      sdl: String
+    }
+
+    union _Entity = T
+
+    type Query {
+      _entities(representations: [_Any!]!): [_Entity]!
+      _service: _Service!
+    }
+    "#;
+
+    #[test]
+    fn expands_everything_if_only_the_federation_spec_is_linked() {
+        let subgraph = build_and_validate(
+            r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+            type T @key(fields: "k") {
+                k: ID!
+            }
+            "#,
+        );
+
+        // TODO(FED-543): `subgraph` is supposed to be compared against `EXPECTED_FULL_SCHEMA`, but
+        //                it's failing due to missing directive definitions. So, we use
+        //                `insta::assert_snapshot` for now.
+        // assert_eq!(subgraph.schema_string(), EXPECTED_FULL_SCHEMA);
+        insta::assert_snapshot!(subgraph.schema_string(), @r###"
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
+          query: Query
+        }
+
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+        directive @federation__override(from: String!) on FIELD_DEFINITION
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
+
+        scalar link__Import
+
+        scalar federation__FieldSet
+
+        scalar _Any
+
+        type _Service {
+          sdl: String
+        }
+
+        union _Entity = T
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+        }
+        "###);
+    }
+
+    // TODO: FED-428
+    #[test]
+    #[should_panic(
+        expected = r#"InvalidLinkDirectiveUsage { message: "Invalid use of @link in schema: the @link specification itself (\"https://specs.apollo.dev/link/v1.0\") is applied multiple times" }"#
+    )]
+    fn expands_definitions_if_both_the_federation_spec_and_link_spec_are_linked() {
+        let subgraph = build_and_validate(
+            r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/link/v1.0")
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+            type T @key(fields: "k") {
+                k: ID!
+            }
+            "#,
+        );
+
+        assert_eq!(subgraph.schema_string(), EXPECTED_FULL_SCHEMA);
+    }
+
+    // TODO: FED-428
+    #[test]
+    #[should_panic(
+        expected = r#"InvalidLinkDirectiveUsage { message: "Invalid use of @link in schema: the @link specification itself (\"https://specs.apollo.dev/link/v1.0\") is applied multiple times" }"#
+    )]
+    fn is_valid_if_a_schema_is_complete_from_the_get_go() {
+        let subgraph = build_and_validate(EXPECTED_FULL_SCHEMA);
+        assert_eq!(subgraph.schema_string(), EXPECTED_FULL_SCHEMA);
+    }
+
+    // TODO: FED-428
+    #[test]
+    #[should_panic(
+        expected = r#"InvalidLinkDirectiveUsage { message: "Invalid use of @link in schema: the @link specification itself (\"https://specs.apollo.dev/link/v1.0\") is applied multiple times" }"#
+    )]
+    fn expands_missing_definitions_when_some_are_partially_provided() {
+        let docs = [
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                type T @key(fields: "k") {
+                  k: ID!
+                }
+
+                directive @key(
+                  fields: federation__FieldSet!
+                  resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                scalar federation__FieldSet
+
+                scalar link__Import
+            "#,
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                type T @key(fields: "k") {
+                  k: ID!
+                }
+
+                scalar link__Import
+            "#,
+            r#"
+                extend schema
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                type T @key(fields: "k") {
+                  k: ID!
+                }
+
+                scalar link__Import
+            "#,
+            r#"
+                extend schema
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                type T @key(fields: "k") {
+                  k: ID!
+                }
+
+                directive @federation__external(
+                  reason: String
+                ) on OBJECT | FIELD_DEFINITION
+            "#,
+            r#"
+                extend schema @link(url: "https://specs.apollo.dev/federation/v2.0")
+
+                type T {
+                  k: ID!
+                }
+
+                enum link__Purpose {
+                  EXECUTION
+                  SECURITY
+                }
+            "#,
+        ];
+
+        // Note that we cannot use `validateFullSchema` as-is for those examples because the order
+        // or directive is going to be different. But that's ok, we mostly care that the validation
+        // doesn't fail, so we can be somewhat sure that if something necessary wasn't expanded
+        // properly, we would have an issue. The main reason we did validate the full schema in
+        // prior tests is so we had at least one full example of a subgraph expansion in the tests.
+        docs.iter().for_each(|doc| {
+            _ = build_and_validate(doc);
+        });
+    }
+
+    // TODO: FED-428
+    #[test]
+    #[should_panic(
+        expected = r#"InvalidLinkDirectiveUsage { message: "Invalid use of @link in schema: the @link specification itself (\"https://specs.apollo.dev/link/v1.0\") is applied multiple times" }"#
+    )]
+    fn allows_known_directives_with_incomplete_but_compatible_definitions() {
+        let docs = [
+            // @key has a `resolvable` argument in its full definition, but it is optional.
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                type T @key(fields: "k") {
+                  k: ID!
+                }
+
+                directive @key(
+                  fields: federation__FieldSet!
+                ) repeatable on OBJECT | INTERFACE
+
+                scalar federation__FieldSet
+            "#,
+            // @inaccessible can be put in a bunch of locations, but you're welcome to restrict
+            // yourself to just fields.
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@inaccessible"]
+                  )
+
+                type T {
+                  k: ID! @inaccessible
+                }
+
+                directive @inaccessible on FIELD_DEFINITION
+            "#,
+            // @key is repeatable, but you're welcome to restrict yourself to never repeating it.
+            r#"
+                extend schema
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                type T @key(fields: "k") {
+                  k: ID!
+                }
+
+                directive @key(
+                  fields: federation__FieldSet!
+                  resolvable: Boolean = true
+                ) on OBJECT | INTERFACE
+
+                scalar federation__FieldSet
+            "#,
+            // @key `resolvable` argument is optional, but you're welcome to force users to always
+            // provide it.
+            r#"
+                extend schema
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                type T @key(fields: "k", resolvable: true) {
+                  k: ID!
+                }
+
+                directive @key(
+                  fields: federation__FieldSet!
+                  resolvable: Boolean!
+                ) repeatable on OBJECT | INTERFACE
+
+                scalar federation__FieldSet
+            "#,
+            // @link `url` argument is allowed to be `null` now, but it used not too, so making
+            // sure we still accept definition where it's mandatory.
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                type T @key(fields: "k") {
+                  k: ID!
+                }
+
+                directive @link(
+                  url: String!
+                  as: String
+                  for: link__Purpose
+                  import: [link__Import]
+                ) repeatable on SCHEMA
+
+                scalar link__Import
+                scalar link__Purpose
+            "#,
+        ];
+
+        // Like above, we really only care that the examples validate.
+        docs.iter().for_each(|doc| {
+            _ = build_and_validate(doc);
+        });
+    }
+
+    #[test]
+    fn errors_on_invalid_known_directive_location() {
+        let errors = build_for_errors(
+            // @external is not allowed on 'schema' and likely never will.
+            r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+            type T @key(fields: "k") {
+                k: ID!
+            }
+
+            directive @federation__external(
+                reason: String
+            ) on OBJECT | FIELD_DEFINITION | SCHEMA
+            "#,
+        );
+
+        assert_errors!(
+            errors,
+            [(
+                "DIRECTIVE_DEFINITION_INVALID",
+                r#"[S] Invalid definition for directive "@federation__external": "@federation__external" should have locations OBJECT, FIELD_DEFINITION, but found (non-subset) OBJECT, FIELD_DEFINITION, SCHEMA"#,
+            )]
+        );
+    }
+
+    #[test]
+    fn errors_on_invalid_non_repeatable_directive_marked_repeatable() {
+        let errors = build_for_errors(
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/federation/v2.0" import: ["@key"])
+
+                type T @key(fields: "k") {
+                  k: ID!
+                }
+
+                directive @federation__external repeatable on OBJECT | FIELD_DEFINITION
+            "#,
+        );
+        assert_errors!(
+            errors,
+            [(
+                "DIRECTIVE_DEFINITION_INVALID",
+                r#"[S] Invalid definition for directive "@federation__external": "@federation__external" should not be repeatable"#,
+            )]
+        );
+    }
+
+    #[test]
+    fn errors_on_unknown_argument_of_known_directive() {
+        let errors = build_for_errors(
+            r#"
+            extend schema
+              @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+            type T @key(fields: "k") {
+              k: ID!
+            }
+
+            directive @federation__external(foo: Int) on OBJECT | FIELD_DEFINITION
+            "#,
+        );
+        assert_errors!(
+            errors,
+            [(
+                "DIRECTIVE_DEFINITION_INVALID",
+                r#"[S] Invalid definition for directive "@federation__external": unknown/unsupported argument "foo""#,
+            )]
+        );
+    }
+
+    #[test]
+    fn errors_on_invalid_type_for_a_known_argument() {
+        let errors = build_for_errors(
+            r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+              type T @key(fields: "k") {
+                k: ID!
+              }
+
+              directive @key(
+                fields: String!
+                resolvable: String
+              ) repeatable on OBJECT | INTERFACE
+            "#,
+        );
+        assert_errors!(
+            errors,
+            [(
+                "DIRECTIVE_DEFINITION_INVALID",
+                r#"[S] Invalid definition for directive "@key": argument "resolvable" should have type "Boolean" but found type "String""#,
+            )]
+        );
+    }
+
+    #[test]
+    fn errors_on_a_required_argument_defined_as_optional() {
+        let errors = build_for_errors(
+            r#"
+                extend schema
+                    @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+                type T @key(fields: "k") {
+                    k: ID!
+                }
+
+                directive @key(
+                    fields: federation__FieldSet
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                scalar federation__FieldSet
+            "#,
+        );
+        assert_errors!(
+            errors,
+            [(
+                "DIRECTIVE_DEFINITION_INVALID",
+                r#"[S] Invalid definition for directive "@key": argument "fields" should have type "federation__FieldSet!" but found type "federation__FieldSet""#,
+            )]
+        );
+    }
+
+    #[test]
+    fn errors_on_invalid_definition_for_link_purpose() {
+        let errors = build_for_errors(
+            r#"
+                extend schema @link(url: "https://specs.apollo.dev/federation/v2.0")
+
+                type T {
+                    k: ID!
+                }
+
+                enum link__Purpose {
+                    EXECUTION
+                    RANDOM
+                }
+            "#,
+        );
+        assert_errors!(
+            errors,
+            [(
+                "TYPE_DEFINITION_INVALID",
+                r#"[S] Invalid definition for type "Purpose": expected values [EXECUTION, SECURITY] but found [EXECUTION, RANDOM]."#,
+            )]
+        );
+    }
+
+    #[test]
+    fn allows_any_non_scalar_type_in_redefinition_when_expected_type_is_a_scalar() {
+        // Just making sure this don't error out.
+        build_and_validate(
+            r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+              type T @key(fields: "k") {
+                k: ID!
+              }
+
+              # 'fields' should be of type 'federation_FieldSet!', but ensure we allow 'String!' alternatively.
+              directive @key(
+                fields: String!
+                resolvable: Boolean = true
+              ) repeatable on OBJECT | INTERFACE
+            "#,
+        );
+    }
+
+    #[test]
+    fn allows_defining_a_repeatable_directive_as_non_repeatable_but_validates_usages() {
+        let doc = r#"
+            type T @key(fields: "k1") @key(fields: "k2") {
+                k1: ID!
+                k2: ID!
+            }
+
+            directive @key(fields: String!) on OBJECT
+        "#;
+
+        // Test for fed2 (with @key being @link-ed)
+        assert_errors!(
+            build_for_errors(doc),
+            [(
+                "INVALID_GRAPHQL",
+                r###"
+                [S] Error: non-repeatable directive key can only be used once per location
+                   ╭─[ S:2:39 ]
+                   │
+                 2 │             type T @key(fields: "k1") @key(fields: "k2") {
+                   │                    ──┬─               ─────────┬────────  
+                   │                      ╰──────────────────────────────────── directive `@key` first called here
+                   │                                                │          
+                   │                                                ╰────────── directive `@key` called again here
+                ───╯
+                "###
+            )]
+        );
+
+        // TODO: Test for fed1
     }
 }


### PR DESCRIPTION
Also fixed some validation functions in `type_and_directive_specification.rs`.

Note: This fix won't change the current production behavior of query planner, since QP initialization won't see invalid cases anyways.


<!-- FED-532 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests
