### PR TITLE
2.4.0: clarify PQ errors

### DIFF
--- a/.changesets/feat_glasser_pq_error_include_extensions.md
+++ b/.changesets/feat_glasser_pq_error_include_extensions.md
@@ -1,5 +1,5 @@
 ### pq: include operation name in `PERSISTED_QUERY_NOT_IN_LIST` error ([PR #7768](https://github.com/apollographql/router/pull/7768))
 
-When persisted query safelisting is enabled and a request has an unknown PQ ID, the GraphQL error now has the extension field `operation_name` containing the GraphQL operation name (if provided explicitly in the request).
+When persisted query safelisting is enabled and a request has an unknown PQ ID, the GraphQL error now has the extension field `operation_name` containing the GraphQL operation name (if provided explicitly in the request). Note that this only applies to the `PERSISTED_QUERY_NOT_IN_LIST` error returned when manifest-based PQs are enabled, APQs are disabled, and the request contains an operation ID that is not in the list.
 
 By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/7768

--- a/docs/source/routing/errors.mdx
+++ b/docs/source/routing/errors.mdx
@@ -152,8 +152,7 @@ The operation was not executed due to exceeding the `max_root_fields` limit.
 </Property>
 <Property name="QUERY_NOT_IN_SAFELIST">
 
-The operation was not executed because it was not found in the persisted query
-safelist.
+The operation was not executed because safelisting is enabled and the freeform GraphQL document provided was not found in the persisted query safelist.
 
 </Property>
 <Property name="PARSING_ERROR">
@@ -180,8 +179,12 @@ An operation attempted to use automatic persisted queries, but the feature was n
 </Property>
 <Property name="PERSISTED_QUERY_NOT_IN_LIST">
 
-The operation was not executed because it was not found in the persisted query
-safelist.
+The operation (specified by ID) was not executed because the ID was not found in the persisted query manifest, and APQs are not enabled.
+
+</Property>
+<Property name="PERSISTED_QUERY_ID_REQUIRED">
+
+The router is configured to only execute operations specified by persisted query ID, but the request contained freeform GraphQL instead.
 
 </Property>
 <Property name="REQUEST_LIMIT_EXCEEDED">


### PR DESCRIPTION
- In changeset for ROUTER-1341, clarify precisely which error this refers to. (We may also want to add this extension to related errors like `QUERY_NOT_IN_SAFELIST` (freeform GraphQL provided, not in safelist) and `PERSISTED_QUERY_NOT_FOUND` (ID provided, APQs enabled) but let's document current behavior clearly.)

- Fix some docs around PQ errors
  - `PERSISTED_QUERY_ID_REQUIRED` was undocumented
  - `PERSISTED_QUERY_NOT_IN_LIST` had a description that was incorrectly identical to `QUERY_NOT_IN_SAFELIST`. The former is "you gave an ID I never heard of" (independently of whether or not safelisting is enabled); the latter is "you gave freeform GraphQL which wasn't in the enabled safelist".

<!-- start metadata -->

<!-- [ROUTER-1341] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

Doc-only change.

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1341]: https://apollographql.atlassian.net/browse/ROUTER-1341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ