### PR TITLE
docs: otlp metrics exporters (backport #7334)

### DIFF
--- a/docs/source/routing/observability/telemetry/metrics-exporters/datadog.mdx
+++ b/docs/source/routing/observability/telemetry/metrics-exporters/datadog.mdx
@@ -1,12 +1,12 @@
 ---
-title: Datadog exporter (via OTLP)
-subtitle: Configure the Datadog exporter for metrics
-description: Configure the Datadog exporter for metrics via OpenTelemetry Protocol (OTLP) in the Apollo GraphOS Router or Apollo Router Core.
+title: Datadog configuration of OTLP exporter
+subtitle: Configure the OTLP metrics exporter for Datadog
+description: Configure the OpenTelemetry Protocol (OTLP) metrics exporter for Datadog in the Apollo GraphOS Router or Apollo Router Core.
 context:
   - telemetry
 ---
 
-Enable and configure the [OTLP exporter](/router/configuration/telemetry/exporters/metrics/otlp) for metrics in the GraphOS Router or Apollo Router Core for use with [Datadog](https://www.datadoghq.com/).
+This metrics exporter is a configuration of the [OTLP exporter](/router/configuration/telemetry/exporters/metrics/otlp) to use with [Datadog](https://www.datadoghq.com/).
 
 For general tracing configuration, refer to [Router Metrics Configuration](/router/configuration/telemetry/exporters/metrics/overview).
 

--- a/docs/source/routing/observability/telemetry/metrics-exporters/dynatrace.mdx
+++ b/docs/source/routing/observability/telemetry/metrics-exporters/dynatrace.mdx
@@ -1,12 +1,12 @@
 ---
-title: Dynatrace exporter (via OTLP)
-subtitle: Configure the Dynatrace exporter for metrics
-description: Configure the Dynatrace exporter for metrics via OpenTelemetry Protocol (OTLP) in the Apollo Router.
+title: Dynatrace configuration of OTLP exporter
+subtitle: Configure the OTLP exporter for Dynatrace
+description: Configure the OTLP metrics exporter for Dynatrace via OpenTelemetry Protocol (OTLP) in the Apollo Router.
 context:
   - telemetry
 ---
 
-Enable and configure the [OTLP exporter](/router/configuration/telemetry/exporters/metrics/otlp) for metrics in the Apollo Router for use with [Dynatrace](https://dynatrace.com/).
+This metrics exporter is a configuration of the [OTLP exporter](/router/configuration/telemetry/exporters/metrics/otlp) to use with [Dynatrace](https://www.dynatrace.com/).
 
 For general tracing configuration, refer to [Router Metrics Configuration](/router/configuration/telemetry/exporters/metrics/overview).
 

--- a/docs/source/routing/observability/telemetry/metrics-exporters/new-relic.mdx
+++ b/docs/source/routing/observability/telemetry/metrics-exporters/new-relic.mdx
@@ -1,12 +1,12 @@
 ---
-title: New Relic exporter (via OTLP)
+title: New Relic configuration of OTLP exporter
 subtitle: Configure the New Relic exporter for metrics
 description: Configure the New Relic exporter for metrics via OpenTelemetry Protocol (OTLP) in the Apollo GraphOS Router or Apollo Router Core.
 context:
   - telemetry
 ---
 
-Enable and configure the [OTLP exporter](/router/configuration/telemetry/exporters/metrics/otlp) for metrics in the GraphOS Router or Apollo Router Core for use with [New Relic](https://newrelic.com/).
+This metrics exporter is a configuration of the [OTLP exporter](/router/configuration/telemetry/exporters/metrics/otlp) to use with [New Relic](https://newrelic.com/).
 
 For general tracing configuration, refer to [Router Metrics Configuration](/router/configuration/telemetry/exporters/metrics/overview).
 

--- a/docs/source/routing/observability/telemetry/metrics-exporters/otlp.mdx
+++ b/docs/source/routing/observability/telemetry/metrics-exporters/otlp.mdx
@@ -16,6 +16,7 @@ Using the OTLP protocol, you can export metrics to any OTLP compatible receiver,
 
 * [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)
 * [Datadog](https://www.datadoghq.com/) (see [configuration instructions](/router/configuration/telemetry/exporters/metrics/datadog))
+* [Dynatrace](https://www.dynatrace.com/) (see [configuration instructions](/router/configuration/telemetry/exporters/metrics/dynatrace))
 * [New Relic](https://www.newrelic.com/) (see [configuration instructions](/router/configuration/telemetry/exporters/metrics/new-relic))
 
 ## OTLP configuration


### PR DESCRIPTION
Add clarification that Datadog, Dynatrace, New Relic exporters are configurations of OTLP exporter<hr>This is an automatic backport of pull request #7334 done by [Mergify](https://mergify.com).