### PR TITLE
Docs: Update Header from Acronym to Full Terminology

### DIFF
--- a/docs/source/routing/cloud/dedicated.mdx
+++ b/docs/source/routing/cloud/dedicated.mdx
@@ -16,7 +16,7 @@ Go the [Cloud Dedicated quickstart](/graphos/routing/cloud/dedicated-quickstart)
 
 </Tip>
 
-## Runs on AWS
+## Runs on Amazon Web Services (AWS)
 
 Cloud Dedicated runs a fleet of GraphOS Routers in the AWS region of your choice. The following regions are currently available:
 


### PR DESCRIPTION
I changed acronym in header to full term. AWS => Amazon Web Services (AWS)