### PR TITLE
pq: allow plugins to override PQ operation ID

### DIFF
--- a/.changesets/feat_glasser_pq_plugin_operation_id.md
+++ b/.changesets/feat_glasser_pq_plugin_operation_id.md
@@ -1,0 +1,8 @@
+### Ability to set persisted query operation ID via plugin ([PR #7771](https://github.com/apollographql/router/pull/7771))
+
+
+A `router_service` plugin can determine the persisted query operation ID for the request and add it to the request context under the key `apollo_persisted_queries::operation_id`. If this is set, the Router will not look in the `persistedQuery` request extension for an operation ID.
+
+This lets you use custom clients that put the operation ID in a header, path name, or query parameter instead. This is especially helpful for onboarding existing clients from other PQ systems, and for path-based logging.
+
+By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/7771

--- a/apollo-router/src/services/layers/persisted_queries/id_extractor.rs
+++ b/apollo-router/src/services/layers/persisted_queries/id_extractor.rs
@@ -2,13 +2,18 @@
 
 use crate::services::SupergraphRequest;
 use crate::services::layers::apq::PersistedQuery;
+use crate::services::layers::persisted_queries::PERSISTED_QUERIES_OPERATION_ID_CONTEXT_KEY;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PersistedQueryIdExtractor;
 
 impl PersistedQueryIdExtractor {
     pub(crate) fn extract_id(request: &SupergraphRequest) -> Option<String> {
-        PersistedQuery::maybe_from_request(request).map(|pq| pq.sha256hash)
+        request
+            .context
+            .get(PERSISTED_QUERIES_OPERATION_ID_CONTEXT_KEY)
+            .unwrap_or_default()
+            .or_else(|| PersistedQuery::maybe_from_request(request).map(|pq| pq.sha256hash))
     }
 }
 

--- a/apollo-router/src/services/layers/persisted_queries/mod.rs
+++ b/apollo-router/src/services/layers/persisted_queries/mod.rs
@@ -27,6 +27,7 @@ use crate::services::SupergraphResponse;
 
 const DONT_CACHE_RESPONSE_VALUE: &str = "private, no-cache, must-revalidate";
 const PERSISTED_QUERIES_CLIENT_NAME_CONTEXT_KEY: &str = "apollo_persisted_queries::client_name";
+const PERSISTED_QUERIES_OPERATION_ID_CONTEXT_KEY: &str = "apollo_persisted_queries::operation_id";
 const PERSISTED_QUERIES_SAFELIST_SKIP_ENFORCEMENT_CONTEXT_KEY: &str =
     "apollo_persisted_queries::safelist::skip_enforcement";
 
@@ -177,6 +178,9 @@ impl PersistedQueryLayer {
             ) {
                 let body = request.supergraph_request.body_mut();
                 body.query = Some(persisted_query_body);
+                // Note that we always remove this extension even if the ID was
+                // set in the context by a plugin, so that the request doesn't
+                // look like an APQ register request.
                 body.extensions.remove("persistedQuery");
                 // Record that we actually used our ID, so we can skip the
                 // safelist check later.
@@ -645,6 +649,62 @@ mod tests {
         );
         assert_eq!(map_to_query("only-cliented", None), None);
         assert_eq!(map_to_query("only-cliented", Some("not-web")), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enabled_pq_layer_operation_id_from_context() {
+        let manifest = PersistedQueryManifest::from(vec![
+            ManifestOperation {
+                id: "id-from-context".to_string(),
+                body: "query { id_from_context: __typename }".to_string(),
+                client_name: None,
+            },
+            ManifestOperation {
+                id: "ignored-id-in-body".to_string(),
+                body: "query { ignored_id_in_body: __typename }".to_string(),
+                client_name: None,
+            },
+        ]);
+        let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
+
+        let pq_layer = PersistedQueryLayer::new(
+            &Configuration::fake_builder()
+                .persisted_query(PersistedQueries::builder().enabled(true).build())
+                .uplink(uplink_config)
+                .build()
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let context = Context::new();
+        context
+            .insert(
+                PERSISTED_QUERIES_OPERATION_ID_CONTEXT_KEY,
+                "id-from-context".to_string(),
+            )
+            .unwrap();
+        let incoming_request = SupergraphRequest::fake_builder()
+            .extension(
+                "persistedQuery",
+                json!({"version": 1, "sha256Hash": "ignored-id-in-body".to_string()}),
+            )
+            .context(context)
+            .build()
+            .unwrap();
+
+        let mapped_query = pq_layer
+            .supergraph_request(incoming_request)
+            .expect("pq layer returned response instead of putting the query on the request")
+            .supergraph_request
+            .body()
+            .query
+            .clone();
+
+        assert_eq!(
+            mapped_query,
+            Some("query { id_from_context: __typename }".to_string())
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -576,6 +576,13 @@ impl RouterService {
                 }
             }
         }).unwrap_or_else(|| {
+            // note: this can occur in the legitimate case of a GET request
+            // which sends a PQ ID using a custom mechanism processed by a
+            // plugin that sets `apollo_persisted_queries::operation_id`. As a
+            // workaround, clients can send some dummy query string, or even
+            // just include a trailing `?`, but maybe this error is too harsh in
+            // that case and we should allow an empty graphql::Request if that
+            // context key is set?
             Err(TranslateError {
                 status: StatusCode::BAD_REQUEST,
                 extension_code: "INVALID_GRAPHQL_REQUEST".to_string(),

--- a/docs/source/routing/security/persisted-queries.mdx
+++ b/docs/source/routing/security/persisted-queries.mdx
@@ -184,6 +184,29 @@ To enable safelisting, you _must_ turn off [automatic persisted queries](/router
 
 GraphOS Router can be [customized](/graphos/routing/customization/overview) via several mechanisms such as [Rhai scripts](/graphos/routing/customization/rhai) and [coprocessors](/graphos/routing/customization/coprocessor). These plugins can affect your router's persistent query processing by writing to the request context.
 
+#### `apollo_persisted_queries::operation_id`
+
+By default, Apollo's protocol for sending PQ IDs from clients to GraphOS Router's protocol for sending is to put the ID in a GraphQL request extension named `persistedQuery`, wrapped in an object under the field `sha256Hash`. (This is the same protocol used for [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQ).) That is, the POST body of the request looks something like
+
+```
+{
+  "extensions": {
+    "persistedQuery": {
+      "version": 1,
+      "sha256Hash": "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b36"
+    }
+  }
+}
+```
+
+However, you can design your own protocol for specifying the PQ ID, such as including it in the URL path or a query parameter. (You are responsible for creating a client that sends PQ IDs in this way.)
+
+Your customization (Rhai script, coprocessor, etc) can examine a request during the [Router Service stage](/graphos/routing/customization/overview#request-path) of the request path and set the `apollo_persisted_queries::operation_id` value in the request context to the request's operation ID. If this value is set, GraphOS Router will not look in the `persistedQuery` extension for the ID.
+
+This means that your GraphQL request does not need to contain any of the usual pieces: `query`, `operationName`, `variables`, or `extensions`. If your request is a POST, you should still include a JSON body containing at least `{}`; if your request is a GET, you should include some query string at the end of the URL (even `?q`).
+
+Note that this only affects PQL-based persisted queries; [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQ) will always use the `persistedQuery` extension.
+
 #### `apollo_persisted_queries::client_name`
 
 When publishing operations to a PQL, you can specify a client name associated with the operation (by including a `clientName` field in the individual operation in your [manifest](/graphos/platform/security/persisted-queries#per-operation-properties), or by including the `--for-client-name` option to `rover persisted-queries publish`). If an operation has a client name, it will only be executed by requests that specify that client name. (Your PQL can contain multiple operations with the same ID and different client names.)


### PR DESCRIPTION
This lets you use alternate clients that put the operation ID in a header, path name, or query parameter instead. This is especially helpful for onboarding existing clients from other PQ systems, and for path-based logging.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
