### PR TITLE
Hoist root type normalization up to expanded subgraph stage

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -344,7 +344,7 @@ fn cmd_subgraph(file_path: &Path) -> Result<(), FederationError> {
     let subgraph = typestate::Subgraph::parse(&name, &format!("http://{name}"), &doc_str)?
         .expand_links()?
         .assume_upgraded()
-        .validate(true)
+        .validate()
         .map_err(|e| e.into_inner())?;
     println!("{}", subgraph.schema_string());
     Ok(())

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -47,7 +47,7 @@ pub fn validate_subgraphs(
     let mut errors: Vec<FederationError> = vec![];
     let validated: Vec<Subgraph<Validated>> = subgraphs
         .into_iter()
-        .map(|s| s.validate(false))
+        .map(|s| s.validate())
         .filter_map(|r| r.map_err(|e| errors.push(e.into())).ok())
         .collect();
     if errors.is_empty() {

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -410,7 +410,9 @@ pub mod test_utils {
         } else {
             subgraph
         };
-        subgraph.expand_links()?.assume_upgraded().validate(true)
+        let mut subgraph = subgraph.expand_links()?.assume_upgraded();
+        subgraph.normalize_root_types()?;
+        subgraph.validate()
     }
 
     pub fn build_inner_expanded(

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -577,10 +577,9 @@ mod tests {
     use apollo_compiler::ast::OperationType;
     use apollo_compiler::name;
 
+    use super::*;
     use crate::subgraph::test_utils::build_and_validate;
     use crate::subgraph::test_utils::build_for_errors;
-
-    use super::*;
 
     #[test]
     fn detects_federation_1_subgraphs_correctly() {


### PR DESCRIPTION
This avoids mutating the schema during the validation phase. `FederationBlueprint` no longer needs to hold the state of whether root type names should be normalized, and it now takes immutable references to the schema and subgraph metadata. The renaming behavior is covered by existing tests.

<!-- FED-559-->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
