### PR TITLE
Some tweaks to `MappingArgument`

### DIFF
--- a/apollo-federation/src/sources/connect/validation/connect/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/selection.rs
@@ -68,10 +68,9 @@ impl<'schema> Selection<'schema> {
 
         let MappingArgument { expression, string } = parse_mapping_argument(
             &selection_arg.value,
-            &coordinate.to_string(),
-            None,
+            coordinate,
             Code::InvalidSelection,
-            &schema.sources,
+            schema,
         )?;
 
         Ok(Self {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_syntax.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_syntax.graphql.snap
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
         code: InvalidSelection,
         message: "`@connect(selection:)` on `Query.something` is not valid: nom::error::ErrorKind::Eof: &how",
         locations: [
-            8:86..8:92,
+            8:87..8:88,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__invalid_mappings.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__invalid_mappings.graphql.snap
@@ -6,30 +6,30 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/url_prope
 [
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v1\")`, the `path` argument is not valid: nom::error::ErrorKind::Eof: .",
+        message: "In `@source(name: \"v1\")`, the `http.path` argument is not valid: nom::error::ErrorKind::Eof: .",
         locations: [
-            6:37..6:40,
+            6:38..6:39,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v1\")`, the `queryParams` argument is not valid: nom::error::ErrorKind::Eof: .",
+        message: "In `@source(name: \"v1\")`, the `http.queryParams` argument is not valid: nom::error::ErrorKind::Eof: .",
         locations: [
-            6:55..6:58,
+            6:56..6:57,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, the `path` argument is not valid: nom::error::ErrorKind::Eof: .",
+        message: "In `@connect` on `Query.resources`, the `http.path` argument is not valid: nom::error::ErrorKind::Eof: .",
         locations: [
-            12:31..12:34,
+            12:32..12:33,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, the `queryParams` argument is not valid: nom::error::ErrorKind::Eof: .",
+        message: "In `@connect` on `Query.resources`, the `http.queryParams` argument is not valid: nom::error::ErrorKind::Eof: .",
         locations: [
-            12:49..12:52,
+            12:50..12:51,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__path.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__path.graphql.snap
@@ -27,28 +27,28 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/url_prope
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, argument `path` is invalid: `*.bad` must start with one of $args, $config, $context, $request",
+        message: "In `@connect` on `Query.resources`, argument `path` is invalid: `*.bad` must start with one of $args, $config, $context, $request",
         locations: [
             23:53..23:56,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, argument `path` is invalid: string values aren't valid here",
+        message: "In `@connect` on `Query.resources`, argument `path` is invalid: string values aren't valid here",
         locations: [
             24:55..24:60,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, argument `path` is invalid: object values aren't valid here",
+        message: "In `@connect` on `Query.resources`, argument `path` is invalid: object values aren't valid here",
         locations: [
             27:34..27:46,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, argument `path` is invalid: string values aren't valid here",
+        message: "In `@connect` on `Query.resources`, argument `path` is invalid: string values aren't valid here",
         locations: [
             12:16..12:22,
             12:13..12:22,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__query_params.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__query_params.graphql.snap
@@ -27,28 +27,28 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/url_prope
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, argument `queryParams` is invalid: `*.bad` must start with one of $args, $config, $context, $request",
+        message: "In `@connect` on `Query.resources`, argument `queryParams` is invalid: `*.bad` must start with one of $args, $config, $context, $request",
         locations: [
             32:39..32:42,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, argument `queryParams` is invalid: string values aren't valid here",
+        message: "In `@connect` on `Query.resources`, argument `queryParams` is invalid: string values aren't valid here",
         locations: [
             37:41..37:46,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, argument `queryParams` is invalid: array values aren't valid here",
+        message: "In `@connect` on `Query.resources`, argument `queryParams` is invalid: array values aren't valid here",
         locations: [
             42:41..42:48,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect(http:)` on `Query.resources`, argument `queryParams` is invalid: string values aren't valid here",
+        message: "In `@connect` on `Query.resources`, argument `queryParams` is invalid: string values aren't valid here",
         locations: [
             16:16..16:22,
             16:13..16:22,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_with_escapes.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_with_escapes.graphql.snap
@@ -8,14 +8,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/valid_sel
         code: InvalidSelection,
         message: "`@connect(selection:)` on `Query.block` is not valid: Path selection . must be followed by key (identifier or quoted string literal): .",
         locations: [
-            8:20..17:12,
+            16:30..16:31,
         ],
     },
     Message {
         code: InvalidSelection,
         message: "`@connect(selection:)` on `Query.standard` is not valid: Path selection . must be followed by key (identifier or quoted string literal): .",
         locations: [
-            22:20..22:97,
+            22:95..22:96,
         ],
     },
 ]


### PR DESCRIPTION
1. Use parsing error location for more accuracy
2. Store the `MappingArgument` in a few places to reuse the expression (vs recreating)
3. Don't allocate coordinate strings unless necessary (using `Display`)