### PR TITLE
fix: limit `http.route` to just the path in telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-futures",
+ "tracing-mock",
  "tracing-opentelemetry",
  "tracing-serde 0.1.3",
  "tracing-subscriber",
@@ -7079,6 +7080,16 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-mock"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff59989fc8854bc58d3daeadbccf5d7fb0b722af043cf839c7785f1ff0daf0e"
+dependencies = [
+ "tracing",
  "tracing-core",
 ]
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -325,6 +325,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 ] }
 tracing-opentelemetry = "0.25.0"
 tracing-test = "0.2.5"
+tracing-mock = "0.1.0-beta.1"
 walkdir = "2.5.0"
 wiremock = "0.5.22"
 libtest-mimic = "0.8.0"

--- a/apollo-router/src/plugins/telemetry/span_factory.rs
+++ b/apollo-router/src/plugins/telemetry/span_factory.rs
@@ -279,11 +279,12 @@ mod tests {
 
     #[test]
     fn test_http_route_on_array_of_router_spans() {
-        const EXPECTED_ROUTES: [(&str, &str); 4] = [
+        let expected_routes = [
             ("https://www.example.com/", "/"),
             ("https://www.example.com/path", "/path"),
             ("http://example.com/path/to/location", "/path/to/location"),
             ("http://www.example.com/path?with=query", "/path"),
+            ("/foo/bar?baz", "/foo/bar"),
         ];
 
         let span_modes = [SpanMode::SpecCompliant, SpanMode::Deprecated];
@@ -292,7 +293,7 @@ mod tests {
             LicenseState::Unlicensed,
         ];
 
-        for (uri, expected_route) in EXPECTED_ROUTES {
+        for (uri, expected_route) in expected_routes {
             let request = http::Request::builder().uri(uri).body("").unwrap();
 
             // test `request` spans

--- a/apollo-router/src/plugins/telemetry/span_factory.rs
+++ b/apollo-router/src/plugins/telemetry/span_factory.rs
@@ -44,7 +44,7 @@ impl SpanMode {
                         REQUEST_SPAN_NAME,
                         "http.method" = %request.method(),
                         "http.request.method" = %request.method(),
-                        "http.route" = %request.uri(),
+                        "http.route" = %request.uri().path(),
                         "http.flavor" = ?request.version(),
                         "http.status" = 500, // This prevents setting later
                         "otel.name" = ::tracing::field::Empty,
@@ -59,7 +59,7 @@ impl SpanMode {
                         REQUEST_SPAN_NAME,
                         "http.method" = %request.method(),
                         "http.request.method" = %request.method(),
-                        "http.route" = %request.uri(),
+                        "http.route" = %request.uri().path(),
                         "http.flavor" = ?request.version(),
                         "otel.name" = ::tracing::field::Empty,
                         "otel.kind" = "SERVER",
@@ -84,7 +84,7 @@ impl SpanMode {
                 let span = info_span!(ROUTER_SPAN_NAME,
                     "http.method" = %request.method(),
                     "http.request.method" = %request.method(),
-                    "http.route" = %request.uri(),
+                    "http.route" = %request.uri().path(),
                     "http.flavor" = ?request.version(),
                     "trace_id" = %trace_id,
                     "client.name" = ::tracing::field::Empty,
@@ -100,7 +100,7 @@ impl SpanMode {
             SpanMode::SpecCompliant => {
                 info_span!(ROUTER_SPAN_NAME,
                     // Needed for apollo_telemetry and datadog span mapping
-                    "http.route" = %request.uri(),
+                    "http.route" = %request.uri().path(),
                     "http.request.method" = %request.method(),
                     "otel.name" = ::tracing::field::Empty,
                     "otel.kind" = "SERVER",


### PR DESCRIPTION
Per the [OpenTelemetry spec](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-route), the `http.route` should only include "the matched route, that is, the path template used in the format used by the respective server framework."

The router currently sends the full URI in `http.route`, which can be high cardinality (ie `/graphql?operation=one_of_many_values`). After this change, the router will only include the path (`/graphql`).

In order to test this, I added a dependency on [`tracing-mock`](https://docs.rs/tracing-mock/latest/tracing_mock/index.html). It's currently in beta, but it's already used within the `tracing` library itself so I think it's probably pretty stable. However I'm happy to come up with another way to test this if preferred.


<!-- start metadata -->
<!-- ROUTER-1268 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
