### PR TITLE
deps: update apollo-compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb8a0d8a54b31d8a9efcc25d4be3d949d823e8105a710861d6d4a4ef811b5f2"
+checksum = "b3eb9f97e5cc573361cdeb65204fbb7c459c9a9d5a6bec48ee37355c642a06ad"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -173,7 +173,7 @@ dependencies = [
  "rowan",
  "serde",
  "serde_json_bytes",
- "thiserror 1.0.69",
+ "thiserror 2.0.10",
  "triomphe",
  "typed-arena",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "1.27.0"
+apollo-compiler = "1.28.0"
 apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"


### PR DESCRIPTION
Changelog:

---

## Features

- **Reject `@skip`/`@include` on subscription root fields - [dariuszkuc] [SimonSapin] and [goto-bus-stop], [pull/963]**

  This implements a [GraphQL spec RFC](https://github.com/graphql/graphql-spec/pull/860), rejecting
  subscriptions in validation that can be invalid during execution.

- **New shorthand methods for mutable directive argument access - [tninesling], [pull/967]**

  Introduces new methods:
  - `DirectiveList::get_all_mut`
  - `DirectiveList::argument_by_name_mut`
  - `DirectiveList::specified_argument_by_name_mut`

## Fixes

- **Update `ariadne` trait implementations - [lrlna], [pull/960]**

  `ariadne@0.5.1` release changed their type signature for `ariadne::Cache` trait, which required an
  update to `apollo-compiler`'s implementation of `ariadne::Cache<FileId>`. 

  This release also had a slight change to path formatting, so if you had any snapshots in your
  tests, you can expect a change from this:
  ```
  Error: `typeFragment1` contains too much nesting
      ╭─[overflow.graphql:11:11]
  ```

  to this (notice the extra white space around the file path):
  ```
  Error: `typeFragment1` contains too much nesting
      ╭─[ overflow.graphql:11:11 ]
  ```

- **Harden stack overflow protection - [goto-bus-stop], [pull/966]**

  Closes a theoretical gap in stack overflow protection when processing long fragment chains, and
  significantly improves validation performance on documents with thousands of fragment definitions.

[lrlna]: https://github.com/lrlna
[dariuszkuc]: https://github.com/dariuszkuc
[goto-bus-stop]: https://github.com/goto-bus-stop
[SimonSapin]: https://github.com/SimonSapin
[tninesling]: https://github.com/tninesling
[pull/960]: https://github.com/apollographql/apollo-rs/pull/960
[pull/963]: https://github.com/apollographql/apollo-rs/pull/963
[pull/966]: https://github.com/apollographql/apollo-rs/pull/966
[pull/967]: https://github.com/apollographql/apollo-rs/pull/967