### PR TITLE
Un-box statically-defined supergraph specifications

### DIFF
--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -27,15 +27,17 @@ pub(crate) struct ContextDirectiveArguments<'doc> {
 #[derive(Clone)]
 pub(crate) struct ContextSpecDefinition {
     url: Url,
+    minimum_federation_version: Version,
 }
 
 impl ContextSpecDefinition {
-    pub(crate) fn new(version: Version) -> Self {
+    pub(crate) fn new(version: Version, minimum_federation_version: Version) -> Self {
         Self {
             url: Url {
                 identity: Identity::context_identity(),
                 version,
             },
+            minimum_federation_version,
         }
     }
 
@@ -69,11 +71,18 @@ impl SpecDefinition for ContextSpecDefinition {
     fn type_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
         todo!()
     }
+
+    fn minimum_federation_version(&self) -> &Version {
+        &self.minimum_federation_version
+    }
 }
 
 pub(crate) static CONTEXT_VERSIONS: LazyLock<SpecDefinitions<ContextSpecDefinition>> =
     LazyLock::new(|| {
         let mut definitions = SpecDefinitions::new(Identity::context_identity());
-        definitions.add(ContextSpecDefinition::new(Version { major: 0, minor: 1 }));
+        definitions.add(ContextSpecDefinition::new(
+            Version { major: 0, minor: 1 },
+            Version { major: 2, minor: 8 },
+        ));
         definitions
     });

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -889,6 +889,10 @@ impl SpecDefinition for FederationSpecDefinition {
             name: FEDERATION_FIELDSET_TYPE_NAME_IN_SPEC,
         })]
     }
+
+    fn minimum_federation_version(&self) -> &Version {
+        &self.url.version
+    }
 }
 
 pub(crate) static FED_1: LazyLock<FederationSpecDefinition> =

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -40,15 +40,17 @@ pub(crate) const INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC: Name = name!("inaccessible
 
 pub(crate) struct InaccessibleSpecDefinition {
     url: Url,
+    minimum_federation_version: Version,
 }
 
 impl InaccessibleSpecDefinition {
-    pub(crate) fn new(version: Version) -> Self {
+    pub(crate) fn new(version: Version, minimum_federation_version: Version) -> Self {
         Self {
             url: Url {
                 identity: Identity::inaccessible_identity(),
                 version,
             },
+            minimum_federation_version,
         }
     }
 
@@ -104,19 +106,23 @@ impl SpecDefinition for InaccessibleSpecDefinition {
     fn type_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
         todo!()
     }
+
+    fn minimum_federation_version(&self) -> &Version {
+        &self.minimum_federation_version
+    }
 }
 
 pub(crate) static INACCESSIBLE_VERSIONS: LazyLock<SpecDefinitions<InaccessibleSpecDefinition>> =
     LazyLock::new(|| {
         let mut definitions = SpecDefinitions::new(Identity::inaccessible_identity());
-        definitions.add(InaccessibleSpecDefinition::new(Version {
-            major: 0,
-            minor: 1,
-        }));
-        definitions.add(InaccessibleSpecDefinition::new(Version {
-            major: 0,
-            minor: 2,
-        }));
+        definitions.add(InaccessibleSpecDefinition::new(
+            Version { major: 0, minor: 1 },
+            Version { major: 1, minor: 0 },
+        ));
+        definitions.add(InaccessibleSpecDefinition::new(
+            Version { major: 0, minor: 2 },
+            Version { major: 2, minor: 0 },
+        ));
         definitions
     });
 

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -169,15 +169,17 @@ pub(crate) struct EnumValueDirectiveArguments {
 #[derive(Clone)]
 pub(crate) struct JoinSpecDefinition {
     url: Url,
+    minimum_federation_version: Version,
 }
 
 impl JoinSpecDefinition {
-    pub(crate) fn new(version: Version) -> Self {
+    pub(crate) fn new(version: Version, minimum_federation_version: Version) -> Self {
         Self {
             url: Url {
                 identity: Identity::join_identity(),
                 version,
             },
+            minimum_federation_version,
         }
     }
 
@@ -418,15 +420,34 @@ impl SpecDefinition for JoinSpecDefinition {
     fn type_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
         todo!()
     }
+
+    fn minimum_federation_version(&self) -> &Version {
+        &self.minimum_federation_version
+    }
 }
 
 pub(crate) static JOIN_VERSIONS: LazyLock<SpecDefinitions<JoinSpecDefinition>> =
     LazyLock::new(|| {
         let mut definitions = SpecDefinitions::new(Identity::join_identity());
-        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 1 }));
-        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 2 }));
-        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 3 }));
-        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 4 }));
-        definitions.add(JoinSpecDefinition::new(Version { major: 0, minor: 5 }));
+        definitions.add(JoinSpecDefinition::new(
+            Version { major: 0, minor: 1 },
+            Version { major: 1, minor: 0 },
+        ));
+        definitions.add(JoinSpecDefinition::new(
+            Version { major: 0, minor: 2 },
+            Version { major: 1, minor: 0 },
+        ));
+        definitions.add(JoinSpecDefinition::new(
+            Version { major: 0, minor: 3 },
+            Version { major: 2, minor: 0 },
+        ));
+        definitions.add(JoinSpecDefinition::new(
+            Version { major: 0, minor: 4 },
+            Version { major: 2, minor: 7 },
+        ));
+        definitions.add(JoinSpecDefinition::new(
+            Version { major: 0, minor: 5 },
+            Version { major: 2, minor: 8 },
+        ));
         definitions
     });

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -46,12 +46,18 @@ pub(crate) const LINK_DIRECTIVE_FEATURE_ARGUMENT_NAME: Name = name!("feature"); 
 
 pub(crate) struct LinkSpecDefinition {
     url: Url,
+    minimum_federation_version: Version,
 }
 
 impl LinkSpecDefinition {
-    pub(crate) fn new(version: Version, identity: Identity) -> Self {
+    pub(crate) fn new(
+        version: Version,
+        identity: Identity,
+        minimum_federation_version: Version,
+    ) -> Self {
         Self {
             url: Url { identity, version },
+            minimum_federation_version,
         }
     }
 
@@ -301,6 +307,10 @@ impl SpecDefinition for LinkSpecDefinition {
         specs
     }
 
+    fn minimum_federation_version(&self) -> &Version {
+        &self.minimum_federation_version
+    }
+
     fn add_elements_to_schema(
         &self,
         _schema: &mut FederationSchema,
@@ -344,10 +354,12 @@ pub(crate) static CORE_VERSIONS: LazyLock<SpecDefinitions<LinkSpecDefinition>> =
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 1 },
             Identity::core_identity(),
+            Version { major: 1, minor: 0 },
         ));
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 2 },
             Identity::core_identity(),
+            Version { major: 2, minor: 0 },
         ));
         definitions
     });
@@ -357,6 +369,7 @@ pub(crate) static LINK_VERSIONS: LazyLock<SpecDefinitions<LinkSpecDefinition>> =
         definitions.add(LinkSpecDefinition::new(
             Version { major: 1, minor: 0 },
             Identity::link_identity(),
+            Version { major: 2, minor: 0 },
         ));
         definitions
     });

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -203,9 +203,7 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
     pub(crate) fn versions(&self) -> Keys<Version, T> {
         self.definitions.keys()
     }
-}
 
-impl<T: SpecDefinition + 'static> SpecDefinitions<T> {
     pub(crate) fn get_minimum_required_version(
         &'static self,
         federation_version: &Version,

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -26,6 +26,8 @@ pub(crate) trait SpecDefinition {
 
     fn type_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>>;
 
+    fn minimum_federation_version(&self) -> &Version;
+
     fn identity(&self) -> &Identity {
         &self.url().identity
     }
@@ -200,5 +202,17 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
 
     pub(crate) fn versions(&self) -> Keys<Version, T> {
         self.definitions.keys()
+    }
+}
+
+impl<T: SpecDefinition + 'static> SpecDefinitions<T> {
+    pub(crate) fn get_minimum_required_version(
+        &'static self,
+        federation_version: &Version,
+    ) -> Option<&'static dyn SpecDefinition> {
+        self.definitions
+            .values()
+            .find(|spec| federation_version.satisfies(spec.minimum_federation_version()))
+            .map(|spec| spec as &dyn SpecDefinition)
     }
 }

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -1954,7 +1954,10 @@ mod test_enum_value {
 
 fn add_core_feature_inaccessible(supergraph: &mut Schema) {
     // @link(url: "https://specs.apollo.dev/inaccessible/v0.2")
-    let spec = InaccessibleSpecDefinition::new(Version { major: 0, minor: 2 });
+    let spec = InaccessibleSpecDefinition::new(
+        Version { major: 0, minor: 2 },
+        Version { major: 2, minor: 0 },
+    );
 
     supergraph
         .schema_definition

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -410,7 +410,7 @@ pub(crate) struct ArgumentMerger {
 
 /// Returns the version of directive spec definition required for the given Federation version to
 /// be used in the supergraph.
-type SupergraphSpecification = dyn Fn(Version) -> Box<dyn SpecDefinition>;
+type SupergraphSpecification = dyn Fn(&Version) -> Option<&'static dyn SpecDefinition>;
 
 type ArgumentMergerFactory =
     dyn Fn(&FederationSchema, Option<&Arc<Link>>) -> Result<ArgumentMerger, FederationError>;
@@ -419,7 +419,7 @@ type StaticArgumentsTransform =
     dyn Fn(&ValidFederationSubgraph, IndexMap<Name, Value>) -> IndexMap<Name, Value>;
 
 pub(crate) struct DirectiveCompositionSpecification {
-    pub(crate) supergraph_specification: Box<SupergraphSpecification>,
+    pub(crate) supergraph_specification: &'static SupergraphSpecification,
     /// Factory function returning an actual argument merger for given federation schema.
     pub(crate) argument_merger: Option<Box<ArgumentMergerFactory>>,
     pub(crate) static_argument_transform: Option<Box<StaticArgumentsTransform>>,
@@ -443,7 +443,7 @@ impl DirectiveSpecification {
         repeatable: bool,
         locations: &[DirectiveLocation],
         composes: bool,
-        supergraph_specification: Option<Box<SupergraphSpecification>>,
+        supergraph_specification: Option<&'static SupergraphSpecification>,
         static_argument_transform: Option<Box<StaticArgumentsTransform>>,
     ) -> Self {
         let mut composition: Option<DirectiveCompositionSpecification> = None;
@@ -891,8 +891,7 @@ mod tests {
 
     use super::ArgumentSpecification;
     use super::DirectiveArgumentSpecification;
-    use crate::link::link_spec_definition::LinkSpecDefinition;
-    use crate::link::spec::Identity;
+    use crate::link::link_spec_definition::LINK_VERSIONS;
     use crate::link::spec::Version;
     use crate::link::spec_definition::SpecDefinition;
     use crate::schema::FederationSchema;
@@ -920,16 +919,6 @@ mod tests {
         expected = "Invalid directive specification for @foo: not all arguments define a composition strategy"
     )]
     fn must_have_a_merge_strategy_on_all_arguments_if_any() {
-        fn link_spec(_version: Version) -> Box<dyn SpecDefinition> {
-            Box::new(LinkSpecDefinition::new(
-                Version { major: 1, minor: 0 },
-                Identity {
-                    domain: String::from("https://specs.apollo.dev/link/v1.0"),
-                    name: name!("link"),
-                },
-            ))
-        }
-
         DirectiveSpecification::new(
             name!("foo"),
             &[
@@ -957,7 +946,11 @@ mod tests {
             false,
             &[DirectiveLocation::Object],
             true,
-            Some(Box::new(link_spec)),
+            Some(&|_| {
+                LINK_VERSIONS
+                    .find(&Version { major: 1, minor: 0 })
+                    .map(|v| v as &'static dyn SpecDefinition)
+            }),
             None,
         );
     }
@@ -967,16 +960,6 @@ mod tests {
         expected = "Invalid directive specification for @foo: @foo is repeatable and should not define composition strategy for its arguments"
     )]
     fn must_be_not_be_repeatable_if_it_has_a_merge_strategy() {
-        fn link_spec(_version: Version) -> Box<dyn SpecDefinition> {
-            Box::new(LinkSpecDefinition::new(
-                Version { major: 1, minor: 0 },
-                Identity {
-                    domain: String::from("https://specs.apollo.dev/link/v1.0"),
-                    name: name!("link"),
-                },
-            ))
-        }
-
         DirectiveSpecification::new(
             name!("foo"),
             &[DirectiveArgumentSpecification {
@@ -990,7 +973,11 @@ mod tests {
             true,
             &[DirectiveLocation::Object],
             true,
-            Some(Box::new(link_spec)),
+            Some(&|_| {
+                LINK_VERSIONS
+                    .find(&Version { major: 1, minor: 0 })
+                    .map(|v| v as &'static dyn SpecDefinition)
+            }),
             None,
         );
     }

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -949,7 +949,7 @@ mod tests {
             Some(&|_| {
                 LINK_VERSIONS
                     .find(&Version { major: 1, minor: 0 })
-                    .map(|v| v as &'static dyn SpecDefinition)
+                    .map(|v| v as &dyn SpecDefinition)
             }),
             None,
         );
@@ -976,7 +976,7 @@ mod tests {
             Some(&|_| {
                 LINK_VERSIONS
                     .find(&Version { major: 1, minor: 0 })
-                    .map(|v| v as &'static dyn SpecDefinition)
+                    .map(|v| v as &dyn SpecDefinition)
             }),
             None,
         );


### PR DESCRIPTION
Takes advantage of the static spec definitions by using `&'static` instead of `Box`. This allows us to define directive definitions with `&|v| MY_SPEC_VERSIONS.find(v)` instead of `Box::new(|v| MY_SPEC_VERSIONS.find(v).cloned())`.

To make this work, I've ported over the constructor parameter we were missing from spec definitions, which gives the minimum federation version for each spec.

<!-- FED-601 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
