### PR TITLE
chore: print logs when samples-based test panics

### DIFF
--- a/apollo-router/tests/samples_tests.rs
+++ b/apollo-router/tests/samples_tests.rs
@@ -152,14 +152,17 @@ fn test(path: &PathBuf, plan: Plan) -> Result<(), Failed> {
     let rt = Runtime::new()?;
 
     // Spawn the root task
-    let caught = rt.block_on(std::panic::AssertUnwindSafe(async {
-        let mut execution = TestExecution::new();
-        for action in plan.actions {
-            execution.execute_action(&action, path, &mut out).await?;
-        }
+    let caught = rt.block_on(
+        std::panic::AssertUnwindSafe(async {
+            let mut execution = TestExecution::new();
+            for action in plan.actions {
+                execution.execute_action(&action, path, &mut out).await?;
+            }
 
-        Ok(())
-    }).catch_unwind());
+            Ok(())
+        })
+        .catch_unwind(),
+    );
 
     match caught {
         Ok(result) => result,


### PR DESCRIPTION
Lately the most common test failure I see is in `/enterprise/persisted-queries/basic` from the "samples" tests. It's very flaky and I've reran workflows because of this test at least 6 times last week. It's impossible to debug though. This adds logging when a samples-based test panics.