### PR TITLE
chore: update tracing-serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
  "tracing-futures",
  "tracing-mock",
  "tracing-opentelemetry",
- "tracing-serde 0.1.3",
+ "tracing-serde",
  "tracing-subscriber",
  "tracing-test",
  "uname",
@@ -6723,16 +6723,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
@@ -6759,7 +6749,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde 0.2.0",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -250,7 +250,7 @@ aws-smithy-async = { version = "1.2.5", features = ["rt-tokio"] }
 aws-smithy-http-client = { version = "1.0.1", default-features = false, features = ["default-client", "rustls-ring"] }
 aws-smithy-runtime-api = { version = "1.7.3", features = ["client"] }
 sha1.workspace = true
-tracing-serde = "0.1.3"
+tracing-serde = "0.2.0"
 time = { version = "0.3.36", features = ["serde"] }
 similar.workspace = true
 console = "0.15.8"


### PR DESCRIPTION
Because it's part of the `tracing-` dependency group, renovate won't
update this independently.

`tracing-subscriber` already uses `tracing-serde` 0.2.0, so upgrading
our own dependency removes a duplicate crate from the dep tree.

The breaking change is in a part of the API that we don't use, and it
does not affect the serialization format: https://github.com/tokio-rs/tracing/releases/tag/tracing-serde-0.2.0
