### PR TITLE
chore: update composition stubs

### DIFF
--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -77,7 +77,7 @@ pub fn merge_subgraphs(
 }
 
 pub fn post_merge_validations(
-    _supergraph: &Supergraph<Merged>
+    _supergraph: &Supergraph<Merged>,
 ) -> Result<(), Vec<FederationError>> {
     panic!("post_merge_validations is not implemented yet")
 }

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -21,10 +21,14 @@ pub fn compose(
     let upgraded_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)?;
     let validated_subgraphs = validate_subgraphs(upgraded_subgraphs)?;
 
+    pre_merge_validations(&validated_subgraphs)?;
     let supergraph = merge_subgraphs(validated_subgraphs)?;
+    post_merge_validations(&supergraph)?;
     validate_satisfiability(supergraph)
 }
 
+/// Apollo Federation allow subgraphs to specify partial schemas (i.e. "import" directives through
+/// `@link`). This function will update subgraph schemas with all missing federation definitions.
 pub fn expand_subgraphs(
     subgraphs: Vec<Subgraph<Initial>>,
 ) -> Result<Vec<Subgraph<Expanded>>, Vec<FederationError>> {
@@ -41,6 +45,8 @@ pub fn expand_subgraphs(
     }
 }
 
+/// Validate subgraph schemas to ensure they satisfy Apollo Federation requirements (e.g. whether
+/// `@key` specifies valid `FieldSet`s etc).
 pub fn validate_subgraphs(
     subgraphs: Vec<Subgraph<Upgraded>>,
 ) -> Result<Vec<Subgraph<Validated>>, Vec<FederationError>> {
@@ -57,8 +63,21 @@ pub fn validate_subgraphs(
     }
 }
 
+/// Perform validations that require information about all available subgraphs.
+pub fn pre_merge_validations(
+    _subgraphs: &Vec<Subgraph<Validated>>,
+) -> Result<(), Vec<FederationError>> {
+    panic!("pre_merge_validations is not implemented yet")
+}
+
 pub fn merge_subgraphs(
     _subgraphs: Vec<Subgraph<Validated>>,
 ) -> Result<Supergraph<Merged>, Vec<FederationError>> {
     panic!("merge_subgraphs is not implemented yet")
+}
+
+pub fn post_merge_validations(
+    _supergraph: &Supergraph<Merged>
+) -> Result<(), Vec<FederationError>> {
+    panic!("post_merge_validations is not implemented yet")
 }

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -65,7 +65,7 @@ pub fn validate_subgraphs(
 
 /// Perform validations that require information about all available subgraphs.
 pub fn pre_merge_validations(
-    _subgraphs: &Vec<Subgraph<Validated>>,
+    _subgraphs: &[Subgraph<Validated>],
 ) -> Result<(), Vec<FederationError>> {
     panic!("pre_merge_validations is not implemented yet")
 }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -96,15 +96,11 @@ pub struct Supergraph<S> {
 impl Supergraph<Merged> {
     pub fn new(schema: Valid<Schema>) -> Self {
         Self {
-            state: Merged {
-                schema
-            }
+            state: Merged { schema },
         }
     }
 
-    pub fn parse(
-        schema_str: &str,
-    ) -> Result<Self, FederationError> {
+    pub fn parse(schema_str: &str) -> Result<Self, FederationError> {
         let schema = Schema::parse_and_validate(schema_str, "schema.graphql")?;
         Ok(Self::new(schema))
     }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -94,8 +94,27 @@ pub struct Supergraph<S> {
 }
 
 impl Supergraph<Merged> {
-    pub fn assume_valid(self) -> Supergraph<Satisfiable> {
+    pub fn new(schema: Valid<Schema>) -> Self {
+        Self {
+            state: Merged {
+                schema
+            }
+        }
+    }
+
+    pub fn parse(
+        schema_str: &str,
+    ) -> Result<Self, FederationError> {
+        let schema = Schema::parse_and_validate(schema_str, "schema.graphql")?;
+        Ok(Self::new(schema))
+    }
+
+    pub fn assume_satisfiable(self) -> Supergraph<Satisfiable> {
         todo!("unimplemented")
+    }
+
+    pub fn schema(&self) -> &Valid<Schema> {
+        &self.state.schema
     }
 }
 
@@ -113,7 +132,7 @@ impl Supergraph<Satisfiable> {
 #[derive(Clone, Debug)]
 #[allow(unused)]
 pub struct Merged {
-    schema: Schema,
+    schema: Valid<Schema>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
* Update `Supergraph<Merged>` state to expose and hold `Valid<Schema>`
* Adds pre_/post_ merge validation steps

<!-- FED-530 -->