### PR TITLE
Align `on_graphql_error` selector return values with `subgraph_on_graphql_error`

### DIFF
--- a/.changesets/feat_caroline_consistent_on_error.md
+++ b/.changesets/feat_caroline_consistent_on_error.md
@@ -1,0 +1,5 @@
+### Align `on_graphql_error` selector return values with `subgraph_on_graphql_error` ([PR #7676](https://github.com/apollographql/router/pull/7676))
+
+The `on_graphql_error` selector will now return `true` or `false`, in alignment with the `subgraph_on_graphql_error` selector. Previously, the selector would return `true` or `None`.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/7676

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/attribute.on_graphql_error/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/attribute.on_graphql_error/metrics.snap
@@ -21,4 +21,8 @@ info:
       - sum: 0.1
         count: 1
         attributes:
+          on.graphql.error: false
+      - sum: 0.1
+        count: 1
+        attributes:
           on.graphql.error: true

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/attribute.on_graphql_error/test.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/attribute.on_graphql_error/test.yaml
@@ -13,3 +13,15 @@ events:
         body: |
           hello
         status: 200
+  - - router_request:
+        uri: "/hello"
+        method: GET
+        body: |
+          hello
+    - context:
+        map:
+          "apollo::telemetry::contains_graphql_error": false
+    - router_response:
+        body: |
+          hello
+        status: 200

--- a/apollo-router/src/plugins/telemetry/config_new/router/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/selectors.rs
@@ -290,13 +290,12 @@ impl Selector for RouterSelector {
                 baggage, default, ..
             } => get_baggage(baggage).or_else(|| default.maybe_to_otel_value()),
             RouterSelector::OnGraphQLError { on_graphql_error } if *on_graphql_error => {
-                if response.context.get_json_value(CONTAINS_GRAPHQL_ERROR)
-                    == Some(serde_json_bytes::Value::Bool(true))
-                {
-                    Some(opentelemetry::Value::Bool(true))
-                } else {
-                    None
-                }
+                let contains_error = response
+                    .context
+                    .get_json_value(CONTAINS_GRAPHQL_ERROR)
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or_default();
+                Some(opentelemetry::Value::Bool(contains_error))
             }
             RouterSelector::Static(val) => Some(val.clone().into()),
             RouterSelector::StaticField { r#static } => Some(r#static.clone().into()),

--- a/apollo-router/src/plugins/telemetry/config_new/router/spans.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/spans.rs
@@ -231,7 +231,7 @@ mod test {
     }
 
     #[test]
-    fn test_router_request_custom_attribute_not_on_graphql_error() {
+    fn test_router_request_custom_attribute_not_on_graphql_error_context_false() {
         let mut spans = RouterSpans::default();
         spans.attributes.custom.insert(
             "test".to_string(),
@@ -252,6 +252,41 @@ mod test {
         );
         let context = Context::new();
         context.insert_json_value(CONTAINS_GRAPHQL_ERROR, serde_json_bytes::Value::Bool(false));
+        let values = spans.attributes.on_response(
+            &router::Response::fake_builder()
+                .header("my-header", "test_val")
+                .context(context)
+                .build()
+                .unwrap(),
+        );
+        assert!(
+            !values
+                .iter()
+                .any(|key_val| key_val.key == opentelemetry::Key::from_static_str("test"))
+        );
+    }
+
+    #[test]
+    fn test_router_request_custom_attribute_not_on_graphql_error_context_missing() {
+        let mut spans = RouterSpans::default();
+        spans.attributes.custom.insert(
+            "test".to_string(),
+            Conditional {
+                selector: RouterSelector::ResponseHeader {
+                    response_header: "my-header".to_string(),
+                    redact: None,
+                    default: None,
+                },
+                condition: Some(Arc::new(Mutex::new(Condition::Eq([
+                    SelectorOrValue::Value(AttributeValue::Bool(true)),
+                    SelectorOrValue::Selector(RouterSelector::OnGraphQLError {
+                        on_graphql_error: true,
+                    }),
+                ])))),
+                value: Arc::new(Default::default()),
+            },
+        );
+        let context = Context::new();
         let values = spans.attributes.on_response(
             &router::Response::fake_builder()
                 .header("my-header", "test_val")

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/selectors.rs
@@ -371,13 +371,12 @@ impl Selector for SupergraphSelector {
                 .and_then(|v| v.maybe_to_otel_value())
                 .or_else(|| default.maybe_to_otel_value()),
             SupergraphSelector::OnGraphQLError { on_graphql_error } if *on_graphql_error => {
-                if response.context.get_json_value(CONTAINS_GRAPHQL_ERROR)
-                    == Some(serde_json_bytes::Value::Bool(true))
-                {
-                    Some(opentelemetry::Value::Bool(true))
-                } else {
-                    None
-                }
+                let contains_error = response
+                    .context
+                    .get_json_value(CONTAINS_GRAPHQL_ERROR)
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or_default();
+                Some(opentelemetry::Value::Bool(contains_error))
             }
             SupergraphSelector::OperationName {
                 operation_name,
@@ -464,13 +463,11 @@ impl Selector for SupergraphSelector {
                     .map(opentelemetry::Value::from),
             },
             SupergraphSelector::OnGraphQLError { on_graphql_error } if *on_graphql_error => {
-                if ctx.get_json_value(CONTAINS_GRAPHQL_ERROR)
-                    == Some(serde_json_bytes::Value::Bool(true))
-                {
-                    Some(opentelemetry::Value::Bool(true))
-                } else {
-                    None
-                }
+                let contains_error = ctx
+                    .get_json_value(CONTAINS_GRAPHQL_ERROR)
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or_default();
+                Some(opentelemetry::Value::Bool(contains_error))
             }
             SupergraphSelector::OperationName {
                 operation_name,


### PR DESCRIPTION
Currently the `subgraph_on_graphql_error` selector will return `true` or `false` while the `on_graphql_error` selector will return `true` or `None`. This updates the `on_graphql_error` selector to return `true` or `false` to align with `subgraph_on_graphql_error`.

<!-- start metadata -->
<!-- ROUTER-928 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
