### PR TITLE
Upgrade to apollo-compiler@1.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb8a0d8a54b31d8a9efcc25d4be3d949d823e8105a710861d6d4a4ef811b5f2"
+checksum = "b3eb9f97e5cc573361cdeb65204fbb7c459c9a9d5a6bec48ee37355c642a06ad"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -173,7 +173,7 @@ dependencies = [
  "rowan",
  "serde",
  "serde_json_bytes",
- "thiserror 1.0.69",
+ "thiserror 2.0.10",
  "triomphe",
  "typed-arena",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "1.27.0"
+apollo-compiler = "1.28.0"
 apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -217,19 +217,15 @@ impl<'a> SchemaUpgrader<'a> {
             for field in &referencers.object_fields.clone() {
                 let field_type = field.make_mut(&mut schema.schema)?.make_mut();
 
-                for directive in field_type.directives.0.iter_mut() {
-                    if directive.name == directive_name {
-                        for arg in directive.make_mut().arguments.iter_mut() {
-                            if arg.name == "fields" {
-                                if let Some(new_fields_string) =
-                                    Self::make_fields_string_if_not(&arg.value)?
-                                {
-                                    *arg.make_mut().value.make_mut() =
-                                        Value::String(new_fields_string);
-                                }
-                                break;
-                            }
+                for directive in field_type.directives.get_all_mut(directive_name) {
+                    if let Some(fields) = directive
+                        .make_mut()
+                        .specified_argument_by_name_mut("fields")
+                    {
+                        if let Some(new_fields_string) = Self::make_fields_string_if_not(fields)? {
+                            *fields.make_mut() = Value::String(new_fields_string);
                         }
+                        break;
                     }
                 }
             }
@@ -241,18 +237,19 @@ impl<'a> SchemaUpgrader<'a> {
         for field in &referencers.object_types.clone() {
             let field_type = field.make_mut(&mut schema.schema)?.make_mut();
 
-            for directive in field_type.directives.0.iter_mut() {
-                if directive.name == "key" {
-                    for arg in directive.make_mut().arguments.iter_mut() {
-                        if arg.name == "fields" {
-                            if let Some(new_fields_string) =
-                                Self::make_fields_string_if_not(&arg.value)?
-                            {
-                                *arg.make_mut().value.make_mut() = Value::String(new_fields_string);
-                            }
-                            break;
-                        }
+            for directive in field_type
+                .directives
+                .iter_mut()
+                .filter(|d| d.name.as_str() == "key")
+            {
+                if let Some(fields) = directive
+                    .make_mut()
+                    .specified_argument_by_name_mut("fields")
+                {
+                    if let Some(new_fields_string) = Self::make_fields_string_if_not(fields)? {
+                        *fields.make_mut() = Value::String(new_fields_string);
                     }
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Bumps `apollo-compiler` to the latest version and applies some small refactors to the Schema Upgrader which can use the mutable API additions.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
