### PR TITLE
docs: fix spelling of `probabilistic_sampling` option

### DIFF
--- a/docs/source/routing/observability/telemetry/trace-exporters/datadog.mdx
+++ b/docs/source/routing/observability/telemetry/trace-exporters/datadog.mdx
@@ -391,7 +391,7 @@ telemetry:
 
 **I want the Datadog Agent to be in control of the percentage of traces sent to Datadog.**
 
-Use the Datadog Agent's `probabalistic_sampling` option sampler and set the `sampler` to `always_on` to allow the agent to control the sampling rate.
+Use the Datadog Agent's `probabilistic_sampling` option sampler and set the `sampler` to `always_on` to allow the agent to control the sampling rate.
 
 Router config:
 ```yaml title="router.yaml"


### PR DESCRIPTION
no comment