### PR TITLE
Improve error message for invalid variables 

### DIFF
--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__invalid_input_enum-2.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__invalid_input_enum-2.snap
@@ -5,7 +5,7 @@ expression: response
 {
   "errors": [
     {
-      "message": "invalid type for variable: 'input'",
+      "message": "invalid input value at input: found JSON string for GraphQL InputEnum",
       "extensions": {
         "name": "input",
         "code": "VALIDATION_INVALID_TYPE_VARIABLE"

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__query_reconstruction.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__query_reconstruction.snap
@@ -5,7 +5,7 @@ expression: stream.next_response().await.unwrap()
 {
   "errors": [
     {
-      "message": "invalid type for variable: 'userId'",
+      "message": "invalid input value at userId: found JSON null for GraphQL ID!",
       "extensions": {
         "name": "userId",
         "code": "VALIDATION_INVALID_TYPE_VARIABLE"

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -12,8 +12,37 @@ use crate::spec::Schema;
 #[derive(Debug)]
 pub(crate) struct InvalidValue;
 
+/// {0}
+#[derive(thiserror::Error, displaydoc::Display, Debug, Clone, Serialize, Eq, PartialEq)]
+pub(crate) struct InvalidInputValue(pub(crate) String);
+
+fn describe_json_value(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "map",
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct FieldType(pub(crate) schema::Type);
+
+/// A path within a JSON object that doesn’t need heap allocation in the happy path
+pub(crate) type JsonValuePath<'a> = Option<&'a JsonValuePathElement<'a>>;
+
+pub(crate) enum JsonValuePathElement<'a> {
+    ObjectKey {
+        key: &'a str,
+        parent: JsonValuePath<'a>,
+    },
+    ArrayItem {
+        index: usize,
+        parent: JsonValuePath<'a>,
+    },
+}
 
 // schema::Type does not implement Serialize or Deserialize,
 // and <https://serde.rs/remote-derive.html> seems not to work for recursive types.
@@ -85,30 +114,51 @@ impl std::fmt::Display for FieldType {
     }
 }
 
+/// This function currently stops at the first error it finds.
+/// It may be nicer to return a `Vec` of errors, but its size should be limited
+/// in case e.g. every item of a large array is invalid.
 fn validate_input_value(
     ty: &schema::Type,
     value: &Value,
     schema: &Schema,
-) -> Result<(), InvalidValue> {
+    path: JsonValuePath<'_>,
+) -> Result<(), InvalidInputValue> {
+    let invalid = || {
+        let path = path
+            .map(|p| p as &dyn std::fmt::Display)
+            .unwrap_or(&"" as _);
+        InvalidInputValue(format!(
+            "invalid input value at {path}: found JSON {} for GraphQL {ty}",
+            describe_json_value(value)
+        ))
+    };
     if value.is_null() {
         return match ty {
             schema::Type::Named(_) | schema::Type::List(_) => Ok(()),
-            schema::Type::NonNullNamed(_) | schema::Type::NonNullList(_) => Err(InvalidValue),
+            schema::Type::NonNullNamed(_) | schema::Type::NonNullList(_) => Err(invalid()),
         };
     }
     let type_name = match ty {
         schema::Type::Named(name) | schema::Type::NonNullNamed(name) => name,
         schema::Type::List(inner_type) | schema::Type::NonNullList(inner_type) => {
-            return if let Value::Array(vec) = value {
-                vec.iter()
-                    .try_for_each(|x| validate_input_value(inner_type, x, schema))
+            if let Value::Array(vec) = value {
+                for (i, x) in vec.iter().enumerate() {
+                    let path = JsonValuePathElement::ArrayItem {
+                        index: i,
+                        parent: path,
+                    };
+                    validate_input_value(inner_type, x, schema, Some(&path))?
+                }
+                return Ok(());
             } else {
                 // For coercion from single value to list
-                validate_input_value(inner_type, value, schema)
-            };
+                return validate_input_value(inner_type, value, schema, path);
+            }
         }
     };
-    let from_bool = |condition| if condition { Ok(()) } else { Err(InvalidValue) };
+    let from_bool = |condition| {
+        if condition { Ok(()) } else { Err(invalid()) }
+    };
     match type_name.as_str() {
         "String" => return from_bool(value.is_string()),
         // Spec: https://spec.graphql.org/June2018/#sec-Int
@@ -129,7 +179,8 @@ fn validate_input_value(
         .supergraph_schema()
         .types
         .get(type_name)
-        .ok_or(InvalidValue)?;
+        // Should never happen in a valid schema
+        .ok_or_else(invalid)?;
     match (type_def, value) {
         // Custom scalar: accept any JSON value
         (schema::ExtendedType::Scalar(_), _) => Ok(()),
@@ -137,25 +188,29 @@ fn validate_input_value(
         (schema::ExtendedType::Enum(def), Value::String(s)) => {
             from_bool(def.values.contains_key(s.as_str()))
         }
-        (schema::ExtendedType::Enum(_), _) => Err(InvalidValue),
+        (schema::ExtendedType::Enum(_), _) => Err(invalid()),
 
         (schema::ExtendedType::InputObject(def), Value::Object(obj)) => {
             // TODO: check keys in `obj` but not in `def.fields`?
-            def.fields
-                .values()
-                .try_for_each(|field| match obj.get(field.name.as_str()) {
+            def.fields.values().try_for_each(|field| {
+                let path = JsonValuePathElement::ObjectKey {
+                    key: &field.name,
+                    parent: path,
+                };
+                match obj.get(field.name.as_str()) {
                     Some(&Value::Null) | None => {
                         let default = field
                             .default_value
                             .as_ref()
                             .and_then(|v| parse_hir_value(v))
                             .unwrap_or(Value::Null);
-                        validate_input_value(&field.ty, &default, schema)
+                        validate_input_value(&field.ty, &default, schema, Some(&path))
                     }
-                    Some(value) => validate_input_value(&field.ty, value, schema),
-                })
+                    Some(value) => validate_input_value(&field.ty, value, schema, Some(&path)),
+                }
+            })
         }
-        _ => Err(InvalidValue),
+        _ => Err(invalid()),
     }
 }
 
@@ -170,8 +225,9 @@ impl FieldType {
         &self,
         value: &Value,
         schema: &Schema,
-    ) -> Result<(), InvalidValue> {
-        validate_input_value(&self.0, value, schema)
+        path: JsonValuePath<'_>,
+    ) -> Result<(), InvalidInputValue> {
+        validate_input_value(&self.0, value, schema, path)
     }
 
     pub(crate) fn is_non_null(&self) -> bool {
@@ -182,6 +238,26 @@ impl FieldType {
 impl From<&'_ schema::Type> for FieldType {
     fn from(ty: &'_ schema::Type) -> Self {
         Self(ty.clone())
+    }
+}
+
+impl std::fmt::Display for JsonValuePathElement<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonValuePathElement::ObjectKey { key, parent } => {
+                if let Some(parent) = parent {
+                    parent.fmt(f)?;
+                    f.write_str(".")?;
+                }
+                f.write_str(key)
+            }
+            JsonValuePathElement::ArrayItem { index, parent } => {
+                if let Some(parent) = parent {
+                    parent.fmt(f)?;
+                }
+                write!(f, "[{index}]")
+            }
+        }
     }
 }
 

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -927,12 +927,19 @@ impl Query {
                         .get(name.as_str())
                         .or(default_value.as_ref())
                         .unwrap_or(&Value::Null);
-                    ty.validate_input_value(value, schema).err().map(|_| {
-                        FetchError::ValidationInvalidTypeVariable {
-                            name: name.as_str().to_string(),
-                        }
-                        .to_graphql_error(None)
-                    })
+                    let path = super::JsonValuePathElement::ObjectKey {
+                        key: name.as_str(),
+                        parent: None,
+                    };
+                    ty.validate_input_value(value, schema, Some(&path))
+                        .err()
+                        .map(|message| {
+                            FetchError::ValidationInvalidTypeVariable {
+                                name: name.clone(),
+                                message,
+                            }
+                            .to_graphql_error(None)
+                        })
                 },
             )
             .collect::<Vec<_>>();

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -589,6 +589,108 @@ async fn missing_variables() {
     assert_eq!(response.errors, expected);
 }
 
+/// <https://github.com/apollographql/router/issues/2984>
+#[tokio::test(flavor = "multi_thread")]
+async fn input_object_variable_validation() {
+    let schema = r#"
+        schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+        {
+          query: Query
+        }
+
+        directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+        directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+        directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+        directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+        directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+        directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+        input CoordinatesInput
+          @join__type(graph: SUBGRAPH1)
+        {
+          latitude: Float!
+          longitude: Float!
+        }
+
+        scalar join__FieldSet
+
+        enum join__Graph {
+          SUBGRAPH1 @join__graph(name: "subgraph1", url: "http://localhost:4001")
+        }
+
+        scalar link__Import
+
+        enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
+
+        input MyInput
+          @join__type(graph: SUBGRAPH1)
+        {
+          coordinates: CoordinatesInput
+        }
+
+        type Query
+          @join__type(graph: SUBGRAPH1)
+        {
+          getData(params: MyInput): Int
+        }
+    "#;
+    let request = apollo_router::services::supergraph::Request::fake_builder()
+        .query("query($x: MyInput) { getData(params: $x) }")
+        .variable(
+            "x",
+            json!({"coordinates": {"latitude": 45.5, "longitude": null}}),
+        )
+        .build()
+        .unwrap();
+    let response = apollo_router::TestHarness::builder()
+        .schema(schema)
+        .build_supergraph()
+        .await
+        .unwrap()
+        .oneshot(request)
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap();
+    insta::assert_debug_snapshot!(&response.errors, @r###"
+    [
+        Error {
+            message: "invalid type for variable: 'x'",
+            locations: [],
+            path: None,
+            extensions: {
+                "name": String(
+                    "x",
+                ),
+                "code": String(
+                    "VALIDATION_INVALID_TYPE_VARIABLE",
+                ),
+            },
+        },
+    ]
+    "###);
+}
+
 const PARSER_LIMITS_TEST_QUERY: &str =
     r#"{ me { reviews { author { reviews { author { name } } } } } }"#;
 const PARSER_LIMITS_TEST_QUERY_TOKEN_COUNT: usize = 36;

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -644,7 +644,7 @@ async fn input_object_variable_validation() {
         input MyInput
           @join__type(graph: SUBGRAPH1)
         {
-          coordinates: CoordinatesInput
+          coordinates: [CoordinatesInput]
         }
 
         type Query
@@ -657,7 +657,7 @@ async fn input_object_variable_validation() {
         .query("query($x: MyInput) { getData(params: $x) }")
         .variable(
             "x",
-            json!({"coordinates": {"latitude": 45.5, "longitude": null}}),
+            json!({"coordinates": [{"latitude": 45.5, "longitude": null}]}),
         )
         .build()
         .unwrap();
@@ -675,7 +675,7 @@ async fn input_object_variable_validation() {
     insta::assert_debug_snapshot!(&response.errors, @r###"
     [
         Error {
-            message: "invalid type for variable: 'x'",
+            message: "invalid input value at x.coordinates[0].longitude: found JSON null for GraphQL Float!",
             locations: [],
             path: None,
             extensions: {


### PR DESCRIPTION
Example:

```diff
-invalid type for variable: 'x'
+invalid input value at x.coordinates[0].longitude: found JSON null for GraphQL Float!
```

Fixes https://github.com/apollographql/router/issues/2984

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
