### PR TITLE
Reduce usage of `GraphQLString`

### DIFF
--- a/apollo-federation/src/connectors/validation/connect/http.rs
+++ b/apollo-federation/src/connectors/validation/connect/http.rs
@@ -29,8 +29,8 @@ use crate::connectors::validation::expression::Context;
 use crate::connectors::validation::expression::MappingArgument;
 use crate::connectors::validation::expression::parse_mapping_argument;
 use crate::connectors::validation::expression::scalars;
-use crate::connectors::validation::graphql::GraphQLString;
 use crate::connectors::validation::graphql::SchemaInfo;
+use crate::connectors::validation::graphql::subslice_location;
 use crate::connectors::validation::http::UrlProperties;
 use crate::connectors::validation::http::headers::Headers;
 use crate::connectors::validation::http::url::validate_url_scheme;
@@ -146,7 +146,7 @@ impl<'schema> Http<'schema> {
 }
 
 struct Body<'schema> {
-    mapping: MappingArgument<'schema>,
+    mapping: MappingArgument,
     coordinate: BodyCoordinate<'schema>,
 }
 
@@ -185,7 +185,7 @@ impl<'schema> Body<'schema> {
             &Context::for_connect_request(
                 schema,
                 coordinate.connect,
-                &mapping.string,
+                &mapping.node,
                 Code::InvalidBody,
             ),
             &Shape::unknown([]),
@@ -219,7 +219,6 @@ struct Transport<'schema> {
     #[allow(dead_code)]
     method: HTTPMethod,
     url: StringTemplate,
-    url_string: GraphQLString<'schema>,
     coordinate: HttpMethodCoordinate<'schema>,
 
     url_properties: UrlProperties<'schema>,
@@ -279,8 +278,8 @@ impl<'schema> Transport<'schema> {
             node: method_value,
         };
 
-        let url_string = GraphQLString::new(coordinate.node, &schema.sources)
-            .map_err(|_| Message {
+        let url_string = coordinate.node.as_str().ok_or_else(|| {
+            vec![Message {
                 code: Code::GraphQLError,
                 message: format!("The value for {coordinate} must be a string."),
                 locations: coordinate
@@ -288,23 +287,20 @@ impl<'schema> Transport<'schema> {
                     .line_column_range(&schema.sources)
                     .into_iter()
                     .collect(),
-            })
-            .map_err(|e| vec![e])?;
-        let url = StringTemplate::from_str(url_string.as_str())
+            }]
+        })?;
+        let url = StringTemplate::from_str(url_string)
             .map_err(|string_template::Error { message, location }| Message {
                 code: Code::InvalidUrl,
                 message: format!("In {coordinate}: {message}"),
-                locations: url_string
-                    .line_col_for_subslice(location, schema)
+                locations: subslice_location(coordinate.node, location, schema)
                     .into_iter()
                     .collect(),
             })
             .map_err(|e| vec![e])?;
 
         if source_name.is_some() {
-            return if url_string.as_str().starts_with("http://")
-                || url_string.as_str().starts_with("https://")
-            {
+            return if url_string.starts_with("http://") || url_string.starts_with("https://") {
                 Err(vec![Message {
                     code: Code::AbsoluteConnectUrlWithSource,
                     message: format!(
@@ -321,19 +317,17 @@ impl<'schema> Transport<'schema> {
                 Ok(Self {
                     method,
                     url,
-                    url_string,
                     coordinate,
                     url_properties,
                 })
             };
         } else {
-            validate_absolute_connect_url(&url, coordinate, coordinate.node, url_string, schema)
+            validate_absolute_connect_url(&url, coordinate, coordinate.node, schema)
                 .map_err(|e| vec![e])?;
         }
         Ok(Self {
             method,
             url,
-            url_string,
             coordinate,
             url_properties,
         })
@@ -346,7 +340,7 @@ impl<'schema> Transport<'schema> {
         let expression_context = Context::for_connect_request(
             schema,
             self.coordinate.connect,
-            &self.url_string,
+            self.coordinate.node,
             Code::InvalidUrl,
         );
 
@@ -378,7 +372,6 @@ fn validate_absolute_connect_url(
     url: &StringTemplate,
     coordinate: HttpMethodCoordinate,
     value: &Node<Value>,
-    str_value: GraphQLString,
     schema: &SchemaInfo,
 ) -> Result<(), Message> {
     let mut is_relative = true;
@@ -429,8 +422,7 @@ fn validate_absolute_connect_url(
             message: format!(
                 "{coordinate} must not contain dynamic pieces in the domain section (before the first `/` or `?`).",
             ),
-            locations: str_value
-                .line_col_for_subslice(dynamic.location.clone(), schema)
+            locations: subslice_location(value, dynamic.location.clone(), schema)
                 .into_iter()
                 .collect(),
         });
@@ -449,7 +441,7 @@ fn validate_absolute_connect_url(
                 .collect(),
         })?;
 
-    validate_url_scheme(&url, coordinate, value, str_value, schema)?;
+    validate_url_scheme(&url, coordinate, value, schema)?;
 
     Ok(())
 }

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
 
 use apollo_compiler::Node;
 use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::ast::Value;
 use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::ObjectType;
@@ -30,8 +31,8 @@ use crate::connectors::validation::coordinates::ConnectDirectiveCoordinate;
 use crate::connectors::validation::coordinates::SelectionCoordinate;
 use crate::connectors::validation::expression::MappingArgument;
 use crate::connectors::validation::expression::parse_mapping_argument;
-use crate::connectors::validation::graphql::GraphQLString;
 use crate::connectors::validation::graphql::SchemaInfo;
+use crate::connectors::validation::graphql::subslice_location;
 use crate::connectors::variable::Phase;
 use crate::connectors::variable::Target;
 use crate::connectors::variable::VariableContext;
@@ -41,7 +42,7 @@ mod variables;
 /// The `@connect(selection:)` argument
 pub(super) struct Selection<'schema> {
     parsed: JSONSelection,
-    string: GraphQLString<'schema>,
+    node: Node<Value>,
     coordinate: SelectionCoordinate<'schema>,
 }
 
@@ -66,7 +67,7 @@ impl<'schema> Selection<'schema> {
                     .collect(),
             })?;
 
-        let MappingArgument { expression, string } = parse_mapping_argument(
+        let MappingArgument { expression, node } = parse_mapping_argument(
             &selection_arg.value,
             coordinate,
             Code::InvalidSelection,
@@ -74,9 +75,9 @@ impl<'schema> Selection<'schema> {
         )?;
 
         Ok(Self {
-            string,
-            coordinate,
             parsed: expression.expression,
+            node,
+            coordinate,
         })
     }
 
@@ -88,7 +89,7 @@ impl<'schema> Selection<'schema> {
         validate_selection_variables(
             &VariableResolver::new(context.clone(), schema),
             self.coordinate,
-            self.string,
+            &self.node,
             schema,
             context,
             self.parsed.external_var_paths(),
@@ -118,7 +119,7 @@ impl<'schema> Selection<'schema> {
                 SelectionValidator::new(
                     schema,
                     PathPart::Root(parent_type),
-                    self.string,
+                    &self.node,
                     self.coordinate,
                 )
                 .walk(group)
@@ -139,7 +140,7 @@ impl<'schema> Selection<'schema> {
                 SelectionValidator::new(
                     schema,
                     PathPart::Root(type_def),
-                    self.string,
+                    &self.node,
                     self.coordinate,
                 )
                 .walk(group)
@@ -159,7 +160,7 @@ impl<'schema> Selection<'schema> {
 pub(super) fn validate_selection_variables<'a>(
     variable_resolver: &VariableResolver,
     coordinate: impl Display,
-    selection_str: GraphQLString,
+    selection_str: &Node<Value>,
     schema: &SchemaInfo,
     context: VariableContext,
     variable_paths: impl IntoIterator<Item = &'a PathSelection>,
@@ -184,7 +185,7 @@ pub(super) fn validate_selection_variables<'a>(
                     .namespace
                     .location
                     .iter()
-                    .flat_map(|range| selection_str.line_col_for_subslice(range.clone(), schema))
+                    .flat_map(|range| subslice_location(selection_str, range.clone(), schema))
                     .collect(),
             });
         }
@@ -196,7 +197,7 @@ struct SelectionValidator<'schema> {
     schema: &'schema SchemaInfo<'schema>,
     root: PathPart<'schema>,
     path: Vec<PathPart<'schema>>,
-    string: GraphQLString<'schema>,
+    node: &'schema Node<Value>,
     coordinate: SelectionCoordinate<'schema>,
     seen_fields: Vec<(Name, Name)>,
 }
@@ -205,14 +206,14 @@ impl<'schema> SelectionValidator<'schema> {
     const fn new(
         schema: &'schema SchemaInfo<'schema>,
         root: PathPart<'schema>,
-        string: GraphQLString<'schema>,
+        node: &'schema Node<Value>,
         coordinate: SelectionCoordinate<'schema>,
     ) -> Self {
         Self {
             schema,
             root,
             path: Vec::new(),
-            string,
+            node,
             coordinate,
             seen_fields: Vec::new(),
         }
@@ -264,7 +265,7 @@ impl SelectionValidator<'_> {
     ) -> impl Iterator<Item = Range<LineColumn>> {
         selection
             .range()
-            .and_then(|range| self.string.line_col_for_subslice(range, self.schema))
+            .and_then(|range| subslice_location(self.node, range, self.schema))
             .into_iter()
     }
 
@@ -274,10 +275,7 @@ impl SelectionValidator<'_> {
     ) -> impl Iterator<Item = Range<LineColumn>> {
         selection
             .as_ref()
-            .and_then(|range| {
-                self.string
-                    .line_col_for_subslice(range.clone(), self.schema)
-            })
+            .and_then(|range| subslice_location(self.node, range.clone(), self.schema))
             .into_iter()
     }
 

--- a/apollo-federation/src/connectors/validation/errors.rs
+++ b/apollo-federation/src/connectors/validation/errors.rs
@@ -24,7 +24,6 @@ use crate::connectors::validation::Code;
 use crate::connectors::validation::Message;
 use crate::connectors::validation::expression;
 use crate::connectors::validation::expression::Context;
-use crate::connectors::validation::graphql::GraphQLString;
 use crate::connectors::validation::graphql::SchemaInfo;
 
 /// A valid, parsed (but not type-checked) `@connect(errors:)` or `@source(errors:)`.
@@ -121,7 +120,7 @@ impl<'schema> Errors<'schema> {
 }
 
 struct ErrorsMessage<'schema> {
-    mapping: MappingArgument<'schema>,
+    mapping: MappingArgument,
     coordinate: ErrorsMessageCoordinate<'schema>,
 }
 
@@ -160,12 +159,12 @@ impl<'schema> ErrorsMessage<'schema> {
         } = self;
         let context = match coordinate.coordinate {
             ErrorsCoordinate::Source { .. } => {
-                &Context::for_source_response(schema, &mapping.string, Code::InvalidErrorsMessage)
+                &Context::for_source_response(schema, &mapping.node, Code::InvalidErrorsMessage)
             }
             ErrorsCoordinate::Connect { connect } => &Context::for_connect_response(
                 schema,
                 connect,
-                &mapping.string,
+                &mapping.node,
                 Code::InvalidErrorsMessage,
             ),
         };
@@ -233,7 +232,7 @@ impl Display for ErrorsMessageCoordinate<'_> {
 
 struct ErrorsExtensions<'schema> {
     selection: JSONSelection,
-    string: GraphQLString<'schema>,
+    node: Node<Value>,
     coordinate: ErrorsExtensionsCoordinate<'schema>,
 }
 
@@ -251,7 +250,7 @@ impl<'schema> ErrorsExtensions<'schema> {
         };
         let coordinate = ErrorsExtensionsCoordinate { coordinate };
 
-        let MappingArgument { expression, string } = parse_mapping_argument(
+        let MappingArgument { expression, node } = parse_mapping_argument(
             value,
             coordinate.clone(),
             Code::InvalidErrorsMessage,
@@ -260,7 +259,7 @@ impl<'schema> ErrorsExtensions<'schema> {
 
         Ok(Some(Self {
             selection: expression.expression,
-            string,
+            node,
             coordinate,
         }))
     }
@@ -269,22 +268,25 @@ impl<'schema> ErrorsExtensions<'schema> {
     pub(super) fn type_check(self, schema: &SchemaInfo) -> Result<(), Message> {
         let Self {
             selection,
-            string,
+            node,
             coordinate,
         } = self;
         let context = match coordinate.coordinate {
             ErrorsCoordinate::Source { .. } => {
-                &Context::for_source_response(schema, &string, Code::InvalidErrorsMessage)
+                &Context::for_source_response(schema, &node, Code::InvalidErrorsMessage)
             }
             ErrorsCoordinate::Connect { connect } => {
-                &Context::for_connect_response(schema, connect, &string, Code::InvalidErrorsMessage)
+                &Context::for_connect_response(schema, connect, &node, Code::InvalidErrorsMessage)
             }
         };
 
         expression::validate(
             &Expression {
                 expression: selection,
-                location: 0..string.as_str().len(),
+                location: 0..node
+                    .location()
+                    .map(|location| location.node_len())
+                    .unwrap_or_default(),
             },
             context,
             &Shape::dict(Shape::unknown([]), []),

--- a/apollo-federation/src/connectors/validation/expression.rs
+++ b/apollo-federation/src/connectors/validation/expression.rs
@@ -26,8 +26,8 @@ use crate::connectors::string_template::Expression;
 use crate::connectors::validation::Code;
 use crate::connectors::validation::Message;
 use crate::connectors::validation::coordinates::ConnectDirectiveCoordinate;
-use crate::connectors::validation::graphql::GraphQLString;
 use crate::connectors::validation::graphql::SchemaInfo;
+use crate::connectors::validation::graphql::subslice_location;
 use crate::connectors::variable::VariableReference;
 
 static REQUEST_SHAPE: LazyLock<Shape> = LazyLock::new(|| {
@@ -61,7 +61,7 @@ fn env_shape() -> Shape {
 pub(super) struct Context<'schema> {
     pub(crate) schema: &'schema SchemaInfo<'schema>,
     var_lookup: IndexMap<Namespace, Shape>,
-    source: &'schema GraphQLString<'schema>,
+    node: &'schema Node<Value>,
     /// The code that all resulting messages will use
     /// TODO: make code dynamic based on coordinate so new validations can be warnings
     code: Code,
@@ -74,7 +74,7 @@ impl<'schema> Context<'schema> {
     pub(super) fn for_connect_request(
         schema: &'schema SchemaInfo,
         coordinate: ConnectDirectiveCoordinate,
-        source: &'schema GraphQLString,
+        node: &'schema Node<Value>,
         code: Code,
     ) -> Self {
         match coordinate.element {
@@ -100,7 +100,7 @@ impl<'schema> Context<'schema> {
                 Self {
                     schema,
                     var_lookup,
-                    source,
+                    node,
                     code,
                     has_response_body: false,
                 }
@@ -120,7 +120,7 @@ impl<'schema> Context<'schema> {
                 Self {
                     schema,
                     var_lookup,
-                    source,
+                    node,
                     code,
                     has_response_body: false,
                 }
@@ -133,7 +133,7 @@ impl<'schema> Context<'schema> {
     pub(super) fn for_connect_response(
         schema: &'schema SchemaInfo,
         coordinate: ConnectDirectiveCoordinate,
-        source: &'schema GraphQLString,
+        node: &'schema Node<Value>,
         code: Code,
     ) -> Self {
         match coordinate.element {
@@ -161,7 +161,7 @@ impl<'schema> Context<'schema> {
                 Self {
                     schema,
                     var_lookup,
-                    source,
+                    node,
                     code,
                     has_response_body: true,
                 }
@@ -183,7 +183,7 @@ impl<'schema> Context<'schema> {
                 Self {
                     schema,
                     var_lookup,
-                    source,
+                    node,
                     code,
                     has_response_body: true,
                 }
@@ -194,7 +194,7 @@ impl<'schema> Context<'schema> {
     /// Create a context valid for expressions within the `@source` directive
     pub(super) fn for_source(
         schema: &'schema SchemaInfo,
-        source: &'schema GraphQLString,
+        node: &'schema Node<Value>,
         code: Code,
     ) -> Self {
         let var_lookup: IndexMap<Namespace, Shape> = [
@@ -208,7 +208,7 @@ impl<'schema> Context<'schema> {
         Self {
             schema,
             var_lookup,
-            source,
+            node,
             code,
             has_response_body: false,
         }
@@ -218,7 +218,7 @@ impl<'schema> Context<'schema> {
     /// Note that we can't use stuff like "this" here cause we have no idea what the "type" is when on a @source block
     pub(super) fn for_source_response(
         schema: &'schema SchemaInfo,
-        source: &'schema GraphQLString,
+        node: &'schema Node<Value>,
         code: Code,
     ) -> Self {
         let var_lookup: IndexMap<Namespace, Shape> = [
@@ -235,7 +235,7 @@ impl<'schema> Context<'schema> {
         Self {
             schema,
             var_lookup,
-            source,
+            node,
             code,
             has_response_body: true,
         }
@@ -286,7 +286,8 @@ pub(crate) fn validate(
                     .location
                     .iter()
                     .filter_map(|location| {
-                        context.source.line_col_for_subslice(
+                        subslice_location(
+                            context.node,
                             location.start + expression.location.start
                                 ..location.end + expression.location.start,
                             context.schema,
@@ -482,7 +483,8 @@ fn transform_locations<'a>(
                 .and_then(|source| source.get_line_column_range(location.span.clone())),
             SourceId::Other(_) => {
                 // Right now, this always refers to the JSONSelection location
-                context.source.line_col_for_subslice(
+                subslice_location(
+                    context.node,
                     location.span.start + expression.location.start
                         ..location.span.end + expression.location.start,
                     context.schema,
@@ -492,7 +494,8 @@ fn transform_locations<'a>(
         .collect();
     if locations.is_empty() {
         // Highlight the whole expression
-        locations.extend(context.source.line_col_for_subslice(
+        locations.extend(subslice_location(
+            context.node,
             expression.location.start..expression.location.end,
             context.schema,
         ))
@@ -519,24 +522,24 @@ fn shape_name(shape: &Shape) -> &'static str {
     }
 }
 
-pub(crate) struct MappingArgument<'schema> {
+pub(crate) struct MappingArgument {
     pub(crate) expression: Expression,
-    pub(crate) string: GraphQLString<'schema>,
+    pub(crate) node: Node<Value>,
 }
 
-impl MappingArgument<'_> {
+impl MappingArgument {
     pub(crate) fn variable_references(&self) -> impl Iterator<Item = VariableReference<Namespace>> {
         self.expression.expression.variable_references()
     }
 }
 
-pub(crate) fn parse_mapping_argument<'schema>(
-    node: &'schema Node<Value>,
+pub(crate) fn parse_mapping_argument(
+    node: &Node<Value>,
     coordinate: impl Display,
     code: Code,
-    schema: &'schema SchemaInfo,
-) -> Result<MappingArgument<'schema>, Message> {
-    let Ok(string) = GraphQLString::new(node, &schema.sources) else {
+    schema: &SchemaInfo,
+) -> Result<MappingArgument, Message> {
+    let Some(string) = node.as_str() else {
         return Err(Message {
             code: Code::GraphQLError,
             message: format!("{coordinate} must be a string."),
@@ -547,14 +550,13 @@ pub(crate) fn parse_mapping_argument<'schema>(
         });
     };
 
-    let selection = match JSONSelection::parse(string.as_str()) {
+    let selection = match JSONSelection::parse(string) {
         Ok(selection) => selection,
         Err(e) => {
             return Err(Message {
                 code,
                 message: format!("{coordinate} is not valid: {e}"),
-                locations: string
-                    .line_col_for_subslice(e.offset..e.offset + 1, schema)
+                locations: subslice_location(node, e.offset..e.offset + 1, schema)
                     .into_iter()
                     .collect(),
             });
@@ -575,9 +577,9 @@ pub(crate) fn parse_mapping_argument<'schema>(
     Ok(MappingArgument {
         expression: Expression {
             expression: selection,
-            location: 0..string.as_str().len(),
+            location: 0..string.len(),
         },
-        string,
+        node: node.clone(),
     })
 }
 
@@ -649,18 +651,15 @@ mod tests {
         let directive = field.directives.get("connect").unwrap();
         let schema_info =
             SchemaInfo::new(&schema, &schema_str, ConnectLink::new(&schema).unwrap()?);
-        let expr_string = GraphQLString::new(
-            &directive
-                .argument_by_name("http", &schema)
-                .unwrap()
-                .as_object()
-                .unwrap()
-                .first()
-                .unwrap()
-                .1,
-            &schema.sources,
-        )
-        .unwrap();
+        let expr_string = directive
+            .argument_by_name("http", &schema)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .first()
+            .unwrap()
+            .1
+            .clone();
         let coordinate = ConnectDirectiveCoordinate {
             element: ConnectedElement::Field {
                 parent_type: object,

--- a/apollo-federation/src/connectors/validation/graphql.rs
+++ b/apollo-federation/src/connectors/validation/graphql.rs
@@ -9,7 +9,7 @@ use shape::Shape;
 
 mod strings;
 
-pub(super) use strings::GraphQLString;
+pub(super) use strings::subslice_location;
 
 use crate::connectors::validation::link::ConnectLink;
 

--- a/apollo-federation/src/connectors/validation/http/headers.rs
+++ b/apollo-federation/src/connectors/validation/http/headers.rs
@@ -13,8 +13,8 @@ use crate::connectors::validation::Message;
 use crate::connectors::validation::coordinates::HttpHeadersCoordinate;
 use crate::connectors::validation::expression;
 use crate::connectors::validation::expression::scalars;
-use crate::connectors::validation::graphql::GraphQLString;
 use crate::connectors::validation::graphql::SchemaInfo;
+use crate::connectors::validation::graphql::subslice_location;
 
 pub(crate) struct Headers<'schema> {
     headers: Vec<Header>,
@@ -57,11 +57,7 @@ impl<'schema> Headers<'schema> {
                             node,
                         } => (
                             message,
-                            GraphQLString::new(&node, sources)
-                                .ok()
-                                .and_then(|expression| {
-                                    expression.line_col_for_subslice(location, schema)
-                                })
+                            subslice_location(&node, location, schema)
                                 .into_iter()
                                 .collect(),
                         ),
@@ -113,19 +109,15 @@ impl<'schema> Headers<'schema> {
             let Some(node) = header.source_node.as_ref() else {
                 continue;
             };
-            let Ok(expression) = GraphQLString::new(node, &schema.sources) else {
-                // This should never fail in practice, we convert to GraphQLString only to hack in location data
-                continue;
-            };
             let expression_context = match coordinate {
                 HttpHeadersCoordinate::Source { .. } => {
-                    expression::Context::for_source(schema, &expression, Code::InvalidHeader)
+                    expression::Context::for_source(schema, node, Code::InvalidHeader)
                 }
                 HttpHeadersCoordinate::Connect { connect, .. } => {
                     expression::Context::for_connect_request(
                         schema,
                         connect,
-                        &expression,
+                        node,
                         Code::InvalidHeader,
                     )
                 }

--- a/apollo-federation/src/connectors/validation/http/url.rs
+++ b/apollo-federation/src/connectors/validation/http/url.rs
@@ -7,14 +7,13 @@ use http::uri::Scheme;
 
 use crate::connectors::validation::Code;
 use crate::connectors::validation::Message;
-use crate::connectors::validation::graphql::GraphQLString;
 use crate::connectors::validation::graphql::SchemaInfo;
+use crate::connectors::validation::graphql::subslice_location;
 
 pub(crate) fn validate_url_scheme(
     url: &Uri,
     coordinate: impl Display,
     value: &Node<Value>,
-    str_value: GraphQLString,
     schema: &SchemaInfo,
 ) -> Result<(), Message> {
     let Some(scheme) = url.scheme() else {
@@ -36,8 +35,7 @@ pub(crate) fn validate_url_scheme(
             message: format!(
                 "The value {value} for {coordinate} must be http or https, got {scheme}.",
             ),
-            locations: str_value
-                .line_col_for_subslice(scheme_location, schema)
+            locations: subslice_location(value, scheme_location, schema)
                 .into_iter()
                 .collect(),
         })

--- a/apollo-federation/src/connectors/validation/http/url_properties.rs
+++ b/apollo-federation/src/connectors/validation/http/url_properties.rs
@@ -97,13 +97,13 @@ impl<'schema> UrlProperties<'schema> {
         let context = match property.coordinate.directive {
             ConnectOrSource::Source(_) => expression::Context::for_source(
                 schema,
-                &property.mapping.string,
+                &property.mapping.node,
                 Code::InvalidUrlProperty,
             ),
             ConnectOrSource::Connect(coord) => expression::Context::for_connect_request(
                 schema,
                 coord,
-                &property.mapping.string,
+                &property.mapping.node,
                 Code::InvalidUrlProperty,
             ),
         };
@@ -122,7 +122,7 @@ impl<'schema> UrlProperties<'schema> {
 
 struct Property<'schema> {
     coordinate: Coordinate<'schema>,
-    mapping: MappingArgument<'schema>,
+    mapping: MappingArgument,
 }
 
 impl Property<'_> {

--- a/apollo-federation/src/connectors/validation/mod.rs
+++ b/apollo-federation/src/connectors/validation/mod.rs
@@ -28,7 +28,6 @@ use strum_macros::IntoStaticStr;
 use crate::connectors::ConnectSpec;
 use crate::connectors::spec::source::SOURCE_DIRECTIVE_NAME_IN_SPEC;
 use crate::connectors::validation::connect::fields_seen_by_all_connects;
-use crate::connectors::validation::graphql::GraphQLString;
 use crate::connectors::validation::graphql::SchemaInfo;
 use crate::connectors::validation::link::ConnectLink;
 use crate::connectors::validation::source::SourceDirective;
@@ -168,7 +167,7 @@ fn parse_url<Coordinate: Display + Copy>(
     coordinate: Coordinate,
     schema: &SchemaInfo,
 ) -> Result<(), Message> {
-    let str_value = GraphQLString::new(value, &schema.sources).map_err(|_| Message {
+    let str_value = value.as_str().ok_or_else(|| Message {
         code: Code::GraphQLError,
         message: format!("The value for {coordinate} must be a string."),
         locations: value
@@ -176,7 +175,7 @@ fn parse_url<Coordinate: Display + Copy>(
             .into_iter()
             .collect(),
     })?;
-    let url = Uri::from_str(str_value.as_str()).map_err(|inner| Message {
+    let url = Uri::from_str(str_value).map_err(|inner| Message {
         code: Code::InvalidUrl,
         message: format!("The value {value} for {coordinate} is not a valid URL: {inner}."),
         locations: value
@@ -184,7 +183,7 @@ fn parse_url<Coordinate: Display + Copy>(
             .into_iter()
             .collect(),
     })?;
-    http::url::validate_url_scheme(&url, coordinate, value, str_value, schema)
+    http::url::validate_url_scheme(&url, coordinate, value, schema)
 }
 
 type DirectiveName = Name;

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@errors.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@errors.graphql.snap
@@ -27,15 +27,15 @@ input_file: apollo-federation/src/connectors/validation/test_data/errors.graphql
         ],
     },
     Message {
-        code: GraphQLError,
-        message: "`@connect(errors.message:)` on `Query.invalid_sourceless_empty_message` must be a string.",
+        code: InvalidErrorsMessage,
+        message: "`@connect(errors.message:)` on `Query.invalid_sourceless_empty_message` is empty",
         locations: [
             114:26..114:28,
         ],
     },
     Message {
-        code: GraphQLError,
-        message: "`@connect(errors.extensions:)` on `Query.invalid_sourceless_empty_extensions` must be a string.",
+        code: InvalidErrorsMessage,
+        message: "`@connect(errors.extensions:)` on `Query.invalid_sourceless_empty_extensions` is empty",
         locations: [
             119:97..119:99,
         ],


### PR DESCRIPTION
Isolates the usage of `GraphQLString` which has a few effects:

1. It will make it easier to share some code with runtime in the future—since we don't want to have `GraphQLString` out there.
2. In cases where there are one or few errors, there's a performance benefit to not pre-creating `GraphQLString`. In cases where there are lots of errors, recreating the `GraphQLString` per error will be more expensive. Not sure we know enough about common usage to optimize further.
3. Helpfully corrects a couple of error messages about error messages
4. It's a bit of pre-work for when we get this feature in `apollo-compiler` and don't need `GraphQLString` at all anymore!

<!-- [CNN-610] -->

[CNN-610]: https://apollographql.atlassian.net/browse/CNN-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ