### PR TITLE
Add failing test for `@defer` on renamed root type

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
@@ -3478,3 +3478,51 @@ fn defer_test_the_path_in_defer_includes_traversed_fragments() {
     "###
     );
 }
+
+#[test]
+fn defer_on_renamed_root_type() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type MyQuery {
+            thing: Thing
+          }
+
+          type Thing {
+            i: Int
+          }
+
+          schema { query: MyQuery }
+          "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+        {
+          ... @defer {
+            thing { i }
+          }
+        }
+        "#,
+        @r#"
+    QueryPlan {
+      Defer {
+        Primary {}, [
+          Deferred(depends: [], path: "") {
+            { thing { i } }:
+            Flatten(path: "") {
+              Fetch(service: "Subgraph1") {
+                {
+                  thing {
+                    i
+                  }
+                }
+              },
+            },
+          },
+        ]
+      },
+    }
+    "#
+    );
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_on_renamed_root_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_on_renamed_root_type.graphql
@@ -1,0 +1,66 @@
+# Composed from subgraphs with hash: 342e57c5d2c95caa99ea85f70fdd3114d65d6ca7
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  thing: Thing
+}
+
+type Thing
+  @join__type(graph: SUBGRAPH1)
+{
+  i: Int
+}


### PR DESCRIPTION
If the root query type is not named `Query` in a subgraph, and you use `@defer` at the root, the query planner produces a subgraph query like this:

```graphql
{
  ... on Query {
    thing { i }
  }
}
```

Normally the `on Query` fragment would be flattened, but the type name in the subgraph is not `Query`, so it doesn't. The subgraph will then fail validation because the `Query` type does not exist.