### PR TITLE
Fix clippy when run with `--all-features`

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -16,8 +16,6 @@ use clap::Args;
 use clap::Parser;
 use clap::Subcommand;
 use clap::builder::FalseyValueParser;
-#[cfg(any(feature = "dhat-heap", feature = "dhat-ad-hoc"))]
-use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use regex::Captures;
 use regex::Regex;
@@ -57,10 +55,10 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 pub(crate) static ALLOC: dhat::Alloc = dhat::Alloc;
 
 #[cfg(feature = "dhat-heap")]
-pub(crate) static mut DHAT_HEAP_PROFILER: OnceCell<dhat::Profiler> = OnceCell::new();
+pub(crate) static DHAT_HEAP_PROFILER: Mutex<Option<dhat::Profiler>> = Mutex::new(None);
 
 #[cfg(feature = "dhat-ad-hoc")]
-pub(crate) static mut DHAT_AD_HOC_PROFILER: OnceCell<dhat::Profiler> = OnceCell::new();
+pub(crate) static DHAT_AD_HOC_PROFILER: Mutex<Option<dhat::Profiler>> = Mutex::new(None);
 
 pub(crate) static APOLLO_ROUTER_DEV_MODE: AtomicBool = AtomicBool::new(false);
 pub(crate) static APOLLO_ROUTER_SUPERGRAPH_PATH_IS_SET: AtomicBool = AtomicBool::new(false);
@@ -76,47 +74,31 @@ const INITIAL_UPLINK_POLL_INTERVAL: Duration = Duration::from_secs(10);
 // main completes, so don't use tracing, use println!() and eprintln!()..
 #[cfg(feature = "dhat-heap")]
 fn create_heap_profiler() {
-    unsafe {
-        match DHAT_HEAP_PROFILER.set(dhat::Profiler::new_heap()) {
-            Ok(p) => {
-                println!("heap profiler installed: {:?}", p);
-                libc::atexit(drop_heap_profiler);
-            }
-            Err(e) => eprintln!("heap profiler install failed: {:?}", e),
-        }
-    }
+    *DHAT_HEAP_PROFILER.lock() = Some(dhat::Profiler::new_heap());
+    println!("heap profiler installed");
+    unsafe { libc::atexit(drop_heap_profiler) };
 }
 
 #[cfg(feature = "dhat-heap")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn drop_heap_profiler() {
-    unsafe {
-        if let Some(p) = DHAT_HEAP_PROFILER.take() {
-            drop(p);
-        }
+    if let Some(p) = DHAT_HEAP_PROFILER.lock().take() {
+        drop(p);
     }
 }
 
 #[cfg(feature = "dhat-ad-hoc")]
 fn create_ad_hoc_profiler() {
-    unsafe {
-        match DHAT_AD_HOC_PROFILER.set(dhat::Profiler::new_ad_hoc()) {
-            Ok(p) => {
-                println!("ad-hoc profiler installed: {:?}", p);
-                libc::atexit(drop_ad_hoc_profiler);
-            }
-            Err(e) => eprintln!("ad-hoc profiler install failed: {:?}", e),
-        }
-    }
+    *DHAT_AD_HOC_PROFILER.lock() = Some(dhat::Profiler::new_heap());
+    println!("ad-hoc profiler installed");
+    unsafe { libc::atexit(drop_ad_hoc_profiler) };
 }
 
 #[cfg(feature = "dhat-ad-hoc")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn drop_ad_hoc_profiler() {
-    unsafe {
-        if let Some(p) = DHAT_AD_HOC_PROFILER.take() {
-            drop(p);
-        }
+    if let Some(p) = DHAT_AD_HOC_PROFILER.lock().take() {
+        drop(p);
     }
 }
 

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -52,6 +52,7 @@ impl Lint {
             "clippy",
             "--all",
             "--all-targets",
+            "--all-features",
             "--no-deps",
             "--",
             "-D",


### PR DESCRIPTION
Use a Mutex for the dhat profiler instead of a `static mut`.

Pass `--all-features` to Clippy in `cargo xtask lint`.

<!-- start metadata -->

<!-- [ROUTER-1198] -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1198]: https://apollographql.atlassian.net/browse/ROUTER-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ