### PR TITLE
Add `cargo run -p apollo-federation-cli plan --json`

### DIFF
--- a/apollo-federation/cli/Cargo.toml
+++ b/apollo-federation/cli/Cargo.toml
@@ -9,10 +9,10 @@ apollo-compiler.workspace = true
 apollo-federation = { path = "..", features = ["correctness"] }
 clap = { version = "4.5.1", features = ["derive"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+serde_json = { version = "1.0.114", features = [
+    "preserve_order",
+] }
 
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["json", "redactions"] }
 serde = { version = "1.0.197", features = ["derive"] }
-serde_json = { version = "1.0.114", features = [
-    "preserve_order",
-] }

--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -77,6 +77,8 @@ enum Command {
     },
     /// Outputs the formatted query plan for the given query and schema
     Plan {
+        #[arg(long)]
+        json: bool,
         query: PathBuf,
         /// Path(s) to one supergraph schema file, `-` for stdin or multiple subgraph schemas.
         schemas: Vec<PathBuf>,
@@ -172,10 +174,11 @@ fn main() -> ExitCode {
         Command::QueryGraph { schemas } => cmd_query_graph(&schemas),
         Command::FederatedGraph { schemas } => cmd_federated_graph(&schemas),
         Command::Plan {
+            json,
             query,
             schemas,
             planner,
-        } => cmd_plan(&query, &schemas, planner),
+        } => cmd_plan(json, &query, &schemas, planner),
         Command::Validate { schemas } => cmd_validate(&schemas),
         Command::Subgraph { subgraph_schema } => cmd_subgraph(&subgraph_schema),
         Command::Compose { schemas } => cmd_compose(&schemas),
@@ -285,6 +288,7 @@ fn cmd_federated_graph(file_paths: &[PathBuf]) -> Result<(), FederationError> {
 }
 
 fn cmd_plan(
+    use_json: bool,
     query_path: &Path,
     schema_paths: &[PathBuf],
     planner: QueryPlannerArgs,
@@ -298,7 +302,11 @@ fn cmd_plan(
     let query_doc =
         ExecutableDocument::parse_and_validate(planner.api_schema().schema(), query, query_path)?;
     let query_plan = planner.build_query_plan(&query_doc, None, Default::default())?;
-    println!("{query_plan}");
+    if use_json {
+        println!("{}", serde_json::to_string_pretty(&query_plan).unwrap());
+    } else {
+        println!("{query_plan}");
+    }
 
     // Check the query plan
     let subgraphs_by_name = supergraph


### PR DESCRIPTION
By default, the `plan` subcommand of the Federation CLI tool shows a custom serialization of a query plan that only includes the most relevant info.

The new `--json` flag makes it print the unabbreviated JSON serialization instead, which includes the full GraphQL for subgraph requests.