### PR TITLE
simplify variable reference collection

### DIFF
--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@batch.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@batch.graphql.snap
@@ -66,11 +66,10 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/batch.g
         max_requests: None,
         entity_resolver: None,
         spec: V0_2,
-        request_variables: {},
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -230,13 +229,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/batch.g
             TypeBatch,
         ),
         spec: V0_2,
-        request_variables: {
-            $batch,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $batch: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $batch: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@carryover.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@carryover.graphql.snap
@@ -150,11 +150,10 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {},
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -353,13 +352,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -480,13 +484,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@interface-object.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@interface-object.graphql.snap
@@ -119,13 +119,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/interfa
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -207,11 +212,10 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/interfa
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {},
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -350,13 +354,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/interfa
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@keys.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@keys.graphql.snap
@@ -131,13 +131,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -321,13 +326,20 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+                "id2",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "id",
+                "id2",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -462,13 +474,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "unselected",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "unselected",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -591,13 +608,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -769,13 +791,20 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+                "id2",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "id",
+                "id2",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -940,15 +969,19 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {
-            $this,
-        },
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "id",
+                "id2",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -1092,13 +1125,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -1284,15 +1322,19 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {
-            $this,
-        },
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "id",
+                "id2",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@nested_inputs.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@nested_inputs.graphql.snap
@@ -254,13 +254,22 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/nested_
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "doubleBaz",
+                "bar",
+                "baz",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "baz",
+                "bar",
+                "doubleBaz",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@normalize_names.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@normalize_names.graphql.snap
@@ -78,11 +78,10 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/normali
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {},
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -221,13 +220,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/normali
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@realistic.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@realistic.graphql.snap
@@ -273,13 +273,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "input",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "input",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -425,13 +430,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "email",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "email",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -627,13 +637,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "company",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "company",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -988,13 +1003,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@sibling_fields.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@sibling_fields.graphql.snap
@@ -82,11 +82,10 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/sibling
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {},
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -212,13 +211,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/sibling
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "k",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "k",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@simple.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@simple.graphql.snap
@@ -78,11 +78,10 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {},
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -221,13 +220,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -414,13 +418,20 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "c",
+                "b",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "b",
+                "c",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@steelthread.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@steelthread.graphql.snap
@@ -78,11 +78,10 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {},
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -221,13 +220,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
             Explicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $args,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -359,13 +363,18 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
             Implicit,
         ),
         spec: V0_1,
-        request_variables: {
-            $this,
-        },
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {
+            $this: {
+                "c",
+            },
+        },
+        response_variable_keys: {
+            $this: {
+                "c",
+            },
+        },
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
@@ -138,11 +138,10 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/types_u
         max_requests: None,
         entity_resolver: None,
         spec: V0_1,
-        request_variables: {},
-        response_variables: {},
         request_headers: {},
         response_headers: {},
-        env: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-federation/src/connectors/runtime/responses.rs
+++ b/apollo-federation/src/connectors/runtime/responses.rs
@@ -101,13 +101,12 @@ impl RawResponse {
                 let inputs = key
                     .inputs()
                     .clone()
-                    .merger(&connector.response_variables)
+                    .merger(&connector.response_variable_keys)
                     .config(connector.config.as_ref())
                     .context(context)
                     .status(parts.status.as_u16())
                     .request(&connector.response_headers, client_headers)
                     .response(&connector.response_headers, Some(&parts))
-                    .env(&connector.env)
                     .merge();
 
                 let (res, apply_to_errors) = key.selection().apply_with_vars(&data, &inputs);
@@ -168,7 +167,7 @@ impl RawResponse {
                 let inputs = LazyCell::new(|| {
                     key.inputs()
                         .clone()
-                        .merger(&connector.response_variables)
+                        .merger(&connector.response_variable_keys)
                         .config(connector.config.as_ref())
                         .context(context)
                         .status(parts.status.as_u16())

--- a/apollo-federation/src/connectors/snapshots/apollo_federation__connectors__models__tests__from_schema_v0_2.snap
+++ b/apollo-federation/src/connectors/snapshots/apollo_federation__connectors__models__tests__from_schema_v0_2.snap
@@ -118,6 +118,7 @@ expression: "&connectors"
         request_headers: {},
         response_headers: {},
         env: {},
+        context_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,
@@ -308,6 +309,7 @@ expression: "&connectors"
         request_headers: {},
         response_headers: {},
         env: {},
+        context_keys: {},
         batch_settings: None,
         error_settings: ConnectorErrorsSettings {
             message: None,

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -406,6 +406,7 @@ async fn deserialize_response<T: HttpBody>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -418,6 +419,7 @@ mod tests {
     use apollo_federation::connectors::HTTPMethod;
     use apollo_federation::connectors::HttpJsonTransport;
     use apollo_federation::connectors::JSONSelection;
+    use apollo_federation::connectors::Namespace;
     use apollo_federation::connectors::runtime::inputs::RequestInputs;
     use apollo_federation::connectors::runtime::key::ResponseKey;
     use http::Uri;
@@ -451,12 +453,11 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         });
 
@@ -562,12 +563,11 @@ mod tests {
             entity_resolver: Some(EntityResolver::Explicit),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         });
 
@@ -680,12 +680,11 @@ mod tests {
             entity_resolver: Some(EntityResolver::TypeBatch),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         });
 
@@ -805,12 +804,11 @@ mod tests {
             entity_resolver: Some(EntityResolver::Implicit),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         });
 
@@ -932,12 +930,11 @@ mod tests {
             entity_resolver: Some(EntityResolver::Explicit),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         });
 
@@ -1199,15 +1196,11 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
             batch_settings: None,
-            response_variables: selection
-                .variable_references()
-                .map(|var_ref| var_ref.namespace.namespace)
-                .collect(),
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: HashMap::from_iter([(Namespace::Status, Default::default())]),
             error_settings: Default::default(),
         });
 

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -62,7 +62,7 @@ fn request_params_to_requests(
             response_key
                 .inputs()
                 .clone()
-                .merger(&connector.request_variables)
+                .merger(&connector.request_variable_keys)
                 .config(connector.config.as_ref())
                 .context(&original_request.context)
                 .request(
@@ -590,12 +590,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -676,12 +676,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -788,12 +788,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -912,12 +912,12 @@ mod tests {
             entity_resolver: Some(super::EntityResolver::Explicit),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -1035,12 +1035,12 @@ mod tests {
             entity_resolver: Some(super::EntityResolver::Explicit),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -1139,12 +1139,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -1265,12 +1265,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -1426,12 +1426,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -1584,12 +1584,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -1713,12 +1713,12 @@ mod tests {
             entity_resolver: Some(super::EntityResolver::TypeBatch),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -1829,12 +1829,12 @@ mod tests {
             entity_resolver: Some(super::EntityResolver::TypeBatch),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: Some(ConnectBatchArguments { max_size: Some(10) }),
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -1950,12 +1950,12 @@ mod tests {
             entity_resolver: Some(super::EntityResolver::TypeBatch),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: Some(ConnectBatchArguments { max_size: Some(5) }),
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -2075,12 +2075,12 @@ mod tests {
             entity_resolver: Some(super::EntityResolver::TypeSingle),
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 
@@ -2154,12 +2154,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 

--- a/apollo-router/src/plugins/connectors/mod.rs
+++ b/apollo-router/src/plugins/connectors/mod.rs
@@ -13,11 +13,10 @@ pub(crate) mod tests;
 use apollo_federation::connectors::runtime::inputs::ContextReader;
 
 impl ContextReader for &crate::Context {
-    fn to_json_map(
-        &self,
-    ) -> serde_json_bytes::Map<serde_json_bytes::ByteString, serde_json_bytes::Value> {
-        self.iter()
-            .map(|entry| (entry.key().as_str().into(), entry.value().clone()))
-            .collect()
+    fn get_key(&self, key: &str) -> Option<serde_json_bytes::Value> {
+        match self.get::<&str, serde_json_bytes::Value>(key) {
+            Ok(Some(value)) => Some(value.clone()),
+            _ => None,
+        }
     }
 }

--- a/apollo-router/src/plugins/connectors/tracing.rs
+++ b/apollo-router/src/plugins/connectors/tracing.rs
@@ -83,12 +83,12 @@ mod tests {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
 

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -1601,12 +1601,12 @@ mod test {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
         let key = ResponseKey::RootField {
@@ -1690,12 +1690,12 @@ mod test {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         };
         let key = ResponseKey::RootField {

--- a/apollo-router/src/plugins/telemetry/config_new/connector/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/events.rs
@@ -190,12 +190,12 @@ mod tests {
                 max_requests: None,
                 entity_resolver: None,
                 spec: ConnectSpec::V0_1,
-                request_variables: Default::default(),
-                response_variables: Default::default(),
+
                 batch_settings: None,
                 request_headers: Default::default(),
                 response_headers: Default::default(),
-                env: Default::default(),
+                request_variable_keys: Default::default(),
+                response_variable_keys: Default::default(),
                 error_settings: Default::default(),
             };
             let response_key = ResponseKey::RootField {
@@ -277,12 +277,12 @@ mod tests {
                 max_requests: None,
                 entity_resolver: None,
                 spec: ConnectSpec::V0_1,
-                request_variables: Default::default(),
-                response_variables: Default::default(),
+
                 batch_settings: None,
                 request_headers: Default::default(),
                 response_headers: Default::default(),
-                env: Default::default(),
+                request_variable_keys: Default::default(),
+                response_variable_keys: Default::default(),
                 error_settings: Default::default(),
             };
             let response_key = ResponseKey::RootField {

--- a/apollo-router/src/plugins/telemetry/config_new/connector/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/selectors.rs
@@ -358,12 +358,12 @@ mod tests {
             max_requests: None,
             entity_resolver: None,
             spec: ConnectSpec::V0_1,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         }
     }

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -3096,12 +3096,12 @@ mod tests {
                                         max_requests: None,
                                         entity_resolver: None,
                                         spec: ConnectSpec::V0_1,
-                                        request_variables: Default::default(),
-                                        response_variables: Default::default(),
+
                                         batch_settings: None,
                                         request_headers: Default::default(),
                                         response_headers: Default::default(),
-                                        env: Default::default(),
+                                        request_variable_keys: Default::default(),
+                                        response_variable_keys: Default::default(),
                                         error_settings: Default::default(),
                                     };
                                     let response_key = ResponseKey::RootField {
@@ -3162,12 +3162,11 @@ mod tests {
                                         max_requests: None,
                                         entity_resolver: None,
                                         spec: ConnectSpec::V0_1,
-                                        request_variables: Default::default(),
-                                        response_variables: Default::default(),
+
                                         batch_settings: None,
                                         request_headers: Default::default(),
                                         response_headers: Default::default(),
-                                        env: Default::default(),
+                                        request_variable_keys: Default::default(), response_variable_keys: Default::default(),
                                         error_settings: Default::default(),
                                     };
                                     let response_key = ResponseKey::RootField {

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -838,12 +838,12 @@ connector:
                     max_requests: None,
                     entity_resolver: None,
                     spec: ConnectSpec::V0_1,
-                    request_variables: Default::default(),
-                    response_variables: Default::default(),
+
                     batch_settings: None,
                     request_headers: Default::default(),
                     response_headers: Default::default(),
-                    env: Default::default(),
+                    request_variable_keys: Default::default(),
+                    response_variable_keys: Default::default(),
                     error_settings: Default::default(),
                 });
                 let response_key = ResponseKey::RootField {
@@ -1192,12 +1192,12 @@ subgraph:
                     max_requests: None,
                     entity_resolver: None,
                     spec: ConnectSpec::V0_1,
-                    request_variables: Default::default(),
-                    response_variables: Default::default(),
+
                     batch_settings: None,
                     request_headers: Default::default(),
                     response_headers: Default::default(),
-                    env: Default::default(),
+                    request_variable_keys: Default::default(),
+                    response_variable_keys: Default::default(),
                     error_settings: Default::default(),
                 });
                 let response_key = ResponseKey::RootField {

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -785,12 +785,12 @@ mod test {
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
-            request_variables: Default::default(),
-            response_variables: Default::default(),
+
             batch_settings: None,
             request_headers: Default::default(),
             response_headers: Default::default(),
-            env: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
             error_settings: Default::default(),
         });
         let key = ResponseKey::RootField {


### PR DESCRIPTION
1. collect variable references and *first level* of keys in one pass
2. use that map instead of the redundant Set of namespaces

I had to leave the headers maps alone because they use the *second* level of keys like `$request.headers.x-foo`.

<!-- start metadata -->

<!-- https://apollographql.atlassian.net/browse/CNN-889 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
