### PR TITLE
Fix the commit for gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,7 +7,7 @@
             "e1e6f93341aea383da2ec6b36a9bfcf7e63a111e",
             "e5590027506337381887dadef9baadd063e05830",
             "b4fdf65c5eaca08057886e5b30553201302b9764",
-            "94fa95a29f3d8fb7a9bb88fc787d2d7389bf1f6a",
+            "c8ae92e47de4e1bb3ae56e9beed27fbc2a1e136a",
 
             # https://github.com/apollographql/router/blob/d826844c8cf433f78938059f02feecc108468e49/licenses.html#L8558
             # https://github.com/apollographql/router-private/blob/d826844c8cf433f78938059f02feecc108468e49/licenses.html#L8558


### PR DESCRIPTION
When I merged #7595, I squashed it and so my .gitleaks.toml updates were no longer correct.

This fixes things.