### PR TITLE
feat(federation/composition): port `ValidationState`, except `validateTransition()`

### DIFF
--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -1,4 +1,5 @@
 mod satisfiability_error;
+mod validation_state;
 
 use apollo_compiler::Name;
 use apollo_compiler::Node;

--- a/apollo-federation/src/composition/satisfiability/validation_state.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_state.rs
@@ -1,0 +1,159 @@
+use std::collections::BTreeMap;
+use std::fmt::Display;
+use std::sync::Arc;
+
+use apollo_compiler::Name;
+use apollo_compiler::collections::IndexMap;
+use apollo_compiler::collections::IndexSet;
+use itertools::Itertools;
+use petgraph::visit::EdgeRef;
+
+use crate::bail;
+use crate::ensure;
+use crate::error::FederationError;
+use crate::query_graph::QueryGraph;
+use crate::query_graph::QueryGraphEdgeTransition;
+use crate::query_graph::QueryGraphNodeType;
+use crate::query_graph::condition_resolver::ConditionResolution;
+use crate::query_graph::graph_path::transition::TransitionGraphPath;
+use crate::query_graph::graph_path::transition::TransitionPathWithLazyIndirectPaths;
+use crate::schema::position::SchemaRootDefinitionKind;
+
+struct ValidationState {
+    /// Path in the supergraph (i.e. the API schema query graph) corresponding to the current state.
+    supergraph_path: TransitionGraphPath,
+    /// All the possible paths we could be in the subgraphs (excluding @provides paths).
+    subgraph_paths: Vec<SubgraphPathInfo>,
+    /// When we encounter a supergraph field with a progressive override (i.e. an @override with a
+    /// label condition), we consider both possibilities for the label value (T/F) as we traverse
+    /// the graph, and record that here. This allows us to exclude paths that can never be taken by
+    /// the query planner (i.e. a path where the condition is T in one case and F in another).
+    #[allow(dead_code)]
+    selected_override_conditions: IndexMap<String, bool>,
+}
+
+struct SubgraphPathInfo {
+    path: TransitionPathWithLazyIndirectPaths,
+    contexts: SubgraphPathContexts,
+}
+
+/// A map from context names to information about their match in the subgraph path, if it exists.
+/// This is a `BTreeMap` to support `Hash`, as this is used in keys in maps.
+type SubgraphPathContexts = Arc<BTreeMap<String, SubgraphPathContextInfo>>;
+
+#[derive(PartialEq, Eq, Hash)]
+struct SubgraphPathContextInfo {
+    subgraph_name: Arc<str>,
+    type_name: Name,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+struct SubgraphContextKey {
+    tail_subgraph_name: Arc<str>,
+    contexts: SubgraphPathContexts,
+}
+
+impl ValidationState {
+    // PORT_NOTE: Named `initial()` in the JS codebase, but conventionally in Rust this kind of
+    // constructor is named `new()`.
+    #[allow(dead_code)]
+    fn new(
+        api_schema_query_graph: Arc<QueryGraph>,
+        federated_query_graph: Arc<QueryGraph>,
+        root_kind: SchemaRootDefinitionKind,
+    ) -> Result<Self, FederationError> {
+        let Some(federated_root_node) =
+            federated_query_graph.root_kinds_to_nodes()?.get(&root_kind)
+        else {
+            bail!(
+                "The supergraph shouldn't have a {} root if no subgraphs have one",
+                root_kind
+            );
+        };
+        let federated_root_node_weight = federated_query_graph.node_weight(*federated_root_node)?;
+        ensure!(
+            federated_root_node_weight.type_ == QueryGraphNodeType::FederatedRootType(root_kind),
+            "Unexpected node type {} for federated query graph root (expected {})",
+            federated_root_node_weight.type_,
+            QueryGraphNodeType::FederatedRootType(root_kind),
+        );
+        let initial_subgraph_path =
+            TransitionGraphPath::from_graph_root(federated_query_graph.clone(), root_kind)?;
+        Ok(Self {
+            supergraph_path: TransitionGraphPath::from_graph_root(
+                api_schema_query_graph,
+                root_kind,
+            )?,
+            subgraph_paths: federated_query_graph
+                .out_edges(*federated_root_node)
+                .into_iter()
+                .map(|edge_ref| {
+                    let path = initial_subgraph_path.add(
+                        QueryGraphEdgeTransition::SubgraphEnteringTransition,
+                        edge_ref.id(),
+                        ConditionResolution::no_conditions(),
+                        None,
+                    )?;
+                    Ok::<_, FederationError>(SubgraphPathInfo {
+                        path: TransitionPathWithLazyIndirectPaths::new(Arc::new(path)),
+                        contexts: Default::default(),
+                    })
+                })
+                .process_results(|iter| iter.collect())?,
+            selected_override_conditions: Default::default(),
+        })
+    }
+
+    #[allow(dead_code)]
+    fn current_subgraph_names(&self) -> Result<IndexSet<Arc<str>>, FederationError> {
+        self.subgraph_paths
+            .iter()
+            .map(|path_info| {
+                Ok(path_info
+                    .path
+                    .path
+                    .graph()
+                    .node_weight(path_info.path.path.tail())?
+                    .source
+                    .clone())
+            })
+            .process_results(|iter| iter.collect())
+    }
+
+    #[allow(dead_code)]
+    fn current_subgraph_context_keys(
+        &self,
+    ) -> Result<IndexSet<SubgraphContextKey>, FederationError> {
+        self.subgraph_paths
+            .iter()
+            .map(|path_info| {
+                Ok(SubgraphContextKey {
+                    tail_subgraph_name: path_info
+                        .path
+                        .path
+                        .graph()
+                        .node_weight(path_info.path.path.tail())?
+                        .source
+                        .clone(),
+                    contexts: path_info.contexts.clone(),
+                })
+            })
+            .process_results(|iter| iter.collect())
+    }
+}
+
+impl Display for ValidationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.supergraph_path.fmt(f)?;
+        write!(f, " <=> ")?;
+        let mut iter = self.subgraph_paths.iter();
+        if let Some(first_path_info) = iter.next() {
+            first_path_info.path.fmt(f)?;
+            for path_info in iter {
+                write!(f, ", ")?;
+                path_info.path.fmt(f)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -78,7 +78,6 @@ impl GraphPathTriggerVariant for QueryGraphEdgeTransition {
 /// ensuring we don't recompute those paths multiple times if we do need them multiple times.
 pub(crate) struct TransitionPathWithLazyIndirectPaths {
     pub(crate) path: Arc<TransitionGraphPath>,
-    #[allow(dead_code)]
     pub(crate) lazily_computed_indirect_paths: Option<TransitionIndirectPaths>,
 }
 
@@ -612,7 +611,7 @@ impl TransitionGraphPath {
 impl TransitionPathWithLazyIndirectPaths {
     // PORT_NOTE: Named `initial()` in the JS codebase, but conventionally in Rust this kind of
     // constructor is named `new()`.
-    fn new(path: Arc<TransitionGraphPath>) -> Self {
+    pub(crate) fn new(path: Arc<TransitionGraphPath>) -> Self {
         Self {
             path,
             lazily_computed_indirect_paths: None,

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -308,7 +308,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         // query graph.
         let tail = parameters
             .federated_query_graph
-            .node_weight(initial_path.tail)?;
+            .node_weight(initial_path.tail())?;
 
         // Two-step initialization: initializing open_branches requires a condition resolver,
         // which `QueryPlanningTraversal` is.
@@ -572,7 +572,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             let mut all_tail_nodes = IndexSet::default();
             for option in &new_options {
                 for path in &option.paths.0 {
-                    all_tail_nodes.insert(path.tail);
+                    all_tail_nodes.insert(path.tail());
                 }
             }
             if self.selection_set_is_fully_local_from_all_nodes(selection_set, &all_tail_nodes)?

--- a/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
@@ -34,7 +34,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 .open_branch
                 .0
                 .iter()
-                .flat_map(|option| option.paths.0.iter().map(|path| path.tail))
+                .flat_map(|option| option.paths.0.iter().map(|path| path.tail()))
                 .collect::<IndexSet<_>>();
             let tail_nodes_info = self.estimate_nodes_with_indirect_options(tail_nodes)?;
 


### PR DESCRIPTION
This PR ports `ValidationState()` from the JS codebase, except `validateTransition()`. Note that:
1. We've skipped `currentSubgraphs()`, as Rust composition doesn't currently at least give node information.
2. The subgraph context keys were strings in JS, but that was just because they needed to be used in JS `Map`s efficiently. We don't have that restriction in Rust, so we use actual data structures for the keys.
    - As part of this, we don't need actually need a map from subgraph names to subgraph enum values (that was used in JS to avoid issues with separator characters in the keys potentially being in the subgraph names). 
3. We did not port any fixes from https://github.com/apollographql/federation/pull/3277 yet to this code.

<!-- FED-574 -->