### PR TITLE
fix(docs): correct mention of schema load duration to `apollo.router.…

### DIFF
--- a/.changesets/docs_lrlna_schema_load_duration.md
+++ b/.changesets/docs_lrlna_schema_load_duration.md
@@ -1,0 +1,5 @@
+### Fix incorrect reference to `apollo.router.schema.load.duration` metric in the docs([PR #7581](https://github.com/apollographql/router/pull/7581))
+
+The [in-memory cache documentation](https://www.apollographql.com/docs/graphos/routing/performance/caching/in-memory#cache-warm-up) was referencing an incorrect metric to track schema load times. Previously it was referred to as `apollo.router.schema.loading.time`, where the metric being emitted by the router since router@2.0.0 is `apollo.router.schema.load.duration`. This is now fixed in the docs.  
+
+By [@lrlna](https://github.com/lrlna) in https://github.com/apollographql/router/pull/7581

--- a/docs/source/routing/performance/caching/in-memory.mdx
+++ b/docs/source/routing/performance/caching/in-memory.mdx
@@ -72,7 +72,7 @@ To get more information on the planning and warm-up process use the following me
 
 * histograms:
   * `apollo.router.query_planning.plan.duration`: time spent planning queries
-  * `apollo.router.schema.loading.time`: time spent loading a schema
+  * `apollo.router.schema.load.duration`: time spent loading a schema
   * `apollo.router.cache.hit.time{kind="query planner", storage="<storage>"}`: time to get a value from the cache
   * `apollo.router.cache.miss.time{kind="query planner", storage="<storage>"}`
 
@@ -81,7 +81,7 @@ To get more information on the planning and warm-up process use the following me
   * `apollo.router.cache.storage.estimated_size{kind="query planner", storage="memory"}`: estimated storage size of the cache (only for in-memory query planner cache)
 
 Typically, we would look at `apollo.router.cache.size` and the cache hit rate to define the right size of the in memory cache,
-then look at `apollo.router.schema.loading.time` and `apollo.router.query_planning.plan.duration` to decide how much time we want to spend warming up queries.
+then look at `apollo.router.schema.load.duration` and `apollo.router.query_planning.plan.duration` to decide how much time we want to spend warming up queries.
 
 #### Cache warm-up with distributed caching
 


### PR DESCRIPTION
The [in-memory cache documentation](https://www.apollographql.com/docs/graphos/routing/performance/caching/in-memory#cache-warm-up) was referencing an incorrect metric to track schema load times. Previously it was referred to as `apollo.router.schema.loading.time`, where the metric being emitted by the router since router@2.0.0 is `apollo.router.schema.load.duration`. This is now fixed in the docs.  

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
