### PR TITLE
Fix several hot reload issues with subscriptions

### DIFF
--- a/.changesets/fix_renee_resubscribe_after_reload.md
+++ b/.changesets/fix_renee_resubscribe_after_reload.md
@@ -1,6 +1,6 @@
-### Fix memory spikes and ordering with subscriptions and hot reload ([PR #7746](https://github.com/apollographql/router/pull/7746))
+### Fix several hot reload issues with subscriptions ([PR #7746](https://github.com/apollographql/router/pull/7746))
 
-When a hot reload is triggered by a configuration change, the router attempted to apply updated configuration to open subscriptions. But this could cause memory spikes and excessive logging.
+When a hot reload is triggered by a configuration change, the router attempted to apply updated configuration to open subscriptions. But this could cause excessive logging.
 
 When a hot reload is triggered by a schema change, the router closed subscriptions with a `SUBSCRIPTION_SCHEMA_RELOAD` error. But this happened *before* the new schema was fully active and warmed up, so clients could reconnect tothe _old_ schema.
 

--- a/.changesets/fix_renee_resubscribe_after_reload.md
+++ b/.changesets/fix_renee_resubscribe_after_reload.md
@@ -1,0 +1,9 @@
+### Fix memory spikes and ordering with subscriptions and hot reload ([PR #7746](https://github.com/apollographql/router/pull/7746))
+
+When a hot reload is triggered by a configuration change, the router attempted to apply updated configuration to open subscriptions. But this could cause memory spikes and excessive logging.
+
+When a hot reload is triggered by a schema change, the router closed subscriptions with a `SUBSCRIPTION_SCHEMA_RELOAD` error. But this happened *before* the new schema was fully active and warmed up, so clients could reconnect tothe _old_ schema.
+
+To fix these issues, a configuration and a schema change now have the same behavior. The router waits for the new configuration and schema to be active, and then closes all subscriptions with a `SUBSCRIPTION_SCHEMA_RELOAD` error, so clients can reconnect.
+
+By [@goto-bus-stop](https://github.com/goto-bus-stop) and [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/7746

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -88,6 +88,7 @@ use crate::spec::operation_limits::OperationLimits;
 use crate::uplink::license_enforcement::LicenseState;
 
 pub(crate) const FIRST_EVENT_CONTEXT_KEY: &str = "apollo::supergraph::first_event";
+const SUBSCRIPTION_RELOAD_EXTENSION_CODE: &str = "SUBSCRIPTION_SCHEMA_RELOAD";
 
 /// An [`IndexMap`] of available plugins.
 pub(crate) type Plugins = IndexMap<String, Box<dyn DynPlugin>>;
@@ -608,7 +609,12 @@ async fn subscription_task(
                     .send(
                         Response::builder()
                             .subscribed(false)
-                            .error(graphql::Error::builder().message("subscription has been closed due to a configuration reload").extension_code("SUBSCRIPTION_CONFIGURATION_RELOAD").build())
+                            .error(
+                                graphql::Error::builder()
+                                    .message("subscription has been closed due to a router reload")
+                                    .extension_code(SUBSCRIPTION_RELOAD_EXTENSION_CODE)
+                                    .build(),
+                            )
                             .build(),
                     )
                     .await;
@@ -618,7 +624,12 @@ async fn subscription_task(
                     .send(
                         Response::builder()
                             .subscribed(false)
-                            .error(graphql::Error::builder().message("subscription has been closed due to a schema reload").extension_code("SUBSCRIPTION_SCHEMA_RELOAD").build())
+                            .error(
+                                graphql::Error::builder()
+                                    .message("subscription has been closed due to a router reload")
+                                    .extension_code(SUBSCRIPTION_RELOAD_EXTENSION_CODE)
+                                    .build(),
+                            )
                             .build(),
                     )
                     .await;

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -1011,7 +1011,6 @@ impl PluggableSupergraphServiceBuilder {
             query_planner_service,
             schema,
             plugins: self.plugins,
-            config: configuration,
             sb,
         })
     }
@@ -1022,7 +1021,6 @@ impl PluggableSupergraphServiceBuilder {
 pub(crate) struct SupergraphCreator {
     query_planner_service: CachingQueryPlanner<QueryPlannerService>,
     schema: Arc<Schema>,
-    config: Arc<Configuration>,
     plugins: Arc<Plugins>,
     sb: Buffer<supergraph::Request, BoxFuture<'static, supergraph::ServiceResult>>,
 }
@@ -1044,16 +1042,6 @@ pub(crate) trait HasSchema {
 impl HasSchema for SupergraphCreator {
     fn schema(&self) -> Arc<Schema> {
         Arc::clone(&self.schema)
-    }
-}
-
-pub(crate) trait HasConfig {
-    fn config(&self) -> Arc<Configuration>;
-}
-
-impl HasConfig for SupergraphCreator {
-    fn config(&self) -> Arc<Configuration> {
-        Arc::clone(&self.config)
     }
 }
 

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_callback_schema_reload-3.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_callback_schema_reload-3.snap
@@ -6,7 +6,7 @@ expression: stream.next_response().await.unwrap()
   "data": null,
   "errors": [
     {
-      "message": "subscription has been closed due to a schema reload",
+      "message": "subscription has been closed due to a router reload",
       "extensions": {
         "code": "SUBSCRIPTION_SCHEMA_RELOAD"
       }

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -157,7 +157,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                             listen_addresses_guard,
                             vec![],
                         )
-                        .map_ok_or_else(Errored, |f| f)
+                        .map_ok_or_else(Errored, |f| f.0)
                         .await,
                     );
                 }
@@ -232,7 +232,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     )
                     .await
                     {
-                        Ok(new_state) => {
+                        Ok((new_state, new_schema)) => {
                             tracing::info!(
                                 new_schema = schema_reload,
                                 new_license = license_reload,
@@ -240,6 +240,18 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                                 event = STATE_CHANGE,
                                 "reload complete"
                             );
+
+                            // We broadcast change notifications _after_ the pipelines have fully
+                            // rolled over.
+                            if configuration_reload {
+                                configuration
+                                    .notify
+                                    .broadcast_configuration(Arc::downgrade(configuration));
+                            }
+                            if schema_reload {
+                                configuration.notify.broadcast_schema(new_schema);
+                            }
+
                             Some(new_state)
                         }
                         Err(e) => {
@@ -301,6 +313,8 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         }
     }
 
+    /// Start a router. Returns the schema so active subscriptions on a previous
+    /// configuration or schema can be notified of the new schema.
     #[allow(clippy::too_many_arguments)]
     async fn try_start<S>(
         state_machine: &mut StateMachine<S, FA>,
@@ -311,7 +325,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         license: LicenseState,
         listen_addresses_guard: &mut OwnedRwLockWriteGuard<ListenAddresses>,
         mut all_connections_stopped_signals: Vec<mpsc::Receiver<()>>,
-    ) -> Result<State<FA>, ApolloRouterError>
+    ) -> Result<(State<FA>, Arc<Schema>), ApolloRouterError>
     where
         S: HttpServerFactory,
         FA: RouterSuperServiceFactory,
@@ -393,7 +407,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             .create(
                 state_machine.is_telemetry_disabled,
                 configuration.clone(),
-                schema,
+                schema.clone(),
                 previous_router_service_factory,
                 None,
                 effective_license,
@@ -451,15 +465,18 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         let metrics =
             apollo_opentelemetry_initialized().then(|| Metrics::new(&configuration, &license));
 
-        Ok(Running {
-            configuration,
-            _metrics: metrics,
-            schema: schema_state,
-            license,
-            server_handle: Some(server_handle),
-            router_service_factory,
-            all_connections_stopped_signals,
-        })
+        Ok((
+            Running {
+                configuration,
+                _metrics: metrics,
+                schema: schema_state,
+                license,
+                server_handle: Some(server_handle),
+                router_service_factory,
+                all_connections_stopped_signals,
+            },
+            schema,
+        ))
     }
 }
 

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -299,7 +299,6 @@ impl<'a> TestHarness<'a> {
                 config.clone(),
                 schema.clone(),
                 None,
-                None,
                 Some(builder.extra_plugins),
                 Default::default(),
             )

--- a/docs/source/routing/operations/subscriptions/configuration.mdx
+++ b/docs/source/routing/operations/subscriptions/configuration.mdx
@@ -356,20 +356,20 @@ Disabling deduplication is useful if you need to create a separate connection to
 
 ### Termination on schema update
 
-Whenever your router's supergraph schema is updated, **the router terminates all active subscriptions.** Clients can detect this special-case termination via an error code and execute a new subscription.
+Whenever your router's supergraph schema or configuration is updated, **the router terminates all active subscriptions.** Clients can detect this special-case termination via an error code and establish a new subscription.
 
-Your router's supergraph schema is updated in the following cases:
+Subscriptions are terminated in the following cases:
 
 - Your router regularly polls GraphOS for its supergraph schema, and an updated schema becomes available.
-- Your router obtains its supergraph schema from a local file, which it watches for updates if the [`--hot-reload` option](/router/configuration/overview#--hr----hot-reload) is set.
+- Your router obtains its supergraph schema or configuration from a local file, which it watches for updates if the [`--hot-reload` option](/router/configuration/overview#--hr----hot-reload) is set.
 
-When the router terminates subscriptions this way, it sends the following as a final response payload to all active subscribing clients:
+The router then sends the following as a final response payload to all active subscribing clients:
 
 ```json
 {
   "errors": [
     {
-      "message": "subscription has been closed due to a schema reload",
+      "message": "subscription has been closed due to a router reload",
       "extensions": {
         "code": "SUBSCRIPTION_SCHEMA_RELOAD"
       }


### PR DESCRIPTION
When a hot reload is triggered by a configuration change, the router attempted to apply updated configuration to open subscriptions. But this could cause excessive logging.

When a hot reload is triggered by a schema change, the router closed subscriptions with a `SUBSCRIPTION_SCHEMA_RELOAD` error. But this happened *before* the new schema was fully active and warmed up, so clients could reconnect tothe _old_ schema.

To fix these issues, a configuration and a schema change now have the same behavior. The router waits for the new configuration and schema to be active, and then closes all subscriptions with a `SUBSCRIPTION_SCHEMA_RELOAD` error, so clients can reconnect.

Drafted pending a test that verifies that the old behaviour is wrong and the new behaviour is correct. No strong indication yet that this is causing serious problems today, but it should be an improvement.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
