### PR TITLE
response_cache: get rid of useless comments and clone

### DIFF
--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -1109,7 +1109,6 @@ fn get_invalidation_root_keys_from_schema(
 
             let mut vars = IndexMap::default();
             vars.insert("$args".to_string(), Value::Object(args));
-            // TODO: it doesn't handle default values for args? or can we just leave it as it will always be the same default value ?
             cache_keys
                 .map(|ck| Ok(ck.interpolate(&vars).map(|(res, _)| res)?))
                 .collect::<Result<Vec<String>, anyhow::Error>>()
@@ -1147,9 +1146,9 @@ async fn cache_lookup_entities(
         .get_multiple(
             &cache_metadata
                 .iter()
-                .map(|k| k.cache_key.clone())
-                .collect::<Vec<String>>(),
-        ) // TODO: probably something better to do than cloning the keys
+                .map(|k| k.cache_key.as_str())
+                .collect::<Vec<&str>>(),
+        )
         .await
         .map(|res| {
             res.into_iter()
@@ -2044,7 +2043,6 @@ async fn insert_entities_in_result(
 
                 // Only in debug mode
                 if let Some(subgraph_request) = &subgraph_request {
-                    // debug_subgraph_request = Some(request.subgraph_request.body().clone());
                     debug_ctx_entries.push(CacheKeyContext {
                         invalidation_keys: invalidation_keys.clone(),
                         kind: CacheEntryKind::Entity {
@@ -2143,7 +2141,6 @@ pub(crate) struct CacheKeyContext {
     pub(super) invalidation_keys: Vec<String>,
     pub(super) kind: CacheEntryKind,
     pub(super) subgraph_name: String,
-    // TODO: it should be optional when it's a cached entity it doesn't make sense to have it
     pub(super) subgraph_request: graphql::Request,
     pub(super) status: CacheKeyStatus,
     pub(super) cache_control: CacheControl,

--- a/apollo-router/src/plugins/response_cache/postgres.rs
+++ b/apollo-router/src/plugins/response_cache/postgres.rs
@@ -341,7 +341,7 @@ impl PostgresCacheStorage {
 
     pub(crate) async fn get_multiple(
         &self,
-        cache_keys: &[String],
+        cache_keys: &[&str],
     ) -> anyhow::Result<Vec<Option<CacheEntry>>> {
         let cache_keys: Vec<_> = cache_keys.iter().map(|ck| self.namespaced(ck)).collect();
         let resp = sqlx::query_as!(


### PR DESCRIPTION
First TODO about default values is already implemented and the second one for the config is something we don't need anymore. It will still be useful to show in the debugger