### PR TITLE
fix: spans should only include path in `http.route` (backport #7390)

### DIFF
--- a/.changesets/fix_caroline_telemetry_http_route.md
+++ b/.changesets/fix_caroline_telemetry_http_route.md
@@ -1,0 +1,7 @@
+### Spans should only include path in `http.route` ([PR #7390](https://github.com/apollographql/router/pull/7390))
+
+Per the [OpenTelemetry spec](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-route), the `http.route` should only include "the matched route, that is, the path template used in the format used by the respective server framework."
+
+The router currently sends the full URI in `http.route`, which can be high cardinality (ie `/graphql?operation=one_of_many_values`). After this change, the router will only include the path (`/graphql`).
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/7390

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-futures",
+ "tracing-mock",
  "tracing-opentelemetry",
  "tracing-serde",
  "tracing-subscriber",
@@ -6936,6 +6937,16 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-mock"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff59989fc8854bc58d3daeadbccf5d7fb0b722af043cf839c7785f1ff0daf0e"
+dependencies = [
+ "tracing",
  "tracing-core",
 ]
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -330,6 +330,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 ] }
 tracing-opentelemetry = "0.21.0"
 tracing-test = "0.2.5"
+tracing-mock = "0.1.0-beta.1"
 walkdir = "2.5.0"
 wiremock = "0.5.22"
 libtest-mimic = "0.7.3"

--- a/apollo-router/src/plugins/telemetry/span_factory.rs
+++ b/apollo-router/src/plugins/telemetry/span_factory.rs
@@ -42,7 +42,7 @@ impl SpanMode {
                         REQUEST_SPAN_NAME,
                         "http.method" = %request.method(),
                         "http.request.method" = %request.method(),
-                        "http.route" = %request.uri(),
+                        "http.route" = %request.uri().path(),
                         "http.flavor" = ?request.version(),
                         "http.status" = 500, // This prevents setting later
                         "otel.name" = ::tracing::field::Empty,
@@ -57,7 +57,7 @@ impl SpanMode {
                         REQUEST_SPAN_NAME,
                         "http.method" = %request.method(),
                         "http.request.method" = %request.method(),
-                        "http.route" = %request.uri(),
+                        "http.route" = %request.uri().path(),
                         "http.flavor" = ?request.version(),
                         "otel.name" = ::tracing::field::Empty,
                         "otel.kind" = "SERVER",
@@ -82,7 +82,7 @@ impl SpanMode {
                 let span = info_span!(ROUTER_SPAN_NAME,
                     "http.method" = %request.method(),
                     "http.request.method" = %request.method(),
-                    "http.route" = %request.uri(),
+                    "http.route" = %request.uri().path(),
                     "http.flavor" = ?request.version(),
                     "trace_id" = %trace_id,
                     "client.name" = ::tracing::field::Empty,
@@ -98,7 +98,7 @@ impl SpanMode {
             SpanMode::SpecCompliant => {
                 info_span!(ROUTER_SPAN_NAME,
                     // Needed for apollo_telemetry and datadog span mapping
-                    "http.route" = %request.uri(),
+                    "http.route" = %request.uri().path(),
                     "http.request.method" = %request.method(),
                     "otel.name" = ::tracing::field::Empty,
                     "otel.kind" = "SERVER",
@@ -204,6 +204,107 @@ impl SpanMode {
                     "apollo_private.ftv1" = ::tracing::field::Empty,
                     "otel.status_code" = ::tracing::field::Empty,
                 )
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing_mock::expect;
+    use tracing_mock::subscriber;
+
+    use crate::plugins::telemetry::SpanMode;
+    use crate::plugins::telemetry::consts::REQUEST_SPAN_NAME;
+    use crate::plugins::telemetry::consts::ROUTER_SPAN_NAME;
+    use crate::uplink::license_enforcement::LicenseState;
+
+    #[test]
+    fn test_specific_span() {
+        // NB: this test checks the behavior of tracing_mock for a specific span.
+        //  Most tests should probably follow the pattern of `test_http_route_on_array_of_router_spans`
+        //  where they check a behavior across a variety of parameters.
+        let request = http::Request::builder()
+            .method("GET")
+            .uri("http://example.com/path/to/location?with=query&another=UN1QU3_query")
+            .header("apollographql-client-name", "client")
+            .body("useful info")
+            .unwrap();
+
+        let expected_fields = expect::field("http.route")
+            .with_value(&tracing::field::display("/path/to/location"))
+            .and(expect::field("http.request.method").with_value(&tracing::field::display("GET")))
+            .and(expect::field("otel.kind").with_value(&"SERVER"))
+            .and(expect::field("apollo_private.request").with_value(&true));
+
+        let expected_span = expect::span()
+            .named(ROUTER_SPAN_NAME)
+            .with_fields(expected_fields);
+
+        let (subscriber, handle) = subscriber::mock()
+            .new_span(expected_span)
+            .enter(ROUTER_SPAN_NAME)
+            .event(expect::event())
+            .exit(ROUTER_SPAN_NAME)
+            .run_with_handle();
+        tracing::subscriber::with_default(subscriber, || {
+            let span = SpanMode::SpecCompliant.create_router(&request);
+            let _guard = span.enter();
+            tracing::info!("an event happened!");
+        });
+        handle.assert_finished();
+    }
+
+    #[test]
+    fn test_http_route_on_array_of_router_spans() {
+        let expected_routes = [
+            ("https://www.example.com/", "/"),
+            ("https://www.example.com/path", "/path"),
+            ("http://example.com/path/to/location", "/path/to/location"),
+            ("http://www.example.com/path?with=query", "/path"),
+            ("/foo/bar?baz", "/foo/bar"),
+        ];
+
+        let span_modes = [SpanMode::SpecCompliant, SpanMode::Deprecated];
+        let license_states = [
+            LicenseState::LicensedHalt { limits: None },
+            LicenseState::Unlicensed,
+        ];
+
+        for (uri, expected_route) in expected_routes {
+            let request = http::Request::builder().uri(uri).body("").unwrap();
+
+            // test `request` spans
+            for license_state in license_states {
+                let expected_span = expect::span().named(REQUEST_SPAN_NAME).with_fields(
+                    expect::field("http.route")
+                        .with_value(&tracing::field::display(expected_route)),
+                );
+
+                let span_mode = SpanMode::Deprecated;
+                let (subscriber, handle) =
+                    subscriber::mock().new_span(expected_span).run_with_handle();
+                tracing::subscriber::with_default(subscriber, || {
+                    let span = span_mode.create_request(&request, license_state);
+                    let _guard = span.enter();
+                });
+                handle.assert_finished();
+            }
+
+            // test `router` spans
+            for span_mode in span_modes {
+                let expected_span = expect::span().named(ROUTER_SPAN_NAME).with_fields(
+                    expect::field("http.route")
+                        .with_value(&tracing::field::display(expected_route)),
+                );
+
+                let (subscriber, handle) =
+                    subscriber::mock().new_span(expected_span).run_with_handle();
+                tracing::subscriber::with_default(subscriber, || {
+                    let span = span_mode.create_router(&request);
+                    let _guard = span.enter();
+                });
+                handle.assert_finished();
             }
         }
     }


### PR DESCRIPTION
Per the [OpenTelemetry spec](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-route), the `http.route` should only include "the matched route, that is, the path template used in the format used by the respective server framework."

The router currently sends the full URI in `http.route`, which can be high cardinality (ie `/graphql?operation=one_of_many_values`). After this change, the router will only include the path (`/graphql`).

In order to test this, I added a dependency on [`tracing-mock`](https://docs.rs/tracing-mock/latest/tracing_mock/index.html). It's currently in beta, but it's already used within the `tracing` library itself so I think it's probably pretty stable. However I'm happy to come up with another way to test this if preferred.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7390 done by [Mergify](https://mergify.com).