### PR TITLE
docs: Recommend wss over ws for WebSocket communication with subgraphs.

### DIFF
--- a/docs/source/routing/operations/subscriptions/configuration.mdx
+++ b/docs/source/routing/operations/subscriptions/configuration.mdx
@@ -43,7 +43,11 @@ After you complete these prerequisites, you can safely [configure your router](#
 
 After completing all [prerequisites](#prerequisites), in your router's [YAML config file](/router/configuration/overview/#yaml-config-file), you configure how the router communicates with each of your subgraphs when executing GraphQL subscriptions.
 
-The router supports two popular [WebSocket protocols](#websocket-setup) for subscriptions, and it also provides support for an [HTTP-callback-based protocol](#http-callback-setup). Your router must use whichever protocol is expected by each subgraph.
+When communicating with subgraphs, the router will use routing URLs defined in the supergraph or, if specified, the router YAML config. The router supports two popular [WebSocket protocols](#websocket-setup) for subscriptions, and it also provides support for an [HTTP-callback-based protocol](#http-callback-setup). Your router must use whichever protocol is expected by each subgraph.
+
+<Note>
+Use `wss://` (WebSocket Secure) instead of `ws://` to encrypt data transmission between the router and subgraphs, providing similar security benefits as using `https://` over `http://`.
+</Note>
 
 ### WebSocket setup
 


### PR DESCRIPTION
This pull request updates the documentation for configuring GraphQL subscriptions in the router. The changes clarify how the router communicates with subgraphs and emphasizes using secure communication practices.  Of course, actual deployments vary and it may not be necessary to use `wss://` over `ws://` (much like `https://` vs `http://`) if you're on a secure local network.

Documentation updates:

* [`docs/source/routing/operations/subscriptions/configuration.mdx`](diffhunk://#diff-83cd99e381c9151daff89360ab08516eae44ec545bcbe38d4d8dbc634cc84d1bL46-R50): Updated the description to specify that the router uses routing URLs defined in the supergraph or the router's YAML configuration. Added a note recommending the use of `wss://` (WebSocket Secure) instead of `ws://` to ensure encrypted data transmission between the router and subgraphs.

<!-- [OE-825] -->

[OE-825]: https://apollographql.atlassian.net/browse/OE-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ