### PR TITLE
new error container for connector errors

### DIFF
--- a/apollo-federation/src/connectors/runtime.rs
+++ b/apollo-federation/src/connectors/runtime.rs
@@ -1,4 +1,5 @@
 pub mod debug;
+pub mod errors;
 pub mod form_encoding;
 pub mod http_json_transport;
 pub mod inputs;

--- a/apollo-federation/src/connectors/runtime/errors.rs
+++ b/apollo-federation/src/connectors/runtime/errors.rs
@@ -1,0 +1,103 @@
+use serde_json_bytes::ByteString;
+use serde_json_bytes::Map;
+use serde_json_bytes::Value;
+
+use crate::connectors::Connector;
+use crate::connectors::runtime::key::ResponseKey;
+
+#[derive(Debug)]
+pub struct RuntimeError {
+    pub message: String,
+    code: Option<String>,
+    pub coordinate: Option<String>,
+    pub subgraph_name: Option<String>,
+    pub response_key: ResponseKey,
+    pub extensions: Map<ByteString, Value>,
+}
+
+impl RuntimeError {
+    pub fn new(message: impl Into<String>, response_key: &ResponseKey) -> Self {
+        Self {
+            message: message.into(),
+            code: None,
+            coordinate: None,
+            subgraph_name: None,
+            response_key: response_key.clone(),
+            extensions: Default::default(),
+        }
+    }
+
+    pub fn extension<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<ByteString>,
+        V: Into<Value>,
+    {
+        self.extensions.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+
+    pub fn code(&self) -> String {
+        self.code
+            .clone()
+            .unwrap_or_else(|| "CONNECTORS_FETCH".to_string())
+    }
+}
+
+/// An error sending a connector request. This represents a problem with sending the request
+/// to the connector, rather than an error returned from the connector itself.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Request limit exceeded")]
+    RequestLimitExceeded,
+
+    #[error("Rate limit exceeded")]
+    RateLimited,
+
+    /// Timeout
+    #[error("Request timed out")]
+    GatewayTimeout,
+
+    /// {0}
+    #[error("Connector error: {0}")]
+    TransportFailure(String),
+}
+
+impl Error {
+    pub fn to_runtime_error(
+        &self,
+        connector: &Connector,
+        response_key: ResponseKey,
+    ) -> RuntimeError {
+        RuntimeError {
+            message: self.to_string(),
+            code: Some(self.code()),
+            coordinate: Some(connector.id.coordinate()),
+            subgraph_name: Some(connector.id.subgraph_name.clone()),
+            response_key,
+            extensions: Default::default(),
+        }
+    }
+
+    pub fn code(&self) -> String {
+        match self {
+            Self::RequestLimitExceeded => "REQUEST_LIMIT_EXCEEDED".to_string(),
+            Self::RateLimited => "RATE_LIMIT_EXCEEDED".to_string(),
+            Self::GatewayTimeout => "GATEWAY_TIMEOUT".to_string(),
+            Self::TransportFailure(_) => "HTTP_CLIENT_ERROR".to_string(),
+        }
+    }
+}
+
+impl Clone for Error {
+    fn clone(&self) -> Self {
+        match self {
+            Self::TransportFailure(err) => Self::TransportFailure(err.to_string()),
+            err => err.clone(),
+        }
+    }
+}

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -8,6 +8,8 @@ use apollo_federation::connectors::ProblemLocation;
 use apollo_federation::connectors::runtime::debug::ConnectorContext;
 use apollo_federation::connectors::runtime::debug::ConnectorDebugHttpRequest;
 use apollo_federation::connectors::runtime::debug::SelectionData;
+use apollo_federation::connectors::runtime::errors::Error;
+use apollo_federation::connectors::runtime::errors::RuntimeError;
 use apollo_federation::connectors::runtime::http_json_transport::HttpResponse;
 use apollo_federation::connectors::runtime::http_json_transport::TransportResponse;
 use apollo_federation::connectors::runtime::key::ResponseKey;
@@ -41,7 +43,6 @@ use crate::plugins::telemetry::consts::OTEL_STATUS_CODE_OK;
 use crate::plugins::telemetry::tracing::apollo_telemetry::emit_error_event;
 use crate::services::connect::Response;
 use crate::services::connector;
-use crate::services::connector::request_service::Error;
 use crate::services::fetch::AddSubgraphNameExt;
 use crate::services::router;
 
@@ -56,14 +57,27 @@ pub(crate) enum HandleResponseError {
     MergeError(String),
 }
 
+impl graphql::Error {
+    fn from_connectors_runtime_error(error: &RuntimeError) -> Self {
+        graphql::Error::builder()
+            .message(error.message.clone())
+            .extension_code(error.code())
+            .path(Path::from_response_key(&error.response_key))
+            .extensions(error.extensions.clone())
+            .build()
+            .with_subgraph_name(error.subgraph_name.as_deref().unwrap_or_default())
+    }
+}
+
 // --- RAW RESPONSE ------------------------------------------------------------
 
+#[allow(clippy::large_enum_variant)]
 enum RawResponse {
     /// This error type is used if:
     /// 1. We didn't even make the request (we hit the request limit)
     /// 2. We couldn't deserialize the response body
     Error {
-        error: graphql::Error,
+        error: RuntimeError,
         key: ResponseKey,
     },
     /// Contains the response data directly from the HTTP response. We'll apply
@@ -87,11 +101,11 @@ impl RawResponse {
     fn map_response(
         self,
         result: Result<TransportResponse, Error>,
-        connector: Arc<Connector>,
+        connector: &Connector,
         context: &Context,
         debug_context: &Option<Arc<Mutex<ConnectorContext>>>,
         supergraph_request: Arc<http::Request<crate::graphql::Request>>,
-    ) -> connector::request_service::Response {
+    ) -> (MappedResponse, Result<TransportResponse, Error>) {
         let mapped_response = match self {
             RawResponse::Error { error, key } => MappedResponse::Error { error, key },
             RawResponse::Data {
@@ -146,12 +160,7 @@ impl RawResponse {
             }
         };
 
-        connector::request_service::Response {
-            context: context.clone(),
-            connector: connector.clone(),
-            transport_result: result,
-            mapped_response,
-        }
+        (mapped_response, result)
     }
 
     /// Returns a `MappedResponse` with a GraphQL error.
@@ -160,11 +169,11 @@ impl RawResponse {
     fn map_error(
         self,
         result: Result<TransportResponse, Error>,
-        connector: Arc<Connector>,
+        connector: &Connector,
         context: &Context,
         debug_context: &Option<Arc<Mutex<ConnectorContext>>>,
         supergraph_request: Arc<http::Request<crate::graphql::Request>>,
-    ) -> connector::request_service::Response {
+    ) -> (MappedResponse, Result<TransportResponse, Error>) {
         use serde_json_bytes::*;
 
         let mapped_response = match self {
@@ -207,9 +216,8 @@ impl RawResponse {
                 };
 
                 // Now we can create the error object using either the default message or the message calculated by the JSONSelection
-                let mut error = graphql::Error::builder()
-                    .message(message)
-                    .path(Path::from_response_key(&key));
+                let mut error = RuntimeError::new(message, &key);
+                error.subgraph_name = Some(connector.id.subgraph_name.clone());
 
                 // First, we will apply defaults... these may get overwritten below by user configured extensions
                 error = error
@@ -285,12 +293,7 @@ impl RawResponse {
                     }
                 }
 
-                // Now we can finally build the actual error!
-                let error = error
-                    .extension_code(extension_code)
-                    .build()
-                    // Always set the subgraph name and if required, it will get filtered out by the include_subgraph_errors plugin
-                    .with_subgraph_name(&connector.id.subgraph_name);
+                error = error.with_code(extension_code);
 
                 if let Some(debug) = debug_context {
                     debug.lock().push_response(
@@ -311,36 +314,18 @@ impl RawResponse {
             }
         };
 
-        if let MappedResponse::Error {
-            error: ref mapped_error,
-            key: _,
-        } = mapped_response
-        {
-            if let Some(Value::String(error_code)) = mapped_error.extensions.get("code") {
-                emit_error_event(
-                    error_code.as_str(),
-                    &mapped_error.message,
-                    mapped_error.path.clone(),
-                );
-            }
-        }
-
-        connector::request_service::Response {
-            context: context.clone(),
-            connector: connector.clone(),
-            transport_result: result,
-            mapped_response,
-        }
+        (mapped_response, result)
     }
 }
 
 // --- MAPPED RESPONSE ---------------------------------------------------------
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum MappedResponse {
     /// This is equivalent to RawResponse::Error, but it also represents errors
     /// when the request is semantically unsuccessful (e.g. 404, 500).
     Error {
-        error: graphql::Error,
+        error: RuntimeError,
         key: ResponseKey,
     },
     /// The response data after applying the selection mapping.
@@ -358,7 +343,7 @@ impl MappedResponse {
     fn add_to_data(
         self,
         data: &mut serde_json_bytes::Map<ByteString, Value>,
-        errors: &mut Vec<graphql::Error>,
+        errors: &mut Vec<RuntimeError>,
         count: usize,
     ) -> Result<(), HandleResponseError> {
         match self {
@@ -488,20 +473,17 @@ pub(crate) async fn process_response<T: HttpBody>(
     debug_context: &Option<Arc<Mutex<ConnectorContext>>>,
     supergraph_request: Arc<http::Request<crate::graphql::Request>>,
 ) -> connector::request_service::Response {
-    match result {
+    let (mapped_response, result) = match result {
         // This occurs when we short-circuit the request when over the limit
         Err(error) => {
             let raw = RawResponse::Error {
-                error: error.to_graphql_error(
-                    connector.clone(),
-                    Some(Path::from_response_key(&response_key)),
-                ),
+                error: error.to_runtime_error(&connector, response_key.clone()),
                 key: response_key,
             };
             Span::current().record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
             raw.map_error(
                 Err(error),
-                connector,
+                &connector,
                 context,
                 debug_context,
                 supergraph_request,
@@ -547,7 +529,7 @@ pub(crate) async fn process_response<T: HttpBody>(
                 Span::current().record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_OK);
                 raw.map_response(
                     result,
-                    connector,
+                    &connector,
                     context,
                     debug_context,
                     supergraph_request,
@@ -556,13 +538,28 @@ pub(crate) async fn process_response<T: HttpBody>(
                 Span::current().record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                 raw.map_error(
                     result,
-                    connector,
+                    &connector,
                     context,
                     debug_context,
                     supergraph_request,
                 )
             }
         }
+    };
+
+    if let MappedResponse::Error { ref error, .. } = mapped_response {
+        emit_error_event(
+            &error.code(),
+            &error.message,
+            Some(Path::from_response_key(&error.response_key)),
+        );
+    }
+
+    connector::request_service::Response {
+        context: context.clone(),
+        connector: connector.clone(),
+        transport_result: result,
+        mapped_response,
     }
 }
 
@@ -597,7 +594,12 @@ pub(crate) fn aggregate_responses(
             .body(
                 graphql::Response::builder()
                     .data(data)
-                    .errors(errors)
+                    .errors(
+                        errors
+                            .into_iter()
+                            .map(|e| graphql::Error::from_connectors_runtime_error(&e))
+                            .collect(),
+                    )
                     .build(),
             )
             .unwrap(),
@@ -618,37 +620,30 @@ async fn deserialize_response<T: HttpBody>(
         Option<Box<ConnectorDebugHttpRequest>>,
         Vec<(ProblemLocation, Problem)>,
     ),
-) -> Result<Value, graphql::Error> {
+) -> Result<Value, RuntimeError> {
     use serde_json_bytes::*;
 
-    let make_err = |path: Path| {
-        graphql::Error::builder()
-            .message("The server returned data in an unexpected format.".to_string())
-            .extension_code("CONNECTOR_RESPONSE_INVALID")
-            .extension("service", connector.id.subgraph_name.clone())
-            .extension(
-                "http",
-                Value::Object(Map::from_iter([(
-                    "status".into(),
-                    Value::Number(parts.status.as_u16().into()),
-                )])),
-            )
-            .extension(
-                "connector",
-                Value::Object(Map::from_iter([(
-                    "coordinate".into(),
-                    Value::String(connector.id.coordinate().into()),
-                )])),
-            )
-            .path(path)
-            .build()
-            .with_subgraph_name(&connector.id.subgraph_name) // for include_subgraph_errors
+    let make_err = || {
+        let mut err = RuntimeError::new(
+            "The server returned data in an unexpected format.".to_string(),
+            response_key,
+        );
+        err.subgraph_name = Some(connector.id.subgraph_name.clone());
+        err = err.with_code("CONNECTOR_RESPONSE_INVALID");
+        err.coordinate = Some(connector.id.coordinate());
+        err = err.extension(
+            "http",
+            Value::Object(Map::from_iter([(
+                "status".into(),
+                Value::Number(parts.status.as_u16().into()),
+            )])),
+        );
+        err
     };
 
-    let path = Path::from_response_key(response_key);
     let body = &router::body::into_bytes(body)
         .await
-        .map_err(|_| make_err(path.clone()))?;
+        .map_err(|_| make_err())?;
 
     let log_response_level = context
         .extensions()
@@ -767,7 +762,7 @@ async fn deserialize_response<T: HttpBody>(
                         debug_request.1.clone(),
                     );
                 }
-                Err(make_err(path))
+                Err(make_err())
             }
         }
     } else if content_type
@@ -792,7 +787,7 @@ async fn deserialize_response<T: HttpBody>(
                     debug_request.1.clone(),
                 );
             }
-            return Err(make_err(path));
+            return Err(make_err());
         }
 
         Ok(Value::String(decoded_body.into_owned().into()))

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::time::Duration;
 
+use apollo_federation::connectors::runtime::errors::Error;
 use apollo_federation::connectors::runtime::http_json_transport::TransportRequest;
 use http::HeaderValue;
 use http::StatusCode;
@@ -38,7 +39,6 @@ use crate::services::RouterResponse;
 use crate::services::SubgraphRequest;
 use crate::services::SubgraphResponse;
 use crate::services::connector;
-use crate::services::connector::request_service::Error;
 use crate::services::connector::request_service::Request;
 use crate::services::connector::request_service::Response;
 use crate::services::http::service::Compression;


### PR DESCRIPTION
instead of using the more generic `graphql::Error` type, that we don't want to bring into apollo-federation, this is a more specific type that can be converted to `graphql::Error` at the end of mapping.

this is not the ideal API, but it unblocked moving the mapping code into apollo-federation.

<!-- start metadata -->

<!-- https://apollographql.atlassian.net/browse/CNN-887 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
