### PR TITLE
[Batch] Improve error message for batch on fields

### DIFF
--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch.graphql.snap
@@ -27,14 +27,14 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch.gra
     },
     Message {
         code: InvalidBody,
-        message: "In `@connect(http: {body:})` on `Query.ts`: $batch is not valid here, must be one of $args, $config, $context, $request",
+        message: "In `@connect(http: {body:})` on `Query.ts`: `$batch` may only be used when `@connect` is applied to a type.",
         locations: [
             14:40..14:49,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `POST` in `@connect(http:)` on `Query.ts`: $batch is not valid here, must be one of $args, $config, $context, $request",
+        message: "In `POST` in `@connect(http:)` on `Query.ts`: `$batch` may only be used when `@connect` is applied to a type.",
         locations: [
             19:31..19:40,
         ],
@@ -98,7 +98,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch.gra
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `T.listRelationship`: $batch is not valid here, must be one of $args, $config, $context, $request, $this",
+        message: "In `GET` in `@connect(http:)` on `T.listRelationship`: `$batch` may only be used when `@connect` is applied to a type.",
         locations: [
             88:28..88:55,
         ],


### PR DESCRIPTION
Improves validation error message when a field connector attempts to use `$batch`.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [X] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
