### PR TITLE
fix: decrease log level for JWT authentication failure

### DIFF
--- a/.changesets/fix_caroline_demote_log_line.md
+++ b/.changesets/fix_caroline_demote_log_line.md
@@ -1,0 +1,5 @@
+### Decrease log level for JWT authentication failure ([PR #7396](https://github.com/apollographql/router/pull/7396))
+
+A recent change increased the log level of JWT authentication failures from `info` to `error`. This reverts that change.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/7396

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -453,7 +453,7 @@ fn authenticate(
         let failed = true;
         increment_jwt_counter_metric(failed);
 
-        tracing::error!(message = %error, "jwt authentication failure");
+        tracing::info!(message = %error, "jwt authentication failure");
 
         let _ = request.context.insert_json_value(
             JWT_CONTEXT_KEY,


### PR DESCRIPTION
This was originally at `info` level and recently changed to `error`. IMO `info` is a more reasonable level for expected failures like these.

NB: 1.x uses `info` level for this message already.

<!-- start metadata -->
<!-- ROUTER-1288 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
