### PR TITLE
chore(ci): codecov on macOS in CI nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ executors:
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: "15.4.0"
-    resource_class: macos.m1.large.gen1
+    resource_class: m2pro.large
     environment:
       MISE_ENV: ci,ci-mac
   macos_test: &macos_test_executor
@@ -62,7 +62,7 @@ executors:
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: "15.4.0"
-    resource_class: macos.m1.large.gen1
+    resource_class: m2pro.large
     environment:
       MISE_ENV: ci,ci-mac
   windows_build: &windows_build_executor
@@ -92,6 +92,9 @@ parameters:
     type: string
     default: '{{ checksum ".circleci/config.yml" }}-v3-{{ checksum "~/.arch" }}-{{ checksum ".config/mise/config.toml" }}-{{ checksum "rust-toolchain.toml" }}-{{ checksum "~/.xtask_version" }}-{{ checksum "~/.merge_version" }}'
   nightly:
+    type: boolean
+    default: false
+  coverage:
     type: boolean
     default: false
   # quick_nightly will skip testing and only build the release artifacts.
@@ -407,6 +410,25 @@ commands:
   # fuzz_build:
   #   steps:
   #     - run: cargo +nightly fuzz build
+  do_coverage:
+    parameters:
+      variant:
+        type: string
+        default: "default"
+    steps:
+      - run:
+          name: Run coverage
+          environment:
+            # Use the settings from the "ci" profile in nextest configuration.
+            NEXTEST_PROFILE: ci
+          command: cargo llvm-cov nextest --ignore-run-fail --codecov --output-path codecov_report.json
+      - run:
+          name: Upload coverage report
+          command: |
+            # Upload the coverage report to Codecov.
+            codecov-cli --auto-load-params-from CircleCI upload-process --file ./codecov_report.json --token "${CODECOV_TOKEN}"
+      - store_artifacts:
+          path: ./codecov_report.json
 
 jobs:
   lint:
@@ -461,6 +483,9 @@ jobs:
       fuzz:
         type: boolean
         default: false
+      coverage:
+        type: boolean
+        default: false
     executor: << parameters.platform >>
     steps:
       - checkout
@@ -475,6 +500,18 @@ jobs:
       #         - equal: [ *arm_linux_test_executor, << parameters.platform >> ]
       #     steps:
       #       - fuzz_build
+  coverage:
+    environment:
+      <<: *common_job_environment
+    parameters:
+      platform:
+        type: executor
+    executor: << parameters.platform >>
+    steps:
+      - checkout
+      - setup_environment:
+          platform: << parameters.platform >>
+      - do_coverage
 
   test_updated:
     environment:
@@ -914,7 +951,6 @@ workflows:
             parameters:
               platform:
                 [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
-
   quick-nightly:
     when: << pipeline.parameters.quick_nightly >>
     jobs:
@@ -927,6 +963,14 @@ workflows:
             parameters:
               platform:
                 [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
+  coverage_only:
+    when: << pipeline.parameters.coverage >>
+    jobs:
+      - coverage:
+          matrix:
+            parameters:
+              platform:
+                [ macos_test ]
   nightly:
     when: << pipeline.parameters.nightly >>
     jobs:
@@ -949,9 +993,15 @@ workflows:
             parameters:
               platform:
                 [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
+      - coverage:
+          matrix:
+            parameters:
+              platform:
+                [ macos_test ]
       - build_release:
           requires:
             - test
+            - coverage
             - check_helm
             - check_compliance
           nightly: true

--- a/.config/mise/config.ci-mac.toml
+++ b/.config/mise/config.ci-mac.toml
@@ -1,3 +1,5 @@
 [tools]
 # renovate-automation: rustc version
-rust = { version = "1.85.1", targets = "x86_64-apple-darwin,aarch64-apple-darwin" }
+rust = { version = "1.85.1", targets = "x86_64-apple-darwin,aarch64-apple-darwin", profile = "default", components = "llvm-tools" }
+"cargo:cargo-llvm-cov" = "0.6.16"
+"ubi:codecov/codecov-cli" = "10.4.0"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,6 +48,10 @@ docker-compose up -d
 have issues and you want to see the logs or if you want to run the service
 in foreground.
 
+### Testing
+
+Tests on this repository are run using [nextest](https://nexte.st/).
+
 ### Run against the docker-compose or Node.js setup
 
 Once the subgraphs are up and running, run the router with this command:
@@ -101,7 +105,7 @@ cargo build --profile release-dhat --features dhat-heap,dhat-ad-hoc
 e.g.: heap allocation tracing
 
 ```shell
-cargo build --profile release-dhat --features dhat-heap 
+cargo build --profile release-dhat --features dhat-heap
 ```
 
 This will create a router in `./target/release-dhat`, which can be run with:
@@ -117,6 +121,18 @@ For more details on interpreting these files and running tests, see the [dhat-rs
 ### Troubleshoot
 
 * If you have an issue with rust-analyzer reporting an unresolved import about `derivative::Derivative` [check this solution](https://github.com/rust-analyzer/rust-analyzer/issues/7459#issuecomment-876796459) found in a rust-analyzer issue.
+
+### Code coverage
+
+Code coverage is run in CI nightly, but not done on every commit.  To view coverage from nightly runs visit [our coverage on Codecov](https://codecov.io/gh/apollographql/router).
+
+To run code coverage locally, you can `cargo install cargo-llvm-cov`, and run:
+
+```shell
+cargo llvm-cov nextest -- --summary
+```
+
+For full information on available options, including HTML reports and `lcov.info` file support, see [nextest documentation](https://nexte.st/book/coverage.html) and [cargo llvm-cov documentation](https://github.com/taiki-e/cargo-llvm-cov#get-coverage-of-cc-code-linked-to-rust-librarybinary).
 
 ## Project maintainers
 


### PR DESCRIPTION
This makes CI work on macOS on *nightly* builds.  Overall, the process of
running codecov on Rust codebases of this size is pretty slow.

It roughly doubled the test run on macOS when it was part of the tests
directly, and it wouldn't even run on most of our Linux boxes due to the
amount of memory that llvm-cov chews up in the process.

To account for that, but still get some coverage numbers, we'll go ahead and
introduce this as a nightly step that lets us get the code coverage once a
day, or on demand as we need it.  To do it on demand on a particular pull
request, this commit also introduces a "triggerable" job on CircleCI called
"coverage_only".

Developers can of course run codecov locally using `cargo llvm-cov nextest`.
