### PR TITLE
Update Router request termination docs (backport #7523)

### DIFF
--- a/docs/source/routing/customization/rhai-reference.mdx
+++ b/docs/source/routing/customization/rhai-reference.mdx
@@ -54,11 +54,28 @@ log_trace("trace-level log message");
 
 ## Terminating client requests
 
-Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from the supergraph service. This returns an `Internal Server Error` to the client with a `500` response code.
+Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from either the router service or supergraph service. This returns an `Internal Server Error` to the client with a `500` response code.
+
+When choosing between router service versus supergraph service termination:
+
+- **Router service**: Cannot access request/response body and executes before parsing and validation; ideal for checks that should be consistently applied, like checking required headers, even when invalid operations are provided by the client.
+- **Supergraph service**: Use whenever you need to examine request bodies to enforce termination.
 
 For example:
 ```rhai
-// Must throw exception from supergraph service
+// Throw exception from router service
+// Note: The request/response body is unavailable from the router_service.
+fn router_service(service) {
+    // Define a closure to process our request
+    let f = |request| {
+        // Something is malformed in the request...
+        throw "An was found to be wrong in the request_service...";
+    };
+    // Map our response using our closure
+    service.map_request(f);
+}
+
+// ...or throw exception from supergraph service
 fn supergraph_service(service) {
     // Define a closure to process our response
     let f = |response| {
@@ -76,7 +93,22 @@ The key must be a number and the message must be something which can be converte
 
 For example:
 ```rhai
-// Must throw exception from supergraph service
+// Throw exception from router service
+// Note: The request/response body is unavailable from the router_service.
+fn router_service(service) {
+    // Define a closure to process our request
+    let f = |request| {
+        // Something is malformed in the request...
+        throw #{
+            status: 400,
+            message: "An was found to be wrong in the request_service..."
+        };
+    };
+    // Map our response using our closure
+    service.map_request(f);
+}
+
+// ...or throw exception from supergraph service
 fn supergraph_service(service) {
     // Define a closure to process our response
     let f = |response| {


### PR DESCRIPTION
The docs currently state:

> Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from the supergraph service.

This is misleading as they can _also_ be terminated from the request service, which can be ideal for some cases since the router service request stage executes before the body is parsed of the operation is validated. So things like rejecting based on a missing header are likely better to be done here.

This PR attempts to update the docs to make it clear that the request can be terminated in the router service.



---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7523 done by [Mergify](https://mergify.com).