### PR TITLE
pq: include operation name in "PQ not found" error

### DIFF
--- a/.changesets/feat_glasser_pq_error_include_extensions.md
+++ b/.changesets/feat_glasser_pq_error_include_extensions.md
@@ -1,0 +1,5 @@
+### pq: include operation name in `PERSISTED_QUERY_NOT_IN_LIST` error ([PR #7768](https://github.com/apollographql/router/pull/7768))
+
+When persisted query safelisting is enabled and a request has an unknown PQ ID, the GraphQL error now has the extension field `operation_name` containing the GraphQL operation name (if provided explicitly in the request).
+
+By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/7768

--- a/apollo-router/src/services/layers/persisted_queries/mod.rs
+++ b/apollo-router/src/services/layers/persisted_queries/mod.rs
@@ -371,11 +371,19 @@ impl ErrorCacheStrategy {
     }
 }
 
-fn graphql_err_operation_not_found(persisted_query_id: &str) -> GraphQLError {
-    graphql_err(
-        "PERSISTED_QUERY_NOT_IN_LIST",
-        &format!("Persisted query '{persisted_query_id}' not found in the persisted query list"),
-    )
+fn graphql_err_operation_not_found(
+    persisted_query_id: &str,
+    operation_name: Option<String>,
+) -> GraphQLError {
+    let mut builder = GraphQLError::builder()
+        .extension_code("PERSISTED_QUERY_NOT_IN_LIST")
+        .message(format!(
+            "Persisted query '{persisted_query_id}' not found in the persisted query list"
+        ));
+    if let Some(operation_name) = operation_name {
+        builder = builder.extension("operation_name", operation_name);
+    }
+    builder.build()
 }
 
 fn supergraph_err_operation_not_found(
@@ -383,7 +391,10 @@ fn supergraph_err_operation_not_found(
     persisted_query_id: &str,
 ) -> SupergraphResponse {
     supergraph_err(
-        graphql_err_operation_not_found(persisted_query_id),
+        graphql_err_operation_not_found(
+            persisted_query_id,
+            request.supergraph_request.body().operation_name.clone(),
+        ),
         request,
         ErrorCacheStrategy::DontCache,
         StatusCode::NOT_FOUND,
@@ -705,7 +716,7 @@ mod tests {
             .expect("could not get response from pq layer");
         assert_eq!(
             response.errors,
-            vec![graphql_err_operation_not_found(invalid_id)]
+            vec![graphql_err_operation_not_found(invalid_id, None)]
         );
     }
 
@@ -1067,6 +1078,7 @@ mod tests {
                 "persistedQuery",
                 json!({"version": 1, "sha256Hash": invalid_id}),
             )
+            .operation_name("SomeOperation")
             .build()
             .unwrap();
 
@@ -1080,7 +1092,10 @@ mod tests {
             .expect("could not get response from pq layer");
         assert_eq!(
             response.errors,
-            vec![graphql_err_operation_not_found(invalid_id)]
+            vec![graphql_err_operation_not_found(
+                invalid_id,
+                Some("SomeOperation".to_string()),
+            )]
         );
     }
 


### PR DESCRIPTION
We have found that during migrations to PQ-based safelisting, it is helpful to have a bit more information about what operation the client is trying to run than just the hashed PQ ID, to help find the client app that is being blocked. While the client name can be found in the context, the operation name (if provided explicitly in the body's `operationName` field by the client) is helpful. We now provide this as an extension on the error.

(It is both directly helpful in that it is available in the JSON error response if you're looking at individual failures, and it also makes it easy for a router_service-level Rust or Rhai plugin that's trying to provide more observability into PQ errors to look at the error for the extra data. This error occurs before supergraph_service runs, which means that the operation name is not in an easily accessible place for plugins.)

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
