### PR TITLE
Remove `audience` from JWT docs as it is not yet available (backport #7672)

### DIFF
--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -47,7 +47,13 @@ Otherwise, if you issue JWTs via a popular third-party IdP (Auth0, Okta, PingOne
        jwt:
          jwks: # This key is required.
            - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
+<<<<<<< HEAD
              issuer: <optional name of issuer>
+=======
+             issuers: # optional list of issuers
+               - https://issuer.one
+               - https://issuer.two
+>>>>>>> 24d9cc22 (Remove `audience` from JWT docs as it is not yet available (#7672))
              poll_interval: <optional poll interval>
              headers: # optional list of static headers added to the HTTP request to the JWKS URL
                - name: User-Agent
@@ -108,7 +114,11 @@ The following configuration options are supported:
 - `url`: **required** URL from which the JWKS file will be read. Must be a valid URL.
   - **If you use a third-party IdP,** consult its documentation to determine its JWKS URL.
   - **If you use your own custom IdP,** you need to make its JWKS available at a router-accessible URL if you haven't already. For more information, see [Creating your own JWKS](#creating-your-own-jwks-advanced).
+<<<<<<< HEAD
 - `issuer`: **optional** name of the issuer, that will be compared to the `iss` claim in the JWT if present. If it does not match, the request will be rejected.
+=======
+- `issuers`: **optional** list of issuers accepted, that will be compared to the `iss` claim in the JWT if present. If none match, the request will be rejected.
+>>>>>>> 24d9cc22 (Remove `audience` from JWT docs as it is not yet available (#7672))
 - `algorithms`: **optional** list of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`
 - `poll_interval`: **optional** interval in human-readable format (e.g. `60s` or `1hour 30s`) at which the JWKS will be polled for changes. If not specified, the JWKS endpoint will be polled every 60 seconds.
 - `headers`: **optional** a list of headers sent when downloading from the JWKS URL


### PR DESCRIPTION
Pulls in #7667 


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #7672 done by [Mergify](https://mergify.com).