### PR TITLE
Remove `tracing::event!` calls inside tracing layers

### DIFF
--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -126,7 +126,7 @@ where
                 extensions.insert(fields);
             }
         } else {
-            eprintln!("Span not found, this is a bug");
+            eprintln!("FmtLayer::on_new_span: Span not found, this is a bug");
         }
     }
 
@@ -140,10 +140,10 @@ where
                     Some(KeyValue::new(Key::new(k), v.maybe_to_otel_value()?))
                 }));
             } else {
-                eprintln!("cannot access to LogAttributes, this is a bug");
+                eprintln!("FmtLayer::on_record: cannot access to LogAttributes, this is a bug");
             }
         } else {
-            eprintln!("Span not found, this is a bug");
+            eprintln!("FmtLayer::on_record: Span not found, this is a bug");
         }
     }
 
@@ -175,7 +175,7 @@ where
             if self.fmt_event.format_event(&ctx, &mut buf, event).is_ok() {
                 let mut writer = self.make_writer.make_writer();
                 if let Err(err) = std::io::Write::write_all(&mut writer, buf.as_bytes()) {
-                    eprintln!("cannot flush the logging buffer, this is a bug: {err:?}");
+                    eprintln!("FmtLayer::on_event: cannot flush the logging buffer, this is a bug: {err:?}");
                 }
             }
             buf.clear();

--- a/apollo-router/src/plugins/telemetry/otel/layer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/layer.rs
@@ -817,7 +817,7 @@ where
                 forced_span_name: None,
             });
         } else {
-            eprintln!("Span not found, this is a bug");
+            eprintln!("OpenTelemetryLayer::on_new_span: Span not found, this is a bug");
         }
     }
 
@@ -838,7 +838,7 @@ where
                 timings.last = now;
             }
         } else {
-            eprintln!("Span not found, this is a bug");
+            eprintln!("OpenTelemetryLayer::on_enter: Span not found, this is a bug");
         }
     }
 
@@ -859,7 +859,7 @@ where
                 timings.last = now;
             }
         } else {
-            eprintln!("Span not found, this is a bug");
+            eprintln!("OpenTelemetryLayer::on_exit: Span not found, this is a bug");
         }
     }
 
@@ -880,7 +880,7 @@ where
                 });
             }
         } else {
-            eprintln!("Span not found, this is a bug");
+            eprintln!("OpenTelemetryLayer::on_record: Span not found, this is a bug");
         }
     }
 
@@ -918,7 +918,7 @@ where
                 data.builder.links = Some(vec![follows_link]);
             }
         } else {
-            eprintln!("Span not found, this is a bug");
+            eprintln!("OpenTelemetryLayer::on_follows_from: Span not found, this is a bug");
         }
     }
 
@@ -1062,7 +1062,7 @@ where
                     .start_with_context(&self.tracer, &parent_cx);
             }
         } else {
-            eprintln!("Span not found, this is a bug");
+            eprintln!("OpenTelemetryLayer::on_close: Span not found, this is a bug");
         }
     }
 


### PR DESCRIPTION
Using `tracing::error!()` or other event macros inside a
tracing-subscriber layer callback may just drop the event.

Elsewhere, we've solved this by manually building an event and using
`context.event()`.
https://github.com/apollographql/router/blob/678dee7e1a85d4520d84e90ef0913b892a55ee65/apollo-router/src/plugins/telemetry/reload.rs#L175-L187

I think this is not appropriate to do in this case. If an error
occurred inside the tracing-subscriber layer, we shouldn't expect to be
able to record new events with `tracing`. So I simply changed these
calls to `eprintln!()`. The messages will at least go _somewhere_.

I think there's an argument that these could be panics, but I don't
want to risk breaking the world.

<!-- [ROUTER-1016] -->


[ROUTER-1016]: https://apollographql.atlassian.net/browse/ROUTER-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ