### PR TITLE
chore: remove unused transitive reqwest dependency from xtask

### DIFF
--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -619,7 +619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50cfdc7f34b7f01909d55c2dcb71d4c13cbcbb4a1605d6c8bd760d654c1144b"
 dependencies = [
  "graphql_query_derive",
- "reqwest",
  "serde",
  "serde_json",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4.34", default-features = false, features = ["clock"] }
 console = "0.15.8"
 dialoguer = "0.11.0"
 flate2 = "1"
-graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }
+graphql_client = "0.14.0"
 itertools = "0.14.0"
 libc = "0.2"
 memorable-wordlist = "0.1.7"
@@ -29,6 +29,7 @@ once_cell = "1"
 regex = "1.10.3"
 reqwest = { version = "0.11", default-features = false, features = [
     "blocking",
+    "json",
     "rustls-tls",
     "rustls-tls-native-roots"
 ] }


### PR DESCRIPTION
This prevents automated updates of reqwest right now, and it seems
unnecessary as our xtask commands compile just fine without the feature.
https://github.com/apollographql/router/pull/7478

`graphql-client` is used to populate changesets from the GitHub API.
I verified that this still works by generating a changeset for this PR (but
I'm not committing it because this is not a user-facing change).
