### PR TITLE
Move the deprecated context key names into a single module

### DIFF
--- a/apollo-router/src/context/deprecated.rs
+++ b/apollo-router/src/context/deprecated.rs
@@ -1,0 +1,97 @@
+//! Support 1.x context key names in 2.x.
+
+use crate::context::DEPRECATED_OPERATION_KIND;
+use crate::context::DEPRECATED_OPERATION_NAME;
+use crate::context::OPERATION_KIND;
+use crate::context::OPERATION_NAME;
+use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
+use crate::plugins::authentication::DEPRECATED_APOLLO_AUTHENTICATION_JWT_CLAIMS;
+use crate::plugins::authorization::AUTHENTICATION_REQUIRED_KEY;
+use crate::plugins::authorization::DEPRECATED_AUTHENTICATION_REQUIRED_KEY;
+use crate::plugins::authorization::DEPRECATED_REQUIRED_POLICIES_KEY;
+use crate::plugins::authorization::DEPRECATED_REQUIRED_SCOPES_KEY;
+use crate::plugins::authorization::REQUIRED_POLICIES_KEY;
+use crate::plugins::authorization::REQUIRED_SCOPES_KEY;
+use crate::plugins::demand_control::COST_ACTUAL_KEY;
+use crate::plugins::demand_control::COST_ESTIMATED_KEY;
+use crate::plugins::demand_control::COST_RESULT_KEY;
+use crate::plugins::demand_control::COST_STRATEGY_KEY;
+use crate::plugins::demand_control::DEPRECATED_COST_ACTUAL_KEY;
+use crate::plugins::demand_control::DEPRECATED_COST_ESTIMATED_KEY;
+use crate::plugins::demand_control::DEPRECATED_COST_RESULT_KEY;
+use crate::plugins::demand_control::DEPRECATED_COST_STRATEGY_KEY;
+use crate::plugins::expose_query_plan::DEPRECATED_ENABLED_CONTEXT_KEY;
+use crate::plugins::expose_query_plan::DEPRECATED_FORMATTED_QUERY_PLAN_CONTEXT_KEY;
+use crate::plugins::expose_query_plan::DEPRECATED_QUERY_PLAN_CONTEXT_KEY;
+use crate::plugins::expose_query_plan::ENABLED_CONTEXT_KEY;
+use crate::plugins::expose_query_plan::FORMATTED_QUERY_PLAN_CONTEXT_KEY;
+use crate::plugins::expose_query_plan::QUERY_PLAN_CONTEXT_KEY;
+use crate::plugins::progressive_override::DEPRECATED_LABELS_TO_OVERRIDE_KEY;
+use crate::plugins::progressive_override::DEPRECATED_UNRESOLVED_LABELS_KEY;
+use crate::plugins::progressive_override::LABELS_TO_OVERRIDE_KEY;
+use crate::plugins::progressive_override::UNRESOLVED_LABELS_KEY;
+use crate::plugins::telemetry::CLIENT_NAME;
+use crate::plugins::telemetry::CLIENT_VERSION;
+use crate::plugins::telemetry::DEPRECATED_CLIENT_NAME;
+use crate::plugins::telemetry::DEPRECATED_CLIENT_VERSION;
+use crate::plugins::telemetry::DEPRECATED_STUDIO_EXCLUDE;
+use crate::plugins::telemetry::DEPRECATED_SUBGRAPH_FTV1;
+use crate::plugins::telemetry::STUDIO_EXCLUDE;
+use crate::plugins::telemetry::SUBGRAPH_FTV1;
+use crate::query_planner::APOLLO_OPERATION_ID;
+use crate::query_planner::DEPRECATED_APOLLO_OPERATION_ID;
+use crate::services::DEPRECATED_FIRST_EVENT_CONTEXT_KEY;
+use crate::services::FIRST_EVENT_CONTEXT_KEY;
+use crate::services::layers::apq::DEPRECATED_PERSISTED_QUERY_CACHE_HIT;
+use crate::services::layers::apq::DEPRECATED_PERSISTED_QUERY_REGISTERED;
+use crate::services::layers::apq::PERSISTED_QUERY_CACHE_HIT;
+use crate::services::layers::apq::PERSISTED_QUERY_REGISTERED;
+
+/// Generate the function pair with a macro to be sure that they handle all the same keys.
+macro_rules! make_deprecated_key_conversions {
+    ( $( $new:ident => $deprecated:ident, )* ) => {
+        /// Convert context key to the deprecated context key (mainly useful for coprocessor/rhai)
+        /// If the context key is not part of a deprecated one it just returns the original one because it doesn't have to be renamed
+        pub(crate) fn context_key_to_deprecated(key: String) -> String {
+            match key.as_str() {
+                $( $new => $deprecated.to_string(), )*
+                _ => key,
+            }
+        }
+
+        /// Convert context key from deprecated to new one (mainly useful for coprocessor/rhai)
+        /// If the context key is not part of a deprecated one it just returns the original one because it doesn't have to be renamed
+        pub(crate) fn context_key_from_deprecated(key: String) -> String {
+            match key.as_str() {
+                $( $deprecated => $new.to_string(), )*
+                _ => key,
+            }
+        }
+    };
+}
+
+make_deprecated_key_conversions!(
+    OPERATION_NAME => DEPRECATED_OPERATION_NAME,
+    OPERATION_KIND => DEPRECATED_OPERATION_KIND,
+    APOLLO_AUTHENTICATION_JWT_CLAIMS => DEPRECATED_APOLLO_AUTHENTICATION_JWT_CLAIMS,
+    AUTHENTICATION_REQUIRED_KEY => DEPRECATED_AUTHENTICATION_REQUIRED_KEY,
+    REQUIRED_SCOPES_KEY => DEPRECATED_REQUIRED_SCOPES_KEY,
+    REQUIRED_POLICIES_KEY => DEPRECATED_REQUIRED_POLICIES_KEY,
+    APOLLO_OPERATION_ID => DEPRECATED_APOLLO_OPERATION_ID,
+    UNRESOLVED_LABELS_KEY => DEPRECATED_UNRESOLVED_LABELS_KEY,
+    LABELS_TO_OVERRIDE_KEY => DEPRECATED_LABELS_TO_OVERRIDE_KEY,
+    FIRST_EVENT_CONTEXT_KEY => DEPRECATED_FIRST_EVENT_CONTEXT_KEY,
+    CLIENT_NAME => DEPRECATED_CLIENT_NAME,
+    CLIENT_VERSION => DEPRECATED_CLIENT_VERSION,
+    STUDIO_EXCLUDE => DEPRECATED_STUDIO_EXCLUDE,
+    SUBGRAPH_FTV1 => DEPRECATED_SUBGRAPH_FTV1,
+    COST_ESTIMATED_KEY => DEPRECATED_COST_ESTIMATED_KEY,
+    COST_ACTUAL_KEY => DEPRECATED_COST_ACTUAL_KEY,
+    COST_RESULT_KEY => DEPRECATED_COST_RESULT_KEY,
+    COST_STRATEGY_KEY => DEPRECATED_COST_STRATEGY_KEY,
+    ENABLED_CONTEXT_KEY => DEPRECATED_ENABLED_CONTEXT_KEY,
+    FORMATTED_QUERY_PLAN_CONTEXT_KEY => DEPRECATED_FORMATTED_QUERY_PLAN_CONTEXT_KEY,
+    QUERY_PLAN_CONTEXT_KEY => DEPRECATED_QUERY_PLAN_CONTEXT_KEY,
+    PERSISTED_QUERY_CACHE_HIT => DEPRECATED_PERSISTED_QUERY_CACHE_HIT,
+    PERSISTED_QUERY_REGISTERED => DEPRECATED_PERSISTED_QUERY_REGISTERED,
+);

--- a/apollo-router/src/context/deprecated.rs
+++ b/apollo-router/src/context/deprecated.rs
@@ -1,51 +1,76 @@
 //! Support 1.x context key names in 2.x.
 
-use crate::context::DEPRECATED_OPERATION_KIND;
-use crate::context::DEPRECATED_OPERATION_NAME;
 use crate::context::OPERATION_KIND;
 use crate::context::OPERATION_NAME;
 use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
-use crate::plugins::authentication::DEPRECATED_APOLLO_AUTHENTICATION_JWT_CLAIMS;
 use crate::plugins::authorization::AUTHENTICATION_REQUIRED_KEY;
-use crate::plugins::authorization::DEPRECATED_AUTHENTICATION_REQUIRED_KEY;
-use crate::plugins::authorization::DEPRECATED_REQUIRED_POLICIES_KEY;
-use crate::plugins::authorization::DEPRECATED_REQUIRED_SCOPES_KEY;
 use crate::plugins::authorization::REQUIRED_POLICIES_KEY;
 use crate::plugins::authorization::REQUIRED_SCOPES_KEY;
 use crate::plugins::demand_control::COST_ACTUAL_KEY;
 use crate::plugins::demand_control::COST_ESTIMATED_KEY;
 use crate::plugins::demand_control::COST_RESULT_KEY;
 use crate::plugins::demand_control::COST_STRATEGY_KEY;
-use crate::plugins::demand_control::DEPRECATED_COST_ACTUAL_KEY;
-use crate::plugins::demand_control::DEPRECATED_COST_ESTIMATED_KEY;
-use crate::plugins::demand_control::DEPRECATED_COST_RESULT_KEY;
-use crate::plugins::demand_control::DEPRECATED_COST_STRATEGY_KEY;
-use crate::plugins::expose_query_plan::DEPRECATED_ENABLED_CONTEXT_KEY;
-use crate::plugins::expose_query_plan::DEPRECATED_FORMATTED_QUERY_PLAN_CONTEXT_KEY;
-use crate::plugins::expose_query_plan::DEPRECATED_QUERY_PLAN_CONTEXT_KEY;
 use crate::plugins::expose_query_plan::ENABLED_CONTEXT_KEY;
 use crate::plugins::expose_query_plan::FORMATTED_QUERY_PLAN_CONTEXT_KEY;
 use crate::plugins::expose_query_plan::QUERY_PLAN_CONTEXT_KEY;
-use crate::plugins::progressive_override::DEPRECATED_LABELS_TO_OVERRIDE_KEY;
-use crate::plugins::progressive_override::DEPRECATED_UNRESOLVED_LABELS_KEY;
 use crate::plugins::progressive_override::LABELS_TO_OVERRIDE_KEY;
 use crate::plugins::progressive_override::UNRESOLVED_LABELS_KEY;
 use crate::plugins::telemetry::CLIENT_NAME;
 use crate::plugins::telemetry::CLIENT_VERSION;
-use crate::plugins::telemetry::DEPRECATED_CLIENT_NAME;
-use crate::plugins::telemetry::DEPRECATED_CLIENT_VERSION;
-use crate::plugins::telemetry::DEPRECATED_STUDIO_EXCLUDE;
-use crate::plugins::telemetry::DEPRECATED_SUBGRAPH_FTV1;
 use crate::plugins::telemetry::STUDIO_EXCLUDE;
 use crate::plugins::telemetry::SUBGRAPH_FTV1;
 use crate::query_planner::APOLLO_OPERATION_ID;
-use crate::query_planner::DEPRECATED_APOLLO_OPERATION_ID;
-use crate::services::DEPRECATED_FIRST_EVENT_CONTEXT_KEY;
 use crate::services::FIRST_EVENT_CONTEXT_KEY;
-use crate::services::layers::apq::DEPRECATED_PERSISTED_QUERY_CACHE_HIT;
-use crate::services::layers::apq::DEPRECATED_PERSISTED_QUERY_REGISTERED;
 use crate::services::layers::apq::PERSISTED_QUERY_CACHE_HIT;
 use crate::services::layers::apq::PERSISTED_QUERY_REGISTERED;
+
+// From crate::context
+pub(crate) const DEPRECATED_OPERATION_NAME: &str = "operation_name";
+pub(crate) const DEPRECATED_OPERATION_KIND: &str = "operation_kind";
+
+// crate::plugins::authentication
+pub(crate) const DEPRECATED_APOLLO_AUTHENTICATION_JWT_CLAIMS: &str =
+    "apollo_authentication::JWT::claims";
+
+// crate::plugins::authorization
+pub(crate) const DEPRECATED_AUTHENTICATION_REQUIRED_KEY: &str =
+    "apollo_authorization::authenticated::required";
+pub(crate) const DEPRECATED_REQUIRED_SCOPES_KEY: &str = "apollo_authorization::scopes::required";
+pub(crate) const DEPRECATED_REQUIRED_POLICIES_KEY: &str =
+    "apollo_authorization::policies::required";
+
+// crate::plugins::demand_control
+pub(crate) const DEPRECATED_COST_ESTIMATED_KEY: &str = "cost.estimated";
+pub(crate) const DEPRECATED_COST_ACTUAL_KEY: &str = "cost.actual";
+pub(crate) const DEPRECATED_COST_RESULT_KEY: &str = "cost.result";
+pub(crate) const DEPRECATED_COST_STRATEGY_KEY: &str = "cost.strategy";
+
+// crate::plugins::expose_query_plan
+pub(crate) const DEPRECATED_QUERY_PLAN_CONTEXT_KEY: &str = "experimental::expose_query_plan.plan";
+pub(crate) const DEPRECATED_FORMATTED_QUERY_PLAN_CONTEXT_KEY: &str =
+    "experimental::expose_query_plan.formatted_plan";
+pub(crate) const DEPRECATED_ENABLED_CONTEXT_KEY: &str = "experimental::expose_query_plan.enabled";
+
+// crate::plugins::progressive_override
+pub(crate) const DEPRECATED_UNRESOLVED_LABELS_KEY: &str = "apollo_override::unresolved_labels";
+pub(crate) const DEPRECATED_LABELS_TO_OVERRIDE_KEY: &str = "apollo_override::labels_to_override";
+
+// crate::plugins::telemetry
+pub(crate) const DEPRECATED_CLIENT_NAME: &str = "apollo_telemetry::client_name";
+pub(crate) const DEPRECATED_CLIENT_VERSION: &str = "apollo_telemetry::client_version";
+pub(crate) const DEPRECATED_SUBGRAPH_FTV1: &str = "apollo_telemetry::subgraph_ftv1";
+pub(crate) const DEPRECATED_STUDIO_EXCLUDE: &str = "apollo_telemetry::studio::exclude";
+
+// crate::query_planner::caching_query_planner
+pub(crate) const DEPRECATED_APOLLO_OPERATION_ID: &str = "apollo_operation_id";
+
+// crate::services::supergraph::service
+pub(crate) const DEPRECATED_FIRST_EVENT_CONTEXT_KEY: &str =
+    "apollo_router::supergraph::first_event";
+
+// crate::services::layers::apq
+pub(crate) const DEPRECATED_PERSISTED_QUERY_CACHE_HIT: &str = "persisted_query_hit";
+pub(crate) const DEPRECATED_PERSISTED_QUERY_REGISTERED: &str = "persisted_query_register";
 
 /// Generate the function pair with a macro to be sure that they handle all the same keys.
 macro_rules! make_deprecated_key_conversions {

--- a/apollo-router/src/context/mod.rs
+++ b/apollo-router/src/context/mod.rs
@@ -18,50 +18,9 @@ use serde::Serialize;
 use tower::BoxError;
 
 use crate::json_ext::Value;
-use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
-use crate::plugins::authentication::DEPRECATED_APOLLO_AUTHENTICATION_JWT_CLAIMS;
-use crate::plugins::authorization::AUTHENTICATION_REQUIRED_KEY;
-use crate::plugins::authorization::DEPRECATED_AUTHENTICATION_REQUIRED_KEY;
-use crate::plugins::authorization::DEPRECATED_REQUIRED_POLICIES_KEY;
-use crate::plugins::authorization::DEPRECATED_REQUIRED_SCOPES_KEY;
-use crate::plugins::authorization::REQUIRED_POLICIES_KEY;
-use crate::plugins::authorization::REQUIRED_SCOPES_KEY;
-use crate::plugins::demand_control::COST_ACTUAL_KEY;
-use crate::plugins::demand_control::COST_ESTIMATED_KEY;
-use crate::plugins::demand_control::COST_RESULT_KEY;
-use crate::plugins::demand_control::COST_STRATEGY_KEY;
-use crate::plugins::demand_control::DEPRECATED_COST_ACTUAL_KEY;
-use crate::plugins::demand_control::DEPRECATED_COST_ESTIMATED_KEY;
-use crate::plugins::demand_control::DEPRECATED_COST_RESULT_KEY;
-use crate::plugins::demand_control::DEPRECATED_COST_STRATEGY_KEY;
-use crate::plugins::expose_query_plan::DEPRECATED_ENABLED_CONTEXT_KEY;
-use crate::plugins::expose_query_plan::DEPRECATED_FORMATTED_QUERY_PLAN_CONTEXT_KEY;
-use crate::plugins::expose_query_plan::DEPRECATED_QUERY_PLAN_CONTEXT_KEY;
-use crate::plugins::expose_query_plan::ENABLED_CONTEXT_KEY;
-use crate::plugins::expose_query_plan::FORMATTED_QUERY_PLAN_CONTEXT_KEY;
-use crate::plugins::expose_query_plan::QUERY_PLAN_CONTEXT_KEY;
-use crate::plugins::progressive_override::DEPRECATED_LABELS_TO_OVERRIDE_KEY;
-use crate::plugins::progressive_override::DEPRECATED_UNRESOLVED_LABELS_KEY;
-use crate::plugins::progressive_override::LABELS_TO_OVERRIDE_KEY;
-use crate::plugins::progressive_override::UNRESOLVED_LABELS_KEY;
-use crate::plugins::telemetry::CLIENT_NAME;
-use crate::plugins::telemetry::CLIENT_VERSION;
-use crate::plugins::telemetry::DEPRECATED_CLIENT_NAME;
-use crate::plugins::telemetry::DEPRECATED_CLIENT_VERSION;
-use crate::plugins::telemetry::DEPRECATED_STUDIO_EXCLUDE;
-use crate::plugins::telemetry::DEPRECATED_SUBGRAPH_FTV1;
-use crate::plugins::telemetry::STUDIO_EXCLUDE;
-use crate::plugins::telemetry::SUBGRAPH_FTV1;
-use crate::query_planner::APOLLO_OPERATION_ID;
-use crate::query_planner::DEPRECATED_APOLLO_OPERATION_ID;
-use crate::services::DEPRECATED_FIRST_EVENT_CONTEXT_KEY;
-use crate::services::FIRST_EVENT_CONTEXT_KEY;
-use crate::services::layers::apq::DEPRECATED_PERSISTED_QUERY_CACHE_HIT;
-use crate::services::layers::apq::DEPRECATED_PERSISTED_QUERY_REGISTERED;
-use crate::services::layers::apq::PERSISTED_QUERY_CACHE_HIT;
-use crate::services::layers::apq::PERSISTED_QUERY_REGISTERED;
 use crate::services::layers::query_analysis::ParsedDocument;
 
+mod deprecated;
 pub(crate) mod extensions;
 
 /// The key of the resolved operation name. This is subject to change and should not be relied on.
@@ -74,6 +33,9 @@ pub(crate) const OPERATION_KIND: &str = "apollo::supergraph::operation_kind";
 pub(crate) const DEPRECATED_OPERATION_KIND: &str = "operation_kind";
 /// The key to know if the response body contains at least 1 GraphQL error
 pub(crate) const CONTAINS_GRAPHQL_ERROR: &str = "apollo::telemetry::contains_graphql_error";
+
+pub(crate) use deprecated::context_key_from_deprecated;
+pub(crate) use deprecated::context_key_to_deprecated;
 
 /// Holds [`Context`] entries.
 pub(crate) type Entries = Arc<DashMap<String, Value>>;
@@ -300,68 +262,6 @@ impl Context {
 impl Default for Context {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// Convert context key to the deprecated context key (mainly useful for coprocessor/rhai)
-/// If the context key is not part of a deprecated one it just returns the original one because it doesn't have to be renamed
-pub(crate) fn context_key_to_deprecated(key: String) -> String {
-    match key.as_str() {
-        OPERATION_NAME => DEPRECATED_OPERATION_NAME.to_string(),
-        OPERATION_KIND => DEPRECATED_OPERATION_KIND.to_string(),
-        APOLLO_AUTHENTICATION_JWT_CLAIMS => DEPRECATED_APOLLO_AUTHENTICATION_JWT_CLAIMS.to_string(),
-        AUTHENTICATION_REQUIRED_KEY => DEPRECATED_AUTHENTICATION_REQUIRED_KEY.to_string(),
-        REQUIRED_SCOPES_KEY => DEPRECATED_REQUIRED_SCOPES_KEY.to_string(),
-        REQUIRED_POLICIES_KEY => DEPRECATED_REQUIRED_POLICIES_KEY.to_string(),
-        APOLLO_OPERATION_ID => DEPRECATED_APOLLO_OPERATION_ID.to_string(),
-        UNRESOLVED_LABELS_KEY => DEPRECATED_UNRESOLVED_LABELS_KEY.to_string(),
-        LABELS_TO_OVERRIDE_KEY => DEPRECATED_LABELS_TO_OVERRIDE_KEY.to_string(),
-        FIRST_EVENT_CONTEXT_KEY => DEPRECATED_FIRST_EVENT_CONTEXT_KEY.to_string(),
-        CLIENT_NAME => DEPRECATED_CLIENT_NAME.to_string(),
-        CLIENT_VERSION => DEPRECATED_CLIENT_VERSION.to_string(),
-        STUDIO_EXCLUDE => DEPRECATED_STUDIO_EXCLUDE.to_string(),
-        SUBGRAPH_FTV1 => DEPRECATED_SUBGRAPH_FTV1.to_string(),
-        COST_ESTIMATED_KEY => DEPRECATED_COST_ESTIMATED_KEY.to_string(),
-        COST_ACTUAL_KEY => DEPRECATED_COST_ACTUAL_KEY.to_string(),
-        COST_RESULT_KEY => DEPRECATED_COST_RESULT_KEY.to_string(),
-        COST_STRATEGY_KEY => DEPRECATED_COST_STRATEGY_KEY.to_string(),
-        ENABLED_CONTEXT_KEY => DEPRECATED_ENABLED_CONTEXT_KEY.to_string(),
-        FORMATTED_QUERY_PLAN_CONTEXT_KEY => DEPRECATED_FORMATTED_QUERY_PLAN_CONTEXT_KEY.to_string(),
-        QUERY_PLAN_CONTEXT_KEY => DEPRECATED_QUERY_PLAN_CONTEXT_KEY.to_string(),
-        PERSISTED_QUERY_CACHE_HIT => DEPRECATED_PERSISTED_QUERY_CACHE_HIT.to_string(),
-        PERSISTED_QUERY_REGISTERED => DEPRECATED_PERSISTED_QUERY_REGISTERED.to_string(),
-        _ => key,
-    }
-}
-
-/// Convert context key from deprecated to new one (mainly useful for coprocessor/rhai)
-/// If the context key is not part of a deprecated one it just returns the original one because it doesn't have to be renamed
-pub(crate) fn context_key_from_deprecated(key: String) -> String {
-    match key.as_str() {
-        DEPRECATED_OPERATION_NAME => OPERATION_NAME.to_string(),
-        DEPRECATED_OPERATION_KIND => OPERATION_KIND.to_string(),
-        DEPRECATED_APOLLO_AUTHENTICATION_JWT_CLAIMS => APOLLO_AUTHENTICATION_JWT_CLAIMS.to_string(),
-        DEPRECATED_AUTHENTICATION_REQUIRED_KEY => AUTHENTICATION_REQUIRED_KEY.to_string(),
-        DEPRECATED_REQUIRED_SCOPES_KEY => REQUIRED_SCOPES_KEY.to_string(),
-        DEPRECATED_REQUIRED_POLICIES_KEY => REQUIRED_POLICIES_KEY.to_string(),
-        DEPRECATED_APOLLO_OPERATION_ID => APOLLO_OPERATION_ID.to_string(),
-        DEPRECATED_UNRESOLVED_LABELS_KEY => UNRESOLVED_LABELS_KEY.to_string(),
-        DEPRECATED_LABELS_TO_OVERRIDE_KEY => LABELS_TO_OVERRIDE_KEY.to_string(),
-        DEPRECATED_FIRST_EVENT_CONTEXT_KEY => FIRST_EVENT_CONTEXT_KEY.to_string(),
-        DEPRECATED_CLIENT_NAME => CLIENT_NAME.to_string(),
-        DEPRECATED_CLIENT_VERSION => CLIENT_VERSION.to_string(),
-        DEPRECATED_STUDIO_EXCLUDE => STUDIO_EXCLUDE.to_string(),
-        DEPRECATED_SUBGRAPH_FTV1 => SUBGRAPH_FTV1.to_string(),
-        DEPRECATED_COST_ESTIMATED_KEY => COST_ESTIMATED_KEY.to_string(),
-        DEPRECATED_COST_ACTUAL_KEY => COST_ACTUAL_KEY.to_string(),
-        DEPRECATED_COST_RESULT_KEY => COST_RESULT_KEY.to_string(),
-        DEPRECATED_COST_STRATEGY_KEY => COST_STRATEGY_KEY.to_string(),
-        DEPRECATED_ENABLED_CONTEXT_KEY => ENABLED_CONTEXT_KEY.to_string(),
-        DEPRECATED_FORMATTED_QUERY_PLAN_CONTEXT_KEY => FORMATTED_QUERY_PLAN_CONTEXT_KEY.to_string(),
-        DEPRECATED_QUERY_PLAN_CONTEXT_KEY => QUERY_PLAN_CONTEXT_KEY.to_string(),
-        DEPRECATED_PERSISTED_QUERY_CACHE_HIT => PERSISTED_QUERY_CACHE_HIT.to_string(),
-        DEPRECATED_PERSISTED_QUERY_REGISTERED => PERSISTED_QUERY_REGISTERED.to_string(),
-        _ => key,
     }
 }
 

--- a/apollo-router/src/context/mod.rs
+++ b/apollo-router/src/context/mod.rs
@@ -20,17 +20,13 @@ use tower::BoxError;
 use crate::json_ext::Value;
 use crate::services::layers::query_analysis::ParsedDocument;
 
-mod deprecated;
+pub(crate) mod deprecated;
 pub(crate) mod extensions;
 
 /// The key of the resolved operation name. This is subject to change and should not be relied on.
 pub(crate) const OPERATION_NAME: &str = "apollo::supergraph::operation_name";
-/// The deprecated key (1.x) of the resolved operation name. This is subject to change and should not be relied on.
-pub(crate) const DEPRECATED_OPERATION_NAME: &str = "operation_name";
 /// The key of the resolved operation kind. This is subject to change and should not be relied on.
 pub(crate) const OPERATION_KIND: &str = "apollo::supergraph::operation_kind";
-/// The deprecated key (1.x) of the resolved operation kind. This is subject to change and should not be relied on.
-pub(crate) const DEPRECATED_OPERATION_KIND: &str = "operation_kind";
 /// The key to know if the response body contains at least 1 GraphQL error
 pub(crate) const CONTAINS_GRAPHQL_ERROR: &str = "apollo::telemetry::contains_graphql_error";
 

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -55,8 +55,6 @@ mod tests;
 
 pub(crate) const AUTHENTICATION_SPAN_NAME: &str = "authentication_plugin";
 pub(crate) const APOLLO_AUTHENTICATION_JWT_CLAIMS: &str = "apollo::authentication::jwt_claims";
-pub(crate) const DEPRECATED_APOLLO_AUTHENTICATION_JWT_CLAIMS: &str =
-    "apollo_authentication::JWT::claims";
 const HEADER_TOKEN_TRUNCATED: &str = "(truncated)";
 
 const DEFAULT_AUTHENTICATION_NETWORK_TIMEOUT: Duration = Duration::from_secs(15);

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -52,15 +52,10 @@ pub(crate) mod authenticated;
 pub(crate) mod policy;
 pub(crate) mod scopes;
 
-pub(crate) const DEPRECATED_AUTHENTICATION_REQUIRED_KEY: &str =
-    "apollo_authorization::authenticated::required";
 pub(crate) const AUTHENTICATION_REQUIRED_KEY: &str =
     "apollo::authorization::authentication_required";
 pub(crate) const REQUIRED_SCOPES_KEY: &str = "apollo::authorization::required_scopes";
-pub(crate) const DEPRECATED_REQUIRED_SCOPES_KEY: &str = "apollo_authorization::scopes::required";
 pub(crate) const REQUIRED_POLICIES_KEY: &str = "apollo::authorization::required_policies";
-pub(crate) const DEPRECATED_REQUIRED_POLICIES_KEY: &str =
-    "apollo_authorization::policies::required";
 
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CacheKeyMetadata {

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -47,13 +47,9 @@ pub(crate) mod cost_calculator;
 pub(crate) mod strategy;
 
 pub(crate) const COST_ESTIMATED_KEY: &str = "apollo::demand_control::estimated_cost";
-pub(crate) const DEPRECATED_COST_ESTIMATED_KEY: &str = "cost.estimated";
 pub(crate) const COST_ACTUAL_KEY: &str = "apollo::demand_control::actual_cost";
-pub(crate) const DEPRECATED_COST_ACTUAL_KEY: &str = "cost.actual";
 pub(crate) const COST_RESULT_KEY: &str = "apollo::demand_control::result";
-pub(crate) const DEPRECATED_COST_RESULT_KEY: &str = "cost.result";
 pub(crate) const COST_STRATEGY_KEY: &str = "apollo::demand_control::strategy";
-pub(crate) const DEPRECATED_COST_STRATEGY_KEY: &str = "cost.strategy";
 
 /// Algorithm for calculating the cost of an incoming query.
 #[derive(Clone, Debug, Deserialize, JsonSchema)]

--- a/apollo-router/src/plugins/expose_query_plan.rs
+++ b/apollo-router/src/plugins/expose_query_plan.rs
@@ -25,13 +25,9 @@ use crate::services::supergraph;
 const EXPOSE_QUERY_PLAN_HEADER_NAME: &str = "Apollo-Expose-Query-Plan";
 const ENABLE_EXPOSE_QUERY_PLAN_ENV: &str = "APOLLO_EXPOSE_QUERY_PLAN";
 pub(crate) const QUERY_PLAN_CONTEXT_KEY: &str = "apollo::expose_query_plan::plan";
-pub(crate) const DEPRECATED_QUERY_PLAN_CONTEXT_KEY: &str = "experimental::expose_query_plan.plan";
 pub(crate) const FORMATTED_QUERY_PLAN_CONTEXT_KEY: &str =
     "apollo::expose_query_plan::formatted_plan";
-pub(crate) const DEPRECATED_FORMATTED_QUERY_PLAN_CONTEXT_KEY: &str =
-    "experimental::expose_query_plan.formatted_plan";
 pub(crate) const ENABLED_CONTEXT_KEY: &str = "apollo::expose_query_plan::enabled";
-pub(crate) const DEPRECATED_ENABLED_CONTEXT_KEY: &str = "experimental::expose_query_plan.enabled";
 
 #[derive(Debug, Clone)]
 struct ExposeQueryPlan {

--- a/apollo-router/src/plugins/progressive_override/mod.rs
+++ b/apollo-router/src/plugins/progressive_override/mod.rs
@@ -24,10 +24,8 @@ use crate::spec;
 use crate::spec::query::traverse;
 
 pub(crate) mod visitor;
-pub(crate) const DEPRECATED_UNRESOLVED_LABELS_KEY: &str = "apollo_override::unresolved_labels";
 pub(crate) const UNRESOLVED_LABELS_KEY: &str = "apollo::progressive_override::unresolved_labels";
 pub(crate) const LABELS_TO_OVERRIDE_KEY: &str = "apollo::progressive_override::labels_to_override";
-pub(crate) const DEPRECATED_LABELS_TO_OVERRIDE_KEY: &str = "apollo_override::labels_to_override";
 
 pub(crate) const JOIN_FIELD_DIRECTIVE_NAME: &str = "join__field";
 pub(crate) const JOIN_SPEC_BASE_URL: &str = "https://specs.apollo.dev/join";

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -171,14 +171,10 @@ pub(crate) mod utils;
 // Tracing consts
 pub(crate) const CLIENT_NAME: &str = "apollo::telemetry::client_name";
 pub(crate) const CLIENT_LIBRARY_NAME: &str = "apollo::telemetry::client_library_name";
-pub(crate) const DEPRECATED_CLIENT_NAME: &str = "apollo_telemetry::client_name";
 pub(crate) const CLIENT_VERSION: &str = "apollo::telemetry::client_version";
 pub(crate) const CLIENT_LIBRARY_VERSION: &str = "apollo::telemetry::client_library_version";
-pub(crate) const DEPRECATED_CLIENT_VERSION: &str = "apollo_telemetry::client_version";
 pub(crate) const SUBGRAPH_FTV1: &str = "apollo::telemetry::subgraph_ftv1";
-pub(crate) const DEPRECATED_SUBGRAPH_FTV1: &str = "apollo_telemetry::subgraph_ftv1";
 pub(crate) const STUDIO_EXCLUDE: &str = "apollo::telemetry::studio_exclude";
-pub(crate) const DEPRECATED_STUDIO_EXCLUDE: &str = "apollo_telemetry::studio::exclude";
 pub(crate) const SUPERGRAPH_SCHEMA_ID_CONTEXT_KEY: &str = "apollo::supergraph_schema_id";
 const GLOBAL_TRACER_NAME: &str = "apollo-router";
 const DEFAULT_EXPOSE_TRACE_ID_HEADER: &str = "apollo-trace-id";
@@ -513,10 +509,18 @@ impl PluginPrivate for Telemetry {
                         //  at the router service to modify the name and version.
                         let get_from_context =
                             |ctx: &Context, key| ctx.get::<&str, String>(key).ok().flatten();
-                        let client_name = get_from_context(&ctx, CLIENT_NAME)
-                            .or_else(|| get_from_context(&ctx, DEPRECATED_CLIENT_NAME));
-                        let client_version = get_from_context(&ctx, CLIENT_VERSION)
-                            .or_else(|| get_from_context(&ctx, DEPRECATED_CLIENT_VERSION));
+                        let client_name = get_from_context(&ctx, CLIENT_NAME).or_else(|| {
+                            get_from_context(
+                                &ctx,
+                                crate::context::deprecated::DEPRECATED_CLIENT_NAME,
+                            )
+                        });
+                        let client_version = get_from_context(&ctx, CLIENT_VERSION).or_else(|| {
+                            get_from_context(
+                                &ctx,
+                                crate::context::deprecated::DEPRECATED_CLIENT_VERSION,
+                            )
+                        });
                         custom_attributes.extend([
                             KeyValue::new(CLIENT_NAME_KEY, client_name.unwrap_or_default()),
                             KeyValue::new(CLIENT_VERSION_KEY, client_version.unwrap_or_default()),

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -52,7 +52,6 @@ pub(crate) type Plugins = IndexMap<String, Box<dyn QueryPlannerPlugin>>;
 pub(crate) type InMemoryCachePlanner =
     InMemoryCache<CachingQueryKey, Result<QueryPlannerContent, Arc<QueryPlannerError>>>;
 pub(crate) const APOLLO_OPERATION_ID: &str = "apollo::supergraph::operation_id";
-pub(crate) const DEPRECATED_APOLLO_OPERATION_ID: &str = "apollo_operation_id";
 
 /// Hashed value of query planner configuration for use in cache keys.
 #[derive(Clone, Hash, PartialEq, Eq)]

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -19,9 +19,7 @@ use crate::services::SupergraphResponse;
 const DONT_CACHE_RESPONSE_VALUE: &str = "private, no-cache, must-revalidate";
 static DONT_CACHE_HEADER_VALUE: HeaderValue = HeaderValue::from_static(DONT_CACHE_RESPONSE_VALUE);
 pub(crate) const PERSISTED_QUERY_CACHE_HIT: &str = "apollo::apq::cache_hit";
-pub(crate) const DEPRECATED_PERSISTED_QUERY_CACHE_HIT: &str = "persisted_query_hit";
 pub(crate) const PERSISTED_QUERY_REGISTERED: &str = "apollo::apq::registered";
-pub(crate) const DEPRECATED_PERSISTED_QUERY_REGISTERED: &str = "persisted_query_register";
 
 /// A persisted query.
 #[derive(Deserialize, Clone, Debug)]

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -88,8 +88,6 @@ use crate::spec::operation_limits::OperationLimits;
 use crate::uplink::license_enforcement::LicenseState;
 
 pub(crate) const FIRST_EVENT_CONTEXT_KEY: &str = "apollo::supergraph::first_event";
-pub(crate) const DEPRECATED_FIRST_EVENT_CONTEXT_KEY: &str =
-    "apollo_router::supergraph::first_event";
 
 /// An [`IndexMap`] of available plugins.
 pub(crate) type Plugins = IndexMap<String, Box<dyn DynPlugin>>;


### PR DESCRIPTION
<!-- [ROUTER-1077] -->

Also use a macro to declare the functions so we're sure that the conversion is always implemented both ways.

[ROUTER-1077]: https://apollographql.atlassian.net/browse/ROUTER-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ