### PR TITLE
fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (backport #7731)

### DIFF
--- a/.changesets/fix_bryn_subscriptions_integration_tests.md
+++ b/.changesets/fix_bryn_subscriptions_integration_tests.md
@@ -1,0 +1,7 @@
+### Coprocessor: improve handling of invalid GraphQL responses with conditional validation ([PR #7731](https://github.com/apollographql/router/pull/7731))
+
+The router was creating invalid GraphQL responses internally, especially when subscriptions terminate. When a coprocessor is configured, it validates all responses for correctness, causing errors to be logged when the router generates invalid internal responses. This affects the reliability of subscription workflows with coprocessors.
+
+Fix handling of invalid GraphQL responses returned from coprocessors, particularly when used with subscriptions. Added conditional response validation and improved testing to ensure correctness. Added the `response_validation` configuration option at the coprocessor level to enable the response validation (by default it's enabled).
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/7731

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "console",
  "cookie",
  "crossbeam-channel",
+ "ctor 0.2.9",
  "dashmap",
  "derivative",
  "derive_more",
@@ -1950,6 +1951,16 @@ checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3684,7 +3695,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a"
 dependencies = [
- "ctor",
+ "ctor 0.1.26",
  "ghost",
 ]
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -303,6 +303,7 @@ tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"], optional = true }
 [dev-dependencies]
 axum = { version = "0.8.1", features = ["http2", "ws"] }
 axum-server = "0.7.1"
+ctor = "0.2.8"
 ecdsa = { version = "0.16.9", features = ["signing", "pem", "pkcs8"] }
 fred = { version = "10.1.0", features = [
     "enable-rustls-ring",
@@ -328,7 +329,7 @@ opentelemetry-proto = { version = "0.7.0", features = [
 ] }
 opentelemetry-datadog = { version = "0.12.0", features = ["reqwest-client"] }
 p256 = "0.13.2"
-pretty_assertions = "1.4.0"
+pretty_assertions = "1.4.1"
 rand_core = "0.6.4"
 reqwest = { version = "0.12.9", default-features = false, features = [
     "json",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1275,6 +1275,11 @@ expression: "&schema"
           "$ref": "#/definitions/ExecutionStage",
           "description": "#/definitions/ExecutionStage"
         },
+        "response_validation": {
+          "default": true,
+          "description": "Response validation defaults to true",
+          "type": "boolean"
+        },
         "router": {
           "$ref": "#/definitions/RouterStage",
           "description": "#/definitions/RouterStage"

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -67,6 +67,7 @@ impl ExecutionStage {
         service: execution::BoxService,
         coprocessor_url: String,
         sdl: Arc<String>,
+        response_validation: bool,
     ) -> execution::BoxService
     where
         C: Service<
@@ -99,6 +100,7 @@ impl ExecutionStage {
                         sdl,
                         request,
                         request_config,
+                        response_validation,
                     )
                     .await
                     .map_err(|error| {
@@ -138,6 +140,7 @@ impl ExecutionStage {
                         sdl,
                         response,
                         response_config,
+                        response_validation,
                     )
                     .await
                     .map_err(|error| {
@@ -184,6 +187,7 @@ async fn process_execution_request_stage<C>(
     sdl: Arc<String>,
     mut request: execution::Request,
     request_config: ExecutionRequestConf,
+    response_validation: bool,
 ) -> Result<ControlFlow<execution::Response, execution::Request>, BoxError>
 where
     C: Service<http::Request<RouterBody>, Response = http::Response<RouterBody>, Error = BoxError>
@@ -247,20 +251,10 @@ where
         let code = control.get_http_status()?;
 
         let res = {
-            let graphql_response =
-                graphql::Response::from_value(co_processor_output.body.unwrap_or(Value::Null))
-                    .unwrap_or_else(|error| {
-                        graphql::Response::builder()
-                            .errors(vec![
-                                Error::builder()
-                                    .message(format!(
-                                        "couldn't deserialize coprocessor output body: {error}"
-                                    ))
-                                    .extension_code("EXTERNAL_DESERIALIZATION_ERROR")
-                                    .build(),
-                            ])
-                            .build()
-                    });
+            let graphql_response = {
+                let body_value = co_processor_output.body.unwrap_or(Value::Null);
+                deserialize_coprocessor_response(body_value, response_validation)
+            };
 
             let mut http_response = http::Response::builder()
                 .status(code)
@@ -331,6 +325,7 @@ async fn process_execution_response_stage<C>(
     sdl: Arc<String>,
     response: execution::Response,
     response_config: ExecutionResponseConf,
+    response_validation: bool,
 ) -> Result<execution::Response, BoxError>
 where
     C: Service<http::Request<RouterBody>, Response = http::Response<RouterBody>, Error = BoxError>
@@ -389,11 +384,20 @@ where
 
     validate_coprocessor_output(&co_processor_output, PipelineStep::ExecutionResponse)?;
 
+    // Check if the incoming GraphQL response was valid according to GraphQL spec
+    let incoming_payload_was_valid =
+        crate::plugins::coprocessor::was_incoming_payload_valid(&first, response_config.body);
+
     // Third, process our reply and act on the contents. Our processing logic is
     // that we replace "bits" of our incoming response with the updated bits if they
     // are present in our co_processor_output. If they aren't present, just use the
     // bits that we sent to the co_processor.
-    let new_body = handle_graphql_response(first, co_processor_output.body)?;
+    let new_body = handle_graphql_response(
+        first,
+        co_processor_output.body,
+        response_validation,
+        incoming_payload_was_valid,
+    )?;
 
     if let Some(control) = co_processor_output.control {
         parts.status = control.get_http_status()?
@@ -459,12 +463,23 @@ where
 
                 validate_coprocessor_output(&co_processor_output, PipelineStep::ExecutionResponse)?;
 
+                // Check if the incoming deferred GraphQL response was valid according to GraphQL spec
+                let incoming_payload_was_valid =
+                    crate::plugins::coprocessor::was_incoming_payload_valid(
+                        &deferred_response,
+                        response_config.body,
+                    );
+
                 // Third, process our reply and act on the contents. Our processing logic is
                 // that we replace "bits" of our incoming response with the updated bits if they
                 // are present in our co_processor_output. If they aren't present, just use the
                 // bits that we sent to the co_processor.
-                let new_deferred_response =
-                    handle_graphql_response(deferred_response, co_processor_output.body)?;
+                let new_deferred_response = handle_graphql_response(
+                    deferred_response,
+                    co_processor_output.body,
+                    response_validation,
+                    incoming_payload_was_valid,
+                )?;
 
                 if let Some(context) = co_processor_output.context {
                     for (mut key, value) in context.try_into_iter()? {
@@ -685,6 +700,7 @@ mod tests {
             mock_execution_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = execution::Request::fake_builder().build();
@@ -754,6 +770,7 @@ mod tests {
             mock_execution_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = execution::Request::fake_builder().build();
@@ -883,6 +900,7 @@ mod tests {
             mock_execution_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = execution::Request::fake_builder().build();
@@ -996,6 +1014,7 @@ mod tests {
             mock_execution_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = execution::Request::fake_builder()
@@ -1019,5 +1038,424 @@ mod tests {
             serde_json_bytes::to_value(&body).unwrap(),
             json!({ "data": { "test": 3, "has_next": false }, "hasNext": false }),
         );
+    }
+
+    // Helper function to create execution stage for validation tests
+    fn create_execution_stage_for_response_validation_test() -> ExecutionStage {
+        ExecutionStage {
+            request: Default::default(),
+            response: ExecutionResponseConf {
+                headers: true,
+                context: ContextConf::NewContextConf(NewContextConf::All),
+                body: true,
+                sdl: true,
+                status_code: false,
+            },
+        }
+    }
+
+    // Helper function to create mock execution service
+    fn create_mock_execution_service() -> MockExecutionService {
+        let mut mock_execution_service = MockExecutionService::new();
+        mock_execution_service
+            .expect_call()
+            .returning(|req: execution::Request| {
+                Ok(execution::Response::builder()
+                    .data(json!({ "test": 1234_u32 }))
+                    .errors(Vec::new())
+                    .extensions(Object::new())
+                    .context(req.context)
+                    .build()
+                    .unwrap())
+            });
+        mock_execution_service
+    }
+
+    // Helper functions for execution request validation tests
+    fn create_execution_stage_for_request_validation_test() -> ExecutionStage {
+        ExecutionStage {
+            request: ExecutionRequestConf {
+                headers: true,
+                context: ContextConf::NewContextConf(NewContextConf::All),
+                body: true,
+                sdl: true,
+                method: true,
+                query_plan: true,
+            },
+            response: Default::default(),
+        }
+    }
+
+    // Helper function to create mock http client that returns valid GraphQL break response
+    fn create_mock_http_client_execution_request_valid_response() -> MockInternalHttpClientService {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "ExecutionRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {
+                        "data": {"test": "valid_response"}
+                    }
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns empty GraphQL break response
+    fn create_mock_http_client_execution_request_empty_response() -> MockInternalHttpClientService {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "ExecutionRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {}
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns invalid GraphQL break response
+    fn create_mock_http_client_execution_request_invalid_response() -> MockInternalHttpClientService
+    {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "ExecutionRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {
+                        "errors": "this should be an array not a string"
+                    }
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns valid GraphQL response
+    fn create_mock_http_client_execution_response_valid_response() -> MockInternalHttpClientService
+    {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "ExecutionResponse",
+                    "control": "continue",
+                    "body": {
+                        "data": {"test": "valid_response"}
+                    }
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns invalid GraphQL response
+    fn create_mock_http_client_invalid_response() -> MockInternalHttpClientService {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "ExecutionResponse",
+                    "control": "continue",
+                    "body": {
+                        "errors": "this should be an array not a string"
+                    }
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns empty response
+    fn create_mock_http_client_empty_response() -> MockInternalHttpClientService {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "ExecutionResponse",
+                    "control": "continue",
+                    "body": {}
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_response_validation_disabled_invalid() {
+        let service = create_execution_stage_for_response_validation_test().as_service(
+            create_mock_http_client_invalid_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            false, // Validation disabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, uses permissive serde deserialization instead of strict GraphQL validation
+        // Falls back to original response when serde deserialization fails (string can't deserialize to Vec<Error>)
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(json!({ "test": 1234_u32 }), body.data.unwrap());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_response_validation_disabled_empty() {
+        let service = create_execution_stage_for_response_validation_test().as_service(
+            create_mock_http_client_empty_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            false, // Validation disabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, empty response deserializes successfully via serde
+        // (all fields are optional with defaults), resulting in a response with no data/errors
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data, None);
+        assert_eq!(body.errors.len(), 0);
+    }
+
+    // ===== EXECUTION REQUEST VALIDATION TESTS =====
+
+    #[tokio::test]
+    async fn external_plugin_execution_request_validation_enabled_valid() {
+        let service = create_execution_stage_for_request_validation_test().as_service(
+            create_mock_http_client_execution_request_valid_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            true, // Validation enabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 due to break with valid GraphQL response
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data.unwrap()["test"], "valid_response");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_request_validation_enabled_empty() {
+        let service = create_execution_stage_for_request_validation_test().as_service(
+            create_mock_http_client_execution_request_empty_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            true, // Validation enabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with validation error since empty response violates GraphQL spec
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        assert!(!body.errors.is_empty());
+        assert!(
+            body.errors[0]
+                .message
+                .contains("couldn't deserialize coprocessor output body")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_request_validation_enabled_invalid() {
+        let service = create_execution_stage_for_request_validation_test().as_service(
+            create_mock_http_client_execution_request_invalid_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            true, // Validation enabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with validation error since errors should be array not string
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        assert!(!body.errors.is_empty());
+        assert!(
+            body.errors[0]
+                .message
+                .contains("couldn't deserialize coprocessor output body")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_request_validation_disabled_valid() {
+        let service = create_execution_stage_for_request_validation_test().as_service(
+            create_mock_http_client_execution_request_valid_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            false, // Validation disabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 due to break with valid response preserved via permissive deserialization
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data.unwrap()["test"], "valid_response");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_request_validation_disabled_empty() {
+        let service = create_execution_stage_for_request_validation_test().as_service(
+            create_mock_http_client_execution_request_empty_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            false, // Validation disabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with empty response preserved via permissive deserialization
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        // Empty object deserializes to GraphQL response with no data/errors
+        assert_eq!(body.data, None);
+        assert_eq!(body.errors.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_request_validation_disabled_invalid() {
+        let service = create_execution_stage_for_request_validation_test().as_service(
+            create_mock_http_client_execution_request_invalid_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            false, // Validation disabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with fallback to original response since invalid structure can't deserialize
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        // Falls back to original response since permissive deserialization fails too
+        assert!(body.data.is_some() || !body.errors.is_empty());
+    }
+
+    // ===== EXECUTION RESPONSE VALIDATION TESTS =====
+
+    #[tokio::test]
+    async fn external_plugin_execution_response_validation_enabled_valid() {
+        let service = create_execution_stage_for_response_validation_test().as_service(
+            create_mock_http_client_execution_response_valid_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            true, // Validation enabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // With validation enabled, valid GraphQL response should be processed normally
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data.unwrap()["test"], "valid_response");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_response_validation_enabled_empty() {
+        let service = create_execution_stage_for_response_validation_test().as_service(
+            create_mock_http_client_empty_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            true, // Validation enabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+
+        // With validation enabled, empty response should cause service call to fail due to GraphQL validation
+        let result = service.oneshot(request).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_response_validation_enabled_invalid() {
+        let service = create_execution_stage_for_response_validation_test().as_service(
+            create_mock_http_client_invalid_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            true, // Validation enabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+
+        // With validation enabled, invalid GraphQL response should cause service call to fail
+        let result = service.oneshot(request).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_execution_response_validation_disabled_valid() {
+        let service = create_execution_stage_for_response_validation_test().as_service(
+            create_mock_http_client_execution_response_valid_response(),
+            create_mock_execution_service().boxed(),
+            "http://test".to_string(),
+            Arc::new("".to_string()),
+            false, // Validation disabled
+        );
+
+        let request = execution::Request::fake_builder().build();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, valid response processed via permissive deserialization
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data.unwrap()["test"], "valid_response");
     }
 }

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -271,6 +271,7 @@ where
             service,
             self.configuration.url.clone(),
             self.sdl.clone(),
+            self.configuration.response_validation,
         )
     }
 
@@ -283,6 +284,7 @@ where
             service,
             self.configuration.url.clone(),
             self.sdl.clone(),
+            self.configuration.response_validation,
         )
     }
 
@@ -295,6 +297,7 @@ where
             service,
             self.configuration.url.clone(),
             self.sdl.clone(),
+            self.configuration.response_validation,
         )
     }
 
@@ -304,6 +307,7 @@ where
             service,
             self.configuration.url.clone(),
             name.to_string(),
+            self.configuration.response_validation,
         )
     }
 }
@@ -398,6 +402,9 @@ struct Conf {
     #[schemars(with = "String", default = "default_timeout")]
     #[serde(default = "default_timeout")]
     timeout: Duration,
+    /// Response validation defaults to true
+    #[serde(default = "default_response_validation")]
+    response_validation: bool,
     /// The router stage request/response configuration
     #[serde(default)]
     router: RouterStage,
@@ -475,6 +482,10 @@ fn default_timeout() -> Duration {
     DEFAULT_EXTERNALIZATION_TIMEOUT
 }
 
+fn default_response_validation() -> bool {
+    true
+}
+
 fn record_coprocessor_duration(stage: PipelineStep, duration: Duration) {
     f64_histogram!(
         "apollo.router.operations.coprocessor.duration",
@@ -500,6 +511,7 @@ impl RouterStage {
         service: router::BoxService,
         coprocessor_url: String,
         sdl: Arc<String>,
+        response_validation: bool,
     ) -> router::BoxService
     where
         C: Service<
@@ -532,6 +544,7 @@ impl RouterStage {
                         sdl,
                         request,
                         request_config,
+                        response_validation,
                     )
                     .await
                     .map_err(|error| {
@@ -569,6 +582,7 @@ impl RouterStage {
                         sdl,
                         response,
                         response_config,
+                        response_validation,
                     )
                     .await
                     .map_err(|error| {
@@ -635,6 +649,7 @@ impl SubgraphStage {
         service: subgraph::BoxService,
         coprocessor_url: String,
         service_name: String,
+        response_validation: bool,
     ) -> subgraph::BoxService
     where
         C: Service<
@@ -666,6 +681,7 @@ impl SubgraphStage {
                         service_name,
                         request,
                         request_config,
+                        response_validation,
                     )
                     .await
                     .map_err(|error| {
@@ -704,6 +720,7 @@ impl SubgraphStage {
                         service_name,
                         response,
                         response_config,
+                        response_validation,
                     )
                     .await
                     .map_err(|error| {
@@ -750,6 +767,7 @@ async fn process_router_request_stage<C>(
     sdl: Arc<String>,
     mut request: router::Request,
     mut request_config: RouterRequestConf,
+    response_validation: bool,
 ) -> Result<ControlFlow<router::Response, router::Request>, BoxError>
 where
     C: Service<http::Request<RouterBody>, Response = http::Response<RouterBody>, Error = BoxError>
@@ -839,18 +857,7 @@ where
                         .build(),
                 ])
                 .build(),
-            _ => graphql::Response::from_value(body_as_value).unwrap_or_else(|error| {
-                graphql::Response::builder()
-                    .errors(vec![
-                        Error::builder()
-                            .message(format!(
-                                "couldn't deserialize coprocessor output body: {error}"
-                            ))
-                            .extension_code(COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
-                            .build(),
-                    ])
-                    .build()
-            }),
+            _ => deserialize_coprocessor_response(body_as_value, response_validation),
         };
 
         let res = router::Response::builder()
@@ -919,6 +926,7 @@ async fn process_router_response_stage<C>(
     sdl: Arc<String>,
     mut response: router::Response,
     response_config: RouterResponseConf,
+    _response_validation: bool, // Router responses don't implement GraphQL validation - streaming responses bypass handle_graphql_response
 ) -> Result<router::Response, BoxError>
 where
     C: Service<http::Request<RouterBody>, Response = http::Response<RouterBody>, Error = BoxError>
@@ -1118,6 +1126,7 @@ async fn process_subgraph_request_stage<C>(
     service_name: String,
     mut request: subgraph::Request,
     mut request_config: SubgraphRequestConf,
+    response_validation: bool,
 ) -> Result<ControlFlow<subgraph::Response, subgraph::Request>, BoxError>
 where
     C: Service<http::Request<RouterBody>, Response = http::Response<RouterBody>, Error = BoxError>
@@ -1194,18 +1203,7 @@ where
                             .build(),
                     ])
                     .build(),
-                value => graphql::Response::from_value(value).unwrap_or_else(|error| {
-                    graphql::Response::builder()
-                        .errors(vec![
-                            Error::builder()
-                                .message(format!(
-                                    "couldn't deserialize coprocessor output body: {error}"
-                                ))
-                                .extension_code(COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
-                                .build(),
-                        ])
-                        .build()
-                }),
+                value => deserialize_coprocessor_response(value, response_validation),
             };
 
             let mut http_response = http::Response::builder()
@@ -1279,6 +1277,7 @@ async fn process_subgraph_response_stage<C>(
     service_name: String,
     mut response: subgraph::Response,
     response_config: SubgraphResponseConf,
+    response_validation: bool,
 ) -> Result<subgraph::Response, BoxError>
 where
     C: Service<http::Request<RouterBody>, Response = http::Response<RouterBody>, Error = BoxError>
@@ -1336,12 +1335,20 @@ where
 
     validate_coprocessor_output(&co_processor_output, PipelineStep::SubgraphResponse)?;
 
+    // Check if the incoming GraphQL response was valid according to GraphQL spec
+    let incoming_payload_was_valid = was_incoming_payload_valid(&body, response_config.body);
+
     // Third, process our reply and act on the contents. Our processing logic is
     // that we replace "bits" of our incoming response with the updated bits if they
     // are present in our co_processor_output. If they aren't present, just use the
     // bits that we sent to the co_processor.
 
-    let new_body = handle_graphql_response(body, co_processor_output.body)?;
+    let new_body = handle_graphql_response(
+        body,
+        co_processor_output.body,
+        response_validation,
+        incoming_payload_was_valid,
+    )?;
 
     response.response = http::Response::from_parts(parts, new_body);
 
@@ -1415,26 +1422,113 @@ pub(super) fn internalize_header_map(
     Ok(output)
 }
 
+// Helper function to apply common post-processing to deserialized GraphQL responses
+fn apply_response_post_processing(
+    mut new_body: graphql::Response,
+    original_response_body: &graphql::Response,
+) -> graphql::Response {
+    // Needs to take back these 2 fields because it's skipped by serde
+    new_body.subscribed = original_response_body.subscribed;
+    new_body.created_at = original_response_body.created_at;
+    // Required because for subscription if data is Some(Null) it won't cut the subscription
+    // And in some languages they don't have any differences between Some(Null) and Null
+    if original_response_body.data == Some(Value::Null)
+        && new_body.data.is_none()
+        && new_body.subscribed == Some(true)
+    {
+        new_body.data = Some(Value::Null);
+    }
+    new_body
+}
+
+/// Check if a GraphQL response is minimally valid according to the GraphQL spec.
+/// A response is invalid if it has no data AND no errors.
+pub(super) fn is_graphql_response_minimally_valid(response: &graphql::Response) -> bool {
+    // According to GraphQL spec, a response without data must contain at least one error
+    response.data.is_some() || !response.errors.is_empty()
+}
+
+/// Check if the incoming payload was valid for conditional validation purposes.
+/// Returns true if body was not sent to coprocessor OR if the response is minimally valid.
+pub(super) fn was_incoming_payload_valid(response: &graphql::Response, body_sent: bool) -> bool {
+    if body_sent {
+        // If we sent the body to the coprocessor, check if it was minimally valid
+        is_graphql_response_minimally_valid(response)
+    } else {
+        // If we didn't send the body, assume it was valid
+        true
+    }
+}
+
+/// Deserializes a GraphQL response from a Value with optional validation
+pub(super) fn deserialize_coprocessor_response(
+    body_as_value: Value,
+    response_validation: bool,
+) -> graphql::Response {
+    if response_validation {
+        graphql::Response::from_value(body_as_value).unwrap_or_else(|error| {
+            graphql::Response::builder()
+                .errors(vec![
+                    Error::builder()
+                        .message(format!(
+                            "couldn't deserialize coprocessor output body: {error}"
+                        ))
+                        .extension_code(COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .build(),
+                ])
+                .build()
+        })
+    } else {
+        // When validation is disabled, use the old behavior - just deserialize without GraphQL validation
+        serde_json_bytes::from_value(body_as_value).unwrap_or_else(|error| {
+            graphql::Response::builder()
+                .errors(vec![
+                    Error::builder()
+                        .message(format!(
+                            "couldn't deserialize coprocessor output body: {error}"
+                        ))
+                        .extension_code(COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION)
+                        .build(),
+                ])
+                .build()
+        })
+    }
+}
+
 pub(super) fn handle_graphql_response(
     original_response_body: graphql::Response,
     copro_response_body: Option<Value>,
+    response_validation: bool,
+    incoming_payload_was_valid: bool,
 ) -> Result<graphql::Response, BoxError> {
+    // Enable conditional validation: only validate coprocessor responses when the incoming payload was valid.
+    // This prevents validation failures for responses that were already invalid before being sent to the coprocessor.
+    // Set to false to restore the previous behavior of always validating coprocessor responses when response_validation is true.
+    const ENABLE_CONDITIONAL_VALIDATION: bool = true;
+
+    // Only apply validation if response_validation is enabled AND either:
+    // 1. Conditional validation is disabled, OR
+    // 2. The incoming payload to the coprocessor was valid
+    let should_validate =
+        response_validation && (!ENABLE_CONDITIONAL_VALIDATION || incoming_payload_was_valid);
+
     Ok(match copro_response_body {
         Some(value) => {
-            let mut new_body = graphql::Response::from_value(value)?;
-            // Needs to take back these 2 fields because it's skipped by serde
-            new_body.subscribed = original_response_body.subscribed;
-            new_body.created_at = original_response_body.created_at;
-            // Required because for subscription if data is Some(Null) it won't cut the subscription
-            // And in some languages they don't have any differences between Some(Null) and Null
-            if original_response_body.data == Some(Value::Null)
-                && new_body.data.is_none()
-                && new_body.subscribed == Some(true)
-            {
-                new_body.data = Some(Value::Null);
+            if should_validate {
+                let new_body = graphql::Response::from_value(value)?;
+                apply_response_post_processing(new_body, &original_response_body)
+            } else {
+                // When validation is disabled, use the old behavior - just deserialize without GraphQL validation
+                match serde_json_bytes::from_value::<graphql::Response>(value) {
+                    Ok(new_body) => {
+                        apply_response_post_processing(new_body, &original_response_body)
+                    }
+                    Err(_) => {
+                        // If deserialization fails completely, return original response
+                        original_response_body
+                    }
+                }
             }
-
-            new_body
         }
         None => original_response_body,
     })

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -71,6 +71,7 @@ impl SupergraphStage {
         service: supergraph::BoxService,
         coprocessor_url: String,
         sdl: Arc<String>,
+        response_validation: bool,
     ) -> supergraph::BoxService
     where
         C: Service<
@@ -103,6 +104,7 @@ impl SupergraphStage {
                         sdl,
                         request,
                         request_config,
+                        response_validation,
                     )
                     .await
                     .map_err(|error| {
@@ -141,6 +143,7 @@ impl SupergraphStage {
                         sdl,
                         response,
                         response_config,
+                        response_validation,
                     )
                     .await
                     .map_err(|error| {
@@ -186,6 +189,7 @@ async fn process_supergraph_request_stage<C>(
     sdl: Arc<String>,
     mut request: supergraph::Request,
     mut request_config: SupergraphRequestConf,
+    response_validation: bool,
 ) -> Result<ControlFlow<supergraph::Response, supergraph::Request>, BoxError>
 where
     C: Service<http::Request<RouterBody>, Response = http::Response<RouterBody>, Error = BoxError>
@@ -248,20 +252,10 @@ where
         let code = control.get_http_status()?;
 
         let res = {
-            let graphql_response =
-                graphql::Response::from_value(co_processor_output.body.unwrap_or(Value::Null))
-                    .unwrap_or_else(|error| {
-                        graphql::Response::builder()
-                            .errors(vec![
-                                Error::builder()
-                                    .message(format!(
-                                        "couldn't deserialize coprocessor output body: {error}"
-                                    ))
-                                    .extension_code("EXTERNAL_DESERIALIZATION_ERROR")
-                                    .build(),
-                            ])
-                            .build()
-                    });
+            let graphql_response = {
+                let body_value = co_processor_output.body.unwrap_or(Value::Null);
+                deserialize_coprocessor_response(body_value, response_validation)
+            };
 
             let mut http_response = http::Response::builder()
                 .status(code)
@@ -332,6 +326,7 @@ async fn process_supergraph_response_stage<C>(
     sdl: Arc<String>,
     response: supergraph::Response,
     response_config: SupergraphResponseConf,
+    response_validation: bool,
 ) -> Result<supergraph::Response, BoxError>
 where
     C: Service<http::Request<RouterBody>, Response = http::Response<RouterBody>, Error = BoxError>
@@ -393,11 +388,20 @@ where
 
     validate_coprocessor_output(&co_processor_output, PipelineStep::SupergraphResponse)?;
 
+    // Check if the incoming GraphQL response was valid according to GraphQL spec
+    let incoming_payload_was_valid =
+        crate::plugins::coprocessor::was_incoming_payload_valid(&first, response_config.body);
+
     // Third, process our reply and act on the contents. Our processing logic is
     // that we replace "bits" of our incoming response with the updated bits if they
     // are present in our co_processor_output. If they aren't present, just use the
     // bits that we sent to the co_processor.
-    let new_body = handle_graphql_response(first, co_processor_output.body)?;
+    let new_body = handle_graphql_response(
+        first,
+        co_processor_output.body,
+        response_validation,
+        incoming_payload_was_valid,
+    )?;
 
     if let Some(control) = co_processor_output.control {
         parts.status = control.get_http_status()?
@@ -471,12 +475,23 @@ where
                     PipelineStep::SupergraphResponse,
                 )?;
 
+                // Check if the incoming deferred GraphQL response was valid according to GraphQL spec
+                let incoming_payload_was_valid =
+                    crate::plugins::coprocessor::was_incoming_payload_valid(
+                        &deferred_response,
+                        response_config.body,
+                    );
+
                 // Third, process our reply and act on the contents. Our processing logic is
                 // that we replace "bits" of our incoming response with the updated bits if they
                 // are present in our co_processor_output. If they aren't present, just use the
                 // bits that we sent to the co_processor.
-                let new_deferred_response =
-                    handle_graphql_response(deferred_response, co_processor_output.body)?;
+                let new_deferred_response = handle_graphql_response(
+                    deferred_response,
+                    co_processor_output.body,
+                    response_validation,
+                    incoming_payload_was_valid,
+                )?;
 
                 if let Some(context) = co_processor_output.context {
                     for (mut key, value) in context.try_into_iter()? {
@@ -697,6 +712,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::fake_builder().build().unwrap();
@@ -774,6 +790,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::fake_builder()
@@ -851,6 +868,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let crate::services::supergraph::Response { context, .. } =
@@ -965,6 +983,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -1079,6 +1098,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder()
@@ -1195,6 +1215,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder()
@@ -1219,5 +1240,425 @@ mod tests {
             serde_json_bytes::to_value(&body).unwrap(),
             json!({ "data": { "test": 3 }, "hasNext": false }),
         );
+    }
+
+    // Helper function to create supergraph stage for validation tests
+    fn create_supergraph_stage_for_response_validation_test() -> SupergraphStage {
+        SupergraphStage {
+            request: Default::default(),
+            response: SupergraphResponseConf {
+                condition: Condition::True,
+                headers: true,
+                context: ContextConf::NewContextConf(NewContextConf::All),
+                body: true,
+                sdl: true,
+                status_code: false,
+            },
+        }
+    }
+
+    // Helper function to create mock supergraph service
+    fn create_mock_supergraph_service() -> MockSupergraphService {
+        let mut mock_supergraph_service = MockSupergraphService::new();
+        mock_supergraph_service
+            .expect_call()
+            .returning(|req: supergraph::Request| {
+                Ok(supergraph::Response::builder()
+                    .data(json!({ "test": 1234_u32 }))
+                    .context(req.context)
+                    .build()
+                    .unwrap())
+            });
+        mock_supergraph_service
+    }
+
+    // Helper functions for supergraph request validation tests
+    fn create_supergraph_stage_for_request_validation_test() -> SupergraphStage {
+        SupergraphStage {
+            request: SupergraphRequestConf {
+                condition: Condition::True,
+                headers: true,
+                context: ContextConf::NewContextConf(NewContextConf::All),
+                body: true,
+                sdl: true,
+                method: true,
+            },
+            response: Default::default(),
+        }
+    }
+
+    // Helper function to create mock http client that returns valid GraphQL break response
+    fn create_mock_http_client_supergraph_request_valid_response() -> MockInternalHttpClientService
+    {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "SupergraphRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {
+                        "data": {"test": "valid_response"}
+                    }
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns empty GraphQL break response
+    fn create_mock_http_client_supergraph_request_empty_response() -> MockInternalHttpClientService
+    {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "SupergraphRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {}
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns invalid GraphQL break response
+    fn create_mock_http_client_supergraph_request_invalid_response() -> MockInternalHttpClientService
+    {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "SupergraphRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {
+                        "errors": "this should be an array not a string"
+                    }
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns valid GraphQL response
+    fn create_mock_http_client_supergraph_response_valid_response() -> MockInternalHttpClientService
+    {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "SupergraphResponse",
+                    "control": "continue",
+                    "body": {
+                        "data": {"test": "valid_response"}
+                    }
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns invalid GraphQL response
+    fn create_mock_http_client_invalid_response() -> MockInternalHttpClientService {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "SupergraphResponse",
+                    "control": "continue",
+                    "body": {
+                        "errors": "this should be an array not a string"
+                    }
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns empty response
+    fn create_mock_http_client_empty_response() -> MockInternalHttpClientService {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "SupergraphResponse",
+                    "control": "continue",
+                    "body": {}
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_response_validation_disabled_invalid() {
+        let service = create_supergraph_stage_for_response_validation_test().as_service(
+            create_mock_http_client_invalid_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            false, // Validation disabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, uses permissive serde deserialization instead of strict GraphQL validation
+        // Falls back to original response when serde deserialization fails (string can't deserialize to Vec<Error>)
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(json!({ "test": 1234_u32 }), body.data.unwrap());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_response_validation_disabled_empty() {
+        let service = create_supergraph_stage_for_response_validation_test().as_service(
+            create_mock_http_client_empty_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            false, // Validation disabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, empty response deserializes successfully via serde
+        // (all fields are optional with defaults), resulting in a response with no data/errors
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data, None);
+        assert_eq!(body.errors.len(), 0);
+    }
+
+    // ===== SUPERGRAPH REQUEST VALIDATION TESTS =====
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_request_validation_enabled_valid() {
+        let service = create_supergraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_supergraph_request_valid_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            true, // Validation enabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 due to break with valid GraphQL response
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data.unwrap()["test"], "valid_response");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_request_validation_enabled_empty() {
+        let service = create_supergraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_supergraph_request_empty_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            true, // Validation enabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with validation error since empty response violates GraphQL spec
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        assert!(!body.errors.is_empty());
+        assert!(
+            body.errors[0]
+                .message
+                .contains("couldn't deserialize coprocessor output body")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_request_validation_enabled_invalid() {
+        let service = create_supergraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_supergraph_request_invalid_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            true, // Validation enabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with validation error since errors should be array not string
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        assert!(!body.errors.is_empty());
+        assert!(
+            body.errors[0]
+                .message
+                .contains("couldn't deserialize coprocessor output body")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_request_validation_disabled_valid() {
+        let service = create_supergraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_supergraph_request_valid_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            false, // Validation disabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 due to break with valid response preserved via permissive deserialization
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data.unwrap()["test"], "valid_response");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_request_validation_disabled_empty() {
+        let service = create_supergraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_supergraph_request_empty_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            false, // Validation disabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with empty response preserved via permissive deserialization
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        // Empty object deserializes to GraphQL response with no data/errors
+        assert_eq!(body.data, None);
+        assert_eq!(body.errors.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_request_validation_disabled_invalid() {
+        let service = create_supergraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_supergraph_request_invalid_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            false, // Validation disabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with fallback to original response since invalid structure can't deserialize
+        assert_eq!(res.response.status(), 400);
+        let body = res.response.body_mut().next().await.unwrap();
+        // Falls back to original response since permissive deserialization fails too
+        assert!(body.data.is_some() || !body.errors.is_empty());
+    }
+
+    // ===== SUPERGRAPH RESPONSE VALIDATION TESTS =====
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_response_validation_enabled_valid() {
+        let service = create_supergraph_stage_for_response_validation_test().as_service(
+            create_mock_http_client_supergraph_response_valid_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            true, // Validation enabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // With validation enabled, valid GraphQL response should be processed normally
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data.unwrap()["test"], "valid_response");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_response_validation_enabled_empty() {
+        let service = create_supergraph_stage_for_response_validation_test().as_service(
+            create_mock_http_client_empty_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            true, // Validation enabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+
+        // With validation enabled, empty response should cause service call to fail due to GraphQL validation
+        let result = service.oneshot(request).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_response_validation_enabled_invalid() {
+        let service = create_supergraph_stage_for_response_validation_test().as_service(
+            create_mock_http_client_invalid_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            true, // Validation enabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+
+        // With validation enabled, invalid GraphQL response should cause service call to fail
+        let result = service.oneshot(request).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_supergraph_response_validation_disabled_valid() {
+        let service = create_supergraph_stage_for_response_validation_test().as_service(
+            create_mock_http_client_supergraph_response_valid_response(),
+            create_mock_supergraph_service().boxed(),
+            "http://test".to_string(),
+            Arc::default(),
+            false, // Validation disabled
+        );
+
+        let request = supergraph::Request::fake_builder().build().unwrap();
+        let mut res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, valid response processed via permissive deserialization
+        let body = res.response.body_mut().next().await.unwrap();
+        assert_eq!(body.data.unwrap()["test"], "valid_response");
     }
 }

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -25,8 +25,11 @@ mod tests {
     use crate::plugin::test::MockRouterService;
     use crate::plugin::test::MockSubgraphService;
     use crate::plugin::test::MockSupergraphService;
+    use crate::plugins::coprocessor::handle_graphql_response;
+    use crate::plugins::coprocessor::is_graphql_response_minimally_valid;
     use crate::plugins::coprocessor::supergraph::SupergraphResponseConf;
     use crate::plugins::coprocessor::supergraph::SupergraphStage;
+    use crate::plugins::coprocessor::was_incoming_payload_valid;
     use crate::plugins::telemetry::config_new::conditions::SelectorOrValue;
     use crate::services::external::EXTERNALIZABLE_VERSION;
     use crate::services::external::Externalizable;
@@ -119,6 +122,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -181,6 +185,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -242,6 +247,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -297,6 +303,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let request = subgraph::Request::fake_builder().build();
@@ -439,6 +446,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let mut request = subgraph::Request::fake_builder().build();
@@ -591,6 +599,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let mut request = subgraph::Request::fake_builder().build();
@@ -757,6 +766,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let mut request = subgraph::Request::fake_builder().build();
@@ -840,6 +850,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let request = subgraph::Request::fake_builder().build();
@@ -903,6 +914,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let request = subgraph::Request::fake_builder().build();
@@ -959,6 +971,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let request = subgraph::Request::fake_builder().build();
@@ -1076,6 +1089,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let mut request = subgraph::Request::fake_builder().build();
@@ -1191,6 +1205,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let mut request = subgraph::Request::fake_builder().build();
@@ -1318,6 +1333,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let mut request = subgraph::Request::fake_builder().build();
@@ -1466,6 +1482,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let mut request = subgraph::Request::fake_builder().build();
@@ -1602,6 +1619,7 @@ mod tests {
             mock_subgraph_service.boxed(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
+            true,
         );
 
         let request = subgraph::Request::fake_builder().build();
@@ -1679,6 +1697,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::default(),
+            true,
         );
 
         let request = supergraph::Request::fake_builder().build().unwrap();
@@ -1768,6 +1787,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::default(),
+            true,
         );
 
         let request = supergraph::Request::fake_builder().build().unwrap();
@@ -1865,6 +1885,7 @@ mod tests {
             mock_supergraph_service.boxed(),
             "http://test".to_string(),
             Arc::default(),
+            true,
         );
 
         let request = supergraph::Request::fake_builder().build().unwrap();
@@ -2013,6 +2034,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -2159,6 +2181,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -2291,6 +2314,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -2420,6 +2444,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::fake_builder()
@@ -2494,6 +2519,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -2578,6 +2604,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -2711,6 +2738,7 @@ mod tests {
             mock_router_service.boxed(),
             "http://test".to_string(),
             Arc::new("".to_string()),
+            true,
         );
 
         let request = supergraph::Request::canned_builder().build().unwrap();
@@ -2741,6 +2769,411 @@ mod tests {
                     .unwrap()
             )
             .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_router_response_validation_disabled_custom() {
+        // Router stage doesn't actually implement response validation - it always uses
+        // permissive deserialization since it handles streaming responses differently
+        let router_stage = RouterStage {
+            response: RouterResponseConf {
+                body: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mock_router_service = router::service::from_supergraph_mock_callback(move |req| {
+            Ok(supergraph::Response::builder()
+                .data(json!({"test": 42}))
+                .context(req.context)
+                .build()
+                .unwrap())
+        })
+        .await;
+
+        let mock_http_client = mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                // Return response that modifies the body - this demonstrates router stage processes
+                // coprocessor responses without GraphQL validation (unlike other stages)
+                let response = json!({
+                    "version": 1,
+                    "stage": "RouterResponse",
+                    "control": "continue",
+                    "body": "{\"data\": {\"test\": \"modified_by_coprocessor\"}}"
+                });
+
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        });
+
+        let service_stack = router_stage
+            .as_service(
+                mock_http_client,
+                mock_router_service.boxed(),
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                false, // response_validation - doesn't matter for router stage
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Response should be processed normally since router stage doesn't validate
+        assert_eq!(res.response.status(), 200);
+
+        // Router stage should accept the coprocessor response without validation
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(body["data"]["test"], "modified_by_coprocessor");
+    }
+
+    // ===== ROUTER RESPONSE VALIDATION TESTS =====
+    // Note: Router response stage doesn't implement GraphQL validation - it always uses permissive
+    // deserialization since it handles streaming responses differently than other stages
+
+    #[tokio::test]
+    async fn external_plugin_router_response_validation_enabled_valid() {
+        let service_stack = create_router_stage_for_response_validation_test()
+            .as_service(
+                create_mock_http_client_router_response_valid_response(),
+                create_mock_router_service_for_validation_test().await,
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                true, // response_validation enabled - but router response ignores this
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Router response stage processes all responses without validation regardless of setting
+        assert_eq!(res.response.status(), 200);
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(body["data"]["test"], "valid_response");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_router_response_validation_enabled_empty() {
+        let service_stack = create_router_stage_for_response_validation_test()
+            .as_service(
+                create_mock_http_client_router_response_empty_response(),
+                create_mock_router_service_for_validation_test().await,
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                true, // response_validation enabled - but router response ignores this
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Router response stage accepts empty responses without validation
+        assert_eq!(res.response.status(), 200);
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        // Empty object passes through unchanged since router response doesn't validate
+        assert!(body.as_object().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_router_response_validation_enabled_invalid() {
+        let service_stack = create_router_stage_for_response_validation_test()
+            .as_service(
+                create_mock_http_client_router_response_invalid_response(),
+                create_mock_router_service_for_validation_test().await,
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                true, // response_validation enabled - but router response ignores this
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Router response stage accepts invalid responses without validation
+        assert_eq!(res.response.status(), 200);
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        // Invalid response passes through unchanged since router response doesn't validate
+        assert_eq!(body["errors"], "this should be an array not a string");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_router_response_validation_disabled_valid() {
+        let service_stack = create_router_stage_for_response_validation_test()
+            .as_service(
+                create_mock_http_client_router_response_valid_response(),
+                create_mock_router_service_for_validation_test().await,
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                false, // response_validation disabled - same behavior as enabled for router response
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Router response stage processes all responses identically regardless of validation setting
+        assert_eq!(res.response.status(), 200);
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(body["data"]["test"], "valid_response");
+    }
+
+    #[tokio::test]
+    async fn external_plugin_router_response_validation_disabled_empty() {
+        let service_stack = create_router_stage_for_response_validation_test()
+            .as_service(
+                create_mock_http_client_router_response_empty_response(),
+                create_mock_router_service_for_validation_test().await,
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                false, // response_validation disabled - same behavior as enabled for router response
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Router response stage behavior is identical whether validation is enabled or disabled
+        assert_eq!(res.response.status(), 200);
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        // Empty object passes through unchanged
+        assert!(body.as_object().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_router_response_validation_disabled_invalid() {
+        let service_stack = create_router_stage_for_response_validation_test()
+            .as_service(
+                create_mock_http_client_router_response_invalid_response(),
+                create_mock_router_service_for_validation_test().await,
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                false, // response_validation disabled - same behavior as enabled for router response
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Router response stage behavior is identical whether validation is enabled or disabled
+        assert_eq!(res.response.status(), 200);
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        // Invalid response passes through unchanged
+        assert_eq!(body["errors"], "this should be an array not a string");
+    }
+
+    // Helper functions for router request validation tests
+    fn create_router_stage_for_validation_test() -> RouterStage {
+        RouterStage {
+            request: RouterRequestConf {
+                body: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    async fn create_mock_router_service_for_validation_test() -> router::BoxService {
+        router::service::from_supergraph_mock_callback(move |req| {
+            Ok(supergraph::Response::builder()
+                .data(json!({"test": 42}))
+                .context(req.context)
+                .build()
+                .unwrap())
+        })
+        .await
+        .boxed()
+    }
+
+    fn create_mock_http_client_empty_router_response() -> MockInternalHttpClientService {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                // Return empty GraphQL break response - passes serde but fails GraphQL validation
+                let response = json!({
+                    "version": 1,
+                    "stage": "RouterRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": "{}"
+                });
+
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper functions for router response validation tests
+    fn create_router_stage_for_response_validation_test() -> RouterStage {
+        RouterStage {
+            request: Default::default(),
+            response: RouterResponseConf {
+                condition: Default::default(),
+                headers: true,
+                context: ContextConf::NewContextConf(NewContextConf::All),
+                body: true,
+                sdl: true,
+                status_code: false,
+            },
+        }
+    }
+
+    // Helper function to create mock http client that returns valid GraphQL response
+    fn create_mock_http_client_router_response_valid_response() -> MockInternalHttpClientService {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "RouterResponse",
+                    "control": "continue",
+                    "body": "{\"data\": {\"test\": \"valid_response\"}}"
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns empty GraphQL response
+    fn create_mock_http_client_router_response_empty_response() -> MockInternalHttpClientService {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "RouterResponse",
+                    "control": "continue",
+                    "body": "{}"
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns invalid GraphQL response
+    fn create_mock_http_client_router_response_invalid_response() -> MockInternalHttpClientService {
+        mock_with_deferred_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "RouterResponse",
+                    "control": "continue",
+                    "body": "{\"errors\": \"this should be an array not a string\"}"
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn external_plugin_router_request_validation_disabled_empty() {
+        let service_stack = create_router_stage_for_validation_test()
+            .as_service(
+                create_mock_http_client_empty_router_response(),
+                create_mock_router_service_for_validation_test().await,
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                false, // response_validation disabled
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Should return 400 due to break, but with permissive deserialization
+        assert_eq!(res.response.status(), 400);
+
+        // Body should contain the empty response that passed serde but failed GraphQL validation
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        // With validation disabled, should get empty object as response
+        assert!(
+            body.as_object().unwrap().is_empty()
+                || body.get("data").is_some()
+                || body.get("errors").is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_router_request_validation_enabled_empty() {
+        let service_stack = create_router_stage_for_validation_test()
+            .as_service(
+                create_mock_http_client_empty_router_response(),
+                create_mock_router_service_for_validation_test().await,
+                "http://test".to_string(),
+                Arc::new("".to_string()),
+                true, // response_validation enabled
+            )
+            .boxed();
+
+        let request = router::Request::fake_builder().build().unwrap();
+        let res = service_stack.oneshot(request).await.unwrap();
+
+        // Should return 400 due to break
+        assert_eq!(res.response.status(), 400);
+
+        // Body should contain validation error from GraphQL validation failure
+        let body_bytes = router::body::into_bytes(res.response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+        // Should contain GraphQL errors from validation failure, not the original empty object
+        assert!(body.get("errors").is_some());
+        // Verify it's a deserialization error (validation failed)
+        let errors = body["errors"].as_array().unwrap();
+        assert!(
+            errors[0]["message"]
+                .as_str()
+                .unwrap()
+                .contains("couldn't deserialize coprocessor output body")
         );
     }
 
@@ -2811,6 +3244,513 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    #[test]
+    fn test_handle_graphql_response_validation_enabled() {
+        let original = graphql::Response::builder()
+            .data(json!({"test": "original"}))
+            .build();
+
+        // Valid GraphQL response should work
+        let valid_response = json!({
+            "data": {"test": "modified"}
+        });
+        let result =
+            handle_graphql_response(original.clone(), Some(valid_response), true, true).unwrap();
+        assert_eq!(result.data, Some(json!({"test": "modified"})));
+
+        // Invalid GraphQL response should return error when validation enabled
+        let invalid_response = json!({
+            "invalid": "structure"
+        });
+        let result = handle_graphql_response(original.clone(), Some(invalid_response), true, true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_handle_graphql_response_validation_disabled() {
+        let original = graphql::Response::builder()
+            .data(json!({"test": "original"}))
+            .build();
+
+        // Valid GraphQL response should work
+        let valid_response = json!({
+            "data": {"test": "modified"}
+        });
+        let result =
+            handle_graphql_response(original.clone(), Some(valid_response), false, true).unwrap();
+        assert_eq!(result.data, Some(json!({"test": "modified"})));
+
+        // Invalid GraphQL response should return original when validation disabled
+        // Use a structure that will actually fail deserialization (wrong type for errors field)
+        let invalid_response = json!({
+            "errors": "this should be an array not a string"
+        });
+        let result =
+            handle_graphql_response(original.clone(), Some(invalid_response), false, true).unwrap();
+        // With validation disabled, uses permissive serde deserialization instead of strict GraphQL validation
+        // Falls back to original response when serde deserialization fails (string can't deserialize to Vec<Error>)
+        assert_eq!(result.data, Some(json!({"test": "original"})));
+    }
+
+    #[test]
+    fn test_handle_graphql_response_validation_disabled_empty_response() {
+        let original = graphql::Response::builder()
+            .data(json!({"test": "original"}))
+            .build();
+
+        // Empty response violates GraphQL spec (must have data or errors) but should pass serde deserialization
+        let empty_response = json!({});
+        let result =
+            handle_graphql_response(original.clone(), Some(empty_response), false, true).unwrap();
+
+        // With validation disabled, empty response deserializes successfully via serde
+        // (all fields are optional with defaults), resulting in a response with no data/errors
+        assert_eq!(result.data, None);
+        assert_eq!(result.errors.len(), 0);
+    }
+
+    #[test]
+    fn test_handle_graphql_response_validation_enabled_empty_response() {
+        let original = graphql::Response::builder()
+            .data(json!({"test": "original"}))
+            .build();
+
+        // Empty response should fail strict GraphQL validation
+        let empty_response = json!({});
+        let result = handle_graphql_response(original.clone(), Some(empty_response), true, true);
+
+        // With validation enabled, should return error due to invalid GraphQL response structure
+        assert!(result.is_err());
+    }
+
+    // Helper function to create subgraph stage for validation tests
+    fn create_subgraph_stage_for_validation_test() -> SubgraphStage {
+        SubgraphStage {
+            request: Default::default(),
+            response: SubgraphResponseConf {
+                condition: Condition::True,
+                headers: true,
+                context: ContextConf::NewContextConf(NewContextConf::All),
+                body: true,
+                service_name: false,
+                status_code: false,
+                subgraph_request_id: false,
+            },
+        }
+    }
+
+    // Helper function to create mock subgraph service
+    fn create_mock_subgraph_service() -> MockSubgraphService {
+        let mut mock_subgraph_service = MockSubgraphService::new();
+        mock_subgraph_service
+            .expect_call()
+            .returning(|req: subgraph::Request| {
+                Ok(subgraph::Response::builder()
+                    .data(json!({ "test": 1234_u32 }))
+                    .errors(Vec::new())
+                    .extensions(Object::new())
+                    .subgraph_name("coprocessorMockSubgraph")
+                    .context(req.context)
+                    .id(req.id)
+                    .build())
+            });
+        mock_subgraph_service
+    }
+
+    // Helper functions for subgraph request validation tests
+    fn create_subgraph_stage_for_request_validation_test() -> SubgraphStage {
+        SubgraphStage {
+            request: SubgraphRequestConf {
+                condition: Condition::True,
+                headers: true,
+                context: ContextConf::NewContextConf(NewContextConf::All),
+                body: true,
+                uri: true,
+                method: true,
+                service_name: true,
+                subgraph_request_id: true,
+            },
+            response: Default::default(),
+        }
+    }
+
+    // Helper function to create mock http client that returns valid GraphQL break response
+    fn create_mock_http_client_subgraph_request_valid_response() -> MockInternalHttpClientService {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "SubgraphRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {
+                        "data": {"test": "valid_response"}
+                    }
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns empty GraphQL break response
+    fn create_mock_http_client_subgraph_request_empty_response() -> MockInternalHttpClientService {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "SubgraphRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {}
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns invalid GraphQL break response
+    fn create_mock_http_client_subgraph_request_invalid_response() -> MockInternalHttpClientService
+    {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let response = json!({
+                    "version": 1,
+                    "stage": "SubgraphRequest",
+                    "control": {
+                        "break": 400
+                    },
+                    "body": {
+                        "errors": "this should be an array not a string"
+                    }
+                });
+                Ok(http::Response::builder()
+                    .status(200)
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&response).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns valid GraphQL response
+    fn create_mock_http_client_subgraph_response_valid_response() -> MockInternalHttpClientService {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "SubgraphResponse",
+                    "control": "continue",
+                    "body": {
+                        "data": {"test": "valid_response"}
+                    }
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns empty GraphQL response
+    fn create_mock_http_client_subgraph_response_empty_response() -> MockInternalHttpClientService {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "SubgraphResponse",
+                    "control": "continue",
+                    "body": {}
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    // Helper function to create mock http client that returns invalid GraphQL response
+    fn create_mock_http_client_invalid_subgraph_response() -> MockInternalHttpClientService {
+        mock_with_callback(move |_: http::Request<RouterBody>| {
+            Box::pin(async {
+                let input = json!({
+                    "version": 1,
+                    "stage": "SubgraphResponse",
+                    "control": "continue",
+                    "body": {
+                        "errors": "this should be an array not a string"
+                    }
+                });
+                Ok(http::Response::builder()
+                    .body(router::body::from_bytes(
+                        serde_json::to_string(&input).unwrap(),
+                    ))
+                    .unwrap())
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_response_validation_disabled_invalid() {
+        let service = create_subgraph_stage_for_validation_test().as_service(
+            create_mock_http_client_invalid_subgraph_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            false, // Validation disabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, uses permissive serde deserialization instead of strict GraphQL validation
+        // Falls back to original response when serde deserialization fails (string can't deserialize to Vec<Error>)
+        assert_eq!(
+            &json!({ "test": 1234_u32 }),
+            res.response.body().data.as_ref().unwrap()
+        );
+    }
+
+    // ===== SUBGRAPH REQUEST VALIDATION TESTS =====
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_request_validation_enabled_valid() {
+        let service = create_subgraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_subgraph_request_valid_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            true, // Validation enabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 due to break with valid GraphQL response
+        assert_eq!(res.response.status(), 400);
+        assert_eq!(
+            &json!({"test": "valid_response"}),
+            res.response.body().data.as_ref().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_request_validation_enabled_empty() {
+        let service = create_subgraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_subgraph_request_empty_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            true, // Validation enabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with validation error since empty response violates GraphQL spec
+        assert_eq!(res.response.status(), 400);
+        assert!(!res.response.body().errors.is_empty());
+        assert!(
+            res.response.body().errors[0]
+                .message
+                .contains("couldn't deserialize coprocessor output body")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_request_validation_enabled_invalid() {
+        let service = create_subgraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_subgraph_request_invalid_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            true, // Validation enabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with validation error since errors should be array not string
+        assert_eq!(res.response.status(), 400);
+        assert!(!res.response.body().errors.is_empty());
+        assert!(
+            res.response.body().errors[0]
+                .message
+                .contains("couldn't deserialize coprocessor output body")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_request_validation_disabled_valid() {
+        let service = create_subgraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_subgraph_request_valid_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            false, // Validation disabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 due to break with valid response preserved via permissive deserialization
+        assert_eq!(res.response.status(), 400);
+        assert_eq!(
+            &json!({"test": "valid_response"}),
+            res.response.body().data.as_ref().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_request_validation_disabled_empty() {
+        let service = create_subgraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_subgraph_request_empty_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            false, // Validation disabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with empty response preserved via permissive deserialization
+        assert_eq!(res.response.status(), 400);
+        // Empty object deserializes to GraphQL response with no data/errors
+        assert_eq!(res.response.body().data, None);
+        assert_eq!(res.response.body().errors.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_request_validation_disabled_invalid() {
+        let service = create_subgraph_stage_for_request_validation_test().as_service(
+            create_mock_http_client_subgraph_request_invalid_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            false, // Validation disabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // Should return 400 with fallback to original response since invalid structure can't deserialize
+        assert_eq!(res.response.status(), 400);
+        // Falls back to original response since permissive deserialization fails too
+        assert!(res.response.body().data.is_some() || !res.response.body().errors.is_empty());
+    }
+
+    // ===== SUBGRAPH RESPONSE VALIDATION TESTS =====
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_response_validation_enabled_valid() {
+        let service = create_subgraph_stage_for_validation_test().as_service(
+            create_mock_http_client_subgraph_response_valid_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            true, // Validation enabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // With validation enabled, valid GraphQL response should be processed normally
+        assert_eq!(
+            &json!({"test": "valid_response"}),
+            res.response.body().data.as_ref().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_response_validation_enabled_empty() {
+        let service = create_subgraph_stage_for_validation_test().as_service(
+            create_mock_http_client_subgraph_response_empty_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            true, // Validation enabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+
+        // With validation enabled, empty response should cause service call to fail due to GraphQL validation
+        let result = service.oneshot(request).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_response_validation_enabled_invalid() {
+        let service = create_subgraph_stage_for_validation_test().as_service(
+            create_mock_http_client_invalid_subgraph_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            true, // Validation enabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+
+        // With validation enabled, invalid GraphQL response should cause service call to fail
+        let result = service.oneshot(request).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_response_validation_disabled_valid() {
+        let service = create_subgraph_stage_for_validation_test().as_service(
+            create_mock_http_client_subgraph_response_valid_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            false, // Validation disabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, valid response processed via permissive deserialization
+        assert_eq!(
+            &json!({"test": "valid_response"}),
+            res.response.body().data.as_ref().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn external_plugin_subgraph_response_validation_disabled_empty() {
+        let service = create_subgraph_stage_for_validation_test().as_service(
+            create_mock_http_client_subgraph_response_empty_response(),
+            create_mock_subgraph_service().boxed(),
+            "http://test".to_string(),
+            "my_subgraph_service_name".to_string(),
+            false, // Validation disabled
+        );
+
+        let request = subgraph::Request::fake_builder().build();
+        let res = service.oneshot(request).await.unwrap();
+
+        // With validation disabled, empty response deserializes successfully via serde
+        // (all fields are optional with defaults), resulting in a response with no data/errors
+        assert_eq!(res.response.body().data, None);
+        assert_eq!(res.response.body().errors.len(), 0);
+    }
+
     #[allow(clippy::type_complexity)]
     fn mock_with_callback(
         callback: fn(
@@ -2853,5 +3793,84 @@ mod tests {
         });
 
         mock_http_client
+    }
+
+    // Tests for conditional validation based on incoming payload validity
+
+    // Helper functions for readable tests
+    fn valid_response() -> crate::graphql::Response {
+        crate::graphql::Response::builder()
+            .data(json!({"field": "value"}))
+            .build()
+    }
+
+    fn valid_response_with_errors() -> crate::graphql::Response {
+        use crate::graphql::Error;
+        crate::graphql::Response::builder()
+            .errors(vec![
+                Error::builder()
+                    .message("error")
+                    .extension_code("TEST")
+                    .build(),
+            ])
+            .build()
+    }
+
+    fn invalid_response() -> crate::graphql::Response {
+        crate::graphql::Response::builder().build() // No data, no errors
+    }
+
+    fn valid_copro_body() -> Value {
+        json!({"data": {"field": "new_value"}})
+    }
+
+    fn invalid_copro_body() -> Value {
+        json!({}) // No data, no errors
+    }
+
+    #[test]
+    fn test_minimal_graphql_validation() {
+        assert!(is_graphql_response_minimally_valid(&valid_response()));
+        assert!(is_graphql_response_minimally_valid(
+            &valid_response_with_errors()
+        ));
+        assert!(!is_graphql_response_minimally_valid(&invalid_response()));
+    }
+
+    #[test]
+    fn test_was_incoming_payload_valid() {
+        // When body is not sent, always return true
+        assert!(was_incoming_payload_valid(&valid_response(), false));
+        assert!(was_incoming_payload_valid(&invalid_response(), false));
+
+        // When body is sent, check validity
+        assert!(was_incoming_payload_valid(&valid_response(), true));
+        assert!(!was_incoming_payload_valid(&invalid_response(), true));
+    }
+
+    #[test]
+    fn test_conditional_validation_logic() {
+        // Invalid incoming + validation enabled = validation bypassed (succeeds with invalid copro response)
+        assert!(
+            handle_graphql_response(invalid_response(), Some(invalid_copro_body()), true, false)
+                .is_ok()
+        );
+
+        // Valid incoming + validation enabled + invalid copro response = validation applied (fails)
+        assert!(
+            handle_graphql_response(valid_response(), Some(invalid_copro_body()), true, true)
+                .is_err()
+        );
+
+        // Valid incoming + validation enabled + valid copro response = validation applied (succeeds)
+        assert!(
+            handle_graphql_response(valid_response(), Some(valid_copro_body()), true, true).is_ok()
+        );
+
+        // Validation disabled = always bypassed (succeeds regardless)
+        assert!(
+            handle_graphql_response(valid_response(), Some(invalid_copro_body()), false, true)
+                .is_ok()
+        );
     }
 }

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_prints_messages_to_log@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_prints_messages_to_log@logs.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields:
+    target: ""
+  level: INFO
+  message: info log

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -269,13 +269,16 @@ fn it_logs_messages() {
 
 #[test]
 fn it_prints_messages_to_log() {
-    let _guard = tracing_test::dispatcher_guard();
+    use tracing::subscriber;
 
-    let engine = new_rhai_test_engine();
-    engine
-        .eval::<()>(r#"print("info log")"#)
-        .expect("it logged a message");
-    assert!(tracing_test::logs_contain("info log"));
+    use crate::assert_snapshot_subscriber;
+
+    subscriber::with_default(assert_snapshot_subscriber!(), || {
+        let engine = new_rhai_test_engine();
+        engine
+            .eval::<()>(r#"print("info log")"#)
+            .expect("it logged a message");
+    });
 }
 
 #[tokio::test]

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -714,11 +714,7 @@ async fn call_websocket(
     subscription_stream_tx.send(Box::pin(handle_stream)).await?;
 
     Ok(SubgraphResponse::new_from_response(
-        resp.map(|_| {
-            graphql::Response::builder()
-                .data(serde_json_bytes::Value::Null)
-                .build()
-        }),
+        resp.map(|_| graphql::Response::default()),
         context,
         service_name,
         subgraph_request_id,
@@ -2689,10 +2685,6 @@ mod tests {
             .await
             .unwrap();
         assert!(response.response.body().errors.is_empty());
-        assert_eq!(
-            response.response.body().data,
-            Some(serde_json_bytes::Value::Null)
-        );
 
         let mut gql_stream = rx_stream.next().await.unwrap();
         let message = gql_stream.next().await.unwrap();

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::fs;
 use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use buildstructor::buildstructor;
@@ -59,6 +61,7 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use uuid::Uuid;
 use wiremock::Mock;
 use wiremock::Respond;
@@ -66,6 +69,39 @@ use wiremock::ResponseTemplate;
 use wiremock::http::Method;
 use wiremock::matchers::method;
 use wiremock::matchers::path_regex;
+
+/// Global registry to keep track of allocated ports across all tests
+/// This helps avoid port conflicts between concurrent tests
+static ALLOCATED_PORTS: OnceLock<Arc<Mutex<HashMap<u16, String>>>> = OnceLock::new();
+
+fn get_allocated_ports() -> &'static Arc<Mutex<HashMap<u16, String>>> {
+    ALLOCATED_PORTS.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+}
+
+/// Allocate a port that's currently available
+/// The port is not actually bound, just marked as allocated to avoid conflicts
+fn allocate_port(name: &str) -> std::io::Result<u16> {
+    let ports_registry = get_allocated_ports();
+
+    // Try to find an available port
+    for _ in 0..100 {
+        // Try up to 100 times to find a port
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        drop(listener); // Release the port immediately
+
+        let mut ports = ports_registry.lock();
+        if let Entry::Vacant(e) = ports.entry(port) {
+            e.insert(name.to_string());
+            return Ok(port);
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AddrInUse,
+        "Could not find available port after 100 attempts",
+    ))
+}
 
 pub struct Query {
     traced: bool,
@@ -158,6 +194,7 @@ pub struct IntegrationTest {
     log: String,
     subgraph_context: Arc<Mutex<Option<SpanContext>>>,
     logs: Vec<String>,
+    port_replacements: HashMap<String, u16>,
 }
 
 impl IntegrationTest {
@@ -165,6 +202,84 @@ impl IntegrationTest {
         self.bind_address
             .lock()
             .expect("no bind address set, router must be started first.")
+    }
+
+    /// Reserve a port for use in the test and return it
+    /// The port placeholder will be immediately replaced in the config file
+    /// Panics if the placeholder is not found in the config
+    /// This helps avoid port conflicts between concurrent tests
+    #[allow(dead_code)]
+    pub fn reserve_address(&mut self, placeholder_name: &str) -> u16 {
+        let port = allocate_port(placeholder_name).expect("Failed to allocate port");
+        self.set_address(placeholder_name, port);
+        port
+    }
+
+    /// Reserve a specific port for use in the test
+    /// The port placeholder will be immediately replaced in the config file
+    /// Panics if the placeholder is not found in the config
+    #[allow(dead_code)]
+    pub fn set_address(&mut self, placeholder_name: &str, port: u16) {
+        // Read current config
+        let current_config = std::fs::read_to_string(&self.test_config_location)
+            .expect("Failed to read config file");
+
+        // Check if placeholder exists in config
+        let placeholder_pattern = format!("{{{{{}}}}}", placeholder_name);
+        let port_pattern = format!(":{{{{{}}}}}", placeholder_name);
+        let addr_pattern = format!("127.0.0.1:{{{{{}}}}}", placeholder_name);
+
+        if !current_config.contains(&placeholder_pattern)
+            && !current_config.contains(&port_pattern)
+            && !current_config.contains(&addr_pattern)
+        {
+            panic!(
+                "Placeholder '{}' not found in config file. Expected one of: '{}', '{}', or '{}'",
+                placeholder_name, placeholder_pattern, port_pattern, addr_pattern
+            );
+        }
+
+        // Store the replacement
+        self.port_replacements
+            .insert(placeholder_name.to_string(), port);
+
+        // Apply the replacement immediately
+        let updated_config = merge_overrides(
+            &current_config,
+            &self._subgraph_overrides,
+            None, // Don't override bind address here
+            &self.redis_namespace,
+            Some(&self.port_replacements),
+        );
+
+        std::fs::write(&self.test_config_location, updated_config)
+            .expect("Failed to write updated config");
+    }
+
+    /// Set an address placeholder using a URI, extracting the port automatically
+    /// This is a convenience method for the common pattern of extracting port from a server URI
+    #[allow(dead_code)]
+    pub fn set_address_from_uri(&mut self, placeholder_name: &str, uri: &str) {
+        let port = uri
+            .split(':')
+            .last()
+            .expect("URI should contain a port")
+            .parse::<u16>()
+            .expect("Port should be a valid u16");
+        self.set_address(placeholder_name, port);
+    }
+
+    /// Replace a string in the config file (for non-port replacements)
+    /// This is useful for dynamic config adjustments beyond port replacements
+    #[allow(dead_code)]
+    pub fn replace_config_string(&mut self, from: &str, to: &str) {
+        let current_config = std::fs::read_to_string(&self.test_config_location)
+            .expect("Failed to read config file");
+
+        let updated_config = current_config.replace(from, to);
+
+        std::fs::write(&self.test_config_location, updated_config)
+            .expect("Failed to write updated config");
     }
 }
 
@@ -421,7 +536,8 @@ impl IntegrationTest {
             .or_insert(url.clone());
 
         // Insert the overrides into the config
-        let config_str = merge_overrides(&config, &subgraph_overrides, None, &redis_namespace);
+        let config_str =
+            merge_overrides(&config, &subgraph_overrides, None, &redis_namespace, None);
 
         let supergraph = supergraph.unwrap_or(PathBuf::from_iter([
             "..",
@@ -499,6 +615,7 @@ impl IntegrationTest {
             log: log.unwrap_or_else(|| "error,apollo_router=info".to_owned()),
             subgraph_context,
             logs: vec![],
+            port_replacements: HashMap::new(),
         }
     }
 
@@ -632,6 +749,7 @@ impl IntegrationTest {
                 &self._subgraph_overrides,
                 Some(self.bind_address()),
                 &self.redis_namespace,
+                Some(&self.port_replacements),
             ),
         )
         .await
@@ -958,6 +1076,52 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
+    pub fn error_logs(&mut self) -> Vec<String> {
+        // Read any remaining logs from buffer
+        self.read_logs();
+
+        const JSON_ERROR_INDICATORS: [&str; 3] = ["\"level\":\"ERROR\"", "panic", "PANIC"];
+
+        let mut error_logs = Vec::new();
+        for line in &self.logs {
+            if JSON_ERROR_INDICATORS.iter().any(|err| line.contains(err))
+                || (line.contains("ERROR") && !line.contains("level"))
+            {
+                error_logs.push(line.clone());
+            }
+        }
+        error_logs
+    }
+    #[allow(dead_code)]
+    pub fn assert_no_error_logs(&mut self) {
+        let error_logs = self.error_logs();
+        if !error_logs.is_empty() {
+            panic!(
+                "Found {} unexpected error(s) in router logs:\n\n{}\n\nFull log dump:\n\n{}",
+                error_logs.len(),
+                error_logs.join("\n"),
+                self.logs.join("\n")
+            );
+        }
+    }
+    #[allow(dead_code)]
+    pub fn assert_no_error_logs_with_exceptions(&mut self, exceptions: &[&str]) {
+        let mut error_logs = self.error_logs();
+
+        // remove any logs that contain our exceptions
+        error_logs.retain(|line| !exceptions.iter().any(|exception| line.contains(exception)));
+        if !error_logs.is_empty() {
+            panic!(
+                "Found {} unexpected error(s) in router logs (excluding {} exceptions):\n\n{}\n\nFull log dump:\n\n{}",
+                error_logs.len(),
+                exceptions.len(),
+                error_logs.join("\n"),
+                self.logs.join("\n")
+            );
+        }
+    }
+
+    #[allow(dead_code)]
     /// Checks the metrics contain the supplied string in prometheus format.
     /// To allow checking of metrics where the value is not stable the magic tag `<any>` can be used.
     /// For example:
@@ -1200,12 +1364,33 @@ fn merge_overrides(
     subgraph_overrides: &HashMap<String, String>,
     bind_addr: Option<SocketAddr>,
     redis_namespace: &str,
+    port_replacements: Option<&HashMap<String, u16>>,
 ) -> String {
     let bind_addr = bind_addr
         .map(|a| a.to_string())
         .unwrap_or_else(|| "127.0.0.1:0".into());
+
+    // Apply port replacements to the YAML string first
+    let mut yaml_with_ports = yaml.to_string();
+    if let Some(port_replacements) = port_replacements {
+        for (placeholder, port) in port_replacements {
+            // Replace placeholder patterns like {{PLACEHOLDER_NAME}} with the actual port
+            let placeholder_pattern = format!("{{{{{}}}}}", placeholder);
+            yaml_with_ports = yaml_with_ports.replace(&placeholder_pattern, &port.to_string());
+
+            // Also replace patterns like :{{PLACEHOLDER_NAME}} with :port
+            let port_pattern = format!(":{{{{{}}}}}", placeholder);
+            yaml_with_ports = yaml_with_ports.replace(&port_pattern, &format!(":{}", port));
+
+            // Replace full address patterns like 127.0.0.1:{{PLACEHOLDER_NAME}}
+            let addr_pattern = format!("127.0.0.1:{{{{{}}}}}", placeholder);
+            yaml_with_ports =
+                yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{}", port));
+        }
+    }
+
     // Parse the config as yaml
-    let mut config: Value = serde_yaml::from_str(yaml).unwrap();
+    let mut config: Value = serde_yaml::from_str(&yaml_with_ports).unwrap();
 
     // Insert subgraph overrides, making sure to keep other overrides if present
     let overrides = subgraph_overrides
@@ -1320,4 +1505,24 @@ pub fn graph_os_enabled() -> bool {
         ),
         (Ok(_), Ok(_))
     )
+}
+
+/// Automatic tracing initialization using ctor for integration tests
+#[ctor::ctor]
+fn init_integration_test_tracing() {
+    // Initialize tracing for integration tests
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new("info,apollo_router=debug"))
+        .unwrap();
+
+    let _ = tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::Layer::default()
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_thread_names(false)
+                .compact()
+                .with_filter(filter),
+        )
+        .try_init();
 }

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -262,7 +262,7 @@ impl IntegrationTest {
     pub fn set_address_from_uri(&mut self, placeholder_name: &str, uri: &str) {
         let port = uri
             .split(':')
-            .last()
+            .next_back()
             .expect("URI should contain a port")
             .parse::<u16>()
             .expect("Port should be a valid u16");

--- a/apollo-router/tests/integration/mod.rs
+++ b/apollo-router/tests/integration/mod.rs
@@ -33,6 +33,7 @@ mod response_cache;
 mod redis;
 mod rhai;
 mod subscription_load_test;
+mod subscriptions;
 mod telemetry;
 mod validation;
 

--- a/apollo-router/tests/integration/rhai.rs
+++ b/apollo-router/tests/integration/rhai.rs
@@ -1,10 +1,6 @@
 use std::path::PathBuf;
 
-use apollo_router::TestHarness;
-use apollo_router::graphql;
-use apollo_router::services::supergraph;
 use serde_json::json;
-use tower::ServiceExt;
 
 use crate::integration::IntegrationTest;
 use crate::integration::common::Query;

--- a/apollo-router/tests/integration/rhai.rs
+++ b/apollo-router/tests/integration/rhai.rs
@@ -7,34 +7,6 @@ use crate::integration::common::Query;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn all_rhai_callbacks_are_invoked() {
-    // <<<<<<< HEAD
-    //     let (sender, receiver) = tokio::sync::oneshot::channel();
-    //     let mut router = IntegrationTest::builder()
-    //         .config(include_str!("fixtures/rhai_logging.router.yaml"))
-    //         .collect_stdio(sender)
-    // ||||||| parent of 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
-    //     let env_filter = "apollo_router=info";
-    //     let mock_writer = tracing_test::internal::MockWriter::new(tracing_test::internal::global_buf());
-    //     let subscriber = tracing_test::internal::get_subscriber(mock_writer, env_filter);
-
-    //     let _guard = tracing::dispatcher::set_default(&subscriber);
-
-    //     let config = serde_json::json!({
-    //         "rhai": {
-    //             "scripts": "tests/fixtures",
-    //             "main": "test_callbacks.rhai",
-    //         }
-    //     });
-    //     let router = TestHarness::builder()
-    //         .configuration_json(config)
-    //         .unwrap()
-    //         .schema(include_str!("../fixtures/supergraph.graphql"))
-    //         .build_router()
-    //         .await
-    //         .unwrap();
-    //     let request = supergraph::Request::fake_builder()
-    //         .query("{ topProducts { name } }")
-    // =======
     let config = r#"
 rhai:
   scripts: tests/fixtures
@@ -44,33 +16,11 @@ rhai:
     let mut router = IntegrationTest::builder()
         .config(config)
         .supergraph(PathBuf::from("tests/fixtures/supergraph.graphql"))
-        // >>>>>>> 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
         .build()
         .await;
 
     router.start().await;
     router.assert_started().await;
-    // <<<<<<< HEAD
-    //     router.execute_query(Query::default()).await;
-    //     router.graceful_shutdown().await;
-
-    //     let logs = receiver.await.expect("logs received");
-    // ||||||| parent of 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
-    //         .unwrap();
-    //     let _response: graphql::Response = serde_json::from_slice(
-    //         router
-    //             .oneshot(request.try_into().unwrap())
-    //             .await
-    //             .unwrap()
-    //             .next_response()
-    //             .await
-    //             .unwrap()
-    //             .unwrap()
-    //             .to_vec()
-    //             .as_slice(),
-    //     )
-    //     .unwrap();
-    // =======
 
     // Execute a query to trigger all the callbacks
     let (_trace_id, response) = router
@@ -88,7 +38,6 @@ rhai:
 
     // Read all the logs
     router.read_logs();
-    // >>>>>>> 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
 
     for expected_log in [
         "router_service setup",
@@ -103,16 +52,7 @@ rhai:
         "subgraph_service setup",
         "from_subgraph_request",
     ] {
-        // <<<<<<< HEAD
-        //         assert!(logs.contains(expected_log));
-        // ||||||| parent of 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
-        //         assert!(
-        //             tracing_test::internal::logs_with_scope_contain("apollo_router", expected_log),
-        //             "log not found: {expected_log}"
-        //         );
-        // =======
         router.assert_log_contained(expected_log);
-        // >>>>>>> 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
     }
 
     router.graceful_shutdown().await;

--- a/apollo-router/tests/integration/rhai.rs
+++ b/apollo-router/tests/integration/rhai.rs
@@ -1,21 +1,98 @@
+use std::path::PathBuf;
+
+use apollo_router::TestHarness;
+use apollo_router::graphql;
+use apollo_router::services::supergraph;
+use serde_json::json;
+use tower::ServiceExt;
+
 use crate::integration::IntegrationTest;
 use crate::integration::common::Query;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn all_rhai_callbacks_are_invoked() {
-    let (sender, receiver) = tokio::sync::oneshot::channel();
+    // <<<<<<< HEAD
+    //     let (sender, receiver) = tokio::sync::oneshot::channel();
+    //     let mut router = IntegrationTest::builder()
+    //         .config(include_str!("fixtures/rhai_logging.router.yaml"))
+    //         .collect_stdio(sender)
+    // ||||||| parent of 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
+    //     let env_filter = "apollo_router=info";
+    //     let mock_writer = tracing_test::internal::MockWriter::new(tracing_test::internal::global_buf());
+    //     let subscriber = tracing_test::internal::get_subscriber(mock_writer, env_filter);
+
+    //     let _guard = tracing::dispatcher::set_default(&subscriber);
+
+    //     let config = serde_json::json!({
+    //         "rhai": {
+    //             "scripts": "tests/fixtures",
+    //             "main": "test_callbacks.rhai",
+    //         }
+    //     });
+    //     let router = TestHarness::builder()
+    //         .configuration_json(config)
+    //         .unwrap()
+    //         .schema(include_str!("../fixtures/supergraph.graphql"))
+    //         .build_router()
+    //         .await
+    //         .unwrap();
+    //     let request = supergraph::Request::fake_builder()
+    //         .query("{ topProducts { name } }")
+    // =======
+    let config = r#"
+rhai:
+  scripts: tests/fixtures
+  main: test_callbacks.rhai
+"#;
+
     let mut router = IntegrationTest::builder()
-        .config(include_str!("fixtures/rhai_logging.router.yaml"))
-        .collect_stdio(sender)
+        .config(config)
+        .supergraph(PathBuf::from("tests/fixtures/supergraph.graphql"))
+        // >>>>>>> 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
         .build()
         .await;
 
     router.start().await;
     router.assert_started().await;
-    router.execute_query(Query::default()).await;
-    router.graceful_shutdown().await;
+    // <<<<<<< HEAD
+    //     router.execute_query(Query::default()).await;
+    //     router.graceful_shutdown().await;
 
-    let logs = receiver.await.expect("logs received");
+    //     let logs = receiver.await.expect("logs received");
+    // ||||||| parent of 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
+    //         .unwrap();
+    //     let _response: graphql::Response = serde_json::from_slice(
+    //         router
+    //             .oneshot(request.try_into().unwrap())
+    //             .await
+    //             .unwrap()
+    //             .next_response()
+    //             .await
+    //             .unwrap()
+    //             .unwrap()
+    //             .to_vec()
+    //             .as_slice(),
+    //     )
+    //     .unwrap();
+    // =======
+
+    // Execute a query to trigger all the callbacks
+    let (_trace_id, response) = router
+        .execute_query(
+            Query::builder()
+                .body(json!({
+                    "query": "{ topProducts { name } }",
+                    "variables": {}
+                }))
+                .build(),
+        )
+        .await;
+
+    assert!(response.status().is_success());
+
+    // Read all the logs
+    router.read_logs();
+    // >>>>>>> 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
 
     for expected_log in [
         "router_service setup",
@@ -30,8 +107,19 @@ async fn all_rhai_callbacks_are_invoked() {
         "subgraph_service setup",
         "from_subgraph_request",
     ] {
-        assert!(logs.contains(expected_log));
+        // <<<<<<< HEAD
+        //         assert!(logs.contains(expected_log));
+        // ||||||| parent of 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
+        //         assert!(
+        //             tracing_test::internal::logs_with_scope_contain("apollo_router", expected_log),
+        //             "log not found: {expected_log}"
+        //         );
+        // =======
+        router.assert_log_contained(expected_log);
+        // >>>>>>> 811ea8d58 (fix(coprocessor): improve handling of invalid GraphQL responses with conditional validation (#7731))
     }
+
+    router.graceful_shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/apollo-router/tests/integration/subscriptions/callback.rs
+++ b/apollo-router/tests/integration/subscriptions/callback.rs
@@ -1,0 +1,502 @@
+use tower::BoxError;
+
+use crate::integration::common::IntegrationTest;
+use crate::integration::common::graph_os_enabled;
+use crate::integration::subscriptions::CALLBACK_CONFIG;
+use crate::integration::subscriptions::CallbackTestState;
+use crate::integration::subscriptions::start_callback_server;
+use crate::integration::subscriptions::start_callback_subgraph_server;
+use crate::integration::subscriptions::start_callback_subgraph_server_with_payloads;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_callback() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+    let nb_events = 3;
+    let interval_ms = 100;
+
+    // Start callback server to receive router callbacks
+    let (callback_addr, callback_state) = start_callback_server().await;
+    let callback_url = format!("http://{}/callback", callback_addr);
+
+    // Start mock subgraph server that will send callbacks
+    let subgraph_server =
+        start_callback_subgraph_server(nb_events, interval_ms, callback_url.clone()).await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(CALLBACK_CONFIG)
+        .build()
+        .await;
+
+    // Reserve ports using the existing external ports and allocate new ones
+    let callback_receiver_port = callback_addr.port();
+    let _callback_listener_port = router.reserve_address("CALLBACK_LISTENER_PORT");
+    router.set_address("CALLBACK_RECEIVER_PORT", callback_receiver_port);
+    router.set_address_from_uri("SUBGRAPH_PORT", &subgraph_server.uri());
+
+    router.start().await;
+    router.assert_started().await;
+
+    let subscription_query = r#"subscription { userWasCreated(intervalMs: 100, nbEvents: 3) { name reviews { body } } }"#;
+
+    // Send subscription request to router
+    // For callback mode, we still need the subscription Accept header to indicate subscription support
+    let mut headers = std::collections::HashMap::new();
+    headers.insert(
+        "Accept".to_string(),
+        "multipart/mixed;subscriptionSpec=1.0".to_string(),
+    );
+
+    let query = crate::integration::common::Query::builder()
+        .body(serde_json::json!({
+            "query": subscription_query
+        }))
+        .headers(headers)
+        .build();
+
+    let (_trace_id, response) = router.execute_query(query).await;
+
+    // Router should respond with subscription acknowledgment
+    assert!(
+        response.status().is_success(),
+        "Subscription request failed: {}",
+        response.status()
+    );
+
+    // Wait for callbacks to be sent
+    tokio::time::sleep(tokio::time::Duration::from_millis(
+        (nb_events as u64 * interval_ms) + 1000,
+    ))
+    .await;
+
+    // Verify callbacks were received - expect default user events
+    let expected_user_events = vec![
+        serde_json::json!({
+            "name": "User 1",
+            "reviews": [{
+                "body": "Review 1 from user 1"
+            }]
+        }),
+        serde_json::json!({
+            "name": "User 2",
+            "reviews": [{
+                "body": "Review 2 from user 2"
+            }]
+        }),
+        serde_json::json!({
+            "name": "User 3",
+            "reviews": [{
+                "body": "Review 3 from user 3"
+            }]
+        }),
+    ];
+    verify_callback_events(&callback_state, expected_user_events).await?;
+
+    // Check for errors in router logs
+    router.assert_no_error_logs();
+
+    Ok(())
+}
+
+async fn verify_callback_events(
+    callback_state: &CallbackTestState,
+    expected_user_events: Vec<serde_json::Value>,
+) -> Result<(), BoxError> {
+    use pretty_assertions::assert_eq;
+
+    let callbacks = callback_state.received_callbacks.lock().unwrap().clone();
+
+    // Should have received: expected_user_events.len() "next" callbacks + 1 "complete" callback
+    let next_callbacks: Vec<_> = callbacks.iter().filter(|c| c.action == "next").collect();
+    let complete_callbacks: Vec<_> = callbacks
+        .iter()
+        .filter(|c| c.action == "complete")
+        .collect();
+
+    // Note: We don't check next_callbacks.len() == expected_user_events.len()
+    // because some callbacks may not have userWasCreated data (e.g., pure error payloads)
+
+    assert_eq!(
+        complete_callbacks.len(),
+        1,
+        "Expected 1 'complete' callback, got {}. All callbacks: {:?}",
+        complete_callbacks.len(),
+        callbacks
+    );
+
+    // Extract userWasCreated events for validation
+    let mut actual_user_events = Vec::new();
+    for callback in &next_callbacks {
+        if let Some(payload) = &callback.payload {
+            if let Some(data) = payload.get("data") {
+                if let Some(user_created) = data.get("userWasCreated") {
+                    actual_user_events.push(user_created.clone());
+                }
+                // If there's a data field but no userWasCreated, it's an empty/error case
+            }
+            // If there's no data field (pure error payload), we don't extract anything
+        }
+    }
+
+    // Simple equality comparison using pretty_assertions
+    assert_eq!(
+        actual_user_events, expected_user_events,
+        "Callback user events do not match expected events"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_callback_error_scenarios() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+    // Test 1: Invalid callback payload (missing fields)
+    let (callback_addr, callback_state) = start_callback_server().await;
+
+    let client = reqwest::Client::new();
+    let callback_url = format!("http://{}/callback/test-id", callback_addr);
+
+    // Test invalid payload - missing required fields
+    let invalid_payload = serde_json::json!({
+        "kind": "subscription",
+        "action": "next"
+        // Missing: id, verifier
+    });
+
+    let response = client
+        .post(&callback_url)
+        .json(&invalid_payload)
+        .send()
+        .await?;
+
+    // Should return 422 Unprocessable Entity for malformed JSON payload (missing required fields)
+    assert_eq!(response.status(), 422, "Invalid payload should return 422");
+
+    // Test 2: ID mismatch between URL and payload
+    let mismatched_payload = serde_json::json!({
+        "kind": "subscription",
+        "action": "next",
+        "id": "different-id",
+        "verifier": "test-verifier"
+    });
+
+    let response = client
+        .post(&callback_url)
+        .json(&mismatched_payload)
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), 400, "ID mismatch should return 400");
+
+    // Test 3: Subscription not found (404 scenarios)
+    let valid_payload = serde_json::json!({
+        "kind": "subscription",
+        "action": "check",
+        "id": "test-id",
+        "verifier": "test-verifier"
+    });
+
+    let response = client
+        .post(&callback_url)
+        .json(&valid_payload)
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        404,
+        "Unknown subscription should return 404"
+    );
+
+    // Test 4: Add subscription ID and test success scenarios
+    {
+        let mut ids = callback_state.subscription_ids.lock().unwrap();
+        ids.push("test-id".to_string());
+    }
+
+    // Now check should succeed
+    let response = client
+        .post(&callback_url)
+        .json(&valid_payload)
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), 204, "Valid check should return 204");
+
+    // Test 5: Test heartbeat with mixed valid/invalid IDs
+    let heartbeat_payload = serde_json::json!({
+        "kind": "subscription",
+        "action": "heartbeat",
+        "id": "test-id",
+        "ids": ["test-id", "invalid-id"],
+        "verifier": "test-verifier"
+    });
+
+    let response = client
+        .post(&callback_url)
+        .json(&heartbeat_payload)
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        404,
+        "Heartbeat with invalid IDs should return 404"
+    );
+
+    // Test 6: Test heartbeat with all valid IDs
+    let valid_heartbeat_payload = serde_json::json!({
+        "kind": "subscription",
+        "action": "heartbeat",
+        "id": "test-id",
+        "ids": ["test-id"],
+        "verifier": "test-verifier"
+    });
+
+    let response = client
+        .post(&callback_url)
+        .json(&valid_heartbeat_payload)
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), 204, "Valid heartbeat should return 204");
+
+    // Test 7: Test completion callback
+    let complete_payload = serde_json::json!({
+        "kind": "subscription",
+        "action": "complete",
+        "id": "test-id",
+        "verifier": "test-verifier"
+    });
+
+    let response = client
+        .post(&callback_url)
+        .json(&complete_payload)
+        .send()
+        .await?;
+
+    assert_eq!(response.status(), 202, "Valid completion should return 202");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_callback_error_payload() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+    let interval_ms = 100;
+
+    // Create custom payloads: one normal event, one error event (no body, empty errors)
+    let custom_payloads = vec![
+        serde_json::json!({
+            "data": {
+                "userWasCreated": {
+                    "name": "User 1",
+                    "reviews": [{
+                        "body": "Review 1 from user 1"
+                    }]
+                }
+            }
+        }),
+        serde_json::json!({
+            "data": {
+                "userWasCreated": {
+                    "name": "User 2"
+                    // Missing reviews field to test error handling
+                }
+            },
+            "errors": []
+        }),
+    ];
+
+    // Start callback server to receive router callbacks
+    let (callback_addr, callback_state) = start_callback_server().await;
+    let callback_url = format!("http://{}/callback", callback_addr);
+
+    // Start mock subgraph server with custom payloads
+    let subgraph_server = start_callback_subgraph_server_with_payloads(
+        custom_payloads.clone(),
+        interval_ms,
+        callback_url.clone(),
+    )
+    .await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(CALLBACK_CONFIG)
+        .build()
+        .await;
+
+    // Reserve ports using the existing external ports and allocate new ones
+    let callback_receiver_port = callback_addr.port();
+    let _callback_listener_port = router.reserve_address("CALLBACK_LISTENER_PORT");
+    router.set_address("CALLBACK_RECEIVER_PORT", callback_receiver_port);
+    router.set_address_from_uri("SUBGRAPH_PORT", &subgraph_server.uri());
+
+    router.start().await;
+    router.assert_started().await;
+
+    let subscription_query = r#"subscription { userWasCreated(intervalMs: 100, nbEvents: 2) { name reviews { body } } }"#;
+
+    // Send subscription request to router
+    let mut headers = std::collections::HashMap::new();
+    headers.insert(
+        "Accept".to_string(),
+        "multipart/mixed;subscriptionSpec=1.0".to_string(),
+    );
+
+    let query = crate::integration::common::Query::builder()
+        .body(serde_json::json!({
+            "query": subscription_query
+        }))
+        .headers(headers)
+        .build();
+
+    let (_trace_id, response) = router.execute_query(query).await;
+
+    // Router should respond with subscription acknowledgment
+    assert!(
+        response.status().is_success(),
+        "Subscription request failed: {}",
+        response.status()
+    );
+
+    // Wait for callbacks to be sent
+    tokio::time::sleep(tokio::time::Duration::from_millis(
+        (custom_payloads.len() as u64 * interval_ms) + 1000,
+    ))
+    .await;
+
+    // Verify callbacks were received - expect the exact user events from custom payloads
+    let expected_user_events = vec![
+        serde_json::json!({
+            "name": "User 1",
+            "reviews": [{
+                "body": "Review 1 from user 1"
+            }]
+        }),
+        serde_json::json!({
+            "name": "User 2"
+            // Missing reviews field to test error handling
+        }),
+    ];
+    verify_callback_events(&callback_state, expected_user_events).await?;
+
+    // Check for errors in router logs
+    router.assert_no_error_logs();
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_callback_pure_error_payload() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+    let interval_ms = 100;
+
+    // Create custom payloads: one normal event, one pure error event (no data, only errors)
+    let custom_payloads = vec![
+        serde_json::json!({
+            "data": {
+                "userWasCreated": {
+                    "name": "User 1",
+                    "reviews": [{
+                        "body": "Review 1 from user 1"
+                    }]
+                }
+            }
+        }),
+        serde_json::json!({
+            "errors": []
+            // No data attribute at all
+        }),
+    ];
+
+    // Start callback server to receive router callbacks
+    let (callback_addr, callback_state) = start_callback_server().await;
+    let callback_url = format!("http://{}/callback", callback_addr);
+
+    // Start mock subgraph server with custom payloads
+    let subgraph_server = start_callback_subgraph_server_with_payloads(
+        custom_payloads.clone(),
+        interval_ms,
+        callback_url.clone(),
+    )
+    .await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(CALLBACK_CONFIG)
+        .build()
+        .await;
+
+    // Reserve ports using the existing external ports and allocate new ones
+    let callback_receiver_port = callback_addr.port();
+    let _callback_listener_port = router.reserve_address("CALLBACK_LISTENER_PORT");
+    router.set_address("CALLBACK_RECEIVER_PORT", callback_receiver_port);
+    router.set_address_from_uri("SUBGRAPH_PORT", &subgraph_server.uri());
+
+    router.start().await;
+    router.assert_started().await;
+
+    let subscription_query = r#"subscription { userWasCreated(intervalMs: 100, nbEvents: 2) { name reviews { body } } }"#;
+
+    // Send subscription request to router
+    let mut headers = std::collections::HashMap::new();
+    headers.insert(
+        "Accept".to_string(),
+        "multipart/mixed;subscriptionSpec=1.0".to_string(),
+    );
+
+    let query = crate::integration::common::Query::builder()
+        .body(serde_json::json!({
+            "query": subscription_query
+        }))
+        .headers(headers)
+        .build();
+
+    let (_trace_id, response) = router.execute_query(query).await;
+
+    // Router should respond with subscription acknowledgment
+    assert!(
+        response.status().is_success(),
+        "Subscription request failed: {}",
+        response.status()
+    );
+
+    // Wait for callbacks to be sent
+    tokio::time::sleep(tokio::time::Duration::from_millis(
+        (custom_payloads.len() as u64 * interval_ms) + 1000,
+    ))
+    .await;
+
+    // Verify callbacks were received - expect only 1 user event since second callback has no userWasCreated data
+    let expected_user_events = vec![
+        serde_json::json!({
+            "name": "User 1",
+            "reviews": [{
+                "body": "Review 1 from user 1"
+            }]
+        }),
+        // Second callback has no userWasCreated data (pure error payload), so nothing is extracted from it
+    ];
+    verify_callback_events(&callback_state, expected_user_events).await?;
+
+    // Check for errors in router logs
+    router.assert_no_error_logs();
+
+    Ok(())
+}

--- a/apollo-router/tests/integration/subscriptions/fixtures/callback.router.yaml
+++ b/apollo-router/tests/integration/subscriptions/fixtures/callback.router.yaml
@@ -1,0 +1,26 @@
+supergraph:
+  listen: 127.0.0.1:4000
+  path: /
+  introspection: true
+homepage:
+  enabled: false
+sandbox:
+  enabled: true
+override_subgraph_url:
+  accounts: http://localhost:{{SUBGRAPH_PORT}}
+include_subgraph_errors:
+  all: true
+subscription:
+  enabled: true
+  mode:
+    callback:
+      public_url: "http://localhost:{{CALLBACK_RECEIVER_PORT}}/callback"
+      listen: "127.0.0.1:{{CALLBACK_LISTENER_PORT}}"
+      path: "/callback" 
+      heartbeat_interval: 5s
+      subgraphs: ["accounts"]
+headers:
+  all:
+    request:
+      - propagate:
+          named: custom_id

--- a/apollo-router/tests/integration/subscriptions/fixtures/subscription.router.yaml
+++ b/apollo-router/tests/integration/subscriptions/fixtures/subscription.router.yaml
@@ -1,0 +1,28 @@
+supergraph:
+  listen: 127.0.0.1:4000
+  path: /
+  introspection: true
+homepage:
+  enabled: false
+sandbox:
+  enabled: true
+override_subgraph_url:
+  products: http://localhost:{{PRODUCTS_PORT}}
+  accounts: http://localhost:{{ACCOUNTS_PORT}}
+include_subgraph_errors:
+  all: true
+subscription:
+  enabled: true
+  mode:
+    passthrough:
+      all:
+        path: /ws
+      subgraphs:
+        rng:
+          path: /ws
+          protocol: graphql_transport_ws
+headers:
+  all: # Header rules for all subgraphs
+    request:
+      - propagate:
+          named: custom_id

--- a/apollo-router/tests/integration/subscriptions/fixtures/subscription_coprocessor.router.yaml
+++ b/apollo-router/tests/integration/subscriptions/fixtures/subscription_coprocessor.router.yaml
@@ -1,0 +1,60 @@
+supergraph:
+  listen: 127.0.0.1:4000
+  path: /
+  introspection: true
+homepage:
+  enabled: false
+sandbox:
+  enabled: true
+override_subgraph_url:
+  products: http://localhost:{{PRODUCTS_PORT}}
+  accounts: http://localhost:{{ACCOUNTS_PORT}}
+include_subgraph_errors:
+  all: true
+subscription:
+  enabled: true
+  mode:
+    passthrough:
+      all:
+        path: /ws
+      subgraphs:
+        accounts:
+          path: /ws
+          protocol: graphql_transport_ws
+coprocessor:
+  url: http://localhost:{{COPROCESSOR_PORT}}
+  timeout: 30s
+  router:
+    request:
+      headers: true
+      body: true
+    response:
+      headers: true
+      body: true
+  supergraph:
+    request:
+      headers: true
+      body: true
+    response:
+      headers: true
+      body: true
+  execution:
+    request:
+      headers: true
+      body: true
+    response:
+      headers: true
+      body: true
+  subgraph:
+    all:
+      request:
+        headers: true
+        body: true
+      response:
+        headers: true
+        body: true
+headers:
+  all: # Header rules for all subgraphs
+    request:
+      - propagate:
+          named: custom_id

--- a/apollo-router/tests/integration/subscriptions/fixtures/supergraph.graphql
+++ b/apollo-router/tests/integration/subscriptions/fixtures/supergraph.graphql
@@ -1,0 +1,120 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+  subscription: Subscription
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+scalar link__Import
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://localhost:4001/graphql")
+  INVENTORY
+    @join__graph(name: "inventory", url: "http://localhost:4002/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://localhost:4003/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://localhost:4004/graphql")
+}
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Subscription @join__type(graph: ACCOUNTS) {
+  userWasCreated(intervalMs: Int, nbEvents: Int): User
+    @join__field(graph: ACCOUNTS)
+}
+
+type Mutation @join__type(graph: PRODUCTS) @join__type(graph: REVIEWS) {
+  createProduct(upc: ID!, name: String): Product @join__field(graph: PRODUCTS)
+  createReview(upc: ID!, id: ID!, body: String): Review
+    @join__field(graph: REVIEWS)
+}
+
+type Product
+  @join__type(graph: ACCOUNTS, key: "upc", extension: true)
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: PRODUCTS, key: "upc")
+  @join__type(graph: REVIEWS, key: "upc") {
+  upc: String!
+  weight: Int
+    @join__field(graph: INVENTORY, external: true)
+    @join__field(graph: PRODUCTS)
+  price: Int
+    @join__field(graph: INVENTORY, external: true)
+    @join__field(graph: PRODUCTS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  name: String @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  reviewsForAuthor(authorID: ID!): [Review] @join__field(graph: REVIEWS)
+}
+
+type Query
+  @join__type(graph: ACCOUNTS)
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS) {
+  me: User @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  body: String @join__field(graph: REVIEWS)
+  product: Product @join__field(graph: REVIEWS)
+}
+
+type User
+  @join__type(graph: ACCOUNTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  name: String @join__field(graph: ACCOUNTS)
+  createdAt: String @join__field(graph: ACCOUNTS)
+  username: String
+    @join__field(graph: ACCOUNTS)
+    @join__field(graph: REVIEWS, external: true)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -304,7 +304,8 @@ async fn websocket_handler(
 ) -> Response {
     debug!("WebSocket upgrade requested");
     debug!("Headers: {:?}", headers);
-    ws.on_upgrade(move |socket| handle_websocket(socket, config))
+    ws.protocols(["graphql-ws"])
+        .on_upgrade(move |socket| handle_websocket(socket, config))
 }
 
 async fn handle_websocket(mut socket: WebSocket, config: SubscriptionServerConfig) {

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -1,0 +1,691 @@
+//! Common subscription testing functionality
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use axum::Router;
+use axum::extract::State;
+use axum::extract::ws::WebSocket;
+use axum::extract::ws::WebSocketUpgrade;
+use axum::http::HeaderMap;
+use axum::http::StatusCode;
+use axum::response::Response;
+use axum::routing::get;
+use axum::routing::post;
+use futures::StreamExt;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::json;
+use tracing::debug;
+use tracing::info;
+use tracing::warn;
+use wiremock::Mock;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+
+pub mod callback;
+pub mod ws_passthrough;
+
+#[derive(Clone)]
+struct SubscriptionServerConfig {
+    payloads: Vec<serde_json::Value>,
+    interval_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CallbackPayload {
+    pub kind: String,
+    pub action: String,
+    pub id: String,
+    pub verifier: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub errors: Option<Vec<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ids: Option<Vec<String>>,
+}
+
+#[derive(Clone)]
+pub struct CallbackTestState {
+    pub received_callbacks: Arc<Mutex<Vec<CallbackPayload>>>,
+    pub subscription_ids: Arc<Mutex<Vec<String>>>,
+}
+
+impl Default for CallbackTestState {
+    fn default() -> Self {
+        Self {
+            received_callbacks: Arc::new(Mutex::new(Vec::new())),
+            subscription_ids: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+pub const SUBSCRIPTION_CONFIG: &str = include_str!("fixtures/subscription.router.yaml");
+pub const SUBSCRIPTION_COPROCESSOR_CONFIG: &str =
+    include_str!("fixtures/subscription_coprocessor.router.yaml");
+pub const CALLBACK_CONFIG: &str = include_str!("fixtures/callback.router.yaml");
+pub fn create_sub_query(interval_ms: u64, nb_events: usize) -> String {
+    format!(
+        r#"subscription {{  userWasCreated(intervalMs: {}, nbEvents: {}) {{    name reviews {{ body }} }}}}"#,
+        interval_ms, nb_events
+    )
+}
+
+pub async fn start_subscription_server_with_payloads(
+    payloads: Vec<serde_json::Value>,
+    interval_ms: u64,
+) -> (SocketAddr, wiremock::MockServer) {
+    let config = SubscriptionServerConfig {
+        payloads,
+        interval_ms,
+    };
+
+    // Start WebSocket server using axum
+    let app = Router::new()
+        .route("/ws", get(websocket_handler))
+        .route("/", get(|| async { "WebSocket server running" }))
+        .fallback(|uri: axum::http::Uri| async move {
+            debug!("Fallback route hit: {}", uri);
+            "Not found"
+        })
+        .with_state(config);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let ws_addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        info!("Starting axum WebSocket server...");
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Wait a moment for the server to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    info!("Axum server running on {}", ws_addr);
+
+    // Start HTTP mock server for regular GraphQL queries
+    let http_server = wiremock::MockServer::start().await;
+
+    // Mock regular GraphQL queries (non-subscription)
+    Mock::given(method("POST"))
+        .respond_with(|req: &wiremock::Request| {
+            let body = req
+                .body_json::<serde_json::Value>()
+                .unwrap_or_else(|_| json!({}));
+
+            if let Some(query) = body.get("query").and_then(|q| q.as_str()) {
+                // Don't handle subscriptions here - they go through WebSocket
+                if !query.contains("subscription") {
+                    return ResponseTemplate::new(200).set_body_json(json!({
+                        "data": {
+                            "_entities": [{
+                                "name": "Test User",
+                                "username": "testuser"
+                            }]
+                        }
+                    }));
+                }
+            }
+
+            // For subscription queries over HTTP, redirect to WebSocket
+            ResponseTemplate::new(400).set_body_json(json!({
+                "errors": [{
+                    "message": "Subscriptions must use WebSocket"
+                }]
+            }))
+        })
+        .mount(&http_server)
+        .await;
+
+    (ws_addr, http_server)
+}
+
+pub async fn start_coprocessor_server() -> wiremock::MockServer {
+    let coprocessor_server = wiremock::MockServer::start().await;
+
+    // Create a coprocessor that echoes back what it receives
+    Mock::given(method("POST"))
+        .respond_with(|req: &wiremock::Request| {
+            // Echo back the request body as the response
+            let body = req.body.clone();
+            debug!(
+                "Coprocessor received request: {}",
+                String::from_utf8_lossy(&body)
+            );
+
+            ResponseTemplate::new(200)
+                .set_body_bytes(body)
+                .append_header("content-type", "application/json")
+        })
+        .mount(&coprocessor_server)
+        .await;
+
+    info!(
+        "Coprocessor server started at: {}",
+        coprocessor_server.uri()
+    );
+    coprocessor_server
+}
+
+pub async fn verify_subscription_events(
+    mut stream: impl futures::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Unpin,
+    expected_events: Vec<serde_json::Value>,
+) -> Result<Vec<serde_json::Value>, String> {
+    use pretty_assertions::assert_eq;
+
+    let mut subscription_events = Vec::new();
+
+    // Set a longer timeout for receiving all events
+    let timeout = tokio::time::timeout(tokio::time::Duration::from_secs(60), async {
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| format!("Stream error: {}", e))?;
+            let chunk_str = String::from_utf8_lossy(&chunk);
+
+            debug!("Received chunk: {}", chunk_str);
+
+            // Parse multipart chunks that contain GraphQL data
+            if chunk_str.contains("content-type: application/json") {
+                // Extract JSON from multipart response
+                if let Some(json_start) = chunk_str.find('{') {
+                    if let Some(json_end) = chunk_str.rfind('}') {
+                        let json_str = &chunk_str[json_start..=json_end];
+
+                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str) {
+                            // Store the raw parsed response without any transformation
+                            subscription_events.push(parsed.clone());
+                            info!(
+                                "Received subscription event {}: {}",
+                                subscription_events.len(),
+                                parsed
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Break when we receive the completion marker
+            if chunk_str.contains("--graphql--") {
+                debug!(
+                    "Breaking on completion marker with {} events received",
+                    subscription_events.len()
+                );
+                break;
+            }
+
+            // If we've received more events than expected, that's an error
+            if subscription_events.len() > expected_events.len() {
+                let extra_event = subscription_events.last().unwrap();
+                return Err(format!(
+                    "Received {} events but only expected {}. Extra events should not arrive after termination.\nUnexpected event: {}",
+                    subscription_events.len(),
+                    expected_events.len(),
+                    serde_json::to_string_pretty(extra_event)
+                        .unwrap_or_else(|_| format!("{:?}", extra_event))
+                ));
+            }
+        }
+        Ok::<(), String>(())
+    });
+
+    timeout
+        .await
+        .map_err(|_| "Subscription test timed out".to_string())??;
+
+    // If we haven't received all expected events, wait a bit more and check for late arrivals
+    if subscription_events.len() < expected_events.len() {
+        return Err(format!(
+            "Received {} events but expected {}. Stream may have terminated early.",
+            subscription_events.len(),
+            expected_events.len()
+        ));
+    }
+
+    // Give the stream a moment to ensure it's properly terminated and no more events arrive
+    let termination_timeout = tokio::time::timeout(
+        tokio::time::Duration::from_millis(1000),
+        async {
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.map_err(|e| format!("Stream error: {}", e))?;
+                let chunk_str = String::from_utf8_lossy(&chunk);
+
+                // Only check for actual data events, ignore heartbeats/keep-alives
+                if chunk_str.contains("content-type: application/json") {
+                    if let Some(json_start) = chunk_str.find('{') {
+                        if let Some(json_end) = chunk_str.rfind('}') {
+                            let json_str = &chunk_str[json_start..=json_end];
+                            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str)
+                            {
+                                let data = parsed
+                                    .get("data")
+                                    .or_else(|| parsed.get("payload").and_then(|p| p.get("data")));
+                                if data.is_some() {
+                                    return Err(format!(
+                                        "Unexpected additional event received after {} expected events: {}",
+                                        expected_events.len(),
+                                        chunk_str
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if chunk_str.contains("--graphql--") {
+                    debug!("Stream properly terminated with completion marker");
+                    break;
+                }
+            }
+            Ok::<(), String>(())
+        },
+    );
+
+    // It's OK if this times out - it means no additional events arrived
+    let _ = termination_timeout.await;
+
+    // Simple equality comparison using pretty_assertions
+    assert_eq!(
+        subscription_events, expected_events,
+        "Subscription events do not match expected events"
+    );
+
+    info!(
+        "✅ Successfully verified {} subscription events",
+        subscription_events.len()
+    );
+
+    Ok(subscription_events)
+}
+
+async fn websocket_handler(
+    State(config): State<SubscriptionServerConfig>,
+    ws: WebSocketUpgrade,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    debug!("WebSocket upgrade requested");
+    debug!("Headers: {:?}", headers);
+    ws.on_upgrade(move |socket| handle_websocket(socket, config))
+}
+
+async fn handle_websocket(mut socket: WebSocket, config: SubscriptionServerConfig) {
+    info!("WebSocket connection established");
+    while let Some(msg) = socket.recv().await {
+        if let Ok(msg) = msg {
+            match msg {
+                axum::extract::ws::Message::Text(text) => {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
+                        match parsed.get("type").and_then(|t| t.as_str()) {
+                            Some("connection_init") => {
+                                // Send connection_ack
+                                let ack = json!({
+                                    "type": "connection_ack"
+                                });
+                                if socket
+                                    .send(axum::extract::ws::Message::text(
+                                        serde_json::to_string(&ack).unwrap(),
+                                    ))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            Some("start") => {
+                                let id = parsed.get("id").and_then(|i| i.as_str()).unwrap_or("1");
+
+                                // Handle subscription
+                                if let Some(payload) = parsed.get("payload") {
+                                    if let Some(query) =
+                                        payload.get("query").and_then(|q| q.as_str())
+                                    {
+                                        if query.contains("userWasCreated") {
+                                            let interval_ms = config.interval_ms;
+                                            let payloads = &config.payloads;
+
+                                            info!(
+                                                "Starting subscription with {} events, interval {}ms (configured)",
+                                                payloads.len(),
+                                                interval_ms
+                                            );
+
+                                            // Give the router time to fully establish the subscription stream
+                                            tokio::time::sleep(tokio::time::Duration::from_millis(
+                                                100,
+                                            ))
+                                            .await;
+
+                                            // Send multiple subscription events
+                                            for (i, custom_payload) in payloads.iter().enumerate() {
+                                                // Always send exactly what we're given - no transformation
+                                                let event_data = json!({
+                                                    "id": id,
+                                                    "type": "data",
+                                                    "payload": custom_payload
+                                                });
+
+                                                if socket
+                                                    .send(axum::extract::ws::Message::text(
+                                                        serde_json::to_string(&event_data).unwrap(),
+                                                    ))
+                                                    .await
+                                                    .is_err()
+                                                {
+                                                    return;
+                                                }
+
+                                                debug!(
+                                                    "Sent subscription event {}/{}",
+                                                    i + 1,
+                                                    payloads.len()
+                                                );
+
+                                                // Wait between events
+                                                if i < payloads.len() - 1 {
+                                                    tokio::time::sleep(
+                                                        tokio::time::Duration::from_millis(
+                                                            interval_ms,
+                                                        ),
+                                                    )
+                                                    .await;
+                                                }
+                                            }
+
+                                            // Send completion
+                                            let complete = json!({
+                                                "id": id,
+                                                "type": "complete"
+                                            });
+                                            if socket
+                                                .send(axum::extract::ws::Message::text(
+                                                    serde_json::to_string(&complete).unwrap(),
+                                                ))
+                                                .await
+                                                .is_err()
+                                            {
+                                                return;
+                                            }
+
+                                            info!(
+                                                "Completed subscription with {} events",
+                                                payloads.len()
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                            Some("stop") => {
+                                // Handle stop message
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                axum::extract::ws::Message::Close(_) => break,
+                _ => {}
+            }
+        }
+    }
+}
+
+pub async fn start_callback_server() -> (SocketAddr, CallbackTestState) {
+    let state = CallbackTestState::default();
+    let app_state = state.clone();
+
+    let app = Router::new()
+        .route("/callback/:id", post(handle_callback))
+        .route("/callback", post(handle_callback_no_id))
+        .route("/", get(|| async { "Callback server running" }))
+        .with_state(app_state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        info!("Starting callback server...");
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    info!("Callback server running on {}", addr);
+
+    (addr, state)
+}
+
+async fn handle_callback(
+    State(state): State<CallbackTestState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    headers: HeaderMap,
+    axum::extract::Json(payload): axum::extract::Json<CallbackPayload>,
+) -> StatusCode {
+    debug!("Received callback for subscription {}: {:?}", id, payload);
+    debug!("Headers: {:?}", headers);
+
+    if payload.id != id {
+        warn!("ID mismatch: URL={}, payload={}", id, payload.id);
+        return StatusCode::BAD_REQUEST;
+    }
+
+    {
+        let mut callbacks = state.received_callbacks.lock().unwrap();
+        callbacks.push(payload.clone());
+    }
+
+    match payload.action.as_str() {
+        "check" => {
+            let ids = state.subscription_ids.lock().unwrap();
+            if ids.contains(&payload.id) {
+                StatusCode::NO_CONTENT
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        }
+        "next" | "complete" => {
+            let ids = state.subscription_ids.lock().unwrap();
+            if ids.contains(&payload.id) {
+                if payload.action == "next" {
+                    StatusCode::OK
+                } else {
+                    StatusCode::ACCEPTED
+                }
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        }
+        "heartbeat" => {
+            let ids = state.subscription_ids.lock().unwrap();
+            let all_valid = payload
+                .ids
+                .as_ref()
+                .is_none_or(|callback_ids| callback_ids.iter().all(|id| ids.contains(id)));
+
+            if all_valid {
+                StatusCode::NO_CONTENT
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        }
+        _ => StatusCode::BAD_REQUEST,
+    }
+}
+
+async fn handle_callback_no_id(
+    State(state): State<CallbackTestState>,
+    headers: HeaderMap,
+    axum::extract::Json(payload): axum::extract::Json<CallbackPayload>,
+) -> StatusCode {
+    debug!("Received callback without ID: {:?}", payload);
+    debug!("Headers: {:?}", headers);
+
+    {
+        let mut callbacks = state.received_callbacks.lock().unwrap();
+        callbacks.push(payload.clone());
+    }
+
+    match payload.action.as_str() {
+        "heartbeat" => StatusCode::NO_CONTENT,
+        _ => StatusCode::BAD_REQUEST,
+    }
+}
+
+pub async fn start_callback_subgraph_server(
+    nb_events: usize,
+    interval_ms: u64,
+    callback_url: String,
+) -> wiremock::MockServer {
+    start_callback_subgraph_server_with_payloads(
+        generate_default_payloads(nb_events),
+        interval_ms,
+        callback_url,
+    )
+    .await
+}
+
+pub async fn start_callback_subgraph_server_with_payloads(
+    payloads: Vec<serde_json::Value>,
+    interval_ms: u64,
+    callback_url: String,
+) -> wiremock::MockServer {
+    let server = wiremock::MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .respond_with(move |req: &wiremock::Request| {
+            let body = req
+                .body_json::<serde_json::Value>()
+                .unwrap_or_else(|_| json!({}));
+
+            if let Some(query) = body.get("query").and_then(|q| q.as_str()) {
+                if query.contains("subscription") && query.contains("userWasCreated") {
+                    let extensions = body.get("extensions");
+                    let subscription_ext = extensions.and_then(|e| e.get("subscription"));
+
+                    if let Some(sub_ext) = subscription_ext {
+                        let subscription_id = sub_ext
+                            .get("subscriptionId")
+                            .and_then(|id| id.as_str())
+                            .unwrap_or("test-sub-id");
+                        let callback_url = sub_ext
+                            .get("callbackUrl")
+                            .and_then(|url| url.as_str())
+                            .unwrap_or(&callback_url);
+
+                        info!(
+                            "Subgraph received subscription request with callback URL: {}",
+                            callback_url
+                        );
+                        info!("Subscription ID: {}", subscription_id);
+
+                        tokio::spawn(send_callback_events_with_payloads(
+                            callback_url.to_string(),
+                            subscription_id.to_string(),
+                            payloads.clone(),
+                            interval_ms,
+                        ));
+
+                        return ResponseTemplate::new(200).set_body_json(json!({
+                            "data": {
+                                "userWasCreated": null
+                            }
+                        }));
+                    }
+                }
+
+                return ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {
+                        "_entities": [{
+                            "name": "Test User",
+                            "username": "testuser"
+                        }]
+                    }
+                }));
+            }
+
+            ResponseTemplate::new(400).set_body_json(json!({
+                "errors": [{
+                    "message": "Invalid request"
+                }]
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    info!("Callback subgraph server started at: {}", server.uri());
+    server
+}
+
+pub fn generate_default_payloads(nb_events: usize) -> Vec<serde_json::Value> {
+    (1..=nb_events)
+        .map(|i| {
+            json!({
+                "data": {
+                    "userWasCreated": {
+                        "name": format!("User {}", i),
+                        "reviews": [{
+                            "body": format!("Review {} from user {}", i, i)
+                        }]
+                    }
+                }
+            })
+        })
+        .collect()
+}
+
+async fn send_callback_events_with_payloads(
+    callback_url: String,
+    subscription_id: String,
+    payloads: Vec<serde_json::Value>,
+    interval_ms: u64,
+) {
+    let client = reqwest::Client::new();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    for (i, custom_payload) in payloads.iter().enumerate() {
+        let payload = CallbackPayload {
+            kind: "subscription".to_string(),
+            action: "next".to_string(),
+            id: subscription_id.clone(),
+            verifier: "test-verifier".to_string(),
+            payload: Some(custom_payload.clone()),
+            errors: None,
+            ids: None,
+        };
+
+        let response = client.post(&callback_url).json(&payload).send().await;
+
+        match response {
+            Ok(resp) => debug!(
+                "Sent callback event {}/{}, status: {}",
+                i + 1,
+                payloads.len(),
+                resp.status()
+            ),
+            Err(e) => warn!("Failed to send callback event {}: {}", i + 1, e),
+        }
+
+        if i < payloads.len() - 1 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(interval_ms)).await;
+        }
+    }
+
+    let complete_payload = CallbackPayload {
+        kind: "subscription".to_string(),
+        action: "complete".to_string(),
+        id: subscription_id.clone(),
+        verifier: "test-verifier".to_string(),
+        payload: None,
+        errors: None,
+        ids: None,
+    };
+
+    let response = client
+        .post(&callback_url)
+        .json(&complete_payload)
+        .send()
+        .await;
+
+    match response {
+        Ok(resp) => info!("Sent completion callback, status: {}", resp.status()),
+        Err(e) => warn!("Failed to send completion callback: {}", e),
+    }
+}

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -434,7 +434,7 @@ pub async fn start_callback_server() -> (SocketAddr, CallbackTestState) {
     let app_state = state.clone();
 
     let app = Router::new()
-        .route("/callback/:id", post(handle_callback))
+        .route("/callback/{id}", post(handle_callback))
         .route("/callback", post(handle_callback_no_id))
         .route("/", get(|| async { "Callback server running" }))
         .with_state(app_state);

--- a/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
+++ b/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
@@ -1,0 +1,546 @@
+use tower::BoxError;
+use tracing::info;
+
+use crate::integration::common::IntegrationTest;
+use crate::integration::common::graph_os_enabled;
+use crate::integration::subscriptions::SUBSCRIPTION_CONFIG;
+use crate::integration::subscriptions::SUBSCRIPTION_COPROCESSOR_CONFIG;
+use crate::integration::subscriptions::create_sub_query;
+use crate::integration::subscriptions::start_coprocessor_server;
+use crate::integration::subscriptions::start_subscription_server_with_payloads;
+use crate::integration::subscriptions::verify_subscription_events;
+
+/// Creates an expected subscription event payload for the given user number
+fn create_expected_user_payload(user_num: u32) -> serde_json::Value {
+    serde_json::json!({
+    "payload": {
+        "data": {
+            "userWasCreated": {
+                "name": format!("User {}", user_num),
+                "reviews": [{"body": format!("Review {} from user {}", user_num, user_num)}]
+            }
+        }
+    }
+    })
+}
+
+/// Creates an expected subscription event payload with null userWasCreated (for empty/error payloads)
+fn create_expected_null_payload() -> serde_json::Value {
+    serde_json::json!({
+    "payload": {
+        "data": {
+            "userWasCreated": null
+        }
+    }
+    })
+}
+
+/// Creates an expected subscription event payload for a user with missing reviews field (becomes null)
+fn create_expected_user_payload_missing_reviews(user_num: u32) -> serde_json::Value {
+    serde_json::json!({
+    "payload": {
+        "data": {
+            "userWasCreated": {
+                "name": format!("User {}", user_num),
+                "reviews": null // Missing reviews field gets transformed to null
+            }
+        }
+    }
+    })
+}
+
+/// Creates an expected subscription event payload for a user with missing reviews field (becomes null) and error
+fn create_expected_partial_error_payload(user_num: u32) -> serde_json::Value {
+    serde_json::json!({
+    "payload": {
+        "data": {
+            "userWasCreated": {
+                "name": format!("User {}", user_num),
+                "reviews": null // Missing reviews field gets transformed to null
+            }
+        },
+        "errors": [
+            {
+                "message": "Internal error handling deferred response",
+                "extensions": {
+                    "code": "INTERNAL_ERROR"
+                }
+            }
+        ]
+    }
+    })
+}
+
+/// Creates an expected subscription event payload for a user with missing reviews field (becomes null) and error
+fn create_expected_error_payload() -> serde_json::Value {
+    serde_json::json!({
+    "payload": {
+        "data": {
+            "userWasCreated": null
+        }
+    },
+    "errors": [{
+        "message": "Internal error handling deferred response",
+        "extensions": {"code": "INTERNAL_ERROR"}
+    }]
+    })
+}
+
+/// Creates the initial empty subscription response
+fn create_initial_empty_response() -> serde_json::Value {
+    serde_json::json!({})
+}
+
+// Input payload helpers (what we send to the mock WebSocket server)
+
+/// Creates a GraphQL data payload for a user (sent to mock server)
+fn create_user_data_payload(user_num: u32) -> serde_json::Value {
+    serde_json::json!({
+    "data": {
+        "userWasCreated": {
+            "name": format!("User {}", user_num),
+            "reviews": [{
+                "body": format!("Review {} from user {}", user_num, user_num)
+            }]
+        }
+    }
+    })
+}
+
+/// Creates a GraphQL data payload with missing reviews field (sent to mock server)
+fn create_user_data_payload_missing_reviews(user_num: u32) -> serde_json::Value {
+    serde_json::json!({
+    "data": {
+        "userWasCreated": {
+            "name": format!("User {}", user_num)
+            // Missing reviews field to test error handling
+        }
+    },
+    "errors": []
+    })
+}
+
+/// Creates an empty payload (sent to mock server)
+fn create_empty_data_payload() -> serde_json::Value {
+    serde_json::json!({
+        // No data attribute at all
+    })
+}
+
+/// Creates an expected error response payload (sent to mock server)
+fn create_partial_error_payload(user_num: u32) -> serde_json::Value {
+    serde_json::json!({
+    "data": {
+        "userWasCreated": {
+            "name": format!("User {}", user_num),
+        }
+    },
+    "errors": [
+        {
+            "message": "Internal error handling deferred response",
+            "extensions": {
+                "code": "INTERNAL_ERROR"
+            }
+        }
+    ]
+    })
+}
+
+/// Creates an expected error response payload (sent to mock server)
+fn create_error_payload() -> serde_json::Value {
+    serde_json::json!({
+    "data": {
+        "userWasCreated": null
+    },
+    "errors": [
+        {
+            "message": "Internal error handling deferred response",
+            "extensions": {
+                "code": "INTERNAL_ERROR"
+            }
+        }
+    ]
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_ws_passthrough() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+
+    // Create fixed payloads for consistent testing
+    let custom_payloads = vec![create_user_data_payload(1), create_user_data_payload(2)];
+    let interval_ms = 10;
+
+    // Start subscription server with fixed payloads
+    let (ws_addr, http_server) =
+        start_subscription_server_with_payloads(custom_payloads.clone(), interval_ms).await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(SUBSCRIPTION_CONFIG)
+        .build()
+        .await;
+
+    // Configure URLs using the string replacement method
+    let ws_url = format!("ws://{}/ws", ws_addr);
+    router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
+    router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
+    router.replace_config_string("rng:", "accounts:");
+
+    info!("WebSocket server started at: {}", ws_url);
+
+    router.start().await;
+    router.assert_started().await;
+
+    // Use the configured query that matches our server configuration
+    let query = create_sub_query(interval_ms, custom_payloads.len());
+    let (_, response) = router.run_subscription(&query).await;
+
+    // Expect the router to handle the subscription successfully
+    assert!(
+        response.status().is_success(),
+        "Subscription request failed with status: {}",
+        response.status()
+    );
+
+    let stream = response.bytes_stream();
+    let expected_events = vec![
+        create_initial_empty_response(),
+        create_expected_user_payload(1),
+        create_expected_user_payload(2),
+    ];
+    let _subscription_events = verify_subscription_events(stream, expected_events)
+        .await
+        .map_err(|e| format!("Event verification failed: {}", e))?;
+
+    // Check for errors in router logs
+    router.assert_no_error_logs();
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_ws_passthrough_with_coprocessor() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+    // Create fixed payloads for this test (different from first test)
+    let custom_payloads = vec![create_user_data_payload(1), create_user_data_payload(2)];
+    let interval_ms = 10;
+
+    // Start subscription server and coprocessor
+    let (ws_addr, http_server) =
+        start_subscription_server_with_payloads(custom_payloads.clone(), interval_ms).await;
+    let coprocessor_server = start_coprocessor_server().await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(SUBSCRIPTION_COPROCESSOR_CONFIG)
+        .build()
+        .await;
+
+    // Configure URLs using the string replacement method
+    let ws_url = format!("ws://{}/ws", ws_addr);
+    router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
+    router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
+    router.replace_config_string(
+        "http://localhost:{{COPROCESSOR_PORT}}",
+        &coprocessor_server.uri(),
+    );
+    router.replace_config_string("rng:", "accounts:");
+
+    info!("WebSocket server started at: {}", ws_url);
+    info!(
+        "Coprocessor server started at: {}",
+        coprocessor_server.uri()
+    );
+
+    router.start().await;
+    router.assert_started().await;
+
+    // Use the configured query that matches our server configuration
+    let query = create_sub_query(interval_ms, custom_payloads.len());
+    let (_, response) = router.run_subscription(&query).await;
+
+    // Expect the router to handle the subscription successfully
+    assert!(
+        response.status().is_success(),
+        "Subscription request failed with status: {}",
+        response.status()
+    );
+
+    let stream = response.bytes_stream();
+    // Now we're storing raw responses, so expect the actual multipart response structure
+    // First event is an empty object (subscription initialization), followed by data events
+    let expected_events = vec![
+        create_initial_empty_response(),
+        create_expected_user_payload(1),
+        create_expected_user_payload(2),
+    ];
+
+    let _subscription_events = verify_subscription_events(stream, expected_events)
+        .await
+        .map_err(|e| format!("Event verification failed: {}", e))?;
+
+    // Check for errors in router logs (allow expected coprocessor error)
+    router.assert_no_error_logs();
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_ws_passthrough_error_payload() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+    // Create custom payloads: one normal event, one error event (no reviews field)
+    let custom_payloads = vec![
+        create_user_data_payload(1),
+        create_user_data_payload_missing_reviews(2),
+    ];
+    let interval_ms = 10;
+
+    // Start subscription server with custom payloads
+    let (ws_addr, http_server) =
+        start_subscription_server_with_payloads(custom_payloads.clone(), interval_ms).await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(SUBSCRIPTION_CONFIG)
+        .build()
+        .await;
+
+    // Configure URLs using the string replacement method
+    let ws_url = format!("ws://{}/ws", ws_addr);
+    router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
+    router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
+    router.replace_config_string("rng:", "accounts:");
+
+    info!("WebSocket server started at: {}", ws_url);
+
+    router.start().await;
+    router.assert_started().await;
+
+    let subscription_query = create_sub_query(interval_ms, custom_payloads.len());
+
+    let response = router
+        .execute_query(
+            crate::integration::common::Query::builder()
+                .body(serde_json::json!({
+                    "query": subscription_query
+                }))
+                .headers(std::collections::HashMap::from([(
+                    "Accept".to_string(),
+                    "multipart/mixed;subscriptionSpec=1.0".to_string(),
+                )]))
+                .build(),
+        )
+        .await;
+
+    assert!(
+        response.1.status().is_success(),
+        "Subscription request failed with status: {}",
+        response.1.status()
+    );
+
+    let stream = response.1.bytes_stream();
+    // Now we're storing raw responses, so expect the actual multipart response structure
+    // First event is an empty object (subscription initialization), followed by data events
+    let expected_events = vec![
+        create_initial_empty_response(),
+        create_expected_user_payload(1),
+        create_expected_user_payload_missing_reviews(2),
+    ];
+    let _subscription_events = verify_subscription_events(stream, expected_events)
+        .await
+        .map_err(|e| format!("Event verification failed: {}", e))?;
+
+    // Check for errors in router logs
+    router.assert_no_error_logs();
+
+    Ok(())
+}
+
+// We have disabled this test because this test is failing for reasons that are understood, but are now preventing us from doing other fixes. We will ensure this is fixed by tracking this in the attached ticket as a follow up on its own PR.
+// The bug is basically an inconsistency in the way we're returning an error, sometimes it's consider as a critical error, sometimes not.
+#[ignore = "ROUTER-1343"]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_ws_passthrough_pure_error_payload() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+    // Create custom payloads: one normal event, one partial error event (data and errors), one pure error event (no data, only errors)
+    let custom_payloads = vec![
+        create_user_data_payload(1),
+        create_partial_error_payload(2),
+        create_error_payload(),
+    ];
+    let interval_ms = 10;
+
+    // Start subscription server with custom payloads
+    let (ws_addr, http_server) =
+        start_subscription_server_with_payloads(custom_payloads.clone(), interval_ms).await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(SUBSCRIPTION_CONFIG)
+        .build()
+        .await;
+
+    // Configure URLs using the string replacement method
+    let ws_url = format!("ws://{}/ws", ws_addr);
+    router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
+    router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
+    router.replace_config_string("rng:", "accounts:");
+
+    info!("WebSocket server started at: {}", ws_url);
+
+    router.start().await;
+    router.assert_started().await;
+
+    let subscription_query = create_sub_query(interval_ms, custom_payloads.len());
+
+    let response = router
+        .execute_query(
+            crate::integration::common::Query::builder()
+                .body(serde_json::json!({
+                    "query": subscription_query
+                }))
+                .headers(std::collections::HashMap::from([(
+                    "Accept".to_string(),
+                    "multipart/mixed;subscriptionSpec=1.0".to_string(),
+                )]))
+                .build(),
+        )
+        .await;
+
+    assert!(
+        response.1.status().is_success(),
+        "Subscription request failed with status: {}",
+        response.1.status()
+    );
+
+    let stream = response.1.bytes_stream();
+    // Now we're storing raw responses, so expect the actual multipart response structure
+    // First event is an empty object (subscription initialization), followed by data events
+    let expected_events = vec![
+        create_initial_empty_response(),
+        create_expected_user_payload(1),
+        create_expected_partial_error_payload(2),
+        create_expected_error_payload(),
+    ];
+    let _subscription_events = verify_subscription_events(stream, expected_events)
+        .await
+        .map_err(|e| format!("Event verification failed: {}", e))?;
+
+    // Check for errors in router logs
+    router.assert_no_error_logs();
+
+    Ok(())
+}
+
+// We have disabled this test because this test is failing for reasons that are understood, but are now preventing us from doing other fixes. We will ensure this is fixed by tracking this in the attached ticket as a follow up on its own PR.
+// The bug is basically an inconsistency in the way we're returning an error, sometimes it's consider as a critical error, sometimes not.
+#[ignore = "ROUTER-1343"]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_ws_passthrough_pure_error_payload_with_coprocessor()
+-> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+    // Create custom payloads: one normal event, one pure error event (no data, only errors)
+    let custom_payloads = vec![
+        create_user_data_payload(1),
+        create_empty_data_payload(), // Missing required "data" or "errors" field
+        create_user_data_payload(2), // This event is received successfully
+        create_partial_error_payload(3),
+        create_error_payload(),
+    ];
+    let interval_ms = 10;
+
+    // Start subscription server and coprocessor
+    let (ws_addr, http_server) =
+        start_subscription_server_with_payloads(custom_payloads.clone(), interval_ms).await;
+    let coprocessor_server = start_coprocessor_server().await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(SUBSCRIPTION_COPROCESSOR_CONFIG)
+        .build()
+        .await;
+
+    // Configure URLs using the string replacement method
+    let ws_url = format!("ws://{}/ws", ws_addr);
+    router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
+    router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
+    router.replace_config_string(
+        "http://localhost:{{COPROCESSOR_PORT}}",
+        &coprocessor_server.uri(),
+    );
+    router.replace_config_string("rng:", "accounts:");
+
+    info!("WebSocket server started at: {}", ws_url);
+    info!(
+        "Coprocessor server started at: {}",
+        coprocessor_server.uri()
+    );
+
+    router.start().await;
+    router.assert_started().await;
+
+    let subscription_query = create_sub_query(interval_ms, custom_payloads.len());
+
+    let response = router
+        .execute_query(
+            crate::integration::common::Query::builder()
+                .body(serde_json::json!({
+                    "query": subscription_query
+                }))
+                .headers(std::collections::HashMap::from([(
+                    "Accept".to_string(),
+                    "multipart/mixed;subscriptionSpec=1.0".to_string(),
+                )]))
+                .build(),
+        )
+        .await;
+
+    assert!(
+        response.1.status().is_success(),
+        "Subscription request failed with status: {}",
+        response.1.status()
+    );
+
+    let stream = response.1.bytes_stream();
+
+    // Now we're storing raw responses, so expect the actual multipart response structure
+    // First event is an empty object (subscription initialization), followed by data events
+    // The coprocessor processes all events successfully (router transforms empty payloads to valid GraphQL)
+    let expected_events = vec![
+        create_initial_empty_response(),
+        create_expected_user_payload(1),
+        create_expected_null_payload(),
+        create_expected_user_payload(2),
+        create_expected_partial_error_payload(3),
+        create_expected_error_payload(),
+    ];
+    let _subscription_events = verify_subscription_events(stream, expected_events)
+        .await
+        .map_err(|e| format!("Event verification failed: {}", e))?;
+
+    // Check for errors in router logs
+    router.assert_no_error_logs();
+
+    Ok(())
+}


### PR DESCRIPTION
## Task

Fix handling of invalid GraphQL responses returned from coprocessors, particularly when used with subscriptions. Added conditional response validation and improved testing to ensure correctness.

## Why this change is needed

The router was creating invalid GraphQL responses internally, especially when subscriptions terminate. When a coprocessor is configured, it validates all responses for correctness, causing errors to be logged when the router generates invalid internal responses. This affects the reliability of subscription workflows with coprocessors.

## How it was tackled

### Coprocessor response validation improvements
- Added conditional response validation that only validates coprocessor responses when the incoming payload was valid
- Added `response_validation` configuration option (defaults to true) for backward compatibility
- Improved handling of invalid responses to prevent validation failures on already-invalid data

### Subscription integration tests
- **WebSocket passthrough tests**: Mock server using axum with GraphQL-WS protocol, tests connection lifecycle and streaming behavior
- **HTTP callback tests**: Mock callback and subgraph servers, tests subscription lifecycle through HTTP callbacks with error scenarios
- Tests cover normal operation, error payloads, pure error responses, and coprocessor integration
- Added consistent event verification and error logging detection

### Documentation updates
- Added comprehensive documentation for the `response_validation` configuration option
- Documented use cases, behavior differences, and migration guidance

## Technical details

- Conditional validation prevents failures on responses that were already invalid before coprocessor processing
- `ENABLE_CONDITIONAL_VALIDATION` const controls the new behavior (set to true)
- `was_incoming_payload_valid()` function checks if original response was minimally valid
- Added comprehensive test coverage for all coprocessor stages with validation enabled/disabled

## Suggested review strategy

- Examine conditional validation logic in `handle_graphql_response()` function in coprocessor/mod.rs
- Review `was_incoming_payload_valid()` implementation for payload validity checking
- Check callback server HTTP protocol implementation in subscription test files
- Validate test coverage for coprocessor validation scenarios across all pipeline stages
- Review documentation accuracy for the new `response_validation` configuration option
<!-- [ROUTER-1345] -->

<hr>This is an automatic backport of pull request #7731 done by [Mergify](https://mergify.com).

[ROUTER-1345]: https://apollographql.atlassian.net/browse/ROUTER-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ