### PR TITLE
chore: tweak mise usage on CI (backport #7466)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,8 +267,9 @@ commands:
                 command: |
                   curl https://mise.jdx.dev/install.sh | sh
                   mise activate bash >> "$BASH_ENV"
-                  mise trust
-                  mise install --yes
+                  # --raw disables the terminal timer/progress bars, so if mise gets stuck,
+                  # it will not continue to produce output preventing CCI from timing it out
+                  mise install --yes --raw
       - when:
           condition:
             or:
@@ -284,8 +285,9 @@ commands:
                 name: Install mise
                 command: |
                   scoop install mise
-                  mise trust
-                  mise install --yes
+                  # --raw disables the terminal timer/progress bars, so if mise gets stuck,
+                  # it will not continue to produce output preventing CCI from timing it out
+                  mise install --yes --raw
   fetch_dependencies:
     steps:
       - run:


### PR DESCRIPTION
Remove usage of `mise trust`, which is not required on CI. (https://github.com/apollographql/router/pull/7393#discussion_r2078004099)

Add the `--raw` flag to `install`, to hopefully handle random hangs.
This flag disables parallel installs (is slower), but importantly disables
the terminal UI with progress bars etc. that mise uses. Without
the progress bar, CircleCI should be able to detect that there
has been no output for a while and kill the job if it gets stuck.
<hr>This is an automatic backport of pull request #7466 done by [Mergify](https://mergify.com).