### PR TITLE
chore(xtask): pass through test name filters

### DIFF
--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -25,6 +25,9 @@ pub struct Test {
     /// Pass --features to cargo test
     #[clap(long)]
     features: Option<String>,
+
+    /// Test name filters
+    filters: Vec<String>,
 }
 
 impl Test {
@@ -56,6 +59,8 @@ impl Test {
                 args.push(features.to_owned());
             }
 
+            args.extend(self.filters.iter().cloned());
+
             cargo!(args);
             return Ok(());
         } else {
@@ -78,6 +83,8 @@ impl Test {
                 args.push("--jobs".to_string());
                 args.push(jobs.to_string());
             }
+
+            args.extend(self.filters.iter().cloned());
 
             args.push("--".to_string());
 


### PR DESCRIPTION
Just a small enhancement, if you use `cargo xtask test` you can pass a
filter in command-line arguments, just like with `cargo test` and `cargo
nextest run`.

Ideally we'd just support any and all arguments to `cargo test` and
`cargo nextest run` here. But I'm not sure how to achieve that and this
is the one I miss the most often by far.
