### PR TITLE
Preserve formatting of `@link` when auto-upgrading connect spec

### DIFF
--- a/apollo-federation/src/sources/connect/validation/link.rs
+++ b/apollo-federation/src/sources/connect/validation/link.rs
@@ -65,10 +65,6 @@ impl<'schema> ConnectLink<'schema> {
     pub(super) fn spec(&self) -> ConnectSpec {
         self.spec
     }
-    pub(super) fn set_spec(&mut self, spec: ConnectSpec) {
-        self.spec = spec;
-        self.link.url.version = spec.into();
-    }
 
     pub(super) fn source_directive_name(&self) -> &Name {
         &self.source_directive_name

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@transformed__upgrade_0.1.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@transformed__upgrade_0.1.graphql-2.snap
@@ -3,5 +3,5 @@ source: apollo-federation/src/sources/connect/validation/mod.rs
 expression: "&diff::lines(&schema,\n&result.transformed).into_iter().filter_map(|res| match res\n{\n    diff::Result::Left(line) => Some(format!(\"- {line}\")),\n    diff::Result::Right(line) => Some(format!(\"+ {line}\")),\n    diff::Result::Both(_, _) => None,\n}).join(\"\\n\")"
 input_file: apollo-federation/src/sources/connect/validation/test_data/transformed/upgrade_0.1.graphql
 ---
--   @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
-+   @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect"])
+-     url: "https://specs.apollo.dev/connect/v0.1", 
++     url: "https://specs.apollo.dev/connect/v0.2",

--- a/apollo-federation/src/sources/connect/validation/test_data/transformed/upgrade_0.1.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/transformed/upgrade_0.1.graphql
@@ -3,7 +3,10 @@ extend schema
     url: "https://specs.apollo.dev/federation/v2.10"
     import: ["@key", "@external", "@requires"]
   )
-  @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.1", 
+    import: ["@connect"]
+  )
 
 type Query {
   something: String


### PR DESCRIPTION
This way, if later stages (JS validations, expansion, override checks) throw errors, the line/col shouldn't be messed up.

<!-- [CNN-760] -->
