### PR TITLE
Improve error handling for coprocessor responses

### DIFF
--- a/.changesets/fix_renee_coprocessor_error_handling.md
+++ b/.changesets/fix_renee_coprocessor_error_handling.md
@@ -1,0 +1,8 @@
+### Improve error handling for coprocessor responses ([PR #7607](https://github.com/apollographql/router/pull/7607))
+
+When a coprocessor returns invalid data, the router now returns an HTTP 500 with extension code `EXTERNAL_CALL_ERROR` instead of `INTERNAL_SERVER_ERROR`, and a slightly improved error message that mentions the coprocessor.
+
+Additionally, there is less potential for errors because unused pieces are not deserialized from a coprocessor response.
+In your coprocessor, we recommend _not_ sending "queryPlan" and "sdl" keys back in the response, because they are not used.
+
+By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/7607

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -245,7 +245,7 @@ where
                 .errors(vec![
                     Error::builder()
                         .message(format!("external coprocessor call failed: {error}"))
-                        .extension_code(super::COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .extension_code(super::COPROCESSOR_CALL_ERROR_EXTENSION)
                         .build(),
                 ])
                 .build();
@@ -406,7 +406,7 @@ where
                 .errors(vec![
                     Error::builder()
                         .message(format!("external coprocessor call failed: {error}"))
-                        .extension_code(super::COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .extension_code(super::COPROCESSOR_CALL_ERROR_EXTENSION)
                         .build(),
                 ])
                 .build();

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -238,7 +238,26 @@ where
     record_coprocessor_duration(PipelineStep::ExecutionRequest, duration);
 
     tracing::debug!(?co_processor_result, "co-processor returned");
-    let co_processor_output = co_processor_result?;
+    let co_processor_output = match co_processor_result {
+        Ok(output) => output,
+        Err(error) => {
+            let graphql_response = graphql::Response::builder()
+                .errors(vec![
+                    Error::builder()
+                        .message(format!("external coprocessor call failed: {error}"))
+                        .extension_code(super::COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .build(),
+                ])
+                .build();
+            let http_response = http::Response::builder()
+                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                .body(stream::once(future::ready(graphql_response)).boxed())?;
+            return Ok(ControlFlow::Break(execution::Response {
+                response: http_response,
+                context: request.context,
+            }));
+        }
+    };
     validate_coprocessor_output(&co_processor_output, PipelineStep::ExecutionRequest)?;
     // unwrap is safe here because validate_coprocessor_output made sure control is available
     let control = co_processor_output.control.expect("validated above; qed");
@@ -380,7 +399,26 @@ where
     record_coprocessor_duration(PipelineStep::ExecutionResponse, duration);
 
     tracing::debug!(?co_processor_result, "co-processor returned");
-    let co_processor_output = co_processor_result?;
+    let co_processor_output = match co_processor_result {
+        Ok(output) => output,
+        Err(error) => {
+            let graphql_response = graphql::Response::builder()
+                .errors(vec![
+                    Error::builder()
+                        .message(format!("external coprocessor call failed: {error}"))
+                        .extension_code(super::COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .build(),
+                ])
+                .build();
+            let http_response = http::Response::builder()
+                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                .body(stream::once(future::ready(graphql_response)).boxed())?;
+            return Ok(execution::Response {
+                response: http_response,
+                context: response.context,
+            });
+        }
+    };
 
     validate_coprocessor_output(&co_processor_output, PipelineStep::ExecutionResponse)?;
 

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -69,6 +69,7 @@ mod supergraph;
 pub(crate) const EXTERNAL_SPAN_NAME: &str = "external_plugin";
 const POOL_IDLE_TIMEOUT_DURATION: Option<Duration> = Some(Duration::from_secs(5));
 const COPROCESSOR_ERROR_EXTENSION: &str = "ERROR";
+const COPROCESSOR_CALL_ERROR_EXTENSION: &str = "EXTERNAL_CALL_ERROR";
 const COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION: &str = "EXTERNAL_DESERIALIZATION_ERROR";
 
 type MapFn = fn(http::Response<hyper::body::Incoming>) -> http::Response<RouterBody>;
@@ -834,7 +835,7 @@ where
                 .errors(vec![
                     Error::builder()
                         .message(format!("external coprocessor call failed: {error}"))
-                        .extension_code(COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .extension_code(COPROCESSOR_CALL_ERROR_EXTENSION)
                         .build(),
                 ])
                 .build();
@@ -1019,7 +1020,7 @@ where
                 .errors(vec![
                     Error::builder()
                         .message(format!("external coprocessor call failed: {error}"))
-                        .extension_code(COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .extension_code(COPROCESSOR_CALL_ERROR_EXTENSION)
                         .build(),
                 ])
                 .build();
@@ -1226,7 +1227,7 @@ where
                 .errors(vec![
                     Error::builder()
                         .message(format!("external coprocessor call failed: {error}"))
-                        .extension_code(COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .extension_code(COPROCESSOR_CALL_ERROR_EXTENSION)
                         .build(),
                 ])
                 .build();
@@ -1397,7 +1398,7 @@ where
                 .errors(vec![
                     Error::builder()
                         .message(format!("external coprocessor call failed: {error}"))
-                        .extension_code(COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .extension_code(COPROCESSOR_CALL_ERROR_EXTENSION)
                         .build(),
                 ])
                 .build();

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -76,6 +76,9 @@ impl Control {
     }
 }
 
+// This structure is used both for the request and the response side of a coprocessor.
+// Data that we do not use in a response should be marked with `skip_deserializing` so that invalid
+// unused data returned from a coprocessor does not cause errors.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Externalizable<T> {
@@ -90,7 +93,7 @@ pub(crate) struct Externalizable<T> {
     pub(crate) body: Option<T>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) context: Option<Context>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", skip_deserializing)]
     pub(crate) sdl: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) uri: Option<String>,
@@ -104,7 +107,7 @@ pub(crate) struct Externalizable<T> {
     pub(crate) status_code: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) has_next: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", skip_deserializing)]
     query_plan: Option<Arc<QueryPlan>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) subgraph_request_id: Option<SubgraphRequestId>,

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -654,7 +654,7 @@ impl IntegrationTest {
                 .env("APOLLO_GRAPH_REF", apollo_graph_ref);
         }
         router
-            .args(dbg!([
+            .args([
                 "--hr",
                 "--config",
                 &self.test_config_location.to_string_lossy(),
@@ -662,7 +662,7 @@ impl IntegrationTest {
                 &self.test_schema_location.to_string_lossy(),
                 "--log",
                 &self.log,
-            ]))
+            ])
             .stdout(Stdio::piped());
 
         let mut router = router.spawn().expect("router should start");

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -236,13 +236,15 @@ async fn test_coprocessor_supergraph_invalid_response_json() -> Result<(), BoxEr
         .await;
 
     let mut router = IntegrationTest::builder()
-        .config(format!(r#"
+        .config(format!(
+            r#"
             coprocessor:
               url: "{coprocessor_address}"
               supergraph:
                 request:
                   method: true
-        "#))
+        "#
+        ))
         .build()
         .await;
 
@@ -252,8 +254,18 @@ async fn test_coprocessor_supergraph_invalid_response_json() -> Result<(), BoxEr
     let (_trace_id, response) = router.execute_default_query().await;
     assert_eq!(response.status(), 500);
     let response: serde_json::Value = response.json().await.unwrap();
-    assert_eq!(response["errors"][0]["extensions"]["code"].as_str().unwrap(), "INTERNAL_SERVER_ERROR");
-    assert!(response["errors"][0]["message"].as_str().unwrap().contains("coprocessor"));
+    assert_eq!(
+        response["errors"][0]["extensions"]["code"]
+            .as_str()
+            .unwrap(),
+        "INTERNAL_SERVER_ERROR"
+    );
+    assert!(
+        response["errors"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("coprocessor")
+    );
 
     router.graceful_shutdown().await;
 
@@ -287,13 +299,15 @@ async fn test_coprocessor_execution_invalid_response_json() -> Result<(), BoxErr
         .await;
 
     let mut router = IntegrationTest::builder()
-        .config(format!(r#"
+        .config(format!(
+            r#"
             coprocessor:
               url: "{coprocessor_address}"
               execution:
                 request:
                   method: true
-        "#))
+        "#
+        ))
         .build()
         .await;
 
@@ -303,8 +317,18 @@ async fn test_coprocessor_execution_invalid_response_json() -> Result<(), BoxErr
     let (_trace_id, response) = router.execute_default_query().await;
     assert_eq!(response.status(), 500);
     let response: serde_json::Value = response.json().await.unwrap();
-    assert_eq!(response["errors"][0]["extensions"]["code"].as_str().unwrap(), "INTERNAL_SERVER_ERROR");
-    assert!(response["errors"][0]["message"].as_str().unwrap().contains("coprocessor"));
+    assert_eq!(
+        response["errors"][0]["extensions"]["code"]
+            .as_str()
+            .unwrap(),
+        "EXTERNAL_DESERIALIZATION_ERROR"
+    );
+    assert!(
+        response["errors"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("coprocessor")
+    );
 
     router.graceful_shutdown().await;
 
@@ -345,13 +369,15 @@ async fn test_coprocessor_execution_ignore_query_plan_in_response_json() -> Resu
         .await;
 
     let mut router = IntegrationTest::builder()
-        .config(format!(r#"
+        .config(format!(
+            r#"
             coprocessor:
               url: "{coprocessor_address}"
               execution:
                 request:
                   query_plan: true
-        "#))
+        "#
+        ))
         .build()
         .await;
 

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -258,7 +258,7 @@ async fn test_coprocessor_supergraph_invalid_response_json() -> Result<(), BoxEr
         response["errors"][0]["extensions"]["code"]
             .as_str()
             .unwrap(),
-        "INTERNAL_SERVER_ERROR"
+        "EXTERNAL_CALL_ERROR"
     );
     assert!(
         response["errors"][0]["message"]
@@ -321,7 +321,7 @@ async fn test_coprocessor_execution_invalid_response_json() -> Result<(), BoxErr
         response["errors"][0]["extensions"]["code"]
             .as_str()
             .unwrap(),
-        "EXTERNAL_DESERIALIZATION_ERROR"
+        "EXTERNAL_CALL_ERROR"
     );
     assert!(
         response["errors"][0]["message"]

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -44,10 +44,20 @@ async fn test_coprocessor_limit_payload() -> Result<(), BoxError> {
     // Expect a small query
     Mock::given(method("POST"))
         .and(path("/"))
-        .and(body_partial_json(json!({"version":1,"stage":"RouterRequest","control":"continue","body":"{\"query\":\"query ExampleQuery {topProducts{name}}\",\"variables\":{}}","method":"POST"})))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({"version":1,"stage":"RouterRequest","control":"continue","body":"{\"query\":\"query {topProducts{name}}\",\"variables\":{}}","method":"POST"})),
-        )
+        .and(body_partial_json(json!({
+            "version": 1,
+            "stage": "RouterRequest",
+            "control": "continue",
+            "body": "{\"query\":\"query ExampleQuery {topProducts{name}}\",\"variables\":{}}",
+            "method":"POST",
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "version": 1,
+            "stage": "RouterRequest",
+            "control": "continue",
+            "body": "{\"query\":\"query {topProducts{name}}\",\"variables\":{}}",
+            "method": "POST",
+        })))
         .expect(1)
         .mount(&mock_server)
         .await;
@@ -212,17 +222,19 @@ async fn test_coprocessor_demand_control_access() -> Result<(), BoxError> {
     Mock::given(method("POST"))
         .and(path("/"))
         .and(body_partial_json(json!({
-        "stage": "ExecutionRequest",
-        "context": {
-            "entries": {
-                "apollo::demand_control::estimated_cost": 10.0,
-                "apollo::demand_control::result": "COST_OK",
-                "apollo::demand_control::strategy": "static_estimated"
-            }}})))
+            "stage": "ExecutionRequest",
+            "context": {
+                "entries": {
+                    "apollo::demand_control::estimated_cost": 10.0,
+                    "apollo::demand_control::result": "COST_OK",
+                    "apollo::demand_control::strategy": "static_estimated",
+                },
+            },
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                        "version":1,
-                        "stage":"ExecutionRequest",
-                        "control":"continue",
+            "version": 1,
+            "stage": "ExecutionRequest",
+            "control": "continue",
         })))
         .expect(1)
         .mount(&mock_server)
@@ -233,16 +245,19 @@ async fn test_coprocessor_demand_control_access() -> Result<(), BoxError> {
         .and(path("/"))
         .and(body_partial_json(json!({
             "stage": "SupergraphResponse",
-            "context": {"entries": {
-            "apollo::demand_control::actual_cost": 3.0,
-            "apollo::demand_control::estimated_cost": 10.0,
-            "apollo::demand_control::result": "COST_OK",
-            "apollo::demand_control::strategy": "static_estimated"
-        }}})))
+            "context": {
+                "entries": {
+                    "apollo::demand_control::actual_cost": 3.0,
+                    "apollo::demand_control::estimated_cost": 10.0,
+                    "apollo::demand_control::result": "COST_OK",
+                    "apollo::demand_control::strategy": "static_estimated",
+                },
+            },
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                        "version":1,
-                        "stage":"SupergraphResponse",
-                        "control":"continue",
+            "version": 1,
+            "stage": "SupergraphResponse",
+            "control": "continue",
         })))
         .expect(1)
         .mount(&mock_server)


### PR DESCRIPTION
When a coprocessor returns some invalid data, you now get an HTTP 500 with extension code "EXTERNAL_CALL_ERROR" instead of "INTERNAL_SERVER_ERROR", and a slightly improved error message that mentions the coprocessor.

Additionally removes some potential for errors by _not_ deserializing the SDL and the query plan from a coprocessor response.

**Todos**
- [x] A changeset
- [ ] Update the docs to discourage responding with read-only keys like "queryPlan" and "sdl"

<!-- [ROUTER-1312] -->
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1312]: https://apollographql.atlassian.net/browse/ROUTER-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ