### PR TITLE
fix(composition): remove unnecessary metadata recomputation

### DIFF
--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -689,18 +689,6 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
             )),
         }
     }
-
-    pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
-        match self {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(type_) => {
-                let _ = type_.remove(schema);
-            }
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(type_) => {
-                let _ = type_.remove(schema);
-            }
-        }
-        Ok(())
-    }
 }
 
 fallible_conversions!(ObjectOrInterfaceTypeDefinitionPosition::Object -> ObjectTypeDefinitionPosition);
@@ -879,13 +867,6 @@ impl ObjectOrInterfaceFieldDefinitionPosition {
         schema: &'schema Schema,
     ) -> Option<&'schema Component<FieldDefinition>> {
         self.get(schema).ok()
-    }
-
-    pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
-        match self {
-            ObjectOrInterfaceFieldDefinitionPosition::Object(field) => field.remove(schema),
-            ObjectOrInterfaceFieldDefinitionPosition::Interface(field) => field.remove(schema),
-        }
     }
 
     pub(crate) fn insert_directive(

--- a/apollo-federation/src/schema/referencer.rs
+++ b/apollo-federation/src/schema/referencer.rs
@@ -115,15 +115,6 @@ pub(crate) struct InterfaceTypeReferencers {
     pub(crate) interface_fields: IndexSet<InterfaceFieldDefinitionPosition>,
 }
 
-impl InterfaceTypeReferencers {
-    pub(crate) fn len(&self) -> usize {
-        self.object_types.len()
-            + self.object_fields.len()
-            + self.interface_types.len()
-            + self.interface_fields.len()
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 pub(crate) struct UnionTypeReferencers {
     pub(crate) object_fields: IndexSet<ObjectFieldDefinitionPosition>,


### PR DESCRIPTION
While upgrading subgraphs we don't need to recompute this metadata.

<!-- FED-663 -->
