### PR TITLE
fix: xtask fails to compile

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -30,7 +30,7 @@ pub static PKG_VERSION: Lazy<String> = Lazy::new(|| {
     let router = metadata
         .packages
         .iter()
-        .find(|x| x.name == "apollo-router")
+        .find(|x| x.name.as_str() == "apollo-router")
         .expect("could not find crate apollo-router");
 
     router.version.to_string()


### PR DESCRIPTION
In https://github.com/apollographql/router/pull/7654, CI passed, but it doesn't build locally (eg. `cargo xtask test`). This updates usage of the cargo_metadata crate so it compiles again.
