### PR TITLE
feat: add `cost` to query planner statistics 

### DIFF
--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -23,7 +23,6 @@ pub type QueryPlanCost = f64;
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct QueryPlan {
     pub node: Option<TopLevelPlanNode>,
-    /// `cost` can be NaN, if the cost is not computed or irrelevant.
     pub statistics: QueryPlanningStatistics,
 }
 

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -172,6 +172,7 @@ impl Default for QueryPlannerDebugConfig {
 pub struct QueryPlanningStatistics {
     pub evaluated_plan_count: Cell<usize>,
     pub evaluated_plan_paths: Cell<usize>,
+    /// `best_plan_cost` can be NaN, if the cost is not computed or irrelevant.
     pub best_plan_cost: f64,
 }
 


### PR DESCRIPTION
We want to expose the query planning cost in router so that we can use it in harness to measure query planning cost as part of our SLO metrics. 

<!-- FED-637 -->
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
