### PR TITLE
docs: trace exporters (backport #7367)

### DIFF
--- a/docs/source/routing/observability/telemetry/trace-exporters/datadog.mdx
+++ b/docs/source/routing/observability/telemetry/trace-exporters/datadog.mdx
@@ -1,14 +1,15 @@
 ---
-title: Datadog exporter (via OTLP)
-subtitle: Configure the Datadog exporter for tracing
-description: Configure the Datadog exporter for tracing via OpenTelemetry Protocol (OTLP) in the Apollo GraphOS Router or Apollo Router Core.
+title: Datadog configuration of OTLP exporter
+subtitle: Configure the OTLP trace exporter for Datadog
+description: Configure the OpenTelemetry Protocol (OTLP) trace exporter for Datadog in the Apollo GraphOS Router or Apollo Router Core.
 context:
   - telemetry
 ---
+
 import BatchProcessorPreamble from '../../../../../shared/batch-processor-preamble.mdx';
 import BatchProcessorRef from '../../../../../shared/batch-processor-ref.mdx';
 
-Enable and configure the [Datadog](https://www.datadoghq.com/) exporter for tracing in the GraphOS Router or Apollo Router Core.
+This tracing exporter is a configuration of the [OTLP exporter](/graphos/routing/observability/trace-exporters/otlp) to use with [Datadog](https://www.datadoghq.com/).
 
 For general tracing configuration, refer to [Router Tracing Configuration](/router/configuration/telemetry/exporters/tracing/overview).
 

--- a/docs/source/routing/observability/telemetry/trace-exporters/dynatrace.mdx
+++ b/docs/source/routing/observability/telemetry/trace-exporters/dynatrace.mdx
@@ -1,12 +1,12 @@
 ---
-title: Dynatrace exporter (via OTLP)
-subtitle: Configure the Dynatrace exporter for tracing
-description: Configure the Dynatrace exporter for tracing via OpenTelemetry Protocol (OTLP) in the Apollo Router.
+title: Dynatrace configuration of OTLP exporter
+subtitle: Configure the OTLP trace exporter for Dynatrace
+description: Configure the OpenTelemetry Protocol (OTLP) trace exporter for Dynatrace in the Apollo GraphOS Router or Apollo Router Core.
 context:
   - telemetry
 ---
 
-Enable and configure the [OTLP exporter](/router/configuration/telemetry/exporters/tracing/otlp) for tracing in the Apollo Router for use with [Dynatrace](https://dynatrace.com/).
+This tracing exporter is a configuration of the [OTLP exporter](/graphos/routing/observability/trace-exporters/otlp) to use with [Dynatrace](https://dynatrace.com/).
 
 For general tracing configuration, refer to [Router Tracing Configuration](/router/configuration/telemetry/exporters/tracing/overview).
 

--- a/docs/source/routing/observability/telemetry/trace-exporters/jaeger.mdx
+++ b/docs/source/routing/observability/telemetry/trace-exporters/jaeger.mdx
@@ -1,15 +1,19 @@
 ---
-title: Jaeger exporter (via OTLP)
-subtitle: Configure the Jaeger exporter for tracing
-description: Configure the Jaeger exporter for tracing via OpenTelemetry Protocol (OTLP) in the Apollo GraphOS Router or Apollo Router Core.
+title: Jaeger configuration of OTLP exporter
+subtitle: Configure the OTLP trace exporter for Jaeger
+description: Configure the OpenTelemetry Protocol (OTLP) trace exporter for Jaeger in the Apollo GraphOS Router or Apollo Router Core.
 context:
   - telemetry
 ---
 
+<<<<<<< HEAD
 import BatchProcessorPreamble from '../../../../../shared/batch-processor-preamble.mdx';
 import BatchProcessorRef from '../../../../../shared/batch-processor-ref.mdx';
 
 Enable and configure the [Jaeger exporter](https://www.jaegertracing.io/) for tracing in the GraphOS Router or Apollo Router Core.
+=======
+This tracing exporter is a configuration of the [OTLP exporter](/graphos/routing/observability/trace-exporters/otlp) to use with [Jaeger](https://www.jaegertracing.io/).
+>>>>>>> 31df9858 (DOC-391 clarify tracing exporters configs of OTLP)
 
 For general tracing configuration, refer to [Router Tracing Configuration](/router/configuration/telemetry/exporters/tracing/overview).
 

--- a/docs/source/routing/observability/telemetry/trace-exporters/new-relic.mdx
+++ b/docs/source/routing/observability/telemetry/trace-exporters/new-relic.mdx
@@ -1,12 +1,12 @@
 ---
-title: New Relic exporter (via OTLP)
-subtitle: Configure the New Relic exporter for tracing
-description: Configure the New Relic exporter for tracing via OpenTelemetry Protocol (OTLP) in the Apollo GraphOS Router or Apollo Router Core.
+title: New Relic configuration of OTLP exporter
+subtitle: Configure the OTLP trace exporter for New Relic
+description: Configure the OpenTelemetry Protocol (OTLP) trace exporter for New Relic in the Apollo GraphOS Router or Apollo Router Core.
 context:
   - telemetry
 ---
 
-Enable and configure the [OTLP exporter](/router/configuration/telemetry/exporters/tracing/otlp) for tracing in the GraphOS Router or Apollo Router Core for use with [New Relic](https://newrelic.com/).
+This tracing exporter is a configuration of the [OTLP exporter](/graphos/routing/observability/trace-exporters/otlp) to use with [New Relic](https://newrelic.com/).
 
 For general tracing configuration, refer to [Router Tracing Configuration](/router/configuration/telemetry/exporters/tracing/overview).
 

--- a/docs/source/routing/observability/telemetry/trace-exporters/overview.mdx
+++ b/docs/source/routing/observability/telemetry/trace-exporters/overview.mdx
@@ -8,12 +8,11 @@ context:
 
 Apollo Router supports a collection of tracing exporters:
 
-* [OpenTelemetry Protocol (OTLP)](/router/configuration/telemetry/exporters/tracing/otlp) over HTTP or gRPC. Configurations of the OTLP trace exporter are provided for:
-    * [Datadog](/router/configuration/telemetry/exporters/tracing/datadog)
-    * [Dynatrace](/router/configuration/telemetry/exporters/tracing/dynatrace)
-    * [Jaeger](/router/configuration/telemetry/exporters/tracing/jaeger)
-    * [New Relic](/router/configuration/telemetry/exporters/tracing/new-relic)
-
+* [OpenTelemetry Protocol (OTLP)](/router/configuration/telemetry/exporters/tracing/otlp) over HTTP or gRPC
+* [Datadog (via OTLP configuration)](/router/configuration/telemetry/exporters/tracing/datadog)
+* [Dynatrace (via OTLP configuration)](/router/configuration/telemetry/exporters/tracing/dynatrace)
+* [Jaeger (via OTLP configuration)](/router/configuration/telemetry/exporters/tracing/jaeger)
+* [New Relic (via OTLP configuration)](/router/configuration/telemetry/exporters/tracing/new-relic)
 * [Zipkin](/router/configuration/telemetry/exporters/tracing/zipkin).
 
 The router generates [**spans**](/router/configuration/telemetry/instrumentation/spans) that include the various phases of serving a request and associated dependencies. This is useful for showing how response time is affected by:

--- a/docs/source/routing/observability/telemetry/trace-exporters/overview.mdx
+++ b/docs/source/routing/observability/telemetry/trace-exporters/overview.mdx
@@ -6,13 +6,15 @@ context:
   - telemetry
 ---
 
-The GraphOS Router and Apollo Router Core support collection of traces with [OpenTelemetry](https://opentelemetry.io/), with exporters for:
+Apollo Router supports a collection of tracing exporters:
 
-* [Jaeger](/router/configuration/telemetry/exporters/tracing/jaeger)
-* [Zipkin](/router/configuration/telemetry/exporters/tracing/zipkin)
-* [Datadog](/router/configuration/telemetry/exporters/tracing/datadog)
-* [New Relic](/router/configuration/telemetry/exporters/tracing/new-relic)
-* [OpenTelemetry Protocol (OTLP)](/router/configuration/telemetry/exporters/tracing/otlp) over HTTP or gRPC
+* [OpenTelemetry Protocol (OTLP)](/router/configuration/telemetry/exporters/tracing/otlp) over HTTP or gRPC. Configurations of the OTLP trace exporter are provided for:
+    * [Datadog](/router/configuration/telemetry/exporters/tracing/datadog)
+    * [Dynatrace](/router/configuration/telemetry/exporters/tracing/dynatrace)
+    * [Jaeger](/router/configuration/telemetry/exporters/tracing/jaeger)
+    * [New Relic](/router/configuration/telemetry/exporters/tracing/new-relic)
+
+* [Zipkin](/router/configuration/telemetry/exporters/tracing/zipkin).
 
 The router generates [**spans**](/router/configuration/telemetry/instrumentation/spans) that include the various phases of serving a request and associated dependencies. This is useful for showing how response time is affected by:
 


### PR DESCRIPTION
Clarify the trace exporters that are configurations of OTLP trace exporter<hr>This is an automatic backport of pull request #7367 done by [Mergify](https://mergify.com).