### PR TITLE
fix(composition): make compose directive argument nullable

### DIFF
--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -811,13 +811,15 @@ impl FederationSpecDefinition {
         )
     }
 
+    // NOTE: due to the long-standing subgraph-js bug we'll continue to define name argument
+    // as nullable and rely on validations to ensure that value is set.
     fn compose_directive_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             FEDERATION_COMPOSEDIRECTIVE_DIRECTIVE_NAME_IN_SPEC,
             &[DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: FEDERATION_NAME_ARGUMENT_NAME,
-                    get_type: |_, _| Ok(ty!(String!)),
+                    get_type: |_, _| Ok(ty!(String)),
                     default_value: None,
                 },
                 composition_strategy: None,

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -1109,7 +1109,7 @@ mod tests {
 
         directive @override(from: String!) on FIELD_DEFINITION
 
-        directive @composeDirective(name: String!) repeatable on SCHEMA
+        directive @composeDirective(name: String) repeatable on SCHEMA
 
         directive @interfaceObject on OBJECT
 
@@ -1458,7 +1458,7 @@ mod tests {
 
         directive @override(from: String!) on FIELD_DEFINITION
 
-        directive @composeDirective(name: String!) repeatable on SCHEMA
+        directive @composeDirective(name: String) repeatable on SCHEMA
 
         directive @interfaceObject on OBJECT
 

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -632,7 +632,7 @@ directive @federation__extends on OBJECT | INTERFACE
 directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
 directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @federation__override(from: String!) on FIELD_DEFINITION
-directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
 directive @federation__interfaceObject on OBJECT
 enum link__Purpose {
   """
@@ -674,7 +674,7 @@ directive @federation__extends on OBJECT | INTERFACE
 directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
 directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
-directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
 directive @federation__interfaceObject on OBJECT
 directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -353,7 +353,7 @@ impl FederationSpecDefinitions {
                 InputValueDefinition {
                     description: None,
                     name: name!("name"),
-                    ty: ty!(String!).into(),
+                    ty: ty!(String).into(),
                     default_value: None,
                     directives: Default::default(),
                 }


### PR DESCRIPTION
Due to the long-standing `subgraph-js` bug we'll continue to define name argument as nullable and rely on validations to ensure that value is set.

<!-- FED-674 -->