### PR TITLE
deps: clean up some duplicate and unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
  "http-serde",
  "humantime",
  "humantime-serde",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "hyperlocal",
@@ -970,7 +970,7 @@ dependencies = [
  "aws-smithy-types",
  "h2",
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -1139,7 +1139,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -1235,7 +1235,7 @@ dependencies = [
  "fs-err",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "tokio",
  "tower-service",
@@ -2344,7 +2344,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "multimap 0.9.1",
  "schemars",
  "serde",
@@ -3169,28 +3169,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -3218,7 +3196,7 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs 0.8.1",
@@ -3235,7 +3213,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3253,7 +3231,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3269,7 +3247,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5256,7 +5234,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -6345,7 +6323,6 @@ dependencies = [
  "apollo-router",
  "http 1.3.1",
  "http-body-util",
- "hyper 0.14.31",
  "serde_json",
  "tokio",
  "tower 0.5.2",
@@ -6597,7 +6574,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -7759,7 +7736,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,26 +340,26 @@ dependencies = [
  "nu-ansi-term 0.50.1",
  "num-traits",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-aws",
  "opentelemetry-datadog",
  "opentelemetry-http",
  "opentelemetry-jaeger-propagator",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
- "opentelemetry-proto 0.5.0",
+ "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry-stdout",
  "opentelemetry-zipkin",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry_sdk",
  "p256",
  "parking_lot",
  "paste",
  "pin-project-lite",
  "pretty_assertions",
  "prometheus",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost",
+ "prost-types",
  "proteus",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -401,7 +401,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "tonic 0.12.3",
+ "tonic",
  "tonic-build",
  "tower 0.5.2",
  "tower-http",
@@ -4267,21 +4267,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
@@ -4301,8 +4286,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2e5bd1a2e1d14877086a2defe4ac968f42a6a15cfc5862a0f0ecd0f3530135"
 dependencies = [
  "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
@@ -4318,10 +4303,10 @@ dependencies = [
  "itertools 0.11.0",
  "itoa",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry_sdk",
  "reqwest",
  "rmp",
  "ryu",
@@ -4338,7 +4323,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.3.1",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "reqwest",
 ]
 
@@ -4348,7 +4333,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a68a13b92fc708d875ad659b08b35d08b8ef2403e01944b39ca21e5b08b17"
 dependencies = [
- "opentelemetry 0.24.0",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -4360,15 +4345,15 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 1.3.1",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto 0.7.0",
- "opentelemetry_sdk 0.24.1",
- "prost 0.13.4",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
  "reqwest",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.12.3",
+ "tonic",
 ]
 
 [[package]]
@@ -4378,24 +4363,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4191ce34aa274621861a7a9d68dbcf618d5b6c66b10081631b61fd81fbc015"
 dependencies = [
  "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prometheus",
  "protobuf",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
-dependencies = [
- "hex",
- "opentelemetry 0.22.0",
- "opentelemetry_sdk 0.22.1",
- "prost 0.12.6",
- "serde",
- "tonic 0.11.0",
 ]
 
 [[package]]
@@ -4404,10 +4375,12 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
 dependencies = [
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
- "prost 0.13.4",
- "tonic 0.12.3",
+ "hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "tonic",
 ]
 
 [[package]]
@@ -4425,8 +4398,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures-util",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "ordered-float",
  "serde",
  "serde_json",
@@ -4443,35 +4416,15 @@ dependencies = [
  "futures-core",
  "http 1.3.1",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry_sdk",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "typed-builder",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "once_cell",
- "opentelemetry 0.22.0",
- "ordered-float",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4487,7 +4440,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
@@ -4880,22 +4833,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
- "prost-derive 0.13.4",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4911,24 +4854,11 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.4",
- "prost-types 0.13.4",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.90",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -4946,20 +4876,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost 0.12.6",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
- "prost 0.13.4",
+ "prost",
 ]
 
 [[package]]
@@ -6539,27 +6460,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
- "percent-encoding",
- "pin-project",
- "prost 0.12.6",
- "tokio",
- "tokio-stream",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
@@ -6579,7 +6479,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.4",
+ "prost",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile",
  "socket2",
@@ -6601,7 +6501,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
- "prost-types 0.13.4",
+ "prost-types",
  "quote",
  "syn 2.0.90",
 ]
@@ -6777,8 +6677,8 @@ checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -171,8 +171,8 @@ opentelemetry-prometheus = "0.17.0"
 paste = "1.0.15"
 pin-project-lite = "0.2.14"
 prometheus = "0.13"
-prost = "0.12.6"
-prost-types = "0.12.6"
+prost = "0.13.0"
+prost-types = "0.13.0"
 proteus = "0.5.0"
 rand = "0.8.5"
 rhai = { version = "1.19.0", features = ["sync", "serde", "internals"] }
@@ -290,7 +290,7 @@ once_cell.workspace = true
 opentelemetry-stdout = { version = "0.5.0", features = ["trace"] }
 opentelemetry = { version = "0.24.0", features = ["testing"] }
 opentelemetry_sdk = { version = "0.24.1", features = ["testing"] }
-opentelemetry-proto = { version = "0.5.0", features = [
+opentelemetry-proto = { version = "0.7.0", features = [
     "metrics",
     "trace",
     "gen-tonic-messages",

--- a/apollo-router/tests/integration/telemetry/otlp.rs
+++ b/apollo-router/tests/integration/telemetry/otlp.rs
@@ -965,10 +965,7 @@ impl Verifier for OtlpTraceSpec<'_> {
                 return Err(BoxError::from("missing sampling priority"));
             }
             for sampling_priority in binding {
-                assert_eq!(
-                    sampling_priority.as_str().expect("psr not a string"),
-                    psr
-                );
+                assert_eq!(sampling_priority.as_str().expect("psr not a string"), psr);
             }
         } else {
             assert!(trace.select_path("$..[?(@.name == 'execution')]..[?(@.key == 'sampling.priority')].value.intValue")?.is_empty())

--- a/apollo-router/tests/integration/telemetry/otlp.rs
+++ b/apollo-router/tests/integration/telemetry/otlp.rs
@@ -966,10 +966,7 @@ impl Verifier for OtlpTraceSpec<'_> {
             }
             for sampling_priority in binding {
                 assert_eq!(
-                    sampling_priority
-                        .as_i64()
-                        .expect("psr not an integer")
-                        .to_string(),
+                    sampling_priority.as_str().expect("psr not a string"),
                     psr
                 );
             }

--- a/apollo-router/tests/snapshots/apollo_otel_traces__batch_send_header-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__batch_send_header-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -64,7 +65,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0
@@ -217,16 +218,16 @@ resourceSpans:
                   stringValue: "[redacted]"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0
@@ -739,16 +740,16 @@ resourceSpans:
                   stringValue: "[redacted]"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__batch_send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__batch_send_header.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -64,7 +65,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0
@@ -217,16 +218,16 @@ resourceSpans:
                   stringValue: "[redacted]"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0
@@ -739,16 +740,16 @@ resourceSpans:
                   stringValue: "[redacted]"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__batch_trace_id-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__batch_trace_id-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -64,7 +65,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0
@@ -217,16 +218,16 @@ resourceSpans:
                   stringValue: "[redacted]"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0
@@ -739,16 +740,16 @@ resourceSpans:
                   stringValue: "[redacted]"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__batch_trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__batch_trace_id.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -64,7 +65,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0
@@ -217,16 +218,16 @@ resourceSpans:
                   stringValue: "[redacted]"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0
@@ -739,16 +740,16 @@ resourceSpans:
                   stringValue: "[redacted]"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__client_name-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__client_name-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__client_name.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__client_name.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__client_version-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__client_version-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__client_version.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__client_version.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__condition_else-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__condition_else-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\nquery($if:Boolean!){topProducts{name...@defer(if:$if){reviews{author{name}}reviews{author{name}}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__condition_else.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__condition_else.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\nquery($if:Boolean!){topProducts{name...@defer(if:$if){reviews{author{name}}reviews{author{name}}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__condition_if-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__condition_if-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\nquery($if:Boolean!){topProducts{name...@defer(if:$if){reviews{author{name}}reviews{author{name}}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__condition_if.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__condition_if.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\nquery($if:Boolean!){topProducts{name...@defer(if:$if){reviews{author{name}}reviews{author{name}}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__non_defer-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__non_defer-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__non_defer.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__non_defer.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__send_header-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__send_header-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__send_header.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__send_variable_value-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__send_variable_value-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\nquery($dontSendValue:Boolean!,$sendValue:Boolean!){topProducts{name reviews@include(if:$sendValue){author{name}}reviews@include(if:$dontSendValue){author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__send_variable_value.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__send_variable_value.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\nquery($dontSendValue:Boolean!,$sendValue:Boolean!){topProducts{name reviews@include(if:$sendValue){author{name}}reviews@include(if:$dontSendValue){author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__trace_id-2.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__trace_id-2.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/apollo-router/tests/snapshots/apollo_otel_traces__trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_otel_traces__trace_id.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/tests/apollo_otel_traces.rs
 expression: report
+snapshot_kind: text
 ---
 resourceSpans:
   - resource:
@@ -88,7 +89,7 @@ resourceSpans:
                   stringValue: POST
               - key: http.response.status_code
                 value:
-                  intValue: 200
+                  intValue: "200"
               - key: trace_id
                 value:
                   stringValue: "[redacted]"
@@ -190,16 +191,16 @@ resourceSpans:
                   stringValue: "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}"
               - key: apollo_private.query.aliases
                 value:
-                  intValue: 0
+                  intValue: "0"
               - key: apollo_private.query.depth
                 value:
-                  intValue: 4
+                  intValue: "4"
               - key: apollo_private.query.height
                 value:
-                  intValue: 7
+                  intValue: "7"
               - key: apollo_private.query.root_fields
                 value:
-                  intValue: 1
+                  intValue: "1"
             droppedAttributesCount: 0
             events: []
             droppedEventsCount: 0

--- a/examples/throw-error/rhai/Cargo.toml
+++ b/examples/throw-error/rhai/Cargo.toml
@@ -13,6 +13,3 @@ http-body-util = "0.1.2"
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5", features = ["full"] }
-
-[dev-dependencies]
-hyper = "0.14.24"


### PR DESCRIPTION
1. Removes an unused hyper 0.14 dependency. Now, only one hyper version exists in our tree!
2. Updates `opentelemetry-proto` to align with other otel dependencies. This removes several duplicate otel and protobuf related dependencies

A snapshot changed because of 2). I can't tell for certain if this is because of insta, prost, or opentelemetry-proto. But it's because the `int_value` proto field is an int64, which is arguably not round-trippable in YAML (...assuming a JSON/JS style number implementation where every number is float64). So sometimes int64s have to be serialized as strings.
I think this is an acceptable change, because it's only asserting how the test parses values from serialized protobuf and then serialized to YAML; if it's parsed into a string, or an int, it doesn't really matter, because both still tell us if the serialized protobuf contained the correct integer value.

Now, the only thing that still uses the http 0.x crates in our dependency tree is the AWS SDK. We can now likely update the AWS SDK to get rid of this. IIRC, the last time i tried to, i ran into some dependency conflict with wiremock, which is resolved as of #7431.