### PR TITLE
feat(federation/composition): port `subgraphNameToGraphEnumValue`

### DIFF
--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -119,6 +119,30 @@ impl Supergraph<Merged> {
     pub fn hints(&self) -> &Vec<CompositionHint> {
         &self.state.hints
     }
+
+    #[allow(unused)]
+    pub(crate) fn subgraph_name_to_graph_enum_value(
+        &self,
+    ) -> Result<IndexMap<String, Name>, FederationError> {
+        // TODO: We can avoid this clone if the `Merged` struct contains a `FederationSchema`.
+        let supergraph_schema = FederationSchema::new(self.schema().clone().into_inner())?;
+        // PORT_NOTE: The JS version calls the `extractSubgraphsFromSupergraph` function, which
+        //            returns the subgraph name to graph enum value mapping, but the corresponding
+        //            `extract_subgraphs_from_supergraph` function in Rust does not need it and
+        //            does not return it. Therefore, a small part of
+        //            `extract_subgraphs_from_supergraph` function is reused here to compute the
+        //            mapping, instead of modifying the function itself.
+        let (_link_spec_definition, join_spec_definition, _context_spec_definition) =
+            crate::validate_supergraph_for_query_planning(&supergraph_schema)?;
+        let (_subgraphs, _federation_spec_definitions, graph_enum_value_name_to_subgraph_name) =
+            collect_empty_subgraphs(&supergraph_schema, join_spec_definition)?;
+        Ok(graph_enum_value_name_to_subgraph_name
+            .into_iter()
+            .map(|(enum_value_name, subgraph_name)| {
+                (subgraph_name.to_string(), enum_value_name.clone())
+            })
+            .collect())
+    }
 }
 
 impl Supergraph<Satisfiable> {


### PR DESCRIPTION
ported the `Supergraph.subgraphNameToGraphEnumValue` method.

The JS implementation's `extractSubgraphsFromSupergraph` is a bit different from the Rust counterpart,`extract_subgraphs_from_supergraph`:

* JS version computes and returns the subgraph name to graph enum value mapping.
* Rust version does not need it and thus does not compute it at all.

Instead of making the Rust version to mimic the JS behavior unnecessarily. A small part of `extract_subgraphs_from_supergraph` has been reused to compute the mapping in the new Rust method to keep the implementation simple.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

This is an incremantal implementation of a new feature. It will be evaluated/tested later.