### PR TITLE
Port specs for inaccessible and tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "serde_json_bytes",
  "sha1",
  "shape",
+ "similar",
  "strum 0.27.1",
  "strum_macros 0.27.1",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ serde_json = { version = "1.0.114", features = [
     "float_roundtrip",
 ] }
 serde_json_bytes = { version = "0.2.5", features = ["preserve_order"] }
+similar = { version = "2.5.0", features = ["inline"] }
 sha1 = "0.10.6"
 tempfile = "3.10.1"
 tokio = { version = "1.36.0", features = ["full"] }

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -54,6 +54,7 @@ diff = "0.1.13"
 hex.workspace = true
 insta.workspace = true
 sha1.workspace = true
+similar.workspace = true
 tempfile.workspace = true
 pretty_assertions = "1.4.0"
 rstest = "0.25.0"

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -174,8 +174,8 @@ impl SpecDefinition for ContextSpecDefinition {
                 DirectiveLocation::Interface,
                 DirectiveLocation::Union,
             ],
-            false, // TODO: Set this to true in the future so @context can go to the supergraph schema
-            None,
+            true,
+            Some(&|v| CONTEXT_VERSIONS.get_minimum_required_version(v)),
             None, // TODO: Add transform
         );
         let from_context_spec = DirectiveSpecification::new(

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -22,6 +22,7 @@ use crate::link;
 use crate::link::argument::directive_optional_boolean_argument;
 use crate::link::argument::directive_optional_string_argument;
 use crate::link::argument::directive_required_string_argument;
+use crate::link::inaccessible_spec_definition::INACCESSIBLE_VERSIONS;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
 use crate::link::spec::Version;
@@ -865,6 +866,12 @@ impl SpecDefinition for FederationSpecDefinition {
         specs.push(Box::new(self.shareable_directive_specification()));
         specs.push(Box::new(self.override_directive_specification()));
         specs.push(Box::new(self.tag_directive_specification()));
+
+        if let Some(inaccessible_spec) =
+            INACCESSIBLE_VERSIONS.get_minimum_required_version(self.version())
+        {
+            specs.extend(inaccessible_spec.directive_specs());
+        }
 
         if self.version().satisfies(&Version { major: 2, minor: 1 }) {
             specs.push(Box::new(Self::compose_directive_directive_specification()));

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -839,22 +839,31 @@ impl SpecDefinition for FederationSpecDefinition {
             Box::new(Self::provides_directive_specification()),
             Box::new(Self::external_directive_specification()),
         ];
-        if self.is_fed1() {
-            specs.push(Box::new(Self::extends_directive_specification()));
-            if let Some(tag_spec) = TAG_VERSIONS.find(&Version { major: 0, minor: 2 }) {
+        // Federation 2.3+ use tag spec v0.3, otherwise use v0.2
+        if self.version().satisfies(&Version { major: 2, minor: 3 }) {
+            if let Some(tag_spec) = TAG_VERSIONS.find(&Version { major: 0, minor: 3 }) {
                 specs.extend(tag_spec.directive_specs());
             }
+        } else if let Some(tag_spec) = TAG_VERSIONS.find(&Version { major: 0, minor: 2 }) {
+            specs.extend(tag_spec.directive_specs());
+        }
+        specs.push(Box::new(Self::extends_directive_specification()));
+
+        if self.is_fed1() {
+            // PORT_NOTE: Fed 1 has `@key`, `@requires`, `@provides`, `@external`, `@tag` (v0.2) and `@extends`.
+            // The specs we return at this point correspond to `legacyFederationDirectives` in JS.
             return specs;
         }
 
         specs.push(Box::new(self.shareable_directive_specification()));
-        specs.push(Box::new(self.override_directive_specification()));
 
         if let Some(inaccessible_spec) =
             INACCESSIBLE_VERSIONS.get_minimum_required_version(self.version())
         {
             specs.extend(inaccessible_spec.directive_specs());
         }
+
+        specs.push(Box::new(self.override_directive_specification()));
 
         if self.version().satisfies(&Version { major: 2, minor: 1 }) {
             specs.push(Box::new(Self::compose_directive_directive_specification()));
@@ -864,15 +873,6 @@ impl SpecDefinition for FederationSpecDefinition {
             specs.push(Box::new(
                 Self::interface_object_directive_directive_specification(),
             ));
-        }
-
-        // Federation 2.3+ use tag spec v0.3, otherwise use v0.2
-        if self.version().satisfies(&Version { major: 2, minor: 3 }) {
-            if let Some(tag_spec) = TAG_VERSIONS.find(&Version { major: 0, minor: 3 }) {
-                specs.extend(tag_spec.directive_specs());
-            }
-        } else if let Some(tag_spec) = TAG_VERSIONS.find(&Version { major: 0, minor: 2 }) {
-            specs.extend(tag_spec.directive_specs());
         }
 
         if self.version().satisfies(&Version { major: 2, minor: 8 }) {

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -34,6 +34,7 @@ use crate::schema::position::ObjectFieldArgumentDefinitionPosition;
 use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
 use crate::schema::position::TypeDefinitionPosition;
+use crate::schema::type_and_directive_specification::DirectiveSpecification;
 use crate::schema::type_and_directive_specification::TypeAndDirectiveSpecification;
 
 pub(crate) const INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC: Name = name!("inaccessible");
@@ -92,6 +93,41 @@ impl InaccessibleSpecDefinition {
     ) -> Result<(), FederationError> {
         remove_inaccessible_elements(schema, self)
     }
+
+    fn directive_specification(&self) -> Box<dyn TypeAndDirectiveSpecification> {
+        let locations: &[DirectiveLocation] =
+            if self.url.version == (Version { major: 0, minor: 1 }) {
+                &[
+                    DirectiveLocation::FieldDefinition,
+                    DirectiveLocation::Object,
+                    DirectiveLocation::Interface,
+                    DirectiveLocation::Union,
+                ]
+            } else {
+                &[
+                    DirectiveLocation::FieldDefinition,
+                    DirectiveLocation::Object,
+                    DirectiveLocation::Interface,
+                    DirectiveLocation::Union,
+                    DirectiveLocation::ArgumentDefinition,
+                    DirectiveLocation::Scalar,
+                    DirectiveLocation::Enum,
+                    DirectiveLocation::EnumValue,
+                    DirectiveLocation::InputObject,
+                    DirectiveLocation::InputFieldDefinition,
+                ]
+            };
+
+        Box::new(DirectiveSpecification::new(
+            INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC,
+            &[],
+            false, // not repeatable
+            locations,
+            true, // composes
+            Some(&|v| INACCESSIBLE_VERSIONS.get_minimum_required_version(v)),
+            None,
+        ))
+    }
 }
 
 impl SpecDefinition for InaccessibleSpecDefinition {
@@ -100,11 +136,12 @@ impl SpecDefinition for InaccessibleSpecDefinition {
     }
 
     fn directive_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
-        todo!()
+        vec![self.directive_specification()]
     }
 
     fn type_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
-        todo!()
+        // No type specs for @inaccessible
+        vec![]
     }
 
     fn minimum_federation_version(&self) -> &Version {
@@ -432,8 +469,8 @@ fn validate_inaccessible_in_fields(
                         }.into());
                     }
                 } else if arg.is_required() {
-                    // When an argument is accessible and required, we check that
-                    // it isn't marked inaccessible in any interface implemented by
+                    // When an argument is accessible and required, we check that it
+                    // isn't marked inaccessible in any interface implemented by
                     // the argument's field. This is because the GraphQL spec
                     // requires that any arguments of an implementing field that
                     // aren't in its implemented field are optional.

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -188,12 +188,13 @@ impl LinkSpecDefinition {
         }
 
         let schema_definition = SchemaDefinitionPosition.get(schema.schema());
-        SchemaDefinitionPosition.insert_directive(
+        SchemaDefinitionPosition.insert_directive_at(
             schema,
             Component {
                 origin: schema_definition.origin_to_use(),
                 node: Node::new(Directive { name, arguments }),
             },
+            0, // @link to link spec should be first
         )?;
         Ok(())
     }

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod join_spec_definition;
 pub(crate) mod link_spec_definition;
 pub mod spec;
 pub(crate) mod spec_definition;
+pub(crate) mod tag_spec_definition;
 
 pub const DEFAULT_LINK_NAME: Name = name!("link");
 pub const DEFAULT_IMPORT_SCALAR_NAME: Name = name!("Import");

--- a/apollo-federation/src/link/spec.rs
+++ b/apollo-federation/src/link/spec.rs
@@ -102,6 +102,13 @@ impl Identity {
             name: name!("context"),
         }
     }
+
+    pub fn tag_identity() -> Identity {
+        Identity {
+            domain: APOLLO_SPEC_DOMAIN.to_string(),
+            name: name!("tag"),
+        }
+    }
 }
 
 /// The version of a `@link` specification, in the form of a major and minor version numbers.

--- a/apollo-federation/src/link/tag_spec_definition.rs
+++ b/apollo-federation/src/link/tag_spec_definition.rs
@@ -1,0 +1,113 @@
+use std::sync::LazyLock;
+
+use apollo_compiler::name;
+use apollo_compiler::schema::DirectiveLocation;
+
+use crate::link::federation_spec_definition::FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::spec::Identity;
+use crate::link::spec::Url;
+use crate::link::spec::Version;
+use crate::link::spec_definition::SpecDefinition;
+use crate::link::spec_definition::SpecDefinitions;
+use crate::schema::type_and_directive_specification::ArgumentSpecification;
+use crate::schema::type_and_directive_specification::DirectiveArgumentSpecification;
+use crate::schema::type_and_directive_specification::DirectiveSpecification;
+use crate::schema::type_and_directive_specification::TypeAndDirectiveSpecification;
+
+pub(crate) struct TagSpecDefinition {
+    url: Url,
+    minimum_federation_version: Version,
+}
+
+impl TagSpecDefinition {
+    pub(crate) fn new(version: Version, minimum_federation_version: Version) -> Self {
+        Self {
+            url: Url {
+                identity: Identity::tag_identity(),
+                version,
+            },
+            minimum_federation_version,
+        }
+    }
+
+    fn directive_locations(&self) -> Vec<DirectiveLocation> {
+        // v0.1: FIELD_DEFINITION, OBJECT, INTERFACE, UNION
+        // v0.2: + ARGUMENT_DEFINITION, SCALAR, ENUM, ENUM_VALUE, INPUT_OBJECT, INPUT_FIELD_DEFINITION
+        // v0.3+: + SCHEMA
+        let mut locations = vec![
+            DirectiveLocation::FieldDefinition,
+            DirectiveLocation::Object,
+            DirectiveLocation::Interface,
+            DirectiveLocation::Union,
+        ];
+        if self.url.version != (Version { major: 0, minor: 1 }) {
+            locations.extend([
+                DirectiveLocation::ArgumentDefinition,
+                DirectiveLocation::Scalar,
+                DirectiveLocation::Enum,
+                DirectiveLocation::EnumValue,
+                DirectiveLocation::InputObject,
+                DirectiveLocation::InputFieldDefinition,
+            ]);
+            if self.url.version != (Version { major: 0, minor: 2 }) {
+                locations.push(DirectiveLocation::Schema);
+            }
+        }
+        locations
+    }
+
+    fn directive_specification(&self) -> Box<dyn TypeAndDirectiveSpecification> {
+        Box::new(DirectiveSpecification::new(
+            FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC,
+            &[DirectiveArgumentSpecification {
+                base_spec: ArgumentSpecification {
+                    name: name!("name"),
+                    get_type: |_, _| Ok(apollo_compiler::ty!(String!)),
+                    default_value: None,
+                },
+                composition_strategy: None,
+            }],
+            true, // repeatable
+            &self.directive_locations(),
+            true, // composes
+            Some(&|v| TAG_VERSIONS.get_minimum_required_version(v)),
+            None,
+        ))
+    }
+}
+
+impl SpecDefinition for TagSpecDefinition {
+    fn url(&self) -> &Url {
+        &self.url
+    }
+
+    fn directive_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
+        vec![self.directive_specification()]
+    }
+
+    fn type_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
+        vec![]
+    }
+
+    fn minimum_federation_version(&self) -> &Version {
+        &self.minimum_federation_version
+    }
+}
+
+pub(crate) static TAG_VERSIONS: LazyLock<SpecDefinitions<TagSpecDefinition>> =
+    LazyLock::new(|| {
+        let mut definitions = SpecDefinitions::new(Identity::tag_identity());
+        definitions.add(TagSpecDefinition::new(
+            Version { major: 0, minor: 1 },
+            Version { major: 1, minor: 0 },
+        ));
+        definitions.add(TagSpecDefinition::new(
+            Version { major: 0, minor: 2 },
+            Version { major: 1, minor: 0 },
+        ));
+        definitions.add(TagSpecDefinition::new(
+            Version { major: 0, minor: 3 },
+            Version { major: 2, minor: 0 },
+        ));
+        definitions
+    });

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -921,6 +921,15 @@ impl SchemaDefinitionPosition {
         schema: &mut FederationSchema,
         directive: Component<Directive>,
     ) -> Result<(), FederationError> {
+        self.insert_directive_at(schema, directive, self.get(&schema.schema).directives.len())
+    }
+
+    pub(crate) fn insert_directive_at(
+        &self,
+        schema: &mut FederationSchema,
+        directive: Component<Directive>,
+        index: usize,
+    ) -> Result<(), FederationError> {
         let schema_definition = self.make_mut(&mut schema.schema);
         if schema_definition
             .directives
@@ -936,7 +945,10 @@ impl SchemaDefinitionPosition {
             .into());
         }
         let name = directive.name.clone();
-        schema_definition.make_mut().directives.push(directive);
+        schema_definition
+            .make_mut()
+            .directives
+            .insert(index, directive);
         self.insert_directive_name_references(&mut schema.referencers, &name)?;
         schema.links_metadata = links_metadata(&schema.schema)?.map(Box::new);
         Ok(())

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -1097,7 +1097,7 @@ mod tests {
 
         insta::assert_snapshot!(
             s1.schema().schema().to_string(), @r###"
-        schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@inaccessible", "@composeDirective", "@interfaceObject", "@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"]) {
           query: Query
         }
 
@@ -1111,17 +1111,19 @@ mod tests {
 
         directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+        directive @extends on OBJECT | INTERFACE
+
         directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 
-        directive @override(from: String!) on FIELD_DEFINITION
-
         directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+        
+        directive @override(from: String!) on FIELD_DEFINITION
 
         directive @composeDirective(name: String!) repeatable on SCHEMA
 
         directive @interfaceObject on OBJECT
-
-        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 
         type Query {
           products: [Product!]! @provides(fields: "description")
@@ -1444,7 +1446,7 @@ mod tests {
         insta::assert_snapshot!(
             subgraph.schema().schema().to_string(),
             @r###"
-        schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@inaccessible", "@composeDirective", "@interfaceObject", "@tag"]) {
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"]) {
           query: Query
         }
 
@@ -1458,17 +1460,19 @@ mod tests {
 
         directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+        directive @extends on OBJECT | INTERFACE
+
         directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 
-        directive @override(from: String!) on FIELD_DEFINITION
-
         directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        directive @override(from: String!) on FIELD_DEFINITION
 
         directive @composeDirective(name: String!) repeatable on SCHEMA
 
         directive @interfaceObject on OBJECT
-
-        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 
         type Query {
           hello: String

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -1097,77 +1097,79 @@ mod tests {
 
         insta::assert_snapshot!(
             s1.schema().schema().to_string(), @r###"
-            schema @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@tag", "@composeDirective", "@interfaceObject"]) @link(url: "https://specs.apollo.dev/link/v1.0") {
-              query: Query
-            }
+        schema @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@tag", "@inaccessible", "@composeDirective", "@interfaceObject"]) @link(url: "https://specs.apollo.dev/link/v1.0") {
+          query: Query
+        }
 
-            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-            directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-            directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+        directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
 
-            directive @provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+        directive @provides(fields: federation__FieldSet!) on FIELD_DEFINITION
 
-            directive @external(reason: String) on OBJECT | FIELD_DEFINITION
+        directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
-            directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+        directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 
-            directive @override(from: String!) on FIELD_DEFINITION
+        directive @override(from: String!) on FIELD_DEFINITION
 
-            directive @tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+        directive @tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-            directive @composeDirective(name: String!) repeatable on SCHEMA
-            
-            directive @interfaceObject on OBJECT
+        directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-            type Query {
-              products: [Product!]! @provides(fields: "description")
-              _entities(representations: [_Any!]!): [_Entity]! @shareable
-              _service: _Service! @shareable
-            }
+        directive @composeDirective(name: String!) repeatable on SCHEMA
 
-            interface I {
-              upc: ID!
-              description: String
-            }
+        directive @interfaceObject on OBJECT
 
-            type Random {
-              x: Int
-            }
+        type Query {
+          products: [Product!]! @provides(fields: "description")
+          _entities(representations: [_Any!]!): [_Entity]! @shareable
+          _service: _Service! @shareable
+        }
 
-            extend type Random {
-              y: Int
-            }
+        interface I {
+          upc: ID!
+          description: String
+        }
 
-            type Product implements I @key(fields: "upc") {
-              upc: ID!
-              inventory: Int
-              description: String @external
-            }
+        type Random {
+          x: Int
+        }
 
-            enum link__Purpose {
-              """
-              `SECURITY` features provide metadata necessary to securely resolve fields.
-              """
-              SECURITY
-              """
-              `EXECUTION` features provide metadata necessary for operation execution.
-              """
-              EXECUTION
-            }
+        extend type Random {
+          y: Int
+        }
 
-            scalar link__Import
+        type Product implements I @key(fields: "upc") {
+          upc: ID!
+          inventory: Int
+          description: String @external
+        }
 
-            scalar federation__FieldSet
+        enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
 
-            scalar _Any
+        scalar link__Import
 
-            type _Service @shareable {
-              sdl: String
-            }
+        scalar federation__FieldSet
 
-            union _Entity = Product
+        scalar _Any
+
+        type _Service @shareable {
+          sdl: String
+        }
+
+        union _Entity = Product
         "###
         );
     }
@@ -1442,55 +1444,57 @@ mod tests {
         insta::assert_snapshot!(
             subgraph.schema().schema().to_string(),
             @r###"
-            schema @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@tag", "@composeDirective", "@interfaceObject"]) @link(url: "https://specs.apollo.dev/link/v1.0") {
-              query: Query
-            }
-            
-            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+        schema @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@tag", "@inaccessible", "@composeDirective", "@interfaceObject"]) @link(url: "https://specs.apollo.dev/link/v1.0") {
+          query: Query
+        }
 
-            directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-            directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+        directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-            directive @provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+        directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
 
-            directive @external(reason: String) on OBJECT | FIELD_DEFINITION
+        directive @provides(fields: federation__FieldSet!) on FIELD_DEFINITION
 
-            directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+        directive @external(reason: String) on OBJECT | FIELD_DEFINITION
 
-            directive @override(from: String!) on FIELD_DEFINITION
+        directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 
-            directive @tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+        directive @override(from: String!) on FIELD_DEFINITION
 
-            directive @composeDirective(name: String!) repeatable on SCHEMA
-            
-            directive @interfaceObject on OBJECT
+        directive @tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-            type Query {
-              hello: String
-              _service: _Service!
-            }
+        directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-            enum link__Purpose {
-              """
-              `SECURITY` features provide metadata necessary to securely resolve fields.
-              """
-              SECURITY
-              """
-              `EXECUTION` features provide metadata necessary for operation execution.
-              """
-              EXECUTION
-            }
+        directive @composeDirective(name: String!) repeatable on SCHEMA
 
-            scalar link__Import
+        directive @interfaceObject on OBJECT
 
-            scalar federation__FieldSet
+        type Query {
+          hello: String
+          _service: _Service!
+        }
 
-            scalar _Any
+        enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
 
-            type _Service {
-              sdl: String
-            }
+        scalar link__Import
+
+        scalar federation__FieldSet
+
+        scalar _Any
+
+        type _Service {
+          sdl: String
+        }
         "###
         );
     }

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -1097,7 +1097,7 @@ mod tests {
 
         insta::assert_snapshot!(
             s1.schema().schema().to_string(), @r###"
-        schema @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@tag", "@inaccessible", "@composeDirective", "@interfaceObject"]) @link(url: "https://specs.apollo.dev/link/v1.0") {
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@inaccessible", "@composeDirective", "@interfaceObject", "@tag"]) {
           query: Query
         }
 
@@ -1115,13 +1115,13 @@ mod tests {
 
         directive @override(from: String!) on FIELD_DEFINITION
 
-        directive @tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
         directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
         directive @composeDirective(name: String!) repeatable on SCHEMA
 
         directive @interfaceObject on OBJECT
+
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 
         type Query {
           products: [Product!]! @provides(fields: "description")
@@ -1444,7 +1444,7 @@ mod tests {
         insta::assert_snapshot!(
             subgraph.schema().schema().to_string(),
             @r###"
-        schema @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@tag", "@inaccessible", "@composeDirective", "@interfaceObject"]) @link(url: "https://specs.apollo.dev/link/v1.0") {
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@shareable", "@override", "@inaccessible", "@composeDirective", "@interfaceObject", "@tag"]) {
           query: Query
         }
 
@@ -1462,13 +1462,13 @@ mod tests {
 
         directive @override(from: String!) on FIELD_DEFINITION
 
-        directive @tag repeatable on ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
         directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
         directive @composeDirective(name: String!) repeatable on SCHEMA
 
         directive @interfaceObject on OBJECT
+
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 
         type Query {
           hello: String

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -926,6 +926,7 @@ mod tests {
             defined_directive_names,
             vec![
                 name!("deprecated"),
+                name!("federation__extends"),
                 name!("federation__external"),
                 name!("federation__inaccessible"),
                 name!("federation__key"),
@@ -972,6 +973,7 @@ mod tests {
             vec![
                 name!("deprecated"),
                 name!("federation__composeDirective"),
+                name!("federation__extends"),
                 name!("federation__external"),
                 name!("federation__inaccessible"),
                 name!("federation__key"),

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -448,12 +448,13 @@ pub(crate) fn add_fed1_link_to_schema(
         })],
     };
     let origin = schema.schema().schema_definition.origin_to_use();
-    crate::schema::position::SchemaDefinitionPosition.insert_directive(
+    crate::schema::position::SchemaDefinitionPosition.insert_directive_at(
         schema,
         Component {
             origin,
             node: directive.into(),
         },
+        0, // @link to link spec should be first
     )
 }
 
@@ -926,6 +927,7 @@ mod tests {
             vec![
                 name!("deprecated"),
                 name!("federation__external"),
+                name!("federation__inaccessible"),
                 name!("federation__key"),
                 name!("federation__override"),
                 name!("federation__provides"),
@@ -971,6 +973,7 @@ mod tests {
                 name!("deprecated"),
                 name!("federation__composeDirective"),
                 name!("federation__external"),
+                name!("federation__inaccessible"),
                 name!("federation__key"),
                 name!("federation__override"),
                 name!("federation__provides"),

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -957,7 +957,9 @@ mod link_handling_tests {
 
     use super::*;
 
-    #[allow(dead_code)]
+    // There are a few whitespace differences between this and the JS version, but the more important difference is that
+    // the links are added as a new extension instead of being attached to the top-level schema definition. We may need
+    // to revisit that later if we're doing strict comparisons of SDLs between versions.
     const EXPECTED_FULL_SCHEMA: &str = r#"schema {
   query: Query
 }
@@ -974,13 +976,15 @@ directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITI
 
 directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
 
-directive @federation__shareable on OBJECT | FIELD_DEFINITION
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-directive @federation__override(from: String!) on FIELD_DEFINITION
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
 
 directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @federation__override(from: String!) on FIELD_DEFINITION
 
 type T @key(fields: "k") {
   k: ID!

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -252,7 +252,7 @@ aws-smithy-runtime-api = { version = "1.7.3", features = ["client"] }
 sha1.workspace = true
 tracing-serde = "0.1.3"
 time = { version = "0.3.36", features = ["serde"] }
-similar = { version = "2.5.0", features = ["inline"] }
+similar.workspace = true
 console = "0.15.8"
 bytesize = { version = "1.3.0", features = ["serde"] }
 ahash = "0.8.11"


### PR DESCRIPTION
* Ports directive specifications for `@inaccessible` and `@tag`.
* Ensures that injected `@link` to the link spec is always first
* Fixes missing composes/supergraph spec config for `@context`

Had some issues with insta snapshot file names being too long, so I updated a few tests comparing long strings to output a text diff via `similar` on failure.

<!-- FED-615 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [X] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
