### PR TITLE
Use new subgraph mocking functionality for canned test supergraph

### DIFF
--- a/apollo-router/src/axum_factory/snapshots/apollo_router__axum_factory__tests__defer_is_not_buffered.snap
+++ b/apollo-router/src/axum_factory/snapshots/apollo_router__axum_factory__tests__defer_is_not_buffered.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/src/axum_factory/tests.rs
 expression: parts
+snapshot_kind: text
 ---
 [
   {
@@ -9,31 +10,82 @@ expression: parts
         {
           "upc": "1",
           "name": "Table",
-          "reviews": null
+          "reviews": [
+            {
+              "id": "1",
+              "product": {
+                "name": "Table"
+              }
+            },
+            {
+              "id": "4",
+              "product": {
+                "name": "Table"
+              }
+            }
+          ]
         },
         {
           "upc": "2",
           "name": "Couch",
-          "reviews": null
+          "reviews": [
+            {
+              "id": "2",
+              "product": {
+                "name": "Couch"
+              }
+            }
+          ]
         }
       ]
     },
-    "errors": [
-      {
-        "message": "couldn't find mock for query {\"query\":\"query($representations: [_Any!]!) { _entities(representations: $representations) { ... on Product { reviews { __typename id product { __typename upc } } } } }\",\"variables\":{\"representations\":[{\"__typename\":\"Product\",\"upc\":\"1\"},{\"__typename\":\"Product\",\"upc\":\"2\"}]}}",
-        "path": [
-          "topProducts",
-          "@"
-        ],
-        "extensions": {
-          "code": "FETCH_ERROR",
-          "service": "reviews"
-        }
-      }
-    ],
     "hasNext": true
   },
   {
-    "hasNext": false
+    "hasNext": false,
+    "incremental": [
+      {
+        "data": {
+          "author": {
+            "id": "1",
+            "name": "Ada Lovelace"
+          }
+        },
+        "path": [
+          "topProducts",
+          0,
+          "reviews",
+          0
+        ]
+      },
+      {
+        "data": {
+          "author": {
+            "id": "2",
+            "name": "Alan Turing"
+          }
+        },
+        "path": [
+          "topProducts",
+          0,
+          "reviews",
+          1
+        ]
+      },
+      {
+        "data": {
+          "author": {
+            "id": "1",
+            "name": "Ada Lovelace"
+          }
+        },
+        "path": [
+          "topProducts",
+          1,
+          "reviews",
+          0
+        ]
+      }
+    ]
   }
 ]

--- a/apollo-router/src/plugin/test/mock/canned.rs
+++ b/apollo-router/src/plugin/test/mock/canned.rs
@@ -28,11 +28,13 @@ pub(crate) fn mock_subgraphs() -> serde_json::Value {
                     "upc": "1",
                     "reviews": [
                         {
+                            "__typename": "Review",
                             "id": "1",
                             "product": { "__typename": "Product", "upc": "1" },
                             "author": { "__typename": "User", "id": "1" },
                         },
                         {
+                            "__typename": "Review",
                             "id": "4",
                             "product": { "__typename": "Product", "upc": "1" },
                             "author": { "__typename": "User", "id": "2" },
@@ -44,12 +46,31 @@ pub(crate) fn mock_subgraphs() -> serde_json::Value {
                     "upc": "2",
                     "reviews": [
                         {
+                            "__typename": "Review",
                             "id": "2",
                             "product": { "__typename": "Product", "upc": "2" },
                             "author": { "__typename": "User", "id": "1" },
                         },
                     ],
-                }
+                },
+                {
+                    "__typename": "Review",
+                    "id": "1",
+                    "product": { "__typename": "Product", "upc": "1" },
+                    "author": { "__typename": "User", "id": "1" },
+                },
+                {
+                    "__typename": "Review",
+                    "id": "2",
+                    "product": { "__typename": "Product", "upc": "2" },
+                    "author": { "__typename": "User", "id": "1" },
+                },
+                {
+                    "__typename": "Review",
+                    "id": "4",
+                    "product": { "__typename": "Product", "upc": "1" },
+                    "author": { "__typename": "User", "id": "2" },
+                },
             ],
         },
     })

--- a/apollo-router/src/plugin/test/mock/canned.rs
+++ b/apollo-router/src/plugin/test/mock/canned.rs
@@ -1,191 +1,56 @@
-//! Canned data for use with MockSugbraph.
-//! Eventually we may replace this with a real subgraph.
+//! Canned data for use with the canned schema (`/testing_schema.graphl`).
 use serde_json::json;
 
-use crate::plugin::test::MockSubgraph;
-
-/// Canned responses for accounts_subgraphs.
-pub(crate) fn accounts_subgraph() -> MockSubgraph {
-    let account_mocks = vec![
-        (
-            json! {{
-                    "query": "query TopProducts__accounts__3($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}",
-                    "operationName": "TopProducts__accounts__3",
-                    "variables": {
-                        "representations": [
-                            {
-                                "__typename": "User",
-                                "id": "1"
-                            },
-                            {
-                                "__typename": "User",
-                                "id": "2"
-                            },
-                        ]
-                    }
-                }},
-            json! {{
-                    "data": {
-                        "_entities": [
-                            {
-                                "name": "Ada Lovelace"
-                            },
-                            {
-                                "name": "Alan Turing"
-                            },
-                        ]
-                    }
-                }}
-        ),
-        (
-            json! {{
-                    "query": "subscription{userWasCreated{name}}",
-                }},
-            json! {{}}
-        )
-    ].into_iter().map(|(query, response)| (serde_json::from_value(query).unwrap(), serde_json::from_value(response).unwrap())).collect();
-    MockSubgraph::new(account_mocks)
-}
-
-/// Canned responses for reviews_subgraphs.
-pub(crate) fn reviews_subgraph() -> MockSubgraph {
-    let review_mocks = vec![
-        (
-            json! {{
-                    "query": "query($representations: [_Any!]!) { _entities(representations: $representations) { ... on Product { reviews { id product { __typename upc } author { __typename id } } } } }",
-                    "variables": {
-                        "representations":[
-                            {
-                                "__typename": "Product",
-                                "upc":"1"
-                            },
-                            {
-                                "__typename": "Product",
-                                "upc": "2"
-                            }
-                        ]
-                    }
-                }},
-            json! {{
-                    "data": {
-                        "_entities": [
-                            {
-                                "reviews": [
-                                    {
-                                        "id": "1",
-                                        "product": {
-                                            "__typename": "Product",
-                                            "upc": "1"
-                                        },
-                                        "author": {
-                                            "__typename": "User",
-                                            "id": "1"
-                                        }
-                                    },
-                                    {
-                                        "id": "4",
-                                        "product": {
-                                            "__typename": "Product",
-                                            "upc": "1"
-                                        },
-                                        "author": {
-                                            "__typename": "User",
-                                            "id": "2"
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "reviews": [
-                                    {
-                                        "id": "2",
-                                        "product": {
-                                            "__typename": "Product",
-                                            "upc": "2"
-                                        },
-                                        "author": {
-                                            "__typename": "User",
-                                            "id": "1"
-                                        }
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }}
-        ),
-        (
-            json! {{
-                    "query": "subscription{reviewAdded{body}}",
-                }},
-            json! {{
-                "errors": [{
-                    "message": "subscription is not enabled"
-                }]
-            }}
-        )
-    ].into_iter().map(|(query, response)| (serde_json::from_value(query).unwrap(), serde_json::from_value(response).unwrap())).collect();
-    MockSubgraph::new(review_mocks)
-}
-
-/// Canned responses for products_subgraphs.
-pub(crate) fn products_subgraph() -> MockSubgraph {
-    let product_mocks = vec![
-        (
-            json!{{
-                    "query": "query TopProducts__products__0($first:Int){topProducts(first:$first){__typename upc name}}",
-                    "operationName": "TopProducts__products__0",
-                    "variables":{
-                        "first":2u8
-                    },
-                }},
-            json!{{
-                    "data": {
-                        "topProducts": [
-                            {
-                                "__typename": "Product",
-                                "upc": "1",
-                                "name":"Table"
-                            },
-                            {
-                                "__typename": "Product",
-                                "upc": "2",
-                                "name": "Couch"
-                            }
-                        ]
-                    }
-                }}
-        ),
-        (
-            json!{{
-                    "query": "query TopProducts__products__2($representations:[_Any!]!){_entities(representations:$representations){...on Product{name}}}",
-                    "operationName": "TopProducts__products__2",
-                    "variables": {
-                        "representations": [
-                            {
-                                "__typename": "Product",
-                                "upc": "1"
-                            },
-                            {
-                                "__typename": "Product",
-                                "upc": "2"
-                            }
-                        ]
-                    }
-                }},
-            json!{{
-                    "data": {
-                        "_entities": [
-                            {
-                                "name": "Table"
-                            },
-                            {
-                                "name": "Couch"
-                            }
-                        ]
-                    }
-                }}
-        )
-    ].into_iter().map(|(query, response)| (serde_json::from_value(query).unwrap(), serde_json::from_value(response).unwrap())).collect();
-    MockSubgraph::new(product_mocks)
+pub(crate) fn mock_subgraphs() -> serde_json::Value {
+    json!({
+        "accounts": {
+            "entities": [
+                { "__typename": "User", "id": "1", "name": "Ada Lovelace" },
+                { "__typename": "User", "id": "2", "name": "Alan Turing" },
+            ],
+        },
+        "products": {
+            "query": {
+                "topProducts": [
+                    { "__typename": "Product", "upc": "1", "name": "Table" },
+                    { "__typename": "Product", "upc": "2", "name": "Couch" },
+                ],
+            },
+            "entities": [
+                { "__typename": "Product", "upc": "1", "name": "Table" },
+                { "__typename": "Product", "upc": "2", "name": "Couch" },
+            ],
+        },
+        "reviews": {
+            "entities": [
+                {
+                    "__typename": "Product",
+                    "upc": "1",
+                    "reviews": [
+                        {
+                            "id": "1",
+                            "product": { "__typename": "Product", "upc": "1" },
+                            "author": { "__typename": "User", "id": "1" },
+                        },
+                        {
+                            "id": "4",
+                            "product": { "__typename": "Product", "upc": "1" },
+                            "author": { "__typename": "User", "id": "2" },
+                        },
+                    ],
+                },
+                {
+                    "__typename": "Product",
+                    "upc": "2",
+                    "reviews": [
+                        {
+                            "id": "2",
+                            "product": { "__typename": "Product", "upc": "2" },
+                            "author": { "__typename": "User", "id": "1" },
+                        },
+                    ],
+                }
+            ],
+        },
+    })
 }

--- a/apollo-router/src/plugins/mock_subgraphs/mod.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/mod.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Schema;
@@ -86,6 +87,10 @@ type OtherJsonMap = serde_json::Map<String, serde_json::Value>;
 
 #[derive(Default)]
 struct HeaderMap(http::HeaderMap);
+
+// Exposed this way for the test harness, so the plugin type itself doesn't need to be made pub.
+pub(crate) static PLUGIN_NAME: LazyLock<&'static str> =
+    LazyLock::new(std::any::type_name::<MockSubgraphsPlugin>);
 
 struct MockSubgraphsPlugin {
     per_subgraph_config: Config,

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_distributed_apq_cache_feature_disabled_with_partial_defaults.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_distributed_apq_cache_feature_disabled_with_partial_defaults.snap
@@ -31,7 +31,7 @@ snapshot_kind: text
               "errors_count": 0,
               "requests_with_errors_count": 0
             },
-            "has_errors": true,
+            "has_errors": false,
             "public_cache_ttl_latency": null,
             "private_cache_ttl_latency": null,
             "registered_operation": false,

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_distributed_apq_cache_feature_enabled_with_partial_defaults.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_distributed_apq_cache_feature_enabled_with_partial_defaults.snap
@@ -31,7 +31,7 @@ snapshot_kind: text
               "errors_count": 0,
               "requests_with_errors_count": 0
             },
-            "has_errors": true,
+            "has_errors": false,
             "public_cache_ttl_latency": null,
             "private_cache_ttl_latency": null,
             "registered_operation": false,

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_features_disabled_when_defaulted.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_features_disabled_when_defaulted.snap
@@ -31,7 +31,7 @@ snapshot_kind: text
               "errors_count": 0,
               "requests_with_errors_count": 0
             },
-            "has_errors": true,
+            "has_errors": false,
             "public_cache_ttl_latency": null,
             "private_cache_ttl_latency": null,
             "registered_operation": false,

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_features_explicitly_disabled.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_features_explicitly_disabled.snap
@@ -31,7 +31,7 @@ snapshot_kind: text
               "errors_count": 0,
               "requests_with_errors_count": 0
             },
-            "has_errors": true,
+            "has_errors": false,
             "public_cache_ttl_latency": null,
             "private_cache_ttl_latency": null,
             "registered_operation": false,

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_features_explicitly_enabled.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_features_explicitly_enabled.snap
@@ -31,7 +31,7 @@ snapshot_kind: text
               "errors_count": 0,
               "requests_with_errors_count": 0
             },
-            "has_errors": true,
+            "has_errors": false,
             "public_cache_ttl_latency": null,
             "private_cache_ttl_latency": null,
             "registered_operation": false,

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_single_operation.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_single_operation.snap
@@ -31,7 +31,7 @@ snapshot_kind: text
               "errors_count": 0,
               "requests_with_errors_count": 0
             },
-            "has_errors": true,
+            "has_errors": false,
             "public_cache_ttl_latency": null,
             "private_cache_ttl_latency": null,
             "registered_operation": false,


### PR DESCRIPTION
Many of our tests use a simple "canned" default schema. This PR replaces the hardcoded query/response mocks with the new subgraph mocking functionality that uses a GraphQL execution engine for that schema.

This is more future-proof in case query plans change in benign ways.

Additionally:
- `axum_factory::tests::defer_is_not_buffered` was using a query that didn't have existing mocks, but now it works
- Some studio metrics tests were using a query that didn't have existing mocks, so they were always reporting `has_errors: true`, now it works