### PR TITLE
refactor(file_uploads): implement proper Tower layer and fix HTTP client buffering

### DIFF
--- a/.changesets/maint_refactor_file_uploads_layer.md
+++ b/.changesets/maint_refactor_file_uploads_layer.md
@@ -1,0 +1,18 @@
+### Improved file uploads plugin architecture ([PR #7693](https://github.com/apollographql/router/pull/7693))
+
+The file uploads plugin has been refactored to use a more robust and consistent architecture. This internal improvement enhances the reliability and maintainability of file upload handling without changing any user-facing functionality.
+
+**What changed:**
+- File uploads now use a proper HTTP service layer instead of a temporary workaround
+- Better integration with the router's service pipeline
+- Improved code organization and consistency with other plugins
+
+**Impact:**
+- No changes to file upload configuration or behavior
+- No breaking changes to existing file upload functionality  
+- Enhanced reliability and performance consistency
+- Better foundation for future file upload improvements
+
+All existing file upload features continue to work exactly as before.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/7693

--- a/apollo-router/src/plugins/file_uploads/layer.rs
+++ b/apollo-router/src/plugins/file_uploads/layer.rs
@@ -1,0 +1,109 @@
+use std::task::Poll;
+
+use futures::future::BoxFuture;
+use http::HeaderValue;
+use http::header::CONTENT_TYPE;
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
+
+use super::multipart_form_data::MultipartFormData;
+use crate::services::http::HttpRequest;
+use crate::services::http::HttpResponse;
+use crate::services::router;
+
+static APOLLO_REQUIRE_PREFLIGHT: http::HeaderName =
+    http::HeaderName::from_static("apollo-require-preflight");
+static TRUE: http::HeaderValue = HeaderValue::from_static("true");
+
+/// Tower layer that handles file upload transformation for HTTP requests
+#[derive(Clone)]
+pub(crate) struct FileUploadLayer {
+    enabled: bool,
+}
+
+impl FileUploadLayer {
+    pub(crate) fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+}
+
+impl<S> Layer<S> for FileUploadLayer {
+    type Service = FileUploadService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        FileUploadService {
+            inner,
+            enabled: self.enabled,
+        }
+    }
+}
+
+/// Tower service that transforms HTTP requests containing multipart file uploads
+#[derive(Clone)]
+pub(crate) struct FileUploadService<S> {
+    inner: S,
+    enabled: bool,
+}
+
+impl<S> Service<HttpRequest> for FileUploadService<S>
+where
+    S: Service<HttpRequest, Response = HttpResponse, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = HttpResponse;
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: HttpRequest) -> Self::Future {
+        if !self.enabled {
+            return Box::pin(self.inner.call(req));
+        }
+
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut inner, &mut self.inner);
+        Box::pin(async move {
+            // Transform the HTTP request if it contains multipart form data
+            let transformed_req = Self::transform_multipart_request(req).await;
+            inner.call(transformed_req).await
+        })
+    }
+}
+
+impl<S> FileUploadService<S> {
+    /// Transforms an HTTP request with multipart form data for file uploads
+    /// This is the equivalent of the original `http_request_wrapper` function
+    async fn transform_multipart_request(req: HttpRequest) -> HttpRequest {
+        let mut http_request = req.http_request;
+        let form = http_request
+            .extensions_mut()
+            .get::<MultipartFormData>()
+            .cloned();
+
+        if let Some(form) = form {
+            let (mut request_parts, operations) = http_request.into_parts();
+            request_parts
+                .headers
+                .insert(APOLLO_REQUIRE_PREFLIGHT.clone(), TRUE.clone());
+
+            // override Content-Type to be 'multipart/form-data'
+            request_parts
+                .headers
+                .insert(CONTENT_TYPE, form.content_type());
+
+            // Create the request body from the multipart form stream
+            let request_body = router::body::from_result_stream(form.into_stream(operations).await);
+
+            http_request = http::Request::from_parts(request_parts, request_body);
+        }
+
+        HttpRequest {
+            http_request,
+            context: req.context,
+        }
+    }
+}

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -23,7 +23,6 @@ use self::multipart_form_data::MultipartFormData;
 use self::multipart_request::MultipartRequest;
 use self::rearrange_query_plan::rearrange_query_plan;
 use crate::json_ext;
-use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
@@ -166,7 +165,7 @@ impl PluginPrivate for FileUploadsPlugin {
 
         ServiceBuilder::new()
             .layer(FileUploadLayer::new(self.enabled))
-            .buffer(DEFAULT_BUFFER_SIZE)
+            .buffered()
             .service(service)
             .boxed()
     }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -62,7 +62,6 @@ use crate::json_ext::Object;
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::plugins::authentication::subgraph::SigningParamsConfig;
 use crate::plugins::content_negotiation::APPLICATION_GRAPHQL_JSON;
-use crate::plugins::file_uploads;
 use crate::plugins::subscription::CallbackMode;
 use crate::plugins::subscription::SUBSCRIPTION_WS_CUSTOM_CONNECTION_PARAMS;
 use crate::plugins::subscription::SubscriptionConfig;
@@ -1297,9 +1296,6 @@ pub(crate) async fn call_single_http(
     // 1. If the content type of the response is not `application/json` or `application/graphql-response+json` then we won't try to parse.
     // 2. If an HTTP status is not 2xx it will always be attached as a graphql error.
     // 3. If the response type is `application/json` and status is not 2xx and the body the entire body will be output if the response is not valid graphql.
-
-    // TODO: Temporary solution to plug FileUploads plugin until 'http_client' will be fixed https://github.com/apollographql/router/pull/4666
-    let request = file_uploads::http_request_wrapper(request).await;
 
     if let Some(level) = log_request_level {
         let mut attrs = Vec::with_capacity(5);

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1463,7 +1463,7 @@ fn get_graphql_content_type(service_name: &str, parts: &Parts) -> Result<Content
 }
 
 async fn do_fetch(
-    mut client: crate::services::http::BoxService,
+    client: crate::services::http::BoxService,
     context: &Context,
     service_name: &str,
     request: Request<RouterBody>,
@@ -1475,8 +1475,9 @@ async fn do_fetch(
     ),
     FetchError,
 > {
+    // oneshot must be used because the client service has actual tower layers in now. Therefore poll_ready must be called.
     let response = client
-        .call(HttpRequest {
+        .oneshot(HttpRequest {
             http_request: request,
             context: context.clone(),
         })

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1185,6 +1185,11 @@ impl IntegrationTest {
 
 impl Drop for IntegrationTest {
     fn drop(&mut self) {
+        if self.router.is_some() {
+            self.read_logs();
+            self.print_logs();
+        }
+
         if let Some(child) = &mut self.router {
             let _ = child.start_kill();
         }


### PR DESCRIPTION
# Task

Refactor file uploads plugin from a temporary function-based approach to a proper Tower layer implementation, and resolve HTTP client service buffering issues that were causing runtime panics.

# Why This Change Is Needed

The file uploads functionality was implemented as a temporary solution using direct function calls (`http_request_wrapper`) in the subgraph service, which violated Tower service architecture principles and created technical debt. Additionally, the HTTP client service buffering was causing `poll_ready` panics due to improper Tower service call patterns.

Key issues resolved:
- Runtime panics: `` `send_item` called without first calling `poll_reserve` ``
- Technical debt from temporary file upload implementation
- Architectural inconsistency with other router plugins
- Improper Tower service buffering patterns

# How It Was Tackled

## Layer Implementation
- Created `FileUploadLayer` and `FileUploadService` following established Tower patterns
- Implemented proper `http_client_service` method in `FileUploadsPlugin`
- Removed temporary `http_request_wrapper` function call from subgraph service
- Eliminated acknowledged TODO about temporary solution

## Service Buffering Fixes
- Switched from `.buffer(DEFAULT_BUFFER_SIZE)` to `.buffered()` for proper Clone handling
- Updated `do_fetch` to use `.oneshot()` instead of `.call()` for correct Tower semantics
- Fixed lint issues (unused imports, unnecessary mut parameters)

# Technical Details

## Tower Service Patterns
- `FileUploadService` implements proper Tower `Service` trait with async request transformation
- Uses standard plugin layer composition with `ServiceBuilder`
- Maintains all existing multipart form data processing functionality

## HTTP Client Service Buffering
- `.buffered()` uses router's `ServiceBuilderExt` which handles Clone requirements correctly
- `.oneshot()` ensures proper `poll_ready`/`call` sequencing in Tower services
- HTTP client services require different buffering patterns than router/supergraph services

## Current Limitation
**Note**: The HTTP client service is currently recreated for each request rather than being cached like other services. This will be addressed in a separate PR to implement proper caching at the factory level.

# Review Strategy

## Architecture Review
- Verify the `FileUploadLayer` follows established plugin patterns
- Confirm removal of temporary solution doesn't break functionality
- Check that Tower service composition is correct

## Testing Focus
- Verify multipart form data processing works across different subgraphs
- Confirm no regressions in subgraph request handling

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
