### PR TITLE
Revert "Add _dd.measured to spans when agent sampling is enabled"

### DIFF
--- a/.changesets/fix_bryn_otlp_export_dd_measured.md
+++ b/.changesets/fix_bryn_otlp_export_dd_measured.md
@@ -1,5 +1,0 @@
-### OTLP trace exporter does not correctly display resources in Datadog APM view ([PR #7344](https://github.com/apollographql/router/pull/7344))
-
-Router 2.x Datadog APM view is now fixed when using `preview_datadog_agent_sampling`. This was underreporting requests due to missing `_dd.measured` attributes.
-
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/7344

--- a/apollo-router/src/plugins/telemetry/tracing/datadog/span_processor.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog/span_processor.rs
@@ -1,5 +1,4 @@
 use opentelemetry::Context;
-use opentelemetry::KeyValue;
 use opentelemetry::trace::SpanContext;
 use opentelemetry::trace::TraceResult;
 use opentelemetry_sdk::Resource;
@@ -37,7 +36,6 @@ impl<T: SpanProcessor> SpanProcessor for DatadogSpanProcessor<T> {
             span.span_context.is_remote(),
             span.span_context.trace_state().clone(),
         );
-        span.attributes.push(KeyValue::new("_dd.measured", 1));
         self.delegate.on_end(span)
     }
 

--- a/apollo-router/tests/integration/telemetry/otlp.rs
+++ b/apollo-router/tests/integration/telemetry/otlp.rs
@@ -386,7 +386,6 @@ async fn test_untraced_request_sample_datadog_agent() -> Result<(), BoxError> {
         .services(["router", "subgraph"].into())
         .priority_sampled("1")
         .subgraph_sampled(true)
-        .measured_spans(["router", "supergraph"].into())
         .build()
         .validate_otlp_trace(
             &mut router,
@@ -720,13 +719,20 @@ impl Verifier for OtlpTraceSpec<'_> {
     }
 
     fn measured_span(&self, trace: &Value, name: &str) -> Result<bool, BoxError> {
-        let binding = trace.select_path(&format!(
-            "$..[?(@.attributes[?(@.key == 'otel.original_name' && @.value.stringValue == '{}')])].attributes[?(@.key == '_dd.measured')].value.intValue",
+        let binding1 = trace.select_path(&format!(
+            "$..[?(@.meta.['otel.original_name'] == '{}')].metrics.['_dd.measured']",
             name
         ))?;
-
-        let measured = binding.first().and_then(|v| v.as_i64()).unwrap_or_default();
-        Ok(measured == 1)
+        let binding2 = trace.select_path(&format!(
+            "$..[?(@.name == '{}')].metrics.['_dd.measured']",
+            name
+        ))?;
+        Ok(binding1
+            .first()
+            .or(binding2.first())
+            .and_then(|v| v.as_f64())
+            .map(|v| v == 1.0)
+            .unwrap_or_default())
     }
 
     async fn find_valid_metrics(&self) -> Result<(), BoxError> {


### PR DESCRIPTION
Reverts apollographql/router#7344, per observation in https://github.com/apollographql/router/pull/7344#pullrequestreview-2811299291

Instead we'll recommend this configuration and add this to our documentation in a follow-up PR:

```yaml
   supergraph:
        attributes:
          "_dd.measured":
            static: 1
```