### PR TITLE
deps: update apollo-compiler (backport #7338)

### DIFF
--- a/.changesets/maint_renee_apollo_compiler_1_28.md
+++ b/.changesets/maint_renee_apollo_compiler_1_28.md
@@ -1,0 +1,5 @@
+### Reject `@skip`/`@include` on subscription root fields in validation ([PR #7338](https://github.com/apollographql/router/pull/7338))
+
+This implements a [GraphQL spec RFC](https://github.com/graphql/graphql-spec/pull/860), rejecting subscriptions in validation that can be invalid during execution.
+
+By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/7338

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,11 +185,7 @@ dependencies = [
  "rowan",
  "serde",
  "serde_json_bytes",
-<<<<<<< HEAD
- "thiserror",
-=======
- "thiserror 2.0.10",
->>>>>>> cef3f130 (deps: update apollo-compiler (#7338))
+ "thiserror 2.0.12",
  "triomphe",
  "typed-arena",
 ]
@@ -228,7 +224,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "time",
  "tracing",
  "url",
@@ -255,7 +251,7 @@ checksum = "c8f05cbc7da3c2e3bb2f86e985aad5f72571d2e2cd26faf8caa7782131576f84"
 dependencies = [
  "memchr",
  "rowan",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -390,7 +386,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "test-log",
- "thiserror",
+ "thiserror 1.0.63",
  "tikv-jemallocator",
  "time",
  "tokio",
@@ -481,7 +477,7 @@ dependencies = [
  "arbitrary",
  "indexmap 2.5.0",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -501,9 +497,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "ariadne"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31beedec3ce83ae6da3a79592b3d8d7afd146a5b15bb9bb940279aced60faa89"
+checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
 dependencies = [
  "concolor",
  "unicode-width",
@@ -643,7 +639,7 @@ dependencies = [
  "serde_urlencoded",
  "static_assertions",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -678,7 +674,7 @@ dependencies = [
  "quote",
  "strum 0.25.0",
  "syn 2.0.90",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -2096,7 +2092,7 @@ dependencies = [
  "console",
  "shell-words",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "zeroize",
 ]
 
@@ -2126,7 +2122,7 @@ checksum = "c3ca7fa3ba397980657070e679f412acddb7a372f1793ff68ef0bbe708680f0f"
 dependencies = [
  "regex",
  "sha2",
- "thiserror",
+ "thiserror 1.0.63",
  "walkdir",
 ]
 
@@ -2866,7 +2862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -2959,7 +2955,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -2973,7 +2969,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -3102,7 +3098,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.63",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3125,7 +3121,7 @@ dependencies = [
  "rand 0.8.5",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
 ]
@@ -3729,7 +3725,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -4412,7 +4408,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.63",
  "urlencoding",
 ]
 
@@ -4442,7 +4438,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "reqwest",
  "rmp",
- "thiserror",
+ "thiserror 1.0.63",
  "url",
 ]
 
@@ -4494,7 +4490,7 @@ dependencies = [
  "opentelemetry_sdk 0.20.0",
  "prost 0.11.9",
  "reqwest",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tonic 0.9.2",
 ]
@@ -4577,7 +4573,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "typed-builder",
 ]
 
@@ -4593,7 +4589,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.63",
  "urlencoding",
 ]
 
@@ -4616,7 +4612,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tokio-stream",
 ]
@@ -4638,7 +4634,7 @@ dependencies = [
  "ordered-float 4.2.1",
  "percent-encoding",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -4765,7 +4761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.63",
  "ucd-trie",
 ]
 
@@ -5027,7 +5023,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -5141,7 +5137,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "typetag",
 ]
 
@@ -5297,7 +5293,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -5878,7 +5874,7 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.90",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -5937,7 +5933,7 @@ checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -6083,7 +6079,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.63",
  "time",
 ]
 
@@ -6408,7 +6404,16 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -6416,6 +6421,17 @@ name = "thiserror-impl"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7042,7 +7058,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls",
  "sha1",
- "thiserror",
+ "thiserror 1.0.63",
  "url",
  "utf-8",
 ]
@@ -7805,7 +7821,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror",
+ "thiserror 1.0.63",
  "windows 0.58.0",
  "windows-core 0.58.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb8a0d8a54b31d8a9efcc25d4be3d949d823e8105a710861d6d4a4ef811b5f2"
+checksum = "b3eb9f97e5cc573361cdeb65204fbb7c459c9a9d5a6bec48ee37355c642a06ad"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -185,7 +185,11 @@ dependencies = [
  "rowan",
  "serde",
  "serde_json_bytes",
+<<<<<<< HEAD
  "thiserror",
+=======
+ "thiserror 2.0.10",
+>>>>>>> cef3f130 (deps: update apollo-compiler (#7338))
  "triomphe",
  "typed-arena",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "1.27.0"
+apollo-compiler = "1.28.0"
 apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"

--- a/apollo-federation/tests/api_schema.rs
+++ b/apollo-federation/tests/api_schema.rs
@@ -2165,15 +2165,15 @@ fn inaccessible_on_builtins() {
     .expect_err("should return validation errors");
 
     // Note this is different from the JS implementation
-    insta::assert_snapshot!(errors, @r###"
+    insta::assert_snapshot!(errors, @r"
     Error: built-in scalar definitions must be omitted
-        ╭─[schema.graphql:26:7]
+        ╭─[ schema.graphql:26:7 ]
         │
      26 │       scalar String @inaccessible
         │       ─────────────┬─────────────  
         │                    ╰─────────────── remove this scalar definition
     ────╯
-    "###);
+    ");
 }
 
 #[test]


### PR DESCRIPTION
This introduces a new validation rule, which will reject more queries than before, but it's not breaking because we already didn't support such queries in other parts of the router.

<!-- [ROUTER-1252] -->

Changelog:

---

## Features

- **Reject `@skip`/`@include` on subscription root fields - [dariuszkuc] [SimonSapin] and [goto-bus-stop], [pull/963]**

  This implements a [GraphQL spec RFC](https://github.com/graphql/graphql-spec/pull/860), rejecting
  subscriptions in validation that can be invalid during execution.

- **New shorthand methods for mutable directive argument access - [tninesling], [pull/967]**

  Introduces new methods:
  - `DirectiveList::get_all_mut`
  - `DirectiveList::argument_by_name_mut`
  - `DirectiveList::specified_argument_by_name_mut`

## Fixes

- **Update `ariadne` trait implementations - [lrlna], [pull/960]**

  `ariadne@0.5.1` release changed their type signature for `ariadne::Cache` trait, which required an
  update to `apollo-compiler`'s implementation of `ariadne::Cache<FileId>`. 

  This release also had a slight change to path formatting, so if you had any snapshots in your
  tests, you can expect a change from this:
  ```
  Error: `typeFragment1` contains too much nesting
      ╭─[overflow.graphql:11:11]
  ```

  to this (notice the extra white space around the file path):
  ```
  Error: `typeFragment1` contains too much nesting
      ╭─[ overflow.graphql:11:11 ]
  ```

- **Harden stack overflow protection - [goto-bus-stop], [pull/966]**

  Closes a theoretical gap in stack overflow protection when processing long fragment chains, and
  significantly improves validation performance on documents with thousands of fragment definitions.

[lrlna]: https://github.com/lrlna
[dariuszkuc]: https://github.com/dariuszkuc
[goto-bus-stop]: https://github.com/goto-bus-stop
[SimonSapin]: https://github.com/SimonSapin
[tninesling]: https://github.com/tninesling
[pull/960]: https://github.com/apollographql/apollo-rs/pull/960
[pull/963]: https://github.com/apollographql/apollo-rs/pull/963
[pull/966]: https://github.com/apollographql/apollo-rs/pull/966
[pull/967]: https://github.com/apollographql/apollo-rs/pull/967

<hr>

This is an automatic backport of pull request #7338 done by [Mergify](https://mergify.com).

[ROUTER-1252]: https://apollographql.atlassian.net/browse/ROUTER-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ