### PR TITLE
Lean into iterator in `UrlProperties`

### DIFF
--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__invalid_mappings.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__invalid_mappings.graphql.snap
@@ -6,28 +6,28 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/url_prope
 [
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v1\")`, the `http.path` argument is not valid: nom::error::ErrorKind::Eof: .",
+        message: "In `@source(name: \"v1\")`, the `path` argument is not valid: nom::error::ErrorKind::Eof: .",
         locations: [
             6:38..6:39,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v1\")`, the `http.queryParams` argument is not valid: nom::error::ErrorKind::Eof: .",
+        message: "In `@source(name: \"v1\")`, the `queryParams` argument is not valid: nom::error::ErrorKind::Eof: .",
         locations: [
             6:56..6:57,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `http.path` argument is not valid: nom::error::ErrorKind::Eof: .",
+        message: "In `@connect` on `Query.resources`, the `path` argument is not valid: nom::error::ErrorKind::Eof: .",
         locations: [
             12:32..12:33,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `http.queryParams` argument is not valid: nom::error::ErrorKind::Eof: .",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is not valid: nom::error::ErrorKind::Eof: .",
         locations: [
             12:50..12:51,
         ],

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__path.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__path.graphql.snap
@@ -6,49 +6,49 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/url_prope
 [
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v2\")`, argument `path` is invalid: `*.bad` must start with one of $config, $context, $request",
+        message: "In `@source(name: \"v2\")`, the `path` argument is invalid: `*.bad` must start with one of $config, $context, $request",
         locations: [
             7:38..7:41,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v3\")`, argument `path` is invalid: string values aren't valid here",
+        message: "In `@source(name: \"v3\")`, the `path` argument is invalid: string values aren't valid here",
         locations: [
             8:40..8:45,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v4\")`, argument `path` is invalid: object values aren't valid here",
+        message: "In `@source(name: \"v4\")`, the `path` argument is invalid: object values aren't valid here",
         locations: [
             9:40..9:52,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, argument `path` is invalid: `*.bad` must start with one of $args, $config, $context, $request",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: `*.bad` must start with one of $args, $config, $context, $request",
         locations: [
             23:53..23:56,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, argument `path` is invalid: string values aren't valid here",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: string values aren't valid here",
         locations: [
             24:55..24:60,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, argument `path` is invalid: object values aren't valid here",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: object values aren't valid here",
         locations: [
             27:34..27:46,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, argument `path` is invalid: string values aren't valid here",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: string values aren't valid here",
         locations: [
             12:16..12:22,
             12:13..12:22,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__query_params.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@url_properties__query_params.graphql.snap
@@ -6,49 +6,49 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/url_prope
 [
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v3\")`, argument `queryParams` is invalid: `*.bad` must start with one of $config, $context, $request",
+        message: "In `@source(name: \"v3\")`, the `queryParams` argument is invalid: `*.bad` must start with one of $config, $context, $request",
         locations: [
             11:45..11:48,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v4\")`, argument `queryParams` is invalid: array values aren't valid here",
+        message: "In `@source(name: \"v4\")`, the `queryParams` argument is invalid: array values aren't valid here",
         locations: [
             12:47..12:49,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v5\")`, argument `queryParams` is invalid: string values aren't valid here",
+        message: "In `@source(name: \"v5\")`, the `queryParams` argument is invalid: string values aren't valid here",
         locations: [
             13:47..13:52,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, argument `queryParams` is invalid: `*.bad` must start with one of $args, $config, $context, $request",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: `*.bad` must start with one of $args, $config, $context, $request",
         locations: [
             32:39..32:42,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, argument `queryParams` is invalid: string values aren't valid here",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: string values aren't valid here",
         locations: [
             37:41..37:46,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, argument `queryParams` is invalid: array values aren't valid here",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: array values aren't valid here",
         locations: [
             42:41..42:48,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, argument `queryParams` is invalid: string values aren't valid here",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: string values aren't valid here",
         locations: [
             16:16..16:22,
             16:13..16:22,


### PR DESCRIPTION
1. Lean into the "properties aren't special, we will have several of them" feel by storing a `Vec<Property>` instead of iterating on `self`
2. Use the same coordinates in type checking as parsing (sans `http.`)
3. Single definition of the list of properties we're interested in via enum `PropertyName`
