### PR TITLE
fix(federation/composition): updated spec link bootstrapping to match JS version

### DIFF
--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -7,7 +7,6 @@ use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::DirectiveLocation;
 use apollo_compiler::ast::Type;
 use apollo_compiler::name;
-use apollo_compiler::schema::Component;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::DirectiveDefinition;
 use apollo_compiler::schema::ExtendedType;
@@ -16,7 +15,6 @@ use apollo_compiler::schema::Value;
 use apollo_compiler::ty;
 
 use crate::ContextSpecDefinition;
-use crate::LinkSpecDefinition;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::internal_error;
@@ -981,27 +979,6 @@ pub(crate) fn get_federation_spec_definition_from_subgraph(
         // No federation link found in schema. The default is v1.0.
         Ok(&FED_1)
     }
-}
-
-/// Adds a bootstrap fed 1 link directive to the schema.
-pub(crate) fn add_fed1_link_to_schema(
-    schema: &mut FederationSchema,
-    link_spec: &LinkSpecDefinition,
-    link_name_in_schema: Name,
-) -> Result<(), FederationError> {
-    // Insert `@core(feature: "http://specs.apollo.dev/federation/v1.0")` directive (or a `@link`
-    // directive, if applicable) to the schema definition.
-    // We can't use `import` argument here since fed1 @core does not support `import`.
-    // We will add imports later (see `fed1_link_imports`).
-    let directive = Directive {
-        name: link_name_in_schema,
-        arguments: vec![Node::new(Argument {
-            name: link_spec.url_arg_name(),
-            value: FED_1.url().to_string().into(),
-        })],
-    };
-    crate::schema::position::SchemaDefinitionPosition
-        .insert_directive(schema, Component::new(directive))
 }
 
 /// Creates a fake imports for fed 1 link directive.

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -77,8 +77,6 @@ impl FederationBlueprint {
         }
         federation_spec.add_elements_to_schema(schema)?;
         Self::expand_known_features(schema)
-
-        // TODO (FED-428): Port `processUnappliedDirectives`.
     }
 
     pub(crate) fn ignore_parsed_field(schema: &FederationSchema, field_name: &str) -> bool {

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -53,8 +53,7 @@ impl SubgraphMetadata {
         let provided_fields = Self::collect_provided_fields(schema)?;
         let required_fields = Self::collect_required_fields(schema)?;
         let shareable_fields = if federation_spec_definition.is_fed1() {
-            // TODO (FED-428): Currently, `@shareable` is not used in Fed 1 schemas. But, the
-            // comments in the `collect_shareable_fields` function suggests that it may be used.
+            // `@shareable` is not used in Fed 1 schemas.
             Default::default()
         } else {
             Self::collect_shareable_fields(schema, federation_spec_definition)?
@@ -198,6 +197,7 @@ impl SubgraphMetadata {
         federation_spec_definition: &'static FederationSpecDefinition,
     ) -> Result<IndexSet<FieldDefinitionPosition>, FederationError> {
         let mut shareable_fields = IndexSet::default();
+        // PORT_NOTE: The comment below is from the JS code. It doesn't seem to apply to the Rust code.
         // @shareable is only available on fed2 schemas, but the schema upgrader call this on fed1 schemas as a shortcut to
         // identify key fields (because if we know nothing is marked @shareable, then the only fields that are shareable
         // by default are key fields).

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -405,7 +405,7 @@ pub mod test_utils {
             Subgraph::parse(name, &format!("http://{name}"), schema_str).expect("valid schema");
         let subgraph = if matches!(build_option, BuildOption::AsFed2) {
             subgraph
-                .into_fed2_subgraph()
+                .into_fed2_test_subgraph()
                 .map_err(|e| SubgraphError::new(name, e))?
         } else {
             subgraph
@@ -424,7 +424,7 @@ pub mod test_utils {
             Subgraph::parse(name, &format!("http://{name}"), schema_str).expect("valid schema");
         let subgraph = if matches!(build_option, BuildOption::AsFed2) {
             subgraph
-                .into_fed2_subgraph()
+                .into_fed2_test_subgraph()
                 .map_err(|e| SubgraphError::new(name, e))?
         } else {
             subgraph

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -14,6 +14,7 @@ use apollo_compiler::schema::Type;
 use crate::LinkSpecDefinition;
 use crate::ValidFederationSchema;
 use crate::bail;
+use crate::ensure;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
@@ -169,12 +170,22 @@ impl Subgraph<Initial> {
     /// - Returns an equivalent subgraph with a `@link` to the auto expanded federation spec.
     /// - This is mainly for testing and not optimized.
     // PORT_NOTE: Corresponds to `asFed2SubgraphDocument` function in JS, but simplified.
-    pub fn into_fed2_subgraph(self) -> Result<Self, SubgraphError> {
+    pub fn into_fed2_test_subgraph(self) -> Result<Self, SubgraphError> {
         let mut schema = self.state.schema;
         let federation_spec = FederationSpecDefinition::auto_expanded_federation_spec();
         add_federation_link_to_schema(&mut schema, federation_spec.version())
             .map_err(|e| SubgraphError::new(self.name.clone(), e))?;
         Ok(Self::new(&self.name, &self.url, schema))
+    }
+
+    /// Converts the schema to a fed2 schema.
+    /// - It is assumed to have no federation spec link.
+    /// - Returns an equivalent subgraph with a `@link` to the auto expanded federation spec.
+    /// - Similar to `into_fed2_test_subgraph`, but more robust.
+    pub fn into_fed2_subgraph(self) -> Result<Self, FederationError> {
+        let schema = new_federation_subgraph_schema(self.state.schema)?;
+        let inner_schema = schema_as_fed2_subgraph(schema, false)?;
+        Ok(Self::new(&self.name, &self.url, inner_schema))
     }
 
     pub fn assume_expanded(self) -> Result<Subgraph<Expanded>, SubgraphError> {
@@ -374,6 +385,32 @@ impl<S: HasMetadata> Subgraph<S> {
     }
 }
 
+// PORT_NOTE: This corresponds to the Schema's constructor in JS.
+fn new_federation_subgraph_schema(
+    inner_schema: Schema,
+) -> Result<FederationSchema, FederationError> {
+    let mut schema = FederationSchema::new_uninitialized(inner_schema)?;
+
+    // First, copy types over from the underlying schema AST to make sure we have built-ins that directives may reference
+    tracing::debug!("new_federation_subgraph_schema: collect_shallow_references");
+    schema.collect_shallow_references();
+
+    // Backfill missing directive definitions. This is primarily making sure we have a definition for `@link`.
+    // Note: Unlike `@core`, `@link` doesn't have to be defined in the schema.
+    tracing::debug!("new_federation_subgraph_schema: missing directive definitions");
+    for directive in &schema.schema().schema_definition.directives.clone() {
+        if schema.get_directive_definition(&directive.name).is_none() {
+            FederationBlueprint::on_missing_directive_definition(&mut schema, directive)?;
+        }
+    }
+
+    // Now that we have the definition for `@link`, the bootstrap directive detection should work.
+    tracing::debug!("new_federation_subgraph_schema: collect_links_metadata");
+    schema.collect_links_metadata()?;
+
+    Ok(schema)
+}
+
 /// Bootstrap link spec and federation spec links.
 /// - Make sure the schema has a link spec definition & link.
 /// - Make sure the schema has a federation spec link.
@@ -420,10 +457,13 @@ fn bootstrap_spec_links(schema: &mut FederationSchema) -> Result<(), FederationE
             // Implicitly add the link spec and federation spec to the schema.
             tracing::debug!("bootstrap_spec_links: has no link/federation spec");
             let link_spec = LinkSpecDefinition::fed1_latest();
-            // TODO: JS version doesn't add a link spec, (maybe) due to a potential name conflict.
-            //       We may generate a random link alias to achieve the same.
-            link_spec.add_to_schema(schema, /*alias*/ None)?;
-            add_fed1_link_to_schema(schema, link_spec, link_spec.identity().name.clone())?;
+            // PORT_NOTE: JS version doesn't add link specs here, (maybe) due to a potential name
+            //            conflict. We generate an alias to avoid conflicts, if necessary.
+            let link_spec_name = &link_spec.identity().name;
+            let alias = find_unused_name_for_directive(schema, link_spec_name)?;
+            let link_name_in_schema = alias.clone().unwrap_or_else(|| link_spec_name.clone());
+            link_spec.add_to_schema(schema, alias)?;
+            add_fed1_link_to_schema(schema, link_spec, link_name_in_schema)?;
         }
     }
     Ok(())
@@ -450,7 +490,8 @@ fn is_fed_spec_link_directive(schema: &Schema, directive: &Directive) -> bool {
 }
 
 /// Adds a federation (v2 or above) link directive to the schema.
-/// - Similar to `add_fed1_link_to_schema`, but the link is added before bootstrapping.
+/// - Similar to `add_fed1_link_to_schema` & `schema_as_fed2_subgraph`, but the link can be added
+///   before collecting metadata.
 /// - This is mainly for testing.
 pub(crate) fn add_federation_link_to_schema(
     schema: &mut Schema,
@@ -491,25 +532,118 @@ pub(crate) fn add_federation_link_to_schema(
     Ok(())
 }
 
-/// Expands schema with all imported federation definitions.
-pub(crate) fn expand_schema(schema: Schema) -> Result<FederationSchema, FederationError> {
-    let mut schema = FederationSchema::new_uninitialized(schema)?;
-    // First, copy types over from the underlying schema AST to make sure we have built-ins that directives may reference
-    tracing::debug!("expand_links: collect_shallow_references");
-    schema.collect_shallow_references();
+/// Turns a schema without a federation spec link into a federation 2 subgraph schema.
+/// - It may have a link spec, but it must not have a federation spec.
+/// - This is related to `add_federation_link_to_schema` but for real subgraphs.
+// PORT_NOTE: This corresponds to the `setSchemaAsFed2Subgraph` function in JS.
+//            The inner Schema is not exposed as mutable at the moment. So, this function consumes
+//            the input and returns the updated inner Schema.
+fn schema_as_fed2_subgraph(
+    mut schema: FederationSchema,
+    use_latest: bool,
+) -> Result<Schema, FederationError> {
+    let (link_spec, metadata) = if let Some(metadata) = schema.metadata() {
+        let spec = metadata.link_spec_definition()?;
+        // We don't accept pre-1.0 @core: this avoid having to care about what the name
+        // of the argument below is, and why would be bother?
+        ensure!(
+            spec.url()
+                .version
+                .satisfies(LinkSpecDefinition::latest().version()),
+            "Fed2 schema must use @link with version >= 1.0, but schema uses {spec_url}",
+            spec_url = spec.url()
+        );
+        (spec, metadata)
+    } else {
+        let default_link_name = &LinkSpecDefinition::latest().identity().name;
+        let alias = find_unused_name_for_directive(&schema, default_link_name)?;
+        LinkSpecDefinition::latest().add_to_schema(&mut schema, alias)?;
+        schema.collect_links_metadata()?;
+        let Some(metadata) = schema.metadata() else {
+            bail!("Schema should now be a core schema")
+        };
+        (LinkSpecDefinition::latest(), metadata)
+    };
 
-    // Backfill missing directive definitions. This is primarily making sure we have a definition for `@link`.
-    // Note: Unlike `@core`, `@link` doesn't have to be defined in the schema.
-    tracing::debug!("expand_links: missing directive definitions");
-    for directive in &schema.schema().schema_definition.directives.clone() {
-        if schema.get_directive_definition(&directive.name).is_none() {
-            FederationBlueprint::on_missing_directive_definition(&mut schema, directive)?;
-        }
+    let Some(link) = link_spec.link_in_schema(&schema)? else {
+        bail!("Core schema is missing @link directive");
+    };
+
+    let fed_spec = if use_latest {
+        FederationSpecDefinition::latest()
+    } else {
+        FederationSpecDefinition::auto_expanded_federation_spec()
+    };
+    ensure!(
+        metadata.for_identity(fed_spec.identity()).is_none(),
+        "Schema already set as a federation subgraph"
+    );
+
+    // Insert `@link(url: "http://specs.apollo.dev/federation/vX.Y", import: ...)`.
+    // - auto import certain directives.
+    let imports: Vec<_> = FederationSpecDefinition::auto_expanded_federation_spec()
+        .directive_specs()
+        .iter()
+        .map(|d| format!("@{}", d.name()).into())
+        .collect();
+
+    let mut inner_schema = schema.into_inner();
+    inner_schema
+        .schema_definition
+        .make_mut()
+        .directives
+        .push(Component::new(Directive {
+            name: link.spec_name_in_schema().clone(),
+            arguments: vec![
+                Node::new(ast::Argument {
+                    name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
+                    value: fed_spec.url().to_string().into(),
+                }),
+                Node::new(ast::Argument {
+                    name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
+                    value: Node::new(ast::Value::List(imports)),
+                }),
+            ],
+        }));
+    Ok(inner_schema)
+}
+
+/// Returns a suitable alias for a named directive.
+/// - Returns Some with an unused directive name.
+/// - Returns None, if aliasing is unnecessary.
+// PORT_NOTE: This corresponds to the `findUnusedNamedForLinkDirective` function in JS.
+fn find_unused_name_for_directive(
+    schema: &FederationSchema,
+    directive_name: &Name,
+) -> Result<Option<Name>, FederationError> {
+    if schema.get_directive_definition(directive_name).is_none() {
+        return Ok(None);
     }
 
-    // Now that we have the definition for `@link`, the bootstrap directive detection should work.
-    tracing::debug!("expand_links: collect_links_metadata");
-    schema.collect_links_metadata()?;
+    // The schema already defines a directive named `@link` so we need to use an alias. To keep it
+    // simple, we add a number in the end (so we try `@link1`, and if that's taken `@link2`, ...)
+    for i in 1..=1000 {
+        let candidate = Name::try_from(format!("{}{}", directive_name, i))?;
+        if schema.get_directive_definition(&candidate).is_none() {
+            return Ok(Some(candidate));
+        }
+    }
+    // We couldn't find one that is not used.
+    Err(internal_error!(
+        "Unable to find a name for the link directive",
+    ))
+}
+
+// PORT_NOTE: This corresponds to the `newEmptyFederation2Schema` function in JS.
+#[allow(unused)]
+pub(crate) fn new_empty_federation_2_subgraph_schema() -> Result<Schema, FederationError> {
+    let mut schema = new_federation_subgraph_schema(Schema::new())?;
+    schema_as_fed2_subgraph(schema, true)
+}
+
+/// Expands schema with all imported federation definitions.
+pub(crate) fn expand_schema(schema: Schema) -> Result<FederationSchema, FederationError> {
+    let mut schema = new_federation_subgraph_schema(schema)?;
 
     // If there's a use of `@link` and we successfully added its definition, add the bootstrap directive
     tracing::debug!("expand_links: bootstrap_spec_links");

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -1021,11 +1021,11 @@ mod link_handling_tests {
         //                `insta::assert_snapshot` for now.
         // assert_eq!(subgraph.schema_string(), EXPECTED_FULL_SCHEMA);
         insta::assert_snapshot!(subgraph.schema_string(), @r###"
-        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
+        schema {
           query: Query
         }
 
-        extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"]) @link(url: "https://specs.apollo.dev/link/v1.0")
 
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -1077,11 +1077,7 @@ mod link_handling_tests {
         "###);
     }
 
-    // TODO: FED-428
     #[test]
-    #[should_panic(
-        expected = r#"InvalidLinkDirectiveUsage { message: "Invalid use of @link in schema: the @link specification itself (\"https://specs.apollo.dev/link/v1.0\") is applied multiple times" }"#
-    )]
     fn expands_definitions_if_both_the_federation_spec_and_link_spec_are_linked() {
         let subgraph = build_and_validate(
             r#"
@@ -1095,24 +1091,78 @@ mod link_handling_tests {
             "#,
         );
 
-        assert_eq!(subgraph.schema_string(), EXPECTED_FULL_SCHEMA);
+        // TODO(FED-543): `subgraph` is supposed to be compared against `EXPECTED_FULL_SCHEMA`, but
+        //                it's failing due to missing directive definitions. So, we use
+        //                `insta::assert_snapshot` for now.
+        // assert_eq!(subgraph.schema_string(), EXPECTED_FULL_SCHEMA);
+        insta::assert_snapshot!(subgraph.schema_string(), @r###"
+        schema {
+          query: Query
+        }
+
+        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+        directive @federation__override(from: String!) on FIELD_DEFINITION
+
+        directive @federation__tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        type T @key(fields: "k") {
+          k: ID!
+        }
+
+        enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
+
+        scalar link__Import
+
+        scalar federation__FieldSet
+
+        scalar _Any
+
+        type _Service {
+          sdl: String
+        }
+
+        union _Entity = T
+
+        type Query {
+          _entities(representations: [_Any!]!): [_Entity]!
+          _service: _Service!
+        }
+        "###);
     }
 
-    // TODO: FED-428
+    // TODO: issue with `@tag` directive validation
     #[test]
     #[should_panic(
-        expected = r#"InvalidLinkDirectiveUsage { message: "Invalid use of @link in schema: the @link specification itself (\"https://specs.apollo.dev/link/v1.0\") is applied multiple times" }"#
+        expected = r#"DirectiveDefinitionInvalid { message: "Invalid definition for directive \"@federation__tag\": unknown/unsupported argument \"name\"" }"#
     )]
     fn is_valid_if_a_schema_is_complete_from_the_get_go() {
         let subgraph = build_and_validate(EXPECTED_FULL_SCHEMA);
         assert_eq!(subgraph.schema_string(), EXPECTED_FULL_SCHEMA);
     }
 
-    // TODO: FED-428
     #[test]
-    #[should_panic(
-        expected = r#"InvalidLinkDirectiveUsage { message: "Invalid use of @link in schema: the @link specification itself (\"https://specs.apollo.dev/link/v1.0\") is applied multiple times" }"#
-    )]
     fn expands_missing_definitions_when_some_are_partially_provided() {
         let docs = [
             r#"
@@ -1202,10 +1252,10 @@ mod link_handling_tests {
         });
     }
 
-    // TODO: FED-428
+    // TODO: an issue with `@key` directive definition check.
     #[test]
     #[should_panic(
-        expected = r#"InvalidLinkDirectiveUsage { message: "Invalid use of @link in schema: the @link specification itself (\"https://specs.apollo.dev/link/v1.0\") is applied multiple times" }"#
+        expected = r#"expanded subgraph to be valid: SubgraphError { subgraph: "S", error: DirectiveDefinitionInvalid { message: "Invalid definition for directive \"@key\": argument \"resolvable\" should have default value true but found no default value" } }"#
     )]
     fn allows_known_directives_with_incomplete_but_compatible_definitions() {
         let docs = [


### PR DESCRIPTION
### Summary

* updated `into_fed2_subgraph` to match the JS behavior.
  * fixed `DirectiveDefinitionInvalid` errors in tests.
  * ported `completeSubgraphSchema`'s behavior more closely.
  * ported `setSchemaAsFed2Subgraph`
* renamed the previous `into_fed2_subgraph` to `into_fed2_test_subgraph`.
* updated `LinkSpecDefinition::add_to_schema` to set the correct origin value.
  * added `SchemaElement` trait to help compute the origin value to use.
* fixed `add_fed1_link_to_schema` to use the correct origin value.
  * (refactor) Also, moved it to `typestate.rs` to group related functions together.

<!-- FED-428 -->
