### PR TITLE
chore: pin hyper-util

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -103,7 +103,8 @@ heck = "0.5.0"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"
 hyper = { version = "1.5.1", features = ["full"] }
-hyper-util = { version = "0.1.10", features = ["full"] }
+# XXX(@goto-bus-stop): Pinned because of undiagnosed tracing failures in 0.1.11 and up: https://github.com/apollographql/router/pull/7159
+hyper-util = { version = "=0.1.10", features = ["full"] }
 hyper-rustls = { version = "0.27.3", default-features = false, features = ["http1", "http2", "rustls-native-certs"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
 itertools = "0.14.0"


### PR DESCRIPTION
https://github.com/apollographql/router/pull/7159 doesn't quite work and
I'm not sure how to solve it right now. It might be a hyper-util bug but
it might also be on our end. It compiles and runs fine but the tracing
tests fail.

Our `test_updated` job is also failing because it's attempting to use
hyper-util 0.1.11. By pinning the dependency that should start working
again.
