### PR TITLE
FederationBlueprint callback implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "indexmap 2.9.0",
  "insta",
  "itertools 0.14.0",
+ "levenshtein",
  "line-col",
  "multi_try",
  "multimap 0.10.0",
@@ -3839,6 +3840,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -29,6 +29,7 @@ hashbrown = "0.15.1"
 indexmap = { version = "2.2.6", features = ["serde"] }
 itertools = "0.14.0"
 line-col = "0.2.1"
+levenshtein = "1"
 multimap = "0.10.0"
 multi_try = "0.3.0"
 nom = "7.1.3"

--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -333,10 +333,8 @@ fn cmd_subgraph(file_path: &Path) -> Result<(), FederationError> {
         .file_name()
         .and_then(|name| name.to_str().map(|x| x.to_string()));
     let name = name.unwrap_or("subgraph".to_string());
-    let subgraph = typestate::Subgraph::parse(&name, &format!("http://{name}"), &doc_str)
-        .expect("valid schema")
-        .expand_links()
-        .expect("expanded subgraph to be valid")
+    let subgraph = typestate::Subgraph::parse(&name, &format!("http://{name}"), &doc_str)?
+        .expand_links()?
         .validate(true)
         .map_err(|e| e.into_inner())?;
     println!("{}", subgraph.schema_string());

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod suggestion;
+
 use std::cmp::Ordering;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -124,8 +126,11 @@ pub enum SingleFederationError {
     // This is a known bug that will take time to fix, and does not require reporting.
     #[error("{message}")]
     InternalUnmergeableFields { message: String },
-    #[error("{diagnostics}")]
-    InvalidGraphQL { diagnostics: DiagnosticList },
+    // InvalidGraphQL: We need to be able to modify the message text from apollo-compiler. So, we
+    //                 format the DiagnosticData into String here. We can add additional data as
+    //                 necessary.
+    #[error("{message}")]
+    InvalidGraphQL { message: String },
     #[error(transparent)]
     InvalidGraphQLName(#[from] InvalidNameError),
     #[error("Subgraph invalid: {message}")]
@@ -655,12 +660,6 @@ impl Display for MultipleFederationErrors {
     }
 }
 
-impl From<DiagnosticList> for SingleFederationError {
-    fn from(diagnostics: DiagnosticList) -> Self {
-        SingleFederationError::InvalidGraphQL { diagnostics }
-    }
-}
-
 impl FromIterator<SingleFederationError> for MultipleFederationErrors {
     fn from_iter<T: IntoIterator<Item = SingleFederationError>>(iter: T) -> Self {
         Self {
@@ -719,7 +718,17 @@ impl std::fmt::Debug for FederationError {
 
 impl From<DiagnosticList> for FederationError {
     fn from(value: DiagnosticList) -> Self {
-        SingleFederationError::from(value).into()
+        let errors: Vec<_> = value
+            .iter()
+            .map(|d| SingleFederationError::InvalidGraphQL {
+                message: d.to_string(),
+            })
+            .collect();
+        match errors.len().cmp(&1) {
+            Ordering::Less => internal_error!("diagnostic list is unexpectedly empty"),
+            Ordering::Equal => errors[0].clone().into(),
+            Ordering::Greater => MultipleFederationErrors { errors }.into(),
+        }
     }
 }
 
@@ -744,12 +753,26 @@ impl FederationError {
         result.into()
     }
 
+    pub fn into_errors(self) -> Vec<SingleFederationError> {
+        match self {
+            FederationError::SingleFederationError(e) => vec![e],
+            FederationError::MultipleFederationErrors(e) => e.errors,
+            FederationError::AggregateFederationError(e) => e.causes,
+        }
+    }
+
     pub fn errors(&self) -> Vec<&SingleFederationError> {
         match self {
             FederationError::SingleFederationError(e) => vec![e],
             FederationError::MultipleFederationErrors(e) => e.errors.iter().collect(),
             FederationError::AggregateFederationError(e) => e.causes.iter().collect(),
         }
+    }
+
+    pub fn has_invalid_graphql_error(&self) -> bool {
+        self.errors()
+            .into_iter()
+            .any(|e| matches!(e, SingleFederationError::InvalidGraphQL { .. }))
     }
 }
 

--- a/apollo-federation/src/error/suggestion.rs
+++ b/apollo-federation/src/error/suggestion.rs
@@ -1,0 +1,47 @@
+use levenshtein::levenshtein;
+
+use crate::utils::human_readable;
+
+pub(crate) fn suggestion_list(
+    input: &str,
+    options: impl IntoIterator<Item = String>,
+) -> Vec<String> {
+    let threshold = 1 + (input.len() as f64 * 0.4).floor() as usize;
+    let input_lowercase = input.to_lowercase();
+    let mut result = Vec::new();
+    for option in options {
+        // Special casing so that if the only mismatch is in upper/lower-case, then the option is
+        // always shown.
+        let distance = if input_lowercase == option.to_lowercase() {
+            1
+        } else {
+            levenshtein(input, &option)
+        };
+        if distance <= threshold {
+            result.push((option, distance));
+        }
+    }
+    result.sort_by(|x, y| x.1.cmp(&y.1));
+    result.into_iter().map(|(s, _)| s.to_string()).collect()
+}
+
+const MAX_SUGGESTIONS: usize = 5;
+
+/// Given [ A, B, C ], returns "Did you mean A, B, or C?".
+pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> String {
+    const MESSAGE: &str = "Did you mean ";
+
+    let suggestion_str = human_readable::join_strings(
+        suggestions
+            .into_iter()
+            .take(MAX_SUGGESTIONS)
+            .map(|s| format!("\"{}\"", s)),
+        human_readable::JoinStringsOptions {
+            separator: ", ",
+            first_separator: None,
+            last_separator: Some(", or "),
+            output_length_limit: None,
+        },
+    );
+    format!("{}{}?", MESSAGE, suggestion_str)
+}

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -900,13 +900,14 @@ impl SubgraphOperationCompression {
         match self {
             Self::GenerateFragments => Ok(operation.generate_fragments()?),
             Self::Disabled => {
-                let operation_document = operation.try_into().map_err(|err| match err {
-                    FederationError::SingleFederationError(
-                        SingleFederationError::InvalidGraphQL { diagnostics },
-                    ) => internal_error!(
-                        "Query planning produced an invalid subgraph operation.\n{diagnostics}"
-                    ),
-                    _ => err,
+                let operation_document = operation.try_into().map_err(|err: FederationError| {
+                    if err.has_invalid_graphql_error() {
+                        internal_error!(
+                            "Query planning produced an invalid subgraph operation.\n{err}"
+                        )
+                    } else {
+                        err
+                    }
                 })?;
                 Ok(operation_document)
             }

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -215,7 +215,7 @@ impl FederationBlueprint {
     }
 
     fn apply_directives_after_parsing() -> bool {
-        todo!()
+        true
     }
 
     fn remove_federation_definitions_broken_in_known_ways(

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -20,6 +20,7 @@ use crate::link::federation_spec_definition::FEDERATION_FIELDS_ARGUMENT_NAME;
 use crate::link::federation_spec_definition::FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::link::link_spec_definition::LinkSpecDefinition;
 use crate::link::spec::Identity;
@@ -126,12 +127,17 @@ impl FederationBlueprint {
         Ok(())
     }
 
-    fn on_added_core_feature(_schema: &mut Schema, _feature: &CoreFeature) {
-        todo!()
-    }
-
-    pub(crate) fn on_invalidation(_: &Schema) {
-        todo!()
+    fn on_added_core_feature(
+        schema: &mut FederationSchema,
+        feature: &CoreFeature,
+    ) -> Result<(), FederationError> {
+        if feature.url.identity == Identity::federation_identity() {
+            FEDERATION_VERSIONS
+                .find(&feature.url.version)
+                .iter()
+                .try_for_each(|spec| spec.add_elements_to_schema(schema))?;
+        }
+        Ok(())
     }
 
     pub(crate) fn on_validation(

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -175,6 +175,7 @@ impl<'a> SchemaUpgrader<'a> {
         object_type_map: &'a HashMap<Name, HashMap<String, TypeInfo>>,
     ) -> Result<Self, FederationError> {
         let schema = original_subgraph.schema().clone();
+        // TODO (FED-428): JS version calls `setSchemaAsFed2Subgraph`.
         Ok(SchemaUpgrader {
             schema,
             expanded_info: ExpandedSubgraphInfo {

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -336,6 +336,9 @@ impl Subgraph<Expanded> {
 
 impl Subgraph<Validated> {
     pub fn invalidate(self) -> Subgraph<Expanded> {
+        // PORT_NOTE: In JS, the metadata gets invalidated by calling
+        // `federationMetadata.onInvalidate` (via `FederationBlueprint.onValidation`). But, it
+        // doesn't seem necessary in Rust, since the metadata is computed eagerly.
         Subgraph {
             name: self.name,
             url: self.url,

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -167,11 +167,14 @@ impl Subgraph<Raw> {
     }
 
     pub fn expand_links(self) -> Result<Subgraph<Expanded>, FederationError> {
+        tracing::debug!("expand_links: expand_links start");
         let mut schema = FederationSchema::new_uninitialized(self.state.schema)?;
         // First, copy types over from the underlying schema AST to make sure we have built-ins that directives may reference
+        tracing::debug!("expand_links: collect_shallow_references");
         schema.collect_shallow_references();
 
         // Backfill missing directive definitions. This is primarily making sure we have a definition for `@link`.
+        tracing::debug!("expand_links: missing directive definitions");
         for directive in &schema.schema().schema_definition.directives.clone() {
             if schema.get_directive_definition(&directive.name).is_none() {
                 FederationBlueprint::on_missing_directive_definition(&mut schema, directive)?;
@@ -180,8 +183,10 @@ impl Subgraph<Raw> {
 
         // If there's a use of `@link`, and we successfully added its definition, add the bootstrap directive
         if schema.get_directive_definition(&name!("link")).is_some() {
+            tracing::debug!("expand_links: add @link spec definition to schema");
             LinkSpecDefinition::latest().add_to_schema(&mut schema, /*alias*/ None)?;
         } else {
+            tracing::debug!("expand_links: add fed1 @link and its spec definition to schema");
             // This must be a Fed 1 schema.
             LinkSpecDefinition::fed1_latest().add_to_schema(&mut schema, /*alias*/ None)?;
 
@@ -191,22 +196,30 @@ impl Subgraph<Raw> {
         };
 
         // Now that we have the definition for `@link` and an application, the bootstrap directive detection should work.
+        tracing::debug!("expand_links: collect_links_metadata");
         schema.collect_links_metadata()?;
 
+        tracing::debug!("expand_links: on_directive_definition_and_schema_parsed");
         FederationBlueprint::on_directive_definition_and_schema_parsed(&mut schema)?;
 
         // Also, the backfilled definitions mean we can collect deep references.
-        schema.collect_deep_references()?;
+        // Ignore the error case, which means the schema has invalid references. It will be
+        // reported later in the validation phase.
+        tracing::debug!("expand_links: collect_deep_references");
+        _ = schema.collect_deep_references();
 
         // TODO: Remove this and use metadata from this Subgraph instead of FederationSchema
+        tracing::debug!("expand_links: on_constructed");
         FederationBlueprint::on_constructed(&mut schema)?;
 
         // PORT_NOTE: JS version calls `addFederationOperations` in the `validate` method.
         //            It seems to make sense for it to be a part of expansion stage. We can create
         //            a separate stage for it between `Expanded` and `Validated` if we need a stage
         //            that is expanded, but federation operations are not added.
+        tracing::debug!("expand_links: add_federation_operations");
         add_federation_operations(&mut schema)?;
 
+        tracing::debug!("expand_links: compute_subgraph_metadata");
         let metadata = compute_subgraph_metadata(&schema)?.ok_or_else(|| {
             internal_error!(
                 "Unable to detect federation version used in subgraph '{}'",
@@ -214,6 +227,7 @@ impl Subgraph<Raw> {
             )
         })?;
 
+        tracing::debug!("expand_links finished");
         Ok(Subgraph {
             name: self.name,
             url: self.url,
@@ -318,6 +332,9 @@ impl Subgraph<Expanded> {
     }
 
     pub fn validate(self, rename_root_types: bool) -> Result<Subgraph<Validated>, SubgraphError> {
+        // PORT_NOTE: The JS version calls GraphQL-js's `validateSDL` function and federation's
+        //            `validateSchema` function here. But, Rust version performs general GraphQL
+        //            validation in the `FederationBlueprint::on_validation` method.
         let blueprint = FederationBlueprint::new(rename_root_types);
         let schema = blueprint
             .on_validation(self.state.schema)

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -1932,8 +1932,6 @@ mod interface_object_and_key_on_interfaces_validation_tests {
     }
 
     #[test]
-    #[ignore = "temporary ignore for build break"]
-    #[should_panic(expected = r#"Mismatched errors:"#)]
     fn only_allow_interface_object_on_entity_types() {
         // There is no meaningful way to make @interfaceObject work on a value type at the moment,
         // because if you have an @interfaceObject, some other subgraph needs to be able to resolve


### PR DESCRIPTION
This PR ports the rest of FederationBlueprint callback implementations.
There are a few places that still need to be revisited (commented as `TODO`). But, the callbacks themselves are useable and ready for review.

<!-- FED-428 -->
