### PR TITLE
chore(federation/composition): fixed a few `custom_error_message_for_misnamed_directives` tests

### DIFF
--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -878,8 +878,6 @@ Did you mean "@shareable"?{}"#,
     }
 
     #[test]
-    #[ignore = "temporary ignore for build break"]
-    #[should_panic(expected = r#"Mismatched errors:"#)]
     fn has_suggestions_if_a_fed2_directive_is_used_in_fed1() {
         let schema_str = r#"
             type T @key(fields: "id") {
@@ -887,20 +885,25 @@ Did you mean "@shareable"?{}"#,
                 foo: String @shareable
             }
         "#;
-        let err = build_for_errors(schema_str);
+        let err = build_for_errors_with_option(schema_str, BuildOption::AsIs);
 
         assert_errors!(
             err,
             [(
                 "INVALID_GRAPHQL",
-                r#"[S] Unknown directive "@shareable". If you meant the \"@shareable\" federation 2 directive, note that this schema is a federation 1 schema. To be a federation 2 schema, it needs to @link to the federation specification v2."#,
+                r#"[S] Error: cannot find directive `@shareable` in this document
+   ╭─[ S:4:29 ]
+   │
+ 4 │                 foo: String @shareable
+   │                             ─────┬────
+   │                                  ╰────── directive not defined
+───╯
+ If you meant the "@shareable" federation 2 directive, note that this schema is a federation 1 schema. To be a federation 2 schema, it needs to @link to the federation specification v2."#,
             )]
         );
     }
 
     #[test]
-    #[ignore = "temporary ignore for build break"]
-    #[should_panic(expected = r#"Mismatched error counts: 1 != 2"#)]
     fn has_suggestions_if_a_fed2_directive_is_used_under_wrong_name_for_the_schema() {
         let schema_str = r#"
             extend schema
@@ -914,18 +917,32 @@ Did you mean "@shareable"?{}"#,
                 foo: String @shareable
             }
         "#;
-        let err = build_for_errors(schema_str);
+        let err = build_for_errors_with_option(schema_str, BuildOption::AsIs);
 
         assert_errors!(
             err,
             [
                 (
                     "INVALID_GRAPHQL",
-                    r#"[S] Unknown directive "@shareable". If you meant the \"@shareable\" federation directive, you should use fully-qualified name "@federation__shareable" or add "@shareable" to the \`import\` argument of the @link to the federation specification."#,
+                    r#"[S] Error: cannot find directive `@key` in this document
+   ╭─[ S:8:20 ]
+   │
+ 8 │             type T @key(fields: "id") {
+   │                    ─────────┬────────
+   │                             ╰────────── directive not defined
+───╯
+ If you meant the "@key" federation directive, you should use "@myKey" as it is imported under that name in the @link to the federation specification of this schema."#,
                 ),
                 (
                     "INVALID_GRAPHQL",
-                    r#"[S] Unknown directive "@key". If you meant the "@key" federation directive, you should use "@myKey" as it is imported under that name in the @link to the federation specification of this schema."#,
+                    r#"[S] Error: cannot find directive `@shareable` in this document
+    ╭─[ S:10:29 ]
+    │
+ 10 │                 foo: String @shareable
+    │                             ─────┬────
+    │                                  ╰────── directive not defined
+────╯
+ If you meant the "@shareable" federation directive, you should use fully-qualified name "@federation__shareable" or add "@shareable" to the \`import\` argument of the @link to the federation specification."#,
                 ),
             ]
         );
@@ -1738,9 +1755,9 @@ mod shareable_tests {
 mod interface_object_and_key_on_interfaces_validation_tests {
     use super::*;
 
+    // TODO: INTERFACE_KEY_NOT_ON_IMPLEMENTATION error messages are currently redundant.
     #[test]
-    #[ignore = "temporary ignore for build break"]
-    #[should_panic(expected = r#"subgraph error was expected:"#)]
+    #[should_panic(expected = r#"Mismatched error counts: 1 != 3"#)]
     fn key_on_interfaces_require_key_on_all_implementations() {
         let doc = r#"
             interface I @key(fields: "id1") @key(fields: "id2") {


### PR DESCRIPTION
This PR changed those tests to call `build_for_errors_with_option`.
Also, dropped an `ignore` annotation by changing the `should_panic` annotation to match the current status.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

This PR only changes test annotations.