### PR TITLE
Add FederationError variant for subgraph errors

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -622,6 +622,8 @@ impl SingleFederationError {
         }
     }
 
+    // TODO: This logic is here to avoid accidentally nesting subgraph name annotations, in the
+    // future we should change the composition error type to make nesting impossible.
     pub(crate) fn unwrap_subgraph_error(self, expected_subgraph: &str) -> Self {
         if let Self::SubgraphError { subgraph, error } = self {
             debug_assert_eq!(
@@ -635,6 +637,8 @@ impl SingleFederationError {
         }
     }
 
+    // TODO: This logic is here to avoid accidentally nesting subgraph name annotations, in the
+    // future we should change the composition error type to make nesting impossible.
     pub(crate) fn add_subgraph(self, subgraph: String) -> Self {
         if let Self::SubgraphError {
             subgraph: existing_subgraph,

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -340,10 +340,9 @@ pub struct SubgraphError {
 
 impl SubgraphError {
     pub fn new(subgraph: impl Into<String>, error: impl Into<FederationError>) -> Self {
-        SubgraphError {
-            subgraph: subgraph.into(),
-            error: error.into(),
-        }
+        let subgraph = subgraph.into();
+        let error = error.into().unwrap_subgraph_errors(&subgraph);
+        SubgraphError { subgraph, error }
     }
 
     pub fn error(&self) -> &FederationError {


### PR DESCRIPTION
There are some places in composition code that need to create a `FederationError`, but annotated with subgraph name. Ideally we would split federation errors into internal errors, query planning errors, and composition errors, and give composition errors the ability to be annotated with subgraph name. But that's further out, so for now, this PR tries to introduce a small changeset for allowing subgraph name annotation. If there's a nicer approach with similar size/simplicity, let me know in review and I'll switch to it.

<!-- FED-426 -->