### PR TITLE
Remove aws-lc from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,8 +821,6 @@ checksum = "8c39646d1a6b51240a1a23bb57ea4eebede7e16fbc237fdc876980233dcecb4f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -833,14 +831,11 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand 2.3.0",
- "hex",
  "http 1.3.1",
- "ring",
  "time",
  "tokio",
  "tracing",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -853,31 +848,6 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "zeroize",
-]
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4e8200b9a4a5801a769d50eeabc05670fec7e959a8cb7a63a93e4e519942ae"
-dependencies = [
- "aws-lc-sys",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "paste",
 ]
 
 [[package]]
@@ -903,52 +873,6 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d4bdb0e5f80f0689e61c77ab678b2b9304af329616af38aef5b6b967b8e736"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand 2.3.0",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.65.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbbb3ce8da257aedbccdcb1aadafbbb6a5fe9adf445db0e1ea897bdc7e22d08"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand 2.3.0",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
 ]
 
 [[package]]
@@ -1031,29 +955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http-client"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aff1159006441d02e57204bf57a1b890ba68bedb6904ffd2873c1c4c11c546b"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "h2 0.4.7",
- "http 1.3.1",
- "hyper 1.6.0",
- "hyper-rustls",
- "hyper-util",
- "pin-project-lite",
- "rustls",
- "rustls-native-certs 0.8.1",
- "rustls-pki-types",
- "tokio",
- "tower 0.5.2",
- "tracing",
-]
-
-[[package]]
 name = "aws-smithy-json"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,7 +991,6 @@ checksum = "0152749e17ce4d1b47c7747bdfec09dac1ccafdcbc741ebf9daa2a373356730f"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1378,29 +1278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools 0.11.0",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.90",
- "which",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,15 +1500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,17 +1563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,15 +1601,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "cmake"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -2708,12 +2556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "fsio"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3248,15 +3090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,7 +3276,6 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "log",
  "rustls",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
@@ -3982,12 +3814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,16 +3827,6 @@ checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5897,7 +5713,6 @@ version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5956,7 +5771,6 @@ version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7551,18 +7365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.42",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sigv4",
+ "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-types",
  "axum 0.8.3",
@@ -951,6 +952,29 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aff1159006441d02e57204bf57a1b890ba68bedb6904ffd2873c1c4c11c546b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.4.7",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tower 0.5.2",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sigv4",
+ "aws-smithy-async",
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-types",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -247,6 +247,7 @@ aws-sigv4 = "1.2.6"
 aws-credential-types = "1.2.1" # XXX: This is the latest version
 aws-config = { version = "1.5.5", default-features = false }
 aws-types = "1.3.3"
+aws-smithy-http-client = { version = "1.0.1", default-features = false, features = ["default-client", "rustls-ring"] }
 aws-smithy-runtime-api = { version = "1.7.3", features = ["client"] }
 sha1.workspace = true
 tracing-serde = "0.1.3"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -92,7 +92,7 @@ dhat = { version = "0.3.3", optional = true }
 diff = "0.1.13"
 displaydoc = "0.2"
 flate2 = "1.0.30"
-fred = { version = "9.4.0", features = ["enable-rustls", "i-cluster"] }
+fred = { version = "9.4.0", features = ["enable-rustls-ring", "i-cluster"] }
 futures = { version = "0.3.30", features = ["thread-pool"] }
 graphql_client = "0.14.0"
 hex.workspace = true
@@ -105,7 +105,7 @@ humantime = "2.1.0"
 humantime-serde = "1.1.1"
 hyper = { version = "1.5.1", features = ["full"] }
 hyper-util = { version = "0.1.10", features = ["full"] }
-hyper-rustls = { version = "0.27.3", features = ["http1", "http2", "rustls-native-certs"] }
+hyper-rustls = { version = "0.27.3", default-features = false, features = ["http1", "http2", "rustls-native-certs"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
 itertools = "0.14.0"
 jsonpath_lib = "0.3.0"
@@ -187,7 +187,7 @@ reqwest = { workspace = true, default-features = false, features = [
 ] }
 
 rust-embed = { version = "8.4.0", features = ["include-exclude"] }
-rustls = "0.23.19"
+rustls = { version = "0.23.19", default-features = false }
 rustls-native-certs = "0.8.1"
 rustls-pemfile = "2.2.0"
 schemars.workspace = true
@@ -232,7 +232,7 @@ wsl = "0.1.0"
 tokio-tungstenite = { version = "0.26.1", features = [
     "rustls-tls-native-roots",
 ] }
-tokio-rustls = "0.26.0"
+tokio-rustls = { version = "0.26.0", default-features = false }
 hickory-resolver = "0.24.1"
 http-serde = "2.1.1"
 hmac = "0.12.1"
@@ -245,7 +245,7 @@ zstd-safe = "7.1.0"
 # note: hyper 1.0 update seems to mean this isn't true...
 aws-sigv4 = "1.2.6"
 aws-credential-types = "1.2.1" # XXX: This is the latest version
-aws-config = "1.5.5"
+aws-config = { version = "1.5.5", default-features = false }
 aws-types = "1.3.3"
 aws-smithy-runtime-api = { version = "1.7.3", features = ["client"] }
 sha1.workspace = true
@@ -277,7 +277,7 @@ tikv-jemallocator = "0.6.0"
 axum = { version = "0.8.1", features = ["http2", "ws"] }
 axum-server = "0.7.1"
 ecdsa = { version = "0.16.9", features = ["signing", "pem", "pkcs8"] }
-fred = { version = "9.4.0", features = ["enable-rustls", "mocks", "i-cluster"] }
+fred = { version = "9.4.0", features = ["enable-rustls-ring", "mocks", "i-cluster"] }
 futures-test = "0.3.30"
 insta.workspace = true
 maplit = "1.0.2"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -247,6 +247,7 @@ aws-sigv4 = "1.2.6"
 aws-credential-types = "1.2.1" # XXX: This is the latest version
 aws-config = { version = "1.5.5", default-features = false }
 aws-types = "1.3.3"
+aws-smithy-async = { version = "1.2.5", features = ["rt-tokio"] }
 aws-smithy-http-client = { version = "1.0.1", default-features = false, features = ["default-client", "rustls-ring"] }
 aws-smithy-runtime-api = { version = "1.7.3", features = ["client"] }
 sha1.workspace = true

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -786,9 +786,6 @@ fn test_configuration_validate_and_sanitize() {
 
 #[test]
 fn load_tls() {
-    // Enable crypto
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
     let mut cert_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     cert_path.push("src");
     cert_path.push("configuration");

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -389,8 +389,6 @@ impl Executable {
             println!("{}", std::env!("CARGO_PKG_VERSION"));
             return Ok(());
         }
-        // Enable crypto
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         *crate::services::APOLLO_KEY.lock() = opt.apollo_key.clone();
         *crate::services::APOLLO_GRAPH_REF.lock() = opt.apollo_graph_ref.clone();

--- a/apollo-router/src/plugins/authentication/subgraph.rs
+++ b/apollo-router/src/plugins/authentication/subgraph.rs
@@ -14,7 +14,6 @@ use aws_sigv4::http_request::SigningSettings;
 use aws_sigv4::http_request::sign;
 use aws_smithy_async::rt::sleep::SharedAsyncSleep;
 use aws_smithy_async::rt::sleep::TokioSleep;
-use aws_smithy_async::rt::sleep::default_async_sleep;
 use aws_smithy_async::time::SystemTimeSource;
 use aws_smithy_http_client::tls::Provider;
 use aws_smithy_http_client::tls::rustls_provider::CryptoMode;

--- a/apollo-router/src/plugins/authentication/subgraph.rs
+++ b/apollo-router/src/plugins/authentication/subgraph.rs
@@ -12,7 +12,6 @@ use aws_sigv4::http_request::SignableBody;
 use aws_sigv4::http_request::SignableRequest;
 use aws_sigv4::http_request::SigningSettings;
 use aws_sigv4::http_request::sign;
-use aws_smithy_async::rt::sleep::SharedAsyncSleep;
 use aws_smithy_async::rt::sleep::TokioSleep;
 use aws_smithy_async::time::SystemTimeSource;
 use aws_smithy_http_client::tls::Provider;

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -96,9 +96,6 @@ impl Plugin for CoprocessorPlugin<HTTPClientService> {
         http_connector.set_keepalive(Some(std::time::Duration::from_secs(60)));
         http_connector.enforce_http(false);
 
-        // Enable crypto
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
         let tls_config = rustls::ClientConfig::builder()
             .with_native_roots()?
             .with_no_client_auth();

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -387,7 +387,7 @@ mod test {
         is_subscription: bool,
     ) -> Result<Vec<SingleStatsReport>, BoxError> {
         let _ = tracing_subscriber::fmt::try_init();
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let mut plugin = create_plugin().await?;
         // Replace the apollo metrics sender so we can test metrics collection.
         let (tx, rx) = tokio::sync::mpsc::channel(100);
@@ -434,7 +434,6 @@ mod test {
     }
 
     fn create_plugin() -> impl Future<Output = Result<Telemetry, BoxError>> {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         create_plugin_with_apollo_config(apollo::Config {
             endpoint: Url::parse(ENDPOINT_DEFAULT).expect("default endpoint must be parseable"),
             apollo_key: Some("key".to_string()),

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -236,9 +236,6 @@ pub(crate) fn generate_tls_client_config(
     tls_cert_store: RootCertStore,
     client_cert_config: Option<&TlsClientAuth>,
 ) -> Result<rustls::ClientConfig, BoxError> {
-    // Enable crypto
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
     let tls_builder = rustls::ClientConfig::builder();
 
     Ok(match client_cert_config {

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -56,9 +56,6 @@ async fn tls_server(
     key: PrivateKeyDer<'static>,
     body: &'static str,
 ) {
-    // Enable crypto
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
     let tls_config = Arc::new(
         ServerConfig::builder()
             .with_no_client_auth()
@@ -446,8 +443,6 @@ async fn tls_server_with_client_auth(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tls_client_auth() {
-    // Enable crypto
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let server_certificate_pem = include_str!("./testdata/server.crt");
     let ca_pem = include_str!("./testdata/CA/ca.crt");
     let server_key_pem = include_str!("./testdata/server.key");
@@ -522,8 +517,6 @@ async fn tls_client_auth() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tls_client_auth_connector() {
-    // Enable crypto
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let server_certificate_pem = include_str!("./testdata/server.crt");
     let ca_pem = include_str!("./testdata/CA/ca.crt");
     let server_key_pem = include_str!("./testdata/server.key");
@@ -618,9 +611,6 @@ async fn emulate_h2c_server(listener: TcpListener) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subgraph_h2c() {
-    // Enable crypto
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let socket_addr = listener.local_addr().unwrap();
     tokio::task::spawn(emulate_h2c_server(listener));
@@ -703,7 +693,6 @@ async fn emulate_subgraph_compressed_response(listener: TcpListener) {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_compressed_request_response_body() {
     // Though the server doesn't use TLS, the client still supports it, and so we need crypto stuff
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let socket_addr = listener.local_addr().unwrap();

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -183,9 +183,6 @@ pub(crate) fn generate_tls_client_config(
     tls_cert_store: Option<RootCertStore>,
     client_cert_config: Option<&TlsClientAuth>,
 ) -> Result<rustls::ClientConfig, BoxError> {
-    // Enable crypto
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
     let tls_builder = rustls::ClientConfig::builder();
     Ok(match (tls_cert_store, client_cert_config) {
         (None, None) => tls_builder.with_native_roots()?.with_no_client_auth(),
@@ -1707,7 +1704,6 @@ mod tests {
 
         // Not sure this is the *right* place to do it, because it's actually clients that
         // use crypto, not the server.
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         loop {
             let (stream, _) = listener.accept().await?;

--- a/apollo-router/src/test_harness/http_snapshot.rs
+++ b/apollo-router/src/test_harness/http_snapshot.rs
@@ -499,8 +499,6 @@ impl SnapshotServer {
             }
         };
 
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
         let http_service = HttpClientService::new(
             "test",
             rustls::ClientConfig::builder()

--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -305,7 +305,6 @@ async fn get_traces<
 where
     Fut: Future<Output = (JoinHandle<()>, BoxCloneService)>,
 {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let _guard = TEST.lock().await;
     reports.lock().await.clear();
     let (task, mut service) = service_fn(reports.clone(), use_legacy_request_span, mocked).await;

--- a/apollo-router/tests/apollo_reports.rs
+++ b/apollo-router/tests/apollo_reports.rs
@@ -358,7 +358,6 @@ async fn get_report<Fut, T: Fn(&&Report) -> bool + Send + Sync + Copy + 'static>
 where
     Fut: Future<Output = (JoinHandle<()>, BoxCloneService)>,
 {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let _guard = TEST.lock().await;
     reports.lock().await.clear();
     let (task, mut service) = service_fn(
@@ -418,7 +417,6 @@ async fn get_batch_stats_report<T: Fn(&&Report) -> bool + Send + Sync + Copy + '
     request: router::Request,
     filter: T,
 ) -> u64 {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let _guard = TEST.lock().await;
     reports.lock().await.clear();
     let (task, mut service) =

--- a/apollo-router/tests/set_context.rs
+++ b/apollo-router/tests/set_context.rs
@@ -313,8 +313,6 @@ fn setup_from_mocks(
     configuration: serde_json::Value,
     mocks: &[(&'static str, &'static str)],
 ) -> TestHarness<'static> {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
     let mut mocked_subgraphs = MockedSubgraphs::default();
 
     for (name, m) in mocks {

--- a/apollo-router/tests/type_conditions.rs
+++ b/apollo-router/tests/type_conditions.rs
@@ -354,8 +354,6 @@ fn setup_from_mocks(
     configuration: serde_json::Value,
     mocks: &[(&'static str, &'static str)],
 ) -> TestHarness<'static> {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
     let mut mocked_subgraphs = MockedSubgraphs::default();
 
     for (name, m) in mocks {

--- a/dev-docs/HYPER_1.0_REVIEW_NOTES.md
+++ b/dev-docs/HYPER_1.0_REVIEW_NOTES.md
@@ -6,6 +6,7 @@ Read HYPER_1.0_UPDATE.md first. This provides a lot of generally
 useful information.
 
 ### Crate updates
+
 Many crates have been updated as part of the update. In some parts of
 codebase we had to continue using the older version of the crate so
 that opentelemetry (which has not been updated to by hyper 1.0
@@ -34,27 +35,6 @@ We removed this since it's not required in hyper 1.0
 
 Anywhere you see a XXX comment is an indication that this should be reviewed
 carefully.
-
-### default crypto
-
-At various places in the code base you'll see code like this:
-```
-    // Enable crypto
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-```
-
-This is because crypto initialisation is now done differently in rustls and
-two crypto stacks are supported: `aws` and `ring`.
-
-If only one stack is enabled, then there is no need to specify a default
-provider. Unfortunately, because some of our crates are quite old, both
-aws and ring are specified. In this case no default is favoured by rustls
-and the crate panics at runtime when crypto functionality is required.
-
-The way around this is to specify a default manually. This has to be done
-once for the main binary and at various places in tests.
-
-Hopefully this situation will improve in the future.
 
 ## Focussed Review
 


### PR DESCRIPTION
`aws-lc-sys` is our slowest dependency to build right now (at least on my machine). We also shouldn't need it, because `ring` (which we also have) is functionally equivalent.

When it was originally added (see the deleted Markdown content), there wasn't a clear way to only keep one of those dependencies—but there seems to be a path now! So this PR removes our slowest-to-build dependency as well as several others that were getting pulled in.

Special thanks to @andrewmcgivery for identifying this dependency bottleneck and @Velfi for helping me fix it!