### PR TITLE
[Batch] Add connector location as  validation location

### DIFF
--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_incorrect_context_key.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_incorrect_context_key.graphql.snap
@@ -7,6 +7,8 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch/bat
     Message {
         code: ConnectorsNonRootBatchKey,
         message: "`$batch` fields must be mapped from the API response body. Variables such as `$context` and `$this` are not supported",
-        locations: [],
+        locations: [
+            12:4..12:11,
+        ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_missing_key.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_missing_key.graphql.snap
@@ -7,6 +7,8 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch/bat
     Message {
         code: ConnectorsBatchKeyNotInSelection,
         message: "The `@connect` directive on `User` specifies a `$batch` entity resolver, but the field `id` could not be found in `@connect(selection: ...)`",
-        locations: [],
+        locations: [
+            12:4..12:11,
+        ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_missing_nested_key.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_missing_nested_key.graphql.snap
@@ -7,6 +7,8 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch/bat
     Message {
         code: ConnectorsBatchKeyNotInSelection,
         message: "The `@connect` directive on `User` specifies a `$batch` entity resolver, but the field `id` could not be found in `@connect(selection: ...)`",
-        locations: [],
+        locations: [
+            12:4..12:11,
+        ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_nested_keys.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_nested_keys.graphql.snap
@@ -14,6 +14,8 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch/bat
     Message {
         code: ConnectorsBatchKeyNotInSelection,
         message: "The `@connect` directive on `T` specifies a `$batch` entity resolver, but the field `c` could not be found in `@connect(selection: ...)`",
-        locations: [],
+        locations: [
+            12:4..12:11,
+        ],
     },
 ]


### PR DESCRIPTION
Adds error locations to new batch validation errors so they will show up correctly in IDE extensions. 

The error location points to the `@connect` directive within which the problem arose as it is not currently possible to point to the correct location within the connector. This will be updated in future work to point to a more exact location within the connector.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
