### PR TITLE
Account for spec aliases/imports when auto-injecting `link` spec directives/types

### DIFF
--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -4,11 +4,13 @@ use std::sync::LazyLock;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast;
+use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::DirectiveLocation;
 use apollo_compiler::ast::Type;
 use apollo_compiler::name;
 use apollo_compiler::schema::Component;
 use apollo_compiler::ty;
+use itertools::Itertools;
 
 use crate::bail;
 use crate::error::FederationError;
@@ -17,7 +19,10 @@ use crate::error::MultiTryAll;
 use crate::error::SingleFederationError;
 use crate::link::DEFAULT_IMPORT_SCALAR_NAME;
 use crate::link::DEFAULT_PURPOSE_ENUM_NAME;
+use crate::link::Import;
 use crate::link::Link;
+use crate::link::argument::directive_optional_list_argument;
+use crate::link::argument::directive_optional_string_argument;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
 use crate::link::spec::Version;
@@ -132,7 +137,7 @@ impl LinkSpecDefinition {
         schema: &mut FederationSchema,
         alias: Option<Name>,
     ) -> Result<(), FederationError> {
-        self.add_definitions_to_schema(schema, alias.clone())?;
+        self.add_definitions_to_schema(schema, alias.clone(), vec![])?;
 
         // This adds `@link(url: "https://specs.apollo.dev/link/v1.0")` to the "schema" definition.
         // And we have a choice to add it either the main definition, or to an `extend schema`.
@@ -174,15 +179,46 @@ impl LinkSpecDefinition {
             }));
         }
         SchemaDefinitionPosition
-            .insert_directive(schema, Component::new(ast::Directive { name, arguments }))?;
+            .insert_directive(schema, Component::new(Directive { name, arguments }))?;
         Ok(())
+    }
+
+    pub(crate) fn extract_alias_and_imports_on_missing_link_directive_definition(
+        application: &Node<Directive>,
+    ) -> Result<(Option<Name>, Vec<Arc<Import>>), FederationError> {
+        // PORT_NOTE: This is really logic encapsulated from onMissingDirectiveDefinition() in the
+        // JS codebase's FederationBlueprint, but moved here since it's all link-specific. The logic
+        // itself has a lot of problems, but we're porting it as-is for now, and we'll address the
+        // problems with it in a later version bump.
+        let url =
+            directive_optional_string_argument(application, &LINK_DIRECTIVE_URL_ARGUMENT_NAME)?;
+        if let Some(url) = url {
+            if url.starts_with(&LinkSpecDefinition::latest().url.identity.to_string()) {
+                let alias = directive_optional_string_argument(
+                    application,
+                    &LINK_DIRECTIVE_AS_ARGUMENT_NAME,
+                )?
+                .map(Name::new)
+                .transpose()?;
+                let imports = directive_optional_list_argument(
+                    application,
+                    &LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
+                )?
+                .into_iter()
+                .flatten()
+                .map(|value| Ok::<_, FederationError>(Arc::new(Import::from_value(value)?)))
+                .process_results(|r| r.collect::<Vec<_>>())?;
+                return Ok((alias, imports));
+            }
+        }
+        Ok((None, vec![]))
     }
 
     pub(crate) fn add_definitions_to_schema(
         &self,
         schema: &mut FederationSchema,
         alias: Option<Name>,
-        // imports: Vec<Import>, // Used by `onMissingDirectiveDefinition` in JS (FED-428)
+        imports: Vec<Arc<Import>>,
     ) -> Result<(), FederationError> {
         if let Some(metadata) = schema.metadata() {
             let link_spec_def = metadata.link_spec_definition()?;
@@ -207,7 +243,7 @@ impl LinkSpecDefinition {
         let mock_link = Arc::new(Link {
             url: self.url.clone(),
             spec_alias: alias,
-            imports: vec![], // TODO (FED-428)
+            imports,
             purpose: None,
         });
         Ok(())

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use apollo_compiler::Name;
+use apollo_compiler::Node;
 use apollo_compiler::Schema;
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::NamedType;
@@ -55,11 +56,14 @@ impl FederationBlueprint {
 
     pub(crate) fn on_missing_directive_definition(
         schema: &mut FederationSchema,
-        directive: &Directive,
+        directive: &Node<Directive>,
     ) -> Result<Option<DirectiveDefinitionPosition>, FederationError> {
         if directive.name == DEFAULT_LINK_NAME {
-            // TODO (FED-428): pass `alias` and `imports`
-            LinkSpecDefinition::latest().add_definitions_to_schema(schema, /*alias*/ None)?;
+            let (alias, imports) =
+                LinkSpecDefinition::extract_alias_and_imports_on_missing_link_directive_definition(
+                    directive,
+                )?;
+            LinkSpecDefinition::latest().add_definitions_to_schema(schema, alias, imports)?;
             Ok(schema.get_directive_definition(&directive.name))
         } else {
             Ok(None)


### PR DESCRIPTION
When the `@link` directive definition is missing, we have some logic that automatically adds the `link` spec's type/directive definitions to the schema. We weren't accounting for the link spec's aliases/imports when doing this, while the JS codebase was, so we've ported that logic here. Note that this logic has several bugs, but we're going to port it as-is for now and address the bugs later.

<!-- FED-541 -->