### PR TITLE
Add configurable server header read timeout (backport #7262)

### DIFF
--- a/.changesets/config_header_read_timeout.md
+++ b/.changesets/config_header_read_timeout.md
@@ -1,0 +1,13 @@
+### Add configurable server header read timeout ([PR #7262](https://github.com/apollographql/router/pull/7262))
+
+This change exposes the server's header read timeout as the `server.http.header_read_timeout` configuration option.
+
+By default, the `server.http.header_read_timeout` is set to previously hard-coded 10 seconds. A longer timeout can be configured using the `server.http.header_read_timeout` option.
+
+```yaml title="router.yaml"
+server:
+  http:
+    header_read_timeout: 30s
+```
+
+By [@gwardwell ](https://github.com/gwardwell) in https://github.com/apollographql/router/pull/7262

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -5,16 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
-<<<<<<< HEAD
-<<<<<<< HEAD
-use std::time::Duration;
 use std::time::Instant;
-=======
-use std::time::{Duration, Instant};
->>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
-=======
-use std::time::Instant;
->>>>>>> de2127f5 (style: fix lint errors)
 
 use axum::Router;
 use axum::error_handling::HandleErrorLayer;
@@ -324,7 +315,7 @@ impl HttpServerFactory for AxumHttpServerFactory {
                 .map_err(ApolloRouterError::ServerCreationError)?;
             let mut http_config = Http::new();
             http_config.http1_keep_alive(true);
-            http_config.http1_header_read_timeout(Duration::from_secs(10));
+            http_config.http1_header_read_timeout(configuration.server.http.header_read_timeout);
 
             #[cfg(feature = "hyper_header_limits")]
             if let Some(max_headers) = configuration.limits.http1_max_request_headers {
@@ -341,18 +332,8 @@ impl HttpServerFactory for AxumHttpServerFactory {
                 configuration.supergraph.connection_shutdown_timeout,
                 actual_main_listen_address.clone(),
                 all_routers.main.1,
-<<<<<<< HEAD
                 true,
                 http_config.clone(),
-=======
-                configuration.limits.http1_max_request_headers,
-                configuration.limits.http1_max_request_buf_size,
-<<<<<<< HEAD
-				configuration.server.http.header_read_timeout,
->>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
-=======
-                configuration.server.http.header_read_timeout,
->>>>>>> de2127f5 (style: fix lint errors)
                 all_connections_stopped_sender.clone(),
             );
 
@@ -393,18 +374,8 @@ impl HttpServerFactory for AxumHttpServerFactory {
                             configuration.supergraph.connection_shutdown_timeout,
                             listen_addr.clone(),
                             router,
-<<<<<<< HEAD
                             false,
                             http_config.clone(),
-=======
-                            configuration.limits.http1_max_request_headers,
-                            configuration.limits.http1_max_request_buf_size,
-<<<<<<< HEAD
-							configuration.server.http.header_read_timeout,
->>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
-=======
-                            configuration.server.http.header_read_timeout,
->>>>>>> de2127f5 (style: fix lint errors)
                             all_connections_stopped_sender.clone(),
                         );
                         (

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -5,8 +5,12 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+<<<<<<< HEAD
 use std::time::Duration;
 use std::time::Instant;
+=======
+use std::time::{Duration, Instant};
+>>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
 
 use axum::Router;
 use axum::error_handling::HandleErrorLayer;
@@ -333,8 +337,14 @@ impl HttpServerFactory for AxumHttpServerFactory {
                 configuration.supergraph.connection_shutdown_timeout,
                 actual_main_listen_address.clone(),
                 all_routers.main.1,
+<<<<<<< HEAD
                 true,
                 http_config.clone(),
+=======
+                configuration.limits.http1_max_request_headers,
+                configuration.limits.http1_max_request_buf_size,
+				configuration.server.http.header_read_timeout,
+>>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
                 all_connections_stopped_sender.clone(),
             );
 
@@ -375,8 +385,14 @@ impl HttpServerFactory for AxumHttpServerFactory {
                             configuration.supergraph.connection_shutdown_timeout,
                             listen_addr.clone(),
                             router,
+<<<<<<< HEAD
                             false,
                             http_config.clone(),
+=======
+                            configuration.limits.http1_max_request_headers,
+                            configuration.limits.http1_max_request_buf_size,
+							configuration.server.http.header_read_timeout,
+>>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
                             all_connections_stopped_sender.clone(),
                         );
                         (

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -6,11 +6,15 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 <<<<<<< HEAD
+<<<<<<< HEAD
 use std::time::Duration;
 use std::time::Instant;
 =======
 use std::time::{Duration, Instant};
 >>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
+=======
+use std::time::Instant;
+>>>>>>> de2127f5 (style: fix lint errors)
 
 use axum::Router;
 use axum::error_handling::HandleErrorLayer;
@@ -343,8 +347,12 @@ impl HttpServerFactory for AxumHttpServerFactory {
 =======
                 configuration.limits.http1_max_request_headers,
                 configuration.limits.http1_max_request_buf_size,
+<<<<<<< HEAD
 				configuration.server.http.header_read_timeout,
 >>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
+=======
+                configuration.server.http.header_read_timeout,
+>>>>>>> de2127f5 (style: fix lint errors)
                 all_connections_stopped_sender.clone(),
             );
 
@@ -391,8 +399,12 @@ impl HttpServerFactory for AxumHttpServerFactory {
 =======
                             configuration.limits.http1_max_request_headers,
                             configuration.limits.http1_max_request_buf_size,
+<<<<<<< HEAD
 							configuration.server.http.header_read_timeout,
 >>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
+=======
+                            configuration.server.http.header_read_timeout,
+>>>>>>> de2127f5 (style: fix lint errors)
                             all_connections_stopped_sender.clone(),
                         );
                         (

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -274,8 +274,12 @@ pub(super) fn serve_router_on_listen_addr(
 =======
     opt_max_headers: Option<usize>,
     opt_max_buf_size: Option<ByteSize>,
+<<<<<<< HEAD
 	opt_http_read_timeout: Duration,
 >>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
+=======
+    http_read_timeout: Duration,
+>>>>>>> de2127f5 (style: fix lint errors)
     all_connections_stopped_sender: mpsc::Sender<()>,
 ) -> (impl Future<Output = Listener>, oneshot::Sender<()>) {
     let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
@@ -368,7 +372,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let http_config = http_connection
                                                          .keep_alive(true)
                                                          .timer(TokioTimer::new())
-                                                         .header_read_timeout(opt_http_read_timeout);
+                                                         .header_read_timeout(http_read_timeout);
                                         if let Some(max_headers) = opt_max_headers {
                                             http_config.max_headers(max_headers);
                                         }
@@ -397,7 +401,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let http_config = http_connection
                                                          .keep_alive(true)
                                                          .timer(TokioTimer::new())
-                                                         .header_read_timeout(opt_http_read_timeout);
+                                                         .header_read_timeout(http_read_timeout);
                                         if let Some(max_headers) = opt_max_headers {
                                             http_config.max_headers(max_headers);
                                         }
@@ -432,7 +436,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let http_config = http_connection
                                                          .keep_alive(true)
                                                          .timer(TokioTimer::new())
-                                                         .header_read_timeout(opt_http_read_timeout);
+                                                         .header_read_timeout(http_read_timeout);
                                         if let Some(max_headers) = opt_max_headers {
                                             http_config.max_headers(max_headers);
                                         }

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -268,22 +268,8 @@ pub(super) fn serve_router_on_listen_addr(
     connection_shutdown_timeout: Duration,
     address: ListenAddr,
     router: axum::Router,
-<<<<<<< HEAD
     main_graphql_port: bool,
     http_config: Http,
-=======
-    opt_max_headers: Option<usize>,
-    opt_max_buf_size: Option<ByteSize>,
-<<<<<<< HEAD
-<<<<<<< HEAD
-	opt_http_read_timeout: Duration,
->>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
-=======
-    http_read_timeout: Duration,
->>>>>>> de2127f5 (style: fix lint errors)
-=======
-    header_read_timeout: Duration,
->>>>>>> f0aa17d8 (refactor: fix header_read_timeout variable name)
     all_connections_stopped_sender: mpsc::Sender<()>,
 ) -> (impl Future<Output = Listener>, oneshot::Sender<()>) {
     let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
@@ -368,24 +354,7 @@ pub(super) fn serve_router_on_listen_addr(
                                                 "this should not fail unless the socket is invalid",
                                             );
 
-<<<<<<< HEAD
                                         let connection = http_config.serve_connection(stream, app);
-=======
-                                        let mut builder = Builder::new(TokioExecutor::new());
-                                        let mut http_connection = builder.http1();
-                                        let http_config = http_connection
-                                                         .keep_alive(true)
-                                                         .timer(TokioTimer::new())
-                                                         .header_read_timeout(header_read_timeout);
-                                        if let Some(max_headers) = opt_max_headers {
-                                            http_config.max_headers(max_headers);
-                                        }
-
-                                        if let Some(max_buf_size) = opt_max_buf_size {
-                                            http_config.max_buf_size(max_buf_size.as_u64() as usize);
-                                        }
-                                        let connection = http_config.serve_connection_with_upgrades(tokio_stream, hyper_service);
->>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
                                         handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
 
                                     }
@@ -393,28 +362,7 @@ pub(super) fn serve_router_on_listen_addr(
                                     NetworkStream::Unix(stream) => {
                                         let received_first_request = Arc::new(AtomicBool::new(false));
                                         let app = IdleConnectionChecker::new(received_first_request.clone(), app);
-<<<<<<< HEAD
                                         let connection = http_config.serve_connection(stream, app);
-=======
-                                        let tokio_stream = TokioIo::new(stream);
-                                        let hyper_service = hyper::service::service_fn(move |request| {
-                                            app.clone().call(request)
-                                        });
-                                        let mut builder = Builder::new(TokioExecutor::new());
-                                        let mut http_connection = builder.http1();
-                                        let http_config = http_connection
-                                                         .keep_alive(true)
-                                                         .timer(TokioTimer::new())
-                                                         .header_read_timeout(header_read_timeout);
-                                        if let Some(max_headers) = opt_max_headers {
-                                            http_config.max_headers(max_headers);
-                                        }
-
-                                        if let Some(max_buf_size) = opt_max_buf_size {
-                                            http_config.max_buf_size(max_buf_size.as_u64() as usize);
-                                        }
-                                        let connection = http_config.serve_connection_with_upgrades(tokio_stream, hyper_service);
->>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
                                         handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
                                     },
                                     NetworkStream::Tls(stream) => {
@@ -430,25 +378,6 @@ pub(super) fn serve_router_on_listen_addr(
                                             let protocol = stream.get_ref().1.alpn_protocol();
                                             let http2 = protocol == Some(&b"h2"[..]);
 
-<<<<<<< HEAD
-=======
-                                        let tokio_stream = TokioIo::new(stream);
-                                        let hyper_service = hyper::service::service_fn(move |request| {
-                                            app.clone().call(request)
-                                        });
-                                        let mut http_connection = builder.http1();
-                                        let http_config = http_connection
-                                                         .keep_alive(true)
-                                                         .timer(TokioTimer::new())
-                                                         .header_read_timeout(header_read_timeout);
-                                        if let Some(max_headers) = opt_max_headers {
-                                            http_config.max_headers(max_headers);
-                                        }
-
-                                        if let Some(max_buf_size) = opt_max_buf_size {
-                                            http_config.max_buf_size(max_buf_size.as_u64() as usize);
-                                        }
->>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
                                         let connection = http_config
                                             .http2_only(http2)
                                             .serve_connection(stream, app);

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -268,8 +268,14 @@ pub(super) fn serve_router_on_listen_addr(
     connection_shutdown_timeout: Duration,
     address: ListenAddr,
     router: axum::Router,
+<<<<<<< HEAD
     main_graphql_port: bool,
     http_config: Http,
+=======
+    opt_max_headers: Option<usize>,
+    opt_max_buf_size: Option<ByteSize>,
+	opt_http_read_timeout: Duration,
+>>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
     all_connections_stopped_sender: mpsc::Sender<()>,
 ) -> (impl Future<Output = Listener>, oneshot::Sender<()>) {
     let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
@@ -354,7 +360,24 @@ pub(super) fn serve_router_on_listen_addr(
                                                 "this should not fail unless the socket is invalid",
                                             );
 
+<<<<<<< HEAD
                                         let connection = http_config.serve_connection(stream, app);
+=======
+                                        let mut builder = Builder::new(TokioExecutor::new());
+                                        let mut http_connection = builder.http1();
+                                        let http_config = http_connection
+                                                         .keep_alive(true)
+                                                         .timer(TokioTimer::new())
+                                                         .header_read_timeout(opt_http_read_timeout);
+                                        if let Some(max_headers) = opt_max_headers {
+                                            http_config.max_headers(max_headers);
+                                        }
+
+                                        if let Some(max_buf_size) = opt_max_buf_size {
+                                            http_config.max_buf_size(max_buf_size.as_u64() as usize);
+                                        }
+                                        let connection = http_config.serve_connection_with_upgrades(tokio_stream, hyper_service);
+>>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
                                         handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
 
                                     }
@@ -362,7 +385,28 @@ pub(super) fn serve_router_on_listen_addr(
                                     NetworkStream::Unix(stream) => {
                                         let received_first_request = Arc::new(AtomicBool::new(false));
                                         let app = IdleConnectionChecker::new(received_first_request.clone(), app);
+<<<<<<< HEAD
                                         let connection = http_config.serve_connection(stream, app);
+=======
+                                        let tokio_stream = TokioIo::new(stream);
+                                        let hyper_service = hyper::service::service_fn(move |request| {
+                                            app.clone().call(request)
+                                        });
+                                        let mut builder = Builder::new(TokioExecutor::new());
+                                        let mut http_connection = builder.http1();
+                                        let http_config = http_connection
+                                                         .keep_alive(true)
+                                                         .timer(TokioTimer::new())
+                                                         .header_read_timeout(opt_http_read_timeout);
+                                        if let Some(max_headers) = opt_max_headers {
+                                            http_config.max_headers(max_headers);
+                                        }
+
+                                        if let Some(max_buf_size) = opt_max_buf_size {
+                                            http_config.max_buf_size(max_buf_size.as_u64() as usize);
+                                        }
+                                        let connection = http_config.serve_connection_with_upgrades(tokio_stream, hyper_service);
+>>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
                                         handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
                                     },
                                     NetworkStream::Tls(stream) => {
@@ -378,6 +422,25 @@ pub(super) fn serve_router_on_listen_addr(
                                             let protocol = stream.get_ref().1.alpn_protocol();
                                             let http2 = protocol == Some(&b"h2"[..]);
 
+<<<<<<< HEAD
+=======
+                                        let tokio_stream = TokioIo::new(stream);
+                                        let hyper_service = hyper::service::service_fn(move |request| {
+                                            app.clone().call(request)
+                                        });
+                                        let mut http_connection = builder.http1();
+                                        let http_config = http_connection
+                                                         .keep_alive(true)
+                                                         .timer(TokioTimer::new())
+                                                         .header_read_timeout(opt_http_read_timeout);
+                                        if let Some(max_headers) = opt_max_headers {
+                                            http_config.max_headers(max_headers);
+                                        }
+
+                                        if let Some(max_buf_size) = opt_max_buf_size {
+                                            http_config.max_buf_size(max_buf_size.as_u64() as usize);
+                                        }
+>>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
                                         let connection = http_config
                                             .http2_only(http2)
                                             .serve_connection(stream, app);

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -275,11 +275,15 @@ pub(super) fn serve_router_on_listen_addr(
     opt_max_headers: Option<usize>,
     opt_max_buf_size: Option<ByteSize>,
 <<<<<<< HEAD
+<<<<<<< HEAD
 	opt_http_read_timeout: Duration,
 >>>>>>> bca998b2 (feat: use server header_read_timeout when creating http_connection)
 =======
     http_read_timeout: Duration,
 >>>>>>> de2127f5 (style: fix lint errors)
+=======
+    header_read_timeout: Duration,
+>>>>>>> f0aa17d8 (refactor: fix header_read_timeout variable name)
     all_connections_stopped_sender: mpsc::Sender<()>,
 ) -> (impl Future<Output = Listener>, oneshot::Sender<()>) {
     let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
@@ -372,7 +376,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let http_config = http_connection
                                                          .keep_alive(true)
                                                          .timer(TokioTimer::new())
-                                                         .header_read_timeout(http_read_timeout);
+                                                         .header_read_timeout(header_read_timeout);
                                         if let Some(max_headers) = opt_max_headers {
                                             http_config.max_headers(max_headers);
                                         }
@@ -401,7 +405,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let http_config = http_connection
                                                          .keep_alive(true)
                                                          .timer(TokioTimer::new())
-                                                         .header_read_timeout(http_read_timeout);
+                                                         .header_read_timeout(header_read_timeout);
                                         if let Some(max_headers) = opt_max_headers {
                                             http_config.max_headers(max_headers);
                                         }
@@ -436,7 +440,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let http_config = http_connection
                                                          .keep_alive(true)
                                                          .timer(TokioTimer::new())
-                                                         .header_read_timeout(http_read_timeout);
+                                                         .header_read_timeout(header_read_timeout);
                                         if let Some(max_headers) = opt_max_headers {
                                             http_config.max_headers(max_headers);
                                         }

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -45,6 +45,11 @@ use self::expansion::Expansion;
 pub(crate) use self::experimental::Discussed;
 pub(crate) use self::schema::generate_config_schema;
 pub(crate) use self::schema::generate_upgrade;
+<<<<<<< HEAD
+=======
+pub(crate) use self::schema::validate_yaml_configuration;
+use self::server::Server;
+>>>>>>> 8683f3a6 (feat: add server configuration to router config)
 use self::subgraph::SubgraphConfiguration;
 use crate::ApolloRouterError;
 use crate::cache::DEFAULT_CACHE_CAPACITY;
@@ -63,7 +68,12 @@ pub(crate) mod expansion;
 mod experimental;
 pub(crate) mod metrics;
 mod persisted_queries;
+<<<<<<< HEAD
 mod schema;
+=======
+pub(crate) mod schema;
+pub(crate) mod server;
+>>>>>>> 8683f3a6 (feat: add server configuration to router config)
 pub(crate) mod shared;
 pub(crate) mod subgraph;
 #[cfg(test)]
@@ -135,6 +145,10 @@ pub struct Configuration {
     /// Homepage configuration
     #[serde(default)]
     pub(crate) homepage: Homepage,
+
+    /// Configuration for the server
+    #[serde(default)]
+    pub(crate) server: Server,
 
     /// Configuration for the supergraph
     #[serde(default)]
@@ -208,6 +222,7 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             health_check: HealthCheck,
             sandbox: Sandbox,
             homepage: Homepage,
+            server: Server,
             supergraph: Supergraph,
             cors: Cors,
             plugins: UserPlugins,
@@ -238,6 +253,7 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             health_check: ad_hoc.health_check,
             sandbox: ad_hoc.sandbox,
             homepage: ad_hoc.homepage,
+            server: ad_hoc.server,
             supergraph: ad_hoc.supergraph,
             cors: ad_hoc.cors,
             tls: ad_hoc.tls,
@@ -291,12 +307,14 @@ impl Configuration {
         uplink: Option<UplinkConfig>,
         experimental_type_conditioned_fetching: Option<bool>,
         batching: Option<Batching>,
+        server: Option<Server>,
     ) -> Result<Self, ConfigurationError> {
         let notify = Self::notify(&apollo_plugins)?;
 
         let conf = Self {
             validated_yaml: Default::default(),
             supergraph: supergraph.unwrap_or_default(),
+            server: server.unwrap_or_default(),
             health_check: health_check.unwrap_or_default(),
             sandbox: sandbox.unwrap_or_default(),
             homepage: homepage.unwrap_or_default(),
@@ -426,9 +444,11 @@ impl Configuration {
         uplink: Option<UplinkConfig>,
         batching: Option<Batching>,
         experimental_type_conditioned_fetching: Option<bool>,
+        server: Option<Server>,
     ) -> Result<Self, ConfigurationError> {
         let configuration = Self {
             validated_yaml: Default::default(),
+            server: server.unwrap_or_default(),
             supergraph: supergraph.unwrap_or_else(|| Supergraph::fake_builder().build()),
             health_check: health_check.unwrap_or_else(|| HealthCheck::fake_builder().build()),
             sandbox: sandbox.unwrap_or_else(|| Sandbox::fake_builder().build()),

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -45,11 +45,7 @@ use self::expansion::Expansion;
 pub(crate) use self::experimental::Discussed;
 pub(crate) use self::schema::generate_config_schema;
 pub(crate) use self::schema::generate_upgrade;
-<<<<<<< HEAD
-=======
-pub(crate) use self::schema::validate_yaml_configuration;
 use self::server::Server;
->>>>>>> 8683f3a6 (feat: add server configuration to router config)
 use self::subgraph::SubgraphConfiguration;
 use crate::ApolloRouterError;
 use crate::cache::DEFAULT_CACHE_CAPACITY;
@@ -68,12 +64,8 @@ pub(crate) mod expansion;
 mod experimental;
 pub(crate) mod metrics;
 mod persisted_queries;
-<<<<<<< HEAD
 mod schema;
-=======
-pub(crate) mod schema;
 pub(crate) mod server;
->>>>>>> 8683f3a6 (feat: add server configuration to router config)
 pub(crate) mod shared;
 pub(crate) mod subgraph;
 #[cfg(test)]

--- a/apollo-router/src/configuration/server.rs
+++ b/apollo-router/src/configuration/server.rs
@@ -1,6 +1,8 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
 
 const DEFAULT_HEADER_READ_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -37,16 +39,6 @@ impl Default for ServerHttpConfig {
 }
 
 #[buildstructor::buildstructor]
-impl ServerHttpConfig {
-    #[builder]
-    pub(crate) fn new(header_read_timeout: Option<Duration>) -> Self {
-        Self {
-            header_read_timeout: header_read_timeout.unwrap_or_default(),
-        }
-    }
-}
-
-#[buildstructor::buildstructor]
 impl Server {
     #[builder]
     pub(crate) fn new(http: Option<ServerHttpConfig>) -> Self {
@@ -65,6 +57,7 @@ impl Default for Server {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -74,21 +67,6 @@ mod tests {
         assert_eq!(
             server_config.http.header_read_timeout,
             default_duration_seconds
-        );
-    }
-
-    #[test]
-    fn it_builds_custom_server_configuration() {
-        let duration_seconds = Duration::from_secs(30);
-        let http_config = ServerHttpConfig::builder()
-            .header_read_timeout(duration_seconds)
-            .build();
-        let server_config = Server::builder()
-            .http(http_config)
-            .build();
-        assert_eq!(
-            server_config.http.header_read_timeout,
-            duration_seconds
         );
     }
 
@@ -115,10 +93,10 @@ mod tests {
     #[test]
     fn it_json_parses_specified_server_config_seconds_correctly() {
         let json_config = json!({
-            "http": {
-                "header_read_timeout": "30s"
-            }
-         });
+           "http": {
+               "header_read_timeout": "30s"
+           }
+        });
 
         let config: Server = serde_json::from_value(json_config).unwrap();
 

--- a/apollo-router/src/configuration/server.rs
+++ b/apollo-router/src/configuration/server.rs
@@ -1,0 +1,140 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+const DEFAULT_HEADER_READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn default_header_read_timeout() -> Duration {
+    DEFAULT_HEADER_READ_TIMEOUT
+}
+
+/// Configuration for HTTP
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields, default)]
+pub(crate) struct ServerHttpConfig {
+    /// Header read timeout in human-readable format; defaults to 10s
+    #[serde(
+        deserialize_with = "humantime_serde::deserialize",
+        default = "default_header_read_timeout"
+    )]
+    #[schemars(with = "String", default = "default_header_read_timeout")]
+    pub(crate) header_read_timeout: Duration,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields, default)]
+pub(crate) struct Server {
+    /// The server http configuration
+    pub(crate) http: ServerHttpConfig,
+}
+
+impl Default for ServerHttpConfig {
+    fn default() -> Self {
+        Self {
+            header_read_timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+#[buildstructor::buildstructor]
+impl ServerHttpConfig {
+    #[builder]
+    pub(crate) fn new(header_read_timeout: Option<Duration>) -> Self {
+        Self {
+            header_read_timeout: header_read_timeout.unwrap_or_default(),
+        }
+    }
+}
+
+#[buildstructor::buildstructor]
+impl Server {
+    #[builder]
+    pub(crate) fn new(http: Option<ServerHttpConfig>) -> Self {
+        Self {
+            http: http.unwrap_or_default(),
+        }
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use super::*;
+
+    #[test]
+    fn it_builds_default_server_configuration() {
+        let default_duration_seconds = Duration::from_secs(10);
+        let server_config = Server::builder().build();
+        assert_eq!(
+            server_config.http.header_read_timeout,
+            default_duration_seconds
+        );
+    }
+
+    #[test]
+    fn it_builds_custom_server_configuration() {
+        let duration_seconds = Duration::from_secs(30);
+        let http_config = ServerHttpConfig::builder()
+            .header_read_timeout(duration_seconds)
+            .build();
+        let server_config = Server::builder()
+            .http(http_config)
+            .build();
+        assert_eq!(
+            server_config.http.header_read_timeout,
+            duration_seconds
+        );
+    }
+
+    #[test]
+    fn it_json_parses_default_header_read_timeout_when_server_http_config_omitted() {
+        let json_server = json!({});
+
+        let config: Server = serde_json::from_value(json_server).unwrap();
+
+        assert_eq!(config.http.header_read_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn it_json_parses_default_header_read_timeout_when_omitted() {
+        let json_config = json!({
+            "http": {}
+        });
+
+        let config: Server = serde_json::from_value(json_config).unwrap();
+
+        assert_eq!(config.http.header_read_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn it_json_parses_specified_server_config_seconds_correctly() {
+        let json_config = json!({
+            "http": {
+                "header_read_timeout": "30s"
+            }
+         });
+
+        let config: Server = serde_json::from_value(json_config).unwrap();
+
+        assert_eq!(config.http.header_read_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn it_json_parses_specified_server_config_minutes_correctly() {
+        let json_config = json!({
+            "http": {
+                "header_read_timeout": "1m"
+            }
+        });
+
+        let config: Server = serde_json::from_value(json_config).unwrap();
+
+        assert_eq!(config.http.header_read_timeout, Duration::from_secs(60));
+    }
+}

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -5326,8 +5326,35 @@ expression: "&schema"
         }
       ]
     },
+<<<<<<< HEAD
     "SocketEndpoint": {
       "type": "string"
+=======
+    "Server": {
+      "additionalProperties": false,
+      "properties": {
+        "http": {
+          "$ref": "#/definitions/ServerHttpConfig",
+          "description": "#/definitions/ServerHttpConfig"
+        }
+      },
+      "type": "object"
+    },
+    "ServerHttpConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for HTTP",
+      "properties": {
+        "header_read_timeout": {
+          "default": {
+            "nanos": 0,
+            "secs": 10
+          },
+          "description": "Header read timeout in human-readable format; defaults to 10s",
+          "type": "string"
+        }
+      },
+      "type": "object"
+>>>>>>> 1b195743 (test: update configuration test snapshot)
     },
     "Source": {
       "oneOf": [
@@ -8358,6 +8385,10 @@ expression: "&schema"
     "sandbox": {
       "$ref": "#/definitions/Sandbox",
       "description": "#/definitions/Sandbox"
+    },
+    "server": {
+      "$ref": "#/definitions/Server",
+      "description": "#/definitions/Server"
     },
     "subscription": {
       "$ref": "#/definitions/SubscriptionConfig",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -5326,10 +5326,6 @@ expression: "&schema"
         }
       ]
     },
-<<<<<<< HEAD
-    "SocketEndpoint": {
-      "type": "string"
-=======
     "Server": {
       "additionalProperties": false,
       "properties": {
@@ -5354,7 +5350,9 @@ expression: "&schema"
         }
       },
       "type": "object"
->>>>>>> 1b195743 (test: update configuration test snapshot)
+    },
+    "SocketEndpoint": {
+      "type": "string"
     },
     "Source": {
       "oneOf": [

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -1122,7 +1122,10 @@ fn it_includes_default_header_read_timeout_when_server_config_omitted() {
 
     let config: Configuration = serde_json::from_value(json_config).unwrap();
 
-    assert_eq!(config.server.http.header_read_timeout, Duration::from_secs(10));
+    assert_eq!(
+        config.server.http.header_read_timeout,
+        Duration::from_secs(10)
+    );
 }
 
 #[test]
@@ -1137,7 +1140,10 @@ fn it_processes_specified_server_config_correctly() {
 
     let config: Configuration = serde_json::from_value(json_config).unwrap();
 
-    assert_eq!(config.server.http.header_read_timeout, Duration::from_secs(30));
+    assert_eq!(
+        config.server.http.header_read_timeout,
+        Duration::from_secs(30)
+    );
 }
 
 fn has_field_level_serde_defaults(lines: &[&str], line_number: usize) -> bool {

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -1116,6 +1116,30 @@ fn it_processes_specified_maximum_batch_limit_correctly() {
     assert_eq!(config.maximum_size, Some(10));
 }
 
+#[test]
+fn it_includes_default_header_read_timeout_when_server_config_omitted() {
+    let json_config = json!({});
+
+    let config: Configuration = serde_json::from_value(json_config).unwrap();
+
+    assert_eq!(config.server.http.header_read_timeout, Duration::from_secs(10));
+}
+
+#[test]
+fn it_processes_specified_server_config_correctly() {
+    let json_config = json!({
+        "server": {
+            "http": {
+                "header_read_timeout": "30s"
+            }
+        }
+    });
+
+    let config: Configuration = serde_json::from_value(json_config).unwrap();
+
+    assert_eq!(config.server.http.header_read_timeout, Duration::from_secs(30));
+}
+
 fn has_field_level_serde_defaults(lines: &[&str], line_number: usize) -> bool {
     let serde_field_default = Regex::new(
         r#"^\s*#[\s\n]*\[serde\s*\((.*,)?\s*default\s*=\s*"[a-zA-Z0-9_:]+"\s*(,.*)?\)\s*\]\s*$"#,

--- a/docs/source/routing/configuration.mdx
+++ b/docs/source/routing/configuration.mdx
@@ -1211,6 +1211,18 @@ traffic_shaping:
     timeout: 60s
 ```
 
+### Header Read Timeout
+
+The header read timeout is the amount of time the Router will wait to receive the complete request headers from a client before timing out. It applies both when the connection is fully idle and when a request has been started but sending the headers has not been completed.
+
+By default, the header read timeout is set to 10 seconds. A longer timeout can be configured using the `server.http.header_read_timeout` configuration option.
+
+```yaml title="router.yaml"
+server:
+  http:
+    header_read_timeout: 30s
+```
+
 ### Plugins
 
 You can customize the router's behavior with [plugins](/router/customizations/overview). Each plugin can have its own section in the configuration file with arbitrary values:


### PR DESCRIPTION
This change exposes the server's header read timeout as the `server.http.header_read_timeout` configuration option.

By default, the `server.http.header_read_timeout` is set to previously hard-coded 10 seconds. A longer timeout can be configured using the `server.http.header_read_timeout` option.

```yaml title="router.yaml"
server:
  http:
    header_read_timeout: 30s
```

<!-- [ROUTER-1275] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7262 done by [Mergify](https://mergify.com).

[ROUTER-1275]: https://apollographql.atlassian.net/browse/ROUTER-1275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ