### PR TITLE
[Connectors] Ensure variable field error has location

### DIFF
--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -4,6 +4,7 @@ mod keys;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use apollo_compiler::Name;
 use apollo_compiler::Schema;
 use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
@@ -321,6 +322,16 @@ impl Connector {
             .clone()
             .unwrap_or_else(|| self.id.synthetic_name());
         format!("{}.{}", self.id.subgraph_name, source_name)
+    }
+
+    /// Get the name of the `@connect` directive associated with this [`Connector`] instance.
+    ///
+    /// The [`Name`] can be used to help locate the connector within a source file.
+    pub fn name(&self) -> Name {
+        match &self.id.directive {
+            ConnectorPosition::Field(field_position) => field_position.directive_name.clone(),
+            ConnectorPosition::Type(type_position) => type_position.directive_name.clone(),
+        }
     }
 }
 

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -300,6 +300,8 @@ pub enum Code {
     ConnectorsBatchKeyNotInSelection,
     /// Connector batch key is derived from a non-root variable such as `$this` or `$context`.
     ConnectorsNonRootBatchKey,
+    /// A `@key` could not be resolved for the given combination of variables.
+    ConnectorsCannotResolveKey,
     /// Part of the `@connect` refers to an `$args` which is not defined.
     UndefinedArgument,
     /// Part of the `@connect` refers to an `$this` which is not defined.

--- a/apollo-federation/src/sources/connect/validation/schema.rs
+++ b/apollo-federation/src/sources/connect/validation/schema.rs
@@ -332,7 +332,7 @@ fn advanced_validations(schema: &SchemaInfo, subgraph_name: &str) -> Vec<Message
             Ok(None) => continue,
             Err(_) => {
                 let variables = connector.variable_references().collect_vec();
-                messages.push(field_set_error(&variables, &connector, &schema));
+                messages.push(field_set_error(&variables, &connector, schema));
             }
             Ok(Some(field_set)) => {
                 entity_checker.add_connector(field_set);

--- a/apollo-federation/src/sources/connect/validation/schema.rs
+++ b/apollo-federation/src/sources/connect/validation/schema.rs
@@ -35,7 +35,6 @@ use crate::link::spec::Identity;
 use crate::sources::connect::Connector;
 use crate::sources::connect::EntityResolver::TypeBatch;
 use crate::sources::connect::Namespace::Batch;
-use crate::sources::connect::id::ConnectorPosition;
 use crate::sources::connect::json_selection::SelectionTrie;
 use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
@@ -318,9 +317,8 @@ fn advanced_validations(schema: &SchemaInfo, subgraph_name: &str) -> Vec<Message
 
     for (_, connector) in &connectors {
         if connector.entity_resolver == Some(TypeBatch) {
-            let root_name = extract_connector_name(connector);
             let input_trie = compute_batch_input_trie(connector);
-            match SelectionSetWalker::new(root_name, schema, &input_trie)
+            match SelectionSetWalker::new(connector.name(), schema, &input_trie)
                 .walk(&connector.selection.shape(), connector)
             {
                 Ok(res) => messages.extend(res),
@@ -334,10 +332,7 @@ fn advanced_validations(schema: &SchemaInfo, subgraph_name: &str) -> Vec<Message
             Ok(None) => continue,
             Err(_) => {
                 let variables = connector.variable_references().collect_vec();
-                messages.push(field_set_error(
-                    &variables,
-                    &connector.id.directive.coordinate(),
-                ));
+                messages.push(field_set_error(&variables, &connector, &schema));
             }
             Ok(Some(field_set)) => {
                 entity_checker.add_connector(field_set);
@@ -362,13 +357,6 @@ fn compute_batch_input_trie(connector: &Connector) -> SelectionTrie {
             let _ = &trie.extend(&var.selection);
         });
     trie
-}
-
-fn extract_connector_name(connector: &Connector) -> Name {
-    match &connector.id.directive {
-        ConnectorPosition::Field(field_position) => field_position.directive_name.clone(),
-        ConnectorPosition::Type(type_position) => type_position.directive_name.clone(),
-    }
 }
 
 struct SelectionSetWalker<'walker> {

--- a/apollo-federation/src/sources/connect/validation/schema/keys.rs
+++ b/apollo-federation/src/sources/connect/validation/schema/keys.rs
@@ -15,6 +15,7 @@ use apollo_compiler::validation::Valid;
 use itertools::Itertools;
 
 use crate::link::federation_spec_definition::FEDERATION_FIELDS_ARGUMENT_NAME;
+use crate::sources::connect::Connector;
 use crate::sources::connect::Namespace;
 use crate::sources::connect::validation::Code;
 use crate::sources::connect::validation::Message;
@@ -119,16 +120,21 @@ impl fmt::Debug for EntityKeyChecker<'_> {
 
 pub(crate) fn field_set_error(
     variables: &[VariableReference<Namespace>],
-    type_name: &str,
+    connector: &Connector,
+    schema: &Schema,
 ) -> Message {
     Message {
         code: Code::GraphQLError,
         message: format!(
-            "Variables used in connector (`{}`) for `{}` cannot be used to create a valid `@key` directive.",
+            "Variables used in connector (`{}`) on type `{}` cannot be used to create a valid `@key` directive.",
             variables.iter().join("`, `"),
-            type_name
+            connector.id.directive.simple_name()
         ),
-        locations: Vec::new(),
+        locations: connector
+            .name()
+            .line_column_range(&schema.sources)
+            .into_iter()
+            .collect(),
     }
 }
 

--- a/apollo-federation/src/sources/connect/validation/schema/keys.rs
+++ b/apollo-federation/src/sources/connect/validation/schema/keys.rs
@@ -124,7 +124,7 @@ pub(crate) fn field_set_error(
     schema: &Schema,
 ) -> Message {
     Message {
-        code: Code::GraphQLError,
+        code: Code::ConnectorsCannotResolveKey,
         message: format!(
             "Variables used in connector (`{}`) on type `{}` cannot be used to create a valid `@key` directive.",
             variables.iter().join("`, `"),

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_incorrect_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_incorrect_field.graphql.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", result.errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/batch/batch_incorrect_field.graphql
+---
+[
+    Message {
+        code: ConnectorsBatchKeyNotInSelection,
+        message: "The `@connect` directive on `User` specifies a `$batch` entity resolver, but the field `foo` could not be found in `@connect(selection: ...)`",
+        locations: [
+            12:4..12:11,
+        ],
+    },
+    Message {
+        code: GraphQLError,
+        message: "Variables used in connector (`$batch { foo }`) on type `User` cannot be used to create a valid `@key` directive.",
+        locations: [
+            12:4..12:11,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_incorrect_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@batch__batch_incorrect_field.graphql.snap
@@ -12,7 +12,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/batch/bat
         ],
     },
     Message {
-        code: GraphQLError,
+        code: ConnectorsCannotResolveKey,
         message: "Variables used in connector (`$batch { foo }`) on type `User` cannot be used to create a valid `@key` directive.",
         locations: [
             12:4..12:11,

--- a/apollo-federation/src/sources/connect/validation/test_data/batch/batch_incorrect_field.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/batch/batch_incorrect_field.graphql
@@ -1,0 +1,29 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@key"])
+  @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@source", "@connect"])
+  @source(name: "my-source", http: { baseURL: "http://127.0.0.1" })
+
+type Query {
+  users: [User]
+    @connect(http: { GET: "http://localhost:4001/users" }, selection: "id")
+}
+
+type User
+  @connect(
+    source: "my-source"
+    http: {
+      GET: "/users?ids={$batch.foo->joinNotNull(',')}"
+    }
+    selection: """
+    $.results {
+      id
+      name
+      profilePic: profile_pic
+    }
+    """
+  )
+{
+  id: ID!
+  name: String
+  profilePic: String
+}


### PR DESCRIPTION
Adds the connector directive as the location of variable field error so these errors will show up correctly in IDEs.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
