### PR TITLE
[JSONSelection] Improve `$batch.a { b c }` input selection analysis

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/helpers.rs
+++ b/apollo-federation/src/sources/connect/json_selection/helpers.rs
@@ -288,6 +288,10 @@ mod tests {
         assert!(is_identifier("hello"));
         assert!(is_identifier("hello_world"));
         assert!(is_identifier("hello_world_123"));
+        assert!(is_identifier("_hello_world"));
+        assert!(is_identifier("hello_world_"));
+        assert!(is_identifier("__hello_world"));
+        assert!(is_identifier("__hello_world__"));
         assert!(!is_identifier("hello world"));
         assert!(!is_identifier("hello-world"));
         assert!(!is_identifier("123hello"));

--- a/apollo-federation/src/sources/connect/json_selection/helpers.rs
+++ b/apollo-federation/src/sources/connect/json_selection/helpers.rs
@@ -5,6 +5,7 @@ use serde_json_bytes::Map as JSONMap;
 use serde_json_bytes::Value as JSON;
 
 use super::ParseResult;
+use super::is_identifier;
 use super::location::Span;
 use super::location::WithRange;
 
@@ -145,6 +146,21 @@ pub(crate) fn json_merge(a: Option<&JSON>, b: Option<&JSON>) -> (Option<JSON>, V
     }
 }
 
+pub(crate) fn quote_if_necessary(input: &str) -> String {
+    if is_identifier(input)
+        || (
+            // We also allow unquoted variable syntax, including $, @, and
+            // $identifier.
+            input == "@"
+                || input.starts_with('$') && (input.len() == 1 || is_identifier(&input[1..]))
+        )
+    {
+        input.to_string()
+    } else {
+        serde_json_bytes::Value::String(input.into()).to_string()
+    }
+}
+
 /// A helper to call `assert_snapshot!` without prepending the module, since prepending the
 /// module makes all the paths in json_selection tests too long for Windows.
 #[cfg(test)]
@@ -172,6 +188,7 @@ macro_rules! assert_debug_snapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sources::connect::json_selection::is_identifier;
     use crate::sources::connect::json_selection::location::new_span;
 
     #[test]
@@ -264,5 +281,37 @@ mod tests {
             # Another comment
         ", "
             "));
+    }
+
+    #[test]
+    fn test_is_identifier() {
+        assert!(is_identifier("hello"));
+        assert!(is_identifier("hello_world"));
+        assert!(is_identifier("hello_world_123"));
+        assert!(!is_identifier("hello world"));
+        assert!(!is_identifier("hello-world"));
+        assert!(!is_identifier("123hello"));
+        assert!(!is_identifier("hello@world"));
+        assert!(!is_identifier("$hello"));
+        assert!(!is_identifier("hello$world"));
+        assert!(!is_identifier(" hello"));
+        assert!(!is_identifier("__hello_world  "));
+        assert!(!is_identifier(" hello_world_123 "));
+    }
+
+    #[test]
+    fn test_quote_if_necessary() {
+        assert_eq!(quote_if_necessary("hello"), "hello");
+        assert_eq!(quote_if_necessary("hello world"), "\"hello world\"");
+        assert_eq!(quote_if_necessary("hello-world"), "\"hello-world\"");
+        assert_eq!(quote_if_necessary("123hello"), "\"123hello\"");
+        assert_eq!(quote_if_necessary("$"), "$");
+        assert_eq!(quote_if_necessary("@"), "@");
+        assert_eq!(quote_if_necessary("$hello"), "$hello");
+        assert_eq!(quote_if_necessary("@asdf"), "\"@asdf\"");
+        assert_eq!(quote_if_necessary("as@df"), "\"as@df\"");
+        assert_eq!(quote_if_necessary("hello$world"), "\"hello$world\"");
+        assert_eq!(quote_if_necessary("hello world!"), "\"hello world!\"");
+        assert_eq!(quote_if_necessary("hello world!@#"), "\"hello world!@#\"");
     }
 }

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -8,6 +8,7 @@ mod methods;
 mod parser;
 mod pretty;
 mod selection_set;
+mod selection_trie;
 
 pub use apply_to::*;
 // Pretty code is currently only used in tests, so this cfg is to suppress the
@@ -17,5 +18,6 @@ pub(crate) use location::Ranged;
 pub use parser::*;
 #[cfg(test)]
 pub(crate) use pretty::*;
+pub(crate) use selection_trie::SelectionTrie;
 #[cfg(test)]
 mod fixtures;

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -1105,6 +1105,10 @@ impl Display for Key {
 
 // Identifier ::= [a-zA-Z_] NO_SPACE [0-9a-zA-Z_]*
 
+pub(super) fn is_identifier(input: &str) -> bool {
+    all_consuming(parse_identifier_no_space)(new_span(input)).is_ok()
+}
+
 fn parse_identifier(input: Span) -> ParseResult<WithRange<String>> {
     preceded(spaces_or_comments, parse_identifier_no_space)(input)
 }

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -3041,7 +3041,11 @@ mod tests {
                     namespace: Namespace::This,
                     location: Some(0..5),
                 },
-                selection: SelectionTrie::new_used(),
+                selection: {
+                    let mut selection = SelectionTrie::new();
+                    selection.add_str_path([]);
+                    selection
+                },
                 location: Some(0..5),
             })
         );

--- a/apollo-federation/src/sources/connect/json_selection/selection_trie.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_trie.rs
@@ -1,0 +1,372 @@
+use std::fmt::Display;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::ops::Range;
+
+use apollo_compiler::collections::IndexMap;
+use apollo_compiler::collections::IndexSet;
+
+use super::Key;
+use super::NamedSelection;
+use super::PathList;
+use super::Ranged;
+use super::SubSelection;
+use super::helpers::quote_if_necessary;
+use super::location::WithRange;
+
+impl PathList {
+    pub(crate) fn compute_selection_trie(&self) -> SelectionTrie {
+        let mut trie = SelectionTrie::new();
+        trie.add_path_list(self);
+        trie
+    }
+}
+
+#[derive(Debug, Eq, Clone)]
+pub(crate) struct SelectionTrie {
+    /// The top-level sub-selections of this [`SelectionTrie`].
+    selections: IndexMap<String, SelectionTrie>,
+
+    /// Whether the path terminating at this [`SelectionTrie`] node was
+    /// explicitly added to the trie.
+    used: bool,
+
+    /// Collected as metadata but ignored by [`PartialEq`] and [`Hash`].
+    key_ranges: IndexMap<String, IndexSet<Range<usize>>>,
+}
+
+impl Display for SelectionTrie {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut need_space = false;
+
+        for (key, sub) in self.selections.iter() {
+            if need_space {
+                write!(f, " ")?;
+            }
+
+            if sub.is_empty() {
+                if sub.is_used() {
+                    write!(f, "{}", quote_if_necessary(key))?;
+                    need_space = true;
+                }
+            } else {
+                write!(f, "{} {{ {} }}", quote_if_necessary(key), sub)?;
+                need_space = true;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialEq for SelectionTrie {
+    fn eq(&self, other: &Self) -> bool {
+        self.used == other.used && self.selections == other.selections
+    }
+}
+
+impl Hash for SelectionTrie {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.selections
+            .iter()
+            .fold(0, |acc, (key, sub)| {
+                let mut hasher = std::hash::DefaultHasher::default();
+                (key, sub).hash(&mut hasher);
+                acc ^ hasher.finish()
+            })
+            .hash(state);
+    }
+}
+
+impl SelectionTrie {
+    pub(crate) fn new() -> Self {
+        Self {
+            used: false,
+            selections: IndexMap::default(),
+            key_ranges: IndexMap::default(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn new_used() -> Self {
+        Self {
+            used: true,
+            selections: IndexMap::default(),
+            key_ranges: IndexMap::default(),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.selections.is_empty()
+    }
+
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &String> {
+        self.selections.keys()
+    }
+
+    pub(crate) fn get(&self, key: impl Into<String>) -> Option<&SelectionTrie> {
+        self.selections.get(&key.into())
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, &SelectionTrie)> {
+        self.selections.iter().map(|(key, sub)| (key.as_str(), sub))
+    }
+
+    pub(crate) fn key_ranges(&self, key: &str) -> impl Iterator<Item = Range<usize>> {
+        self.key_ranges
+            .get(key)
+            .into_iter()
+            .flat_map(|ranges| ranges.iter())
+            .cloned()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn has_str_path<'a>(&self, path: impl IntoIterator<Item = &'a str>) -> bool {
+        let mut current = self;
+        for key in path {
+            if let Some(sub) = current.get(key) {
+                current = sub;
+            } else {
+                return false;
+            }
+        }
+        current.is_used()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn add_str_path<'a>(
+        &mut self,
+        path: impl IntoIterator<Item = &'a str>,
+    ) -> &mut Self {
+        path.into_iter()
+            .fold(self, |trie, key| trie.add_str(key))
+            .set_used()
+    }
+
+    pub(super) fn add_path_list(&mut self, path_list: &PathList) -> &mut Self {
+        match path_list {
+            PathList::Key(key, tail) => self.add_key(key).add_path_list(tail.as_ref()),
+            PathList::Selection(sub) => self.add_subselection(sub),
+            // If we get to the end of the PathList, mark the path used.
+            PathList::Empty => self.set_used(),
+            // TODO Support PathList::Method and inputs used within method
+            // arguments. For now, assume we use the whole path up to the
+            // unhandled PathList element.
+            _ => self.set_used(),
+        }
+    }
+
+    pub(crate) fn add_subselection(&mut self, sub: &SubSelection) -> &mut Self {
+        for selection in sub.selections_iter() {
+            match selection {
+                NamedSelection::Field(_, key, nested_selection) => {
+                    let result = self.add_key(key);
+                    if let Some(nested) = nested_selection {
+                        result.add_subselection(nested);
+                    } else {
+                        result.set_used();
+                    }
+                }
+                NamedSelection::Path { path, .. } => {
+                    self.add_path_list(path.path.as_ref());
+                }
+                NamedSelection::Group(_, sub) => {
+                    self.add_subselection(sub);
+                }
+            }
+        }
+        self
+    }
+
+    pub(crate) fn add_selection_trie(&mut self, other: &SelectionTrie) -> &mut Self {
+        for (key, sub) in other.selections.iter() {
+            self.add_str_with_ranges(key, other.key_ranges(key))
+                .add_selection_trie(sub);
+        }
+        if self.is_used() || other.is_used() {
+            self.set_used()
+        } else {
+            self
+        }
+    }
+
+    /// Like [`SelectionTrie::extend`] but producing a new SelectionTrie
+    /// instance instead of modifying self.
+    #[allow(dead_code)]
+    pub(crate) fn merge(&self, other: &SelectionTrie) -> Self {
+        let mut merged = SelectionTrie::new();
+        merged.extend(self);
+        merged.extend(other);
+        merged
+    }
+
+    fn add_str(&mut self, key: &str) -> &mut Self {
+        self.selections
+            .entry(key.to_string())
+            .or_insert_with(SelectionTrie::new)
+    }
+
+    fn add_str_with_ranges(
+        &mut self,
+        key: &str,
+        ranges: impl IntoIterator<Item = Range<usize>>,
+    ) -> &mut Self {
+        self.key_ranges
+            .entry(key.to_string())
+            .or_default()
+            .extend(ranges);
+        self.add_str(key)
+    }
+
+    fn add_key(&mut self, key: &WithRange<Key>) -> &mut Self {
+        self.add_str_with_ranges(key.as_str(), key.range())
+    }
+
+    fn set_used(&mut self) -> &mut Self {
+        self.used = true;
+        self
+    }
+
+    fn is_used(&self) -> bool {
+        self.used
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let trie = SelectionTrie::new();
+        assert!(trie.is_empty());
+        assert_eq!(trie.keys().count(), 0);
+        assert_eq!(trie.iter().count(), 0);
+        assert_eq!(trie.key_ranges("field").count(), 0);
+        assert!(!trie.is_used());
+
+        let used = SelectionTrie::new_used();
+        assert!(used.is_empty());
+        assert_eq!(used.keys().count(), 0);
+        assert_eq!(used.iter().count(), 0);
+        assert_eq!(used.key_ranges("saves").count(), 0);
+        assert!(used.is_used());
+    }
+
+    #[test]
+    fn test_selection_trie_add_key() {
+        let mut trie = SelectionTrie::new();
+        trie.add_key(&WithRange::new(Key::Field("field".to_string()), Some(0..5)))
+            .set_used();
+
+        assert!(!trie.is_empty());
+        assert_eq!(trie.keys().count(), 1);
+        assert_eq!(trie.key_ranges("field").count(), 1);
+        assert!(!trie.is_used());
+
+        assert!(trie.set_used().is_used());
+        assert!(trie.is_used());
+
+        assert_eq!(trie.key_ranges("field").collect::<Vec<_>>(), vec![0..5]);
+
+        trie.add_key(&WithRange::new(
+            Key::Field("field".to_string()),
+            Some(5..10),
+        ))
+        .set_used();
+        assert_eq!(
+            trie.key_ranges("field").collect::<Vec<_>>(),
+            vec![0..5, 5..10]
+        );
+        assert_eq!(trie.keys().count(), 1);
+
+        trie.add_key(&WithRange::new(
+            Key::Field("other".to_string()),
+            Some(15..20),
+        ))
+        .set_used();
+        assert_eq!(trie.keys().count(), 2);
+        assert_eq!(trie.key_ranges("other").collect::<Vec<_>>(), vec![15..20]);
+        assert_eq!(
+            trie.key_ranges("field").collect::<Vec<_>>(),
+            vec![0..5, 5..10]
+        );
+        assert!(trie.is_used());
+
+        assert_eq!(trie.to_string(), "field other");
+    }
+
+    #[test]
+    fn test_selection_trie_add_path() {
+        let mut trie = SelectionTrie::new();
+        trie.add_str_path(["a", "b", "c"]);
+
+        assert!(!trie.is_empty());
+        assert_eq!(trie.keys().count(), 1);
+        assert_eq!(trie.key_ranges("a").count(), 0);
+        assert_eq!(trie.key_ranges("b").count(), 0);
+        assert_eq!(trie.key_ranges("c").count(), 0);
+        assert!(!trie.is_used());
+        assert_eq!(trie.to_string(), "a { b { c } }");
+
+        assert!(trie.has_str_path(["a", "b", "c"]));
+        assert!(!trie.has_str_path(["a", "b"]));
+        assert!(!trie.has_str_path(["a"]));
+        assert!(!trie.has_str_path(["b"]));
+        assert!(!trie.has_str_path(["c"]));
+        assert!(!trie.has_str_path(["a", "b", "c", "d"]));
+        assert!(!trie.has_str_path(["a", "b", "c", "d", "e"]));
+        assert!(!trie.has_str_path([]));
+
+        trie.add_str_path(["a", "c", "e"]);
+        assert!(trie.has_str_path(["a", "c", "e"]));
+        assert!(!trie.has_str_path(["a", "c"]));
+        assert!(!trie.has_str_path(["a"]));
+        assert!(!trie.has_str_path(["c"]));
+        assert!(!trie.has_str_path(["e"]));
+        assert!(!trie.has_str_path(["a", "c", "e", "f"]));
+        assert!(!trie.has_str_path(["a", "c", "e", "f", "g"]));
+        assert!(!trie.has_str_path([]));
+
+        trie.add_str_path([]);
+        assert!(trie.has_str_path([]));
+        assert!(!trie.has_str_path(["a"]));
+
+        assert_eq!(trie.to_string(), "a { b { c } c { e } }");
+    }
+
+    #[test]
+    fn test_selection_trie_merge() {
+        let mut trie1 = SelectionTrie::new();
+        trie1.add_str_path(["a", "b", "c"]);
+        trie1.add_str_path(["a", "d", "e"]);
+        assert_eq!(trie1.to_string(), "a { b { c } d { e } }");
+
+        let mut trie2 = SelectionTrie::new();
+        trie2.add_str_path(["a", "b", "f"]);
+        trie2.add_str_path(["g", "h"]);
+        assert_eq!(trie2.to_string(), "a { b { f } } g { h }");
+
+        let mut merged = trie1.merge(&trie2);
+        assert_eq!(merged.to_string(), "a { b { c f } d { e } } g { h }");
+
+        let merged_2_with_1 = trie2.merge(&trie1);
+        assert_eq!(
+            merged_2_with_1.to_string(),
+            "a { b { f c } d { e } } g { h }",
+        );
+
+        merged.add_str_path(["a", "b", "x", "y"]);
+
+        assert_eq!(
+            merged.to_string(),
+            "a { b { c f x { y } } d { e } } g { h }"
+        );
+        assert_eq!(
+            merged_2_with_1.to_string(),
+            "a { b { f c } d { e } } g { h }",
+        );
+        assert_eq!(trie1.to_string(), "a { b { c } d { e } }");
+        assert_eq!(trie2.to_string(), "a { b { f } } g { h }");
+    }
+}

--- a/apollo-federation/src/sources/connect/json_selection/selection_trie.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_trie.rs
@@ -31,15 +31,12 @@ impl JSONSelection {
 
         use super::ExternalVarPaths;
         for path in self.external_var_paths() {
-            match path.path.as_ref() {
-                PathList::Var(known_var, tail) => {
-                    trie.add_str(known_var.as_str())
-                        .add_path_list(tail.as_ref());
-                }
-                _ => {
-                    // The self.external_var_paths() method should only return
-                    // PathList::Var elements.
-                }
+            if let PathList::Var(known_var, tail) = path.path.as_ref() {
+                trie.add_str(known_var.as_str())
+                    .add_path_list(tail.as_ref());
+            } else {
+                // The self.external_var_paths() method should only return
+                // PathSelection elements whose path starts with PathList::Var.
             }
         }
 

--- a/apollo-federation/src/sources/connect/json_selection/selection_trie.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_trie.rs
@@ -116,7 +116,7 @@ impl SelectionTrie {
             .cloned()
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn has_str_path<'a>(&self, path: impl IntoIterator<Item = &'a str>) -> bool {
         let mut current = self;
         for key in path {
@@ -129,7 +129,7 @@ impl SelectionTrie {
         current.is_leaf()
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn add_str_path<'a>(
         &mut self,
         path: impl IntoIterator<Item = &'a str>,
@@ -200,7 +200,7 @@ impl SelectionTrie {
 
     /// Like [`SelectionTrie::extend`] but producing a new SelectionTrie
     /// instance instead of modifying self.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn merge(&self, other: &SelectionTrie) -> Self {
         let mut merged = SelectionTrie::new();
         merged.extend(self);

--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -371,11 +371,13 @@ fn extract_header_references(
             if var_ref.namespace.namespace != Namespace::Request
                 && var_ref.namespace.namespace != Namespace::Response
             {
-                vec![]
-            } else if let Some(headers_subselection) = var_ref.selection.get("headers") {
-                headers_subselection.keys().cloned().collect()
+                Vec::new()
             } else {
-                vec![]
+                var_ref
+                    .selection
+                    .get("headers")
+                    .map(|headers_subtrie| headers_subtrie.keys().cloned().collect())
+                    .unwrap_or_default()
             }
         })
         .collect()

--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -365,29 +365,20 @@ fn determine_entity_resolver(
 fn extract_header_references(
     variable_references: HashSet<VariableReference<Namespace>>,
 ) -> HashSet<String> {
-    let headers: HashSet<String> = variable_references
+    variable_references
         .iter()
-        .filter_map(|var_ref| {
+        .flat_map(|var_ref| {
             if var_ref.namespace.namespace != Namespace::Request
                 && var_ref.namespace.namespace != Namespace::Response
             {
-                return None;
+                vec![]
+            } else if let Some(headers_subselection) = var_ref.selection.get("headers") {
+                headers_subselection.keys().cloned().collect()
+            } else {
+                vec![]
             }
-
-            // We only care if the path references starts with "headers"
-            if var_ref
-                .path
-                .first()
-                .is_none_or(|path| path.part != "headers")
-            {
-                return None;
-            }
-
-            // Grab the name of the header from the path
-            var_ref.path.get(1).map(|path| path.part.to_string())
         })
-        .collect();
-    headers
+        .collect()
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/sources/connect/models/keys.rs
+++ b/apollo-federation/src/sources/connect/models/keys.rs
@@ -1,10 +1,5 @@
-use std::fmt;
-use std::fmt::Display;
-use std::fmt::Formatter;
-
 use apollo_compiler::Name;
 use apollo_compiler::Schema;
-use apollo_compiler::collections::IndexMap;
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::validation::WithErrors;
@@ -12,16 +7,16 @@ use itertools::Itertools;
 
 use super::VariableReference;
 use crate::sources::connect::Namespace;
+use crate::sources::connect::json_selection::SelectionTrie;
 
 /// Given the variables relevant to entity fetching, synthesize a FieldSet
 /// appropriate for use in a @key directive.
-pub(crate) fn make_key_field_set_from_variables<'a>(
+pub(crate) fn make_key_field_set_from_variables(
     schema: &Schema,
     object_type_name: &Name,
-    variables: impl Iterator<Item = VariableReference<'a, Namespace>>,
+    variables: impl Iterator<Item = VariableReference<Namespace>>,
     namespace: Namespace,
 ) -> Result<Option<Valid<FieldSet>>, WithErrors<FieldSet>> {
-    // TODO: does this work with subselections like $this { something }?
     let params = variables
         .filter(|var| var.namespace.namespace == namespace)
         .unique()
@@ -31,9 +26,10 @@ pub(crate) fn make_key_field_set_from_variables<'a>(
         return Ok(None);
     }
 
-    let mut merged = TrieNode::default();
+    // let mut merged = TrieNode::default();
+    let mut merged = SelectionTrie::new();
     for param in params {
-        merged.insert(&param.path.iter().map(|p| p.as_str()).collect::<Vec<_>>());
+        merged.add_selection_trie(&param.selection);
     }
 
     FieldSet::parse_and_validate(
@@ -45,69 +41,51 @@ pub(crate) fn make_key_field_set_from_variables<'a>(
     .map(Some)
 }
 
-#[derive(Default)]
-struct TrieNode(IndexMap<String, TrieNode>);
-
-impl TrieNode {
-    fn insert(&mut self, path: &[&str]) {
-        let mut node = self;
-        for head in path {
-            node = node.0.entry(head.to_string()).or_default();
-        }
-    }
-}
-
-impl Display for TrieNode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        for (i, (key, node)) in self.0.iter().enumerate() {
-            write!(f, "{}", key)?;
-            if !node.0.is_empty() {
-                write!(f, " {{ {} }}", node)?;
-            }
-            if i != self.0.len() - 1 {
-                write!(f, " ")?;
-            }
-        }
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use apollo_compiler::Schema;
     use apollo_compiler::name;
 
-    use super::TrieNode;
     use super::make_key_field_set_from_variables;
     use crate::sources::connect::Namespace;
     use crate::sources::connect::PathSelection;
 
     #[test]
-    fn test_trie() {
-        let mut trie = TrieNode::default();
-        trie.insert(&["a", "b", "c"]);
-        trie.insert(&["a", "b", "d"]);
-        trie.insert(&["a", "b", "e"]);
-        trie.insert(&["a", "c"]);
-        trie.insert(&["a", "d"]);
-        trie.insert(&["b"]);
-        assert_eq!(trie.to_string(), "a { b { c d e } c d } b");
-    }
-
-    #[test]
-    fn test_make_key_field_set_from_variables() {
+    fn test_make_args_field_set_from_variables() {
         let result = make_key_field_set_from_variables(
             &Schema::parse_and_validate("type Query { t: T } type T { a: A b: ID } type A { b: B c: ID d: ID } type B { c: ID d: ID e: ID }", "").unwrap(),
             &name!("T"),
             vec![
                 PathSelection::parse("$args.a.b.c".into()).unwrap().1.variable_reference().unwrap(),
-                PathSelection::parse("$args.a.b.d".into()).unwrap().1.variable_reference().unwrap(),
-                PathSelection::parse("$args.a.b.e".into()).unwrap().1.variable_reference().unwrap(),
+                PathSelection::parse("$args.a.b { d e }".into()).unwrap().1.variable_reference().unwrap(),
                 PathSelection::parse("$args.a.c".into()).unwrap().1.variable_reference().unwrap(),
                 PathSelection::parse("$args.a.d".into()).unwrap().1.variable_reference().unwrap(),
-                PathSelection::parse("$args.b".into()).unwrap().1.variable_reference().unwrap(),
+                PathSelection::parse("$args { b }".into()).unwrap().1.variable_reference().unwrap(),
             ].into_iter(),
             Namespace::Args,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            result.serialize().no_indent().to_string(),
+            "a { b { c d e } c d } b"
+        );
+    }
+
+    #[test]
+    fn test_make_batch_field_set_from_variables() {
+        let result = make_key_field_set_from_variables(
+            &Schema::parse_and_validate("type Query { t: T } type T { a: A b: ID } type A { b: B c: ID d: ID } type B { c: ID d: ID e: ID }", "").unwrap(),
+            &name!("T"),
+            vec![
+                PathSelection::parse("$batch.a.b.c".into()).unwrap().1.variable_reference().unwrap(),
+                PathSelection::parse("$batch.a.b { d e }".into()).unwrap().1.variable_reference().unwrap(),
+                PathSelection::parse("$batch.a.c".into()).unwrap().1.variable_reference().unwrap(),
+                PathSelection::parse("$batch.a.d".into()).unwrap().1.variable_reference().unwrap(),
+                PathSelection::parse("$batch { b }".into()).unwrap().1.variable_reference().unwrap(),
+            ].into_iter(),
+            Namespace::Batch,
         )
         .unwrap()
         .unwrap();

--- a/apollo-federation/src/sources/connect/models/keys.rs
+++ b/apollo-federation/src/sources/connect/models/keys.rs
@@ -29,7 +29,7 @@ pub(crate) fn make_key_field_set_from_variables(
     // let mut merged = TrieNode::default();
     let mut merged = SelectionTrie::new();
     for param in params {
-        merged.add_selection_trie(&param.selection);
+        merged.extend(&param.selection);
     }
 
     FieldSet::parse_and_validate(

--- a/apollo-federation/src/sources/connect/validation/connect/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/selection.rs
@@ -180,12 +180,11 @@ pub(super) fn validate_selection_variables<'a>(
                     namespace = reference.namespace.namespace.as_str(),
                     available = context.namespaces_joined(),
                 ),
-                locations: selection_str
-                    .line_col_for_subslice(
-                        reference.namespace.location.start..reference.namespace.location.end,
-                        schema,
-                    )
-                    .into_iter()
+                locations: reference
+                    .namespace
+                    .location
+                    .iter()
+                    .flat_map(|range| selection_str.line_col_for_subslice(range.clone(), schema))
                     .collect(),
             });
         }

--- a/apollo-federation/src/sources/connect/validation/connect/selection/variables.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/selection/variables.rs
@@ -241,6 +241,7 @@ impl NamespaceResolver for ArgsResolver<'_> {
                 .arguments
                 .iter()
                 .find(|arg| arg.name == root)
+                .map(|arg| arg.ty.clone())
                 .ok_or_else(|| Message {
                     code: Code::UndefinedArgument,
                     message: format!(
@@ -252,8 +253,7 @@ impl NamespaceResolver for ArgsResolver<'_> {
                         .key_ranges(root)
                         .flat_map(|range| expression.line_col_for_subslice(range, schema))
                         .collect(),
-                })
-                .map(|field| field.ty.clone())?;
+                })?;
 
             resolve_path(schema, sub_trie, expression, &field_type, self.field)?;
         }

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch.graphql.snap
@@ -100,7 +100,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch.gra
         code: InvalidUrl,
         message: "In `GET` in `@connect(http:)` on `T.listRelationship`: $batch is not valid here, must be one of $args, $config, $context, $request, $this",
         locations: [
-            88:28..88:37,
+            88:28..88:55,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@keys_and_entities__valid__entity_field_counts_as_key_resolver.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@keys_and_entities__valid__entity_field_counts_as_key_resolver.graphql.snap
@@ -3,10 +3,4 @@ source: apollo-federation/src/sources/connect/validation/mod.rs
 expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/sources/connect/validation/test_data/keys_and_entities/valid/entity_field_counts_as_key_resolver.graphql
 ---
-[
-    Message {
-        code: GraphQLError,
-        message: "Variables used in connector (`$this`) for `Product.price@connect[0]` cannot be used to create a valid `@key` directive.",
-        locations: [],
-    },
-]
+[]

--- a/apollo-federation/src/sources/connect/variable.rs
+++ b/apollo-federation/src/sources/connect/variable.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use itertools::Itertools;
 
 use super::id::ConnectedElement;
+use super::json_selection::SelectionTrie;
 use crate::sources::connect::validation::Code;
 
 /// A variable context for Apollo Connectors. Variables are used within a `@connect` or `@source`
@@ -144,24 +145,25 @@ impl Display for Namespace {
 /// A variable reference. Consists of a namespace starting with a `$` and an optional path
 /// separated by '.' characters.
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
-pub struct VariableReference<'a, N: FromStr + ToString> {
+pub struct VariableReference<N: FromStr + ToString> {
     /// The namespace of the variable - `$this`, `$args`, `$status`, etc.
     pub namespace: VariableNamespace<N>,
 
     /// The path elements of this reference. For example, the reference `$this.a.b.c`
     /// has path elements `a`, `b`, `c`. May be empty in some cases, as in the reference `$status`.
-    pub(crate) path: Vec<VariablePathPart<'a>>,
+    pub(crate) selection: SelectionTrie,
 
     /// The location of the reference within the original text.
-    pub(crate) location: Range<usize>,
+    pub(crate) location: Option<Range<usize>>,
 }
 
-impl<N: FromStr + ToString> Display for VariableReference<'_, N> {
+impl<N: FromStr + ToString> Display for VariableReference<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.namespace.namespace.to_string().as_str())?;
-        for part in &self.path {
-            f.write_str(".")?;
-            f.write_str(part.as_str())?;
+        if !self.selection.is_empty() {
+            f.write_str(" { ")?;
+            f.write_str(self.selection.to_string().as_str())?;
+            f.write_str(" }")?;
         }
         Ok(())
     }
@@ -171,25 +173,5 @@ impl<N: FromStr + ToString> Display for VariableReference<'_, N> {
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct VariableNamespace<N: FromStr + ToString> {
     pub namespace: N,
-    pub(crate) location: Range<usize>,
-}
-
-/// Part of a variable path, like `a` in `$this.a.b.c`
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
-pub(crate) struct VariablePathPart<'a> {
-    pub(crate) part: &'a str,
-    pub(crate) location: Range<usize>,
-}
-
-impl VariablePathPart<'_> {
-    pub(crate) const fn as_str(&self) -> &str {
-        self.part
-    }
-}
-
-impl Display for VariablePathPart<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.part.to_string().as_str())?;
-        Ok(())
-    }
+    pub(crate) location: Option<Range<usize>>,
 }

--- a/apollo-federation/src/sources/connect/variable.rs
+++ b/apollo-federation/src/sources/connect/variable.rs
@@ -161,9 +161,7 @@ impl<N: FromStr + ToString> Display for VariableReference<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.namespace.namespace.to_string().as_str())?;
         if !self.selection.is_empty() {
-            f.write_str(" { ")?;
-            f.write_str(self.selection.to_string().as_str())?;
-            f.write_str(" }")?;
+            write!(f, " {{ {} }}", self.selection)?;
         }
         Ok(())
     }


### PR DESCRIPTION
This PR changes `VariableReference::path: Vec<VariablePathPart>` to `VariableReference::selection: SelectionTrie`, introducing a new data structure called `SelectionTrie`, because a single variable reference may involve a nested structure of sub-selections, rather than a single linear path. Acknowledging this complexity allows us to capture more accurate `$batch` usage information, so all essential keys will be included in `@key(fields: "...")`.

There are a number of selection set-related data structures currently in use in this codebase, like `FieldSet` and `apollo_compiler::executable::SelectionSet` and `apollo-federation::operation::SelectionSet`, but `SelectionTrie` seemed worthwhile because it can track location information for all the field names it stores (see `SelectionTrie::key_ranges`), which did not seem to be an off-the-shelf feature of the other options.

Less important than location information but still relevant to this decision, `SelectionTrie` supports more efficient `extend`/`merge` operations than the other options, because it stores `SelectionTrie::selections` as an `IndexMap` rather than a `Vec`, and because the values of that map are `Arc<SelectionTrie>` (note: `Rc` would work too), enabling cheap copy-on-write semantics when merging one trie into another.

This implementation does not yet understand `$batch` usage that happens _after_ `->` method calls, so `$batch->first.id` probably will not analyze correctly (that is, like `$batch.id->first`, producing a selection of `$batch { id }`), until we have a more robust way to record all input names while processing method shapes. If every `Shape` knew what part of the input it came from, we could lean more heavily on that metadata, but that depends on https://github.com/apollographql/shape-rs/pull/25 which we decided should not block the improvements in this PR.