### PR TITLE
[JSONSelection] Reenable `->` method shape checking and fully implement `math_shape`

### DIFF
--- a/apollo-federation/src/connectors/json_selection/methods/future/arithmetic.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/future/arithmetic.rs
@@ -136,7 +136,6 @@ infix_math_op!(mul_op, *);
 infix_math_op!(div_op, /);
 infix_math_op!(rem_op, %);
 
-#[allow(dead_code)] // method type-checking disabled until we add name resolution
 fn math_shape(
     method_name: &WithRange<String>,
     method_args: Option<&MethodArgs>,

--- a/apollo-federation/src/connectors/json_selection/methods/future/arithmetic.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/future/arithmetic.rs
@@ -328,7 +328,141 @@ mod tests {
     use shape::Shape;
     use shape::location::SourceId;
 
+    use super::CheckNumericResult;
+    use super::check_numeric_shape;
     use crate::selection;
+
+    #[test]
+    fn test_check_numeric_shape() {
+        assert_eq!(
+            check_numeric_shape(&Shape::int([])),
+            CheckNumericResult::IntForSure
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::float([])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::unknown([])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::bool([])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::string([])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::null([])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::none()),
+            CheckNumericResult::Neither
+        );
+
+        assert_eq!(
+            check_numeric_shape(&Shape::one(vec![Shape::int([])], [])),
+            CheckNumericResult::IntForSure
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::one(vec![Shape::float([])], [])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::one(vec![Shape::unknown([])], [])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::one(vec![Shape::bool([])], [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::one(vec![Shape::string([])], [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::one(vec![Shape::null([])], [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::one(vec![Shape::none()], [])),
+            CheckNumericResult::Neither
+        );
+
+        assert_eq!(
+            check_numeric_shape(&Shape::all(vec![Shape::int([])], [])),
+            CheckNumericResult::IntForSure
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::all(vec![Shape::float([])], [])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::all(vec![Shape::unknown([])], [])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::all(vec![Shape::bool([])], [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::all(vec![Shape::string([])], [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::all(vec![Shape::null([])], [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::all(vec![Shape::none()], [])),
+            CheckNumericResult::Neither
+        );
+
+        assert_eq!(
+            check_numeric_shape(&Shape::name("Person", [])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::name("Person", []).field("age", [])),
+            CheckNumericResult::FloatPossible
+        );
+
+        assert_eq!(
+            check_numeric_shape(&Shape::error_with_partial("Error", Shape::int([]), [])),
+            CheckNumericResult::IntForSure
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::error_with_partial("Error", Shape::float([]), [])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::error_with_partial("Error", Shape::unknown([]), [])),
+            CheckNumericResult::FloatPossible
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::error_with_partial("Error", Shape::bool([]), [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::error_with_partial("Error", Shape::string([]), [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::error_with_partial("Error", Shape::null([]), [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::error_with_partial("Error", Shape::none(), [])),
+            CheckNumericResult::Neither
+        );
+        assert_eq!(
+            check_numeric_shape(&Shape::error("Error", [])),
+            CheckNumericResult::Neither
+        );
+    }
 
     #[test]
     fn add_should_add_whole_numbers() {

--- a/apollo-federation/src/connectors/json_selection/methods/future/arithmetic.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/future/arithmetic.rs
@@ -2,6 +2,7 @@ use apollo_compiler::collections::IndexMap;
 use serde_json::Number;
 use serde_json_bytes::Value as JSON;
 use shape::Shape;
+use shape::ShapeCase;
 use shape::location::SourceId;
 
 use crate::connectors::json_selection::ApplyToError;
@@ -139,13 +140,165 @@ infix_math_op!(rem_op, %);
 #[allow(dead_code)] // method type-checking disabled until we add name resolution
 fn math_shape(
     method_name: &WithRange<String>,
-    _method_args: Option<&MethodArgs>,
-    _input_shape: Shape,
-    _dollar_shape: Shape,
-    _named_var_shapes: &IndexMap<&str, Shape>,
+    method_args: Option<&MethodArgs>,
+    input_shape: Shape,
+    dollar_shape: Shape,
+    named_var_shapes: &IndexMap<&str, Shape>,
     source_id: &SourceId,
 ) -> Shape {
-    Shape::error("TODO: math_shape", method_name.shape_location(source_id))
+    let mut check_result = check_numeric_shape(&input_shape);
+
+    if matches!(check_result, CheckNumericResult::Neither) {
+        return Shape::error(
+            format!(
+                "Method ->{} received non-numeric input",
+                method_name.as_ref()
+            ),
+            input_shape.locations.iter().cloned(),
+        );
+    }
+
+    if method_name.as_ref() == "div" {
+        // The ->div method stays safe by always returning Float, so
+        // check_result starts off false in that case.
+        check_result = CheckNumericResult::FloatPossible;
+    }
+
+    for (i, arg) in method_args
+        .iter()
+        .flat_map(|args| args.args.iter())
+        .enumerate()
+    {
+        let arg_shape = arg.compute_output_shape(
+            input_shape.clone(),
+            dollar_shape.clone(),
+            named_var_shapes,
+            source_id,
+        );
+
+        match check_numeric_shape(&arg_shape) {
+            CheckNumericResult::IntForSure => {}
+            CheckNumericResult::FloatPossible => {
+                check_result = CheckNumericResult::FloatPossible;
+            }
+            CheckNumericResult::Neither => {
+                return Shape::error(
+                    format!(
+                        "Method ->{} received non-numeric argument {}",
+                        method_name.as_ref(),
+                        i
+                    ),
+                    arg_shape.locations.iter().cloned(),
+                );
+            }
+        }
+    }
+
+    match check_result {
+        CheckNumericResult::IntForSure => {
+            // TODO If we wanted to climb Mount Cleverest, we could perform
+            // static integer math when all the inputs are statically known, and
+            // return a specific Shape::int_value when that math succeeds. That
+            // might require using different shape functions for each of the
+            // math operations, rather than a single math_shape function.
+            Shape::int(method_name.shape_location(source_id))
+        }
+        CheckNumericResult::FloatPossible => Shape::float(method_name.shape_location(source_id)),
+        CheckNumericResult::Neither => unreachable!("handled above"),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum CheckNumericResult {
+    IntForSure,
+    FloatPossible,
+    Neither,
+}
+
+fn check_numeric_shape(arg_shape: &Shape) -> CheckNumericResult {
+    match arg_shape.case() {
+        // This includes both the general Int case and any specific
+        // ShapeCase::Int(Some(value)) integer shapes.
+        ShapeCase::Int(_) => CheckNumericResult::IntForSure,
+
+        // Beside the obvious ShapeCase::Float variant, Name and Unknown shapes
+        // could potentially turn out to be numeric (i.e. Float but not
+        // necessarily Int), so they do not warrant an error (yet).
+        ShapeCase::Name(_, _) | ShapeCase::Unknown | ShapeCase::Float => {
+            CheckNumericResult::FloatPossible
+        }
+
+        ShapeCase::One(one) => {
+            let mut result = CheckNumericResult::IntForSure;
+
+            for shape in one.iter() {
+                match check_numeric_shape(shape) {
+                    CheckNumericResult::IntForSure => {
+                        // Leave result == IntForSure if not already
+                        // FloatPossible. This means all the member shapes have
+                        // to be Int in order the final result to be IntForSure.
+                    }
+                    CheckNumericResult::FloatPossible => {
+                        result = CheckNumericResult::FloatPossible;
+                    }
+                    CheckNumericResult::Neither => {
+                        // If any of the member shapes is not numeric, there's a
+                        // chance this math method will fail at runtime.
+                        return CheckNumericResult::Neither;
+                    }
+                };
+            }
+
+            result
+        }
+
+        ShapeCase::All(all) => {
+            let mut saw_int = false;
+            let mut saw_float = false;
+
+            for shape in all.iter() {
+                match check_numeric_shape(shape) {
+                    CheckNumericResult::IntForSure => {
+                        saw_int = true;
+                    }
+                    CheckNumericResult::FloatPossible => {
+                        saw_float = true;
+                    }
+                    CheckNumericResult::Neither => {}
+                };
+            }
+
+            // Because the ShapeCase::All intersection claims to be all the
+            // member shapes simultaneously, the answer is IntForSure if any
+            // member is an Int, even if some members are FloatPossible or even
+            // Neither. If no member is an Int, but some are FloatPossible,
+            // that's the answer. Otherwise, the answer is Neither.
+            if saw_int {
+                CheckNumericResult::IntForSure
+            } else if saw_float {
+                CheckNumericResult::FloatPossible
+            } else {
+                CheckNumericResult::Neither
+            }
+        }
+
+        // Math methods refuse to operate on definitely non-numeric values.
+        ShapeCase::Bool(_)
+        | ShapeCase::String(_)
+        | ShapeCase::Null
+        | ShapeCase::None
+        | ShapeCase::Object { .. }
+        | ShapeCase::Array { .. } => CheckNumericResult::Neither,
+
+        // An Error with a partial shape delegates to the partial shape.
+        ShapeCase::Error(shape::Error { partial, .. }) => {
+            if let Some(partial) = partial {
+                check_numeric_shape(partial)
+            } else {
+                CheckNumericResult::Neither
+            }
+        }
+    }
 }
 
 macro_rules! infix_math_method {
@@ -170,7 +323,10 @@ infix_math_method!(ModMethod, mod_method, rem_op);
 
 #[cfg(test)]
 mod tests {
+    use apollo_compiler::collections::IndexMap;
     use serde_json_bytes::json;
+    use shape::Shape;
+    use shape::location::SourceId;
 
     use crate::selection;
 
@@ -347,6 +503,173 @@ mod tests {
         assert_eq!(
             selection!("$->mod(2, 3, 5, 7)").apply_to(&json!(2100)),
             (Some(json!(0)), vec![]),
+        );
+    }
+
+    #[test]
+    fn add_shape_can_return_int() {
+        assert_eq!(selection!("$(1->add(2, 3))").shape().pretty_print(), "Int");
+
+        assert_eq!(
+            selection!("$(-1->add(2, -3))").shape().pretty_print(),
+            "Int",
+        );
+
+        assert_eq!(
+            selection!("$(1->add(2.1, -3))").shape().pretty_print(),
+            "Float",
+        );
+
+        assert_eq!(
+            selection!("$(-1.1->add(2, 3))").shape().pretty_print(),
+            "Float",
+        );
+    }
+
+    #[test]
+    fn sub_shape_can_return_int() {
+        assert_eq!(selection!("$(1->sub(2, 3))").shape().pretty_print(), "Int");
+
+        assert_eq!(
+            selection!("$(-1->sub(2, -3))").shape().pretty_print(),
+            "Int",
+        );
+
+        assert_eq!(
+            selection!("$(1->sub(2.1, -3))").shape().pretty_print(),
+            "Float",
+        );
+
+        assert_eq!(
+            selection!("$(-1.1->sub(2, 3))").shape().pretty_print(),
+            "Float",
+        );
+    }
+
+    #[test]
+    fn mul_shape_can_return_int() {
+        assert_eq!(selection!("$(1->mul(2, 3))").shape().pretty_print(), "Int");
+
+        assert_eq!(
+            selection!("$(-1->mul(2, -3))").shape().pretty_print(),
+            "Int",
+        );
+
+        assert_eq!(
+            selection!("$(1->mul(2.1, -3))").shape().pretty_print(),
+            "Float",
+        );
+
+        assert_eq!(
+            selection!("$(-1.1->mul(2, 3))").shape().pretty_print(),
+            "Float",
+        );
+    }
+
+    #[test]
+    fn div_shape_cannot_return_int() {
+        assert_eq!(
+            selection!("$(1->div(2, 3))").shape().pretty_print(),
+            "Float"
+        );
+
+        assert_eq!(
+            selection!("$(-1->div(2, -3))").shape().pretty_print(),
+            "Float",
+        );
+
+        assert_eq!(
+            selection!("$(1->div(2.1, -3))").shape().pretty_print(),
+            "Float",
+        );
+
+        assert_eq!(
+            selection!("$(-1.1->div(2, 3))").shape().pretty_print(),
+            "Float",
+        );
+    }
+
+    #[test]
+    fn mod_shape_can_return_int() {
+        assert_eq!(selection!("$(1->mod(2, 3))").shape().pretty_print(), "Int");
+
+        assert_eq!(
+            selection!("$(-1->mod(2, -3))").shape().pretty_print(),
+            "Int",
+        );
+
+        assert_eq!(
+            selection!("$(1->mod(2.1, -3))").shape().pretty_print(),
+            "Float"
+        );
+    }
+
+    #[test]
+    fn check_errors_for_non_numeric_arguments() {
+        assert_eq!(
+            selection!("$->add(1, 'foo')").shape().pretty_print(),
+            "Error<\"Method ->add received non-numeric argument 1\">",
+        );
+
+        assert_eq!(
+            selection!("$->add(1, 2, true)").shape().pretty_print(),
+            "Error<\"Method ->add received non-numeric argument 2\">",
+        );
+
+        let add_one_selection = selection!("$->add(1)");
+        let add_one_shape = add_one_selection.compute_output_shape(
+            Shape::string([]),
+            &IndexMap::default(),
+            &SourceId::Other("JSONSelection".into()),
+        );
+
+        assert_eq!(
+            add_one_shape.pretty_print(),
+            "Error<\"Method ->add received non-numeric input\">",
+        );
+    }
+
+    #[test]
+    fn test_union_argument_shapes() {
+        let all_numeric_union =
+            selection!("$->add(@->eq(0)->match([true, 1], [false, 2], [@, 3]))");
+        let all_numeric_union_shape = all_numeric_union.compute_output_shape(
+            Shape::int([]),
+            &IndexMap::default(),
+            &SourceId::Other("JSONSelection".into()),
+        );
+        assert_eq!(all_numeric_union_shape.pretty_print(), "Int");
+
+        let missing_catchall_case = selection!("$->add(@->eq(0)->match([true, 1], [false, 2]))");
+        let missing_catchall_case_shape = missing_catchall_case.compute_output_shape(
+            Shape::int([]),
+            &IndexMap::default(),
+            &SourceId::Other("JSONSelection".into()),
+        );
+        assert_eq!(
+            missing_catchall_case_shape.pretty_print(),
+            "Error<\"Method ->add received non-numeric argument 0\">"
+        );
+
+        let mixed_float_union =
+            selection!("$->add(@->eq(0)->match([true, 1], [false, 2.5], [@, 3]))");
+        let mixed_float_union_shape = mixed_float_union.compute_output_shape(
+            Shape::int([]),
+            &IndexMap::default(),
+            &SourceId::Other("JSONSelection".into()),
+        );
+        assert_eq!(mixed_float_union_shape.pretty_print(), "Float");
+
+        let no_number_union =
+            selection!("$->add(@->eq(0)->match([true, 'a'], [false, 'b'], [@, null]))");
+        let no_number_union_shape = no_number_union.compute_output_shape(
+            Shape::int([]),
+            &IndexMap::default(),
+            &SourceId::Other("JSONSelection".into()),
+        );
+        assert_eq!(
+            no_number_union_shape.pretty_print(),
+            "Error<\"Method ->add received non-numeric argument 0\">"
         );
     }
 }

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types.graphql.snap
@@ -6,9 +6,23 @@ input_file: apollo-federation/src/connectors/validation/test_data/headers/expres
 [
     Message {
         code: InvalidHeader,
+        message: "In `@source(http.headers:)`: array values aren't valid here",
+        locations: [
+            11:50..11:52,
+        ],
+    },
+    Message {
+        code: InvalidHeader,
         message: "In `@source(http.headers:)`: object values aren't valid here",
         locations: [
             12:45..12:47,
+        ],
+    },
+    Message {
+        code: InvalidHeader,
+        message: "In `@source(http.headers:)`: object values aren't valid here",
+        locations: [
+            13:73..13:75,
         ],
     },
     Message {


### PR DESCRIPTION
Although we have not made them public yet, one precondition for shipping the arithmetic methods (`->add`, `->sub`, `->mul`, `->div`, and `->mod`) is fully implementing the code responsible for statically determining the output "shape" of each method (given input/argument shapes), which in this case is always `Int`, `Float`, or possibly a `Error` if the input/argument shapes are not acceptable.

This PR provides this implementation for `math_shape`, but in order to make these changes meaningful/testable, I've also included a commit that reenables method shape checking as part of `PathList::compute_output_shape`, aligning it better with the runtime changes to `PathList::apply_to_path` from PR #7144, and resolving [this open JIRA task](https://apollographql.atlassian.net/browse/CNN-722) (see commit messages for more details).