### PR TITLE
Share `SourceName` model/parsing with runtime

### DIFF
--- a/apollo-federation/src/connectors/expand/mod.rs
+++ b/apollo-federation/src/connectors/expand/mod.rs
@@ -164,11 +164,11 @@ fn split_subgraph(
     let expander = helpers::Expander::new(link, &subgraph);
     connector_map
         .into_iter()
-        .map(|(id, connector)| {
+        .map(|connector| {
             // Build a subgraph using only the necessary fields from the directive
             let schema = expander.expand(&connector)?;
             let subgraph = Subgraph::new(
-                id.synthetic_name().as_str(),
+                connector.id.synthetic_name().as_str(),
                 &subgraph.url,
                 &schema.schema().serialize().to_string(),
             )?;

--- a/apollo-federation/src/connectors/mod.rs
+++ b/apollo-federation/src/connectors/mod.rs
@@ -57,6 +57,7 @@ pub use self::models::HTTPMethod;
 pub use self::models::HeaderSource;
 pub use self::models::HttpJsonTransport;
 pub use self::models::MakeUriError;
+pub use self::models::SourceName;
 pub use self::spec::schema::ConnectBatchArguments;
 use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
@@ -66,7 +67,7 @@ use crate::schema::position::ObjectOrInterfaceFieldDirectivePosition;
 pub struct ConnectId {
     pub label: String,
     pub subgraph_name: String,
-    pub source_name: Option<String>,
+    pub source_name: Option<SourceName>,
     pub(crate) directive: ConnectorPosition,
 }
 
@@ -81,8 +82,12 @@ impl ConnectId {
     }
 
     pub fn subgraph_source(&self) -> String {
-        let source = format!(".{}", self.source_name.as_deref().unwrap_or(""));
-        format!("{}{}", self.subgraph_name, source)
+        let source = self
+            .source_name
+            .as_ref()
+            .map(SourceName::as_str)
+            .unwrap_or("");
+        format!("{}.{}", self.subgraph_name, source)
     }
 
     pub fn coordinate(&self) -> String {
@@ -115,7 +120,7 @@ impl ConnectId {
     /// Intended for tests in apollo-router
     pub fn new(
         subgraph_name: String,
-        source_name: Option<String>,
+        source_name: Option<SourceName>,
         type_name: Name,
         field_name: Name,
         index: usize,
@@ -141,7 +146,7 @@ impl ConnectId {
     /// Intended for tests in apollo-router
     pub fn new_on_object(
         subgraph_name: String,
-        source_name: Option<String>,
+        source_name: Option<SourceName>,
         type_name: Name,
         index: usize,
         label: &str,

--- a/apollo-federation/src/connectors/models.rs
+++ b/apollo-federation/src/connectors/models.rs
@@ -1,5 +1,6 @@
 mod http_json_transport;
 mod keys;
+mod source;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -7,7 +8,6 @@ use std::sync::Arc;
 use apollo_compiler::Name;
 use apollo_compiler::Schema;
 use apollo_compiler::collections::HashSet;
-use apollo_compiler::collections::IndexMap;
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::validation::Valid;
 use keys::make_key_field_set_from_variables;
@@ -19,6 +19,7 @@ pub(crate) use self::http_json_transport::HeaderParseError;
 pub use self::http_json_transport::HeaderSource;
 pub use self::http_json_transport::HttpJsonTransport;
 pub use self::http_json_transport::MakeUriError;
+pub use self::source::SourceName;
 use super::ConnectId;
 use super::JSONSelection;
 use super::PathSelection;
@@ -144,7 +145,7 @@ impl Connector {
         schema: &Schema,
         subgraph_name: &str,
         spec: ConnectSpec,
-    ) -> Result<IndexMap<ConnectId, Self>, FederationError> {
+    ) -> Result<Vec<Self>, FederationError> {
         let connect_identity = ConnectSpec::identity();
         let Some((link, _)) = Link::for_identity(schema, &connect_identity) else {
             return Ok(Default::default());
@@ -168,11 +169,10 @@ impl Connector {
         spec: ConnectSpec,
         connect: ConnectDirectiveArguments,
         source_arguments: &[SourceDirectiveArguments],
-    ) -> Result<(ConnectId, Self), FederationError> {
+    ) -> Result<Self, FederationError> {
         let source = connect
             .source
-            .as_ref()
-            .and_then(|name| source_arguments.iter().find(|s| s.name == *name));
+            .and_then(|name| source_arguments.iter().find(|s| s.name == name));
         let source_name = source.map(|s| s.name.clone());
 
         // Create our transport
@@ -217,14 +217,19 @@ impl Connector {
             &request_variables,
         );
         let id = ConnectId {
-            label: make_label(subgraph_name, &source_name, &transport, &entity_resolver),
+            label: make_label(
+                subgraph_name,
+                source_name.as_ref(),
+                &transport,
+                &entity_resolver,
+            ),
             subgraph_name: subgraph_name.to_string(),
-            source_name: source_name.clone(),
+            source_name,
             directive: connect.position,
         };
 
-        let connector = Connector {
-            id: id.clone(),
+        Ok(Connector {
+            id,
             transport,
             selection: connect.selection,
             entity_resolver,
@@ -237,9 +242,7 @@ impl Connector {
             response_headers,
             batch_settings,
             error_settings,
-        };
-
-        Ok((id, connector))
+        })
     }
 
     pub(crate) fn variable_references(&self) -> impl Iterator<Item = VariableReference<Namespace>> {
@@ -308,12 +311,11 @@ impl Connector {
     /// source_name will be "none" here when we are using a "sourceless" connector. In this situation, we'll use
     /// the synthetic_name instead so that we have some kind of a unique identifier for this source.
     pub fn source_config_key(&self) -> String {
-        let source_name = self
-            .id
-            .source_name
-            .clone()
-            .unwrap_or_else(|| self.id.synthetic_name());
-        format!("{}.{}", self.id.subgraph_name, source_name)
+        if let Some(source_name) = &self.id.source_name {
+            format!("{}.{}", self.id.subgraph_name, source_name)
+        } else {
+            format!("{}.{}", self.id.subgraph_name, self.id.synthetic_name())
+        }
     }
 
     /// Get the name of the `@connect` directive associated with this [`Connector`] instance.
@@ -329,16 +331,16 @@ impl Connector {
 
 fn make_label(
     subgraph_name: &str,
-    source: &Option<String>,
+    source: Option<&SourceName>,
     transport: &HttpJsonTransport,
     entity_resolver: &Option<EntityResolver>,
 ) -> String {
-    let source = format!(".{}", source.as_deref().unwrap_or(""));
+    let source = source.map(|name| name.as_str()).unwrap_or_default();
     let batch = match entity_resolver {
         Some(EntityResolver::TypeBatch) => "[BATCH] ",
         _ => "",
     };
-    format!("{}{}{} {}", batch, subgraph_name, source, transport.label())
+    format!("{batch}{subgraph_name}.{source} {}", transport.label())
 }
 
 fn determine_entity_resolver(
@@ -413,22 +415,9 @@ mod tests {
         let connectors =
             Connector::from_schema(subgraph.schema.schema(), "connectors", ConnectSpec::V0_1)
                 .unwrap();
-        assert_debug_snapshot!(&connectors, @r###"
-        {
-            ConnectId {
-                label: "connectors.json http: GET /users",
-                subgraph_name: "connectors",
-                source_name: Some(
-                    "json",
-                ),
-                directive: Field(
-                    ObjectOrInterfaceFieldDirectivePosition {
-                        field: Object(Query.users),
-                        directive_name: "connect",
-                        directive_index: 0,
-                    },
-                ),
-            }: Connector {
+        assert_debug_snapshot!(&connectors, @r#"
+        [
+            Connector {
                 id: ConnectId {
                     label: "connectors.json http: GET /users",
                     subgraph_name: "connectors",
@@ -531,20 +520,7 @@ mod tests {
                     connect_extensions: None,
                 },
             },
-            ConnectId {
-                label: "connectors.json http: GET /posts",
-                subgraph_name: "connectors",
-                source_name: Some(
-                    "json",
-                ),
-                directive: Field(
-                    ObjectOrInterfaceFieldDirectivePosition {
-                        field: Object(Query.posts),
-                        directive_name: "connect",
-                        directive_index: 0,
-                    },
-                ),
-            }: Connector {
+            Connector {
                 id: ConnectId {
                     label: "connectors.json http: GET /posts",
                     subgraph_name: "connectors",
@@ -659,8 +635,8 @@ mod tests {
                     connect_extensions: None,
                 },
             },
-        }
-        "###);
+        ]
+        "#);
     }
 
     #[test]

--- a/apollo-federation/src/connectors/models/source.rs
+++ b/apollo-federation/src/connectors/models/source.rs
@@ -1,0 +1,238 @@
+use std::fmt;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::hash::Hash;
+use std::ops::Range;
+use std::sync::Arc;
+
+use apollo_compiler::Name;
+use apollo_compiler::Node;
+use apollo_compiler::ast::Directive;
+use apollo_compiler::ast::Value;
+use apollo_compiler::parser::LineColumn;
+use apollo_compiler::parser::SourceMap;
+use apollo_compiler::schema::Component;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+
+use crate::connectors::spec::schema::CONNECT_SOURCE_ARGUMENT_NAME;
+use crate::connectors::spec::schema::SOURCE_NAME_ARGUMENT_NAME;
+use crate::connectors::validation::Code;
+use crate::connectors::validation::Message;
+
+/// The `name` argument of a `@source` directive.
+#[derive(Clone, Eq)]
+pub struct SourceName {
+    pub value: Arc<str>,
+    node: Option<Arc<Node<Value>>>,
+}
+
+impl SourceName {
+    /// Create a `SourceName`, but without checking most validations.
+    ///
+    /// Useful for speeding up parsing at runtime & tests.
+    ///
+    /// For enhanced validity checks, use [`SourceName::from_directive`]
+    pub(crate) fn from_directive_permissive(
+        directive: &Component<Directive>,
+        sources: &SourceMap,
+    ) -> Result<Self, Message> {
+        Self::parse_basics(directive, sources)
+    }
+
+    /// Cast a string into a `SourceName` for when they don't come from directives
+    pub fn cast(name: &str) -> Self {
+        Self {
+            value: Arc::from(name),
+            node: None,
+        }
+    }
+    fn parse_basics(
+        directive: &Component<Directive>,
+        sources: &SourceMap,
+    ) -> Result<Self, Message> {
+        let coordinate = NameCoordinate {
+            directive_name: &directive.name,
+            value: None,
+        };
+        let Some(arg) = directive
+            .arguments
+            .iter()
+            .find(|arg| arg.name == SOURCE_NAME_ARGUMENT_NAME)
+        else {
+            return Err(Message {
+                code: Code::GraphQLError,
+                message: format!("The {coordinate} argument is required.",),
+                locations: directive.line_column_range(sources).into_iter().collect(),
+            });
+        };
+        let node = &arg.value;
+        let Some(str_value) = node.as_str() else {
+            return Err(Message {
+                message: format!("{coordinate} is invalid; source names must be strings.",),
+                code: Code::InvalidSourceName,
+                locations: node.line_column_range(sources).into_iter().collect(),
+            });
+        };
+        Ok(Self {
+            value: Arc::from(str_value),
+            node: Some(Arc::new(node.clone())),
+        })
+    }
+
+    pub(crate) fn from_connect(directive: &Node<Directive>) -> Option<Self> {
+        let arg = directive
+            .arguments
+            .iter()
+            .find(|arg| arg.name == CONNECT_SOURCE_ARGUMENT_NAME)?;
+        let node = &arg.value;
+        let str_value = node.as_str()?;
+        Some(Self {
+            value: Arc::from(str_value),
+            node: Some(Arc::new(node.clone())),
+        })
+    }
+    pub(crate) fn from_directive(
+        directive: &Component<Directive>,
+        sources: &SourceMap,
+    ) -> (Option<Self>, Option<Message>) {
+        let name = match Self::parse_basics(directive, sources) {
+            Ok(name) => name,
+            Err(message) => return (None, Some(message)),
+        };
+
+        let coordinate = NameCoordinate {
+            directive_name: &directive.name,
+            value: Some(name.value.clone()),
+        };
+
+        let Some(first_char) = name.value.chars().next() else {
+            let locations = name.locations(sources);
+            return (
+                Some(name),
+                Some(Message {
+                    code: Code::EmptySourceName,
+                    message: format!("The value for {coordinate} can't be empty.",),
+                    locations,
+                }),
+            );
+        };
+        let message = if !first_char.is_ascii_alphabetic() {
+            Some(Message {
+                message: format!(
+                    "{coordinate} is invalid; source names must start with an ASCII letter (a-z or A-Z)",
+                ),
+                code: Code::InvalidSourceName,
+                locations: name.locations(sources),
+            })
+        } else if name.value.len() > 64 {
+            Some(Message {
+                message: format!(
+                    "{coordinate} is invalid; source names must be 64 characters or fewer",
+                ),
+                code: Code::InvalidSourceName,
+                locations: name.locations(sources),
+            })
+        } else {
+            name.value
+                .chars()
+                .find(|c| !c.is_ascii_alphanumeric() && *c != '_' && *c != '-').map(|unacceptable| Message {
+                message: format!(
+                    "{coordinate} can't contain `{unacceptable}`; only ASCII letters, numbers, underscores, or hyphens are allowed",
+                ),
+                code: Code::InvalidSourceName,
+                locations: name.locations(sources),
+            })
+        };
+        (Some(name), message)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+
+    pub(crate) fn locations(&self, sources: &SourceMap) -> Vec<Range<LineColumn>> {
+        self.node
+            .as_ref()
+            .map(|node| node.line_column_range(sources))
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+}
+
+impl Display for SourceName {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl Debug for SourceName {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(&self.as_str(), f)
+    }
+}
+
+impl PartialEq<Node<Value>> for SourceName {
+    fn eq(&self, other: &Node<Value>) -> bool {
+        other
+            .as_str()
+            .is_some_and(|value| value == self.value.as_ref())
+    }
+}
+
+impl PartialEq<SourceName> for SourceName {
+    fn eq(&self, other: &SourceName) -> bool {
+        self.value == other.value
+    }
+}
+
+impl Hash for SourceName {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+impl Serialize for SourceName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.value)
+    }
+}
+
+impl<'de> Deserialize<'de> for SourceName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Arc::deserialize(deserializer)?;
+        Ok(Self { value, node: None })
+    }
+}
+
+struct NameCoordinate<'schema> {
+    directive_name: &'schema Name,
+    value: Option<Arc<str>>,
+}
+
+impl Display for NameCoordinate<'_> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        if let Some(value) = &self.value {
+            write!(
+                f,
+                "`@{}({SOURCE_NAME_ARGUMENT_NAME}: \"{value}\")`",
+                self.directive_name,
+            )
+        } else {
+            write!(
+                f,
+                "`@{}({SOURCE_NAME_ARGUMENT_NAME}:)`",
+                self.directive_name
+            )
+        }
+    }
+}

--- a/apollo-federation/src/connectors/spec/schema.rs
+++ b/apollo-federation/src/connectors/spec/schema.rs
@@ -6,6 +6,7 @@ use http::Uri;
 
 use crate::connectors::ConnectorPosition;
 use crate::connectors::HeaderSource;
+use crate::connectors::SourceName;
 use crate::connectors::json_selection::JSONSelection;
 
 pub(crate) const CONNECT_DIRECTIVE_NAME_IN_SPEC: Name = name!("connect");
@@ -48,7 +49,7 @@ pub(crate) const URL_PATH_TEMPLATE_SCALAR_NAME: Name = name!("URLTemplate");
 #[cfg_attr(test, derive(Debug))]
 pub(crate) struct SourceDirectiveArguments {
     /// The friendly name of this source for use in `@connect` directives
-    pub(crate) name: String,
+    pub(crate) name: SourceName,
 
     /// Common HTTP options
     pub(crate) http: SourceHTTPArguments,
@@ -90,7 +91,7 @@ pub(crate) struct ConnectDirectiveArguments {
     /// The upstream source for shared connector configuration.
     ///
     /// Must match the `name` argument of a @source directive in this schema.
-    pub(crate) source: Option<String>,
+    pub(crate) source: Option<SourceName>,
 
     /// HTTP options for this connector
     ///

--- a/apollo-federation/src/connectors/validation/connect.rs
+++ b/apollo-federation/src/connectors/validation/connect.rs
@@ -1,5 +1,7 @@
 //! Parsing and validation of `@connect` directives
 
+use std::fmt;
+
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::schema::ExtendedType;
@@ -13,14 +15,13 @@ use self::selection::Selection;
 use super::Code;
 use super::Message;
 use super::coordinates::ConnectDirectiveCoordinate;
-use super::coordinates::connect_directive_name_coordinate;
-use super::coordinates::source_name_value_coordinate;
 use super::errors::ErrorsCoordinate;
-use super::source::SourceName;
 use crate::connectors::Namespace;
+use crate::connectors::SourceName;
 use crate::connectors::id::ConnectedElement;
 use crate::connectors::id::ObjectCategory;
 use crate::connectors::spec::schema::CONNECT_SOURCE_ARGUMENT_NAME;
+use crate::connectors::spec::schema::SOURCE_NAME_ARGUMENT_NAME;
 use crate::connectors::validation::connect::http::Http;
 use crate::connectors::validation::errors::Errors;
 use crate::connectors::validation::graphql::SchemaInfo;
@@ -151,7 +152,7 @@ impl<'schema> Connect<'schema> {
     fn parse(
         coordinate: ConnectDirectiveCoordinate<'schema>,
         schema: &'schema SchemaInfo,
-        source_names: &'schema [SourceName],
+        source_names: &[SourceName],
     ) -> Result<Self, Vec<Message>> {
         if coordinate.element.is_root_type(schema) {
             return Err(vec![Message {
@@ -172,9 +173,9 @@ impl<'schema> Connect<'schema> {
         let (selection, http, errors) = Selection::parse(coordinate, schema)
             .map_err(|err| vec![err])
             .and_try(
-                validate_source_name(&coordinate, source_names, schema)
+                validate_source_name(coordinate, source_names, schema)
                     .map_err(|err| vec![err])
-                    .and_then(|source_name| Http::parse(coordinate, source_name, schema)),
+                    .and_then(|source_name| Http::parse(coordinate, source_name.as_ref(), schema)),
             )
             .and_try(Errors::parse(
                 ErrorsCoordinate::Connect {
@@ -289,34 +290,24 @@ pub(super) struct ResolvedField {
     pub field_name: Name,
 }
 
-fn validate_source_name<'schema>(
-    coordinate: &ConnectDirectiveCoordinate,
-    source_names: &'schema [SourceName],
+fn validate_source_name(
+    coordinate: ConnectDirectiveCoordinate,
+    source_names: &[SourceName],
     schema: &SchemaInfo,
-) -> Result<Option<&'schema SourceName<'schema>>, Message> {
-    let Some(source_name_arg) = coordinate
-        .directive
-        .arguments
-        .iter()
-        .find(|arg| arg.name == CONNECT_SOURCE_ARGUMENT_NAME)
-    else {
+) -> Result<Option<SourceName>, Message> {
+    let Some(source_name) = SourceName::from_connect(coordinate.directive) else {
         return Ok(None);
     };
 
-    let resolved_source_name = source_names
-        .iter()
-        .find(|name| **name == source_name_arg.value);
-
-    if let Some(source_name) = resolved_source_name {
+    if source_names.contains(&source_name) {
         return Ok(Some(source_name));
     }
     // A source name was set but doesn't match a defined source
     // TODO: Pick a suggestion that's not just the first defined source
-    let qualified_directive = connect_directive_name_coordinate(
-        schema.connect_directive_name(),
-        &source_name_arg.value,
-        coordinate,
-    );
+    let qualified_directive = ConnectSourceCoordinate {
+        connect: coordinate,
+        source: source_name.as_str(),
+    };
     if let Some(first_source_name) = source_names.first() {
         Err(Message {
             code: Code::SourceNameMismatch,
@@ -324,25 +315,33 @@ fn validate_source_name<'schema>(
                 "{qualified_directive} does not match any defined sources. Did you mean \"{first_source_name}\"?",
                 first_source_name = first_source_name.as_str(),
             ),
-            locations: source_name_arg
-                .line_column_range(&schema.sources)
-                .into_iter()
-                .collect(),
+            locations: source_name.locations(&schema.sources),
         })
     } else {
         Err(Message {
             code: Code::NoSourcesDefined,
             message: format!(
-                "{qualified_directive} specifies a source, but none are defined. Try adding {coordinate} to the schema.",
-                coordinate = source_name_value_coordinate(
-                    schema.source_directive_name(),
-                    &source_name_arg.value
-                ),
+                "{qualified_directive} specifies a source, but none are defined. Try adding `@{source_directive_name}({SOURCE_NAME_ARGUMENT_NAME}: \"{value}\")` to the schema.",
+                source_directive_name = schema.source_directive_name(),
+                value = source_name,
             ),
-            locations: source_name_arg
-                .line_column_range(&schema.sources)
-                .into_iter()
-                .collect(),
+            locations: source_name.locations(&schema.sources),
         })
+    }
+}
+
+struct ConnectSourceCoordinate<'schema> {
+    source: &'schema str,
+    connect: ConnectDirectiveCoordinate<'schema>,
+}
+impl fmt::Display for ConnectSourceCoordinate<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "`@{connect_directive_name}({CONNECT_SOURCE_ARGUMENT_NAME}: \"{source}\")` on `{element}`",
+            connect_directive_name = self.connect.directive.name,
+            element = self.connect.element,
+            source = self.source,
+        )
     }
 }

--- a/apollo-federation/src/connectors/validation/connect/http.rs
+++ b/apollo-federation/src/connectors/validation/connect/http.rs
@@ -11,6 +11,7 @@ use shape::Shape;
 
 use crate::connectors::HTTPMethod;
 use crate::connectors::Namespace;
+use crate::connectors::SourceName;
 use crate::connectors::spec::schema::CONNECT_BODY_ARGUMENT_NAME;
 use crate::connectors::spec::schema::CONNECT_SOURCE_ARGUMENT_NAME;
 use crate::connectors::spec::schema::HTTP_ARGUMENT_NAME;
@@ -33,7 +34,6 @@ use crate::connectors::validation::graphql::SchemaInfo;
 use crate::connectors::validation::http::UrlProperties;
 use crate::connectors::validation::http::headers::Headers;
 use crate::connectors::validation::http::url::validate_url_scheme;
-use crate::connectors::validation::source::SourceName;
 
 /// A valid, parsed (but not type-checked) `@connect(http:)`.
 ///
@@ -57,7 +57,7 @@ impl<'schema> Http<'schema> {
     /// The order these pieces run in doesn't matter and shouldn't affect the output.
     pub(super) fn parse(
         coordinate: ConnectDirectiveCoordinate<'schema>,
-        source_name: Option<&'schema SourceName>,
+        source_name: Option<&SourceName>,
         schema: &'schema SchemaInfo,
     ) -> Result<Self, Vec<Message>> {
         let Some((http_arg, http_arg_node)) = coordinate
@@ -230,7 +230,7 @@ impl<'schema> Transport<'schema> {
         http_arg: &'schema [(Name, Node<Value>)],
         coordinate: ConnectHTTPCoordinate<'schema>,
         http_arg_node: &Node<Value>,
-        source_name: Option<&SourceName<'schema>>,
+        source_name: Option<&SourceName>,
         schema: &'schema SchemaInfo<'schema>,
     ) -> Result<Self, Vec<Message>> {
         let source_map = &schema.sources;

--- a/apollo-federation/src/connectors/validation/coordinates.rs
+++ b/apollo-federation/src/connectors/validation/coordinates.rs
@@ -8,15 +8,13 @@ use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::Value;
 
 use super::DirectiveName;
-use super::source::SourceName;
 use crate::connectors::HTTPMethod;
+use crate::connectors::SourceName;
 use crate::connectors::id::ConnectedElement;
 use crate::connectors::spec::schema::CONNECT_SELECTION_ARGUMENT_NAME;
-use crate::connectors::spec::schema::CONNECT_SOURCE_ARGUMENT_NAME;
 use crate::connectors::spec::schema::HEADERS_ARGUMENT_NAME;
 use crate::connectors::spec::schema::HTTP_ARGUMENT_NAME;
 use crate::connectors::spec::schema::SOURCE_BASE_URL_ARGUMENT_NAME;
-use crate::connectors::spec::schema::SOURCE_NAME_ARGUMENT_NAME;
 
 /// The location of a `@connect` directive.
 #[derive(Clone, Copy)]
@@ -37,9 +35,9 @@ impl Display for ConnectDirectiveCoordinate<'_> {
 }
 
 /// The location of a `@source` directive.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(super) struct SourceDirectiveCoordinate<'a> {
-    pub(crate) name: SourceName<'a>,
+    pub(crate) name: SourceName,
     pub(super) directive: &'a Node<Directive>,
 }
 
@@ -147,28 +145,6 @@ impl Display for BaseUrlCoordinate<'_> {
 
 pub(super) fn source_http_argument_coordinate(source_directive_name: &DirectiveName) -> String {
     format!("`@{source_directive_name}({HTTP_ARGUMENT_NAME}:)`")
-}
-
-pub(super) fn source_name_argument_coordinate(source_directive_name: &DirectiveName) -> String {
-    format!("`@{source_directive_name}({SOURCE_NAME_ARGUMENT_NAME}:)`")
-}
-
-pub(super) fn source_name_value_coordinate(
-    source_directive_name: &DirectiveName,
-    value: &Node<Value>,
-) -> String {
-    format!("`@{source_directive_name}({SOURCE_NAME_ARGUMENT_NAME}: {value})`")
-}
-
-pub(super) fn connect_directive_name_coordinate(
-    connect_directive_name: &Name,
-    source: &Node<Value>,
-    coordinate: &ConnectDirectiveCoordinate,
-) -> String {
-    format!(
-        "`@{connect_directive_name}({CONNECT_SOURCE_ARGUMENT_NAME}: {source})` on `{element}`",
-        element = coordinate.element
-    )
 }
 
 /// Coordinate for an `HTTP.headers` argument in `@source` or `@connect`.

--- a/apollo-federation/src/connectors/validation/errors.rs
+++ b/apollo-federation/src/connectors/validation/errors.rs
@@ -47,7 +47,7 @@ impl<'schema> Errors<'schema> {
         coordinate: ErrorsCoordinate<'schema>,
         schema: &'schema SchemaInfo,
     ) -> Result<Self, Vec<Message>> {
-        let directive = match coordinate {
+        let directive = match &coordinate {
             ErrorsCoordinate::Source { source } => source.directive,
             ErrorsCoordinate::Connect { connect } => connect.directive,
         };
@@ -59,7 +59,7 @@ impl<'schema> Errors<'schema> {
         };
 
         if let Some(errors_arg) = arg.as_object() {
-            ErrorsMessage::parse(errors_arg, coordinate, schema)
+            ErrorsMessage::parse(errors_arg, coordinate.clone(), schema)
                 .and_try(ErrorsExtensions::parse(errors_arg, coordinate, schema))
                 .map(|(message, extensions)| Self {
                     message,
@@ -139,8 +139,12 @@ impl<'schema> ErrorsMessage<'schema> {
         };
         let coordinate = ErrorsMessageCoordinate { coordinate };
 
-        let mapping =
-            parse_mapping_argument(value, coordinate, Code::InvalidErrorsMessage, schema)?;
+        let mapping = parse_mapping_argument(
+            value,
+            coordinate.clone(),
+            Code::InvalidErrorsMessage,
+            schema,
+        )?;
 
         Ok(Some(Self {
             mapping,
@@ -176,7 +180,7 @@ impl<'schema> ErrorsMessage<'schema> {
 }
 
 /// Coordinate for an `errors` argument in `@source` or `@connect`.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(super) enum ErrorsCoordinate<'a> {
     Source {
         source: SourceDirectiveCoordinate<'a>,
@@ -199,14 +203,14 @@ impl Display for ErrorsCoordinate<'_> {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct ErrorsMessageCoordinate<'schema> {
     coordinate: ErrorsCoordinate<'schema>,
 }
 
 impl Display for ErrorsMessageCoordinate<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self.coordinate {
+        match &self.coordinate {
             ErrorsCoordinate::Source { source } => {
                 write!(
                     f,
@@ -247,8 +251,12 @@ impl<'schema> ErrorsExtensions<'schema> {
         };
         let coordinate = ErrorsExtensionsCoordinate { coordinate };
 
-        let MappingArgument { expression, string } =
-            parse_mapping_argument(value, coordinate, Code::InvalidErrorsMessage, schema)?;
+        let MappingArgument { expression, string } = parse_mapping_argument(
+            value,
+            coordinate.clone(),
+            Code::InvalidErrorsMessage,
+            schema,
+        )?;
 
         Ok(Some(Self {
             selection: expression.expression,
@@ -288,14 +296,14 @@ impl<'schema> ErrorsExtensions<'schema> {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct ErrorsExtensionsCoordinate<'schema> {
     coordinate: ErrorsCoordinate<'schema>,
 }
 
 impl Display for ErrorsExtensionsCoordinate<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self.coordinate {
+        match &self.coordinate {
             ErrorsCoordinate::Source { source } => {
                 write!(
                     f,

--- a/apollo-federation/src/connectors/validation/http/url_properties.rs
+++ b/apollo-federation/src/connectors/validation/http/url_properties.rs
@@ -53,11 +53,11 @@ impl<'schema> UrlProperties<'schema> {
             })
             .map(|(property, value)| {
                 let coordinate = Coordinate {
-                    directive,
+                    directive: directive.clone(),
                     property,
                 };
                 let mapping =
-                    parse_mapping_argument(value, coordinate, Code::InvalidUrlProperty, schema)?;
+                    parse_mapping_argument(value, &coordinate, Code::InvalidUrlProperty, schema)?;
                 Ok(Property {
                     coordinate,
                     mapping,
@@ -130,7 +130,7 @@ impl Property<'_> {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct Coordinate<'schema> {
     directive: ConnectOrSource<'schema>,
     property: PropertyName,
@@ -149,7 +149,7 @@ impl fmt::Display for Coordinate<'_> {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum ConnectOrSource<'schema> {
     Source(SourceDirectiveCoordinate<'schema>),
     Connect(ConnectDirectiveCoordinate<'schema>),

--- a/apollo-federation/src/connectors/validation/mod.rs
+++ b/apollo-federation/src/connectors/validation/mod.rs
@@ -83,7 +83,7 @@ pub fn validate(mut source_text: String, file_name: &str) -> ValidationResult {
     let (source_directives, mut messages) = SourceDirective::find(&schema_info);
     let all_source_names = source_directives
         .iter()
-        .map(|directive| directive.name)
+        .map(|directive| directive.name.clone())
         .collect_vec();
 
     for source in source_directives {

--- a/apollo-federation/src/connectors/validation/schema.rs
+++ b/apollo-federation/src/connectors/validation/schema.rs
@@ -315,7 +315,7 @@ fn advanced_validations(schema: &SchemaInfo, subgraph_name: &str) -> Vec<Message
         entity_checker.add_key(&field_set, directive);
     }
 
-    for (_, connector) in &connectors {
+    for connector in &connectors {
         if connector.entity_resolver == Some(TypeBatch) {
             let input_trie = compute_batch_input_trie(connector);
             match SelectionSetWalker::new(connector.name(), schema, &input_trie)
@@ -327,7 +327,7 @@ fn advanced_validations(schema: &SchemaInfo, subgraph_name: &str) -> Vec<Message
         }
     }
 
-    for (_, connector) in connectors {
+    for connector in connectors {
         match connector.resolvable_key(schema) {
             Ok(None) => continue,
             Err(_) => {

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@batch.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@batch.graphql.snap
@@ -22,7 +22,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/batch.graphql
         code: SourceNameMismatch,
         message: "`@connect(source: \"missing\")` on `T` does not match any defined sources. Did you mean \"json\"?",
         locations: [
-            31:5..31:22,
+            31:13..31:22,
         ],
     },
     Message {

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@connect_source_name_mismatch.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@connect_source_name_mismatch.graphql.snap
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/connect_source
         code: SourceNameMismatch,
         message: "`@connect(source: \"v1\")` on `Query.resources` does not match any defined sources. Did you mean \"v2\"?",
         locations: [
-            10:14..10:26,
+            10:22..10:26,
         ],
     },
 ]

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@connect_source_undefined.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@connect_source_undefined.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", errors)"
+expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/connectors/validation/test_data/connect_source_undefined.graphql
 ---
 [
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/connect_source
         code: NoSourcesDefined,
         message: "`@connect(source: \"v1\")` on `Query.resources` specifies a source, but none are defined. Try adding `@source(name: \"v1\")` to the schema.",
         locations: [
-            9:14..9:26,
+            9:22..9:26,
         ],
     },
 ]

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@empty_source_name.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@empty_source_name.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", errors)"
+expression: "format!(\"{:#?}\", result.errors)"
 input_file: apollo-federation/src/connectors/validation/test_data/empty_source_name.graphql
 ---
 [
     Message {
         code: EmptySourceName,
-        message: "The value for `@source(name:)` can't be empty.",
+        message: "The value for `@source(name: \"\")` can't be empty.",
         locations: [
             6:17..6:19,
         ],

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@missing_source_import.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@missing_source_import.graphql.snap
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/missing_source
         code: NoSourcesDefined,
         message: "`@connect(source: \"v2\")` on `Query.resources` specifies a source, but none are defined. Try adding `@connect__source(name: \"v2\")` to the schema.",
         locations: [
-            7:14..7:26,
+            7:22..7:26,
         ],
     },
     Message {

--- a/apollo-federation/src/connectors/validation/source.rs
+++ b/apollo-federation/src/connectors/validation/source.rs
@@ -1,21 +1,13 @@
 //! Validates `@source` directives
 
-use std::fmt;
-use std::fmt::Display;
-use std::fmt::Formatter;
-
-use apollo_compiler::Node;
 use apollo_compiler::ast::Directive;
-use apollo_compiler::parser::SourceMap;
 use apollo_compiler::schema::Component;
-use apollo_compiler::schema::Value;
 use hashbrown::HashMap;
 
 use super::coordinates::SourceDirectiveCoordinate;
-use super::coordinates::source_name_argument_coordinate;
-use super::coordinates::source_name_value_coordinate;
 use super::errors::ErrorsCoordinate;
 use super::http::UrlProperties;
+use crate::connectors::SourceName;
 use crate::connectors::spec::schema::HTTP_ARGUMENT_NAME;
 use crate::connectors::spec::schema::SOURCE_BASE_URL_ARGUMENT_NAME;
 use crate::connectors::spec::schema::SOURCE_NAME_ARGUMENT_NAME;
@@ -31,7 +23,7 @@ use crate::connectors::validation::parse_url;
 
 /// A `@source` directive along with any errors related to it.
 pub(super) struct SourceDirective<'schema> {
-    pub(crate) name: SourceName<'schema>,
+    pub(crate) name: SourceName,
     directive: &'schema Component<Directive>,
     url: Option<UrlProperties<'schema>>,
     headers: Option<Headers<'schema>>,
@@ -55,7 +47,7 @@ impl<'schema> SourceDirective<'schema> {
         let mut valid_source_names = HashMap::new();
         for directive in &directives {
             valid_source_names
-                .entry(&directive.name.0)
+                .entry(directive.name.as_str())
                 .or_insert_with(Vec::new)
                 .extend(directive.directive.node.line_column_range(&schema.sources))
         }
@@ -78,13 +70,21 @@ impl<'schema> SourceDirective<'schema> {
         let mut messages = Vec::new();
         let (name, name_messages) = SourceName::from_directive(directive, &schema.sources);
         messages.extend(name_messages);
+        let Some(name) = name else {
+            return (None, messages);
+        };
 
         let coordinate = SourceDirectiveCoordinate {
             directive,
-            name: name.unwrap_or_default(),
+            name: name.clone(),
         };
 
-        let errors = match Errors::parse(ErrorsCoordinate::Source { source: coordinate }, schema) {
+        let errors = match Errors::parse(
+            ErrorsCoordinate::Source {
+                source: coordinate.clone(),
+            },
+            schema,
+        ) {
             Ok(errors) => Some(errors),
             Err(errs) => {
                 messages.extend(errs);
@@ -108,7 +108,7 @@ impl<'schema> SourceDirective<'schema> {
                     .collect(),
             });
             return (
-                name.map(|name| SourceDirective {
+                Some(SourceDirective {
                     name,
                     schema,
                     directive,
@@ -160,7 +160,7 @@ impl<'schema> SourceDirective<'schema> {
         };
 
         (
-            name.map(|name| SourceDirective {
+            Some(SourceDirective {
                 name,
                 directive,
                 url,
@@ -187,110 +187,5 @@ impl<'schema> SourceDirective<'schema> {
             messages.extend(headers.type_check(self.schema).err().into_iter().flatten());
         }
         messages
-    }
-}
-
-/// The `name` argument of a `@source` directive.
-#[derive(Clone, Debug, Copy, Default)]
-pub(super) struct SourceName<'schema>(&'schema str);
-
-impl<'schema> SourceName<'schema> {
-    pub(crate) fn from_directive(
-        directive: &'schema Component<Directive>,
-        sources: &SourceMap,
-    ) -> (Option<Self>, Option<Message>) {
-        let directive_name = directive.name.clone();
-        let Some(arg) = directive
-            .arguments
-            .iter()
-            .find(|arg| arg.name == SOURCE_NAME_ARGUMENT_NAME)
-        else {
-            return (
-                None,
-                Some(Message {
-                    code: Code::GraphQLError,
-                    message: format!(
-                        "The {coordinate} argument is required.",
-                        coordinate = source_name_argument_coordinate(&directive_name)
-                    ),
-                    locations: directive.line_column_range(sources).into_iter().collect(),
-                }),
-            );
-        };
-        let value = &arg.value;
-        let Some(str_value) = value.as_str() else {
-            return (
-                None,
-                Some(Message {
-                    message: format!(
-                        "{coordinate} is invalid; source names must be strings.",
-                        coordinate = source_name_value_coordinate(&directive_name, value)
-                    ),
-                    code: Code::InvalidSourceName,
-                    locations: value.line_column_range(sources).into_iter().collect(),
-                }),
-            );
-        };
-        let name = Some(Self(str_value));
-        let Some(first_char) = str_value.chars().next() else {
-            return (
-                name,
-                Some(Message {
-                    code: Code::EmptySourceName,
-                    message: format!(
-                        "The value for {coordinate} can't be empty.",
-                        coordinate = source_name_argument_coordinate(&directive_name)
-                    ),
-                    locations: arg.value.line_column_range(sources).into_iter().collect(),
-                }),
-            );
-        };
-        let message = if !first_char.is_ascii_alphabetic() {
-            Some(Message {
-                message: format!(
-                    "{coordinate} is invalid; source names must start with an ASCII letter (a-z or A-Z)",
-                    coordinate = source_name_value_coordinate(&directive_name, value)
-                ),
-                code: Code::InvalidSourceName,
-                locations: value.line_column_range(sources).into_iter().collect(),
-            })
-        } else if str_value.len() > 64 {
-            Some(Message {
-                message: format!(
-                    "{coordinate} is invalid; source names must be 64 characters or fewer",
-                    coordinate = source_name_value_coordinate(&directive_name, value)
-                ),
-                code: Code::InvalidSourceName,
-                locations: value.line_column_range(sources).into_iter().collect(),
-            })
-        } else {
-            str_value
-            .chars()
-            .find(|c| !c.is_ascii_alphanumeric() && *c != '_' && *c != '-').map(|unacceptable| Message {
-                message: format!(
-                    "{coordinate} can't contain `{unacceptable}`; only ASCII letters, numbers, underscores, or hyphens are allowed",
-                    coordinate = source_name_value_coordinate(&directive_name, value)
-                ),
-                code: Code::InvalidSourceName,
-                locations: value.line_column_range(sources).into_iter().collect(),
-            })
-        };
-        (name, message)
-    }
-
-    pub(crate) fn as_str(&self) -> &str {
-        self.0
-    }
-}
-
-impl Display for SourceName<'_> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl PartialEq<Node<Value>> for SourceName<'_> {
-    fn eq(&self, other: &Node<Value>) -> bool {
-        other.as_str().is_some_and(|value| value == self.0)
     }
 }

--- a/apollo-router/src/plugins/connectors/configuration.rs
+++ b/apollo-router/src/plugins/connectors/configuration.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use apollo_federation::connectors::CustomConfiguration;
+use apollo_federation::connectors::SourceName;
 use apollo_federation::connectors::expand::Connectors;
 use http::Uri;
 use schemars::JsonSchema;
@@ -67,7 +68,7 @@ pub(crate) struct ConnectorsConfig {
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct SubgraphConnectorConfiguration {
     /// A map of `@source(name:)` to configuration for that source
-    pub(crate) sources: HashMap<String, SourceConfiguration>,
+    pub(crate) sources: HashMap<SourceName, SourceConfiguration>,
 
     /// Other values that can be used by connectors via `{$config.<key>}`
     #[serde(rename = "$config")]

--- a/apollo-router/src/plugins/connectors/incompatible/authentication.rs
+++ b/apollo-router/src/plugins/connectors/incompatible/authentication.rs
@@ -90,7 +90,8 @@ impl IncompatiblePlugin for AuthIncompatPlugin {
                     connector
                         .id
                         .source_name
-                        .clone()
+                        .as_ref()
+                        .map(|name| name.to_string())
                         .unwrap_or(format!("<anonymous source for {}>", connector.id)),
                 )
             })

--- a/apollo-router/src/plugins/connectors/request_limit.rs
+++ b/apollo-router/src/plugins/connectors/request_limit.rs
@@ -8,13 +8,14 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
 use apollo_federation::connectors::ConnectId;
+use apollo_federation::connectors::SourceName;
 use parking_lot::Mutex;
 
 /// Key to access request limits for a connector
 #[derive(Eq, Hash, PartialEq)]
 pub(crate) enum RequestLimitKey {
     /// A key to access the request limit for a connector referencing a source directive
-    SourceName(String),
+    SourceName(SourceName),
 
     /// A key to access the request limit for a connector without a corresponding source directive
     ConnectorLabel(String),

--- a/apollo-router/src/plugins/telemetry/config_new/connector/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/attributes.rs
@@ -110,7 +110,7 @@ impl Selectors<ConnectorRequest, ConnectorResponse, ()> for ConnectorAttributes 
             .and_then(|a| a.key(CONNECTOR_SOURCE_NAME))
         {
             if let Some(ref source_name) = request.connector.id.source_name {
-                attrs.push(KeyValue::new(key, source_name.clone()));
+                attrs.push(KeyValue::new(key, source_name.value.clone()));
             }
         }
         if let Some(key) = self

--- a/apollo-router/src/plugins/telemetry/config_new/connector/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/events.rs
@@ -134,6 +134,7 @@ mod tests {
     use apollo_federation::connectors::Connector;
     use apollo_federation::connectors::HttpJsonTransport;
     use apollo_federation::connectors::JSONSelection;
+    use apollo_federation::connectors::SourceName;
     use apollo_federation::connectors::StringTemplate;
     use http::HeaderValue;
     use tracing::instrument::WithSubscriber;
@@ -172,7 +173,7 @@ mod tests {
             let connector = Connector {
                 id: ConnectId::new(
                     "subgraph".into(),
-                    Some("source".into()),
+                    Some(SourceName::cast("source")),
                     name!(Query),
                     name!(users),
                     0,
@@ -258,7 +259,7 @@ mod tests {
             let connector = Connector {
                 id: ConnectId::new(
                     "subgraph".into(),
-                    Some("source".into()),
+                    Some(SourceName::cast("source")),
                     name!(Query),
                     name!(users),
                     0,

--- a/apollo-router/src/plugins/telemetry/config_new/connector/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/selectors.rs
@@ -127,7 +127,7 @@ impl Selector for ConnectorSelector {
                 .id
                 .source_name
                 .as_ref()
-                .cloned()
+                .map(|name| name.value.clone())
                 .map(opentelemetry::Value::from),
             ConnectorSelector::ConnectorHttpMethod {
                 connector_http_method,
@@ -302,6 +302,7 @@ mod tests {
     use apollo_federation::connectors::Connector;
     use apollo_federation::connectors::HttpJsonTransport;
     use apollo_federation::connectors::JSONSelection;
+    use apollo_federation::connectors::SourceName;
     use apollo_federation::connectors::StringTemplate;
     use http::HeaderValue;
     use http::StatusCode;
@@ -340,7 +341,7 @@ mod tests {
         Connector {
             id: ConnectId::new(
                 TEST_SUBGRAPH_NAME.into(),
-                Some(TEST_SOURCE_NAME.into()),
+                Some(SourceName::cast(TEST_SOURCE_NAME)),
                 name!(Query),
                 name!(users),
                 0,

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -2450,6 +2450,7 @@ mod tests {
     use apollo_federation::connectors::HTTPMethod;
     use apollo_federation::connectors::HttpJsonTransport;
     use apollo_federation::connectors::JSONSelection;
+    use apollo_federation::connectors::SourceName;
     use apollo_federation::connectors::StringTemplate;
     use http::HeaderMap;
     use http::HeaderName;
@@ -3072,7 +3073,7 @@ mod tests {
                                     let connector = Connector {
                                         id: ConnectId::new(
                                             subgraph_name,
-                                            Some(source_name),
+                                            Some(SourceName::cast(&source_name)),
                                             name!(Query),
                                             name!(field),
                                             0,
@@ -3137,7 +3138,7 @@ mod tests {
                                     let connector = Connector {
                                         id: ConnectId::new(
                                             subgraph_name,
-                                            Some(source_name),
+                                            Some(SourceName::cast(&source_name)),
                                             name!(Query),
                                             name!(field),
                                             0,

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -268,6 +268,7 @@ mod tests {
     use apollo_federation::connectors::Connector;
     use apollo_federation::connectors::HttpJsonTransport;
     use apollo_federation::connectors::JSONSelection;
+    use apollo_federation::connectors::SourceName;
     use apollo_federation::connectors::StringTemplate;
     use http::HeaderValue;
     use http::header::CONTENT_LENGTH;
@@ -821,7 +822,7 @@ connector:
                 let connector = Arc::new(Connector {
                     id: ConnectId::new(
                         "connector_subgraph".into(),
-                        Some("source".into()),
+                        Some(SourceName::cast("source")),
                         name!(Query),
                         name!(users),
                         0,
@@ -1174,7 +1175,7 @@ subgraph:
                 let connector = Arc::new(Connector {
                     id: ConnectId::new(
                         "connector_subgraph".into(),
-                        Some("source".into()),
+                        Some(SourceName::cast("source")),
                         name!(Query),
                         name!(users),
                         0,

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -582,6 +582,7 @@ mod test {
     use apollo_federation::connectors::Connector;
     use apollo_federation::connectors::HttpJsonTransport;
     use apollo_federation::connectors::JSONSelection;
+    use apollo_federation::connectors::SourceName;
     use bytes::Bytes;
     use http::HeaderMap;
     use http::Uri;
@@ -769,7 +770,7 @@ mod test {
             spec: ConnectSpec::V0_1,
             id: ConnectId::new(
                 "test_subgraph".into(),
-                Some("test_sourcename".into()),
+                Some(SourceName::cast("test_sourcename")),
                 name!(Query),
                 name!(hello),
                 0,

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use apollo_federation::connectors::Connector;
+use apollo_federation::connectors::SourceName;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
 use opentelemetry::Key;
@@ -61,11 +62,11 @@ pub(crate) struct ConnectorService {
 #[derive(Hash, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub(crate) struct ConnectorSourceRef {
     pub(crate) subgraph_name: String,
-    pub(crate) source_name: String,
+    pub(crate) source_name: SourceName,
 }
 
 impl ConnectorSourceRef {
-    pub(crate) fn new(subgraph_name: String, source_name: String) -> Self {
+    pub(crate) fn new(subgraph_name: String, source_name: SourceName) -> Self {
         Self {
             subgraph_name,
             source_name,
@@ -84,9 +85,8 @@ impl FromStr for ConnectorSourceRef {
             .to_string();
         let source_name = parts
             .next()
-            .ok_or(format!("Invalid connector source reference '{}'", s))?
-            .to_string();
-        Ok(Self::new(subgraph_name, source_name))
+            .ok_or(format!("Invalid connector source reference '{}'", s))?;
+        Ok(Self::new(subgraph_name, SourceName::cast(source_name)))
     }
 }
 
@@ -166,7 +166,7 @@ impl tower::Service<ConnectRequest> for ConnectorService {
                 span.record("apollo.connector.detail", detail);
             }
             if let Some(source_name) = connector.id.source_name.as_ref() {
-                span.record("apollo.connector.source.name", source_name);
+                span.record("apollo.connector.source.name", source_name.as_str());
                 if let Ok(detail) = serde_json::to_string(
                     &serde_json::json!({ "baseURL": transport.source_url.as_ref().map(|uri| uri.to_string()) }),
                 ) {


### PR DESCRIPTION
This PR is the first step toward sharing more parsing/model code between validations & runtime. It comes with a few key improvements:

1. There are two fewer places where argument definitions can drift, since `@connect(source:)` and `@source(name:)` parsing is now shared instead of redefined.
2. Using the dedicated `SourceName` type instead of `String` everywhere will make it easier to find usages and prevent potential bugs (putting the wrong string in the wrong place)
3. `SourceName` uses `Arc<str>` instead of `String` which will reduce of ton of little clones all over the place. This isn't expected to meaningfully impact performance, though.
4. While walking through the code, I was able to rethink/simplify a few things, like getting rid of the map of connectors.

This first step also reveals a few insights about this refactor effort:

1. We are not going to be able to use the same lifetime/copy-based approach we have been in validation, since the runtime can't keep track of those lifetimes. Instead, we should be using reference counting (which has to be `Arc` since runtime is asynchronous) where things are shared. This makes for a bit more effort in rewriting and _may_ have a performance implication for validations of very large schemas.
2. There's probably a lot of other tech debt lurking that we're going to uncover while unifying parsing.
3. It's going to take a lot of work just to figure out the right _order_ to tackle these things in. This PR is actually the third branch as I followed a rabbit hole, realized something else had to be ported first, then continued.