### PR TITLE
federation: update visibility of some composition methods

### DIFF
--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -2,7 +2,7 @@ mod satisfiability;
 
 use std::vec;
 
-use crate::composition::satisfiability::validate_satisfiability;
+pub use crate::composition::satisfiability::validate_satisfiability;
 use crate::error::FederationError;
 pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
 use crate::subgraph::typestate::Expanded;
@@ -10,9 +10,9 @@ use crate::subgraph::typestate::Initial;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Upgraded;
 use crate::subgraph::typestate::Validated;
-use crate::supergraph::Merged;
-use crate::supergraph::Satisfiable;
-use crate::supergraph::Supergraph;
+pub use crate::supergraph::Merged;
+pub use crate::supergraph::Satisfiable;
+pub use crate::supergraph::Supergraph;
 
 pub fn compose(
     subgraphs: Vec<Subgraph<Initial>>,

--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -3,7 +3,7 @@ use crate::supergraph::Merged;
 use crate::supergraph::Satisfiable;
 use crate::supergraph::Supergraph;
 
-pub(crate) fn validate_satisfiability(
+pub fn validate_satisfiability(
     _supergraph: Supergraph<Merged>,
 ) -> Result<Supergraph<Satisfiable>, Vec<FederationError>> {
     panic!("validate_satisfiability is not implemented yet")


### PR DESCRIPTION
Updating visibility of some additional composition methods so we can call it from `HybridComposer`