### PR TITLE
Temporarily disable cargo-fuzz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,7 +402,7 @@ commands:
       - store_test_results:
           # The results from nextest that power the CircleCI Insights.
           path: ./target/nextest/ci/junit.xml
-  # Temporarily disable cargo-fuzz
+  # Temporarily disable cargo-fuzz https://github.com/apollographql/router/pull/7488
   # fuzz_build:
   #   steps:
   #     - run: cargo +nightly fuzz build
@@ -466,7 +466,7 @@ jobs:
       - setup_environment:
           platform: << parameters.platform >>
       - xtask_test
-      # Temporarily disable cargo-fuzz.
+      # Temporarily disable cargo-fuzz https://github.com/apollographql/router/pull/7488
       # - when:
       #     condition:
       #       and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,9 +402,10 @@ commands:
       - store_test_results:
           # The results from nextest that power the CircleCI Insights.
           path: ./target/nextest/ci/junit.xml
-  fuzz_build:
-    steps:
-      - run: cargo +nightly fuzz build
+  # Temporarily disable cargo-fuzz
+  # fuzz_build:
+  #   steps:
+  #     - run: cargo +nightly fuzz build
 
 jobs:
   lint:
@@ -465,13 +466,14 @@ jobs:
       - setup_environment:
           platform: << parameters.platform >>
       - xtask_test
-      - when:
-          condition:
-            and:
-              - equal: [ true, << parameters.fuzz >> ]
-              - equal: [ *arm_linux_test_executor, << parameters.platform >> ]
-          steps:
-            - fuzz_build
+      # Temporarily disable cargo-fuzz.
+      # - when:
+      #     condition:
+      #       and:
+      #         - equal: [ true, << parameters.fuzz >> ]
+      #         - equal: [ *arm_linux_test_executor, << parameters.platform >> ]
+      #     steps:
+      #       - fuzz_build
 
   test_updated:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,7 +817,6 @@ jobs:
                 docker_layer_caching: true
             - attach_workspace:
                 at: artifacts
-            - gh/setup
             - run:
                 command: >
                   cd artifacts && sha256sum *.tar.gz > sha256sums.txt

--- a/.config/mise/config.ci.toml
+++ b/.config/mise/config.ci.toml
@@ -1,3 +1,4 @@
 [tools]
-"cargo:cargo-fuzz" = "0.12.0"
+# Temporarily disable cargo-fuzz.
+# "cargo:cargo-fuzz" = "0.12.0"
 kubeconform = "0.6.7"

--- a/.config/mise/config.ci.toml
+++ b/.config/mise/config.ci.toml
@@ -1,4 +1,4 @@
 [tools]
-# Temporarily disable cargo-fuzz.
+# Temporarily disable cargo-fuzz https://github.com/apollographql/router/pull/7488
 # "cargo:cargo-fuzz" = "0.12.0"
 kubeconform = "0.6.7"


### PR DESCRIPTION
There seem to be some sporadic `mise install` failures happening in CI that seem directly attriubted to `cargo-fuzz`.  There are a few theories here (e.g., is it a combination of nightly builds and `cargo binstall` usage?), but to just eliminate them for now, we'll try disabling it and not installing it.  This should give us an angle on which to figure out next steps.

Let's give it a week.
