### PR TITLE
Create schema-differ function for LSP

### DIFF
--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -82,6 +82,10 @@ use crate::subgraph::ValidSubgraph;
 pub use crate::supergraph::ValidFederationSubgraph;
 pub use crate::supergraph::ValidFederationSubgraphs;
 
+pub mod internal_lsp_api {
+    pub use crate::subgraph::schema_diff_expanded_from_initial;
+}
+
 pub(crate) type SupergraphSpecs = (
     &'static LinkSpecDefinition,
     &'static JoinSpecDefinition,

--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -16,6 +16,7 @@ use crate::error::FederationError;
 use crate::internal_error;
 use crate::link::argument::directive_required_string_argument;
 use crate::link::federation_spec_definition::FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::federation_spec_definition::FEDERATION_FIELD_ARGUMENT_NAME;
 use crate::link::federation_spec_definition::FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_NAME_ARGUMENT_NAME;
 use crate::link::spec::Identity;
@@ -75,10 +76,10 @@ impl ContextSpecDefinition {
     fn field_argument_specification() -> DirectiveArgumentSpecification {
         DirectiveArgumentSpecification {
             base_spec: ArgumentSpecification {
-                name: CONTEXTFIELDVALUE_SCALAR_NAME,
+                name: FEDERATION_FIELD_ARGUMENT_NAME,
                 get_type: |schema, _| {
                     Self::context_field_value_type(schema)
-                        .map(|pos| Type::non_null(Type::Named(pos.type_name)))
+                        .map(|pos| Type::nullable(Type::Named(pos.type_name)))
                 },
                 default_value: None,
             },

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -532,3 +532,174 @@ pub mod test_utils {
         };
     }
 }
+
+// INTERNAL: For use by Language Server Protocol (LSP) team
+// Generates a diff string containing directives and types not included in initial schema string
+pub fn schema_diff_expanded_from_initial(
+    schema_str: String,
+) -> Result<String, FederationError> {
+    // Parse schema string as Schema
+    let initial_schema = Schema::parse(schema_str, "")?;
+
+    // Initialize and expand subgraph, without validation
+    let initial_subgraph = typestate::Subgraph::new("S", "http://S", initial_schema.clone());
+    let expanded_subgraph = initial_subgraph
+        .expand_links()
+        .map_err(|e| e.into_inner())?;
+
+    // Build string of missing directives and types from initial to expanded
+    let mut diff = String::new();
+
+    // Push newly added directives onto diff
+    for (dir_name, dir_def) in &expanded_subgraph.schema().schema().directive_definitions {
+        if !initial_schema.directive_definitions.contains_key(dir_name) {
+            diff.push_str(&dir_def.to_string());
+            diff.push('\n');
+        }
+    }
+
+    // Push newly added types onto diff
+    for (named_ty, extended_ty) in &expanded_subgraph.schema().schema().types {
+        if !initial_schema.types.contains_key(named_ty) {
+            diff.push_str(&extended_ty.to_string());
+        }
+    }
+
+    Ok(diff)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::subgraph::schema_diff_expanded_from_initial;
+
+    #[test]
+    fn returns_correct_schema_diff_for_fed_2_0() {
+        let schema_string = r#"
+                extend schema @link(url: "https://specs.apollo.dev/federation/v2.0")
+
+                type Query {
+                    s: String
+                }"#.to_string();
+
+        let diff = schema_diff_expanded_from_initial(schema_string);
+
+        insta::assert_snapshot!(diff.unwrap_or_default(), @r#"directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @federation__extends on OBJECT | INTERFACE
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @federation__override(from: String!) on FIELD_DEFINITION
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+scalar link__Import
+scalar federation__FieldSet
+scalar _Any
+type _Service {
+  sdl: String
+}"#);
+    }
+
+    #[test]
+    fn returns_correct_schema_diff_for_fed_2_4() {
+        let schema_string = r#"
+                extend schema @link(url: "https://specs.apollo.dev/federation/v2.4")
+
+                type Query {
+                    s: String
+                }"#.to_string();
+
+        let diff = schema_diff_expanded_from_initial(schema_string);
+
+        insta::assert_snapshot!(diff.unwrap_or_default(), @r#"directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+directive @federation__extends on OBJECT | INTERFACE
+directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @federation__override(from: String!) on FIELD_DEFINITION
+directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+directive @federation__interfaceObject on OBJECT
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+scalar link__Import
+scalar federation__FieldSet
+scalar _Any
+type _Service {
+  sdl: String
+}"#);
+    }
+
+    #[test]
+    fn returns_correct_schema_diff_for_fed_2_9() {
+        let schema_string = r#"
+                extend schema @link(url: "https://specs.apollo.dev/federation/v2.9")
+
+                type Query {
+                    s: String
+                }"#.to_string();
+
+        let diff = schema_diff_expanded_from_initial(schema_string);
+
+        insta::assert_snapshot!(diff.unwrap_or_default(), @r#"directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+directive @federation__extends on OBJECT | INTERFACE
+directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+directive @federation__interfaceObject on OBJECT
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+directive @federation__policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+directive @federation__context(name: String!) repeatable on OBJECT | INTERFACE | UNION
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+scalar link__Import
+scalar federation__FieldSet
+scalar federation__Scope
+scalar federation__Policy
+scalar federation__ContextFieldValue
+scalar _Any
+type _Service {
+  sdl: String
+}"#);
+    }
+}

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -535,9 +535,7 @@ pub mod test_utils {
 
 // INTERNAL: For use by Language Server Protocol (LSP) team
 // Generates a diff string containing directives and types not included in initial schema string
-pub fn schema_diff_expanded_from_initial(
-    schema_str: String,
-) -> Result<String, FederationError> {
+pub fn schema_diff_expanded_from_initial(schema_str: String) -> Result<String, FederationError> {
     // Parse schema string as Schema
     let initial_schema = Schema::parse(schema_str, "")?;
 
@@ -579,7 +577,8 @@ mod tests {
 
                 type Query {
                     s: String
-                }"#.to_string();
+                }"#
+        .to_string();
 
         let diff = schema_diff_expanded_from_initial(schema_string);
 
@@ -618,7 +617,8 @@ type _Service {
 
                 type Query {
                     s: String
-                }"#.to_string();
+                }"#
+        .to_string();
 
         let diff = schema_diff_expanded_from_initial(schema_string);
 
@@ -659,7 +659,8 @@ type _Service {
 
                 type Query {
                     s: String
-                }"#.to_string();
+                }"#
+        .to_string();
 
         let diff = schema_diff_expanded_from_initial(schema_string);
 


### PR DESCRIPTION
Implement a function which accepts an initial schema as a `String`, expands that schema, and returns the diff as a `String`.

This is the first of two changes toward exposing an endpoint for this purpose in the CLI tool.

Context for this change including example input and output can be found here: [Federation LSP Schema-Diffing Endpoint Overview](https://apollographql.atlassian.net/wiki/x/gYC0Y).

<!-- start metadata -->
<!-- FED-606 -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changes are compatible[^1]
- Tests added and passing[^2]
    - [x] Unit tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
