### PR TITLE
Fix broken link to in-memory caching docs page

### DIFF
--- a/docs/source/routing/performance/caching/distributed.mdx
+++ b/docs/source/routing/performance/caching/distributed.mdx
@@ -19,7 +19,7 @@ To use this feature:
 
 Whenever a router instance requires a query plan or APQ query string to resolve a client operation:
 
-1. The router instance checks its own [in-memory cache](#in-memory-caching) for the required value and uses it if found.
+1. The router instance checks its own [in-memory cache](/router/configuration/in-memory-caching) for the required value and uses it if found.
 2. If _not_ found, the router instance then checks the distributed Redis cache for the required value and uses it if found. It also then replicates the found value in its own in-memory cache.
 3. If _not_ found, the router instance _generates_ the required query plan or requests the full operation string from the client for APQ.
 4. The router instance stores the obtained value in both the distributed cache _and_ its in-memory cache. 


### PR DESCRIPTION
What's changing:
- Updates a link to the in-memory caching page, which currently goes nowhere