### PR TITLE
merge-error: inadvertent preserval of unnecessary orb use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -815,7 +815,6 @@ jobs:
                 docker_layer_caching: true
             - attach_workspace:
                 at: artifacts
-            - gh/setup
             - run:
                 command: >
                   cd artifacts && sha256sum *.tar.gz > sha256sums.txt


### PR DESCRIPTION
We no longer need `gh` installed at this step, but i accidientally re-introduced it in my merge conflict resolution when releasing 2.2.1
