### PR TITLE
docs(demand-control): Rhai reference for cost measurements as response headers

### DIFF
--- a/.changesets/docs_baby_fellow_hard_historian.md
+++ b/.changesets/docs_baby_fellow_hard_historian.md
@@ -1,5 +1,5 @@
 ### Rhai script examples for returning Demand Control metrics as response headers ([PR #7564](https://github.com/apollographql/router/pull/7564))
 
-Added a new section to the [demand control documentation](https://www.apollographql.com/docs/graphos/routing/security/demand-control#exposing-cost-estimates-in-response-headers) showing how to use Rhai scripts to expose cost estimation data in response headers. This allows clients to see the estimated cost, actual cost, and other demand control metrics directly in HTTP responses, which is useful for debugging and client-side optimization.
+Added a new section to the [demand control documentation](https://www.apollographql.com/docs/graphos/routing/security/demand-control#accessing-programmatically) showing how to use Rhai scripts to expose cost estimation data in response headers. This allows clients to see the estimated cost, actual cost, and other demand control metrics directly in HTTP responses, which is useful for debugging and client-side optimization.
 
 By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/7564

--- a/.changesets/docs_baby_fellow_hard_historian.md
+++ b/.changesets/docs_baby_fellow_hard_historian.md
@@ -1,0 +1,5 @@
+### Rhai script examples for returning Demand Control metrics as response headers ([PR #7564](https://github.com/apollographql/router/pull/7564))
+
+Added a new section to the [demand control documentation](https://www.apollographql.com/docs/graphos/routing/security/demand-control#exposing-cost-estimates-in-response-headers) showing how to use Rhai scripts to expose cost estimation data in response headers. This allows clients to see the estimated cost, actual cost, and other demand control metrics directly in HTTP responses, which is useful for debugging and client-side optimization.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/7564

--- a/docs/source/routing/security/demand-control.mdx
+++ b/docs/source/routing/security/demand-control.mdx
@@ -434,13 +434,13 @@ You can also chart the percentage of operations that would be allowed or rejecte
   width="600"
 />
 
-## Accessing Demand Control Data with Rhai
+## Accessing programmatically
 
-You can programmatically access demand control cost data using [Rhai scripts](/routing/customization/rhai). This can be useful for custom logging, decision making, or exposing cost data to clients.
+You can programmatically access demand control cost data using [Rhai scripts](/routing/customization/rhai) or Coprocessors. This can be useful for custom logging, decision making, or exposing cost data to clients.
 
-### Exposing Cost Estimates in Response Headers
+### Exposing cost in response headers
 
-You can access cost estimation data and expose it to clients through response headers using Rhai scripts. This is useful for debugging or providing transparency about query costs.
+It's possible to expose cost information in the HTTP response payload returned to clients, which can be useful for debugging. This can be accomplished via a Rhai script on the `supergraph_service` hook:
 
 ```rust
 fn supergraph_service(service) {

--- a/docs/source/routing/security/demand-control.mdx
+++ b/docs/source/routing/security/demand-control.mdx
@@ -433,3 +433,46 @@ You can also chart the percentage of operations that would be allowed or rejecte
   src="../../images/demand-control-example-cost-result.png"
   width="600"
 />
+
+## Accessing Demand Control Data with Rhai
+
+You can programmatically access demand control cost data using [Rhai scripts](/routing/customization/rhai). This can be useful for custom logging, decision making, or exposing cost data to clients.
+
+### Exposing Cost Estimates in Response Headers
+
+You can access cost estimation data and expose it to clients through response headers using Rhai scripts. This is useful for debugging or providing transparency about query costs.
+
+```rust
+fn supergraph_service(service) {
+  service.map_response(|response| {
+    if response.is_primary() {
+      try {
+        // Get cost estimation values from context
+        let estimated_cost = response.context[Router.APOLLO_COST_ESTIMATED_KEY];
+        let actual_cost = response.context[Router.APOLLO_COST_ACTUAL_KEY];
+        let strategy = response.context[Router.APOLLO_COST_STRATEGY_KEY];
+        let result = response.context[Router.APOLLO_COST_RESULT_KEY];
+
+        // Add them as response headers
+        if estimated_cost != () {
+          response.headers["apollo-cost-estimate"] = estimated_cost.to_string();
+        }
+
+        if actual_cost != () {
+          response.headers["apollo-cost-actual"] = actual_cost.to_string();
+        }
+
+        if strategy != () {
+          response.headers["apollo-cost-strategy"] = strategy.to_string();
+        }
+
+        if result != () {
+          response.headers["apollo-cost-result"] = result.to_string();
+        }
+      } catch(err) {
+        log_debug(`Could not add cost headers: ${err}`);
+      }
+    }
+  });
+}
+```


### PR DESCRIPTION
<!-- [ROUTER-1306] -->

[ROUTER-1306]: https://apollographql.atlassian.net/browse/ROUTER-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ