### PR TITLE
Implement post-merge validations

### DIFF
--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -27,14 +27,13 @@ use crate::link::spec_definition::SpecDefinition;
 use crate::schema::FederationSchema;
 use crate::schema::ValidFederationSchema;
 use crate::schema::compute_subgraph_metadata;
-use crate::schema::field_set::parse_field_set;
 use crate::schema::position::DirectiveDefinitionPosition;
-use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::subgraph_metadata::SubgraphMetadata;
 use crate::schema::validators::context::validate_context_directives;
 use crate::schema::validators::cost::validate_cost_directives;
 use crate::schema::validators::external::validate_external_directives;
 use crate::schema::validators::from_context::validate_from_context_directives;
+use crate::schema::validators::interface_object::validate_interface_object_directives;
 use crate::schema::validators::key::validate_key_directives;
 use crate::schema::validators::list_size::validate_list_size_directives;
 use crate::schema::validators::provides::validate_provides_directives;
@@ -42,9 +41,6 @@ use crate::schema::validators::requires::validate_requires_directives;
 use crate::subgraph;
 use crate::supergraph::FEDERATION_ENTITIES_FIELD_NAME;
 use crate::supergraph::FEDERATION_SERVICE_FIELD_NAME;
-use crate::utils::human_readable::HumanReadableListOptions;
-use crate::utils::human_readable::HumanReadableListPrefix;
-use crate::utils::human_readable::human_readable_list;
 
 pub(crate) struct FederationBlueprint {}
 
@@ -140,15 +136,7 @@ impl FederationBlueprint {
         validate_provides_directives(schema, meta, &mut error_collector)?;
         validate_requires_directives(schema, meta, &mut error_collector)?;
         validate_external_directives(schema, meta, &mut error_collector)?;
-
-        // TODO: Remaining validations
-        Self::validate_keys_on_interfaces_are_also_on_all_implementations(
-            schema,
-            meta,
-            &mut error_collector,
-        )?;
-        Self::validate_interface_objects_are_on_entities(schema, meta, &mut error_collector)?;
-
+        validate_interface_object_directives(schema, meta, &mut error_collector)?;
         validate_cost_directives(schema, &mut error_collector)?;
         validate_list_size_directives(schema, &mut error_collector)?;
 
@@ -366,154 +354,6 @@ impl FederationBlueprint {
                         message: format!("Detected unsupported cost specification version {}. Please upgrade to a composition version which supports that version, or select one of the following supported versions: {}.", link.url.version, COST_VERSIONS.versions().join(", "))
                     })?;
                 spec.add_elements_to_schema(schema)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn validate_keys_on_interfaces_are_also_on_all_implementations(
-        schema: &ValidFederationSchema,
-        metadata: &SubgraphMetadata,
-        error_collector: &mut MultipleFederationErrors,
-    ) -> Result<(), FederationError> {
-        let key_directive_definition_name = &metadata
-            .federation_spec_definition()
-            .key_directive_definition(schema)?
-            .name;
-        for type_pos in schema.get_types() {
-            let Ok(type_pos): Result<InterfaceTypeDefinitionPosition, _> = type_pos.try_into()
-            else {
-                continue;
-            };
-            let implementation_types = schema.possible_runtime_types(type_pos.clone().into())?;
-            let type_ = type_pos.get(schema.schema())?;
-            for application in type_.directives.get_all(key_directive_definition_name) {
-                let arguments = metadata
-                    .federation_spec_definition()
-                    .key_directive_arguments(application)?;
-                // Note that we will have validated all @key field sets by this point, so we skip
-                // re-validating here.
-                let fields = parse_field_set(schema, type_.name.clone(), arguments.fields, false)?;
-                let mut implementations_with_non_resolvable_keys = vec![];
-                let mut implementations_with_missing_keys = vec![];
-                for implementation_type_pos in &implementation_types {
-                    let implementation_type = implementation_type_pos.get(schema.schema())?;
-                    let mut matching_application_arguments = None;
-                    for implementation_application in implementation_type
-                        .directives
-                        .get_all(key_directive_definition_name)
-                    {
-                        let implementation_arguments = metadata
-                            .federation_spec_definition()
-                            .key_directive_arguments(implementation_application)?;
-                        let implementation_fields = parse_field_set(
-                            schema,
-                            implementation_type.name.clone(),
-                            implementation_arguments.fields,
-                            false,
-                        )?;
-                        if implementation_fields == fields {
-                            matching_application_arguments = Some(implementation_arguments);
-                            break;
-                        }
-                    }
-                    if let Some(matching_application_arguments) = matching_application_arguments {
-                        // TODO: This code assumes there's at most one matching application for a
-                        // given fieldset, but I'm not sure whether other validation code guarantees
-                        // this.
-                        if arguments.resolvable && !matching_application_arguments.resolvable {
-                            implementations_with_non_resolvable_keys.push(implementation_type_pos);
-                        }
-                    } else {
-                        implementations_with_missing_keys.push(implementation_type_pos);
-                    }
-
-                    if !implementations_with_missing_keys.is_empty() {
-                        let types_list = human_readable_list(
-                            implementations_with_missing_keys
-                                .iter()
-                                .map(|pos| format!("\"{}\"", pos)),
-                            HumanReadableListOptions {
-                                prefix: Some(HumanReadableListPrefix {
-                                    singular: "type",
-                                    plural: "types",
-                                }),
-                                ..Default::default()
-                            },
-                        );
-                        error_collector.errors.push(
-                            SingleFederationError::InterfaceKeyNotOnImplementation {
-                                message: format!(
-                                    "Key {} on interface type \"{}\" is missing on implementation {}",
-                                    application.serialize(),
-                                    type_pos,
-                                    types_list,
-                                )
-                            }
-                        )
-                    } else if !implementations_with_non_resolvable_keys.is_empty() {
-                        let types_list = human_readable_list(
-                            implementations_with_non_resolvable_keys
-                                .iter()
-                                .map(|pos| format!("\"{}\"", pos)),
-                            HumanReadableListOptions {
-                                prefix: Some(HumanReadableListPrefix {
-                                    singular: "type",
-                                    plural: "types",
-                                }),
-                                ..Default::default()
-                            },
-                        );
-                        error_collector.errors.push(
-                            SingleFederationError::InterfaceKeyNotOnImplementation {
-                                message: format!(
-                                    "Key {} on interface type \"{}\" should be resolvable on all implementation types, but is declared with argument \"@key(resolvable:)\" set to false in {}",
-                                    application.serialize(),
-                                    type_pos,
-                                    types_list,
-                                )
-                            }
-                        )
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn validate_interface_objects_are_on_entities(
-        schema: &ValidFederationSchema,
-        metadata: &SubgraphMetadata,
-        error_collector: &mut MultipleFederationErrors,
-    ) -> Result<(), FederationError> {
-        let Some(interface_object_directive_definition) = &metadata
-            .federation_spec_definition()
-            .interface_object_directive_definition(schema)?
-        else {
-            return Ok(());
-        };
-        let key_directive_definition_name = &metadata
-            .federation_spec_definition()
-            .key_directive_definition(schema)?
-            .name;
-        for type_pos in &schema
-            .referencers
-            .get_directive(&interface_object_directive_definition.name)?
-            .object_types
-        {
-            if !type_pos
-                .get(schema.schema())?
-                .directives
-                .has(key_directive_definition_name)
-            {
-                error_collector.errors.push(
-                    SingleFederationError::InterfaceObjectUsageError {
-                        message: format!(
-                            "The @interfaceObject directive can only be applied to entity types but type \"{}\" has no @key in this subgraph.",
-                            type_pos
-                        )
-                    }
-                )
             }
         }
         Ok(())

--- a/apollo-federation/src/schema/validators/interface_object.rs
+++ b/apollo-federation/src/schema/validators/interface_object.rs
@@ -1,0 +1,167 @@
+use crate::error::FederationError;
+use crate::error::MultipleFederationErrors;
+use crate::error::SingleFederationError;
+use crate::schema::ValidFederationSchema;
+use crate::schema::field_set::parse_field_set;
+use crate::schema::position::InterfaceTypeDefinitionPosition;
+use crate::schema::subgraph_metadata::SubgraphMetadata;
+use crate::utils::human_readable::HumanReadableListOptions;
+use crate::utils::human_readable::HumanReadableListPrefix;
+use crate::utils::human_readable::human_readable_list;
+
+pub(crate) fn validate_interface_object_directives(
+    schema: &ValidFederationSchema,
+    metadata: &SubgraphMetadata,
+    errors: &mut MultipleFederationErrors,
+) -> Result<(), FederationError> {
+    validate_keys_on_interfaces_are_also_on_all_implementations(schema, metadata, errors)?;
+    validate_interface_objects_are_on_entities(schema, metadata, errors)?;
+    Ok(())
+}
+
+fn validate_keys_on_interfaces_are_also_on_all_implementations(
+    schema: &ValidFederationSchema,
+    metadata: &SubgraphMetadata,
+    error_collector: &mut MultipleFederationErrors,
+) -> Result<(), FederationError> {
+    let key_directive_definition_name = &metadata
+        .federation_spec_definition()
+        .key_directive_definition(schema)?
+        .name;
+    for type_pos in schema.get_types() {
+        let Ok(type_pos): Result<InterfaceTypeDefinitionPosition, _> = type_pos.try_into() else {
+            continue;
+        };
+        let implementation_types = schema.possible_runtime_types(type_pos.clone().into())?;
+        let type_ = type_pos.get(schema.schema())?;
+        for application in type_.directives.get_all(key_directive_definition_name) {
+            let arguments = metadata
+                .federation_spec_definition()
+                .key_directive_arguments(application)?;
+            // Note that we will have validated all @key field sets by this point, so we skip
+            // re-validating here.
+            let fields = parse_field_set(schema, type_.name.clone(), arguments.fields, false)?;
+            let mut implementations_with_non_resolvable_keys = vec![];
+            let mut implementations_with_missing_keys = vec![];
+            for implementation_type_pos in &implementation_types {
+                let implementation_type = implementation_type_pos.get(schema.schema())?;
+                let mut matching_application_arguments = None;
+                for implementation_application in implementation_type
+                    .directives
+                    .get_all(key_directive_definition_name)
+                {
+                    let implementation_arguments = metadata
+                        .federation_spec_definition()
+                        .key_directive_arguments(implementation_application)?;
+                    let implementation_fields = parse_field_set(
+                        schema,
+                        implementation_type.name.clone(),
+                        implementation_arguments.fields,
+                        false,
+                    )?;
+                    if implementation_fields == fields {
+                        matching_application_arguments = Some(implementation_arguments);
+                        break;
+                    }
+                }
+                if let Some(matching_application_arguments) = matching_application_arguments {
+                    // TODO: This code assumes there's at most one matching application for a
+                    // given fieldset, but I'm not sure whether other validation code guarantees
+                    // this.
+                    if arguments.resolvable && !matching_application_arguments.resolvable {
+                        implementations_with_non_resolvable_keys.push(implementation_type_pos);
+                    }
+                } else {
+                    implementations_with_missing_keys.push(implementation_type_pos);
+                }
+
+                if !implementations_with_missing_keys.is_empty() {
+                    let types_list = human_readable_list(
+                        implementations_with_missing_keys
+                            .iter()
+                            .map(|pos| format!("\"{}\"", pos)),
+                        HumanReadableListOptions {
+                            prefix: Some(HumanReadableListPrefix {
+                                singular: "type",
+                                plural: "types",
+                            }),
+                            ..Default::default()
+                        },
+                    );
+                    error_collector.errors.push(
+                        SingleFederationError::InterfaceKeyNotOnImplementation {
+                            message: format!(
+                                "Key {} on interface type \"{}\" is missing on implementation {}",
+                                application.serialize(),
+                                type_pos,
+                                types_list,
+                            ),
+                        },
+                    )
+                } else if !implementations_with_non_resolvable_keys.is_empty() {
+                    let types_list = human_readable_list(
+                        implementations_with_non_resolvable_keys
+                            .iter()
+                            .map(|pos| format!("\"{}\"", pos)),
+                        HumanReadableListOptions {
+                            prefix: Some(HumanReadableListPrefix {
+                                singular: "type",
+                                plural: "types",
+                            }),
+                            ..Default::default()
+                        },
+                    );
+                    error_collector.errors.push(
+                        SingleFederationError::InterfaceKeyNotOnImplementation {
+                            message: format!(
+                                "Key {} on interface type \"{}\" should be resolvable on all implementation types, but is declared with argument \"@key(resolvable:)\" set to false in {}",
+                                application.serialize(),
+                                type_pos,
+                                types_list,
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_interface_objects_are_on_entities(
+    schema: &ValidFederationSchema,
+    metadata: &SubgraphMetadata,
+    error_collector: &mut MultipleFederationErrors,
+) -> Result<(), FederationError> {
+    let Some(interface_object_directive_definition) = &metadata
+        .federation_spec_definition()
+        .interface_object_directive_definition(schema)?
+    else {
+        return Ok(());
+    };
+    let key_directive_definition_name = &metadata
+        .federation_spec_definition()
+        .key_directive_definition(schema)?
+        .name;
+    for type_pos in &schema
+        .referencers
+        .get_directive(&interface_object_directive_definition.name)?
+        .object_types
+    {
+        if !type_pos
+            .get(schema.schema())?
+            .directives
+            .has(key_directive_definition_name)
+        {
+            error_collector.errors.push(
+                SingleFederationError::InterfaceObjectUsageError {
+                    message: format!(
+                        "The @interfaceObject directive can only be applied to entity types but type \"{}\" has no @key in this subgraph.",
+                        type_pos
+                    )
+                }
+            )
+        }
+    }
+    Ok(())
+}

--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -1,0 +1,368 @@
+use std::sync::LazyLock;
+
+use apollo_compiler::Name;
+use apollo_compiler::schema::Directive;
+use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::schema::FieldDefinition;
+use itertools::Itertools;
+use regex::Regex;
+
+use crate::ValidFederationSubgraphs;
+use crate::bail;
+use crate::ensure;
+use crate::error::FederationError;
+use crate::error::MultipleFederationErrors;
+use crate::error::SingleFederationError;
+use crate::schema::ValidFederationSchema;
+use crate::schema::field_set::parse_field_set;
+use crate::schema::position::CompositeTypeDefinitionPosition;
+use crate::schema::position::InterfaceTypeDefinitionPosition;
+use crate::schema::position::ObjectFieldDefinitionPosition;
+use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
+use crate::utils::human_readable::human_readable_subgraph_names;
+
+// PORT_NOTE: Named `postMergeValidations` in the JS codebase, but adjusted here to follow the
+// naming convention in this directory. Note that this was normally a method in `Merger`, but as
+// noted below, the logic overlaps with subgraph validation logic, so to facilitate that future
+// de-duplication we're putting it here.
+// TODO: The code here largely duplicates logic that is in subgraph schema validation, except that
+// when it detects an error, it provides an error in terms of subgraph inputs (rather than what the
+// merged/supergraph schema). We could try to avoid that duplication in the future.
+#[allow(dead_code)]
+pub(crate) fn validate_merged_schema(
+    supergraph_schema: &ValidFederationSchema,
+    subgraphs: &ValidFederationSubgraphs,
+    errors: &mut MultipleFederationErrors,
+) -> Result<(), FederationError> {
+    for type_pos in supergraph_schema.get_types() {
+        let Ok(type_pos): Result<ObjectOrInterfaceTypeDefinitionPosition, _> = type_pos.try_into()
+        else {
+            continue;
+        };
+        let interface_names = match &type_pos {
+            ObjectOrInterfaceTypeDefinitionPosition::Object(type_pos) => {
+                &type_pos
+                    .get(supergraph_schema.schema())?
+                    .implements_interfaces
+            }
+            ObjectOrInterfaceTypeDefinitionPosition::Interface(type_pos) => {
+                &type_pos
+                    .get(supergraph_schema.schema())?
+                    .implements_interfaces
+            }
+        };
+        for interface_name in interface_names {
+            let interface_pos = InterfaceTypeDefinitionPosition::new(interface_name.name.clone());
+            for interface_field_pos in interface_pos.fields(supergraph_schema.schema())? {
+                let field_pos = type_pos.field(interface_field_pos.field_name.clone());
+                if field_pos.get(supergraph_schema.schema()).is_err() {
+                    // This means that the type was defined (or at least implemented the interface)
+                    // only in subgraphs where the interface didn't have that field.
+                    let subgraphs_with_interface_field = subgraphs
+                        .subgraphs
+                        .values()
+                        .filter(|subgraph| interface_pos.get(subgraph.schema.schema()).is_ok())
+                        .map(|subgraph| subgraph.name.clone())
+                        .collect::<Vec<_>>();
+                    let subgraphs_with_type_implementing_interface = subgraphs
+                        .subgraphs
+                        .values()
+                        .filter(|subgraph| {
+                            let Some(subgraph_type) =
+                                subgraph.schema.schema().types.get(type_pos.type_name())
+                            else {
+                                return false;
+                            };
+                            match &subgraph_type {
+                                ExtendedType::Object(subgraph_type) => {
+                                    subgraph_type.implements_interfaces.contains(interface_name)
+                                }
+                                ExtendedType::Interface(subgraph_type) => {
+                                    subgraph_type.implements_interfaces.contains(interface_name)
+                                }
+                                _ => false,
+                            }
+                        })
+                        .map(|subgraph| subgraph.name.clone())
+                        .collect::<Vec<_>>();
+                    errors.push(SingleFederationError::InterfaceFieldNoImplem {
+                        message: format!(
+                            "Interface field \"{}\" is declared in {} but type \"{}\" which implements \"${}\" only in {} does not have field \"{}\"",
+                            interface_field_pos,
+                            human_readable_subgraph_names(subgraphs_with_interface_field.iter()),
+                            type_pos,
+                            interface_name,
+                            human_readable_subgraph_names(subgraphs_with_type_implementing_interface.iter()),
+                            interface_field_pos.field_name,
+                        )
+                    }.into())
+                }
+
+                // TODO: Should we validate more? Can we have some invalid implementation of a field
+                // post-merging?
+            }
+        }
+    }
+
+    // We need to redo some validation for @requires after merging. The reason is that each subgraph
+    // validates that its own @requires are valid relative to its own schema, but "requirements" are
+    // really requested from _other_ subgraphs (by definition of @requires really), and there are a
+    // few situations (see the details below) where validity within the @requires-declaring subgraph
+    // does not entail validity for all subgraphs that would have to provide those "requirements".
+    // To summarize, we need to re-validate every @requires against the supergraph to guarantee it
+    // will always work at runtime.
+    for subgraph in subgraphs.subgraphs.values() {
+        let Some(metadata) = &subgraph.schema.subgraph_metadata else {
+            bail!("Subgraph schema unexpectedly missing metadata");
+        };
+        let requires_directive_definition_name = &metadata
+            .federation_spec_definition()
+            .requires_directive_definition(&subgraph.schema)?
+            .name;
+        let requires_referencers = subgraph
+            .schema
+            .referencers
+            .get_directive(requires_directive_definition_name)?;
+        // Note that @requires is only supported on object fields.
+        for parent_field_pos in &requires_referencers.object_fields {
+            let Some(requires_directive) = parent_field_pos
+                .get(subgraph.schema.schema())?
+                .directives
+                .get(requires_directive_definition_name)
+            else {
+                bail!("@requires unexpectedly missing from field that references it");
+            };
+            let requires_arguments = &metadata
+                .federation_spec_definition()
+                .requires_directive_arguments(requires_directive)?;
+            // The type should exist in the supergraph schema. There are a few types we don't merge,
+            // but those are from specific link/core features and they shouldn't have @requires. In
+            // fact, if we were to not merge a type with a @requires, this would essentially mean
+            // that @requires would not work, so its worth catching the issue early if this ever
+            // happens for some reason. And of course, the type should be composite since it's also
+            // one in at least the subgraph we're currently checking.
+            let parent_type_pos_in_supergraph: CompositeTypeDefinitionPosition = supergraph_schema
+                .get_type(parent_field_pos.type_name.clone())?
+                .try_into()?;
+            // TODO: Once parse_field_set() gains the ability to rewrite error messages, we should
+            // explicitly disable that here (as it's subgraph-specific error rewriting).
+            let Some(error) = parse_field_set(
+                supergraph_schema,
+                parent_type_pos_in_supergraph.type_name().clone(),
+                requires_arguments.fields,
+                true,
+            )
+            .err() else {
+                continue;
+            };
+            // Providing a useful error message to the user here is tricky in the general case
+            // because what we checked is that a given subgraph @requires application is invalid "on
+            // the supergraph", but the user seeing the error will not have the supergraph, so we
+            // need to express the error in terms of the subgraphs.
+            //
+            // But in practice, there is only a handful of cases that can trigger an error here.
+            // Indeed, at this point we know that:
+            //  - The @requires application is valid in its original subgraph.
+            //  - There was no merging errors (we don't call this method otherwise).
+            // This eliminates the risk of the error being due to some invalid syntax, some
+            // selection set on a non-composite type or missing selection set on a composite one
+            // (merging would have errored), some unknown field in the field set (output types
+            // are merged by union, so any field in the subgraph will be in the supergraph), or even
+            // any error due to the types of fields involved (because the merged type is always a
+            // (non-strict) supertype of its counterpart in any subgraph, and anything that could be
+            // queried in a subtype can be queried on a supertype).
+            //
+            // As such, the only errors that we can have here are due to field arguments: because
+            // they are merged by intersection, it _is_ possible that something that is valid in a
+            // subgraph is not valid in the supergraph. And the only 2 things that can make such an
+            // invalidity are:
+            //  1. An argument may not be in the supergraph: it is in the subgraph, but not in all
+            //     the subgraphs having the field, and the `@requires` passes a concrete value to
+            //     that argument.
+            //  2. The type of an argument in the supergraph is a strict subtype of the type of that
+            //     argument in the subgraph (the one with the `@requires`) _and_ the @requires
+            //     field set relies on the type difference. Now, argument types are input types, and
+            //     the only subtyping difference that can occur with input types is related to
+            //     nullability (input types support neither interfaces nor unions), so the only case
+            //     this can happen is if a field `x` has some argument `a` with type `A` in the
+            //     subgraph but type `A!` with no default in the supergraph, _and_ the `@requires`
+            //     field set queries that field `x` _without_ a value for `a` (valid when `a` has
+            //     type `A` but not with `A!` and no default).
+            // So to ensure we provide good error messages, we brute-force detecting those 2
+            // possible cases and have a special treatment for each.
+            //
+            // Note that this detection is based on pattern-matching the error message, which is
+            // somewhat fragile, but because we only have 2 cases, we can easily cover them with
+            // unit tests, which means there is no practical risk of a message change breaking this
+            // code and being released undetected. A cleaner implementation would probably require
+            // having error codes and variants for all the GraphQL validations. The apollo-compiler
+            // crate has this already, but it's crate-private and potentially unstable, so we can't
+            // use that for now.
+            for error in error.into_errors() {
+                let SingleFederationError::InvalidGraphQL { message } = error else {
+                    errors.push(error.into());
+                    continue;
+                };
+                if let Some(captures) =
+                    APOLLO_COMPILER_UNDEFINED_ARGUMENT_PATTERN.captures(&message)
+                {
+                    let Some(argument_name) = captures.get(1).map(|m| m.as_str()) else {
+                        bail!("Unexpectedly no argument name in undefined argument error regex")
+                    };
+                    let Some(type_name) = captures.get(2).map(|m| m.as_str()) else {
+                        bail!("Unexpectedly no type name in undefined argument error regex")
+                    };
+                    let Some(field_name) = captures.get(3).map(|m| m.as_str()) else {
+                        bail!("Unexpectedly no field name in undefined argument error regex")
+                    };
+                    add_requires_error(
+                        parent_field_pos,
+                        requires_directive,
+                        &subgraph.name,
+                        type_name,
+                        field_name,
+                        argument_name,
+                        |field_definition| {
+                            Ok(field_definition.argument_by_name(argument_name).is_none())
+                        },
+                        |incompatible_subgraphs| {
+                            Ok(format!(
+                                "cannot provide a value for argument \"{}\" of field \"{}\" as argument \"{}\" is not defined in {}",
+                                argument_name, field_name, argument_name, incompatible_subgraphs,
+                            ))
+                        },
+                        subgraphs,
+                        errors,
+                    )?;
+                    continue;
+                }
+                if let Some(captures) = APOLLO_COMPILER_REQUIRED_ARGUMENT_PATTERN.captures(&message)
+                {
+                    let Some(type_name) = captures.get(1).map(|m| m.as_str()) else {
+                        bail!("Unexpectedly no type name in required argument error regex");
+                    };
+                    let Some(field_name) = captures.get(2).map(|m| m.as_str()) else {
+                        bail!("Unexpectedly no field name in required argument error regex");
+                    };
+                    let Some(argument_name) = captures.get(3).map(|m| m.as_str()) else {
+                        bail!("Unexpectedly no argument name in required argument error regex");
+                    };
+                    add_requires_error(
+                        parent_field_pos,
+                        requires_directive,
+                        &subgraph.name,
+                        type_name,
+                        field_name,
+                        argument_name,
+                        |field_definition| {
+                            Ok(field_definition
+                                .argument_by_name(argument_name)
+                                .map(|arg| arg.is_required())
+                                .unwrap_or_default())
+                        },
+                        |incompatible_subgraphs| {
+                            Ok(format!(
+                                "no value provided for argument \"{}\" of field \"{}\" but a value is mandatory as \"{}\" is required in {}",
+                                argument_name, field_name, argument_name, incompatible_subgraphs,
+                            ))
+                        },
+                        subgraphs,
+                        errors,
+                    )?;
+                    continue;
+                }
+                bail!(
+                    "Unexpected error throw by {} when evaluated on supergraph: {}",
+                    requires_directive,
+                    message,
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// This matches the error message for `DiagnosticData::UndefinedArgument` as defined in
+// https://github.com/apollographql/apollo-rs/blob/apollo-compiler%401.28.0/crates/apollo-compiler/src/validation/diagnostics.rs#L36
+static APOLLO_COMPILER_UNDEFINED_ARGUMENT_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"the argument `((?-u:\w)+)` is not supported by `((?-u:\w)+)\.((?-u:\w)+)`"#)
+        .unwrap()
+});
+
+// This matches the error message for `DiagnosticData::RequiredArgument` as defined in
+// https://github.com/apollographql/apollo-rs/blob/apollo-compiler%401.28.0/crates/apollo-compiler/src/validation/diagnostics.rs#L88
+static APOLLO_COMPILER_REQUIRED_ARGUMENT_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"the required argument `((?-u:\w)+)\.((?-u:\w)+)\(((?-u:\w)+):\)` is not provided"#,
+    )
+    .unwrap()
+});
+
+#[allow(clippy::too_many_arguments)]
+fn add_requires_error(
+    requires_parent_field_pos: &ObjectFieldDefinitionPosition,
+    requires_application: &Directive,
+    subgraph_name: &str,
+    type_name: &str,
+    field_name: &str,
+    argument_name: &str,
+    is_field_incompatible: impl Fn(&FieldDefinition) -> Result<bool, FederationError>,
+    message_for_incompatible_subgraphs: impl Fn(&str) -> Result<String, FederationError>,
+    subgraphs: &ValidFederationSubgraphs,
+    errors: &mut MultipleFederationErrors,
+) -> Result<(), FederationError> {
+    let type_name = Name::new(type_name)?;
+    let field_name = Name::new(field_name)?;
+    let argument_name = Name::new(argument_name)?;
+    let incompatible_subgraph_names = subgraphs
+        .subgraphs
+        .values()
+        .map(|other_subgraph| {
+            if other_subgraph.name == subgraph_name {
+                return Ok(None);
+            }
+            let Ok(type_pos_in_other_subgraph) = other_subgraph.schema.get_type(type_name.clone())
+            else {
+                return Ok(None);
+            };
+            let Ok(type_pos_in_other_subgraph): Result<ObjectOrInterfaceTypeDefinitionPosition, _> =
+                type_pos_in_other_subgraph.try_into()
+            else {
+                return Ok(None);
+            };
+            let Some(field_in_other_subgraph) = type_pos_in_other_subgraph
+                .field(field_name.clone())
+                .try_get(other_subgraph.schema.schema())
+            else {
+                return Ok(None);
+            };
+            let is_field_incompatible = is_field_incompatible(field_in_other_subgraph)?;
+            if is_field_incompatible {
+                Ok::<_, FederationError>(Some(other_subgraph.name.to_string()))
+            } else {
+                Ok(None)
+            }
+        })
+        .process_results(|iter| iter.flatten().collect::<Vec<_>>())?;
+    ensure!(
+        !incompatible_subgraph_names.is_empty(),
+        "Got error on argument \"{}\" of field \"{}\" but no \"incompatible\" subgraphs",
+        argument_name,
+        field_name,
+    );
+    let incompatible_subgraph_names =
+        human_readable_subgraph_names(incompatible_subgraph_names.into_iter());
+    let message = message_for_incompatible_subgraphs(&incompatible_subgraph_names)?;
+
+    errors.push(
+        SingleFederationError::RequiresInvalidFields {
+            coordinate: requires_parent_field_pos.to_string(),
+            application: requires_application.to_string(),
+            message,
+        }
+        .add_subgraph(subgraph_name.to_owned())
+        .into(),
+    );
+    Ok(())
+}

--- a/apollo-federation/src/schema/validators/mod.rs
+++ b/apollo-federation/src/schema/validators/mod.rs
@@ -22,8 +22,10 @@ pub(crate) mod context;
 pub(crate) mod cost;
 pub(crate) mod external;
 pub(crate) mod from_context;
+pub(crate) mod interface_object;
 pub(crate) mod key;
 pub(crate) mod list_size;
+pub(crate) mod merged;
 pub(crate) mod provides;
 pub(crate) mod requires;
 

--- a/apollo-federation/src/utils/human_readable.rs
+++ b/apollo-federation/src/utils/human_readable.rs
@@ -148,3 +148,20 @@ pub(crate) fn human_readable_list(
         joined_strings
     }
 }
+
+// PORT_NOTE: Named `printSubgraphNames` in the JS codebase, but "print" in Rust has the implication
+// it prints to stdout/stderr, so we've renamed it here to `human_readable_subgraph_names`
+pub(crate) fn human_readable_subgraph_names(
+    subgraph_names: impl Iterator<Item = impl AsRef<str>>,
+) -> String {
+    human_readable_list(
+        subgraph_names.map(|name| format!("\"{}\"", name.as_ref())),
+        HumanReadableListOptions {
+            prefix: Some(HumanReadableListPrefix {
+                singular: "subgraph",
+                plural: "subgraphs",
+            }),
+            ..Default::default()
+        },
+    )
+}


### PR DESCRIPTION
This PR implements post-merge validations for composition. Note that:
- These validations are placed in `apollo-federation/src/schema/validators` instead of on `Merger` as would be the case in JS, since (as the TODO notes) there's logic shared with subgraph validations that we'd like to refactor out in the future. (Also, the current Rust `Merger` struct is for the old composition code.)
- Unrelatedly, we also move interface object validations to `apollo-federation/src/schema/validators` to adhere to existing patterns.

<!-- FED-426 -->