### PR TITLE
Let subgraph mocks specify extensions.apollo(Entity)SurrogateKeys

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -6403,7 +6403,7 @@ expression: "&schema"
       "properties": {
         "entities": {
           "default": [],
-          "description": "Entities that can be queried through Federation’s special `_entities` field",
+          "description": "Entities that can be queried through Federation’s special `_entities` field\n\nIn maps directly in the top-level `Vec` (but not in other maps nested deeper), the `__surrogateKeys` key is special. Instead of representing a field that can be selected, when its parent entity is selected its contents are added to the `response.extensions[\"apolloEntitySurrogateKeys\"]` array.",
           "items": {
             "additionalProperties": true,
             "type": "object"
@@ -6427,7 +6427,7 @@ expression: "&schema"
         "query": {
           "additionalProperties": true,
           "default": {},
-          "description": "Data for `query` operations (excluding the special `_entities` field)",
+          "description": "Data for `query` operations (excluding the special `_entities` field)\n\nIn maps nested in this one (but not at the top level), the `__surrogateKeys` key is special. Instead of representing a field that can be selected, when its parent field is selected its value is expected to be an array which is appended to the `response.extensions[\"apolloSurrogateKeys\"]` array.",
           "type": "object"
         }
       },

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -119,6 +119,7 @@ pub mod _private {
     pub use crate::plugin::PLUGINS;
     pub use crate::plugin::PluginFactory;
     // For tests
+    pub use crate::plugins::mock_subgraphs::testing_subgraph_call as mock_subgraphs_subgraph_call;
     pub use crate::router_factory::create_test_service_factory_from_yaml;
     pub use crate::services::APOLLO_GRAPH_REF;
     pub use crate::services::APOLLO_KEY;

--- a/apollo-router/src/plugins/mock_subgraphs/execution/mod.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/execution/mod.rs
@@ -9,6 +9,8 @@
 //!
 //! * `ResolvedValue::List` contains an iterator of results,
 //!   in case an error happens during iteration.
+//! * `Resolver::type_name` can return a `&str` not necessarily `&'static str`.
+//! * Added the `response_extensions` parameter.
 
 #[macro_use]
 pub(crate) mod resolver;

--- a/apollo-router/src/plugins/mock_subgraphs/execution/resolver.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/execution/resolver.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use apollo_compiler::response::JsonMap;
 use serde_json_bytes::Value as JsonValue;
 
@@ -18,6 +20,7 @@ pub(crate) trait Resolver {
     /// in the schema.
     fn resolve_field<'a>(
         &'a self,
+        response_extensions: &'a RefCell<JsonMap>,
         field_name: &'a str,
         arguments: &'a JsonMap,
     ) -> Result<ResolvedValue<'a>, ResolverError>;

--- a/apollo-router/src/plugins/mock_subgraphs/execution/result_coercion.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/execution/result_coercion.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Schema;
 use apollo_compiler::executable::Field;
@@ -28,6 +30,7 @@ pub(crate) fn complete_value<'a, 'b>(
     document: &'a Valid<ExecutableDocument>,
     variable_values: &'a Valid<JsonMap>,
     errors: &'b mut Vec<GraphQLError>,
+    response_extensions: &RefCell<JsonMap>,
     path: LinkedPath<'b>,
     mode: ExecutionMode,
     ty: &'a Type,
@@ -81,6 +84,7 @@ pub(crate) fn complete_value<'a, 'b>(
                         document,
                         variable_values,
                         errors,
+                        response_extensions,
                         Some(&inner_path),
                         mode,
                         inner_ty,
@@ -219,6 +223,7 @@ pub(crate) fn complete_value<'a, 'b>(
         document,
         variable_values,
         errors,
+        response_extensions,
         path,
         mode,
         object_type,

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -38,7 +38,7 @@ pub(crate) mod healthcheck;
 mod include_subgraph_errors;
 pub(crate) mod license_enforcement;
 pub(crate) mod limits;
-mod mock_subgraphs;
+pub(crate) mod mock_subgraphs;
 pub(crate) mod override_url;
 pub(crate) mod progressive_override;
 mod record_replay;

--- a/apollo-router/tests/integration/mock_subgraphs.rs
+++ b/apollo-router/tests/integration/mock_subgraphs.rs
@@ -1,0 +1,74 @@
+use apollo_router::_private::mock_subgraphs_subgraph_call;
+use apollo_router::graphql::Request;
+use serde_json_bytes::json;
+
+#[test]
+fn test_surrogate_keys() {
+    let sdl = include_str!("../fixtures/supergraph.graphql");
+    let supergraph = apollo_federation::Supergraph::new(sdl).unwrap();
+    let subgraphs = supergraph.extract_subgraphs().unwrap();
+
+    let schema = subgraphs.get("products").unwrap().schema.schema();
+    let config = json!({
+        "query": {
+            "topProducts": [
+                {"upc": "1", "__surrogateKeys": ["topProducts"]},
+                {"upc": "2"},
+            ],
+        },
+    });
+    let query = "{ topProducts { upc } }";
+    let request = Request::fake_builder().query(query).build();
+    let response = mock_subgraphs_subgraph_call(config.clone(), schema, &request).unwrap();
+    insta::assert_yaml_snapshot!(response, @r###"
+    data:
+      topProducts:
+        - upc: "1"
+        - upc: "2"
+    extensions:
+      apolloSurrogateKeys:
+        - topProducts
+    "###);
+
+    let schema = subgraphs.get("reviews").unwrap().schema.schema();
+    let config = json!({
+        "entities": [
+            {
+                "__surrogateKeys": ["product-1"],
+                "__typename": "Product",
+                "upc": "1",
+                "reviews": [{"id": "r1a"}, {"id": "r1b"}],
+            },
+            {
+                "__surrogateKeys": ["product-2"],
+                "__typename": "Product",
+                "upc": "2",
+                "reviews": [{"id": "r2"}],
+            },
+        ],
+    });
+    let query = r#"
+        {
+            _entities(representations: [{upc: "2"}, {upc: "1"}]) {
+                ... on Product {
+                    reviews { id }
+                }
+            }
+        }
+    "#;
+    let request = Request::fake_builder().query(query).build();
+    let response = mock_subgraphs_subgraph_call(config.clone(), schema, &request).unwrap();
+    insta::assert_yaml_snapshot!(response, @r###"
+    data:
+      _entities:
+        - reviews:
+            - id: r2
+        - reviews:
+            - id: r1a
+            - id: r1b
+    extensions:
+      apolloEntitySurrogateKeys:
+        - - product-2
+        - - product-1
+    "###);
+}

--- a/apollo-router/tests/integration/mod.rs
+++ b/apollo-router/tests/integration/mod.rs
@@ -12,6 +12,7 @@ mod entity_cache;
 mod file_upload;
 mod introspection;
 mod lifecycle;
+mod mock_subgraphs;
 mod operation_limits;
 mod operation_name;
 mod query_planner;


### PR DESCRIPTION
<!-- ROUTER-1320 -->
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
