### PR TITLE
Batching is not supported for GET requests

### DIFF
--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -517,60 +517,21 @@ impl RouterService {
         self,
         parts: &Parts,
     ) -> Result<(Vec<graphql::Request>, bool), TranslateError> {
-        let mut is_batch = false;
         parts.uri.query().map(|q| {
-            let mut result = vec![];
-
             match graphql::Request::from_urlencoded_query(q.to_string()) {
                 Ok(request) => {
-                    result.push(request);
+                    Ok((vec![request], false))
                 }
                 Err(err) => {
-                    // It may be a batch of requests, so try that (if config allows) before
-                    // erroring out
-                    if self.batching.enabled
-                        && matches!(self.batching.mode, BatchingMode::BatchHttpLink)
-                    {
-                        result = graphql::Request::batch_from_urlencoded_query(q.to_string())
-                            .map_err(|e| TranslateError {
-                                status: StatusCode::BAD_REQUEST,
-                                extension_code: "INVALID_GRAPHQL_REQUEST".to_string(),
-                                extension_details: format!(
-                                    "failed to decode a valid GraphQL request from path {e}"
-                                ),
-                            })?;
-                        if result.is_empty() {
-                            return Err(TranslateError {
-                                status: StatusCode::BAD_REQUEST,
-                                extension_code: "INVALID_GRAPHQL_REQUEST".to_string(),
-                                extension_details: "failed to decode a valid GraphQL request from path: empty array ".to_string()
-                            });
-                        }
-                        is_batch = true;
-                    } else if !q.is_empty() && q.as_bytes()[0] == b'[' {
-                        let extension_details = if self.batching.enabled
-                            && !matches!(self.batching.mode, BatchingMode::BatchHttpLink) {
-                            format!("batching not supported for mode `{}`", self.batching.mode)
-                        } else {
-                            "batching not enabled".to_string()
-                        };
-                        return Err(TranslateError {
-                            status: StatusCode::BAD_REQUEST,
-                            extension_code: "BATCHING_NOT_ENABLED".to_string(),
-                            extension_details,
-                        });
-                    } else {
-                        return Err(TranslateError {
-                            status: StatusCode::BAD_REQUEST,
-                            extension_code: "INVALID_GRAPHQL_REQUEST".to_string(),
-                            extension_details: format!(
-                                "failed to decode a valid GraphQL request from path {err}"
-                            ),
-                        });
-                    }
+                    Err(TranslateError {
+                        status: StatusCode::BAD_REQUEST,
+                        extension_code: "INVALID_GRAPHQL_REQUEST".to_string(),
+                        extension_details: format!(
+                            "failed to decode a valid GraphQL request from path {err}"
+                        ),
+                    })
                 }
-            };
-            Ok((result, is_batch))
+            }
         }).unwrap_or_else(|| {
             Err(TranslateError {
                 status: StatusCode::BAD_REQUEST,


### PR DESCRIPTION
When sending an operation as a GET request, like `/graphql?query={ user { id } }`, you cannot send a batch request.

We use `serde_urlencoded` to parse such requests, and the behaviour is like this:
```rust
use serde_json::Value;
use serde_json::json;

assert_eq!(
    serde_urlencoded::from_str::<Value>("query=graphql").unwrap(),
    json!({ "query": "graphql" }),
);
assert_eq!(
    serde_urlencoded::from_str::<Value>("query=graphql&query=other").unwrap(),
    json!({ "query": "other" }),
);
assert_eq!(
    serde_urlencoded::from_str::<Value>("query[]=graphql&query[]=other").unwrap(),
    json!({ "query[]": "other" }),
);
```

That is, there is no way for `batch_from_urlencoded_query` to ever parse a `serde_json::Value::Array` from the query string.

That means that parsing a batch from a query string is essentially a no-op, and I suggest we remove the code for it.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

There were already no tests.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
