### PR TITLE
chore(federation): Use `try_from()` instead of `try_into()` to avoid having to write explicit type signatures

### DIFF
--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1153,8 +1153,8 @@ impl FederatedQueryGraphBuilder {
                 // allow a type to be an entity in some subgraphs but not others, this is not
                 // the place to impose that restriction, and this may be at least temporarily
                 // useful to allow convert a type to an entity).
-                let Ok(type_pos): Result<ObjectOrInterfaceTypeDefinitionPosition, _> =
-                    type_pos.clone().try_into()
+                let Ok(type_pos) =
+                    ObjectOrInterfaceTypeDefinitionPosition::try_from(type_pos.clone())
                 else {
                     return Err(SingleFederationError::Internal {
                             message: format!(

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -494,9 +494,8 @@ impl TransitionGraphPath {
                                 parent_type_pos, tail_type_pos, subgraph,
                             );
                         }
-                        let Some(Ok::<CompositeTypeDefinitionPosition, _>(
-                            parent_type_pos_in_subgraph,
-                        )) = parent_type_pos_in_subgraph.map(|pos| pos.try_into())
+                        let Some(Ok(parent_type_pos_in_subgraph)) = parent_type_pos_in_subgraph
+                            .map(CompositeTypeDefinitionPosition::try_from)
                         else {
                             break 'details format!(
                                 "cannot find field \"{}\"",
@@ -840,9 +839,8 @@ impl TransitionPathWithLazyIndirectPaths {
                         }
                         let parent_type_pos_in_subgraph =
                             subgraph_schema.try_get_type(parent_type_pos.type_name().clone());
-                        let Some(Ok::<CompositeTypeDefinitionPosition, _>(
-                            parent_type_pos_in_subgraph,
-                        )) = parent_type_pos_in_subgraph.map(|pos| pos.try_into())
+                        let Some(Ok(parent_type_pos_in_subgraph)) = parent_type_pos_in_subgraph
+                            .map(CompositeTypeDefinitionPosition::try_from)
                         else {
                             continue;
                         };
@@ -868,8 +866,10 @@ impl TransitionPathWithLazyIndirectPaths {
                             // `tail_type_pos_in_subgraph` exists, so it's either equal to
                             // `parent_type_pos_in_subgraph`, or it's an interface of it. In any
                             // case, it's composite.
-                            let Ok::<CompositeTypeDefinitionPosition, _>(tail_type_pos_in_subgraph) =
-                                tail_type_pos_in_subgraph.clone().try_into()
+                            let Ok(tail_type_pos_in_subgraph) =
+                                CompositeTypeDefinitionPosition::try_from(
+                                    tail_type_pos_in_subgraph.clone(),
+                                )
                             else {
                                 bail!(
                                     "Type {} in {} should be composite",

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -931,11 +931,9 @@ impl QueryGraph {
                 field_definition_position,
                 ..
             } => {
-                let Ok(_): Result<CompositeTypeDefinitionPosition, _> =
-                    tail_type_pos.clone().try_into()
-                else {
+                if CompositeTypeDefinitionPosition::try_from(tail_type_pos.clone()).is_err() {
                     return Ok(IndexSet::default());
-                };
+                }
                 let schema = self.schema_by_source(source)?;
                 let mut new_possible_runtime_types = IndexSet::default();
                 for possible_runtime_type in possible_runtime_types {

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -4049,11 +4049,11 @@ fn compute_nodes_for_op_path_element<'a>(
             node.selection_set
                 .add_at_path(path_in_parent, Some(&Arc::new(key_inputs)))?;
 
-            let Ok(input_type): Result<CompositeTypeDefinitionPosition, _> = dependency_graph
-                .supergraph_schema
-                .get_type(source_type.type_name().clone())?
-                .try_into()
-            else {
+            let Ok(input_type) = CompositeTypeDefinitionPosition::try_from(
+                dependency_graph
+                    .supergraph_schema
+                    .get_type(source_type.type_name().clone())?,
+            ) else {
                 bail!(
                     "Type {} should exist in the supergraph and be a composite type",
                     source_type.type_name()

--- a/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
@@ -533,12 +533,11 @@ pub(crate) fn precompute_non_local_selection_metadata(
             } => {
                 // We skip selections where the tail is a non-composite type, as we'll never
                 // need to estimate the next nodes for such selections.
-                let Ok(_): Result<CompositeTypeDefinitionPosition, _> = graph
-                    .node_weight(edge_ref.target())?
-                    .type_
-                    .clone()
-                    .try_into()
-                else {
+                if CompositeTypeDefinitionPosition::try_from(
+                    graph.node_weight(edge_ref.target())?.type_.clone(),
+                )
+                .is_err()
+                {
                     continue;
                 };
                 let target = edge_ref
@@ -677,8 +676,8 @@ pub(crate) fn precompute_non_local_selection_metadata(
     // For all composite type nodes, we pretend that there's a self-downcast edge for that type,
     // as this simplifies next node calculation.
     for (node, node_weight) in graph.graph().node_references() {
-        let Ok(node_type_pos): Result<CompositeTypeDefinitionPosition, _> =
-            node_weight.type_.clone().try_into()
+        let Ok(node_type_pos) =
+            CompositeTypeDefinitionPosition::try_from(node_weight.type_.clone())
         else {
             continue;
         };

--- a/apollo-federation/src/schema/validators/external.rs
+++ b/apollo-federation/src/schema/validators/external.rs
@@ -51,8 +51,7 @@ fn validate_all_external_fields_used(
     errors: &mut MultipleFederationErrors,
 ) -> Result<(), FederationError> {
     for type_pos in schema.get_types() {
-        let Ok(type_pos): Result<ObjectOrInterfaceTypeDefinitionPosition, _> = type_pos.try_into()
-        else {
+        let Ok(type_pos) = ObjectOrInterfaceTypeDefinitionPosition::try_from(type_pos) else {
             continue;
         };
         type_pos.fields(schema.schema())?

--- a/apollo-federation/src/schema/validators/interface_object.rs
+++ b/apollo-federation/src/schema/validators/interface_object.rs
@@ -29,7 +29,7 @@ fn validate_keys_on_interfaces_are_also_on_all_implementations(
         .key_directive_definition(schema)?
         .name;
     for type_pos in schema.get_types() {
-        let Ok(type_pos): Result<InterfaceTypeDefinitionPosition, _> = type_pos.try_into() else {
+        let Ok(type_pos) = InterfaceTypeDefinitionPosition::try_from(type_pos) else {
             continue;
         };
         let implementation_types = schema.possible_runtime_types(type_pos.clone().into())?;

--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -40,8 +40,7 @@ pub(crate) fn validate_merged_schema(
     errors: &mut MultipleFederationErrors,
 ) -> Result<(), FederationError> {
     for type_pos in supergraph_schema.get_types() {
-        let Ok(type_pos): Result<ObjectOrInterfaceTypeDefinitionPosition, _> = type_pos.try_into()
-        else {
+        let Ok(type_pos) = ObjectOrInterfaceTypeDefinitionPosition::try_from(type_pos) else {
             continue;
         };
         let interface_names = match &type_pos {
@@ -334,8 +333,8 @@ fn add_requires_error(
             else {
                 return Ok(None);
             };
-            let Ok(type_pos_in_other_subgraph): Result<ObjectOrInterfaceTypeDefinitionPosition, _> =
-                type_pos_in_other_subgraph.try_into()
+            let Ok(type_pos_in_other_subgraph) =
+                ObjectOrInterfaceTypeDefinitionPosition::try_from(type_pos_in_other_subgraph)
             else {
                 return Ok(None);
             };

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -1933,8 +1933,7 @@ pub(crate) fn remove_inactive_requires_and_provides_from_subgraph(
         }
 
         // Ignore non-object/interface types.
-        let Ok(type_pos): Result<ObjectOrInterfaceTypeDefinitionPosition, _> = type_pos.try_into()
-        else {
+        let Ok(type_pos) = ObjectOrInterfaceTypeDefinitionPosition::try_from(type_pos) else {
             continue;
         };
 


### PR DESCRIPTION
I got some feedback in a previous PR that we could avoid manually having to specify type signatures in a `match` with `try_into()` if we just used `try_from()` instead, and realized we had that issue in a few different places. This also avoids a particular IntelliJ issue where it wouldn't be able to infer types in these cases.

<!-- FED-573 -->