### PR TITLE
Tighten up security on docker compose files (backport #7681)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ version: "3.9"
 services:
   redis:
     image: redis:latest
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
     ports:
       - 6379:6379
   jaeger:
@@ -13,9 +16,15 @@ services:
       - 14268:14268
   zipkin:
     image: openzipkin/zipkin:latest
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
     ports:
       - 9411:9411
   datadog:
     image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
     ports:
       - 8126:8126

--- a/dockerfiles/docker-compose-redis.yml
+++ b/dockerfiles/docker-compose-redis.yml
@@ -2,6 +2,8 @@ version: '2'
 services:
   redis-node-0:
     image: docker.io/bitnami/redis-cluster:7.2
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - redis-cluster_data-0:/bitnami/redis/data
     environment:
@@ -12,6 +14,8 @@ services:
 
   redis-node-1:
     image: docker.io/bitnami/redis-cluster:7.2
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - redis-cluster_data-1:/bitnami/redis/data
     environment:
@@ -22,6 +26,8 @@ services:
 
   redis-node-2:
     image: docker.io/bitnami/redis-cluster:7.2
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - redis-cluster_data-2:/bitnami/redis/data
     environment:
@@ -32,6 +38,8 @@ services:
 
   redis-node-3:
     image: docker.io/bitnami/redis-cluster:7.2
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - redis-cluster_data-3:/bitnami/redis/data
     environment:
@@ -42,6 +50,8 @@ services:
 
   redis-node-4:
     image: docker.io/bitnami/redis-cluster:7.2
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - redis-cluster_data-4:/bitnami/redis/data
     environment:
@@ -52,6 +62,8 @@ services:
 
   redis-node-5:
     image: docker.io/bitnami/redis-cluster:7.2
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - redis-cluster_data-5:/bitnami/redis/data
     depends_on:


### PR DESCRIPTION
In our docker compose files (used for integration testing):

    - Enable no-new-privileges to prevent privilege escalation attacks.
    - Make root file systems read-only where possible





[OE-826]: https://apollographql.atlassian.net/browse/OE-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OE-827]: https://apollographql.atlassian.net/browse/OE-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #7681 done by [Mergify](https://mergify.com).