### PR TITLE
feat(federation/composition): implemented `UNSUPPORTED_ON_INTERFACE` errors

### DIFF
--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -29,6 +29,7 @@ use crate::schema::field_set::parse_field_set;
 use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::subgraph_metadata::SubgraphMetadata;
+use crate::schema::validators::external::validate_external_directives;
 use crate::schema::validators::key::validate_key_directives;
 use crate::schema::validators::provides::validate_provides_directives;
 use crate::schema::validators::requires::validate_requires_directives;
@@ -147,6 +148,7 @@ impl FederationBlueprint {
         validate_key_directives(&schema, &mut error_collector)?;
         validate_provides_directives(&schema, meta, &mut error_collector)?;
         validate_requires_directives(&schema, meta, &mut error_collector)?;
+        validate_external_directives(&schema, meta, &mut error_collector)?;
 
         // TODO: Remaining validations
         Self::validate_keys_on_interfaces_are_also_on_all_implementations(

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -145,7 +145,7 @@ impl FederationBlueprint {
             return error_collector.into_result().map(|_| schema);
         }
 
-        validate_key_directives(&schema, &mut error_collector)?;
+        validate_key_directives(&schema, meta, &mut error_collector)?;
         validate_provides_directives(&schema, meta, &mut error_collector)?;
         validate_requires_directives(&schema, meta, &mut error_collector)?;
         validate_external_directives(&schema, meta, &mut error_collector)?;

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -12,7 +12,6 @@ use apollo_compiler::executable::FieldSet;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::validation::WithErrors;
-use position::ObjectFieldDefinitionPosition;
 use position::ObjectOrInterfaceTypeDefinitionPosition;
 use position::TagDirectiveTargetPosition;
 use referencer::Referencers;
@@ -41,6 +40,7 @@ use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::EnumTypeDefinitionPosition;
 use crate::schema::position::InputObjectTypeDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
+use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::ScalarTypeDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
@@ -486,7 +486,8 @@ impl FederationSchema {
             .get_directive(&provides_directive_definition.name)?;
 
         let mut applications: Vec<Result<ProvidesDirective, FederationError>> = Vec::new();
-        for field_definition_position in &provides_directive_referencers.object_fields {
+        for field_definition_position in provides_directive_referencers.object_or_interface_fields()
+        {
             match field_definition_position.get(self.schema()) {
                 Ok(field_definition) => {
                     let directives = &field_definition.directives;
@@ -497,7 +498,7 @@ impl FederationSchema {
                             .provides_directive_arguments(provides_directive_application);
                         applications.push(arguments.map(|args| ProvidesDirective {
                             arguments: args,
-                            target: field_definition_position,
+                            target: field_definition_position.clone(),
                             target_return_type: field_definition.ty.inner_named_type(),
                         }));
                     }
@@ -518,18 +519,19 @@ impl FederationSchema {
             .get_directive(&requires_directive_definition.name)?;
 
         let mut applications = Vec::new();
-        for field_definition_position in &requires_directive_referencers.object_fields {
+        for field_definition_position in requires_directive_referencers.object_or_interface_fields()
+        {
             match field_definition_position.get(self.schema()) {
                 Ok(field_definition) => {
                     let directives = &field_definition.directives;
-                    for provides_directive_application in
+                    for directive_application in
                         directives.get_all(&requires_directive_definition.name)
                     {
-                        let arguments = federation_spec
-                            .requires_directive_arguments(provides_directive_application);
+                        let arguments =
+                            federation_spec.requires_directive_arguments(directive_application);
                         applications.push(arguments.map(|args| RequiresDirective {
                             arguments: args,
-                            target: field_definition_position,
+                            target: field_definition_position.clone(),
                         }));
                     }
                 }
@@ -643,7 +645,9 @@ pub(crate) struct ProvidesDirective<'schema> {
     /// The parsed arguments of this `@provides` application
     arguments: ProvidesDirectiveArguments<'schema>,
     /// The schema position to which this directive is applied
-    target: &'schema ObjectFieldDefinitionPosition,
+    /// - Although the directive is not allowed on interfaces, we still need to collect them
+    ///   for validation purposes.
+    target: ObjectOrInterfaceFieldDefinitionPosition,
     /// The return type of the target field
     target_return_type: &'schema Name,
 }
@@ -664,7 +668,9 @@ pub(crate) struct RequiresDirective<'schema> {
     /// The parsed arguments of this `@requires` application
     arguments: RequiresDirectiveArguments<'schema>,
     /// The schema position to which this directive is applied
-    target: &'schema ObjectFieldDefinitionPosition,
+    /// - Although the directive is not allowed on interfaces, we still need to collect them
+    ///   for validation purposes.
+    target: ObjectOrInterfaceFieldDefinitionPosition,
 }
 
 impl HasFields for RequiresDirective<'_> {
@@ -673,7 +679,7 @@ impl HasFields for RequiresDirective<'_> {
     }
 
     fn target_type(&self) -> &Name {
-        &self.target.type_name
+        self.target.type_name()
     }
 }
 

--- a/apollo-federation/src/schema/referencer.rs
+++ b/apollo-federation/src/schema/referencer.rs
@@ -15,6 +15,7 @@ use crate::schema::position::InterfaceFieldDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectFieldArgumentDefinitionPosition;
 use crate::schema::position::ObjectFieldDefinitionPosition;
+use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::ScalarTypeDefinitionPosition;
 use crate::schema::position::SchemaDefinitionPosition;
@@ -150,4 +151,19 @@ pub(crate) struct DirectiveReferencers {
     pub(crate) input_object_types: IndexSet<InputObjectTypeDefinitionPosition>,
     pub(crate) input_object_fields: IndexSet<InputObjectFieldDefinitionPosition>,
     pub(crate) directive_arguments: IndexSet<DirectiveArgumentDefinitionPosition>,
+}
+
+impl DirectiveReferencers {
+    pub(crate) fn object_or_interface_fields(
+        &self,
+    ) -> impl Iterator<Item = ObjectOrInterfaceFieldDefinitionPosition> {
+        self.object_fields
+            .iter()
+            .map(|pos| ObjectOrInterfaceFieldDefinitionPosition::Object(pos.clone()))
+            .chain(
+                self.interface_fields
+                    .iter()
+                    .map(|pos| ObjectOrInterfaceFieldDefinitionPosition::Interface(pos.clone())),
+            )
+    }
 }

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -173,7 +173,7 @@ impl SubgraphMetadata {
         for requires_directive in applications.into_iter().filter_map(|d| d.ok()) {
             required_fields.extend(collect_target_fields_from_field_set(
                 unwrap_schema(schema),
-                requires_directive.target.type_name.clone(),
+                requires_directive.target.type_name().clone(),
                 requires_directive.arguments.fields,
                 false,
             )?);

--- a/apollo-federation/src/schema/validators/external.rs
+++ b/apollo-federation/src/schema/validators/external.rs
@@ -1,0 +1,72 @@
+// the `@external` directive validation
+
+use crate::error::FederationError;
+use crate::error::MultipleFederationErrors;
+use crate::error::SingleFederationError;
+use crate::schema::FederationSchema;
+use crate::schema::position::InterfaceTypeDefinitionPosition;
+use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
+use crate::schema::subgraph_metadata::SubgraphMetadata;
+
+pub(crate) fn validate_external_directives(
+    schema: &FederationSchema,
+    metadata: &SubgraphMetadata,
+    errors: &mut MultipleFederationErrors,
+) -> Result<(), FederationError> {
+    validate_no_external_on_interface_fields(schema, metadata, errors)?;
+    validate_all_external_fields_used(schema, metadata, errors)?;
+    Ok(())
+}
+
+fn validate_no_external_on_interface_fields(
+    schema: &FederationSchema,
+    metadata: &SubgraphMetadata,
+    errors: &mut MultipleFederationErrors,
+) -> Result<(), FederationError> {
+    for type_name in schema.referencers().interface_types.keys() {
+        let type_pos: InterfaceTypeDefinitionPosition =
+            schema.get_type(type_name.clone())?.try_into()?;
+        for field_pos in type_pos.fields(schema.schema())? {
+            let is_external = metadata
+                .external_metadata()
+                .is_external(&field_pos.clone().into());
+            if is_external {
+                errors.push(SingleFederationError::ExternalOnInterface {
+                    message: format!(
+                        r#"Interface type field "{field_pos}" is marked @external but @external is not allowed on interface fields."#
+                    ),
+                 }.into())
+            }
+        }
+    }
+    Ok(())
+}
+
+// Checks that all fields marked @external is used in a federation directive (@key, @provides or
+// @requires) _or_ to satisfy an interface implementation. Otherwise, the field declaration is
+// somewhat useless.
+fn validate_all_external_fields_used(
+    schema: &FederationSchema,
+    metadata: &SubgraphMetadata,
+    errors: &mut MultipleFederationErrors,
+) -> Result<(), FederationError> {
+    for type_pos in schema.get_types() {
+        let Ok(type_pos): Result<ObjectOrInterfaceTypeDefinitionPosition, _> = type_pos.try_into()
+        else {
+            continue;
+        };
+        type_pos.fields(schema.schema())?
+            .for_each(|field| {
+                let field = field.into();
+                if !metadata.is_field_external(&field) || metadata.is_field_used(&field) {
+                    return;
+                }
+                errors.push(SingleFederationError::ExternalUnused {
+                    message: format!(
+                        r#"Field "{field}" is marked @external but is not used in any federation directive (@key, @provides, @requires) or to satisfy an interface; the field declaration has no use and should be removed (or the field should not be @external)."#
+                    ),
+                }.into());
+            });
+    }
+    Ok(())
+}

--- a/apollo-federation/src/schema/validators/mod.rs
+++ b/apollo-federation/src/schema/validators/mod.rs
@@ -14,6 +14,7 @@ use crate::schema::position::InterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::subgraph_metadata::SubgraphMetadata;
 
+pub(crate) mod external;
 pub(crate) mod key;
 pub(crate) mod provides;
 pub(crate) mod requires;

--- a/apollo-federation/src/schema/validators/provides.rs
+++ b/apollo-federation/src/schema/validators/provides.rs
@@ -10,7 +10,6 @@ use crate::link::federation_spec_definition::FEDERATION_PROVIDES_DIRECTIVE_NAME_
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::FederationSchema;
 use crate::schema::HasFields;
-use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::subgraph_metadata::SubgraphMetadata;
 use crate::schema::validators::DenyFieldsWithDirectiveApplications;
 use crate::schema::validators::DenyNonExternalLeafFields;
@@ -41,23 +40,22 @@ pub(crate) fn validate_provides_directives(
         match provides_directive {
             Ok(provides) => {
                 // PORT NOTE: In JS, these two checks are done inside the `targetTypeExtractor`.
-                if metadata
-                    .is_field_external(&FieldDefinitionPosition::Object(provides.target.clone()))
-                {
+                if metadata.is_field_external(&provides.target.clone().into()) {
                     errors.errors.push(
                         SingleFederationError::ExternalCollisionWithAnotherDirective {
                             message: format!(
                                 "Cannot have both @provides and @external on field \"{}.{}\"",
-                                provides.target.type_name, provides.target.field_name
+                                provides.target.type_name(),
+                                provides.target.field_name()
                             ),
                         },
                     )
                 }
                 if !schema
-                    .get_type(provides.target.type_name.clone())
+                    .get_type(provides.target.type_name().clone())
                     .is_ok_and(|ty| ty.is_composite_type())
                 {
-                    errors.errors.push(SingleFederationError::ProvidesOnNonObjectField { message: format!("Invalid @provides directive on field \"{}.{}\": field has type \"{}\"", provides.target.type_name, provides.target.field_name, provides.target_return_type) })
+                    errors.errors.push(SingleFederationError::ProvidesOnNonObjectField { message: format!("Invalid @provides directive on field \"{}.{}\": field has type \"{}\"", provides.target.type_name(), provides.target.field_name(), provides.target_return_type) })
                 }
 
                 // PORT NOTE: Think of this as `validateFieldSet`, but the set of rules are already filtered to account for what were boolean flags in JS

--- a/apollo-federation/src/schema/validators/provides.rs
+++ b/apollo-federation/src/schema/validators/provides.rs
@@ -14,6 +14,7 @@ use crate::schema::subgraph_metadata::SubgraphMetadata;
 use crate::schema::validators::DenyFieldsWithDirectiveApplications;
 use crate::schema::validators::DenyNonExternalLeafFields;
 use crate::schema::validators::SchemaFieldSetValidator;
+use crate::schema::validators::deny_unsupported_directive_on_interface_field;
 
 pub(crate) fn validate_provides_directives(
     schema: &FederationSchema,
@@ -39,6 +40,13 @@ pub(crate) fn validate_provides_directives(
     for provides_directive in schema.provides_directive_applications()? {
         match provides_directive {
             Ok(provides) => {
+                deny_unsupported_directive_on_interface_field(
+                    &provides_directive_name,
+                    &provides,
+                    schema,
+                    errors,
+                );
+
                 // PORT NOTE: In JS, these two checks are done inside the `targetTypeExtractor`.
                 if metadata.is_field_external(&provides.target.clone().into()) {
                     errors.errors.push(

--- a/apollo-federation/src/schema/validators/requires.rs
+++ b/apollo-federation/src/schema/validators/requires.rs
@@ -40,7 +40,7 @@ pub(crate) fn validate_requires_directives(
             Ok(requires) => match requires.parse_fields(schema.schema()) {
                 Ok(fields) => {
                     for rule in fieldset_rules.iter() {
-                        rule.visit(&requires.target.type_name, &fields, errors);
+                        rule.visit(requires.target.type_name(), &fields, errors);
                     }
                 }
                 Err(e) => errors.push(e.into()),

--- a/apollo-federation/src/schema/validators/requires.rs
+++ b/apollo-federation/src/schema/validators/requires.rs
@@ -14,6 +14,7 @@ use crate::schema::subgraph_metadata::SubgraphMetadata;
 use crate::schema::validators::DenyFieldsWithDirectiveApplications;
 use crate::schema::validators::DenyNonExternalLeafFields;
 use crate::schema::validators::SchemaFieldSetValidator;
+use crate::schema::validators::deny_unsupported_directive_on_interface_field;
 
 pub(crate) fn validate_requires_directives(
     schema: &FederationSchema,
@@ -37,14 +38,22 @@ pub(crate) fn validate_requires_directives(
 
     for requires_directive in schema.requires_directive_applications()? {
         match requires_directive {
-            Ok(requires) => match requires.parse_fields(schema.schema()) {
-                Ok(fields) => {
-                    for rule in fieldset_rules.iter() {
-                        rule.visit(requires.target.type_name(), &fields, errors);
+            Ok(requires) => {
+                deny_unsupported_directive_on_interface_field(
+                    &requires_directive_name,
+                    &requires,
+                    schema,
+                    errors,
+                );
+                match requires.parse_fields(schema.schema()) {
+                    Ok(fields) => {
+                        for rule in fieldset_rules.iter() {
+                            rule.visit(requires.target.type_name(), &fields, errors);
+                        }
                     }
+                    Err(e) => errors.push(e.into()),
                 }
-                Err(e) => errors.push(e.into()),
-            },
+            }
             Err(e) => errors.push(e),
         }
     }

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -256,8 +256,9 @@ mod fieldset_based_directives {
         }
     }
 
+    // TODO: UNSUPPORTED_ON_INTERFACE
     #[test]
-    #[should_panic(expected = r#"subgraph error was expected:"#)]
+    #[should_panic(expected = r#"Mismatched errors:"#)]
     fn rejects_provides_on_interfaces() {
         let schema_str = r#"
             type Query {
@@ -283,8 +284,9 @@ mod fieldset_based_directives {
         );
     }
 
+    // TODO: UNSUPPORTED_ON_INTERFACE
     #[test]
-    #[should_panic(expected = r#"subgraph error was expected:"#)]
+    #[should_panic(expected = r#"Mismatched errors:"#)]
     fn rejects_requires_on_interfaces() {
         let schema_str = r#"
             type Query {
@@ -307,14 +309,13 @@ mod fieldset_based_directives {
                 ),
                 (
                     "EXTERNAL_ON_INTERFACE",
-                    r#"[S] Interface type field "T.f" is marked @external but @external is not allowed on interface fields (it is nonsensical)."#,
+                    r#"[S] Interface type field "T.f" is marked @external but @external is not allowed on interface fields."#,
                 ),
             ]
         );
     }
 
     #[test]
-    #[should_panic(expected = r#"subgraph error was expected:"#)]
     fn rejects_unused_external() {
         let schema_str = r#"
             type Query {

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -226,7 +226,6 @@ mod fieldset_based_directives {
     }
 
     #[test]
-    #[should_panic(expected = r#"subgraph error was expected:"#)]
     fn rejects_key_on_interfaces_in_all_specs() {
         for version in ["2.0", "2.1", "2.2"] {
             let schema_str = format!(
@@ -256,9 +255,7 @@ mod fieldset_based_directives {
         }
     }
 
-    // TODO: UNSUPPORTED_ON_INTERFACE
     #[test]
-    #[should_panic(expected = r#"subgraph error was expected:"#)]
     fn rejects_provides_on_interfaces() {
         let schema_str = r#"
             type Query {
@@ -284,9 +281,7 @@ mod fieldset_based_directives {
         );
     }
 
-    // TODO: UNSUPPORTED_ON_INTERFACE
     #[test]
-    #[should_panic(expected = r#"Mismatched error counts: 2 != 1"#)]
     fn rejects_requires_on_interfaces() {
         let schema_str = r#"
             type Query {

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -258,7 +258,7 @@ mod fieldset_based_directives {
 
     // TODO: UNSUPPORTED_ON_INTERFACE
     #[test]
-    #[should_panic(expected = r#"Mismatched errors:"#)]
+    #[should_panic(expected = r#"subgraph error was expected:"#)]
     fn rejects_provides_on_interfaces() {
         let schema_str = r#"
             type Query {
@@ -286,7 +286,7 @@ mod fieldset_based_directives {
 
     // TODO: UNSUPPORTED_ON_INTERFACE
     #[test]
-    #[should_panic(expected = r#"Mismatched errors:"#)]
+    #[should_panic(expected = r#"Mismatched error counts: 2 != 1"#)]
     fn rejects_requires_on_interfaces() {
         let schema_str = r#"
             type Query {


### PR DESCRIPTION
(This is a follow-up PR for https://github.com/apollographql/router/pull/7381.)

Also, this PR fixed incorrect `EXTERNAL_UNUSED` errors by collecting `@requires`/`@provides` directive application on interface fields.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests