### PR TITLE
federation: implement composition stubs

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -343,6 +343,7 @@ fn cmd_subgraph(file_path: &Path) -> Result<(), FederationError> {
     let name = name.unwrap_or("subgraph".to_string());
     let subgraph = typestate::Subgraph::parse(&name, &format!("http://{name}"), &doc_str)?
         .expand_links()?
+        .assume_upgraded()
         .validate(true)
         .map_err(|e| e.into_inner())?;
     println!("{}", subgraph.schema_string());

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -3,7 +3,7 @@ mod satisfiability;
 use std::vec;
 
 use crate::error::FederationError;
-use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
+pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
 use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Initial;
 use crate::subgraph::typestate::Subgraph;

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -2,6 +2,7 @@ mod satisfiability;
 
 use std::vec;
 
+use crate::composition::satisfiability::validate_satisfiability;
 use crate::error::FederationError;
 pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
 use crate::subgraph::typestate::Expanded;
@@ -9,6 +10,7 @@ use crate::subgraph::typestate::Initial;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Upgraded;
 use crate::subgraph::typestate::Validated;
+use crate::supergraph::Merged;
 use crate::supergraph::Satisfiable;
 use crate::supergraph::Supergraph;
 
@@ -17,11 +19,10 @@ pub fn compose(
 ) -> Result<Supergraph<Satisfiable>, Vec<FederationError>> {
     let expanded_subgraphs = expand_subgraphs(subgraphs)?;
     let upgraded_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)?;
-    let _validated_subgraphs = validate_subgraphs(upgraded_subgraphs)?;
+    let validated_subgraphs = validate_subgraphs(upgraded_subgraphs)?;
 
-    todo!("implement magic here")
-    // let supergraph = merge_subgraphs(validated_subgraphs)?;
-    // validate_satisfiability(supergraph)?
+    let supergraph = merge_subgraphs(validated_subgraphs)?;
+    validate_satisfiability(supergraph)
 }
 
 pub fn expand_subgraphs(
@@ -54,4 +55,10 @@ pub fn validate_subgraphs(
     } else {
         Err(errors)
     }
+}
+
+pub fn merge_subgraphs(
+    _subgraphs: Vec<Subgraph<Validated>>,
+) -> Result<Supergraph<Merged>, Vec<FederationError>> {
+    panic!("merge_subgraphs is not implemented yet")
 }

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -29,13 +29,13 @@ pub fn expand_subgraphs(
     subgraphs: Vec<Subgraph<Initial>>,
 ) -> Result<Vec<Subgraph<Expanded>>, Vec<FederationError>> {
     let mut errors: Vec<FederationError> = vec![];
-    let upgraded: Vec<Subgraph<Expanded>> = subgraphs
+    let expanded: Vec<Subgraph<Expanded>> = subgraphs
         .into_iter()
         .map(|s| s.expand_links())
         .filter_map(|r| r.map_err(|e| errors.push(e.into())).ok())
         .collect();
     if errors.is_empty() {
-        Ok(upgraded)
+        Ok(expanded)
     } else {
         Err(errors)
     }

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -1,0 +1,57 @@
+mod satisfiability;
+
+use std::vec;
+
+use crate::error::FederationError;
+use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
+use crate::subgraph::typestate::Expanded;
+use crate::subgraph::typestate::Initial;
+use crate::subgraph::typestate::Subgraph;
+use crate::subgraph::typestate::Upgraded;
+use crate::subgraph::typestate::Validated;
+use crate::supergraph::Satisfiable;
+use crate::supergraph::Supergraph;
+
+pub fn compose(
+    subgraphs: Vec<Subgraph<Initial>>,
+) -> Result<Supergraph<Satisfiable>, Vec<FederationError>> {
+    let expanded_subgraphs = expand_subgraphs(subgraphs)?;
+    let upgraded_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)?;
+    let _validated_subgraphs = validate_subgraphs(upgraded_subgraphs)?;
+
+    todo!("implement magic here")
+    // let supergraph = merge_subgraphs(validated_subgraphs)?;
+    // validate_satisfiability(supergraph)?
+}
+
+pub fn expand_subgraphs(
+    subgraphs: Vec<Subgraph<Initial>>,
+) -> Result<Vec<Subgraph<Expanded>>, Vec<FederationError>> {
+    let mut errors: Vec<FederationError> = vec![];
+    let upgraded: Vec<Subgraph<Expanded>> = subgraphs
+        .into_iter()
+        .map(|s| s.expand_links())
+        .filter_map(|r| r.map_err(|e| errors.push(e.into())).ok())
+        .collect();
+    if errors.is_empty() {
+        Ok(upgraded)
+    } else {
+        Err(errors)
+    }
+}
+
+pub fn validate_subgraphs(
+    subgraphs: Vec<Subgraph<Upgraded>>,
+) -> Result<Vec<Subgraph<Validated>>, Vec<FederationError>> {
+    let mut errors: Vec<FederationError> = vec![];
+    let validated: Vec<Subgraph<Validated>> = subgraphs
+        .into_iter()
+        .map(|s| s.validate(false))
+        .filter_map(|r| r.map_err(|e| errors.push(e.into())).ok())
+        .collect();
+    if errors.is_empty() {
+        Ok(validated)
+    } else {
+        Err(errors)
+    }
+}

--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -1,8 +1,10 @@
+use crate::error::FederationError;
 use crate::supergraph::Merged;
 use crate::supergraph::Satisfiable;
 use crate::supergraph::Supergraph;
 
-#[allow(unused)]
-pub(crate) fn validate_satisfiability(_supergraph: Supergraph<Merged>) -> Supergraph<Satisfiable> {
-    todo!("magic happens here")
+pub(crate) fn validate_satisfiability(
+    _supergraph: Supergraph<Merged>,
+) -> Result<Supergraph<Satisfiable>, Vec<FederationError>> {
+    panic!("validate_satisfiability is not implemented yet")
 }

--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -1,0 +1,8 @@
+use crate::supergraph::Merged;
+use crate::supergraph::Satisfiable;
+use crate::supergraph::Supergraph;
+
+#[allow(unused)]
+pub(crate) fn validate_satisfiability(_supergraph: Supergraph<Merged>) -> Supergraph<Satisfiable> {
+    todo!("magic happens here")
+}

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -27,6 +27,7 @@
 
 mod api_schema;
 mod compat;
+pub mod composition;
 #[cfg(feature = "correctness")]
 pub mod correctness;
 mod display_helpers;
@@ -61,6 +62,7 @@ use crate::link::spec_definition::SpecDefinitions;
 use crate::merge::MergeFailure;
 use crate::merge::merge_subgraphs;
 use crate::schema::ValidFederationSchema;
+pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
 use crate::sources::connect::ConnectSpec;
 use crate::subgraph::ValidSubgraph;
 pub use crate::supergraph::ValidFederationSubgraph;

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -62,7 +62,6 @@ use crate::link::spec_definition::SpecDefinitions;
 use crate::merge::MergeFailure;
 use crate::merge::merge_subgraphs;
 use crate::schema::ValidFederationSchema;
-pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
 use crate::sources::connect::ConnectSpec;
 use crate::subgraph::ValidSubgraph;
 pub use crate::supergraph::ValidFederationSubgraph;

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -61,7 +61,7 @@ struct UpgradeMetadata {
 }
 
 impl SchemaUpgrader {
-    pub(crate) fn new(subgraphs: &Vec<Subgraph<Expanded>>) -> Self {
+    pub(crate) fn new(subgraphs: &[Subgraph<Expanded>]) -> Self {
         let mut object_type_map: HashMap<Name, HashMap<String, TypeInfo>> = Default::default();
         for subgraph in subgraphs.iter() {
             for pos in subgraph.schema().get_types() {
@@ -712,7 +712,7 @@ impl SchemaUpgrader {
                 for field in pos.fields(schema.schema())? {
                     has_fields = true;
                     let field_def = FieldDefinitionPosition::from(field.clone());
-                    let metadata = compute_subgraph_metadata(&schema)?.ok_or_else(|| {
+                    let metadata = compute_subgraph_metadata(schema)?.ok_or_else(|| {
                         internal_error!(
                             "Unable to detect federation version used in subgraph '{}'",
                             upgrade_metadata.subgraph_name

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -5,8 +5,6 @@ use apollo_compiler::Node;
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::HashMap;
-use apollo_compiler::collections::IndexMap;
-use apollo_compiler::collections::IndexSet;
 use apollo_compiler::name;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ExtendedType;
@@ -25,308 +23,160 @@ use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
 use crate::internal_error;
+use crate::link::federation_spec_definition::FederationSpecDefinition;
+use crate::link::spec_definition::SpecDefinition;
 use crate::schema::SubgraphMetadata;
 use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
+use crate::subgraph::SubgraphError;
 use crate::subgraph::typestate::Expanded;
-use crate::subgraph::typestate::Raw;
 use crate::subgraph::typestate::Subgraph;
+use crate::subgraph::typestate::Upgraded;
+use crate::subgraph::typestate::add_federation_link_to_schema;
+use crate::subgraph::typestate::expand_schema;
 use crate::supergraph::GRAPHQL_SUBSCRIPTION_TYPE_NAME;
 use crate::supergraph::remove_inactive_requires_and_provides_from_subgraph;
 use crate::utils::FallibleIterator;
 
+// TODO should this module be under subgraph mod?
 #[derive(Debug)]
-struct SchemaUpgrader<'a> {
-    schema: FederationSchema,
-    expanded_info: ExpandedSubgraphInfo,
-    subgraphs: &'a IndexMap<String, Subgraph<Expanded>>,
-    object_type_map: &'a HashMap<Name, HashMap<String, TypeInfo>>,
+pub(crate) struct SchemaUpgrader {
+    subgraphs: HashMap<String, Subgraph<Expanded>>,
+    object_type_map: HashMap<Name, HashMap<String, TypeInfo>>,
 }
 
 #[derive(Clone, Debug)]
-#[allow(unused)]
 struct TypeInfo {
     pos: TypeDefinitionPosition,
     metadata: SubgraphMetadata,
 }
 
 #[derive(Debug)]
-struct ExpandedSubgraphInfo {
+struct UpgradeMetadata {
     subgraph_name: String,
-    subgraph_url: String,
     key_directive_name: Option<Name>,
     requires_directive_name: Option<Name>,
     provides_directive_name: Option<Name>,
     extends_directive_name: Option<Name>,
 }
 
-#[allow(unused)]
-// PORT_NOTE: In JS, this returns upgraded subgraphs along with a set of messages about what changed.
-// However, those messages were never used, so we have omitted them here.
-pub(crate) fn upgrade_subgraphs_if_necessary(
-    subgraphs: Vec<Subgraph<Expanded>>,
-) -> Result<Vec<Subgraph<Expanded>>, FederationError> {
-    // if all subgraphs are fed 2, there is no upgrade to be done
-    if subgraphs
-        .iter()
-        .all(|subgraph| subgraph.metadata().is_fed_2_schema())
-    {
-        return Ok(subgraphs);
-    }
-
-    let mut object_type_map: HashMap<Name, HashMap<String, TypeInfo>> = Default::default();
-    for subgraph in subgraphs.iter() {
-        for pos in subgraph.schema().get_types() {
-            if matches!(
-                pos,
-                TypeDefinitionPosition::Object(_) | TypeDefinitionPosition::Interface(_)
-            ) {
-                object_type_map
-                    .entry(pos.type_name().clone())
-                    .or_default()
-                    .insert(
-                        subgraph.name.clone(),
-                        TypeInfo {
-                            pos: pos.clone(),
-                            metadata: subgraph.metadata().clone(), // TODO: Prefer not to clone
-                        },
-                    );
+impl SchemaUpgrader {
+    pub(crate) fn new(subgraphs: &Vec<Subgraph<Expanded>>) -> Self {
+        let mut object_type_map: HashMap<Name, HashMap<String, TypeInfo>> = Default::default();
+        for subgraph in subgraphs.iter() {
+            for pos in subgraph.schema().get_types() {
+                if matches!(
+                    pos,
+                    TypeDefinitionPosition::Object(_) | TypeDefinitionPosition::Interface(_)
+                ) {
+                    object_type_map
+                        .entry(pos.type_name().clone())
+                        .or_default()
+                        .insert(
+                            subgraph.name.clone(),
+                            TypeInfo {
+                                pos: pos.clone(),
+                                metadata: subgraph.metadata().clone(), // TODO: Prefer not to clone
+                            },
+                        );
+                }
             }
         }
-    }
 
-    // insertion order is preserved with IndexMap
-    let subgraphs: IndexMap<String, Subgraph<Expanded>> = subgraphs
-        .into_iter()
-        .map(|subgraph| (subgraph.name.clone(), subgraph))
-        .collect();
-    let mut subgraphs_using_interface_object: IndexSet<String> = Default::default();
-
-    let mut upgraded: HashMap<String, Subgraph<Expanded>> = Default::default();
-    for (name, subgraph) in subgraphs.iter() {
-        if !subgraph.metadata().is_fed_2_schema() {
-            let mut upgrader = SchemaUpgrader::new(subgraph, &subgraphs, &object_type_map)?;
-            upgrader.upgrade()?;
-            let new_subgraph = Subgraph::<Raw>::new(
-                subgraph.name.as_str(),
-                subgraph.url.as_str(),
-                upgrader.schema.schema().clone(),
-            )
-            .assume_expanded()?;
-            upgraded.insert(subgraph.name.clone(), new_subgraph);
-        } else if let Some(interface_object_def) = subgraph
-            .metadata()
-            .federation_spec_definition()
-            .interface_object_directive_definition(subgraph.schema())?
-        {
-            let referencers = subgraph
-                .schema()
-                .referencers()
-                .get_directive(interface_object_def.name.as_str())?;
-            if !referencers.object_types.is_empty() {
-                subgraphs_using_interface_object.insert(name.clone());
-            }
-        }
-    }
-
-    if !subgraphs_using_interface_object.is_empty() {
-        // TODO: Make this a composition error and make the strings "human readable"
-        let cond_1_str = subgraphs_using_interface_object
+        let subgraphs: HashMap<String, Subgraph<Expanded>> = subgraphs
             .iter()
-            .cloned()
-            .map(|k| format!("\"{k}\""))
-            .collect::<Vec<_>>()
-            .join(" ");
-        let cond_2_str = upgraded
-            .keys()
-            .map(|k| format!("\"{k}\""))
-            .collect::<Vec<_>>()
-            .join(" ");
-        return Err(internal_error!(
-            "The @interfaceObject directive can only be used if all subgraphs have federation 2 subgraph schema (schema with a `@link` to \"https://specs.apollo.dev/federation\" version 2.0 or newer): @interfaceObject is used in subgraph {} but subgraph {} is not a federation 2 subgraph schema.",
-            cond_1_str,
-            cond_2_str
-        ));
-    }
-    Ok(subgraphs
-        .into_iter()
-        .map(|(name, subgraph)| {
-            if !subgraph.metadata().is_fed_2_schema() {
-                return upgraded.remove(&name).unwrap();
-            }
-            subgraph
-        })
-        .collect())
-}
-
-// Extensions for FederationError to provide additional error types
-impl FederationError {
-    pub fn extension_with_no_base(message: &str) -> Self {
-        // Fixed: use internal() instead of new()
-        FederationError::internal(format!("EXTENSION_WITH_NO_BASE: {}", message))
-    }
-}
-
-impl<'a> SchemaUpgrader<'a> {
-    #[allow(unused)]
-    fn new(
-        original_subgraph: &'a Subgraph<Expanded>,
-        subgraphs: &'a IndexMap<String, Subgraph<Expanded>>,
-        object_type_map: &'a HashMap<Name, HashMap<String, TypeInfo>>,
-    ) -> Result<Self, FederationError> {
-        let schema = original_subgraph.schema().clone();
-        // TODO (FED-428): JS version calls `setSchemaAsFed2Subgraph`.
-        Ok(SchemaUpgrader {
-            schema,
-            expanded_info: ExpandedSubgraphInfo {
-                subgraph_name: original_subgraph.name.clone(),
-                subgraph_url: original_subgraph.url.clone(),
-                key_directive_name: original_subgraph.key_directive_name()?.clone(),
-                requires_directive_name: original_subgraph.requires_directive_name()?.clone(),
-                provides_directive_name: original_subgraph.provides_directive_name()?.clone(),
-                extends_directive_name: original_subgraph.extends_directive_name()?.clone(),
-            },
+            .map(|subgraph| (subgraph.name.clone(), subgraph.clone()))
+            .collect();
+        SchemaUpgrader {
             subgraphs,
             object_type_map,
-        })
+        }
     }
 
-    // because the schema may have been changed since the last time metadata was calculated, we need to create it every time it's needed.
-    fn subgraph_metadata(&self) -> Result<SubgraphMetadata, FederationError> {
-        compute_subgraph_metadata(&self.schema)?.ok_or_else(|| {
-            internal_error!(
-                "Unable to detect federation version used in subgraph '{}'",
-                self.expanded_info.subgraph_name
-            )
-        })
-    }
-
-    fn remove_links_and_reexpand(&mut self) -> Result<(), FederationError> {
-        // for @core, we want to remove both the definition and all references, but for other
-        // federation directives, just remove the definitions
-        let directives_to_remove = [
-            name!("extends"),
-            name!("key"),
-            name!("provides"),
-            name!("requires"),
-            name!("external"),
-            name!("tag"),
-        ];
-
-        let definitions: Vec<DirectiveDefinitionPosition> =
-            self.schema.get_directive_definitions().collect();
-        for definition in &definitions {
-            if directives_to_remove.contains(&definition.directive_name) {
-                self.schema
-                    .schema
-                    .directive_definitions
-                    .shift_remove(&definition.directive_name);
-                self.schema
-                    .referencers
-                    .directives
-                    .shift_remove(&definition.directive_name)
-                    .ok_or_else(|| SingleFederationError::Internal {
-                        message: format!(
-                            "Schema missing referencers for directive \"{}\"",
-                            &definition.directive_name
-                        ),
-                    })?;
-            } else if definition.directive_name == name!("core") {
-                definition.remove(&mut self.schema)?;
-            }
-        }
-
-        // now remove other federation types
-        let schema = &mut self.schema;
-        if let Some(TypeDefinitionPosition::Enum(enum_obj)) =
-            schema.try_get_type(name!("core__Purpose"))
-        {
-            enum_obj.remove(schema)?;
-        }
-        if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) =
-            schema.try_get_type(name!("core__Import"))
-        {
-            scalar_obj.remove(schema)?;
-        }
-        if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) =
-            schema.try_get_type(name!("_FieldSet"))
-        {
-            scalar_obj.remove(schema)?;
-        }
-        if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) = schema.try_get_type(name!("_Any"))
-        {
-            scalar_obj.remove(schema)?;
-        }
-        if let Some(TypeDefinitionPosition::Object(obj)) = schema.try_get_type(name!("_Service")) {
-            obj.remove(schema)?;
-        }
-        if let Some(TypeDefinitionPosition::Union(union_obj)) =
-            schema.try_get_type(name!("_Entity"))
-        {
-            union_obj.remove(schema)?;
-        }
-        let subgraph = Subgraph::new(
-            self.expanded_info.subgraph_name.as_str(),
-            self.expanded_info.subgraph_url.as_str(),
-            schema.schema.clone(), // TODO: It's unfortunate that we have to do multiple clones here. Ideally we'd allow subgraph to accept and release ownership
-        )
-        .into_fed2_subgraph()?
-        .expand_links()?;
-        self.schema = subgraph.schema().clone();
-        Ok(())
-    }
-
-    // function to get subgraph from list of subgraphs by name. Right now it will just iterate, but perhaps the struct should be a HashMap eventually
     fn get_subgraph_by_name(&self, name: &String) -> Option<&Subgraph<Expanded>> {
         self.subgraphs.get(name)
     }
 
-    #[allow(unused)]
-    fn upgrade(&mut self) -> Result<(), FederationError> {
+    pub(crate) fn upgrade(
+        &self,
+        subgraph: Subgraph<Expanded>,
+    ) -> Result<Subgraph<Upgraded>, SubgraphError> {
+        let subgraph_name = subgraph.name.clone();
+        self.upgrade_inner(subgraph)
+            .map_err(|e| SubgraphError::new(subgraph_name, e))
+    }
+
+    pub(crate) fn upgrade_inner(
+        &self,
+        subgraph: Subgraph<Expanded>,
+    ) -> Result<Subgraph<Upgraded>, FederationError> {
         // Run pre-upgrade validations to check for issues that would prevent upgrade
-        self.pre_upgrade_validations()?;
+        let upgrade_metadata = UpgradeMetadata {
+            subgraph_name: subgraph.name.clone(),
+            key_directive_name: subgraph.key_directive_name()?.clone(),
+            requires_directive_name: subgraph.requires_directive_name()?.clone(),
+            provides_directive_name: subgraph.provides_directive_name()?.clone(),
+            extends_directive_name: subgraph.extends_directive_name()?.clone(),
+        };
+        self.pre_upgrade_validations(&upgrade_metadata, &subgraph)?;
+
+        // TODO avoid cloning here
+        let mut schema = subgraph.schema().clone();
 
         // Fix federation directive arguments (fields) to ensure they're proper strings
         // Note: Implementation simplified for compilation purposes
-        self.fix_federation_directives_arguments()?;
+        self.fix_federation_directives_arguments(&mut schema)?;
 
-        self.remove_links_and_reexpand()?;
+        self.remove_links(&mut schema)?;
 
-        self.remove_external_on_interface();
+        // re-expand all federation directive definitions
+        let federation_spec = FederationSpecDefinition::auto_expanded_federation_spec();
+        add_federation_link_to_schema(&mut schema.schema, federation_spec.version())?;
+        let mut schema = expand_schema(schema.into_inner())?;
 
-        self.remove_external_on_object_types();
+        self.remove_external_on_interface(&mut schema);
+
+        self.remove_external_on_object_types(&mut schema);
 
         // Note that we remove all external on type extensions first, so we don't have to care about it later in @key, @provides and @requires.
-        self.remove_external_on_type_extensions()?;
+        self.remove_external_on_type_extensions(&upgrade_metadata, &mut schema)?;
 
-        self.fix_inactive_provides_and_requires();
+        self.fix_inactive_provides_and_requires(&mut schema)?;
 
-        self.remove_type_extensions();
+        self.remove_type_extensions(&upgrade_metadata, &mut schema)?;
 
-        self.remove_directives_on_interface();
+        self.remove_directives_on_interface(&upgrade_metadata, &mut schema)?;
 
-        // Note that this rule rely on being after `removeDirectivesOnInterface` in practice (in that it doesn't check interfaces).
-        self.remove_provides_on_non_composite();
+        // Note that this rule rely on being after `remove_directives_on_interface` in practice (in that it doesn't check interfaces).
+        self.remove_provides_on_non_composite(&mut schema)?;
 
         // Note that this should come _after_ all the other changes that may remove/update federation directives, since those may create unused
         // externals. Which is why this is toward  the end.
-        self.remove_unused_externals();
+        self.remove_unused_externals(&upgrade_metadata, &mut schema)?;
 
-        self.add_shareable()?;
+        self.add_shareable(&upgrade_metadata, &mut schema)?;
 
-        self.remove_tag_on_external()?;
+        self.remove_tag_on_external(&upgrade_metadata, &mut schema)?;
 
-        Ok(())
+        let upgraded_subgraph =
+            Subgraph::new(subgraph.name.as_str(), subgraph.url.as_str(), schema.schema)
+                .assume_expanded()?
+                .assume_upgraded();
+        Ok(upgraded_subgraph)
     }
 
     // integrates checkForExtensionWithNoBase from the JS code
-    fn pre_upgrade_validations(&self) -> Result<(), FederationError> {
-        let schema = &self.schema;
+    fn pre_upgrade_validations(
+        &self,
+        upgrade_metadata: &UpgradeMetadata,
+        subgraph: &Subgraph<Expanded>,
+    ) -> Result<(), FederationError> {
+        let schema = subgraph.schema();
 
         // Iterate through all types and check if they're federation type extensions without a base
         for type_pos in schema.get_types() {
-            if self.is_root_type_extension(&type_pos)
-                || !self.is_federation_type_extension(&type_pos)?
+            if self.is_root_type_extension(&type_pos, upgrade_metadata, schema)
+                || !self.is_federation_type_extension(&type_pos, upgrade_metadata, schema)?
             {
                 continue;
             }
@@ -343,7 +193,7 @@ impl<'a> SchemaUpgrader<'a> {
                         .iter()
                         .filter(|(subgraph_name, _)| {
                             // Fixed: dereference the string for comparison
-                            subgraph_name.as_str() != self.expanded_info.subgraph_name.as_str()
+                            subgraph_name.as_str() != subgraph.name.as_str()
                         })
                         .fallible_any(|(other_name, type_info)| {
                             let Some(other_subgraph) = self.get_subgraph_by_name(other_name) else {
@@ -359,10 +209,9 @@ impl<'a> SchemaUpgrader<'a> {
                 .unwrap_or(Ok(false))?;
 
             if !has_non_extension_definition {
-                return Err(FederationError::extension_with_no_base(&format!(
-                    "Type \"{}\" is an extension type, but there is no type definition for \"{}\" in any subgraph.",
-                    type_name, type_name
-                )));
+                return Err(SingleFederationError::ExtensionWithNoBase {
+                    message: format!("Type \"{type_name}\" is an extension type, but there is no type definition for \"{type_name}\" in any subgraph.")
+                }.into());
             }
         }
 
@@ -387,9 +236,10 @@ impl<'a> SchemaUpgrader<'a> {
         Ok(None)
     }
 
-    fn fix_federation_directives_arguments(&mut self) -> Result<(), FederationError> {
-        let schema = &mut self.schema;
-
+    fn fix_federation_directives_arguments(
+        &self,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
         // both @provides and @requires will only have an object_fields referencer
         for directive_name in ["requires", "provides"] {
             let referencers = schema.referencers().get_directive(directive_name)?;
@@ -429,16 +279,81 @@ impl<'a> SchemaUpgrader<'a> {
         Ok(())
     }
 
-    fn remove_external_on_interface(&mut self) -> Result<(), FederationError> {
-        let schema = &mut self.schema;
+    fn remove_links(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        // for @core, we want to remove both the definition and all references, but for other
+        // federation directives, just remove the definitions
+        let directives_to_remove = [
+            name!("extends"),
+            name!("key"),
+            name!("provides"),
+            name!("requires"),
+            name!("external"),
+            name!("tag"),
+        ];
+
+        let definitions: Vec<DirectiveDefinitionPosition> =
+            schema.get_directive_definitions().collect();
+        for definition in &definitions {
+            if directives_to_remove.contains(&definition.directive_name) {
+                schema
+                    .schema
+                    .directive_definitions
+                    .shift_remove(&definition.directive_name);
+                schema
+                    .referencers
+                    .directives
+                    .shift_remove(&definition.directive_name)
+                    .ok_or_else(|| SingleFederationError::Internal {
+                        message: format!(
+                            "Schema missing referencers for directive \"{}\"",
+                            &definition.directive_name
+                        ),
+                    })?;
+            } else if definition.directive_name == name!("core") {
+                definition.remove(schema)?;
+            }
+        }
+
+        // now remove other federation types
+        if let Some(TypeDefinitionPosition::Enum(enum_obj)) =
+            schema.try_get_type(name!("core__Purpose"))
+        {
+            enum_obj.remove(schema)?;
+        }
+        if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) =
+            schema.try_get_type(name!("core__Import"))
+        {
+            scalar_obj.remove(schema)?;
+        }
+        if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) =
+            schema.try_get_type(name!("_FieldSet"))
+        {
+            scalar_obj.remove(schema)?;
+        }
+        if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) = schema.try_get_type(name!("_Any"))
+        {
+            scalar_obj.remove(schema)?;
+        }
+        if let Some(TypeDefinitionPosition::Object(obj)) = schema.try_get_type(name!("_Service")) {
+            obj.remove(schema)?;
+        }
+        if let Some(TypeDefinitionPosition::Union(union_obj)) =
+            schema.try_get_type(name!("_Entity"))
+        {
+            union_obj.remove(schema)?;
+        }
+        Ok(())
+    }
+
+    fn remove_external_on_interface(&self, schema: &mut FederationSchema) {
         let Some(metadata) = &schema.subgraph_metadata else {
-            return Ok(());
+            return;
         };
         let Ok(external_directive) = metadata
             .federation_spec_definition()
             .external_directive_definition(schema)
         else {
-            return Ok(());
+            return;
         };
         let mut to_delete: Vec<(InterfaceFieldDefinitionPosition, Node<Directive>)> = vec![];
         for (itf_name, ty) in schema.schema().types.iter() {
@@ -461,19 +376,17 @@ impl<'a> SchemaUpgrader<'a> {
         for (pos, directive) in to_delete {
             pos.remove_directive(schema, &directive);
         }
-        Ok(())
     }
 
-    fn remove_external_on_object_types(&mut self) -> Result<(), FederationError> {
-        let schema = &mut self.schema;
+    fn remove_external_on_object_types(&self, schema: &mut FederationSchema) {
         let Some(metadata) = &schema.subgraph_metadata else {
-            return Ok(());
+            return;
         };
         let Ok(external_directive) = metadata
             .federation_spec_definition()
             .external_directive_definition(schema)
         else {
-            return Ok(());
+            return;
         };
         let mut to_delete: Vec<(ObjectTypeDefinitionPosition, Component<Directive>)> = vec![];
         for (obj_name, ty) in &schema.schema().types {
@@ -490,43 +403,47 @@ impl<'a> SchemaUpgrader<'a> {
         for (pos, directive) in to_delete {
             pos.remove_directive(schema, &directive);
         }
-        Ok(())
     }
 
-    fn remove_external_on_type_extensions(&mut self) -> Result<(), FederationError> {
-        let Some(metadata) = &self.schema.subgraph_metadata else {
+    fn remove_external_on_type_extensions(
+        &self,
+        upgrade_metadata: &UpgradeMetadata,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
+        let Some(metadata) = &schema.subgraph_metadata else {
             return Ok(());
         };
-        let types: Vec<_> = self.schema.get_types().collect();
+        let types: Vec<_> = schema.get_types().collect();
         let key_directive = metadata
             .federation_spec_definition()
-            .key_directive_definition(&self.schema)?;
+            .key_directive_definition(schema)?;
         let external_directive = metadata
             .federation_spec_definition()
-            .external_directive_definition(&self.schema)?;
+            .external_directive_definition(schema)?;
 
         let mut to_remove = vec![];
         for ty in &types {
             if !ty.is_composite_type()
-                || (!self.is_federation_type_extension(ty)? && !self.is_root_type_extension(ty))
+                || (!self.is_federation_type_extension(ty, upgrade_metadata, schema)?
+                    && !self.is_root_type_extension(ty, upgrade_metadata, schema))
             {
                 continue;
             }
 
-            let key_applications = ty.get_applied_directives(&self.schema, &key_directive.name);
+            let key_applications = ty.get_applied_directives(schema, &key_directive.name);
             if !key_applications.is_empty() {
                 for directive in key_applications {
                     let args = metadata
                         .federation_spec_definition()
                         .key_directive_arguments(directive)?;
                     for field in collect_target_fields_from_field_set(
-                        Valid::assume_valid_ref(self.schema.schema()),
+                        Valid::assume_valid_ref(schema.schema()),
                         ty.type_name().clone(),
                         args.fields,
                         false,
                     )? {
                         let external =
-                            field.get_applied_directives(&self.schema, &external_directive.name);
+                            field.get_applied_directives(schema, &external_directive.name);
                         if !external.is_empty() {
                             to_remove.push((field.clone(), external[0].clone()));
                         }
@@ -548,7 +465,7 @@ impl<'a> SchemaUpgrader<'a> {
                     continue;
                 };
                 for (subgraph_name, info) in entries.iter() {
-                    if subgraph_name == self.expanded_info.subgraph_name.as_str() {
+                    if subgraph_name == upgrade_metadata.subgraph_name.as_str() {
                         continue;
                     }
                     let Some(other_schema) = self.get_subgraph_by_name(subgraph_name) else {
@@ -570,7 +487,7 @@ impl<'a> SchemaUpgrader<'a> {
                         .federation_spec_definition()
                         .key_directive_arguments(directive)?;
                     for field in collect_target_fields_from_field_set(
-                        Valid::assume_valid_ref(self.schema.schema()),
+                        Valid::assume_valid_ref(schema.schema()),
                         ty.type_name().clone(),
                         args.fields,
                         false,
@@ -579,7 +496,7 @@ impl<'a> SchemaUpgrader<'a> {
                             continue;
                         }
                         let external =
-                            field.get_applied_directives(&self.schema, &external_directive.name);
+                            field.get_applied_directives(schema, &external_directive.name);
                         if !external.is_empty() {
                             to_remove.push((field.clone(), external[0].clone()));
                         }
@@ -589,26 +506,35 @@ impl<'a> SchemaUpgrader<'a> {
         }
 
         for (pos, directive) in &to_remove {
-            pos.remove_directive(&mut self.schema, directive);
+            pos.remove_directive(schema, directive);
         }
         Ok(())
     }
 
-    fn fix_inactive_provides_and_requires(&mut self) -> Result<(), FederationError> {
-        let cloned_schema = self.schema.clone();
+    fn fix_inactive_provides_and_requires(
+        &self,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
+        let cloned_schema = schema.clone();
         remove_inactive_requires_and_provides_from_subgraph(
             &cloned_schema, // TODO: I don't know what this value should be
-            &mut self.schema,
+            schema,
         )
     }
 
-    fn remove_type_extensions(&mut self) -> Result<(), FederationError> {
-        let types: Vec<_> = self.schema.get_types().collect();
+    fn remove_type_extensions(
+        &self,
+        upgrade_metadata: &UpgradeMetadata,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
+        let types: Vec<_> = schema.get_types().collect();
         for ty in types {
-            if !self.is_federation_type_extension(&ty)? && !self.is_root_type_extension(&ty) {
+            if !self.is_federation_type_extension(&ty, upgrade_metadata, schema)?
+                && !self.is_root_type_extension(&ty, upgrade_metadata, schema)
+            {
                 continue;
             }
-            ty.remove_extensions(&mut self.schema)?;
+            ty.remove_extensions(schema)?;
         }
         Ok(())
     }
@@ -626,10 +552,11 @@ impl<'a> SchemaUpgrader<'a> {
     fn is_federation_type_extension(
         &self,
         ty: &TypeDefinitionPosition,
+        upgrade_metadata: &UpgradeMetadata,
+        schema: &FederationSchema,
     ) -> Result<bool, FederationError> {
-        let type_ = ty.get(self.schema.schema())?;
-        let has_extend = self
-            .expanded_info
+        let type_ = ty.get(schema.schema())?;
+        let has_extend = upgrade_metadata
             .extends_directive_name
             .as_ref()
             .is_some_and(|extends| type_.directives().has(extends.as_str()));
@@ -680,17 +607,19 @@ impl<'a> SchemaUpgrader<'a> {
     }
 
     /// Whether the type is a root type but is declared only as an extension, which federation 1 actually accepts.
-    fn is_root_type_extension(&self, pos: &TypeDefinitionPosition) -> bool {
-        if !matches!(pos, TypeDefinitionPosition::Object(_))
-            || !Self::is_root_type(&self.schema, pos)
-        {
+    fn is_root_type_extension(
+        &self,
+        pos: &TypeDefinitionPosition,
+        upgrade_metadata: &UpgradeMetadata,
+        schema: &FederationSchema,
+    ) -> bool {
+        if !matches!(pos, TypeDefinitionPosition::Object(_)) || !Self::is_root_type(schema, pos) {
             return false;
         }
-        let Ok(ty) = pos.get(self.schema.schema()) else {
+        let Ok(ty) = pos.get(schema.schema()) else {
             return false;
         };
-        let has_extends_directive = self
-            .expanded_info
+        let has_extends_directive = upgrade_metadata
             .extends_directive_name
             .as_ref()
             .is_some_and(|extends| ty.directives().has(extends.as_str()));
@@ -707,24 +636,27 @@ impl<'a> SchemaUpgrader<'a> {
             .any(|op| op.1.as_str() == ty.type_name().as_str())
     }
 
-    fn remove_directives_on_interface(&mut self) -> Result<(), FederationError> {
-        if let Some(key) = &self.expanded_info.key_directive_name {
-            for pos in &self
-                .schema
+    fn remove_directives_on_interface(
+        &self,
+        upgrade_metadata: &UpgradeMetadata,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
+        if let Some(key) = &upgrade_metadata.key_directive_name {
+            for pos in schema
                 .referencers()
                 .get_directive(key)?
                 .interface_types
                 .clone()
             {
-                pos.remove_directive_name(&mut self.schema, key);
+                pos.remove_directive_name(schema, key);
 
-                let fields: Vec<_> = pos.fields(self.schema.schema())?.collect();
+                let fields: Vec<_> = pos.fields(schema.schema())?.collect();
                 for field in fields {
-                    if let Some(provides) = &self.expanded_info.provides_directive_name {
-                        field.remove_directive_name(&mut self.schema, provides);
+                    if let Some(provides) = &upgrade_metadata.provides_directive_name {
+                        field.remove_directive_name(schema, provides);
                     }
-                    if let Some(requires) = &self.expanded_info.requires_directive_name {
-                        field.remove_directive_name(&mut self.schema, requires);
+                    if let Some(requires) = &upgrade_metadata.requires_directive_name {
+                        field.remove_directive_name(schema, requires);
                     }
                 }
             }
@@ -733,8 +665,10 @@ impl<'a> SchemaUpgrader<'a> {
         Ok(())
     }
 
-    fn remove_provides_on_non_composite(&mut self) -> Result<(), FederationError> {
-        let schema = &mut self.schema;
+    fn remove_provides_on_non_composite(
+        &self,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
         let Some(metadata) = &schema.subgraph_metadata else {
             return Ok(());
         };
@@ -763,19 +697,27 @@ impl<'a> SchemaUpgrader<'a> {
         Ok(())
     }
 
-    fn remove_unused_externals(&mut self) -> Result<(), FederationError> {
+    fn remove_unused_externals(
+        &self,
+        upgrade_metadata: &UpgradeMetadata,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
         let mut error = MultipleFederationErrors::new();
         let mut fields_to_remove: HashSet<ObjectOrInterfaceFieldDefinitionPosition> =
             HashSet::new();
         let mut types_to_remove: HashSet<ObjectOrInterfaceTypeDefinitionPosition> = HashSet::new();
-        for type_ in self.schema.get_types() {
+        for type_ in schema.get_types() {
             if let Ok(pos) = ObjectOrInterfaceTypeDefinitionPosition::try_from(type_) {
                 let mut has_fields = false;
-                for field in pos.fields(self.schema.schema())? {
+                for field in pos.fields(schema.schema())? {
                     has_fields = true;
                     let field_def = FieldDefinitionPosition::from(field.clone());
-
-                    let metadata = self.subgraph_metadata()?;
+                    let metadata = compute_subgraph_metadata(&schema)?.ok_or_else(|| {
+                        internal_error!(
+                            "Unable to detect federation version used in subgraph '{}'",
+                            upgrade_metadata.subgraph_name
+                        )
+                    })?;
                     if metadata.is_field_external(&field_def) && !metadata.is_field_used(&field_def)
                     {
                         fields_to_remove.insert(field);
@@ -783,14 +725,12 @@ impl<'a> SchemaUpgrader<'a> {
                 }
                 if !has_fields {
                     let is_referenced = match &pos {
-                        ObjectOrInterfaceTypeDefinitionPosition::Object(obj_pos) => self
-                            .schema
+                        ObjectOrInterfaceTypeDefinitionPosition::Object(obj_pos) => schema
                             .referencers()
                             .object_types
                             .get(&obj_pos.type_name)
                             .is_some_and(|r| r.len() > 0),
-                        ObjectOrInterfaceTypeDefinitionPosition::Interface(itf_pos) => self
-                            .schema
+                        ObjectOrInterfaceTypeDefinitionPosition::Interface(itf_pos) => schema
                             .referencers()
                             .interface_types
                             .get(&itf_pos.type_name)
@@ -810,35 +750,38 @@ impl<'a> SchemaUpgrader<'a> {
         }
 
         for field in fields_to_remove {
-            field.remove(&mut self.schema)?;
+            field.remove(schema)?;
         }
         for type_ in types_to_remove {
-            type_.remove(&mut self.schema)?;
+            type_.remove(schema)?;
         }
         error.into_result()
     }
 
-    fn add_shareable(&mut self) -> Result<(), FederationError> {
-        let Some(metadata) = &self.schema.subgraph_metadata else {
+    fn add_shareable(
+        &self,
+        upgrade_metadata: &UpgradeMetadata,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
+        let Some(metadata) = &schema.subgraph_metadata else {
             return Ok(());
         };
 
-        let Some(key_directive_name) = &self.expanded_info.key_directive_name else {
+        let Some(key_directive_name) = &upgrade_metadata.key_directive_name else {
             return Ok(());
         };
 
         let shareable_directive_name = metadata
             .federation_spec_definition()
-            .shareable_directive_definition(&self.schema)?
+            .shareable_directive_definition(schema)?
             .name
             .clone();
 
         let mut fields_to_add_shareable = vec![];
         let mut types_to_add_shareable = vec![];
-        for type_pos in self.schema.get_types() {
-            let has_key_directive =
-                type_pos.has_applied_directive(&self.schema, key_directive_name);
-            let is_root_type = Self::is_root_type(&self.schema, &type_pos);
+        for type_pos in schema.get_types() {
+            let has_key_directive = type_pos.has_applied_directive(schema, key_directive_name);
+            let is_root_type = Self::is_root_type(schema, &type_pos);
             let TypeDefinitionPosition::Object(obj_pos) = type_pos else {
                 continue;
             };
@@ -848,7 +791,7 @@ impl<'a> SchemaUpgrader<'a> {
                 continue;
             }
             if has_key_directive || is_root_type {
-                for field in obj_pos.fields(self.schema.schema())? {
+                for field in obj_pos.fields(schema.schema())? {
                     let obj_field = FieldDefinitionPosition::Object(field.clone());
                     if metadata.is_field_shareable(&obj_field) {
                         continue;
@@ -865,7 +808,7 @@ impl<'a> SchemaUpgrader<'a> {
                             .type_field(&field.type_name, &field.field_name)
                             .is_ok();
 
-                        if (subgraph_name != self.expanded_info.subgraph_name.as_str())
+                        if (subgraph_name != upgrade_metadata.subgraph_name.as_str())
                             && field_exists
                             && (!info.metadata.is_field_external(&obj_field)
                                 || info.metadata.is_field_partially_external(&obj_field))
@@ -875,7 +818,7 @@ impl<'a> SchemaUpgrader<'a> {
                         false
                     });
                     if type_in_other_subgraphs
-                        && !obj_field.has_applied_directive(&self.schema, &shareable_directive_name)
+                        && !obj_field.has_applied_directive(schema, &shareable_directive_name)
                     {
                         fields_to_add_shareable.push(field.clone());
                     }
@@ -885,13 +828,13 @@ impl<'a> SchemaUpgrader<'a> {
                     continue;
                 };
                 let type_in_other_subgraphs = entries.iter().any(|(subgraph_name, _info)| {
-                    if subgraph_name != self.expanded_info.subgraph_name.as_str() {
+                    if subgraph_name != upgrade_metadata.subgraph_name.as_str() {
                         return true;
                     }
                     false
                 });
                 if type_in_other_subgraphs
-                    && !obj_pos.has_applied_directive(&self.schema, &shareable_directive_name)
+                    && !obj_pos.has_applied_directive(schema, &shareable_directive_name)
                 {
                     types_to_add_shareable.push(obj_pos.clone());
                 }
@@ -899,7 +842,7 @@ impl<'a> SchemaUpgrader<'a> {
         }
         for pos in &fields_to_add_shareable {
             pos.insert_directive(
-                &mut self.schema,
+                schema,
                 Node::new(Directive {
                     name: shareable_directive_name.clone(),
                     arguments: vec![],
@@ -908,7 +851,7 @@ impl<'a> SchemaUpgrader<'a> {
         }
         for pos in &types_to_add_shareable {
             pos.insert_directive(
-                &mut self.schema,
+                schema,
                 Component::new(Directive {
                     name: shareable_directive_name.clone(),
                     arguments: vec![],
@@ -918,8 +861,11 @@ impl<'a> SchemaUpgrader<'a> {
         Ok(())
     }
 
-    fn remove_tag_on_external(&mut self) -> Result<(), FederationError> {
-        let schema = &mut self.schema;
+    fn remove_tag_on_external(
+        &self,
+        upgrade_metadata: &UpgradeMetadata,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
         let applications = schema.tag_directive_applications()?;
         let mut to_delete: Vec<(FieldDefinitionPosition, Node<Directive>)> = vec![];
         if let Some(metadata) = &schema.subgraph_metadata {
@@ -935,7 +881,7 @@ impl<'a> SchemaUpgrader<'a> {
                                 let used_in_other_definitions =
                                     self.subgraphs.iter().fallible_any(
                                         |(name, subgraph)| -> Result<bool, FederationError> {
-                                            if &self.expanded_info.subgraph_name != name {
+                                            if &upgrade_metadata.subgraph_name != name {
                                                 // check to see if the field is external in the other subgraphs
                                                 if let Some(other_metadata) =
                                                     &subgraph.schema().subgraph_metadata
@@ -1002,6 +948,89 @@ impl<'a> SchemaUpgrader<'a> {
     }
 }
 
+// PORT_NOTE: In JS, this returns upgraded subgraphs along with a set of messages about what changed.
+// However, those messages were never used, so we have omitted them here.
+pub fn upgrade_subgraphs_if_necessary(
+    subgraphs: Vec<Subgraph<Expanded>>,
+) -> Result<Vec<Subgraph<Upgraded>>, Vec<FederationError>> {
+    // if all subgraphs are fed 2, there is no upgrade to be done
+    if subgraphs
+        .iter()
+        .all(|subgraph| subgraph.metadata().is_fed_2_schema())
+    {
+        return Ok(subgraphs.into_iter().map(|s| s.assume_upgraded()).collect());
+    }
+
+    let mut subgraphs_using_interface_object = vec![];
+    let mut fed_1_subgraphs = vec![];
+    let mut errors: Vec<FederationError> = vec![];
+    let schema_upgrader: SchemaUpgrader = SchemaUpgrader::new(&subgraphs);
+    let upgraded_subgraphs: Vec<Subgraph<Upgraded>> = subgraphs
+        .into_iter()
+        .map(|subgraph| {
+            if !subgraph.metadata().is_fed_2_schema() {
+                fed_1_subgraphs.push(subgraph.name.clone());
+                schema_upgrader.upgrade(subgraph)
+            } else {
+                if is_interface_object_used(&subgraph)
+                    .map_err(|e| SubgraphError::new(subgraph.name.clone(), e))?
+                {
+                    subgraphs_using_interface_object.push(subgraph.name.clone())
+                };
+                Ok(subgraph.assume_upgraded())
+            }
+        })
+        .filter_map(|r| r.map_err(|e| errors.push(e.into())).ok())
+        .collect();
+
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
+    if !subgraphs_using_interface_object.is_empty() {
+        fn format_subgraph_names(subgraph_names: Vec<String>) -> String {
+            let prefix = if subgraph_names.len() == 1 {
+                "subgraph"
+            } else {
+                "subgraphs"
+            };
+            let formatted_subgraphs = subgraph_names
+                .iter()
+                .map(|s| format!("\"{s}\""))
+                .collect::<Vec<_>>()
+                .join(" ");
+            format!("{prefix} {formatted_subgraphs}")
+        }
+
+        let interface_object_subgraphs = format_subgraph_names(subgraphs_using_interface_object);
+        let fed_v1_subgraphs = format_subgraph_names(fed_1_subgraphs);
+        return Err(vec![SingleFederationError::InterfaceObjectUsageError {
+            message: format!("The @interfaceObject directive can only be used if all subgraphs have \
+            federation 2 subgraph schema (schema with a `@link` to \"https://specs.apollo.dev/federation\" \
+            version 2.0 or newer): @interfaceObject is used in {interface_object_subgraphs} but \
+            {fed_v1_subgraphs} is not a federation 2 subgraph schema.")
+        }.into()]);
+    }
+    Ok(upgraded_subgraphs)
+}
+
+fn is_interface_object_used(subgraph: &Subgraph<Expanded>) -> Result<bool, FederationError> {
+    if let Some(interface_object_def) = subgraph
+        .metadata()
+        .federation_spec_definition()
+        .interface_object_directive_definition(subgraph.schema())?
+    {
+        let referencers = subgraph
+            .schema()
+            .referencers()
+            .get_directive(interface_object_def.name.as_str())?;
+        if !referencers.object_types.is_empty() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1061,7 +1090,7 @@ mod tests {
         .expand_links()
         .expect("expands schema");
 
-        let [s1, _s2]: [Subgraph<Expanded>; 2] = upgrade_subgraphs_if_necessary(vec![s1, s2])
+        let [s1, _s2]: [Subgraph<Upgraded>; 2] = upgrade_subgraphs_if_necessary(vec![s1, s2])
             .expect("upgrades schema")
             .try_into()
             .expect("Expected 2 elements");
@@ -1164,7 +1193,7 @@ mod tests {
         .expand_links()
         .expect("expands schema");
 
-        let [s]: [Subgraph<Expanded>; 1] = upgrade_subgraphs_if_necessary(vec![s])
+        let [s]: [Subgraph<Upgraded>; 1] = upgrade_subgraphs_if_necessary(vec![s])
             .expect("upgrades schema")
             .try_into()
             .expect("Expected 1 element");
@@ -1229,7 +1258,7 @@ mod tests {
         .expand_links()
         .expect("expands schema");
 
-        let [s1, s2]: [Subgraph<Expanded>; 2] = upgrade_subgraphs_if_necessary(vec![s1, s2])
+        let [s1, s2]: [Subgraph<Upgraded>; 2] = upgrade_subgraphs_if_necessary(vec![s1, s2])
             .expect("upgrades schema")
             .try_into()
             .expect("Expected 2 elements");
@@ -1307,12 +1336,10 @@ mod tests {
         .expect("expands schema");
 
         let errors = upgrade_subgraphs_if_necessary(vec![s1, s2]).expect_err("should fail");
-
+        assert_eq!(errors.len(), 1);
         assert_eq!(
-            errors.to_string(),
-            r#"An internal error has occurred, please report this bug to Apollo.
-
-Details: The @interfaceObject directive can only be used if all subgraphs have federation 2 subgraph schema (schema with a `@link` to "https://specs.apollo.dev/federation" version 2.0 or newer): @interfaceObject is used in subgraph "s1" but subgraph "s2" is not a federation 2 subgraph schema."#
+            errors[0].to_string(),
+            r#"The @interfaceObject directive can only be used if all subgraphs have federation 2 subgraph schema (schema with a `@link` to "https://specs.apollo.dev/federation" version 2.0 or newer): @interfaceObject is used in subgraph "s1" but subgraph "s2" is not a federation 2 subgraph schema."#
         );
     }
 
@@ -1353,7 +1380,7 @@ Details: The @interfaceObject directive can only be used if all subgraphs have f
         .expand_links()
         .expect("expands schema");
 
-        let [s1, s2]: [Subgraph<Expanded>; 2] = upgrade_subgraphs_if_necessary(vec![s1, s2])
+        let [s1, s2]: [Subgraph<Upgraded>; 2] = upgrade_subgraphs_if_necessary(vec![s1, s2])
             .expect("upgrades schema")
             .try_into()
             .expect("Expected 2 elements");
@@ -1391,7 +1418,7 @@ Details: The @interfaceObject directive can only be used if all subgraphs have f
         .expand_links()
         .expect("expands schema");
 
-        let [subgraph]: [Subgraph<Expanded>; 1] = upgrade_subgraphs_if_necessary(vec![subgraph])
+        let [subgraph]: [Subgraph<Upgraded>; 1] = upgrade_subgraphs_if_necessary(vec![subgraph])
             .expect("upgrades schema")
             .try_into()
             .expect("Expected 1 element");
@@ -1504,7 +1531,7 @@ Details: The @interfaceObject directive can only be used if all subgraphs have f
         .expand_links()
         .expect("expands schema");
 
-        let [subgraph1, subgraph2]: [Subgraph<Expanded>; 2] =
+        let [subgraph1, subgraph2]: [Subgraph<Upgraded>; 2] =
             upgrade_subgraphs_if_necessary(vec![subgraph1, subgraph2])
                 .expect("upgrades schema")
                 .try_into()

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -411,8 +411,7 @@ pub mod test_utils {
             subgraph
         };
         subgraph
-            .expand_links()
-            .map_err(|e| SubgraphError::new(name, e))?
+            .expand_links()?
             .assume_upgraded()
             .validate(true)
     }
@@ -433,7 +432,6 @@ pub mod test_utils {
         };
         subgraph
             .expand_links()
-            .map_err(|e| SubgraphError::new(name, e))
     }
 
     pub fn build_and_validate(schema_str: &str) -> Subgraph<Validated> {

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -410,10 +410,7 @@ pub mod test_utils {
         } else {
             subgraph
         };
-        subgraph
-            .expand_links()?
-            .assume_upgraded()
-            .validate(true)
+        subgraph.expand_links()?.assume_upgraded().validate(true)
     }
 
     pub fn build_inner_expanded(
@@ -430,8 +427,7 @@ pub mod test_utils {
         } else {
             subgraph
         };
-        subgraph
-            .expand_links()
+        subgraph.expand_links()
     }
 
     pub fn build_and_validate(schema_str: &str) -> Subgraph<Validated> {

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -14,6 +14,7 @@ use indexmap::map::Entry;
 
 use crate::ValidFederationSubgraph;
 use crate::error::FederationError;
+use crate::internal_error;
 use crate::link::DEFAULT_LINK_NAME;
 use crate::link::Link;
 use crate::link::LinkError;
@@ -357,7 +358,7 @@ impl SubgraphError {
     // And return them as a vector of (error_code, error_message) tuples
     // - Gather associated errors from the validation error.
     // - Split each error into its code and message.
-    // - Add the subgraph name prefix to FederationError message.
+    // - Add the subgraph name prefix to CompositionError message.
     pub fn format_errors(&self) -> Vec<(String, String)> {
         self.error
             .errors()
@@ -375,6 +376,12 @@ impl SubgraphError {
 impl Display for SubgraphError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "[{}] {}", self.subgraph, self.error)
+    }
+}
+
+impl From<SubgraphError> for FederationError {
+    fn from(value: SubgraphError) -> Self {
+        internal_error!("[{}] {}", value.subgraph, value.error)
     }
 }
 
@@ -406,6 +413,7 @@ pub mod test_utils {
         subgraph
             .expand_links()
             .map_err(|e| SubgraphError::new(name, e))?
+            .assume_upgraded()
             .validate(true)
     }
 

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -477,7 +477,7 @@ impl FederationSchema {
         })
     }
 
-    fn representations_arguments_field_spec(&self) -> ResolvedArgumentSpecification {
+    fn representations_arguments_field_spec() -> ResolvedArgumentSpecification {
         ResolvedArgumentSpecification {
             name: FEDERATION_REPRESENTATIONS_ARGUMENTS_NAME,
             ty: Type::NonNullList(Box::new(Type::NonNullNamed(FEDERATION_ANY_TYPE_NAME))),
@@ -492,7 +492,7 @@ impl FederationSchema {
         Ok(FieldSpecification {
             name: FEDERATION_ENTITIES_FIELD_NAME,
             ty: Type::NonNullList(Box::new(Type::Named(entity_type.type_name))),
-            arguments: vec![self.representations_arguments_field_spec()],
+            arguments: vec![Self::representations_arguments_field_spec()],
         })
     }
 
@@ -964,159 +964,5 @@ mod tests {
                 .root_operation(OperationType::Subscription),
             Some(name!("MySubscription")).as_ref()
         );
-    }
-}
-
-// PORT_NOTE: Corresponds to '@core/@link handling' tests in JS
-#[cfg(test)]
-mod link_handling_tests {
-    use super::*;
-
-    // TODO(FED-543): Remaining directive definitions should be added to the schema
-    #[allow(dead_code)]
-    const EXPECTED_FULL_SCHEMA: &str = r#"
-    schema
-      @link(url: "https://specs.apollo.dev/link/v1.0")
-      @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
-    {
-      query: Query
-    }
-
-    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-
-    directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
-
-    directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
-
-    directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
-
-    directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
-
-    directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
-    directive @federation__extends on OBJECT | INTERFACE
-
-    directive @federation__shareable on OBJECT | FIELD_DEFINITION
-
-    directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
-    directive @federation__override(from: String!) on FIELD_DEFINITION
-
-    type T
-      @key(fields: "k")
-    {
-      k: ID!
-    }
-
-    enum link__Purpose {
-      """
-      \`SECURITY\` features provide metadata necessary to securely resolve fields.
-      """
-      SECURITY
-
-      """
-      \`EXECUTION\` features provide metadata necessary for operation execution.
-      """
-      EXECUTION
-    }
-
-    scalar link__Import
-
-    scalar federation__FieldSet
-
-    scalar _Any
-
-    type _Service {
-      sdl: String
-    }
-
-    union _Entity = T
-
-    type Query {
-      _entities(representations: [_Any!]!): [_Entity]!
-      _service: _Service!
-    }
-    "#;
-
-    #[test]
-    fn expands_everything_if_only_the_federation_spec_is_linked() {
-        let subgraph = Subgraph::parse(
-            "S",
-            "",
-            r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
-
-            type T @key(fields: "k") {
-                k: ID!
-            }
-            "#,
-        )
-        .expect("valid schema")
-        .expand_links()
-        .expect("expands subgraph")
-        .assume_upgraded()
-        .validate(true)
-        .expect("expanded subgraph to be valid");
-
-        // TODO(FED-543): `subgraph` is supposed to be compared against `EXPECTED_FULL_SCHEMA`, but
-        //                it's failing due to missing directive definitions. So, we use
-        //                `insta::assert_snapshot` for now.
-        // assert_eq!(subgraph.schema().schema().to_string(), EXPECTED_FULL_SCHEMA);
-        insta::assert_snapshot!(subgraph.schema().schema().to_string(), @r###"
-        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
-          query: Query
-        }
-
-        extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
-
-        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-
-        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
-
-        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
-
-        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
-
-        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
-
-        directive @federation__shareable on OBJECT | FIELD_DEFINITION
-
-        directive @federation__override(from: String!) on FIELD_DEFINITION
-
-        directive @federation__tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
-        type T @key(fields: "k") {
-          k: ID!
-        }
-
-        enum link__Purpose {
-          """
-          `SECURITY` features provide metadata necessary to securely resolve fields.
-          """
-          SECURITY
-          """
-          `EXECUTION` features provide metadata necessary for operation execution.
-          """
-          EXECUTION
-        }
-
-        scalar link__Import
-
-        scalar federation__FieldSet
-
-        scalar _Any
-
-        type _Service {
-          sdl: String
-        }
-
-        union _Entity = T
-
-        type Query {
-          _entities(representations: [_Any!]!): [_Entity]!
-          _service: _Service!
-        }
-        "###);
     }
 }

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -49,12 +49,18 @@ use crate::supergraph::FEDERATION_SERVICE_FIELD_NAME;
 use crate::supergraph::SERVICE_TYPE_SPEC;
 
 #[derive(Clone, Debug)]
-pub struct Raw {
+pub struct Initial {
     schema: Schema,
 }
 
 #[derive(Clone, Debug)]
 pub struct Expanded {
+    schema: FederationSchema,
+    metadata: SubgraphMetadata,
+}
+
+#[derive(Clone, Debug)]
+pub struct Upgraded {
     schema: FederationSchema,
     metadata: SubgraphMetadata,
 }
@@ -80,6 +86,16 @@ impl HasMetadata for Expanded {
     }
 }
 
+impl HasMetadata for Upgraded {
+    fn metadata(&self) -> &SubgraphMetadata {
+        &self.metadata
+    }
+
+    fn schema(&self) -> &FederationSchema {
+        &self.schema
+    }
+}
+
 impl HasMetadata for Validated {
     fn metadata(&self) -> &SubgraphMetadata {
         &self.metadata
@@ -95,18 +111,19 @@ impl HasMetadata for Validated {
 /// We aim to encode these state transitions using the [typestate pattern](https://cliffle.com/blog/rust-typestate).
 ///
 /// ```text
-///   (expand)     (validate)
-/// Raw ──► Expanded ──► Validated
-///            ▲             │
-///            └────────────┘
-///          (mutate/invalidate)
+///      (expand)                  (validate)
+/// Initial ──► Expanded ──► Upgraded ──► Validated
+///                       ▲            │
+///                       └────────────┘
+///                   (mutate/invalidate)
 ///  ```
 ///
 /// Subgraph states and their invariants:
-/// - `Raw`: The initial state, containing a raw schema. This provides no guarantees about the schema, other than
-///   that it can be parsed.
+/// - `Initial`: The initial state, containing original schema. This provides no guarantees about the schema,
+///   other than that it can be parsed.
 /// - `Expanded`: The schema's links have been expanded to include missing directive definitions and subgraph
 ///   metadata has been computed.
+/// - `Upgraded`: The schema has been upgraded to Federation v2 format (if starting with Fed v2 schema then this is no-op).
 /// - `Validated`: The schema has been validated according to Federation rules. Iterators over directives are
 ///   infallible at this stage.
 #[derive(Clone, Debug)]
@@ -116,12 +133,12 @@ pub struct Subgraph<S> {
     pub state: S,
 }
 
-impl Subgraph<Raw> {
-    pub fn new(name: &str, url: &str, schema: Schema) -> Subgraph<Raw> {
+impl Subgraph<Initial> {
+    pub fn new(name: &str, url: &str, schema: Schema) -> Subgraph<Initial> {
         Subgraph {
             name: name.to_string(),
             url: url.to_string(),
-            state: Raw { schema },
+            state: Initial { schema },
         }
     }
 
@@ -129,11 +146,12 @@ impl Subgraph<Raw> {
         name: &str,
         url: &str,
         schema_str: &str,
-    ) -> Result<Subgraph<Raw>, FederationError> {
+    ) -> Result<Subgraph<Initial>, SubgraphError> {
         let schema = Schema::builder()
             .adopt_orphan_extensions()
             .parse(schema_str, name)
-            .build()?;
+            .build()
+            .map_err(|e| SubgraphError::new(name, e))?;
 
         Ok(Self::new(name, url, schema))
     }
@@ -143,21 +161,27 @@ impl Subgraph<Raw> {
     /// - Returns an equivalent subgraph with a `@link` to the auto expanded federation spec.
     /// - This is mainly for testing and not optimized.
     // PORT_NOTE: Corresponds to `asFed2SubgraphDocument` function in JS, but simplified.
-    pub fn into_fed2_subgraph(self) -> Result<Self, FederationError> {
+    pub fn into_fed2_subgraph(self) -> Result<Self, SubgraphError> {
         let mut schema = self.state.schema;
         let federation_spec = FederationSpecDefinition::auto_expanded_federation_spec();
-        add_federation_link_to_schema(&mut schema, federation_spec.version())?;
+        add_federation_link_to_schema(&mut schema, federation_spec.version())
+            .map_err(|e| SubgraphError::new(self.name.clone(), e))?;
         Ok(Self::new(&self.name, &self.url, schema))
     }
 
-    pub fn assume_expanded(self) -> Result<Subgraph<Expanded>, FederationError> {
-        let schema = FederationSchema::new(self.state.schema)?;
-        let metadata = compute_subgraph_metadata(&schema)?.ok_or_else(|| {
-            internal_error!(
-                "Unable to detect federation version used in subgraph '{}'",
-                self.name
-            )
-        })?;
+    pub fn assume_expanded(self) -> Result<Subgraph<Expanded>, SubgraphError> {
+        let schema = FederationSchema::new(self.state.schema)
+            .map_err(|e| SubgraphError::new(self.name.clone(), e))?;
+        let metadata = compute_subgraph_metadata(&schema)
+            .and_then(|m| {
+                m.ok_or_else(|| {
+                    internal_error!(
+                        "Unable to detect federation version used in subgraph '{}'",
+                        self.name
+                    )
+                })
+            })
+            .map_err(|e| SubgraphError::new(self.name.clone(), e))?;
 
         Ok(Subgraph {
             name: self.name,
@@ -166,59 +190,15 @@ impl Subgraph<Raw> {
         })
     }
 
-    pub fn expand_links(self) -> Result<Subgraph<Expanded>, FederationError> {
+    pub fn expand_links(self) -> Result<Subgraph<Expanded>, SubgraphError> {
         tracing::debug!("expand_links: expand_links start");
-        let mut schema = FederationSchema::new_uninitialized(self.state.schema)?;
-        // First, copy types over from the underlying schema AST to make sure we have built-ins that directives may reference
-        tracing::debug!("expand_links: collect_shallow_references");
-        schema.collect_shallow_references();
+        let subgraph_name = self.name.clone();
+        self.expand_links_internal()
+            .map_err(|e| SubgraphError::new(subgraph_name, e))
+    }
 
-        // Backfill missing directive definitions. This is primarily making sure we have a definition for `@link`.
-        tracing::debug!("expand_links: missing directive definitions");
-        for directive in &schema.schema().schema_definition.directives.clone() {
-            if schema.get_directive_definition(&directive.name).is_none() {
-                FederationBlueprint::on_missing_directive_definition(&mut schema, directive)?;
-            }
-        }
-
-        // If there's a use of `@link`, and we successfully added its definition, add the bootstrap directive
-        if schema.get_directive_definition(&name!("link")).is_some() {
-            tracing::debug!("expand_links: add @link spec definition to schema");
-            LinkSpecDefinition::latest().add_to_schema(&mut schema, /*alias*/ None)?;
-        } else {
-            tracing::debug!("expand_links: add fed1 @link and its spec definition to schema");
-            // This must be a Fed 1 schema.
-            LinkSpecDefinition::fed1_latest().add_to_schema(&mut schema, /*alias*/ None)?;
-
-            // PORT_NOTE: JS doesn't actually add the 1.0 federation spec link to the schema. In
-            //            Rust, we add it, so that fed 1 and fed 2 can be processed the same way.
-            add_fed1_link_to_schema(&mut schema)?;
-        };
-
-        // Now that we have the definition for `@link` and an application, the bootstrap directive detection should work.
-        tracing::debug!("expand_links: collect_links_metadata");
-        schema.collect_links_metadata()?;
-
-        tracing::debug!("expand_links: on_directive_definition_and_schema_parsed");
-        FederationBlueprint::on_directive_definition_and_schema_parsed(&mut schema)?;
-
-        // Also, the backfilled definitions mean we can collect deep references.
-        // Ignore the error case, which means the schema has invalid references. It will be
-        // reported later in the validation phase.
-        tracing::debug!("expand_links: collect_deep_references");
-        _ = schema.collect_deep_references();
-
-        // TODO: Remove this and use metadata from this Subgraph instead of FederationSchema
-        tracing::debug!("expand_links: on_constructed");
-        FederationBlueprint::on_constructed(&mut schema)?;
-
-        // PORT_NOTE: JS version calls `addFederationOperations` in the `validate` method.
-        //            It seems to make sense for it to be a part of expansion stage. We can create
-        //            a separate stage for it between `Expanded` and `Validated` if we need a stage
-        //            that is expanded, but federation operations are not added.
-        tracing::debug!("expand_links: add_federation_operations");
-        add_federation_operations(&mut schema)?;
-
+    fn expand_links_internal(self) -> Result<Subgraph<Expanded>, FederationError> {
+        let schema = expand_schema(self.state.schema)?;
         tracing::debug!("expand_links: compute_subgraph_metadata");
         let metadata = compute_subgraph_metadata(&schema)?.ok_or_else(|| {
             internal_error!(
@@ -236,101 +216,20 @@ impl Subgraph<Raw> {
     }
 }
 
-/// Adds a federation (v2 or above) link directive to the schema.
-/// - Similar to `add_fed1_link_to_schema`, but the link is added before bootstrapping.
-/// - This is mainly for testing.
-fn add_federation_link_to_schema(
-    schema: &mut Schema,
-    federation_version: &Version,
-) -> Result<(), FederationError> {
-    let federation_spec = FEDERATION_VERSIONS
-        .find(federation_version)
-        .ok_or_else(|| internal_error!(
-            "Subgraph unexpectedly does not use a supported federation spec version. Requested version: {}",
-            federation_version,
-        ))?;
-
-    // Insert `@link(url: "http://specs.apollo.dev/federation/vX.Y", import: ...)`.
-    // - auto import all directives.
-    let imports: Vec<_> = federation_spec
-        .directive_specs()
-        .iter()
-        .map(|d| format!("@{}", d.name()).into())
-        .collect();
-
-    schema
-        .schema_definition
-        .make_mut()
-        .directives
-        .push(Component::new(Directive {
-            name: Identity::link_identity().name,
-            arguments: vec![
-                Node::new(ast::Argument {
-                    name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
-                    value: federation_spec.url().to_string().into(),
-                }),
-                Node::new(ast::Argument {
-                    name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
-                    value: Node::new(ast::Value::List(imports)),
-                }),
-            ],
-        }));
-    Ok(())
-}
-
-fn add_federation_operations(schema: &mut FederationSchema) -> Result<(), FederationError> {
-    // Add federation operation types
-    ANY_TYPE_SPEC.check_or_add(schema, None)?;
-    SERVICE_TYPE_SPEC.check_or_add(schema, None)?;
-    entity_type_spec(schema)?.check_or_add(schema, None)?;
-
-    // Add the root `Query` Type (if not already present) and get the actual name in the schema.
-    let query_root_pos = SchemaRootDefinitionPosition {
-        root_kind: SchemaRootDefinitionKind::Query,
-    };
-    let query_root_type_name = if query_root_pos.try_get(schema.schema()).is_none() {
-        // If not present, add the default Query type with empty fields.
-        EMPTY_QUERY_TYPE_SPEC.check_or_add(schema, None)?;
-        query_root_pos.insert(schema, ComponentName::from(EMPTY_QUERY_TYPE_SPEC.name))?;
-        EMPTY_QUERY_TYPE_SPEC.name
-    } else {
-        query_root_pos.get(schema.schema())?.name.clone()
-    };
-
-    // Add or remove `Query._entities` (if applicable)
-    let entity_field_pos = ObjectFieldDefinitionPosition {
-        type_name: query_root_type_name.clone(),
-        field_name: FEDERATION_ENTITIES_FIELD_NAME,
-    };
-    if let Some(_entity_type) = schema.entity_type()? {
-        if entity_field_pos.try_get(schema.schema()).is_none() {
-            entity_field_pos.insert(schema, Component::new(entities_field_spec(schema)?.into()))?;
-        }
-        // PORT_NOTE: JS version checks if the entity field definition's type is null when the
-        //            definition is found, but the `type` field is not nullable in Rust.
-    } else {
-        // Remove the `_entities` field if it is present
-        // PORT_NOTE: It's unclear why this is necessary. Maybe it's to avoid schema confusion?
-        entity_field_pos.remove(schema)?;
-    }
-
-    // Add `Query._service` (if not already present)
-    let service_field_pos = ObjectFieldDefinitionPosition {
-        type_name: query_root_type_name,
-        field_name: FEDERATION_SERVICE_FIELD_NAME,
-    };
-    if service_field_pos.try_get(schema.schema()).is_none() {
-        service_field_pos.insert(schema, Component::new(service_field_spec(schema)?.into()))?;
-    }
-
-    Ok(())
-}
-
 impl Subgraph<Expanded> {
-    pub fn upgrade(&mut self) -> Result<Self, SubgraphError> {
-        todo!("Implement upgrade logic for expanded subgraphs");
+    pub fn assume_upgraded(self) -> Subgraph<Upgraded> {
+        Subgraph {
+            name: self.name,
+            url: self.url,
+            state: Upgraded {
+                schema: self.state.schema,
+                metadata: self.state.metadata,
+            },
+        }
     }
+}
 
+impl Subgraph<Upgraded> {
     pub fn validate(self, rename_root_types: bool) -> Result<Subgraph<Validated>, SubgraphError> {
         // PORT_NOTE: The JS version calls GraphQL-js's `validateSDL` function and federation's
         //            `validateSchema` function here. But, Rust version performs general GraphQL
@@ -352,14 +251,14 @@ impl Subgraph<Expanded> {
 }
 
 impl Subgraph<Validated> {
-    pub fn invalidate(self) -> Subgraph<Expanded> {
+    pub fn invalidate(self) -> Subgraph<Upgraded> {
         // PORT_NOTE: In JS, the metadata gets invalidated by calling
         // `federationMetadata.onInvalidate` (via `FederationBlueprint.onValidation`). But, it
         // doesn't seem necessary in Rust, since the metadata is computed eagerly.
         Subgraph {
             name: self.name,
             url: self.url,
-            state: Expanded {
+            state: Upgraded {
                 // Other holders may still need the data in the `Arc`, so we clone the contents to allow mutation later
                 schema: (*self.state.schema).clone(),
                 metadata: self.state.metadata,
@@ -408,54 +307,202 @@ impl<S: HasMetadata> Subgraph<S> {
     }
 }
 
-// Constructs the `_Entity` type spec for the subgraph schema.
-// PORT_NOTE: Corresponds to the `entityTypeSpec` constant definition.
-fn entity_type_spec(schema: &FederationSchema) -> Result<UnionTypeSpecification, FederationError> {
-    // Please note that `_Entity` cannot use "interface entities" since interface types cannot
-    // be in unions. It is ok in practice because _Entity is only use as return type for
-    // `_entities`, and even when interfaces are involve, the result of an `_entities` call
-    // will always be an object type anyway, and since we force all implementations of an
-    // interface entity to be entity themselves in a subgraph, we're fine.
-    let mut entity_members = IndexSet::default();
-    for key_directive_app in schema.key_directive_applications()?.into_iter() {
-        let key_directive_app = key_directive_app?;
-        let target = key_directive_app.target();
-        if let ObjectOrInterfaceTypeDefinitionPosition::Object(obj_ty) = target {
-            entity_members.insert(ComponentName::from(&obj_ty.type_name));
+/// Adds a federation (v2 or above) link directive to the schema.
+/// - Similar to `add_fed1_link_to_schema`, but the link is added before bootstrapping.
+/// - This is mainly for testing.
+pub(crate) fn add_federation_link_to_schema(
+    schema: &mut Schema,
+    federation_version: &Version,
+) -> Result<(), FederationError> {
+    let federation_spec = FEDERATION_VERSIONS
+        .find(federation_version)
+        .ok_or_else(|| internal_error!(
+            "Subgraph unexpectedly does not use a supported federation spec version. Requested version: {}",
+            federation_version,
+        ))?;
+
+    // Insert `@link(url: "http://specs.apollo.dev/federation/vX.Y", import: ...)`.
+    // - auto import all directives.
+    let imports: Vec<_> = federation_spec
+        .directive_specs()
+        .iter()
+        .map(|d| format!("@{}", d.name()).into())
+        .collect();
+
+    schema
+        .schema_definition
+        .make_mut()
+        .directives
+        .push(Component::new(Directive {
+            name: Identity::link_identity().name,
+            arguments: vec![
+                Node::new(ast::Argument {
+                    name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
+                    value: federation_spec.url().to_string().into(),
+                }),
+                Node::new(ast::Argument {
+                    name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
+                    value: Node::new(ast::Value::List(imports)),
+                }),
+            ],
+        }));
+    Ok(())
+}
+
+/// Expands schema with all imported federation definitions.
+pub(crate) fn expand_schema(schema: Schema) -> Result<FederationSchema, FederationError> {
+    let mut schema = FederationSchema::new_uninitialized(schema)?;
+    // First, copy types over from the underlying schema AST to make sure we have built-ins that directives may reference
+    tracing::debug!("expand_links: collect_shallow_references");
+    schema.collect_shallow_references();
+
+    // Backfill missing directive definitions. This is primarily making sure we have a definition for `@link`.
+    tracing::debug!("expand_links: missing directive definitions");
+    for directive in &schema.schema().schema_definition.directives.clone() {
+        if schema.get_directive_definition(&directive.name).is_none() {
+            FederationBlueprint::on_missing_directive_definition(&mut schema, directive)?;
         }
     }
 
-    Ok(UnionTypeSpecification {
-        name: FEDERATION_ENTITY_TYPE_NAME,
-        members: Box::new(move |_| entity_members.clone()),
-    })
-}
+    // If there's a use of `@link`, and we successfully added its definition, add the bootstrap directive
+    if schema.get_directive_definition(&name!("link")).is_some() {
+        tracing::debug!("expand_links: add @link spec definition to schema");
+        LinkSpecDefinition::latest().add_to_schema(&mut schema, /*alias*/ None)?;
+    } else {
+        tracing::debug!("expand_links: add fed1 @link and its spec definition to schema");
+        // This must be a Fed 1 schema.
+        LinkSpecDefinition::fed1_latest().add_to_schema(&mut schema, /*alias*/ None)?;
 
-fn representations_arguments_field_spec() -> ResolvedArgumentSpecification {
-    ResolvedArgumentSpecification {
-        name: FEDERATION_REPRESENTATIONS_ARGUMENTS_NAME,
-        ty: Type::NonNullList(Box::new(Type::NonNullNamed(FEDERATION_ANY_TYPE_NAME))),
-        default_value: None,
-    }
-}
-
-fn entities_field_spec(schema: &FederationSchema) -> Result<FieldSpecification, FederationError> {
-    let Some(entity_type) = schema.entity_type()? else {
-        bail!("The federation entity type is expected to be defined, but not found")
+        // PORT_NOTE: JS doesn't actually add the 1.0 federation spec link to the schema. In
+        //            Rust, we add it, so that fed 1 and fed 2 can be processed the same way.
+        add_fed1_link_to_schema(&mut schema)?;
     };
-    Ok(FieldSpecification {
-        name: FEDERATION_ENTITIES_FIELD_NAME,
-        ty: Type::NonNullList(Box::new(Type::Named(entity_type.type_name))),
-        arguments: vec![representations_arguments_field_spec()],
-    })
+
+    // Now that we have the definition for `@link` and an application, the bootstrap directive detection should work.
+    tracing::debug!("expand_links: collect_links_metadata");
+    schema.collect_links_metadata()?;
+
+    tracing::debug!("expand_links: on_directive_definition_and_schema_parsed");
+    FederationBlueprint::on_directive_definition_and_schema_parsed(&mut schema)?;
+
+    // Also, the backfilled definitions mean we can collect deep references.
+    // Ignore the error case, which means the schema has invalid references. It will be
+    // reported later in the validation phase.
+    tracing::debug!("expand_links: collect_deep_references");
+    _ = schema.collect_deep_references();
+
+    // TODO: Remove this and use metadata from this Subgraph instead of FederationSchema
+    tracing::debug!("expand_links: on_constructed");
+    FederationBlueprint::on_constructed(&mut schema)?;
+
+    // PORT_NOTE: JS version calls `addFederationOperations` in the `validate` method.
+    //            It seems to make sense for it to be a part of expansion stage. We can create
+    //            a separate stage for it between `Expanded` and `Validated` if we need a stage
+    //            that is expanded, but federation operations are not added.
+    tracing::debug!("expand_links: add_federation_operations");
+    schema.add_federation_operations()?;
+    Ok(schema)
 }
 
-fn service_field_spec(schema: &FederationSchema) -> Result<FieldSpecification, FederationError> {
-    Ok(FieldSpecification {
-        name: FEDERATION_SERVICE_FIELD_NAME,
-        ty: Type::NonNullNamed(schema.service_type()?.type_name),
-        arguments: vec![],
-    })
+impl FederationSchema {
+    fn add_federation_operations(&mut self) -> Result<(), FederationError> {
+        // Add federation operation types
+        ANY_TYPE_SPEC.check_or_add(self, None)?;
+        SERVICE_TYPE_SPEC.check_or_add(self, None)?;
+        self.entity_type_spec()?.check_or_add(self, None)?;
+
+        // Add the root `Query` Type (if not already present) and get the actual name in the schema.
+        let query_root_pos = SchemaRootDefinitionPosition {
+            root_kind: SchemaRootDefinitionKind::Query,
+        };
+        let query_root_type_name = if query_root_pos.try_get(self.schema()).is_none() {
+            // If not present, add the default Query type with empty fields.
+            EMPTY_QUERY_TYPE_SPEC.check_or_add(self, None)?;
+            query_root_pos.insert(self, ComponentName::from(EMPTY_QUERY_TYPE_SPEC.name))?;
+            EMPTY_QUERY_TYPE_SPEC.name
+        } else {
+            query_root_pos.get(self.schema())?.name.clone()
+        };
+
+        // Add or remove `Query._entities` (if applicable)
+        let entity_field_pos = ObjectFieldDefinitionPosition {
+            type_name: query_root_type_name.clone(),
+            field_name: FEDERATION_ENTITIES_FIELD_NAME,
+        };
+        if let Some(_entity_type) = self.entity_type()? {
+            if entity_field_pos.try_get(self.schema()).is_none() {
+                entity_field_pos
+                    .insert(self, Component::new(self.entities_field_spec()?.into()))?;
+            }
+            // PORT_NOTE: JS version checks if the entity field definition's type is null when the
+            //            definition is found, but the `type` field is not nullable in Rust.
+        } else {
+            // Remove the `_entities` field if it is present
+            // PORT_NOTE: It's unclear why this is necessary. Maybe it's to avoid schema confusion?
+            entity_field_pos.remove(self)?;
+        }
+
+        // Add `Query._service` (if not already present)
+        let service_field_pos = ObjectFieldDefinitionPosition {
+            type_name: query_root_type_name,
+            field_name: FEDERATION_SERVICE_FIELD_NAME,
+        };
+        if service_field_pos.try_get(self.schema()).is_none() {
+            service_field_pos.insert(self, Component::new(self.service_field_spec()?.into()))?;
+        }
+
+        Ok(())
+    }
+
+    // Constructs the `_Entity` type spec for the subgraph schema.
+    // PORT_NOTE: Corresponds to the `entityTypeSpec` constant definition.
+    fn entity_type_spec(&self) -> Result<UnionTypeSpecification, FederationError> {
+        // Please note that `_Entity` cannot use "interface entities" since interface types cannot
+        // be in unions. It is ok in practice because _Entity is only use as return type for
+        // `_entities`, and even when interfaces are involve, the result of an `_entities` call
+        // will always be an object type anyway, and since we force all implementations of an
+        // interface entity to be entity themselves in a subgraph, we're fine.
+        let mut entity_members = IndexSet::default();
+        for key_directive_app in self.key_directive_applications()?.into_iter() {
+            let key_directive_app = key_directive_app?;
+            let target = key_directive_app.target();
+            if let ObjectOrInterfaceTypeDefinitionPosition::Object(obj_ty) = target {
+                entity_members.insert(ComponentName::from(&obj_ty.type_name));
+            }
+        }
+
+        Ok(UnionTypeSpecification {
+            name: FEDERATION_ENTITY_TYPE_NAME,
+            members: Box::new(move |_| entity_members.clone()),
+        })
+    }
+
+    fn representations_arguments_field_spec(&self) -> ResolvedArgumentSpecification {
+        ResolvedArgumentSpecification {
+            name: FEDERATION_REPRESENTATIONS_ARGUMENTS_NAME,
+            ty: Type::NonNullList(Box::new(Type::NonNullNamed(FEDERATION_ANY_TYPE_NAME))),
+            default_value: None,
+        }
+    }
+
+    fn entities_field_spec(&self) -> Result<FieldSpecification, FederationError> {
+        let Some(entity_type) = self.entity_type()? else {
+            bail!("The federation entity type is expected to be defined, but not found")
+        };
+        Ok(FieldSpecification {
+            name: FEDERATION_ENTITIES_FIELD_NAME,
+            ty: Type::NonNullList(Box::new(Type::Named(entity_type.type_name))),
+            arguments: vec![self.representations_arguments_field_spec()],
+        })
+    }
+
+    fn service_field_spec(&self) -> Result<FieldSpecification, FederationError> {
+        Ok(FieldSpecification {
+            name: FEDERATION_SERVICE_FIELD_NAME,
+            ty: Type::NonNullNamed(self.service_type()?.type_name),
+            arguments: vec![],
+        })
+    }
 }
 
 #[cfg(test)]
@@ -729,6 +776,7 @@ mod tests {
         .expect("parses schema")
         .expand_links()
         .expect("expands links")
+        .assume_upgraded()
         .validate(true)
         .expect_err("fails validation");
 
@@ -760,6 +808,7 @@ mod tests {
         .expect("parses schema")
         .expand_links()
         .expect("expands links")
+        .assume_upgraded()
         .validate(true)
         .expect_err("fails validation");
 
@@ -791,6 +840,7 @@ mod tests {
         .expect("parses schema")
         .expand_links()
         .expect("expands links")
+        .assume_upgraded()
         .validate(true)
         .expect_err("fails validation");
 
@@ -828,6 +878,7 @@ mod tests {
         .expect("parses schema")
         .expand_links()
         .expect("expands links")
+        .assume_upgraded()
         .validate(true)
         .expect("is valid");
 
@@ -885,6 +936,7 @@ mod tests {
         .expect("parses schema")
         .expand_links()
         .expect("expands links")
+        .assume_upgraded()
         .validate(false)
         .expect("is valid");
 
@@ -912,5 +964,159 @@ mod tests {
                 .root_operation(OperationType::Subscription),
             Some(name!("MySubscription")).as_ref()
         );
+    }
+}
+
+// PORT_NOTE: Corresponds to '@core/@link handling' tests in JS
+#[cfg(test)]
+mod link_handling_tests {
+    use super::*;
+
+    // TODO(FED-543): Remaining directive definitions should be added to the schema
+    #[allow(dead_code)]
+    const EXPECTED_FULL_SCHEMA: &str = r#"
+    schema
+      @link(url: "https://specs.apollo.dev/link/v1.0")
+      @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+    {
+      query: Query
+    }
+
+    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+    directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+    directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+    directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+    directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+    directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+    directive @federation__extends on OBJECT | INTERFACE
+
+    directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+    directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+    directive @federation__override(from: String!) on FIELD_DEFINITION
+
+    type T
+      @key(fields: "k")
+    {
+      k: ID!
+    }
+
+    enum link__Purpose {
+      """
+      \`SECURITY\` features provide metadata necessary to securely resolve fields.
+      """
+      SECURITY
+
+      """
+      \`EXECUTION\` features provide metadata necessary for operation execution.
+      """
+      EXECUTION
+    }
+
+    scalar link__Import
+
+    scalar federation__FieldSet
+
+    scalar _Any
+
+    type _Service {
+      sdl: String
+    }
+
+    union _Entity = T
+
+    type Query {
+      _entities(representations: [_Any!]!): [_Entity]!
+      _service: _Service!
+    }
+    "#;
+
+    #[test]
+    fn expands_everything_if_only_the_federation_spec_is_linked() {
+        let subgraph = Subgraph::parse(
+            "S",
+            "",
+            r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+            type T @key(fields: "k") {
+                k: ID!
+            }
+            "#,
+        )
+        .expect("valid schema")
+        .expand_links()
+        .expect("expands subgraph")
+        .assume_upgraded()
+        .validate(true)
+        .expect("expanded subgraph to be valid");
+
+        // TODO(FED-543): `subgraph` is supposed to be compared against `EXPECTED_FULL_SCHEMA`, but
+        //                it's failing due to missing directive definitions. So, we use
+        //                `insta::assert_snapshot` for now.
+        // assert_eq!(subgraph.schema().schema().to_string(), EXPECTED_FULL_SCHEMA);
+        insta::assert_snapshot!(subgraph.schema().schema().to_string(), @r###"
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
+          query: Query
+        }
+
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+        directive @federation__override(from: String!) on FIELD_DEFINITION
+
+        directive @federation__tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
+
+        scalar link__Import
+
+        scalar federation__FieldSet
+
+        scalar _Any
+
+        type _Service {
+          sdl: String
+        }
+
+        union _Entity = T
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+        }
+        "###);
     }
 }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -126,6 +126,7 @@ pub struct Satisfiable {
 
 #[derive(Clone, Debug)]
 #[allow(unused)]
+#[allow(unreachable_pub)]
 pub struct SupergraphMetadata {
     /// A set of the names of interface types for which at least one subgraph use an
     /// @interfaceObject to abstract that interface.
@@ -139,6 +140,7 @@ pub struct SupergraphMetadata {
 //  @see apollo-federation-types BuildMessage for what is currently used by rover
 #[derive(Clone, Debug)]
 #[allow(unused)]
+#[allow(unreachable_pub)]
 pub struct CompositionHint {
     message: String,
 }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -10,6 +10,7 @@ use std::sync::LazyLock;
 
 use apollo_compiler::Name;
 use apollo_compiler::Node;
+use apollo_compiler::Schema;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
@@ -43,6 +44,8 @@ use self::subgraph::FederationSubgraph;
 use self::subgraph::FederationSubgraphs;
 pub use self::subgraph::ValidFederationSubgraph;
 pub use self::subgraph::ValidFederationSubgraphs;
+use crate::ApiSchemaOptions;
+use crate::api_schema;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
@@ -59,6 +62,7 @@ use crate::link::spec::Identity;
 use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::FederationSchema;
+use crate::schema::ValidFederationSchema;
 use crate::schema::field_set::parse_field_set_without_normalization;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::DirectiveDefinitionPosition;
@@ -82,6 +86,62 @@ use crate::schema::type_and_directive_specification::ScalarTypeSpecification;
 use crate::schema::type_and_directive_specification::TypeAndDirectiveSpecification;
 use crate::schema::type_and_directive_specification::UnionTypeSpecification;
 use crate::utils::FallibleIterator;
+
+#[derive(Debug)]
+#[allow(unused)]
+pub struct Supergraph<S> {
+    pub state: S,
+}
+
+impl Supergraph<Merged> {
+    pub fn assume_valid(self) -> Supergraph<Satisfiable> {
+        todo!("unimplemented")
+    }
+}
+
+impl Supergraph<Satisfiable> {
+    /// Generates an API Schema from this supergraph schema. The API Schema represents the combined
+    /// API of the supergraph that's visible to end users.
+    pub fn to_api_schema(
+        &self,
+        options: ApiSchemaOptions,
+    ) -> Result<ValidFederationSchema, FederationError> {
+        api_schema::to_api_schema(self.state.schema.clone(), options)
+    }
+}
+
+#[derive(Clone, Debug)]
+#[allow(unused)]
+pub struct Merged {
+    schema: Schema,
+}
+
+#[derive(Clone, Debug)]
+#[allow(unused)]
+pub struct Satisfiable {
+    schema: ValidFederationSchema,
+    metadata: SupergraphMetadata,
+    hints: Vec<CompositionHint>,
+}
+
+#[derive(Clone, Debug)]
+#[allow(unused)]
+pub struct SupergraphMetadata {
+    /// A set of the names of interface types for which at least one subgraph use an
+    /// @interfaceObject to abstract that interface.
+    interface_types_with_interface_objects: IndexSet<InterfaceTypeDefinitionPosition>,
+    /// A set of the names of interface or union types that have inconsistent "runtime types" across
+    /// subgraphs.
+    abstract_types_with_inconsistent_runtime_types: IndexSet<Name>,
+}
+
+// TODO this should be expanded as needed
+//  @see apollo-federation-types BuildMessage for what is currently used by rover
+#[derive(Clone, Debug)]
+#[allow(unused)]
+pub struct CompositionHint {
+    message: String,
+}
 
 /// Assumes the given schema has been validated.
 ///


### PR DESCRIPTION
Initial version of overall composition process with placeholders for various composition phases.

Composition process consists of following phases
1. expand subgraphs - add missing federation definitions to the schema
2. upgrade subgraphs - upgrade fed v1 subgraphs to be compatible with fed v2
3. validate subgraphs - run subgraph validations
4. merge subgraphs - generates supergraph
4. validate satisfiability - ensure we can generate plan for any query

<!-- FED-530 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
