### PR TITLE
feat(subscription): add operation_name label to apollo.router.opened.subscriptions counter (backport #7606)

### DIFF
--- a/.changesets/fix_bnjjj_add_operation_name_subscription_metric.md
+++ b/.changesets/fix_bnjjj_add_operation_name_subscription_metric.md
@@ -1,0 +1,5 @@
+### Add graphql.operation.name label to apollo.router.opened.subscriptions counter ([PR #7606](https://github.com/apollographql/router/pull/7606))
+
+`apollo.router.opened.subscriptions` metric contains `graphql.operation.name` label to know exactly which subscription is still opened.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/7606

--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-=======
 //! APIs for integrating with the router's metrics.
 //!
 //! The macros contained here are a replacement for the telemetry crate's `MetricsLayer`. We will
@@ -69,9 +67,6 @@
 //! );
 //! ```
 
-use std::collections::HashMap;
->>>>>>> e7b7e401 (feat(subscription): add operation_name label to apollo.router.opened.subscriptions counter (#7606))
-#[cfg(test)]
 use std::future::Future;
 #[cfg(test)]
 use std::pin::Pin;
@@ -1339,7 +1334,7 @@ pub(crate) trait FutureMetricsExt<T> {
             Default::default(),
             async move {
                 // We want to eagerly create the meter provider, the reason is that this will be shared among subtasks that use `with_current_meter_provider`.
-                let _ = meter_provider_internal();
+                let _ = meter_provider();
                 let result = self.await;
                 let _ = tokio::task::spawn_blocking(|| {
                     meter_provider().shutdown();

--- a/apollo-router/src/notification.rs
+++ b/apollo-router/src/notification.rs
@@ -28,6 +28,7 @@ use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 use crate::Configuration;
 use crate::graphql;
+use crate::metrics::FutureMetricsExt;
 use crate::spec::Schema;
 
 static NOTIFY_CHANNEL_SIZE: usize = 1024;
@@ -66,6 +67,8 @@ pub(crate) enum Notification<K, V> {
         // To know if it has been created or re-used
         response_sender: ResponseSenderWithCreated<V>,
         heartbeat_enabled: bool,
+        // Useful for the metric we create
+        operation_name: Option<String>,
     },
     Subscribe {
         topic: K,
@@ -153,7 +156,9 @@ where
     ) -> Notify<K, V> {
         let (sender, receiver) = mpsc::channel(NOTIFY_CHANNEL_SIZE);
         let receiver_stream: ReceiverStream<Notification<K, V>> = ReceiverStream::new(receiver);
-        tokio::task::spawn(task(receiver_stream, ttl, heartbeat_error_message));
+        tokio::task::spawn(
+            task(receiver_stream, ttl, heartbeat_error_message).with_current_meter_provider(),
+        );
         Notify {
             sender,
             queue_size,
@@ -210,6 +215,7 @@ where
         &mut self,
         topic: K,
         heartbeat_enabled: bool,
+        operation_name: Option<String>,
     ) -> Result<(Handle<K, V>, bool), NotifyError<K, V>> {
         let (sender, _receiver) =
             broadcast::channel(self.queue_size.unwrap_or(DEFAULT_MSG_CHANNEL_SIZE));
@@ -221,6 +227,7 @@ where
                 msg_sender: sender,
                 response_sender: tx,
                 heartbeat_enabled,
+                operation_name,
             })
             .await?;
 
@@ -615,8 +622,8 @@ async fn task<K, V>(
                         match message {
                             Notification::Unsubscribe { topic } => pubsub.unsubscribe(topic),
                             Notification::ForceDelete { topic } => pubsub.force_delete(topic),
-                            Notification::CreateOrSubscribe { topic,  msg_sender, response_sender, heartbeat_enabled } => {
-                                pubsub.subscribe_or_create(topic, msg_sender, response_sender, heartbeat_enabled);
+                            Notification::CreateOrSubscribe { topic,  msg_sender, response_sender, heartbeat_enabled, operation_name } => {
+                                pubsub.subscribe_or_create(topic, msg_sender, response_sender, heartbeat_enabled, operation_name);
                             }
                             Notification::Subscribe {
                                 topic,
@@ -695,14 +702,20 @@ struct Subscription<V> {
     msg_sender: broadcast::Sender<Option<V>>,
     heartbeat_enabled: bool,
     updated_at: Instant,
+    operation_name: Option<String>,
 }
 
 impl<V> Subscription<V> {
-    fn new(msg_sender: broadcast::Sender<Option<V>>, heartbeat_enabled: bool) -> Self {
+    fn new(
+        msg_sender: broadcast::Sender<Option<V>>,
+        heartbeat_enabled: bool,
+        operation_name: Option<String>,
+    ) -> Self {
         Self {
             msg_sender,
             heartbeat_enabled,
             updated_at: Instant::now(),
+            operation_name,
         }
     }
     // Update the updated_at value
@@ -749,17 +762,22 @@ where
         topic: K,
         sender: broadcast::Sender<Option<V>>,
         heartbeat_enabled: bool,
+        operation_name: Option<String>,
     ) {
         let existed = self
             .subscriptions
-            .insert(topic, Subscription::new(sender, heartbeat_enabled))
+            .insert(
+                topic,
+                Subscription::new(sender, heartbeat_enabled, operation_name.clone()),
+            )
             .is_some();
         if !existed {
             // TODO: deprecated name, should use our new convention apollo.router. for router next
             i64_up_down_counter!(
                 "apollo_router_opened_subscriptions",
                 "Number of opened subscriptions",
-                1
+                1,
+                graphql.operation.name = operation_name.unwrap_or_default()
             );
         }
     }
@@ -784,6 +802,7 @@ where
         msg_sender: broadcast::Sender<Option<V>>,
         sender: ResponseSenderWithCreated<V>,
         heartbeat_enabled: bool,
+        operation_name: Option<String>,
     ) {
         match self.subscriptions.get(&topic) {
             Some(subscription) => {
@@ -794,7 +813,7 @@ where
                 ));
             }
             None => {
-                self.create_topic(topic, msg_sender.clone(), heartbeat_enabled);
+                self.create_topic(topic, msg_sender.clone(), heartbeat_enabled, operation_name);
 
                 let _ = sender.send((msg_sender.clone(), msg_sender.subscribe(), true));
             }
@@ -812,11 +831,12 @@ where
         #[allow(clippy::collapsible_if)]
         if topic_to_delete {
             tracing::trace!("deleting subscription from unsubscribe");
-            if self.subscriptions.remove(&topic).is_some() {
+            if let Some(sub) = self.subscriptions.remove(&topic) {
                 i64_up_down_counter!(
                     "apollo_router_opened_subscriptions",
                     "Number of opened subscriptions",
-                    -1
+                    -1,
+                    graphql.operation.name = sub.operation_name.unwrap_or_default()
                 );
             }
         };
@@ -889,7 +909,8 @@ where
                 i64_up_down_counter!(
                     "apollo_router_opened_subscriptions",
                     "Number of opened subscriptions",
-                    -1
+                    -1,
+                    graphql.operation.name = subscription.operation_name.unwrap_or_default()
                 );
                 if let Some(heartbeat_error_message) = &heartbeat_error_message {
                     let _ = subscription
@@ -919,7 +940,8 @@ where
             i64_up_down_counter!(
                 "apollo_router_opened_subscriptions",
                 "Number of opened subscriptions",
-                -1
+                -1,
+                graphql.operation.name = sub.operation_name.unwrap_or_default()
             );
             let _ = sub.msg_sender.send(None);
         }
@@ -988,6 +1010,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+    use crate::metrics::FutureMetricsExt;
 
     #[tokio::test]
     async fn subscribe() {
@@ -995,9 +1018,15 @@ mod tests {
         let topic_1 = Uuid::new_v4();
         let topic_2 = Uuid::new_v4();
 
-        let (handle1, created) = notify.create_or_subscribe(topic_1, false).await.unwrap();
+        let (handle1, created) = notify
+            .create_or_subscribe(topic_1, false, None)
+            .await
+            .unwrap();
         assert!(created);
-        let (_handle2, created) = notify.create_or_subscribe(topic_2, false).await.unwrap();
+        let (_handle2, created) = notify
+            .create_or_subscribe(topic_2, false, None)
+            .await
+            .unwrap();
         assert!(created);
 
         let handle_1_bis = notify.subscribe(topic_1).await.unwrap();
@@ -1034,9 +1063,15 @@ mod tests {
         let topic_1 = Uuid::new_v4();
         let topic_2 = Uuid::new_v4();
 
-        let (handle1, created) = notify.create_or_subscribe(topic_1, true).await.unwrap();
+        let (handle1, created) = notify
+            .create_or_subscribe(topic_1, true, None)
+            .await
+            .unwrap();
         assert!(created);
-        let (_handle2, created) = notify.create_or_subscribe(topic_2, true).await.unwrap();
+        let (_handle2, created) = notify
+            .create_or_subscribe(topic_2, true, None)
+            .await
+            .unwrap();
         assert!(created);
 
         let mut _handle_1_bis = notify.subscribe(topic_1).await.unwrap();
@@ -1072,6 +1107,99 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn it_subscribe_and_delete_metrics() {
+        async {
+            let mut notify = Notify::builder().build();
+            let topic_1 = Uuid::new_v4();
+            let topic_2 = Uuid::new_v4();
+
+            let (handle1, created) = notify
+                .create_or_subscribe(topic_1, true, Some("TestSubscription".to_string()))
+                .await
+                .unwrap();
+            assert!(created);
+            let (_handle2, created) = notify
+                .create_or_subscribe(topic_2, true, Some("TestSubscriptionBis".to_string()))
+                .await
+                .unwrap();
+            assert!(created);
+            assert_up_down_counter!(
+                "apollo.router.opened.subscriptions",
+                1i64,
+                "graphql.operation.name" = "TestSubscription"
+            );
+            assert_up_down_counter!(
+                "apollo.router.opened.subscriptions",
+                1i64,
+                "graphql.operation.name" = "TestSubscriptionBis"
+            );
+
+            let mut _handle_1_bis = notify.subscribe(topic_1).await.unwrap();
+            let mut _handle_1_other = notify.subscribe(topic_1).await.unwrap();
+            let mut cloned_notify = notify.clone();
+            let mut handle = cloned_notify.subscribe(topic_1).await.unwrap().into_sink();
+            handle
+                .send_sync(serde_json_bytes::json!({"test": "ok"}))
+                .unwrap();
+            drop(handle);
+            assert!(notify.exist(topic_1).await.unwrap());
+            drop(_handle_1_bis);
+            drop(_handle_1_other);
+
+            notify.try_delete(topic_1).unwrap();
+            assert_up_down_counter!(
+                "apollo.router.opened.subscriptions",
+                1i64,
+                "graphql.operation.name" = "TestSubscription"
+            );
+            assert_up_down_counter!(
+                "apollo.router.opened.subscriptions",
+                1i64,
+                "graphql.operation.name" = "TestSubscriptionBis"
+            );
+
+            let subscriptions_nb = notify.debug().await.unwrap();
+            assert_eq!(subscriptions_nb, 1);
+
+            assert!(!notify.exist(topic_1).await.unwrap());
+
+            notify.force_delete(topic_1).await.unwrap();
+            assert_up_down_counter!(
+                "apollo.router.opened.subscriptions",
+                0i64,
+                "graphql.operation.name" = "TestSubscription"
+            );
+            assert_up_down_counter!(
+                "apollo.router.opened.subscriptions",
+                1i64,
+                "graphql.operation.name" = "TestSubscriptionBis"
+            );
+
+            let mut handle1 = handle1.into_stream();
+            let new_msg = handle1.next().await.unwrap();
+            assert_eq!(new_msg, serde_json_bytes::json!({"test": "ok"}));
+            assert!(handle1.next().await.is_none());
+            assert!(notify.exist(topic_2).await.unwrap());
+            notify.try_delete(topic_2).unwrap();
+
+            let subscriptions_nb = notify.debug().await.unwrap();
+            assert_eq!(subscriptions_nb, 0);
+            assert_up_down_counter!(
+                "apollo.router.opened.subscriptions",
+                0i64,
+                "graphql.operation.name" = "TestSubscription"
+            );
+            assert_up_down_counter!(
+                "apollo.router.opened.subscriptions",
+                0i64,
+                "graphql.operation.name" = "TestSubscriptionBis"
+            );
+        }
+        .with_metrics()
+        .await;
+    }
+
+    #[tokio::test]
     async fn it_test_ttl() {
         let mut notify = Notify::builder()
             .ttl(Duration::from_millis(300))
@@ -1080,9 +1208,15 @@ mod tests {
         let topic_1 = Uuid::new_v4();
         let topic_2 = Uuid::new_v4();
 
-        let (handle1, created) = notify.create_or_subscribe(topic_1, true).await.unwrap();
+        let (handle1, created) = notify
+            .create_or_subscribe(topic_1, true, None)
+            .await
+            .unwrap();
         assert!(created);
-        let (_handle2, created) = notify.create_or_subscribe(topic_2, true).await.unwrap();
+        let (_handle2, created) = notify
+            .create_or_subscribe(topic_2, true, None)
+            .await
+            .unwrap();
         assert!(created);
 
         let handle_1_bis = notify.subscribe(topic_1).await.unwrap();

--- a/apollo-router/src/notification.rs
+++ b/apollo-router/src/notification.rs
@@ -1124,12 +1124,12 @@ mod tests {
                 .unwrap();
             assert!(created);
             assert_up_down_counter!(
-                "apollo.router.opened.subscriptions",
+                "apollo_router_opened_subscriptions",
                 1i64,
                 "graphql.operation.name" = "TestSubscription"
             );
             assert_up_down_counter!(
-                "apollo.router.opened.subscriptions",
+                "apollo_router_opened_subscriptions",
                 1i64,
                 "graphql.operation.name" = "TestSubscriptionBis"
             );
@@ -1148,12 +1148,12 @@ mod tests {
 
             notify.try_delete(topic_1).unwrap();
             assert_up_down_counter!(
-                "apollo.router.opened.subscriptions",
+                "apollo_router_opened_subscriptions",
                 1i64,
                 "graphql.operation.name" = "TestSubscription"
             );
             assert_up_down_counter!(
-                "apollo.router.opened.subscriptions",
+                "apollo_router_opened_subscriptions",
                 1i64,
                 "graphql.operation.name" = "TestSubscriptionBis"
             );
@@ -1165,12 +1165,12 @@ mod tests {
 
             notify.force_delete(topic_1).await.unwrap();
             assert_up_down_counter!(
-                "apollo.router.opened.subscriptions",
+                "apollo_router_opened_subscriptions",
                 0i64,
                 "graphql.operation.name" = "TestSubscription"
             );
             assert_up_down_counter!(
-                "apollo.router.opened.subscriptions",
+                "apollo_router_opened_subscriptions",
                 1i64,
                 "graphql.operation.name" = "TestSubscriptionBis"
             );
@@ -1185,12 +1185,12 @@ mod tests {
             let subscriptions_nb = notify.debug().await.unwrap();
             assert_eq!(subscriptions_nb, 0);
             assert_up_down_counter!(
-                "apollo.router.opened.subscriptions",
+                "apollo_router_opened_subscriptions",
                 0i64,
                 "graphql.operation.name" = "TestSubscription"
             );
             assert_up_down_counter!(
-                "apollo.router.opened.subscriptions",
+                "apollo_router_opened_subscriptions",
                 0i64,
                 "graphql.operation.name" = "TestSubscriptionBis"
             );

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -781,7 +781,7 @@ mod tests {
         assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
         let new_sub_id = uuid::Uuid::new_v4().to_string();
         let (handler, _created) = notify
-            .create_or_subscribe(new_sub_id.clone(), true)
+            .create_or_subscribe(new_sub_id.clone(), true, None)
             .await
             .unwrap();
         let verifier = create_verifier(&new_sub_id).unwrap();
@@ -928,7 +928,7 @@ mod tests {
         assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
         let new_sub_id = uuid::Uuid::new_v4().to_string();
         let (_handler, _created) = notify
-            .create_or_subscribe(new_sub_id.clone(), true)
+            .create_or_subscribe(new_sub_id.clone(), true, None)
             .await
             .unwrap();
         let verifier = String::from("XXX");
@@ -1019,7 +1019,7 @@ mod tests {
         assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
         let new_sub_id = uuid::Uuid::new_v4().to_string();
         let (handler, _created) = notify
-            .create_or_subscribe(new_sub_id.clone(), true)
+            .create_or_subscribe(new_sub_id.clone(), true, None)
             .await
             .unwrap();
         let verifier = create_verifier(&new_sub_id).unwrap();

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -55,6 +55,7 @@ use crate::batching::assemble_batch;
 use crate::configuration::Batching;
 use crate::configuration::BatchingMode;
 use crate::configuration::TlsClientAuth;
+use crate::context::OPERATION_NAME;
 use crate::error::FetchError;
 use crate::error::SubgraphBatchingError;
 use crate::graphql;
@@ -286,9 +287,11 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                         // Hash the subgraph_request
                         let subscription_id = hashed_request;
 
+                        let operation_name =
+                            context.get::<_, String>(OPERATION_NAME).ok().flatten();
                         // Call create_or_subscribe on notify
                         let (handle, created) = notify
-                            .create_or_subscribe(subscription_id.clone(), true)
+                            .create_or_subscribe(subscription_id.clone(), true, operation_name)
                             .await?;
 
                         // If it existed before just send the right stream (handle) and early return
@@ -507,9 +510,9 @@ async fn call_websocket(
             service: service_name.clone(),
             reason: "cannot get the websocket stream".to_string(),
         })?;
-
+    let supergraph_operation_name = context.get::<_, String>(OPERATION_NAME).ok().flatten();
     let (handle, created) = notify
-        .create_or_subscribe(subscription_hash.clone(), false)
+        .create_or_subscribe(subscription_hash.clone(), false, supergraph_operation_name)
         .await?;
     u64_counter!(
         "apollo.router.operations.subscriptions",

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -974,7 +974,7 @@ async fn root_typename_with_defer() {
 async fn subscription_with_callback() {
     let mut notify = Notify::builder().build();
     let (handle, _) = notify
-        .create_or_subscribe("TEST_TOPIC".to_string(), false)
+        .create_or_subscribe("TEST_TOPIC".to_string(), false, None)
         .await
         .unwrap();
     let subgraphs = MockedSubgraphs([
@@ -1055,7 +1055,7 @@ async fn subscription_with_callback() {
 async fn subscription_callback_schema_reload() {
     let mut notify = Notify::builder().build();
     let (handle, _) = notify
-        .create_or_subscribe("TEST_TOPIC".to_string(), false)
+        .create_or_subscribe("TEST_TOPIC".to_string(), false, None)
         .await
         .unwrap();
     let orga_subgraph = MockSubgraph::builder().with_json(
@@ -1144,7 +1144,7 @@ async fn subscription_callback_schema_reload() {
 async fn subscription_with_callback_with_limit() {
     let mut notify = Notify::builder().build();
     let (handle, _) = notify
-        .create_or_subscribe("TEST_TOPIC".to_string(), false)
+        .create_or_subscribe("TEST_TOPIC".to_string(), false, None)
         .await
         .unwrap();
     let subgraphs = MockedSubgraphs([

--- a/apollo-router/tests/integration/mod.rs
+++ b/apollo-router/tests/integration/mod.rs
@@ -19,7 +19,7 @@ mod typename;
 #[cfg(any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux")))]
 mod redis;
 mod rhai;
-mod subscription;
+mod subscription_load_test;
 mod telemetry;
 mod validation;
 

--- a/apollo-router/tests/integration/subscription_load_test.rs
+++ b/apollo-router/tests/integration/subscription_load_test.rs
@@ -1,4 +1,4 @@
-//! This file is to load test subscriptions and should be launched manually, not in our CI
+//! This file is to load-test subscriptions and should be launched manually, not in our CI
 use futures::StreamExt;
 use http::HeaderValue;
 use serde_json::json;

--- a/dev-docs/metrics.md
+++ b/dev-docs/metrics.md
@@ -130,6 +130,9 @@ When using the macro in a test you will need a different pattern depending on if
 
 Make sure to use `.with_metrics()` method on the async block to ensure that the metrics are stored in a task local.
 *Tests will silently fail to record metrics if this is not done.*
+
+For testing metrics across spawned tasks, use `.with_current_meter_provider()` to propagate the meter provider to child tasks:
+
 ```rust
     #[tokio::test(flavor = "multi_thread")]
     async fn test_async_multi() {
@@ -152,10 +155,29 @@ Make sure to use `.with_metrics()` method on the async block to ensure that the 
         .with_metrics()
         .await;
     }
+
+    #[tokio::test]
+    async fn test_metrics_across_tasks() {
+        async {
+            u64_counter!("apollo.router.test", "metric", 1);
+            assert_counter!("apollo.router.test", 1);
+
+            // Use with_current_meter_provider to propagate metrics to spawned task
+            tokio::spawn(async move {
+                u64_counter!("apollo.router.test", "metric", 2);
+            }.with_current_meter_provider())
+            .await
+            .unwrap();
+
+            // Now the metric correctly resolves to 3 since the meter provider was propagated
+            assert_counter!("apollo.router.test", 3);
+        }
+        .with_metrics()
+        .await;
+    }
 ```
 
-Note: this relies on metrics being updated within the same thread. Metrics that are updated from multiple threads will
-not be collected correctly.
+Note: Without using `with_current_meter_provider()`, metrics updated from spawned tasks will not be collected correctly:
 
 ```rust
 #[tokio::test]

--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -106,14 +106,9 @@ The initial call to Uplink during router startup is not reflected in metrics.
 
 </Tip>
 
-<<<<<<< HEAD
-- `apollo_router_opened_subscriptions` - Number of different opened subscriptions (not the number of clients with an opened subscriptions in case it's deduplicated)
+- `apollo_router_opened_subscriptions` - Number of different opened subscriptions (not the number of clients with an opened subscriptions in case it's deduplicated). This metric contains `graphql.operation.name` label to know exactly which subscription is still opened.
 - `apollo_router_deduplicated_subscriptions_total` - Number of subscriptions that has been deduplicated
 - `apollo_router_skipped_event_count` - Number of subscription events that has been skipped because too many events have been received from the subgraph but not yet sent to the client.
-=======
-- `apollo.router.opened.subscriptions` - Number of different opened subscriptions (not the number of clients with an opened subscriptions in case it's deduplicated). This metric contains `graphql.operation.name` label to know exactly which subscription is still opened.
-- `apollo.router.skipped.event.count` - Number of subscription events that has been skipped because too many events have been received from the subgraph but not yet sent to the client.
->>>>>>> e7b7e401 (feat(subscription): add operation_name label to apollo.router.opened.subscriptions counter (#7606))
 
 ### Batching
 

--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -106,9 +106,14 @@ The initial call to Uplink during router startup is not reflected in metrics.
 
 </Tip>
 
+<<<<<<< HEAD
 - `apollo_router_opened_subscriptions` - Number of different opened subscriptions (not the number of clients with an opened subscriptions in case it's deduplicated)
 - `apollo_router_deduplicated_subscriptions_total` - Number of subscriptions that has been deduplicated
 - `apollo_router_skipped_event_count` - Number of subscription events that has been skipped because too many events have been received from the subgraph but not yet sent to the client.
+=======
+- `apollo.router.opened.subscriptions` - Number of different opened subscriptions (not the number of clients with an opened subscriptions in case it's deduplicated). This metric contains `graphql.operation.name` label to know exactly which subscription is still opened.
+- `apollo.router.skipped.event.count` - Number of subscription events that has been skipped because too many events have been received from the subgraph but not yet sent to the client.
+>>>>>>> e7b7e401 (feat(subscription): add operation_name label to apollo.router.opened.subscriptions counter (#7606))
 
 ### Batching
 


### PR DESCRIPTION
This PR adds a new label on `apollo.router.opened.subscriptions` metric to know exactly which subscription is still opened.


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7606 done by [Mergify](https://mergify.com).