### PR TITLE
chore: Fix release process

### DIFF
--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -69,10 +69,12 @@ pub struct Prepare {
 
 macro_rules! replace_in_file {
     ($path:expr, $regex:expr, $replacement:expr) => {
-        let before = std::fs::read_to_string($path)?;
+        let before = std::fs::read_to_string($path)
+            .map_err(|e| anyhow!("failed to read {:?}: {}", $path, e))?;
         let re = regex::Regex::new(&format!("(?m){}", $regex))?;
         let after = re.replace_all(&before, $replacement);
-        std::fs::write($path, &after.as_ref())?;
+        std::fs::write($path, &after.as_ref())
+            .map_err(|e| anyhow!("failed to write to {:?}: {}", $path, e))?;
     };
 }
 
@@ -271,11 +273,6 @@ impl Prepare {
             "./docs/source/routing/self-hosted/containerization/docker.mdx",
             "with your chosen version. e.g.: `v[^`]+`",
             format!("with your chosen version. e.g.: `v{version}`")
-        );
-        replace_in_file!(
-            "./docs/source/routing/self-hosted/containerization/kubernetes.mdx",
-            "https://github.com/apollographql/router/tree/[^/]+/helm/chart/router",
-            format!("https://github.com/apollographql/router/tree/v{version}/helm/chart/router")
         );
         let helm_chart = String::from_utf8(
             std::process::Command::new(which::which("helm")?)


### PR DESCRIPTION
The release script failed to replace a string in a file that did not exist, and there was no information about what failed.

The replacement in has been removed as this has not been effective for a long time as the source docs changed.

I have checked the source docs and the wording is generic enough that we don't need to update on every release.

The PR that broke the release script was: https://github.com/apollographql/router/pull/7497


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
