### PR TITLE
fix(subscription): set a valid graphql response for websocket handshake response

### DIFF
--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -714,7 +714,11 @@ async fn call_websocket(
     subscription_stream_tx.send(Box::pin(handle_stream)).await?;
 
     Ok(SubgraphResponse::new_from_response(
-        resp.map(|_| graphql::Response::default()),
+        resp.map(|_| {
+            graphql::Response::builder()
+                .data(serde_json_bytes::Value::Null)
+                .build()
+        }),
         context,
         service_name,
         subgraph_request_id,
@@ -2692,6 +2696,10 @@ mod tests {
             .await
             .unwrap();
         assert!(response.response.body().errors.is_empty());
+        assert_eq!(
+            response.response.body().data,
+            Some(serde_json_bytes::Value::Null)
+        );
 
         let mut gql_stream = rx_stream.next().await.unwrap();
         let message = gql_stream.next().await.unwrap();


### PR DESCRIPTION
Since this [PR](https://github.com/apollographql/router/pull/7141) we added more checks on graphql response returned by coprocessors to be compliant with GraphQL specs. When it's a subscription using websocket it was not returning any data and so was not a correct GraphQL response payload. This is a fix to always return valid GraphQL response when doing the websocket handshake.


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
