### PR TITLE
Fix validating pre-encoded symbols before the first expression in an absolute URL

### DIFF
--- a/apollo-federation/src/sources/connect/validation/connect/http.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/http.rs
@@ -384,6 +384,10 @@ fn validate_absolute_connect_url(
     let mut is_relative = true;
     let mut dynamic_in_domain = None;
 
+    // Consume each part of the string template that *should* result in a static, valid base URI (scheme+host+port).
+    // - if we don't encounter a scheme, it's not a valid base URL
+    // - once we encounter a character not allowed in scheme+host+port, stop consuming
+    // - if we encounter a dynamic part before we break, we have an illegal dynamic component
     for part in &url.parts {
         match part {
             Part::Constant(constant) => {
@@ -432,6 +436,8 @@ fn validate_absolute_connect_url(
         });
     }
 
+    // Evaluate the template, replacing all dynamic expressions with empty strings. This should result in a valid
+    // URL because of the URL building logic in `interpolate_uri`, even if the result is illogical with missing values.
     let url = url
         .interpolate_uri(&Default::default())
         .map_err(|err| Message {

--- a/apollo-federation/src/sources/connect/validation/connect/http.rs
+++ b/apollo-federation/src/sources/connect/validation/connect/http.rs
@@ -384,9 +384,9 @@ fn validate_absolute_connect_url(
     let mut is_relative = true;
     let mut dynamic_in_domain = None;
 
-    // Consume each part of the string template that *should* result in a static, valid base URI (scheme+host+port).
-    // - if we don't encounter a scheme, it's not a valid base URL
-    // - once we encounter a character not allowed in scheme+host+port, stop consuming
+    // Check each part of the string template that *should* result in a static, valid base URI (scheme+host+port).
+    // - if we don't encounter a scheme, it's not a valid absolute URL
+    // - once we encounter a character that ends the authority (starts the path, query, or fragment) we break
     // - if we encounter a dynamic part before we break, we have an illegal dynamic component
     for part in &url.parts {
         match part {

--- a/apollo-federation/src/sources/connect/validation/test_data/uri_templates/valid_connect_absolute_url.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/uri_templates/valid_connect_absolute_url.graphql
@@ -3,5 +3,10 @@ extend schema
 
 type Query {
   resources(anArg: String): [String!]!
-    @connect(http: { GET: "http://127.0.0.1:8000/{$args.anArg}?{$args.anArg}={$args.anArg}" }, selection: "$")
+    @connect(
+      http: {
+        GET: "http://127.0.0.1:8000/ with spaces /{$args.anArg}?{$args.anArg}={$args.anArg}"
+      }
+      selection: "$"
+    )
 }


### PR DESCRIPTION
Motivating case is spaces, but this also handles other symbols we will automatically encode at runtime.

<!-- [CNN-804] -->


[CNN-804]: https://apollographql.atlassian.net/browse/CNN-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ