### PR TITLE
chore: simplify yaml config in traffic shaping tests

### DIFF
--- a/apollo-router/tests/integration/traffic_shaping.rs
+++ b/apollo-router/tests/integration/traffic_shaping.rs
@@ -11,7 +11,11 @@ use crate::integration::common::Query;
 use crate::integration::common::Telemetry;
 use crate::integration::common::graph_os_enabled;
 
-const PROMETHEUS_CONFIG: &str = r#"
+#[tokio::test(flavor = "multi_thread")]
+async fn test_router_timeout() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(format!(
+            r#"
             telemetry:
                 exporters:
                     metrics:
@@ -19,14 +23,6 @@ const PROMETHEUS_CONFIG: &str = r#"
                             listen: 127.0.0.1:4000
                             enabled: true
                             path: /metrics
-"#;
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_router_timeout() -> Result<(), BoxError> {
-    let mut router = IntegrationTest::builder()
-        .config(format!(
-            r#"
-            {PROMETHEUS_CONFIG}
             traffic_shaping:
                 router:
                     timeout: 1ns
@@ -56,7 +52,13 @@ async fn test_subgraph_timeout() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(format!(
             r#"
-            {PROMETHEUS_CONFIG}
+            telemetry:
+                exporters:
+                    metrics:
+                        prometheus:
+                            listen: 127.0.0.1:4000
+                            enabled: true
+                            path: /metrics
             include_subgraph_errors:
                 all: true
             traffic_shaping:
@@ -89,7 +91,13 @@ async fn test_connector_timeout() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(format!(
             r#"
-            {PROMETHEUS_CONFIG}
+            telemetry:
+                exporters:
+                    metrics:
+                        prometheus:
+                            listen: 127.0.0.1:4000
+                            enabled: true
+                            path: /metrics
             traffic_shaping:
                 connector:
                     sources:
@@ -180,7 +188,13 @@ async fn test_router_custom_metric() -> Result<(), BoxError> {
         .telemetry(Telemetry::Otlp { endpoint: None })
         .config(format!(
             r#"
-            {PROMETHEUS_CONFIG}
+            telemetry:
+                exporters:
+                    metrics:
+                        prometheus:
+                            listen: 127.0.0.1:4000
+                            enabled: true
+                            path: /metrics
                 instrumentation:
                     instruments:
                         router:
@@ -218,7 +232,13 @@ async fn test_router_rate_limit() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(format!(
             r#"
-            {PROMETHEUS_CONFIG}
+            telemetry:
+                exporters:
+                    metrics:
+                        prometheus:
+                            listen: 127.0.0.1:4000
+                            enabled: true
+                            path: /metrics
             traffic_shaping:
                 router:
                     global_rate_limit:
@@ -255,7 +275,13 @@ async fn test_subgraph_rate_limit() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(format!(
             r#"
-            {PROMETHEUS_CONFIG}
+            telemetry:
+                exporters:
+                    metrics:
+                        prometheus:
+                            listen: 127.0.0.1:4000
+                            enabled: true
+                            path: /metrics
             include_subgraph_errors:
                 all: true
             traffic_shaping:
@@ -294,7 +320,13 @@ async fn test_connector_rate_limit() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(format!(
             r#"
-            {PROMETHEUS_CONFIG}
+            telemetry:
+                exporters:
+                    metrics:
+                        prometheus:
+                            listen: 127.0.0.1:4000
+                            enabled: true
+                            path: /metrics
             include_subgraph_errors:
                 all: true
             traffic_shaping:


### PR DESCRIPTION
I was reading this for unrelated reasons and was a bit horrified that we're using string concatenation to merge config in a language with significant whitespace. I think there's not much benefit to factoring out this config, and it makes the tests harder to read, so I've just copy-pasted it into each usage site.