### PR TITLE
feat: update fred to 10.1, add timeouts and connection health checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
  "rstest",
  "rust-embed",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pemfile",
  "ryu",
  "schemars",
@@ -1046,7 +1046,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tower 0.5.2",
@@ -1886,16 +1886,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
@@ -2002,15 +1992,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2559,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -2658,24 +2639,24 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fred"
-version = "9.4.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdd5378252ea124b712e0ac55147d26ae3af575883b34b8423091a4c719606b"
+checksum = "3a7b2fd0f08b23315c13b6156f971aeedb6f75fb16a29ac1872d2eabccc1490e"
 dependencies = [
  "arc-swap",
  "async-trait",
  "bytes",
  "bytes-utils",
- "crossbeam-queue",
  "float-cmp",
  "fred-macros",
  "futures",
+ "glob-match",
  "log",
  "parking_lot",
  "rand 0.8.5",
  "redis-protocol",
  "rustls",
- "rustls-native-certs 0.7.3",
+ "rustls-native-certs",
  "semver",
  "socket2",
  "tokio",
@@ -2931,6 +2912,12 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "glob-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "globset"
@@ -3445,7 +3432,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -5434,9 +5421,9 @@ dependencies = [
 
 [[package]]
 name = "redis-protocol"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65deb7c9501fbb2b6f812a30d59c0253779480853545153a51d8e9e444ddc99f"
+checksum = "9cdba59219406899220fc4cdfd17a95191ba9c9afb719b5fa5a083d63109a9f1"
 dependencies = [
  "bytes",
  "bytes-utils",
@@ -5550,7 +5537,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -5909,19 +5896,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
@@ -5929,7 +5903,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.0.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -6039,25 +6013,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6821,7 +6782,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -6903,7 +6864,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.4",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pemfile",
  "socket2",
  "tokio",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -92,7 +92,7 @@ dhat = { version = "0.3.3", optional = true }
 diff = "0.1.13"
 displaydoc = "0.2"
 flate2 = "1.0.30"
-fred = { version = "9.4.0", features = ["enable-rustls", "i-cluster"] }
+fred = { version = "10.1.0", features = ["enable-rustls", "i-cluster", "tcp-user-timeouts"] }
 futures = { version = "0.3.30", features = ["thread-pool"] }
 graphql_client = "0.14.0"
 hex.workspace = true
@@ -277,7 +277,7 @@ tikv-jemallocator = "0.6.0"
 axum = { version = "0.8.1", features = ["http2", "ws"] }
 axum-server = "0.7.1"
 ecdsa = { version = "0.16.9", features = ["signing", "pem", "pkcs8"] }
-fred = { version = "9.4.0", features = ["enable-rustls", "mocks", "i-cluster"] }
+fred = { version = "10.1.0", features = ["enable-rustls", "mocks", "i-cluster", "tcp-user-timeouts"] }
 futures-test = "0.3.30"
 insta.workspace = true
 maplit = "1.0.2"

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -9,20 +9,19 @@ use fred::interfaces::EventInterface;
 #[cfg(test)]
 use fred::mocks::Mocks;
 use fred::prelude::ClientLike;
+use fred::prelude::Error as RedisError;
+use fred::prelude::ErrorKind as RedisErrorKind;
 use fred::prelude::KeysInterface;
-use fred::prelude::RedisClient;
-use fred::prelude::RedisError;
-use fred::prelude::RedisErrorKind;
-use fred::prelude::RedisPool;
-use fred::types::ClusterRouting;
-use fred::types::Expiration;
-use fred::types::FromRedis;
-use fred::types::PerformanceConfig;
-use fred::types::ReconnectPolicy;
-use fred::types::RedisConfig;
-use fred::types::ScanResult;
-use fred::types::TlsConfig;
-use fred::types::TlsHostMapping;
+use fred::prelude::Pool as RedisPool;
+use fred::prelude::{Client as RedisClient, TcpConfig};
+use fred::types::FromValue;
+use fred::types::cluster::ClusterRouting;
+use fred::types::config::ReconnectPolicy;
+use fred::types::config::TlsConfig;
+use fred::types::config::TlsHostMapping;
+use fred::types::config::{Config as RedisConfig, UnresponsiveConfig};
+use fred::types::scan::ScanResult;
+use fred::types::{Builder, Expiration};
 use futures::FutureExt;
 use futures::Stream;
 use tower::BoxError;
@@ -41,6 +40,9 @@ const SUPPORTED_REDIS_SCHEMES: [&str; 6] = [
     "redis-sentinel",
     "rediss-sentinel",
 ];
+
+/// Timeout applied to internal Redis operations, such as TCP connection initialization, TLS handshakes, AUTH or HELLO, cluster health checks, etc.
+const DEFAULT_INTERNAL_REDIS_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct RedisKey<K>(pub(crate) K)
@@ -104,7 +106,7 @@ where
     }
 }
 
-impl<K> From<RedisKey<K>> for fred::types::RedisKey
+impl<K> From<RedisKey<K>> for fred::types::Key
 where
     K: KeyType,
 {
@@ -122,13 +124,13 @@ where
     }
 }
 
-impl<V> FromRedis for RedisValue<V>
+impl<V> FromValue for RedisValue<V>
 where
     V: ValueType,
 {
-    fn from_value(value: fred::types::RedisValue) -> Result<Self, RedisError> {
+    fn from_value(value: fred::types::Value) -> Result<Self, RedisError> {
         match value {
-            fred::types::RedisValue::Bytes(data) => {
+            fred::types::Value::Bytes(data) => {
                 serde_json::from_slice(&data).map(RedisValue).map_err(|e| {
                     RedisError::new(
                         RedisErrorKind::Parse,
@@ -136,7 +138,7 @@ where
                     )
                 })
             }
-            fred::types::RedisValue::String(s) => {
+            fred::types::Value::String(s) => {
                 serde_json::from_str(&s).map(RedisValue).map_err(|e| {
                     RedisError::new(
                         RedisErrorKind::Parse,
@@ -144,9 +146,7 @@ where
                     )
                 })
             }
-            fred::types::RedisValue::Null => {
-                Err(RedisError::new(RedisErrorKind::NotFound, "not found"))
-            }
+            fred::types::Value::Null => Err(RedisError::new(RedisErrorKind::NotFound, "not found")),
             _res => Err(RedisError::new(
                 RedisErrorKind::Parse,
                 "the data is the wrong type",
@@ -155,13 +155,13 @@ where
     }
 }
 
-impl<V> TryInto<fred::types::RedisValue> for RedisValue<V>
+impl<V> TryInto<fred::types::Value> for RedisValue<V>
 where
     V: ValueType,
 {
     type Error = RedisError;
 
-    fn try_into(self) -> Result<fred::types::RedisValue, Self::Error> {
+    fn try_into(self) -> Result<fred::types::Value, Self::Error> {
         let v = serde_json::to_vec(&self.0).map_err(|e| {
             tracing::error!("couldn't serialize value to redis {}. This is a bug in the router, please file an issue: https://github.com/apollographql/router/issues/new", e);
             RedisError::new(
@@ -170,7 +170,7 @@ where
             )
         })?;
 
-        Ok(fred::types::RedisValue::Bytes(v.into()))
+        Ok(fred::types::Value::Bytes(v.into()))
     }
 }
 
@@ -198,7 +198,7 @@ impl RedisCacheStorage {
             let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_client_config));
 
             client_config.tls = Some(TlsConfig {
-                connector: fred::types::TlsConnector::Rustls(connector),
+                connector: fred::types::config::TlsConnector::Rustls(connector),
                 hostnames: TlsHostMapping::None,
             });
         }
@@ -247,17 +247,25 @@ impl RedisCacheStorage {
         is_cluster: bool,
         caller: &'static str,
     ) -> Result<Self, BoxError> {
-        let pooled_client = RedisPool::new(
-            client_config,
-            Some(PerformanceConfig {
-                default_command_timeout: timeout,
-                ..Default::default()
-            }),
-            None,
-            Some(ReconnectPolicy::new_exponential(0, 1, 2000, 5)),
-            pool_size,
-        )?;
-        let _handle = pooled_client.connect();
+        let pooled_client = Builder::from_config(client_config)
+            .with_connection_config(|config| {
+                config.internal_command_timeout = DEFAULT_INTERNAL_REDIS_TIMEOUT;
+                config.reconnect_on_auth_error = true;
+                config.tcp = TcpConfig {
+                    #[cfg(target_os = "linux")]
+                    user_timeout: Some(timeout),
+                    ..Default::default()
+                };
+                config.unresponsive = UnresponsiveConfig {
+                    max_timeout: Some(DEFAULT_INTERNAL_REDIS_TIMEOUT),
+                    interval: Duration::from_secs(3),
+                };
+            })
+            .with_performance_config(|config| {
+                config.default_command_timeout = timeout;
+            })
+            .set_policy(ReconnectPolicy::new_exponential(0, 1, 2000, 5))
+            .build_pool(pool_size)?;
 
         for client in pooled_client.clients() {
             // spawn tasks that listen for connection close or reconnect events
@@ -273,8 +281,12 @@ impl RedisCacheStorage {
             );
 
             tokio::spawn(async move {
-                while let Ok(error) = error_rx.recv().await {
-                    tracing::error!("Client disconnected with error: {:?}", error);
+                while let Ok((error, server)) = error_rx.recv().await {
+                    tracing::error!(
+                        "Client disconnected from {:?} with error: {:?}",
+                        server,
+                        error
+                    );
                 }
             });
             tokio::spawn(async move {
@@ -291,13 +303,7 @@ impl RedisCacheStorage {
             });
         }
 
-        // a TLS connection to a TCP Redis could hang, so we add a timeout
-        tokio::time::timeout(Duration::from_secs(5), pooled_client.wait_for_connect())
-            .await
-            .map_err(|_| {
-                RedisError::new(RedisErrorKind::Timeout, "timeout connecting to Redis")
-            })??;
-
+        let _handle = pooled_client.init().await?;
         tracing::trace!("redis connection established");
         Ok(Self {
             inner: Arc::new(DropSafeRedisPool(Arc::new(pooled_client))),
@@ -421,7 +427,7 @@ impl RedisCacheStorage {
                 let pipeline: fred::clients::Pipeline<RedisClient> = self.inner.next().pipeline();
                 let key = self.make_key(key);
                 let res = pipeline
-                    .get::<fred::types::RedisValue, _>(&key)
+                    .get::<fred::types::Value, _>(&key)
                     .await
                     .map_err(|e| {
                         if !e.is_not_found() {
@@ -434,8 +440,8 @@ impl RedisCacheStorage {
                     tracing::error!("could not queue GET command");
                     return None;
                 }
-                let res: fred::types::RedisValue = pipeline
-                    .expire(&key, ttl.as_secs() as i64)
+                let res: fred::types::Value = pipeline
+                    .expire(&key, ttl.as_secs() as i64, None)
                     .await
                     .map_err(|e| {
                         if !e.is_not_found() {
@@ -607,11 +613,8 @@ impl RedisCacheStorage {
 
     /// Delete keys *without* adding the `namespace` prefix because `keys` is from
     /// `scan_with_namespaced_results` and already includes it.
-    pub(crate) async fn delete_from_scan_result(
-        &self,
-        keys: Vec<fred::types::RedisKey>,
-    ) -> Option<u32> {
-        let mut h: HashMap<u16, Vec<fred::types::RedisKey>> = HashMap::new();
+    pub(crate) async fn delete_from_scan_result(&self, keys: Vec<fred::types::Key>) -> Option<u32> {
+        let mut h: HashMap<u16, Vec<fred::types::Key>> = HashMap::new();
         for key in keys.into_iter() {
             let hash = ClusterRouting::hash_key(key.as_bytes());
             let entry = h.entry(hash).or_default();
@@ -675,7 +678,7 @@ mod test {
             time: std::time::UNIX_EPOCH - std::time::Duration::new(1, 0),
         });
 
-        let as_value: Result<fred::types::RedisValue, _> = invalid_json_payload.try_into();
+        let as_value: Result<fred::types::Value, _> = invalid_json_payload.try_into();
 
         assert!(as_value.is_err());
     }

--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use fred::error::RedisError;
-use fred::types::Scanner;
+use fred::error::Error as RedisError;
+use fred::types::scan::Scanner;
 use futures::StreamExt;
 use futures::stream;
 use itertools::Itertools;
@@ -133,7 +133,7 @@ impl Invalidation {
                             count += deleted;
                         }
                     }
-                    scan_res.next()?;
+                    scan_res.next();
                 }
             }
         }

--- a/apollo-router/src/plugins/cache/tests.rs
+++ b/apollo-router/src/plugins/cache/tests.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use apollo_compiler::Schema;
 use bytes::Bytes;
-use fred::error::RedisErrorKind;
+use fred::error::ErrorKind as RedisErrorKind;
 use fred::mocks::MockCommand;
 use fred::mocks::Mocks;
-use fred::prelude::RedisError;
-use fred::prelude::RedisValue;
+use fred::prelude::Error as RedisError;
+use fred::prelude::Value as RedisValue;
 use http::HeaderValue;
 use http::header::CACHE_CONTROL;
 use parking_lot::Mutex;

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -8,12 +8,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use buildstructor::buildstructor;
-use fred::clients::RedisClient;
+use fred::clients::Client as RedisClient;
 use fred::interfaces::ClientLike;
 use fred::interfaces::KeysInterface;
-use fred::prelude::RedisConfig;
-use fred::types::ScanType;
-use fred::types::Scanner;
+use fred::prelude::Config as RedisConfig;
+use fred::types::scan::ScanType;
+use fred::types::scan::Scanner;
 use futures::StreamExt;
 use http::header::ACCEPT;
 use http::header::CONTENT_TYPE;

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -28,9 +28,12 @@ use apollo_router::plugin::test::MockSubgraph;
 use apollo_router::services::router;
 use apollo_router::services::supergraph;
 use fred::cmd;
+use fred::prelude::Client as RedisClient;
+use fred::prelude::Config as RedisConfig;
+use fred::prelude::Value as RedisValue;
 use fred::prelude::*;
-use fred::types::ScanType;
-use fred::types::Scanner;
+use fred::types::scan::ScanType;
+use fred::types::scan::Scanner;
 use futures::StreamExt;
 use http::HeaderValue;
 use http::Method;
@@ -58,8 +61,7 @@ async fn query_planner_cache() -> Result<(), BoxError> {
 
     let config = RedisConfig::from_url("redis://127.0.0.1:6379").unwrap();
     let client = RedisClient::new(config, None, None, None);
-    let connection_task = client.connect();
-    client.wait_for_connect().await.unwrap();
+    let connection_task = client.init().await.unwrap();
 
     client.del::<String, _>(known_cache_key).await.unwrap();
 
@@ -193,8 +195,7 @@ async fn apq() -> Result<(), BoxError> {
 
     let config = RedisConfig::from_url("redis://127.0.0.1:6379").unwrap();
     let client = RedisClient::new(config, None, None, None);
-    let connection_task = client.connect();
-    client.wait_for_connect().await.unwrap();
+    let connection_task = client.init().await.unwrap();
 
     let config = json!({
         "apq": {
@@ -337,8 +338,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
 
     let config = RedisConfig::from_url("redis://127.0.0.1:6379").unwrap();
     let client = RedisClient::new(config, None, None, None);
-    let connection_task = client.connect();
-    client.wait_for_connect().await.unwrap();
+    let connection_task = client.init().await.unwrap();
 
     let mut subgraphs = MockedSubgraphs::default();
     subgraphs.insert(
@@ -593,8 +593,7 @@ async fn entity_cache_authorization() -> Result<(), BoxError> {
 
     let config = RedisConfig::from_url("redis://127.0.0.1:6379").unwrap();
     let client = RedisClient::new(config, None, None, None);
-    let connection_task = client.connect();
-    client.wait_for_connect().await.unwrap();
+    let connection_task = client.init().await.unwrap();
 
     let mut subgraphs = MockedSubgraphs::default();
     subgraphs.insert(


### PR DESCRIPTION
* Update `fred` to 10.1.0
* Adds some configuration options to improve client resiliency under various failure modes (TCP failures and timeouts, unresponsive sockets, Redis server failures, etc)
* Refactor client initialization

Notes:
* Fred v10 has significantly improved write throughput vs v9, but I didn't add any specific tests or benchmarks in this repo related to benchmarking. Let me know if you'd like to see that added though.
* This PR removes the timeout on `wait_for_connect` in `RedisCacheStorage::create_client`. The `internal_command_timeout` and `unresponsive` config fields should handle timeouts on connection creation, so hopefully that's not necessary. If you find you still need that timeout please let me know, I'd consider that a bug in the client.

Fixes [#**6855**](https://github.com/apollographql/router/issues/6855)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
