### PR TITLE
NEBULA-4397: Issue with enforcing SafeListing for both internal and external clients (backport #7509)

### DIFF
--- a/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
+++ b/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
@@ -3,18 +3,22 @@ source: apollo-router/src/services/layers/persisted_queries/mod.rs
 expression: yaml
 ---
 - fields:
+    enforcement_skipped: false
     operation_body: "query SomeQuery { me { id } }"
   level: WARN
   message: unknown operation
 - fields:
+    enforcement_skipped: true
     operation_body: "query SomeQuery { me { id } }"
   level: WARN
   message: unknown operation
 - fields:
+    enforcement_skipped: false
     operation_body: "fragment A on Query { me { id } }    query SomeOp { ...A ...B }    fragment,,, B on Query{me{username,name}  } # yeah"
   level: WARN
   message: unknown operation
 - fields:
+    enforcement_skipped: false
     operation_body: "fragment F on Query { __typename foo: __schema { __typename } me { id } } query Q { __type(name: \"foo\") { name } ...F }"
   level: WARN
   message: unknown operation


### PR DESCRIPTION
A customer reported an issue while using a setup with both internal and external traffic where:

- They have safelisting enabled for persisted queries
- They use `apollo_persisted_queries::safelist::skip_enforcement` in context to bypass safelisting for internal operations
- They enabled `log_unknown` to audit which operations would be blocked once fully enforced
- Even when they skip enforcement for internal operations, the `log_unknown` feature still logs these operations as "unknown operations"

This is problematic because it makes it difficult to distinguish between:
- Operations that are truly unknown and will be blocked when enforcement is turned on
- Internal operations that are deliberately allowed via the skip_enforcement flag

This PR makes changes so that when logging unknown operations, we will include information about whether enforcement was skipped. This will enable the customer to filter their logs and distinguish between truly problematic external operations (`where enforcement_skipped` is false) and internal operations that are intentionally allowed to bypass safelisting (`where enforcement_skipped` is true).

<!-- [ROUTER-1305] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7509 done by [Mergify](https://mergify.com).

[ROUTER-1305]: https://apollographql.atlassian.net/browse/ROUTER-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ