### PR TITLE
Fix metric `apollo.router.operations.batching.size` (backport #7306)

### DIFF
--- a/.changesets/fix_bnjjj_rh_845.md
+++ b/.changesets/fix_bnjjj_rh_845.md
@@ -1,0 +1,5 @@
+### Avoid fractional decimals when generating `apollo.router.operations.batching.size` metrics for GraphQL request batch sizes ([PR #7306](https://github.com/apollographql/router/pull/7306))
+
+Correct the calculation of the `apollo.router.operations.batching.size` metric to reflect accurate batch sizes rather than occasionally returning fractional numbers.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/7306

--- a/apollo-router/src/graphql/request.rs
+++ b/apollo-router/src/graphql/request.rs
@@ -199,7 +199,7 @@ impl Request {
             u64_histogram!(
                 "apollo.router.operations.batching.size",
                 "Number of queries contained within each query batch",
-                result.len() as u64,
+                entries.len() as u64,
                 mode = BatchingMode::BatchHttpLink.to_string() // Only supported mode right now
             );
 
@@ -227,7 +227,7 @@ impl Request {
             u64_histogram!(
                 "apollo.router.operations.batching.size",
                 "Number of queries contained within each query batch",
-                result.len() as u64,
+                entries.len() as u64,
                 mode = BatchingMode::BatchHttpLink.to_string() // Only supported mode right now
             );
 

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -290,12 +290,35 @@ async fn it_processes_a_valid_query_batch() {
             .await
             .unwrap()
     }
+<<<<<<< HEAD
     // Send a request
     let response = with_config().await.response;
     assert_eq!(response.status(), http::StatusCode::OK);
     let data: serde_json::Value =
         serde_json::from_slice(&get_body_bytes(response.into_body()).await.unwrap()).unwrap();
     assert_eq!(expected_response, data);
+=======
+    async move {
+        // Send a request
+        let response = with_config().await.response;
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let data: serde_json::Value = serde_json::from_slice(
+            &router::body::into_bytes(response.into_body())
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(expected_response, data);
+
+        assert_histogram_sum!(
+            "apollo.router.operations.batching.size",
+            3,
+            "mode" = "batch_http_link"
+        );
+    }
+    .with_metrics()
+    .await;
+>>>>>>> 517ec16f (Fix metric `apollo.router.operations.batching.size` (#7306))
 }
 
 #[tokio::test]

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -16,6 +16,7 @@ use tower_service::Service;
 
 use crate::Context;
 use crate::graphql;
+use crate::metrics::FutureMetricsExt;
 use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
@@ -290,26 +291,14 @@ async fn it_processes_a_valid_query_batch() {
             .await
             .unwrap()
     }
-<<<<<<< HEAD
-    // Send a request
-    let response = with_config().await.response;
-    assert_eq!(response.status(), http::StatusCode::OK);
-    let data: serde_json::Value =
-        serde_json::from_slice(&get_body_bytes(response.into_body()).await.unwrap()).unwrap();
-    assert_eq!(expected_response, data);
-=======
+
     async move {
         // Send a request
         let response = with_config().await.response;
         assert_eq!(response.status(), http::StatusCode::OK);
-        let data: serde_json::Value = serde_json::from_slice(
-            &router::body::into_bytes(response.into_body())
-                .await
-                .unwrap(),
-        )
-        .unwrap();
+        let data: serde_json::Value =
+            serde_json::from_slice(&get_body_bytes(response.into_body()).await.unwrap()).unwrap();
         assert_eq!(expected_response, data);
-
         assert_histogram_sum!(
             "apollo.router.operations.batching.size",
             3,
@@ -318,7 +307,6 @@ async fn it_processes_a_valid_query_batch() {
     }
     .with_metrics()
     .await;
->>>>>>> 517ec16f (Fix metric `apollo.router.operations.batching.size` (#7306))
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fix the metric `apollo.router.operations.batching.size`, it will now contain the right batch size.


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1256]: https://apollographql.atlassian.net/browse/ROUTER-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #7306 done by [Mergify](https://mergify.com).