### PR TITLE
fix(deps): add missing files to rustc update configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,9 +30,9 @@
         '(^|/)Dockerfile[^/]*$',
         '^rust-toolchain\\.toml$',
         '^docs/.*?\\.mdx$',
-	'^.config/mise/.*?\\.toml$',
-	'^apollo-router/Cargo\\.toml$',
-	'^apollo-router/README\\.md$',
+        '^.config/mise/.*?\\.toml$',
+        '^apollo-router/Cargo\\.toml$',
+        '^apollo-router/README\\.md$',
       ],
       matchStrings: [
         '(#|<!--)\\s*renovate-automation: rustc version\\s*(?:-->)?\\n[^.]*?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\b',

--- a/renovate.json5
+++ b/renovate.json5
@@ -30,6 +30,9 @@
         '(^|/)Dockerfile[^/]*$',
         '^rust-toolchain\\.toml$',
         '^docs/.*?\\.mdx$',
+	'^.config/mise/.*?\\.toml$',
+	'^apollo-router/Cargo\\.toml$',
+	'^apollo-router/README\\.md$',
       ],
       matchStrings: [
         '(#|<!--)\\s*renovate-automation: rustc version\\s*(?:-->)?\\n[^.]*?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\b',
@@ -39,16 +42,17 @@
     },
   ],
   packageRules: [
-    // Don't do `rust` image updates on Dockerfiles since they'll we want them
-    // managed/grouped into the package rule directly after this one.  This
-    // prevents multiple PRs for the same bump, and puts all our Rust version
-    // bumps together.
+    // Don't do `rust` image updates separately since they'll we want them
+    // managed/grouped into the rule directly above this one.  This prevents
+    // multiple PRs for the same bump, and puts all our Rust version bumps
+    // together.
     {
       matchPackageNames: [
         'rust',
       ],
       matchManagers: [
         'dockerfile',
+        'mise',
       ],
       enabled: false,
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -120,5 +120,12 @@
         '/^apollo-/',
       ],
     },
+    // Not a monorepo, but belong together
+    {
+      groupName: 'rand crates',
+      groupSlug: 'rust-rand',
+      matchManagers: ['cargo'],
+      matchPackageNames: ['/^rand$/', '/^rand[-_]/'],
+    },
   ],
 }


### PR DESCRIPTION
Fixes several problems with automatic rustc updates:
- rustc updates in `mise` were opened as separate PRs (https://github.com/apollographql/router/pull/7506)
- MSRV was not bumped when the mise/docker rustc versions are bumped, causing cargo failures on dependency updates (https://app.circleci.com/pipelines/github/apollographql/router/36356/workflows/d1064bf3-df77-4698-9c0e-4f6ccca4a54b/jobs/269920)

While there, added a dependency group for rand crates as they must be updated together but are not auto-detected as a monorepo (https://github.com/apollographql/router/pull/6979 + https://github.com/apollographql/router/pull/7477)

<!-- start metadata -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

No changesets necessary for an internal change.
Testing will be done by merging the PR :)

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
