### PR TITLE
PoC: Require reporting configuration based on entitlements

### DIFF
--- a/apollo-router/src/plugins/license_enforcement/mod.rs
+++ b/apollo-router/src/plugins/license_enforcement/mod.rs
@@ -124,6 +124,7 @@ mod test {
                     capacity: 1,
                     interval: Duration::from_millis(150),
                 }),
+                usage_reporting: None,
             }),
         };
 
@@ -180,6 +181,7 @@ mod test {
                         capacity: 1,
                         interval: Duration::from_millis(150),
                     }),
+                    usage_reporting: None,
                 }),
             };
 

--- a/apollo-router/src/plugins/license_enforcement/mod.rs
+++ b/apollo-router/src/plugins/license_enforcement/mod.rs
@@ -120,6 +120,7 @@ mod test {
         // * the router limits plugin
         let license = LicenseState::Licensed {
             limits: Some(LicenseLimits {
+                restricted: Some(true),
                 tps: Some(TpsLimit {
                     capacity: 1,
                     interval: Duration::from_millis(150),
@@ -177,6 +178,7 @@ mod test {
             // * the router limits plugin
             let license = LicenseState::Licensed {
                 limits: Some(LicenseLimits {
+                    restricted: Some(true),
                     tps: Some(TpsLimit {
                         capacity: 1,
                         interval: Duration::from_millis(150),

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -327,8 +327,8 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         match license {
             LicenseState::Licensed { limits } => {
                 let license_is_restricted = limits
-                    .map(|limits| limits.restricted.unwrap_or(false))
-                    .unwrap_or(false);
+                    .map(|limits| limits.restricted.unwrap_or(true))
+                    .unwrap_or(true); // TODO: Revert me.  Unless we were to update all the licenses first, this should default to false.  Useful for testing though.
                 if report.uses_restricted_features() && license_is_restricted {
                     tracing::error!(
                         "Insufficient license. An upgraded license is required enable the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -327,8 +327,8 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         match license {
             LicenseState::Licensed { limits } => {
                 let license_is_restricted = limits
-                    .map(|limits| limits.restricted.unwrap_or(true))
-                    .unwrap_or(true); // TODO: Revert me.  Unless we were to update all the licenses first, this should default to false.  Useful for testing though.
+                    .map(|limits| limits.restricted.unwrap_or(false))
+                    .unwrap_or(false);
                 if report.uses_restricted_features() && license_is_restricted {
                     tracing::error!(
                         "Insufficient license. An upgraded license is required enable the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -397,7 +397,7 @@ impl LicenseEnforcementReport {
                 .build(),
         ];
         if let Some(limits) = license_limits {
-            let restrict_usage_reporting = limits.usage_reporting.unwrap_or(true); // TODO: revert me, should default to false.
+            let restrict_usage_reporting = limits.usage_reporting.unwrap_or(false);
             if restrict_usage_reporting {
                 restrictions.push(
                     ConfigurationRestriction::builder()

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -76,6 +76,8 @@ pub(crate) struct Claims {
     #[serde(deserialize_with = "deserialize_epoch_seconds", rename = "haltAt")]
     /// When to halt the router because of an expired license
     pub(crate) halt_at: SystemTime,
+    /// Enforce license violations.  If true, requires that there are no violations.
+    pub(crate) restricted: Option<bool>,
     /// TPS limits. These may not exist in a License; if not, no limits apply
     #[serde(rename = "throughputLimit")]
     pub(crate) tps: Option<TpsLimit>,
@@ -552,6 +554,9 @@ pub(crate) struct TpsLimit {
 /// as an example
 #[derive(Debug, Builder, Copy, Clone, Default, Eq, PartialEq)]
 pub struct LicenseLimits {
+    /// Controls whether license violations are enforced.  If true, prevents Router startup
+    /// if there are any license violations.
+    pub(crate) restricted: Option<bool>,
     /// Transaction Per Second limits. If none are found in the License's claims, there are no
     /// limits to apply
     pub(crate) tps: Option<TpsLimit>,
@@ -806,6 +811,7 @@ mod test {
             include_str!("testdata/restricted.router.yaml"),
             include_str!("testdata/oss.graphql"),
             Some(&LicenseLimits {
+                restricted: Some(true),
                 tps: Default::default(),
                 usage_reporting: Some(true),
             }),
@@ -875,6 +881,7 @@ mod test {
                 aud: OneOrMany::One(Audience::SelfHosted),
                 warn_at: UNIX_EPOCH + Duration::from_secs(1676808000),
                 halt_at: UNIX_EPOCH + Duration::from_secs(1678017600),
+                restricted: Default::default(),
                 tps: Default::default(),
                 usage_reporting: Default::default(),
             }),
@@ -892,6 +899,7 @@ mod test {
                 aud: OneOrMany::One(Audience::SelfHosted),
                 warn_at: UNIX_EPOCH + Duration::from_secs(1676808000),
                 halt_at: UNIX_EPOCH + Duration::from_secs(1678017600),
+                restricted: Default::default(),
                 tps: Default::default(),
                 usage_reporting: Default::default(),
             }),

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -30,6 +30,8 @@ use thiserror::Error;
 use super::parsed_link_spec::ParsedLinkSpec;
 use crate::Configuration;
 use crate::plugins::authentication::jwks::convert_key_algorithm;
+use crate::plugins::telemetry::apollo::ENDPOINT_DEFAULT;
+use crate::plugins::telemetry::apollo::OTLP_ENDPOINT_DEFAULT;
 use crate::spec::LINK_DIRECTIVE_NAME;
 use crate::spec::Schema;
 
@@ -74,9 +76,12 @@ pub(crate) struct Claims {
     #[serde(deserialize_with = "deserialize_epoch_seconds", rename = "haltAt")]
     /// When to halt the router because of an expired license
     pub(crate) halt_at: SystemTime,
-    /// TPS limits. These may not exist in a Licnese; if not, no limits apply
+    /// TPS limits. These may not exist in a License; if not, no limits apply
     #[serde(rename = "throughputLimit")]
     pub(crate) tps: Option<TpsLimit>,
+    /// Telemetry requirements.  If true, requires certain telemetry to be in place.
+    #[serde(rename = "usageReporting")]
+    pub(crate) usage_reporting: Option<bool>,
 }
 
 fn deserialize_epoch_seconds<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
@@ -109,11 +114,12 @@ impl LicenseEnforcementReport {
     pub(crate) fn build(
         configuration: &Configuration,
         schema: &Schema,
+        license_limits: Option<&LicenseLimits>,
     ) -> LicenseEnforcementReport {
         LicenseEnforcementReport {
             restricted_config_in_use: Self::validate_configuration(
                 configuration,
-                &Self::configuration_restrictions(),
+                &Self::configuration_restrictions(license_limits),
             ),
             restricted_schema_in_use: Self::validate_schema(schema, &Self::schema_restrictions()),
         }
@@ -137,6 +143,10 @@ impl LicenseEnforcementReport {
             {
                 if let Some(restriction_value) = &restriction.value {
                     if *value == restriction_value {
+                        configuration_violations.push(restriction.clone());
+                    }
+                } else if let Some(required_value) = &restriction.require_value {
+                    if *value != required_value {
                         configuration_violations.push(restriction.clone());
                     }
                 } else {
@@ -281,8 +291,10 @@ impl LicenseEnforcementReport {
         schema_violations
     }
 
-    fn configuration_restrictions() -> Vec<ConfigurationRestriction> {
-        vec![
+    fn configuration_restrictions(
+        license_limits: Option<&LicenseLimits>,
+    ) -> Vec<ConfigurationRestriction> {
+        let mut restrictions = vec![
             ConfigurationRestriction::builder()
                 .path("$.plugins.['experimental.restricted'].enabled")
                 .value(true)
@@ -381,7 +393,27 @@ impl LicenseEnforcementReport {
                 .value("extended")
                 .name("Apollo metrics extended references")
                 .build(),
-        ]
+        ];
+        if let Some(limits) = license_limits {
+            let restrict_usage_reporting = limits.usage_reporting.unwrap_or(false);
+            if restrict_usage_reporting {
+                restrictions.push(
+                    ConfigurationRestriction::builder()
+                        .path("$.telemetry.apollo.endpoint")
+                        .require_value(ENDPOINT_DEFAULT)
+                        .name("Apollo usage reporting override")
+                        .build(),
+                );
+                restrictions.push(
+                    ConfigurationRestriction::builder()
+                        .path("$.telemetry.apollo.experimental_otlp_endpoint")
+                        .require_value(OTLP_ENDPOINT_DEFAULT)
+                        .name("Apollo OTLP usage reporting override")
+                        .build(),
+                );
+            }
+        }
+        restrictions
     }
 
     fn schema_restrictions() -> Vec<SchemaRestriction> {
@@ -523,6 +555,8 @@ pub struct LicenseLimits {
     /// Transaction Per Second limits. If none are found in the License's claims, there are no
     /// limits to apply
     pub(crate) tps: Option<TpsLimit>,
+    /// Telemetry requirements.  If true, requires certain telemetry to be in place.
+    pub(crate) usage_reporting: Option<bool>,
 }
 
 /// Licenses are converted into a stream of license states by the expander
@@ -623,7 +657,10 @@ impl FromStr for License {
 pub(crate) struct ConfigurationRestriction {
     name: String,
     path: String,
+    // Configuration with this value will be restricted.
     value: Option<Value>,
+    // Configuration with any value other than this will be restricted.
+    require_value: Option<Value>,
 }
 
 // An individual check for the supergraph schema
@@ -712,6 +749,7 @@ mod test {
     use insta::assert_snapshot;
     use serde_json::json;
 
+    use super::LicenseLimits;
     use crate::Configuration;
     use crate::spec::Schema;
     use crate::uplink::license_enforcement::Audience;
@@ -722,11 +760,15 @@ mod test {
     use crate::uplink::license_enforcement::SchemaViolation;
 
     #[track_caller]
-    fn check(router_yaml: &str, supergraph_schema: &str) -> LicenseEnforcementReport {
+    fn check(
+        router_yaml: &str,
+        supergraph_schema: &str,
+        license_limits: Option<&LicenseLimits>,
+    ) -> LicenseEnforcementReport {
         let config = Configuration::from_str(router_yaml).expect("router config must be valid");
         let schema =
             Schema::parse(supergraph_schema, &config).expect("supergraph schema must be valid");
-        LicenseEnforcementReport::build(&config, &schema)
+        LicenseEnforcementReport::build(&config, &schema, license_limits)
     }
 
     #[test]
@@ -734,6 +776,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/oss.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -747,6 +790,7 @@ mod test {
         let report = check(
             include_str!("testdata/restricted.router.yaml"),
             include_str!("testdata/oss.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -757,10 +801,44 @@ mod test {
     }
 
     #[test]
+    fn test_restricted_features_via_config_with_limits() {
+        let report_with_limits = check(
+            include_str!("testdata/restricted.router.yaml"),
+            include_str!("testdata/oss.graphql"),
+            Some(&LicenseLimits {
+                tps: Default::default(),
+                usage_reporting: Some(true),
+            }),
+        );
+        assert!(
+            !report_with_limits.restricted_config_in_use.is_empty(),
+            "should have found restricted features"
+        );
+        let expected_restriction = report_with_limits
+            .restricted_config_in_use
+            .iter()
+            .find(|config| config.name == "Apollo usage reporting override");
+        assert!(
+            expected_restriction.is_some(),
+            "should have found a usage reporting restriction"
+        );
+        let expected_otlp_restriction = report_with_limits
+            .restricted_config_in_use
+            .iter()
+            .find(|config| config.name == "Apollo OTLP usage reporting override");
+        assert!(
+            expected_otlp_restriction.is_some(),
+            "should have found an OTLP usage reporting restriction"
+        );
+        assert_snapshot!(report_with_limits.to_string());
+    }
+
+    #[test]
     fn test_restricted_authorization_directives_via_schema() {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/authorization.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -776,6 +854,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/unix_socket.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -796,7 +875,8 @@ mod test {
                 aud: OneOrMany::One(Audience::SelfHosted),
                 warn_at: UNIX_EPOCH + Duration::from_secs(1676808000),
                 halt_at: UNIX_EPOCH + Duration::from_secs(1678017600),
-                tps: Default::default()
+                tps: Default::default(),
+                usage_reporting: Default::default(),
             }),
         );
     }
@@ -812,7 +892,8 @@ mod test {
                 aud: OneOrMany::One(Audience::SelfHosted),
                 warn_at: UNIX_EPOCH + Duration::from_secs(1676808000),
                 halt_at: UNIX_EPOCH + Duration::from_secs(1678017600),
-                tps: Default::default()
+                tps: Default::default(),
+                usage_reporting: Default::default(),
             }),
         );
     }
@@ -839,6 +920,11 @@ mod test {
             "aud": ["CLOUD", "SELF_HOSTED"],
             "warnAt": 122,
             "haltAt": 123,
+            "throughputLimit": {
+                "capacity": 100,
+                "durationMs": 1000,
+            },
+            "usageReporting": true,
         }))
         .expect("json must deserialize");
 
@@ -857,6 +943,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/progressive_override.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -871,6 +958,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/set_context.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -885,6 +973,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/progressive_override_renamed_join.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -899,6 +988,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/schema_enforcement_spec_version_in_range.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -913,6 +1003,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/schema_enforcement_spec_version_out_of_range.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -926,6 +1017,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/schema_enforcement_directive_arg_version_in_range.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -940,6 +1032,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/schema_enforcement_directive_arg_version_out_of_range.graphql"),
+            Default::default(),
         );
 
         assert!(
@@ -953,6 +1046,7 @@ mod test {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/schema_enforcement_connectors.graphql"),
+            Default::default(),
         );
 
         assert_eq!(

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -397,7 +397,7 @@ impl LicenseEnforcementReport {
                 .build(),
         ];
         if let Some(limits) = license_limits {
-            let restrict_usage_reporting = limits.usage_reporting.unwrap_or(false);
+            let restrict_usage_reporting = limits.usage_reporting.unwrap_or(true); // TODO: revert me, should default to false.
             if restrict_usage_reporting {
                 restrictions.push(
                     ConfigurationRestriction::builder()

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -181,6 +181,7 @@ fn reset_checks_for_licenses(
     // Router limitations based on claims
     let limits = if claims.tps.is_some() || claims.usage_reporting.is_some() {
         let license_limits = LicenseLimits::builder()
+            .and_restricted(claims.restricted)
             .and_tps(claims.tps.map(|tps_limit| {
                 TpsLimit::builder()
                     .capacity(tps_limit.capacity)
@@ -498,6 +499,7 @@ mod test {
                 aud: OneOrMany::One(Audience::SelfHosted),
                 warn_at: now + Duration::from_millis(warn_delta),
                 halt_at: now + Duration::from_millis(halt_delta),
+                restricted: Some(true),
                 tps: Default::default(),
                 usage_reporting: Default::default(),
             }),
@@ -553,6 +555,7 @@ mod test {
                     aud: OneOrMany::One(Audience::Offline),
                     warn_at: SystemTime::now(),
                     halt_at: SystemTime::now(),
+                    restricted: Some(true),
                     tps: Default::default(),
                     usage_reporting: Default::default(),
                 }),
@@ -575,6 +578,7 @@ mod test {
                     aud: OneOrMany::One(Audience::SelfHosted),
                     warn_at: SystemTime::now(),
                     halt_at: SystemTime::now(),
+                    restricted: Some(true),
                     tps: Default::default(),
                     usage_reporting: Default::default(),
                 }),
@@ -597,6 +601,7 @@ mod test {
                     aud: OneOrMany::Many(vec![Audience::SelfHosted, Audience::Offline]),
                     warn_at: SystemTime::now(),
                     halt_at: SystemTime::now(),
+                    restricted: Some(true),
                     tps: Default::default(),
                     usage_reporting: Default::default(),
                 }),
@@ -619,6 +624,7 @@ mod test {
                     aud: OneOrMany::Many(vec![Audience::SelfHosted, Audience::SelfHosted]),
                     warn_at: SystemTime::now(),
                     halt_at: SystemTime::now(),
+                    restricted: Some(true),
                     tps: Default::default(),
                     usage_reporting: Default::default(),
                 }),

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -179,16 +179,19 @@ fn reset_checks_for_licenses(
     checks.clear();
     let claims = license.claims.as_ref().expect("claims is gated, qed");
     // Router limitations based on claims
-    let limits = claims.tps.map(|tps_limit| {
-        LicenseLimits::builder()
-            .tps(
+    let limits = if claims.tps.is_some() || claims.usage_reporting.is_some() {
+        let license_limits = LicenseLimits::builder()
+            .and_tps(claims.tps.map(|tps_limit| {
                 TpsLimit::builder()
                     .capacity(tps_limit.capacity)
                     .interval(tps_limit.interval)
-                    .build(),
-            )
-            .build()
-    });
+                    .build()
+            }))
+            .and_usage_reporting(claims.usage_reporting);
+        Some(license_limits.build())
+    } else {
+        None
+    };
     let halt_at = to_positive_instant(claims.halt_at);
     let warn_at = to_positive_instant(claims.warn_at);
     let now = Instant::now();
@@ -496,6 +499,7 @@ mod test {
                 warn_at: now + Duration::from_millis(warn_delta),
                 halt_at: now + Duration::from_millis(halt_delta),
                 tps: Default::default(),
+                usage_reporting: Default::default(),
             }),
         }
     }
@@ -549,7 +553,8 @@ mod test {
                     aud: OneOrMany::One(Audience::Offline),
                     warn_at: SystemTime::now(),
                     halt_at: SystemTime::now(),
-                    tps: Default::default()
+                    tps: Default::default(),
+                    usage_reporting: Default::default(),
                 }),
             }))
             .validate_audience([Audience::Offline, Audience::Cloud])
@@ -570,7 +575,8 @@ mod test {
                     aud: OneOrMany::One(Audience::SelfHosted),
                     warn_at: SystemTime::now(),
                     halt_at: SystemTime::now(),
-                    tps: Default::default()
+                    tps: Default::default(),
+                    usage_reporting: Default::default(),
                 }),
             }))
             .validate_audience([Audience::Offline, Audience::Cloud])
@@ -591,7 +597,8 @@ mod test {
                     aud: OneOrMany::Many(vec![Audience::SelfHosted, Audience::Offline]),
                     warn_at: SystemTime::now(),
                     halt_at: SystemTime::now(),
-                    tps: Default::default()
+                    tps: Default::default(),
+                    usage_reporting: Default::default(),
                 }),
             }))
             .validate_audience([Audience::Offline, Audience::Cloud])
@@ -612,7 +619,8 @@ mod test {
                     aud: OneOrMany::Many(vec![Audience::SelfHosted, Audience::SelfHosted]),
                     warn_at: SystemTime::now(),
                     halt_at: SystemTime::now(),
-                    tps: Default::default()
+                    tps: Default::default(),
+                    usage_reporting: Default::default(),
                 }),
             }))
             .validate_audience([Audience::Offline, Audience::Cloud])

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_with_limits.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_with_limits.snap
@@ -1,0 +1,67 @@
+---
+source: apollo-router/src/uplink/license_enforcement.rs
+expression: report_with_limits.to_string()
+---
+Configuration yaml:
+* Restricted
+  .plugins.['experimental.restricted'].enabled
+
+* Authentication plugin
+  .authentication.router
+
+* Coprocessor plugin
+  .coprocessor
+
+* Query plan caching
+  .supergraph.query_planning.cache.redis
+
+* APQ caching
+  .apq.router.cache.redis
+
+* Subgraph entity caching
+  .preview_entity_cache.enabled
+
+* Federated subscriptions
+  .subscription.enabled
+
+* Operation depth limiting
+  .limits.max_depth
+
+* Operation height limiting
+  .limits.max_height
+
+* Operation root fields limiting
+  .limits.max_root_fields
+
+* Operation aliases limiting
+  .limits.max_aliases
+
+* Advanced telemetry
+  .telemetry..spans.router
+
+* Advanced telemetry
+  .telemetry..spans.supergraph
+
+* Advanced telemetry
+  .telemetry..spans.subgraph
+
+* Advanced telemetry
+  .telemetry..instruments
+
+* Advanced telemetry
+  .telemetry..graphql
+
+* File uploads plugin
+  .preview_file_uploads
+
+* Demand control plugin
+  .demand_control
+
+* Apollo metrics extended references
+  .telemetry.apollo.metrics_reference_mode
+
+* Apollo usage reporting override
+  .telemetry.apollo.endpoint
+
+* Apollo OTLP usage reporting override
+  .telemetry.apollo.experimental_otlp_endpoint

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -70,6 +70,8 @@ preview_entity_cache:
 telemetry:
   apollo:
     metrics_reference_mode: extended
+    endpoint: http://localhost:4000
+    experimental_otlp_endpoint: http://localhost:4000
   instrumentation:
     spans:
       router:


### PR DESCRIPTION
- Adds support for a theoretical `restricted` claim, which when set on the license, requires that there are NO license violations, otherwise prevents the Router from starting (effectively allows a license to conditionally behave like the unlicensed path).

- Adds support for a theoretical `usage_reporting` claim, which when set on the license, requires that you don’t change the usage reporting URL.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

Manual test with a free account using the env var to override:
![image](https://github.com/user-attachments/assets/b5380860-2377-4496-89c3-10a29270bae0)

Manual test using additional restricted features:
![image](https://github.com/user-attachments/assets/cdeb7ad7-26a0-41be-bb9f-198c2f2a37d3)



**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
