### PR TITLE
feat(federation): ported `checkFeatureSupport` function and its tests

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -248,7 +248,7 @@ fn load_supergraph_file(
     file_path: &Path,
 ) -> Result<apollo_federation::Supergraph, FederationError> {
     let doc_str = read_input(file_path);
-    apollo_federation::Supergraph::new(&doc_str)
+    apollo_federation::Supergraph::new_with_router_specs(&doc_str)
 }
 
 /// Load either single supergraph schema file or compose one from multiple subgraph files.
@@ -402,7 +402,7 @@ fn cmd_expand(
     // what specific portion of the expansion process failed. Work will need to be
     // done to expansion to allow for returning an error type that carries the error
     // and the expanded subgraph as seen until the error.
-    let expanded = Supergraph::new(&raw_sdl)?;
+    let expanded = Supergraph::new_with_router_specs(&raw_sdl)?;
 
     let subgraphs = expanded.extract_subgraphs()?;
     if let Some(dest) = dest {

--- a/apollo-federation/examples/api_schema.rs
+++ b/apollo-federation/examples/api_schema.rs
@@ -14,7 +14,7 @@ fn main() -> ExitCode {
     let schema = Schema::parse_and_validate(source, name).unwrap();
     let supergraph = Supergraph::from_schema(
         schema,
-        Some(&apollo_federation::DEFAULT_SUPPORTED_SUPERGRAPH_SPECS),
+        Some(apollo_federation::default_supported_supergraph_specs()),
     )
     .unwrap();
 

--- a/apollo-federation/examples/api_schema.rs
+++ b/apollo-federation/examples/api_schema.rs
@@ -14,7 +14,7 @@ fn main() -> ExitCode {
     let schema = Schema::parse_and_validate(source, name).unwrap();
     let supergraph = Supergraph::from_schema(
         schema,
-        Some(apollo_federation::default_supported_supergraph_specs()),
+        Some(&apollo_federation::default_supported_supergraph_specs()),
     )
     .unwrap();
 

--- a/apollo-federation/examples/api_schema.rs
+++ b/apollo-federation/examples/api_schema.rs
@@ -12,7 +12,11 @@ fn main() -> ExitCode {
     };
 
     let schema = Schema::parse_and_validate(source, name).unwrap();
-    let supergraph = Supergraph::from_schema(schema).unwrap();
+    let supergraph = Supergraph::from_schema(
+        schema,
+        Some(&apollo_federation::DEFAULT_SUPPORTED_SUPERGRAPH_SPECS),
+    )
+    .unwrap();
 
     match supergraph.to_api_schema(Default::default()) {
         Ok(result) => println!("{}", result.schema()),

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -760,6 +760,16 @@ impl MultipleFederationErrors {
         }
     }
 
+    pub(crate) fn and_try(mut self, other: Result<(), FederationError>) -> Self {
+        match other {
+            Ok(_) => self,
+            Err(e) => {
+                self.push(e);
+                self
+            }
+        }
+    }
+
     pub(crate) fn unwrap_subgraph_errors(self, expected_subgraph: &str) -> Self {
         Self {
             errors: self

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -51,6 +51,7 @@ use apollo_compiler::validation::Valid;
 use itertools::Itertools;
 use link::join_spec_definition::JOIN_VERSIONS;
 use schema::FederationSchema;
+use strum::IntoEnumIterator;
 
 pub use crate::api_schema::ApiSchemaOptions;
 use crate::error::FederationError;
@@ -77,7 +78,6 @@ use crate::merge::MergeFailure;
 use crate::merge::merge_subgraphs;
 use crate::schema::ValidFederationSchema;
 use crate::sources::connect::ConnectSpec;
-use crate::sources::connect::spec::CONNECT_VERSIONS;
 use crate::subgraph::ValidSubgraph;
 pub use crate::supergraph::ValidFederationSubgraph;
 pub use crate::supergraph::ValidFederationSubgraphs;
@@ -249,7 +249,7 @@ pub fn router_supported_supergraph_specs() -> Vec<Url> {
         .chain(urls(&POLICY_VERSIONS))
         .chain(urls(&CONTEXT_VERSIONS))
         .chain(urls(&COST_VERSIONS))
-        .chain(CONNECT_VERSIONS.into_iter().map(|s| s.url()))
+        .chain(ConnectSpec::iter().map(|s| s.url()))
         .collect()
 }
 

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -142,7 +142,6 @@ pub struct Supergraph {
 }
 
 impl Supergraph {
-    /// For tests only.
     pub fn new_with_spec_check(
         schema_str: &str,
         supported_specs: &[&str],
@@ -151,16 +150,14 @@ impl Supergraph {
         Self::from_schema(schema, Some(supported_specs))
     }
 
-    /// For tests only.
-    pub fn new_without_spec_check(schema_str: &str) -> Result<Self, FederationError> {
-        let schema = Schema::parse_and_validate(schema_str, "schema.graphql")?;
-        Self::from_schema(schema, None)
-    }
-
     /// Same as `new_with_spec_check(...)` with the default set of supported specs.
-    /// For tests only.
     pub fn new(schema_str: &str) -> Result<Self, FederationError> {
         Self::new_with_spec_check(schema_str, &DEFAULT_SUPPORTED_SUPERGRAPH_SPECS)
+    }
+
+    /// Same as `new_with_spec_check(...)` with the specs supported by Router.
+    pub fn new_with_router_specs(schema_str: &str) -> Result<Self, FederationError> {
+        Self::new_with_spec_check(schema_str, &ROUTER_SUPPORTED_SUPERGRAPH_SPECS)
     }
 
     /// Construct from a pre-validation supergraph schema, which will be validated.

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -233,7 +233,7 @@ pub const DEFAULT_SUPPORTED_SUPERGRAPH_SPECS: [&str; 12] = [
     "https://specs.apollo.dev/inaccessible/v0.2",
 ];
 
-pub const ROUTER_SUPPORTED_SUPERGRAPH_SPECS: [&str; 20] = [
+pub const ROUTER_SUPPORTED_SUPERGRAPH_SPECS: [&str; 22] = [
     "https://specs.apollo.dev/core/v0.1",
     "https://specs.apollo.dev/core/v0.2",
     "https://specs.apollo.dev/join/v0.1",
@@ -248,6 +248,7 @@ pub const ROUTER_SUPPORTED_SUPERGRAPH_SPECS: [&str; 20] = [
     "https://specs.apollo.dev/inaccessible/v0.2",
     // Additional specs for Router below:
     "https://specs.apollo.dev/authenticated/v0.1",
+    "https://specs.apollo.dev/authenticated/v0.2",
     "https://specs.apollo.dev/requiresScopes/v0.1",
     "https://specs.apollo.dev/policy/v0.1",
     "https://specs.apollo.dev/source/v0.1",
@@ -255,6 +256,7 @@ pub const ROUTER_SUPPORTED_SUPERGRAPH_SPECS: [&str; 20] = [
     "https://specs.apollo.dev/cost/v0.1",
     "https://specs.apollo.dev/connect/v0.1",
     "https://specs.apollo.dev/connect/v0.2",
+    "https://specs.apollo.dev/connect/v0.3",
 ];
 
 fn is_core_version_zero_dot_one(url: &Url) -> bool {

--- a/apollo-federation/src/link/spec.rs
+++ b/apollo-federation/src/link/spec.rs
@@ -133,7 +133,7 @@ impl Identity {
 }
 
 /// The version of a `@link` specification, in the form of a major and minor version numbers.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct Version {
     /// The major number part of the version.
     pub major: u32,
@@ -209,7 +209,7 @@ impl Version {
 }
 
 /// A `@link` specification url, which identifies a specific version of a specification.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Url {
     /// The identity of the `@link` specification pointed by this url.
     pub identity: Identity,

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -204,6 +204,10 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
         self.definitions.keys()
     }
 
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Version, &T)> {
+        self.definitions.iter()
+    }
+
     pub(crate) fn get_minimum_required_version(
         &'static self,
         federation_version: &Version,

--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -9,7 +9,6 @@ use itertools::Itertools;
 use multimap::MultiMap;
 
 use crate::ApiSchemaOptions;
-use crate::ROUTER_SUPPORTED_SUPERGRAPH_SPECS;
 use crate::Supergraph;
 use crate::ValidFederationSubgraph;
 use crate::error::FederationError;
@@ -62,8 +61,7 @@ pub fn expand_connectors(
         return Ok(ExpansionResult::Unchanged);
     }
 
-    let supergraph =
-        Supergraph::new_with_spec_check(supergraph_str, &ROUTER_SUPPORTED_SUPERGRAPH_SPECS)?;
+    let supergraph = Supergraph::new_with_router_specs(supergraph_str)?;
     let api_schema = supergraph.to_api_schema(api_schema_options.clone())?;
 
     let (connect_subgraphs, graphql_subgraphs): (Vec<_>, Vec<_>) = supergraph

--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use multimap::MultiMap;
 
 use crate::ApiSchemaOptions;
+use crate::ROUTER_SUPPORTED_SUPERGRAPH_SPECS;
 use crate::Supergraph;
 use crate::ValidFederationSubgraph;
 use crate::error::FederationError;
@@ -61,7 +62,8 @@ pub fn expand_connectors(
         return Ok(ExpansionResult::Unchanged);
     }
 
-    let supergraph = Supergraph::new(supergraph_str)?;
+    let supergraph =
+        Supergraph::new_with_spec_check(supergraph_str, &ROUTER_SUPPORTED_SUPERGRAPH_SPECS)?;
     let api_schema = supergraph.to_api_schema(api_schema_options.clone())?;
 
     let (connect_subgraphs, graphql_subgraphs): (Vec<_>, Vec<_>) = supergraph

--- a/apollo-federation/src/sources/connect/spec/mod.rs
+++ b/apollo-federation/src/sources/connect/spec/mod.rs
@@ -186,3 +186,6 @@ impl From<ConnectSpec> for Version {
         }
     }
 }
+
+pub(crate) const CONNECT_VERSIONS: [ConnectSpec; 3] =
+    [ConnectSpec::V0_1, ConnectSpec::V0_2, ConnectSpec::V0_3];

--- a/apollo-federation/src/sources/connect/spec/mod.rs
+++ b/apollo-federation/src/sources/connect/spec/mod.rs
@@ -186,6 +186,3 @@ impl From<ConnectSpec> for Version {
         }
     }
 }
-
-pub(crate) const CONNECT_VERSIONS: [ConnectSpec; 3] =
-    [ConnectSpec::V0_1, ConnectSpec::V0_2, ConnectSpec::V0_3];

--- a/apollo-federation/tests/core_test.rs
+++ b/apollo-federation/tests/core_test.rs
@@ -1,0 +1,422 @@
+// PORT_NOTE: This file ports `gateway-js/src/core/__tests__/core.test.ts`.
+use apollo_federation::Supergraph;
+
+mod core_v0_1 {
+    use super::*;
+
+    #[test]
+    fn throws_no_errors_when_using_a_valid_core_v0_1_document() {
+        let sdl = r#"
+            schema
+                @core(feature: "https://specs.apollo.dev/core/v0.1")
+                @core(feature: "https://specs.apollo.dev/join/v0.1") {
+                query: Query
+            }
+
+            directive @core(feature: String!) repeatable on SCHEMA
+
+            directive @join__field(
+                graph: join__Graph
+                requires: join__FieldSet
+                provides: join__FieldSet
+            ) on FIELD_DEFINITION
+
+            directive @join__type(
+                graph: join__Graph!
+                key: join__FieldSet
+            ) repeatable on OBJECT | INTERFACE
+
+            directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            directive @tag(
+                name: String!
+            ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            enum CacheControlScope {
+                PRIVATE
+                PUBLIC
+            }
+
+            scalar join__FieldSet
+
+            enum join__Graph {
+                WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
+            }
+
+            type Query {
+                hello: String! @join__field(graph: WORLD)
+            }
+        "#;
+        Supergraph::new(sdl).expect("parse and validate");
+    }
+
+    #[test]
+    fn throws_error_when_for_argument_is_used_in_core_v0_1_document() {
+        let sdl = r#"
+            schema
+                @core(feature: "https://specs.apollo.dev/core/v0.1")
+                @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
+                @core(
+                    feature: "https://specs.apollo.dev/something-unsupported/v0.1"
+                    for: SECURITY
+                ) {
+                query: Query
+            }
+
+            directive @core(feature: String!) repeatable on SCHEMA
+
+            directive @join__field(
+                graph: join__Graph
+                requires: join__FieldSet
+                provides: join__FieldSet
+            ) on FIELD_DEFINITION
+
+            directive @join__type(
+                graph: join__Graph!
+                key: join__FieldSet
+            ) repeatable on OBJECT | INTERFACE
+
+            directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            directive @tag(
+                name: String!
+            ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            enum CacheControlScope {
+                PRIVATE
+                PUBLIC
+            }
+
+            scalar join__FieldSet
+
+            enum join__Graph {
+                WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
+            }
+
+            type Query {
+                hello: String! @join__field(graph: WORLD)
+            }
+        "#;
+
+        let err = Supergraph::new(sdl).expect_err("parsing schema with unsupported feature");
+        // PORT_NOTE: The JS version delays schema validation so `checkFeatureSupport` function can
+        //            specialize the error for core v0.1. However, in Rust version, the schema
+        //            validation happens eagerly and generates the error below without
+        //            specialization.
+        insta::assert_snapshot!(
+            err.to_string(),
+            @r###"
+        The following errors occurred:
+          - Error: the argument `for` is not supported by `@core`
+               ╭─[ schema.graphql:4:70 ]
+               │
+             4 │                 @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
+               │                 ──────────────────────────────────┬─────────────────────────┬───────  
+               │                                                   ╰─────────────────────────────────── @core defined here
+               │                                                                             │         
+               │                                                                             ╰───────── argument by this name not found
+            ───╯
+            
+          - Error: the argument `for` is not supported by `@core`
+               ╭─[ schema.graphql:7:21 ]
+               │
+             5 │ ╭─▶                 @core(
+               ┆ ┆   
+             7 │ │                       for: SECURITY
+               │ │                       ──────┬──────  
+               │ │                             ╰──────── argument by this name not found
+             8 │ ├─▶                 ) {
+               │ │                         
+               │ ╰───────────────────────── @core defined here
+            ───╯
+        "###,
+        );
+    }
+}
+
+mod core_v0_2 {
+    use super::*;
+
+    #[test]
+    fn does_not_throw_errors_when_using_supported_features() {
+        let sdl = r#"
+            schema
+                @core(feature: "https://specs.apollo.dev/core/v0.2")
+                @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
+                @core(feature: "https://specs.apollo.dev/tag/v0.2") {
+                query: Query
+            }
+
+            directive @core(
+                feature: String!
+                as: String
+                for: core__Purpose
+            ) repeatable on SCHEMA
+
+            directive @join__field(
+                graph: join__Graph
+                requires: join__FieldSet
+                provides: join__FieldSet
+            ) on FIELD_DEFINITION
+
+            directive @join__type(
+                graph: join__Graph!
+                key: join__FieldSet
+            ) repeatable on OBJECT | INTERFACE
+
+            directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            directive @tag(
+                name: String!
+            ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            enum CacheControlScope {
+                PRIVATE
+                PUBLIC
+            }
+
+            enum core__Purpose {
+                """
+                `EXECUTION` features provide metadata necessary to for operation execution.
+                """
+                EXECUTION
+
+                """
+                `SECURITY` features provide metadata necessary to securely resolve fields.
+                """
+                SECURITY
+            }
+
+            scalar join__FieldSet
+
+            enum join__Graph {
+                WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
+            }
+
+            type Query {
+                hello: String! @join__field(graph: WORLD)
+            }
+        "#;
+
+        Supergraph::new(sdl).expect("parse and validate");
+    }
+
+    #[test]
+    fn does_not_throw_errors_when_using_unsupported_features_with_no_for_argument() {
+        let sdl = r#"
+            schema
+                @core(feature: "https://specs.apollo.dev/core/v0.2")
+                @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
+                @core(feature: "https://specs.apollo.dev/tag/v0.2")
+                @core(feature: "https://specs.apollo.dev/unsupported-feature/v0.1") {
+                query: Query
+            }
+
+            directive @core(
+                feature: String!
+                as: String
+                for: core__Purpose
+            ) repeatable on SCHEMA
+
+            directive @join__field(
+                graph: join__Graph
+                requires: join__FieldSet
+                provides: join__FieldSet
+            ) on FIELD_DEFINITION
+
+            directive @join__type(
+                graph: join__Graph!
+                key: join__FieldSet
+            ) repeatable on OBJECT | INTERFACE
+
+            directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            directive @tag(
+                name: String!
+            ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            enum CacheControlScope {
+                PRIVATE
+                PUBLIC
+            }
+
+            enum core__Purpose {
+                """
+                `EXECUTION` features provide metadata necessary to for operation execution.
+                """
+                EXECUTION
+
+                """
+                `SECURITY` features provide metadata necessary to securely resolve fields.
+                """
+                SECURITY
+            }
+
+            scalar join__FieldSet
+
+            enum join__Graph {
+                WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
+            }
+
+            type Query {
+                hello: String! @join__field(graph: WORLD)
+            }
+        "#;
+
+        Supergraph::new(sdl).expect("parse and validate");
+    }
+
+    #[test]
+    fn throws_errors_when_using_unsupported_features_for_execution() {
+        let sdl = r#"
+            schema
+                @core(feature: "https://specs.apollo.dev/core/v0.2")
+                @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
+                @core(
+                    feature: "https://specs.apollo.dev/unsupported-feature/v0.1"
+                    for: EXECUTION
+                ) {
+                query: Query
+            }
+
+            directive @core(
+                feature: String!
+                as: String
+                for: core__Purpose
+            ) repeatable on SCHEMA
+
+            directive @join__field(
+                graph: join__Graph
+                requires: join__FieldSet
+                provides: join__FieldSet
+            ) on FIELD_DEFINITION
+
+            directive @join__type(
+                graph: join__Graph!
+                key: join__FieldSet
+            ) repeatable on OBJECT | INTERFACE
+
+            directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            directive @tag(
+                name: String!
+            ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            enum CacheControlScope {
+                PRIVATE
+                PUBLIC
+            }
+
+            enum core__Purpose {
+                """
+                `EXECUTION` features provide metadata necessary to for operation execution.
+                """
+                EXECUTION
+
+                """
+                `SECURITY` features provide metadata necessary to securely resolve fields.
+                """
+                SECURITY
+            }
+
+            scalar join__FieldSet
+
+            enum join__Graph {
+                WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
+            }
+
+            type Query {
+                hello: String! @join__field(graph: WORLD)
+            }
+        "#;
+
+        let err = Supergraph::new(sdl).expect_err("should error on validation");
+        assert_eq!(
+            err.to_string(),
+            "feature https://specs.apollo.dev/unsupported-feature/v0.1 is for: EXECUTION but is unsupported",
+        );
+    }
+
+    #[test]
+    fn throws_errors_when_using_unsupported_features_for_security() {
+        let sdl = r#"
+            schema
+                @core(feature: "https://specs.apollo.dev/core/v0.2")
+                @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
+                @core(
+                    feature: "https://specs.apollo.dev/unsupported-feature/v0.1"
+                    for: SECURITY
+                ) {
+                query: Query
+            }
+
+            directive @core(
+                feature: String!
+                as: String
+                for: core__Purpose
+            ) repeatable on SCHEMA
+
+            directive @join__field(
+                graph: join__Graph
+                requires: join__FieldSet
+                provides: join__FieldSet
+            ) on FIELD_DEFINITION
+
+            directive @join__type(
+                graph: join__Graph!
+                key: join__FieldSet
+            ) repeatable on OBJECT | INTERFACE
+
+            directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            directive @tag(
+                name: String!
+            ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            enum CacheControlScope {
+                PRIVATE
+                PUBLIC
+            }
+
+            enum core__Purpose {
+                """
+                `EXECUTION` features provide metadata necessary to for operation execution.
+                """
+                EXECUTION
+
+                """
+                `SECURITY` features provide metadata necessary to securely resolve fields.
+                """
+                SECURITY
+            }
+
+            scalar join__FieldSet
+
+            enum join__Graph {
+                WORLD @join__graph(name: "world", url: "https://world.api.com.invalid")
+            }
+
+            type Query {
+                hello: String! @join__field(graph: WORLD)
+            }
+        "#;
+
+        let err = Supergraph::new(sdl).expect_err("should error on validation");
+        assert_eq!(
+            err.to_string(),
+            "feature https://specs.apollo.dev/unsupported-feature/v0.1 is for: SECURITY but is unsupported",
+        );
+    }
+}

--- a/apollo-federation/tests/main.rs
+++ b/apollo-federation/tests/main.rs
@@ -1,5 +1,6 @@
 mod api_schema;
 mod composition_tests;
+mod core_test;
 mod extract_subgraphs;
 mod query_plan;
 mod subgraph;

--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 use apollo_compiler::collections::IndexSet;
+use apollo_federation::ROUTER_SUPPORTED_SUPERGRAPH_SPECS;
 use apollo_federation::query_plan::FetchNode;
 use apollo_federation::query_plan::PlanNode;
 use apollo_federation::query_plan::QueryPlan;
@@ -92,7 +93,11 @@ pub(crate) fn test_planner(
     subgraph_names_and_schemas: &[(&str, &str)],
 ) -> QueryPlanner {
     let supergraph = compose(function_path, subgraph_names_and_schemas);
-    let supergraph = apollo_federation::Supergraph::new(&supergraph).expect("valid supergraph");
+    let supergraph = apollo_federation::Supergraph::new_with_spec_check(
+        &supergraph,
+        &ROUTER_SUPPORTED_SUPERGRAPH_SPECS,
+    )
+    .expect("valid supergraph");
     QueryPlanner::new(&supergraph, config).expect("can create query planner")
 }
 

--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -3,7 +3,6 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 use apollo_compiler::collections::IndexSet;
-use apollo_federation::ROUTER_SUPPORTED_SUPERGRAPH_SPECS;
 use apollo_federation::query_plan::FetchNode;
 use apollo_federation::query_plan::PlanNode;
 use apollo_federation::query_plan::QueryPlan;
@@ -93,11 +92,8 @@ pub(crate) fn test_planner(
     subgraph_names_and_schemas: &[(&str, &str)],
 ) -> QueryPlanner {
     let supergraph = compose(function_path, subgraph_names_and_schemas);
-    let supergraph = apollo_federation::Supergraph::new_with_spec_check(
-        &supergraph,
-        &ROUTER_SUPPORTED_SUPERGRAPH_SPECS,
-    )
-    .expect("valid supergraph");
+    let supergraph = apollo_federation::Supergraph::new_with_router_specs(&supergraph)
+        .expect("valid supergraph");
     QueryPlanner::new(&supergraph, config).expect("can create query planner")
 }
 

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -10,6 +10,7 @@ use apollo_compiler::Name;
 use apollo_compiler::schema::Implementers;
 use apollo_compiler::validation::Valid;
 use apollo_federation::ApiSchemaOptions;
+use apollo_federation::ROUTER_SUPPORTED_SUPERGRAPH_SPECS;
 use apollo_federation::Supergraph;
 use apollo_federation::schema::ValidFederationSchema;
 use apollo_federation::sources::connect::expand::Connectors;
@@ -153,7 +154,8 @@ impl Schema {
         );
 
         let implementers_map = definitions.implementers_map();
-        let supergraph = Supergraph::from_schema(definitions)?;
+        let supergraph =
+            Supergraph::from_schema(definitions, Some(&ROUTER_SUPPORTED_SUPERGRAPH_SPECS))?;
 
         let schema_id = Schema::schema_id(&raw_sdl.sdl);
 

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -10,8 +10,8 @@ use apollo_compiler::Name;
 use apollo_compiler::schema::Implementers;
 use apollo_compiler::validation::Valid;
 use apollo_federation::ApiSchemaOptions;
-use apollo_federation::ROUTER_SUPPORTED_SUPERGRAPH_SPECS;
 use apollo_federation::Supergraph;
+use apollo_federation::router_supported_supergraph_specs;
 use apollo_federation::schema::ValidFederationSchema;
 use apollo_federation::sources::connect::expand::Connectors;
 use apollo_federation::sources::connect::expand::ExpansionResult;
@@ -155,7 +155,7 @@ impl Schema {
 
         let implementers_map = definitions.implementers_map();
         let supergraph =
-            Supergraph::from_schema(definitions, Some(&ROUTER_SUPPORTED_SUPERGRAPH_SPECS))?;
+            Supergraph::from_schema(definitions, Some(router_supported_supergraph_specs()))?;
 
         let schema_id = Schema::schema_id(&raw_sdl.sdl);
 

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -155,7 +155,7 @@ impl Schema {
 
         let implementers_map = definitions.implementers_map();
         let supergraph =
-            Supergraph::from_schema(definitions, Some(router_supported_supergraph_specs()))?;
+            Supergraph::from_schema(definitions, Some(&router_supported_supergraph_specs()))?;
 
         let schema_id = Schema::schema_id(&raw_sdl.sdl);
 

--- a/apollo-router/src/uplink/testdata/schema_enforcement_spec_version_out_of_range.graphql
+++ b/apollo-router/src/uplink/testdata/schema_enforcement_spec_version_out_of_range.graphql
@@ -1,7 +1,9 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/authenticated/v0.2", for: SECURITY) {
+  # Note: `for` argument is not used on the `authenticated` link. Otherwise, schema validation
+  #       would fail before license enforcement.
+  @link(url: "https://specs.apollo.dev/authenticated/v0.2") {
   query: Query
 }
 


### PR DESCRIPTION
This PR ports the `checkFeatureSupport` function and its tests (`core.tests.ts` file).

* The router now checks if all link specs w/ purpose argument are supported.
* Updated query planner tests to check supported links.
 
<!-- FED-602 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

This PR is intended to match the JS federation's behavior. So, the new behavior is expected and no changeset will be necessary.