### PR TITLE
added changeset entry for PR #7587

### DIFF
--- a/.changesets/fix_query_plan_defer_invalid_root_type.md
+++ b/.changesets/fix_query_plan_defer_invalid_root_type.md
@@ -1,0 +1,5 @@
+### (Query Planner) Fix invalid type condition in `@defer` fetch
+
+The query planner could add an inline spread conditioned on the `Query` type in deferred subgraph fetch queries. Such a query would be invalid in the subgraph when the subgraph schema renamed the root query type. This fix removes the root type condition from all subgraph queries, so that they stay valid even when root types were renamed.
+
+By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/7580


### PR DESCRIPTION
I forgot to add a changeset entry for PR https://github.com/apollographql/router/pull/7587. I'm adding it now.
This may need to be backported to main, so it can be included in the release note.

Note: This is a second one. The other changeset PR is https://github.com/apollographql/router/pull/7642.
