### PR TITLE
Update Router request termination docs

### DIFF
--- a/docs/source/routing/customization/rhai/reference.mdx
+++ b/docs/source/routing/customization/rhai/reference.mdx
@@ -59,10 +59,10 @@ log_trace("trace-level log message");
 
 Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from either the router service or supergraph service. This returns an `Internal Server Error` to the client with a `500` response code.
 
-When choosing between terminating the request from the router service versus the supergraph service, consider that:
+When choosing between router service versus supergraph service termination:
 
-* The request/response body is not available in the router service. If you need to examine the body when determining whether or not to terminate the request, you will need to do so in the supergraph service.
-* The router service request stage happens before the supergraph service request stage and before the request body is parsed and the operation is validated. So it may be best to perform some actions, like enforcing a required header, in the router service request stage so they can be consistently applied even when an invalid operation is provided by the client.
+- **Router service**: Cannot access request/response body and executes before parsing and validation; ideal for checks that should be consistently applied, like checking required headers, even when invalid operations are provided by the client.
+- **Supergraph service**: Use whenever you need to examine request bodies to enforce termination.
 
 For example:
 ```rhai

--- a/docs/source/routing/customization/rhai/reference.mdx
+++ b/docs/source/routing/customization/rhai/reference.mdx
@@ -57,11 +57,23 @@ log_trace("trace-level log message");
 
 ## Terminating client requests
 
-Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from the supergraph service. This returns an `Internal Server Error` to the client with a `500` response code.
+Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from either the router service or supergraph service. This returns an `Internal Server Error` to the client with a `500` response code.
 
 For example:
 ```rhai
-// Must throw exception from supergraph service
+// Throw exception from router service
+// Note: The request/response body is unavailable from the router_service.
+fn router_service(service) {
+    // Define a closure to process our request
+    let f = |request| {
+        // Something is malformed in the request...
+        throw "An was found to be wrong in the request_service...";
+    };
+    // Map our response using our closure
+    service.map_request(f);
+}
+
+// ...or throw exception from supergraph service
 fn supergraph_service(service) {
     // Define a closure to process our response
     let f = |response| {
@@ -79,7 +91,22 @@ The key must be a number and the message must be something which can be converte
 
 For example:
 ```rhai
-// Must throw exception from supergraph service
+// Throw exception from router service
+// Note: The request/response body is unavailable from the router_service.
+fn router_service(service) {
+    // Define a closure to process our request
+    let f = |request| {
+        // Something is malformed in the request...
+        throw #{
+            status: 400,
+            message: "An was found to be wrong in the request_service..."
+        };
+    };
+    // Map our response using our closure
+    service.map_request(f);
+}
+
+// ...or throw exception from supergraph service
 fn supergraph_service(service) {
     // Define a closure to process our response
     let f = |response| {

--- a/docs/source/routing/customization/rhai/reference.mdx
+++ b/docs/source/routing/customization/rhai/reference.mdx
@@ -59,6 +59,11 @@ log_trace("trace-level log message");
 
 Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from either the router service or supergraph service. This returns an `Internal Server Error` to the client with a `500` response code.
 
+When choosing between terminating the request from the router service versus the supergraph service, consider that:
+
+* The request/response body is not available in the router service. If you need to examine the body when determining whether or not to terminate the request, you will need to do so in the supergraph service.
+* The router service request stage happens before the supergraph service request stage and before the request body is parsed and the operation is validated. So it may be best to perform some actions, like enforcing a required header, in the router service request stage so they can be consistently applied even when an invalid operation is provided by the client.
+
 For example:
 ```rhai
 // Throw exception from router service


### PR DESCRIPTION
The docs currently state:

> Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from the supergraph service.

This is misleading as they can _also_ be terminated from the request service, which can be ideal for some cases since the router service request stage executes before the body is parsed of the operation is validated. So things like rejecting based on a missing header are likely better to be done here.

This PR attempts to update the docs to make it clear that the request can be terminated in the router service.


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
