### PR TITLE
Add OCI schema store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,6 +1693,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "context-data"
 version = "0.1.0"
 dependencies = [
@@ -4358,9 +4378,9 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474675fdc023fbcc9dcf4782e938a3a1ae5fd469c728d8db40599bd25c77e1ba"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
 dependencies = [
  "bytes",
  "chrono",
@@ -4376,7 +4396,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "unicase",
@@ -4384,17 +4404,18 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da406e58efe2eb5986a6139626d611ce426e5324a824133d76367c765cf0b882"
+checksum = "57e9beda9d92fac7bf4904c34c83340ef1024159faee67179a04e0277523da33"
 dependencies = [
+ "const_format",
  "derive_builder",
  "getset",
  "regex",
  "serde",
  "serde_json",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "thiserror 2.0.12",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "dhat",
  "diff",
  "displaydoc",
+ "docker_credential",
  "ecdsa",
  "encoding_rs",
  "flate2",
@@ -340,6 +341,7 @@ dependencies = [
  "notify",
  "nu-ansi-term 0.50.1",
  "num-traits",
+ "oci-client",
  "once_cell",
  "opentelemetry",
  "opentelemetry-aws",
@@ -1259,6 +1261,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1515,8 +1523,10 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -2008,6 +2018,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2134,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2728,6 +2780,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "ghost"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,6 +3148,15 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3674,6 +3747,21 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -4269,6 +4357,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474675fdc023fbcc9dcf4782e938a3a1ae5fd469c728d8db40599bd25c77e1ba"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 1.3.1",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da406e58efe2eb5986a6139626d611ce426e5324a824133d76367c765cf0b882"
+dependencies = [
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4838,6 +4979,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6912,6 +7075,15 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -83,6 +83,7 @@ cookie = { version = "0.18.0", default-features = false }
 crossbeam-channel = "0.5.15"
 ci_info = { version = "0.14.14", features = ["serde-1"] }
 dashmap = { version = "6.0.0", features = ["serde"] }
+docker_credential = "1.3.1"
 derivative = "2.2.0"
 derive_more = { version = "2.0.0", default-features = false, features = [
     "from",
@@ -127,6 +128,7 @@ notify = { version = "6.1.1", default-features = false, features = [
 ] }
 nu-ansi-term = "0.50"
 num-traits = "0.2.19"
+oci-client = { version = "0.14.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "trust-dns", "test-registry"] }
 once_cell = "1.19.0"
 
 # Any package that starts with `opentelemetry` needs to be updated with care

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -128,7 +128,7 @@ notify = { version = "6.1.1", default-features = false, features = [
 ] }
 nu-ansi-term = "0.50"
 num-traits = "0.2.19"
-oci-client = { version = "0.14.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "trust-dns", "test-registry"] }
+oci-client = { version = "0.14.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "trust-dns"] }
 once_cell = "1.19.0"
 
 # Any package that starts with `opentelemetry` needs to be updated with care

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -128,7 +128,7 @@ notify = { version = "6.1.1", default-features = false, features = [
 ] }
 nu-ansi-term = "0.50"
 num-traits = "0.2.19"
-oci-client = { version = "0.14.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "trust-dns"] }
+oci-client = { version = "0.15.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots", "trust-dns"] }
 once_cell = "1.19.0"
 
 # Any package that starts with `opentelemetry` needs to be updated with care

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -228,7 +228,7 @@ pub struct Opt {
     /// An OCI reference to an image that contains the supergraph schema for the router.
     #[clap(long, env, action = ArgAction::Append)]
     // TODO: Update name to be final public name
-     graph_artifact_reference: Option<String>,
+    graph_artifact_reference: Option<String>,
 
     /// Disable sending anonymous usage information to Apollo.
     #[clap(long, env = "APOLLO_TELEMETRY_DISABLED", value_parser = FalseyValueParser::new())]
@@ -297,7 +297,7 @@ impl Opt {
                 .clone()
                 .ok_or(Self::err_require_opt("APOLLO_KEY"))?,
             reference: self
-                . graph_artifact_reference
+                .graph_artifact_reference
                 .clone()
                 .ok_or(Self::err_require_opt(" GRAPH_ARTIFACT_REFERENCE"))?,
         })
@@ -639,7 +639,7 @@ impl Executable {
                             return Err(anyhow!("Failed to read Apollo key file: {}", err));
                         }
                     };
-                    match opt. graph_artifact_reference {
+                    match opt.graph_artifact_reference {
                         None => SchemaSource::Registry(opt.uplink_config()?),
                         Some(_) => SchemaSource::OCI(opt.oci_config()?),
                     }
@@ -648,7 +648,7 @@ impl Executable {
             (_, None, None, Some(_apollo_key), None) => {
                 tracing::info!("{apollo_router_msg}");
                 tracing::info!("{apollo_telemetry_msg}");
-                match opt. graph_artifact_reference {
+                match opt.graph_artifact_reference {
                     None => SchemaSource::Registry(opt.uplink_config()?),
                     Some(_) => SchemaSource::OCI(opt.oci_config()?),
                 }

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -542,7 +542,7 @@ impl Executable {
         // 2. Env APOLLO_ROUTER_SUPERGRAPH_PATH
         // 3. Env APOLLO_ROUTER_SUPERGRAPH_URLS
         // 4. Env APOLLO_KEY and APOLLO_OCI_REGISTRY_ENDPOINT
-        // 4. Env APOLLO_KEY and APOLLO_GRAPH_REF
+        // 5. Env APOLLO_KEY and APOLLO_GRAPH_REF
         #[cfg(unix)]
         let akp = &opt.apollo_key_path;
         #[cfg(not(unix))]

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -541,6 +541,7 @@ impl Executable {
         // 1. Cli --supergraph
         // 2. Env APOLLO_ROUTER_SUPERGRAPH_PATH
         // 3. Env APOLLO_ROUTER_SUPERGRAPH_URLS
+        // 4. Env APOLLO_KEY and APOLLO_OCI_REGISTRY_ENDPOINT
         // 4. Env APOLLO_KEY and APOLLO_GRAPH_REF
         #[cfg(unix)]
         let akp = &opt.apollo_key_path;

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -225,7 +225,7 @@ pub struct Opt {
     // Should be a Vec<Url> when https://github.com/clap-rs/clap/discussions/3796 is solved
     apollo_uplink_endpoints: Option<String>,
 
-    /// The endpoint used to fetch the supergraph schema from the OCI registry.
+    /// An OCI reference to an image that contains the supergraph schema for the router.
     #[clap(long, env, action = ArgAction::Append)]
     // TODO: Update name to be final public name
      graph_artifact_reference: Option<String>,

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -224,7 +224,7 @@ pub struct Opt {
     #[clap(long, env, action = ArgAction::Append)]
     // Should be a Vec<Url> when https://github.com/clap-rs/clap/discussions/3796 is solved
     apollo_uplink_endpoints: Option<String>,
-    
+
     /// The endpoint used to fetch the supergraph schema from the OCI registry.
     #[clap(long, env, action = ArgAction::Append)]
     // TODO: Update name to be final public name
@@ -639,12 +639,8 @@ impl Executable {
                         }
                     };
                     match opt.apollo_oci_registry_endpoint {
-                        None => {
-                            SchemaSource::Registry(opt.uplink_config()?)
-                        }
-                        Some(_) => {
-                            SchemaSource::OCI(opt.oci_config()?)
-                        }
+                        None => SchemaSource::Registry(opt.uplink_config()?),
+                        Some(_) => SchemaSource::OCI(opt.oci_config()?),
                     }
                 }
             }
@@ -652,12 +648,8 @@ impl Executable {
                 tracing::info!("{apollo_router_msg}");
                 tracing::info!("{apollo_telemetry_msg}");
                 match opt.apollo_oci_registry_endpoint {
-                    None => {
-                        SchemaSource::Registry(opt.uplink_config()?)
-                    }
-                    Some(_) => {
-                        SchemaSource::OCI(opt.oci_config()?)
-                    }
+                    None => SchemaSource::Registry(opt.uplink_config()?),
+                    Some(_) => SchemaSource::OCI(opt.oci_config()?),
                 }
             }
             _ => {

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -228,7 +228,7 @@ pub struct Opt {
     /// The endpoint used to fetch the supergraph schema from the OCI registry.
     #[clap(long, env, action = ArgAction::Append)]
     // TODO: Update name to be final public name
-    apollo_oci_registry_endpoint: Option<String>,
+     graph_artifact_reference: Option<String>,
 
     /// Disable sending anonymous usage information to Apollo.
     #[clap(long, env = "APOLLO_TELEMETRY_DISABLED", value_parser = FalseyValueParser::new())]
@@ -296,10 +296,10 @@ impl Opt {
                 .apollo_key
                 .clone()
                 .ok_or(Self::err_require_opt("APOLLO_KEY"))?,
-            url: self
-                .apollo_oci_registry_endpoint
+            reference: self
+                . graph_artifact_reference
                 .clone()
-                .ok_or(Self::err_require_opt("APOLLO_OCI_REGISTRY_ENDPOINT"))?,
+                .ok_or(Self::err_require_opt(" GRAPH_ARTIFACT_REFERENCE"))?,
         })
     }
 
@@ -541,7 +541,7 @@ impl Executable {
         // 1. Cli --supergraph
         // 2. Env APOLLO_ROUTER_SUPERGRAPH_PATH
         // 3. Env APOLLO_ROUTER_SUPERGRAPH_URLS
-        // 4. Env APOLLO_KEY and APOLLO_OCI_REGISTRY_ENDPOINT
+        // 4. Env APOLLO_KEY and  GRAPH_ARTIFACT_REFERENCE
         // 5. Env APOLLO_KEY and APOLLO_GRAPH_REF
         #[cfg(unix)]
         let akp = &opt.apollo_key_path;
@@ -639,7 +639,7 @@ impl Executable {
                             return Err(anyhow!("Failed to read Apollo key file: {}", err));
                         }
                     };
-                    match opt.apollo_oci_registry_endpoint {
+                    match opt. graph_artifact_reference {
                         None => SchemaSource::Registry(opt.uplink_config()?),
                         Some(_) => SchemaSource::OCI(opt.oci_config()?),
                     }
@@ -648,7 +648,7 @@ impl Executable {
             (_, None, None, Some(_apollo_key), None) => {
                 tracing::info!("{apollo_router_msg}");
                 tracing::info!("{apollo_telemetry_msg}");
-                match opt.apollo_oci_registry_endpoint {
+                match opt. graph_artifact_reference {
                     None => SchemaSource::Registry(opt.uplink_config()?),
                     Some(_) => SchemaSource::OCI(opt.oci_config()?),
                 }

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -32,7 +32,7 @@ use crate::configuration::validate_yaml_configuration;
 use crate::metrics::meter_provider_internal;
 use crate::plugin::plugins;
 use crate::plugins::telemetry::reload::init_telemetry;
-use crate::registry::OCIConfig;
+use crate::registry::OciConfig;
 use crate::router::ConfigurationSource;
 use crate::router::RouterHttpServer;
 use crate::router::SchemaSource;
@@ -290,8 +290,8 @@ impl Opt {
         })
     }
 
-    pub(crate) fn oci_config(&self) -> Result<OCIConfig, anyhow::Error> {
-        Ok(OCIConfig {
+    pub(crate) fn oci_config(&self) -> Result<OciConfig, anyhow::Error> {
+        Ok(OciConfig {
             apollo_key: self
                 .apollo_key
                 .clone()

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -83,6 +83,7 @@ mod uplink;
 
 #[doc(hidden)]
 pub mod otel_compat;
+mod registry;
 
 pub use crate::configuration::Configuration;
 pub use crate::configuration::ListenAddr;

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -1,0 +1,125 @@
+use std::string::FromUtf8Error;
+use docker_credential::CredentialRetrievalError;
+use docker_credential::DockerCredential;
+use oci_client::Client as ociClient;
+use oci_client::Reference;
+use oci_client::errors::OciDistributionError;
+use oci_client::secrets::RegistryAuth;
+use thiserror::Error;
+
+/// Configuration for fetching an OCI Bundle
+/// This struct does not change on router reloads - they are all sourced from CLI options.
+#[derive(Debug, Clone)]
+pub struct OCIConfig {
+    /// The Apollo key: `<YOUR_GRAPH_API_KEY>`
+    pub apollo_key: String,
+
+    // Should this be a reference instead?
+    pub url: String,
+}
+
+pub(crate) struct OCIResult {
+    pub schema: String
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum Error {
+    #[error("OCI layer has not title")]
+    OCILayerMissingTitle,
+    #[error("Oci Distribution error: {0}")]
+    OCIDistributionError(OciDistributionError),
+    #[error("Oci Parsing error: {0}")]
+    OCIParseError(oci_client::ParseError),
+    #[error("Unable to parse layer: {0}")]
+    OCILayerParseError(FromUtf8Error),
+}
+
+impl From<oci_client::ParseError> for Error {
+    fn from(value: oci_client::ParseError) -> Self {
+        Error::OCIParseError(value)
+    }
+}
+
+impl From<OciDistributionError> for Error {
+    fn from(value: OciDistributionError) -> Self {
+        Error::OCIDistributionError(value)
+    }
+}
+
+impl From<FromUtf8Error> for Error {
+    fn from(value: FromUtf8Error) -> Self {
+        Error::OCILayerParseError(value)
+    }
+}
+
+fn build_auth(reference: &Reference, _apollo_key: &String) -> RegistryAuth {
+    let server = reference
+        .resolve_registry()
+        .strip_suffix('/')
+        .unwrap_or_else(|| reference.resolve_registry());
+
+    match docker_credential::get_credential(server) {
+        Err(CredentialRetrievalError::ConfigNotFound) => RegistryAuth::Anonymous,
+        Err(CredentialRetrievalError::NoCredentialConfigured) => RegistryAuth::Anonymous,
+        Err(e) => {
+            tracing::warn!("Error handling docker configuration file: {}", e);
+            RegistryAuth::Anonymous
+        }
+        Ok(DockerCredential::UsernamePassword(username, password)) => {
+            tracing::debug!("Found docker credentials");
+            RegistryAuth::Basic(username, password)
+        }
+        Ok(DockerCredential::IdentityToken(_)) => {
+            tracing::warn!(
+                "Cannot use contents of docker config, identity token not supported. Using anonymous auth"
+            );
+            RegistryAuth::Anonymous
+        }
+    }
+}
+
+async fn pull_oci(
+    client: &mut ociClient,
+    auth: &RegistryAuth,
+    reference: &Reference,
+) -> Result<OCIResult, Error> {
+    tracing::info!(?reference, "pulling oci bundle");
+    let supported_types = vec![
+        "application/json",
+        "text/plain",
+        "application/vnd.oci.empty.v1+json"
+    ];
+    let image = client
+        .pull(reference, auth, supported_types.clone())
+        .await?;
+
+    let schema = image
+        .layers
+        .iter()
+        .find(|layer| layer.media_type == "application/apollo.schema")
+        .ok_or(Error::OCILayerMissingTitle)?
+        .clone();
+
+    Ok(OCIResult {
+        schema: String::from_utf8(schema.data)?,
+    })
+}
+
+/// Fetch an OCI bundle
+pub(crate) async fn fetch_oci(oci_config: OCIConfig) -> Result<OCIResult, Error> {
+    let reference: Reference = oci_config.url.as_str().parse()?;
+    let client_config = oci_client::client::ClientConfig {
+        protocol: oci_client::client::ClientProtocol::Https,
+        ..Default::default()
+    };
+
+    let mut client = ociClient::new(client_config);
+
+    let auth = build_auth(&reference, &oci_config.apollo_key);
+
+    // let output = cli.output.unwrap_or("/tmp".to_string());
+    pull_oci(&mut client, &auth, &reference).await
+}
+
+#[cfg(test)]
+mod tests {}

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -1,4 +1,5 @@
 use std::string::FromUtf8Error;
+
 use docker_credential::CredentialRetrievalError;
 use docker_credential::DockerCredential;
 use oci_client::Client as ociClient;
@@ -19,7 +20,7 @@ pub struct OCIConfig {
 }
 
 pub(crate) struct OCIResult {
-    pub schema: String
+    pub schema: String,
 }
 
 #[derive(Debug, Error)]
@@ -93,7 +94,7 @@ async fn pull_oci(
     let supported_types = vec![
         "application/json",
         "text/plain",
-        "application/vnd.oci.empty.v1+json"
+        "application/vnd.oci.empty.v1+json",
     ];
     let image = client
         .pull(reference, auth, supported_types.clone())
@@ -134,7 +135,9 @@ mod tests {
     #[test]
     fn test_build_auth_apollo_registry() {
         // Create a reference for an Apollo registry
-        let reference: Reference = "registry.apollographql.com/my-graph:latest".parse().unwrap();
+        let reference: Reference = "registry.apollographql.com/my-graph:latest"
+            .parse()
+            .unwrap();
         let apollo_key = "test-api-key".to_string();
 
         // Call build_auth

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -17,7 +17,7 @@ pub struct OciConfig {
     pub apollo_key: String,
 
     /// OCI Compliant URL pointing to the release bundle
-    pub url: String,
+    pub reference: String,
 }
 
 #[derive(Debug, Clone)]
@@ -121,7 +121,7 @@ async fn pull_oci(
 
 /// Fetch an OCI bundle
 pub(crate) async fn fetch_oci(oci_config: OciConfig) -> Result<OciContent, OciError> {
-    let reference: Reference = oci_config.url.as_str().parse()?;
+    let reference: Reference = oci_config.reference.as_str().parse()?;
     let auth = build_auth(&reference, &oci_config.apollo_key);
     pull_oci(&mut Client::default(), &auth, &reference).await
 }

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -77,14 +77,12 @@ fn build_auth(reference: &Reference, apollo_key: &str) -> RegistryAuth {
             RegistryAuth::Anonymous
         }
         Ok(DockerCredential::UsernamePassword(username, password)) => {
-            tracing::debug!("Found docker credentials");
+            tracing::debug!("Found username/password docker credentials");
             RegistryAuth::Basic(username, password)
         }
-        Ok(DockerCredential::IdentityToken(_)) => {
-            tracing::warn!(
-                "Cannot use contents of docker config, identity token not supported. Using anonymous auth"
-            );
-            RegistryAuth::Anonymous
+        Ok(DockerCredential::IdentityToken(token)) => {
+            tracing::debug!("Found identity token docker credentials");
+            RegistryAuth::Bearer(token)
         }
     }
 }
@@ -105,7 +103,7 @@ async fn pull_oci(
     let schema = image
         .layers
         .iter()
-        .find(|layer| layer.media_type == "application/apollo.schema")
+        .find(|layer| layer.media_type == APOLLO_SCHEMA_MEDIA_TYPE)
         .ok_or(Error::OCILayerMissingTitle)?
         .clone();
 

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -21,7 +21,7 @@ pub struct OciConfig {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct OciResult {
+pub(crate) struct OciContent {
     pub schema: String,
 }
 
@@ -93,7 +93,7 @@ async fn pull_oci(
     client: &mut ociClient,
     auth: &RegistryAuth,
     reference: &Reference,
-) -> Result<OciResult, OciError> {
+) -> Result<OciContent, OciError> {
     tracing::debug!(?reference, "pulling oci bundle");
 
     // We aren't using the default `pull` function because that validates that all the layers are in the
@@ -114,13 +114,13 @@ async fn pull_oci(
         .pull_blob(reference, &schema_layer, &mut schema)
         .await?;
 
-    Ok(OciResult {
+    Ok(OciContent {
         schema: String::from_utf8(schema)?,
     })
 }
 
 /// Fetch an OCI bundle
-pub(crate) async fn fetch_oci(oci_config: OciConfig) -> Result<OciResult, OciError> {
+pub(crate) async fn fetch_oci(oci_config: OciConfig) -> Result<OciContent, OciError> {
     let reference: Reference = oci_config.url.as_str().parse()?;
     let auth = build_auth(&reference, &oci_config.apollo_key);
     pull_oci(&mut Client::default(), &auth, &reference).await

--- a/apollo-router/src/router/event/schema.rs
+++ b/apollo-router/src/router/event/schema.rs
@@ -161,7 +161,6 @@ impl SchemaSource {
             }
             SchemaSource::OCI(oci_config) => {
                 futures::stream::once(async move {
-                    // TODO: Fix error handling
                     match fetch_oci(oci_config).await {
                         Ok(oci_result) => {
                             Some(SchemaState {

--- a/apollo-router/src/router/event/schema.rs
+++ b/apollo-router/src/router/event/schema.rs
@@ -8,7 +8,7 @@ use derive_more::From;
 use futures::prelude::*;
 use url::Url;
 
-use crate::registry::OCIConfig;
+use crate::registry::OciConfig;
 use crate::registry::fetch_oci;
 use crate::router::Event;
 use crate::router::Event::NoMoreSchema;
@@ -55,7 +55,7 @@ pub enum SchemaSource {
     },
 
     #[display("Registry")]
-    OCI(OCIConfig),
+    OCI(OciConfig),
 }
 
 impl From<&'_ str> for SchemaSource {

--- a/apollo-router/src/router/event/schema.rs
+++ b/apollo-router/src/router/event/schema.rs
@@ -2,7 +2,14 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 
-use crate::registry::{OCIConfig, fetch_oci};
+use derivative::Derivative;
+use derive_more::Display;
+use derive_more::From;
+use futures::prelude::*;
+use url::Url;
+
+use crate::registry::OCIConfig;
+use crate::registry::fetch_oci;
 use crate::router::Event;
 use crate::router::Event::NoMoreSchema;
 use crate::router::Event::UpdateSchema;
@@ -10,11 +17,6 @@ use crate::uplink::UplinkConfig;
 use crate::uplink::schema::SchemaState;
 use crate::uplink::schema_stream::SupergraphSdlQuery;
 use crate::uplink::stream_from_uplink;
-use derivative::Derivative;
-use derive_more::Display;
-use derive_more::From;
-use futures::prelude::*;
-use url::Url;
 
 type SchemaStream = Pin<Box<dyn Stream<Item = String> + Send>>;
 

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -175,6 +175,25 @@ For default behavior and possible values, see [Apollo Uplink](/federation/manage
 <tr>
 <td style="min-width: 150px;">
 
+##### `--graph-artifact-reference`
+
+`GRAPH_ARTIFACT_REFERENCE`
+
+</td>
+<td>
+
+An OCI reference to an image that contains the supergraph schema for the router.<br/>
+
+When this option is set, the router will fetch the schema from the specified OCI image instead of using Apollo Uplink. Note that Apollo Uplink will still be used for entitlements and persisted queries.<br/>
+
+⚠️ **This option does not support hot reloading schemas.**
+
+</td>
+</tr>
+
+<tr>
+<td style="min-width: 150px;">
+
 ##### `--apollo-uplink-timeout`
 
 `APOLLO_UPLINK_TIMEOUT`

--- a/docs/source/routing/self-hosted/containerization/docker.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker.mdx
@@ -131,7 +131,11 @@ The router runs under the control of [heaptrack](https://github.com/KDE/heaptrac
 
 ## Specifying the supergraph
 
-If you don't want to automatically update your supergraph via [Apollo Uplink](/federation/managed-federation/uplink/), or you don't have connectivity to access Apollo Uplink from your environment, you can manually specify the details of your supergraph in a `docker run` command:
+If you don't want to automatically update your supergraph via [Apollo Uplink](/federation/managed-federation/uplink/), or you don't have connectivity to access Apollo Uplink from your environment, you have two options:
+
+### Using a local supergraph file
+
+You can manually specify the details of your supergraph in a `docker run` command:
 
 ```bash
 docker run -p 4000:4000 \
@@ -141,6 +145,20 @@ docker run -p 4000:4000 \
 ```
 
 In this example, we have to mount the local definition of the supergraph into our image, _and_ specify the location of the file. It doesn't have to be mounted in the `/dist/schema` directory, but it's a reasonable location to use. We must specify the configuration file location as well, since overriding the default params will override our default config file location. In this case, since we don't want to change our router configuration but want to make sure it's used, we just specify the default location of the default configuration.
+
+### Using an OCI image reference
+
+You can use the `--graph-artifact-reference` option to fetch the supergraph schema from an OCI image:
+
+```bash
+docker run -p 4000:4000 \
+  --env APOLLO_KEY="<your-graph-api-key>" \
+  --env GRAPH_ARTIFACT_REFERENCE="<your-oci-reference>" \
+  --rm \
+  ghcr.io/apollographql/router:<router-image-version>
+```
+
+When using this option, the router will fetch the schema from the specified OCI image instead of using Apollo Uplink.
 
 ## Building your own container
 


### PR DESCRIPTION
Support fetching the supergraph schema from Apollo OCI Registry, instead of uplink. We also aren't supporting hot-reloading of supergraph schemas as part of this workflow. 

---

<!-- [ROUTER-1338] -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1338]: https://apollographql.atlassian.net/browse/ROUTER-1338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ