### PR TITLE
feat(federation/composition): Port `validate_transition()`

### DIFF
--- a/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
+++ b/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
@@ -1,13 +1,20 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast;
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable;
+use itertools::Itertools;
 use petgraph::graph::EdgeIndex;
 
 use crate::bail;
+use crate::composition::satisfiability::validation_state::ValidationState;
 use crate::ensure;
+use crate::error::CompositionError;
 use crate::error::FederationError;
-use crate::error::SingleFederationError;
 use crate::operation::FieldSelection;
 use crate::operation::InlineFragment;
 use crate::operation::InlineFragmentSelection;
@@ -22,15 +29,20 @@ use crate::schema::ValidFederationSchema;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
+use crate::supergraph::CompositionHint;
 use crate::utils::MultiIndexMap;
+use crate::utils::human_readable::HumanReadableListOptions;
+use crate::utils::human_readable::HumanReadableListPrefix;
+use crate::utils::human_readable::human_readable_list;
+use crate::utils::human_readable::human_readable_subgraph_names;
 
 /// Returns a satisfiability error in Ok case; Otherwise, returns another error in Err case.
 #[allow(dead_code)]
-fn satisfiability_error(
+pub(super) fn satisfiability_error(
     unsatisfiable_path: &TransitionGraphPath,
-    _subgraphs_paths: &[TransitionGraphPath],
+    _subgraphs_paths: &[&TransitionGraphPath],
     subgraphs_paths_unadvanceables: &[Unadvanceables],
-    errors: &mut Vec<SingleFederationError>,
+    errors: &mut Vec<CompositionError>,
 ) -> Result<(), FederationError> {
     let witness = build_witness_operation(unsatisfiable_path)?;
     let operation = witness.to_string();
@@ -43,7 +55,125 @@ fn satisfiability_error(
     );
     // PORT_NOTE: We're not using `_subgraphs_paths` parameter, since we didn't port
     //            the `ValidationError` class, yet.
-    errors.push(SingleFederationError::SatisfiabilityError { message });
+    errors.push(CompositionError::SatisfiabilityError { message });
+    Ok(())
+}
+
+pub(super) fn shareable_field_non_intersecting_runtime_types_error(
+    invalid_state: &ValidationState,
+    field_definition_position: &FieldDefinitionPosition,
+    runtime_types_to_subgraphs: &IndexMap<Arc<BTreeSet<Name>>, IndexSet<Arc<str>>>,
+    errors: &mut Vec<CompositionError>,
+) -> Result<(), FederationError> {
+    let witness = build_witness_operation(invalid_state.supergraph_path())?;
+    let operation = witness.to_string();
+    let type_strings = runtime_types_to_subgraphs
+        .iter()
+        .map(|(runtime_types, subgraphs)| {
+            format!(
+                " - in {}, {}",
+                human_readable_subgraph_names(subgraphs.iter()),
+                human_readable_list(
+                    runtime_types
+                        .iter()
+                        .map(|runtime_type| format!("\"{}\"", runtime_type)),
+                    HumanReadableListOptions {
+                        prefix: Some(HumanReadableListPrefix {
+                            singular: "type",
+                            plural: "types",
+                        }),
+                        empty_output: "no runtime type is defined",
+                        ..Default::default()
+                    }
+                )
+            )
+        })
+        .join(";\n");
+    let field = field_definition_position
+        .get(invalid_state.supergraph_path().graph().schema()?.schema())?;
+    let message = format!(
+        "For the following supergraph API query:\n\
+        {}\n\
+        Shared field \"{}\" return type \"{}\" has a non-intersecting set of possible runtime \
+        types across subgraphs. Runtime types in subgraphs are:\n\
+        {}.\n\
+        This is not allowed as shared fields must resolve the same way in all subgraphs, and that \
+        implies at least some common runtime types between the subgraphs.",
+        operation,
+        field_definition_position,
+        field.ty.inner_named_type(),
+        type_strings,
+    );
+    errors.push(CompositionError::ShareableHasMismatchedRuntimeTypes { message });
+    Ok(())
+}
+
+pub(super) fn shareable_field_mismatched_runtime_types_hint(
+    state: &ValidationState,
+    field_definition_position: &FieldDefinitionPosition,
+    common_runtime_types: &BTreeSet<Name>,
+    runtime_types_per_subgraphs: &IndexMap<Arc<str>, Arc<BTreeSet<Name>>>,
+    hints: &mut Vec<CompositionHint>,
+) -> Result<(), FederationError> {
+    let witness = build_witness_operation(state.supergraph_path())?;
+    let operation = witness.to_string();
+    let all_subgraphs = state.current_subgraph_names()?;
+    fn print_types(types: impl Iterator<Item = impl AsRef<str>>) -> String {
+        human_readable_list(
+            types.map(|t| format!("\"{}\"", t.as_ref())),
+            HumanReadableListOptions {
+                prefix: Some(HumanReadableListPrefix {
+                    singular: "type",
+                    plural: "types",
+                }),
+                ..Default::default()
+            },
+        )
+    }
+    let subgraphs_with_type_not_in_intersection_string = all_subgraphs
+        .iter()
+        .map(|subgraph| {
+            let Some(runtime_types) = runtime_types_per_subgraphs.get(subgraph) else {
+                bail!("Unexpectedly no runtime types for path's tail's subgraph");
+            };
+            let types_to_not_implement = runtime_types
+                .iter()
+                .filter(|type_name| !common_runtime_types.contains(*type_name))
+                .collect::<Vec<_>>();
+            if types_to_not_implement.is_empty() {
+                return Ok::<_, FederationError>(None);
+            };
+            Ok(Some(format!(
+                " - subgraph \"{}\" should never resolve \"{}\" to an object of {}",
+                subgraph,
+                field_definition_position,
+                print_types(types_to_not_implement.into_iter()),
+            )))
+        })
+        .process_results(|iter| iter.flatten().join(";\n"))?;
+    let field =
+        field_definition_position.get(state.supergraph_path().graph().schema()?.schema())?;
+    let message = format!(
+        "For the following supergraph API query:\n\
+        {}\n\
+        Shared field \"{}\" return type \"{}\" has different sets of possible runtime types across \
+        subgraphs.\n\
+        Since a shared field must be resolved the same way in all subgraphs, make sure that {} \
+        only resolve \"{}\" to objects of {}. In particular:\n\
+        {}\n\
+        Otherwise the @shareable contract will be broken.",
+        operation,
+        field_definition_position,
+        field.ty.inner_named_type(),
+        human_readable_subgraph_names(all_subgraphs.iter()),
+        field_definition_position,
+        human_readable_subgraph_names(common_runtime_types.iter()),
+        subgraphs_with_type_not_in_intersection_string,
+    );
+    hints.push(CompositionHint {
+        message,
+        code: "INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN".to_owned(),
+    });
     Ok(())
 }
 

--- a/apollo-federation/src/composition/satisfiability/validation_state.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_state.rs
@@ -1,25 +1,40 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
+use either::Either;
 use itertools::Itertools;
+use petgraph::graph::EdgeIndex;
 use petgraph::visit::EdgeRef;
 
 use crate::bail;
+use crate::composition::satisfiability::ValidationContext;
+use crate::composition::satisfiability::satisfiability_error::satisfiability_error;
+use crate::composition::satisfiability::satisfiability_error::shareable_field_mismatched_runtime_types_hint;
+use crate::composition::satisfiability::satisfiability_error::shareable_field_non_intersecting_runtime_types_error;
 use crate::ensure;
+use crate::error::CompositionError;
 use crate::error::FederationError;
+use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraph;
 use crate::query_graph::QueryGraphEdgeTransition;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_graph::condition_resolver::ConditionResolution;
+use crate::query_graph::condition_resolver::ConditionResolver;
+use crate::query_graph::graph_path::UnadvanceableClosures;
+use crate::query_graph::graph_path::Unadvanceables;
 use crate::query_graph::graph_path::transition::TransitionGraphPath;
 use crate::query_graph::graph_path::transition::TransitionPathWithLazyIndirectPaths;
+use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
+use crate::supergraph::CompositionHint;
+use crate::utils::iter_into_single_item;
 
-struct ValidationState {
+pub(super) struct ValidationState {
     /// Path in the supergraph (i.e. the API schema query graph) corresponding to the current state.
     supergraph_path: TransitionGraphPath,
     /// All the possible paths we could be in the subgraphs (excluding @provides paths).
@@ -28,8 +43,7 @@ struct ValidationState {
     /// label condition), we consider both possibilities for the label value (T/F) as we traverse
     /// the graph, and record that here. This allows us to exclude paths that can never be taken by
     /// the query planner (i.e. a path where the condition is T in one case and F in another).
-    #[allow(dead_code)]
-    selected_override_conditions: IndexMap<String, bool>,
+    selected_override_conditions: Arc<OverrideConditions>,
 }
 
 struct SubgraphPathInfo {
@@ -41,7 +55,7 @@ struct SubgraphPathInfo {
 /// This is a `BTreeMap` to support `Hash`, as this is used in keys in maps.
 type SubgraphPathContexts = Arc<BTreeMap<String, SubgraphPathContextInfo>>;
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 struct SubgraphPathContextInfo {
     subgraph_name: Arc<str>,
     type_name: Name,
@@ -54,6 +68,10 @@ struct SubgraphContextKey {
 }
 
 impl ValidationState {
+    pub(super) fn supergraph_path(&self) -> &TransitionGraphPath {
+        &self.supergraph_path
+    }
+
     // PORT_NOTE: Named `initial()` in the JS codebase, but conventionally in Rust this kind of
     // constructor is named `new()`.
     #[allow(dead_code)]
@@ -104,8 +122,289 @@ impl ValidationState {
         })
     }
 
+    /// Validates that the current state can always be advanced for the provided supergraph edge,
+    /// and returns the updated state if so.
+    ///
+    /// If the state cannot be properly advanced, then an error will be pushed onto the provided
+    /// `errors` array, nothing will be pushed onto the provided `hints` array, and no updated state
+    /// will be returned. Otherwise, nothing will be pushed onto the `errors` array, a hint may be
+    /// pushed onto the `hints` array, and an updated state will be returned except for the case
+    /// where the transition is guaranteed to yield no results (in which case no state is returned).
+    /// This exception occurs when the edge corresponds to a type condition that does not intersect
+    /// with the possible runtime types of the old path's tail, in which case further validation on
+    /// the new path is not necessary.
     #[allow(dead_code)]
-    fn current_subgraph_names(&self) -> Result<IndexSet<Arc<str>>, FederationError> {
+    fn validate_transition(
+        &mut self,
+        context: &ValidationContext,
+        supergraph_edge: EdgeIndex,
+        matching_contexts: &IndexSet<String>,
+        condition_resolver: &mut impl ConditionResolver,
+        errors: &mut Vec<CompositionError>,
+        hints: &mut Vec<CompositionHint>,
+    ) -> Result<Option<ValidationState>, FederationError> {
+        let edge_weight = self.supergraph_path.graph().edge_weight(supergraph_edge)?;
+        ensure!(
+            edge_weight.conditions.is_none(),
+            "Supergraph edges should not have conditions ({})",
+            edge_weight,
+        );
+        let (_, transition_tail) = self
+            .supergraph_path
+            .graph()
+            .edge_endpoints(supergraph_edge)?;
+        let transition_tail_weight = self.supergraph_path.graph().node_weight(transition_tail)?;
+        let QueryGraphNodeType::SchemaType(target_type) = &transition_tail_weight.type_ else {
+            bail!("Unexpectedly encountered federation root node as tail node.");
+        };
+        let new_override_conditions =
+            if let Some(override_condition) = &edge_weight.override_condition {
+                let mut conditions = self.selected_override_conditions.as_ref().clone();
+                conditions.insert(
+                    override_condition.label.clone(),
+                    override_condition.condition,
+                );
+                Arc::new(conditions)
+            } else {
+                self.selected_override_conditions.clone()
+            };
+
+        let mut new_subgraph_paths: Vec<SubgraphPathInfo> = Default::default();
+        let mut dead_ends: Vec<UnadvanceableClosures> = Default::default();
+        for SubgraphPathInfo { path, contexts } in self.subgraph_paths.iter_mut() {
+            let options = path.advance_with_transition(
+                &edge_weight.transition,
+                target_type,
+                self.supergraph_path.graph().schema()?,
+                condition_resolver,
+                &new_override_conditions,
+            )?;
+            let options = match options {
+                Either::Left(options) => options,
+                Either::Right(closures) => {
+                    dead_ends.push(closures);
+                    continue;
+                }
+            };
+            if options.is_empty() {
+                // This means that the edge is a type condition and that if we follow the path in
+                // this subgraph, we're guaranteed that handling that type condition give us no
+                // matching results, and so we can skip this supergraph path entirely.
+                return Ok(None);
+            }
+            let new_contexts = if matching_contexts.is_empty() {
+                contexts.clone()
+            } else {
+                let tail_weight = path.path.graph().node_weight(path.path.tail())?;
+                let tail_subgraph = tail_weight.source.clone();
+                let QueryGraphNodeType::SchemaType(tail_type) = &tail_weight.type_ else {
+                    bail!("Unexpectedly encountered federation root node as tail node.");
+                };
+                let mut contexts = contexts.as_ref().clone();
+                for matching_context in matching_contexts {
+                    contexts.insert(
+                        matching_context.clone(),
+                        SubgraphPathContextInfo {
+                            subgraph_name: tail_subgraph.clone(),
+                            type_name: tail_type.type_name().clone(),
+                        },
+                    );
+                }
+                Arc::new(contexts)
+            };
+            new_subgraph_paths.extend(options.into_iter().map(|option| SubgraphPathInfo {
+                path: option,
+                contexts: new_contexts.clone(),
+            }))
+        }
+        let new_supergraph_path = self.supergraph_path.add(
+            edge_weight.transition.clone(),
+            supergraph_edge,
+            ConditionResolution::no_conditions(),
+            None,
+        )?;
+        if new_subgraph_paths.is_empty() {
+            satisfiability_error(
+                &new_supergraph_path,
+                &self
+                    .subgraph_paths
+                    .iter()
+                    .map(|path| path.path.path.as_ref())
+                    .collect::<Vec<_>>(),
+                &dead_ends
+                    .into_iter()
+                    .map(Unadvanceables::try_from)
+                    .process_results(|iter| iter.collect::<Vec<_>>())?,
+                errors,
+            )?;
+            return Ok(None);
+        }
+
+        let updated_state = ValidationState {
+            supergraph_path: new_supergraph_path,
+            subgraph_paths: new_subgraph_paths,
+            selected_override_conditions: new_override_conditions,
+        };
+
+        // When handling a @shareable field, we also compare the set of runtime types for each of
+        // the subgraphs involved. If there is no common intersection between those sets, then we
+        // record an error: a @shareable field should resolve the same way in all the subgraphs in
+        // which it is resolved, and there is no way this can be true if each subgraph returns
+        // runtime objects that we know can never be the same.
+        //
+        // Additionally, if those sets of runtime types are not the same, we let it compose, but we
+        // log a warning. Indeed, having different runtime types is a red flag: it would be
+        // incorrect for a subgraph to resolve to an object of a type that the other subgraph cannot
+        // possibly return, so having some subgraph having types that the other doesn't know feels
+        // like something worth double-checking on the user side. Of course, as long as there is
+        // some runtime types intersection and the field resolvers only return objects of that
+        // intersection, then this could be a valid implementation. And this case can in particular
+        // happen temporarily as subgraphs evolve (potentially independently), but it is well worth
+        // warning in general.
+
+        // Note that we ignore any path where the type is not an abstract type, because in practice
+        // this means an @interfaceObject and this should not be considered as an implementation
+        // type. Besides, @interfaceObject types always "stand-in" for every implementation type so
+        // they're never a problem for this check and can be ignored.
+        if updated_state.subgraph_paths.len() < 2 {
+            return Ok(Some(updated_state));
+        }
+        let QueryGraphEdgeTransition::FieldCollection {
+            field_definition_position,
+            ..
+        } = &edge_weight.transition
+        else {
+            return Ok(Some(updated_state));
+        };
+        let new_supergraph_path_tail_weight = updated_state
+            .supergraph_path
+            .graph()
+            .node_weight(updated_state.supergraph_path.tail())?;
+        let QueryGraphNodeType::SchemaType(new_supergraph_path_tail_type) =
+            &new_supergraph_path_tail_weight.type_
+        else {
+            bail!("Unexpectedly encountered federation root node as tail node.");
+        };
+        if AbstractTypeDefinitionPosition::try_from(new_supergraph_path_tail_type.clone()).is_err()
+        {
+            return Ok(Some(updated_state));
+        }
+        if !context.is_shareable(field_definition_position)? {
+            return Ok(Some(updated_state));
+        }
+        let filtered_paths_count = updated_state
+            .subgraph_paths
+            .iter()
+            .map(|path| {
+                let path_tail_weight = path.path.path.graph().node_weight(path.path.path.tail())?;
+                let QueryGraphNodeType::SchemaType(path_tail_type) = &path_tail_weight.type_ else {
+                    bail!("Unexpectedly encountered federation root node as tail node.");
+                };
+                Ok::<_, FederationError>(path_tail_type)
+            })
+            .process_results(|iter| {
+                iter.filter(|type_pos| {
+                    AbstractTypeDefinitionPosition::try_from((*type_pos).clone()).is_ok()
+                })
+                .count()
+            })?;
+        if filtered_paths_count < 2 {
+            return Ok(Some(updated_state));
+        }
+
+        // We start our intersection by using all the supergraph path types, both because it's a
+        // convenient "max" set to start our intersection, but also because that means we will
+        // ignore @inaccessible types in our checks (which is probably not very important because
+        // I believe the rules of @inaccessible kind of exclude having them here, but if that ever
+        // changes, it makes more sense this way).
+        let all_runtime_types = BTreeSet::from_iter(
+            updated_state
+                .supergraph_path()
+                .runtime_types_of_tail()
+                .iter()
+                .map(|type_pos| type_pos.type_name.clone()),
+        );
+        let mut intersection = all_runtime_types.clone();
+
+        let mut runtime_types_to_subgraphs: IndexMap<Arc<BTreeSet<Name>>, IndexSet<Arc<str>>> =
+            Default::default();
+        let mut runtime_types_per_subgraphs: IndexMap<Arc<str>, Arc<BTreeSet<Name>>> =
+            Default::default();
+        let mut has_all_empty = true;
+        for new_subgraph_path in updated_state.subgraph_paths.iter() {
+            let new_subgraph_path_tail_weight = new_subgraph_path
+                .path
+                .path
+                .graph()
+                .node_weight(new_subgraph_path.path.path.tail())?;
+            let subgraph = &new_subgraph_path_tail_weight.source;
+            let type_names = Arc::new(BTreeSet::from_iter(
+                new_subgraph_path
+                    .path
+                    .path
+                    .runtime_types_of_tail()
+                    .iter()
+                    .map(|type_pos| type_pos.type_name.clone()),
+            ));
+
+            // If we see a type here that is not included in the list of all runtime types, it is
+            // safe to assume that it is an interface behaving like a runtime type (i.e. an
+            // @interfaceObject) and we should allow it to stand in for any runtime type.
+            if let Some(type_name) = iter_into_single_item(type_names.iter()) {
+                if !all_runtime_types.contains(type_name) {
+                    continue;
+                }
+            }
+            runtime_types_per_subgraphs.insert(subgraph.clone(), type_names.clone());
+            // PORT_NOTE: The JS code couldn't really use sets as map keys, so it instead used the
+            // formatted output text as the map key. We instead use a `BTreeSet<Name>`, and move
+            // the formatting logic into `shareable_field_non_intersecting_runtime_types_error()`.
+            runtime_types_to_subgraphs
+                .entry(type_names.clone())
+                .or_default()
+                .insert(subgraph.clone());
+            if !type_names.is_empty() {
+                has_all_empty = false;
+            }
+            intersection.retain(|type_name| type_names.contains(type_name));
+        }
+
+        // If `has_all_empty` is true, then it means that none of the subgraphs define any runtime
+        // types. If this occurs, typically all subgraphs define a given interface, but none have
+        // implementations. In that case, the intersection will be empty, but it's actually fine
+        // (which is why we special case this). In fact, assuming valid GraphQL subgraph servers
+        // (and it's not the place to sniff for non-compliant subgraph servers), the only value to
+        // which each subgraph can resolve is `null` and so that essentially guarantees that all
+        // subgraphs do resolve the same way.
+        if !has_all_empty {
+            if intersection.is_empty() {
+                shareable_field_non_intersecting_runtime_types_error(
+                    &updated_state,
+                    field_definition_position,
+                    &runtime_types_to_subgraphs,
+                    errors,
+                )?;
+                return Ok(None);
+            }
+
+            // As we said earlier, we accept it if there's an intersection, but if the runtime types
+            // are not all the same, we still emit a warning to make it clear that the fields should
+            // not resolve any of the types not in the intersection.
+            if runtime_types_to_subgraphs.len() > 1 {
+                shareable_field_mismatched_runtime_types_hint(
+                    &updated_state,
+                    field_definition_position,
+                    &intersection,
+                    &runtime_types_per_subgraphs,
+                    hints,
+                )?;
+            }
+        }
+
+        Ok(Some(updated_state))
+    }
+
+    pub(super) fn current_subgraph_names(&self) -> Result<IndexSet<Arc<str>>, FederationError> {
         self.subgraph_paths
             .iter()
             .map(|path_info| {

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -145,6 +145,10 @@ pub enum CompositionError {
     #[error("{message}")]
     TypeKindMismatch { message: String },
     #[error("{message}")]
+    ShareableHasMismatchedRuntimeTypes { message: String },
+    #[error("{message}")]
+    SatisfiabilityError { message: String },
+    #[error("{message}")]
     InternalError { message: String },
 }
 
@@ -162,6 +166,10 @@ impl CompositionError {
             Self::TypeDefinitionInvalid { .. } => ErrorCode::TypeDefinitionInvalid,
             Self::InterfaceObjectUsageError { .. } => ErrorCode::InterfaceObjectUsageError,
             Self::TypeKindMismatch { .. } => ErrorCode::TypeKindMismatch,
+            Self::ShareableHasMismatchedRuntimeTypes { .. } => {
+                ErrorCode::ShareableHasMismatchedRuntimeTypes
+            }
+            Self::SatisfiabilityError { .. } => ErrorCode::SatisfiabilityError,
             Self::InternalError { .. } => ErrorCode::Internal,
         }
     }
@@ -187,6 +195,14 @@ impl CompositionError {
                 message: format!("{message}{appendix}"),
             },
             Self::TypeKindMismatch { message } => Self::TypeKindMismatch {
+                message: format!("{message}{appendix}"),
+            },
+            Self::ShareableHasMismatchedRuntimeTypes { message } => {
+                Self::ShareableHasMismatchedRuntimeTypes {
+                    message: format!("{message}{appendix}"),
+                }
+            }
+            Self::SatisfiabilityError { message } => Self::SatisfiabilityError {
                 message: format!("{message}{appendix}"),
             },
             Self::InternalError { message } => Self::InternalError {

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -36,6 +36,7 @@ use crate::operation::Field;
 use crate::operation::FieldSetDisplay;
 use crate::operation::Selection;
 use crate::operation::SelectionSet;
+use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraph;
 use crate::query_graph::QueryGraphEdge;
 use crate::query_graph::QueryGraphEdgeTransition;
@@ -47,7 +48,6 @@ use crate::query_graph::condition_resolver::UnsatisfiedConditionReason;
 use crate::query_graph::path_tree::OpPathTree;
 use crate::query_plan::FetchDataPathElement;
 use crate::query_plan::QueryPlanCost;
-use crate::query_plan::query_planner::EnabledOverrideConditions;
 use crate::schema::ValidFederationSchema;
 use crate::schema::field_set::parse_field_value_without_validation;
 use crate::schema::field_set::validate_field_value;
@@ -560,6 +560,9 @@ where
     }
     pub(crate) fn tail(&self) -> NodeIndex {
         self.tail
+    }
+    pub(crate) fn runtime_types_of_tail(&self) -> &Arc<IndexSet<ObjectTypeDefinitionPosition>> {
+        &self.runtime_types_of_tail
     }
 
     /// Creates a new (empty) path starting at the provided `head` node.
@@ -1521,7 +1524,7 @@ where
         condition_resolver: &mut impl ConditionResolver,
         excluded_destinations: &ExcludedDestinations,
         excluded_conditions: &ExcludedConditions,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
         transition_and_context_to_trigger: impl Fn(
             &QueryGraphEdgeTransition,
             &OpGraphPathContext,
@@ -1530,7 +1533,7 @@ where
             &Arc<QueryGraph>,
             NodeIndex,
             &Arc<TTrigger>,
-            &EnabledOverrideConditions,
+            &OverrideConditions,
         ) -> Result<Option<TEdge>, FederationError>,
         disabled_subgraphs: &IndexSet<Arc<str>>,
     ) -> Result<IndirectPaths<TTrigger, TEdge, TDeadEnds>, FederationError>
@@ -2182,9 +2185,9 @@ where
             &Arc<QueryGraph>,
             NodeIndex,
             &Arc<TTrigger>,
-            &EnabledOverrideConditions,
+            &OverrideConditions,
         ) -> Result<Option<TEdge>, FederationError>,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
     ) -> Result<Option<NodeIndex>, FederationError> {
         // TODO: Temporary fix to avoid optimization if context exists, a permanent fix is here:
         //       https://github.com/apollographql/federation/pull/3017#pullrequestreview-2083949094

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -32,6 +32,7 @@ use crate::operation::SelectionId;
 use crate::operation::SelectionKey;
 use crate::operation::SelectionSet;
 use crate::operation::SiblingTypename;
+use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraphEdgeTransition;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_graph::condition_resolver::ConditionResolution;
@@ -44,7 +45,6 @@ use crate::query_graph::graph_path::IndirectPaths;
 use crate::query_graph::graph_path::OverrideId;
 use crate::query_graph::path_tree::Preference;
 use crate::query_plan::FetchDataPathElement;
-use crate::query_plan::query_planner::EnabledOverrideConditions;
 use crate::schema::ValidFederationSchema;
 use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::CompositeTypeDefinitionPosition;
@@ -605,7 +605,7 @@ impl OpGraphPath {
     fn next_edge_for_field(
         &self,
         field: &Field,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
     ) -> Option<EdgeIndex> {
         self.graph
             .edge_for_field(self.tail, field, override_conditions)
@@ -736,7 +736,7 @@ impl OpGraphPath {
 
     pub(crate) fn terminate_with_non_requested_typename_field(
         &self,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
     ) -> Result<OpGraphPath, FederationError> {
         // If the last step of the path was a fragment/type-condition, we want to remove it before
         // we get __typename. The reason is that this avoid cases where this method would make us
@@ -1120,7 +1120,7 @@ impl OpGraphPath {
         operation_element: &OpPathElement,
         context: &OpGraphPathContext,
         condition_resolver: &mut impl ConditionResolver,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
         check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
         disabled_subgraphs: &IndexSet<Arc<str>>,
     ) -> Result<(Option<Vec<SimultaneousPaths>>, Option<bool>), FederationError> {
@@ -1987,7 +1987,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
         &mut self,
         path_index: usize,
         condition_resolver: &mut impl ConditionResolver,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
         disabled_subgraphs: &IndexSet<Arc<str>>,
     ) -> Result<OpIndirectPaths, FederationError> {
         if let Some(indirect_paths) = &self.lazily_computed_indirect_paths[path_index] {
@@ -2008,7 +2008,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
         &self,
         path_index: usize,
         condition_resolver: &mut impl ConditionResolver,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
         disabled_subgraphs: &IndexSet<Arc<str>>,
     ) -> Result<OpIndirectPaths, FederationError> {
         self.paths.0[path_index].advance_with_non_collecting_and_type_preserving_transitions(
@@ -2060,7 +2060,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
         supergraph_schema: ValidFederationSchema,
         operation_element: &OpPathElement,
         condition_resolver: &mut impl ConditionResolver,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
         check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
         disabled_subgraphs: &IndexSet<Arc<str>>,
     ) -> Result<Option<Vec<SimultaneousPathsWithLazyIndirectPaths>>, FederationError> {
@@ -2294,7 +2294,7 @@ pub(crate) fn create_initial_options(
     condition_resolver: &mut impl ConditionResolver,
     excluded_edges: ExcludedDestinations,
     excluded_conditions: ExcludedConditions,
-    override_conditions: &EnabledOverrideConditions,
+    override_conditions: &OverrideConditions,
     disabled_subgraphs: &IndexSet<Arc<str>>,
 ) -> Result<Vec<SimultaneousPathsWithLazyIndirectPaths>, FederationError> {
     let initial_paths = SimultaneousPaths::from(initial_path);

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -17,6 +17,7 @@ use crate::ensure;
 use crate::error::FederationError;
 use crate::operation::Field;
 use crate::operation::Selection;
+use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraphEdgeTransition;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_graph::condition_resolver::ConditionResolution;
@@ -30,7 +31,6 @@ use crate::query_graph::graph_path::UnadvanceableClosure;
 use crate::query_graph::graph_path::UnadvanceableClosures;
 use crate::query_graph::graph_path::UnadvanceableReason;
 use crate::query_graph::graph_path::Unadvanceables;
-use crate::query_plan::query_planner::EnabledOverrideConditions;
 use crate::schema::ValidFederationSchema;
 use crate::schema::field_set::parse_field_set;
 use crate::schema::position::CompositeTypeDefinitionPosition;
@@ -254,7 +254,7 @@ impl TransitionGraphPath {
         &self,
         transition: &QueryGraphEdgeTransition,
         condition_resolver: &mut impl ConditionResolver,
-        override_conditions: &Arc<EnabledOverrideConditions>,
+        override_conditions: &Arc<OverrideConditions>,
     ) -> Result<Either<Vec<Arc<TransitionGraphPath>>, UnadvanceableClosures>, FederationError> {
         ensure!(
             transition.collect_operation_elements(),
@@ -350,7 +350,7 @@ impl TransitionGraphPath {
                             "Unable to take edge {} because override condition \"{}\" is {}",
                             edge_weight,
                             override_condition.label,
-                            override_conditions.contains(&override_condition.label)
+                            override_conditions.contains_key(&override_condition.label)
                         ),
                     })])))
                 }))));
@@ -622,7 +622,7 @@ impl TransitionPathWithLazyIndirectPaths {
     fn indirect_options(
         &mut self,
         condition_resolver: &mut impl ConditionResolver,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
     ) -> Result<TransitionIndirectPaths, FederationError> {
         if let Some(indirect_paths) = &self.lazily_computed_indirect_paths {
             Ok(indirect_paths.clone())
@@ -637,7 +637,7 @@ impl TransitionPathWithLazyIndirectPaths {
     fn compute_indirect_paths(
         &self,
         condition_resolver: &mut impl ConditionResolver,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
     ) -> Result<TransitionIndirectPaths, FederationError> {
         self.path
             .advance_with_non_collecting_and_type_preserving_transitions(
@@ -664,14 +664,13 @@ impl TransitionPathWithLazyIndirectPaths {
     /// that as far as composition validation goes, we can ignore that transition (and anything that
     /// follows) and otherwise continue.
     // PORT_NOTE: In the JS codebase, this was named `advancePathWithTransition`.
-    #[allow(dead_code)]
-    fn advance_with_transition(
+    pub(crate) fn advance_with_transition(
         &mut self,
         transition: &QueryGraphEdgeTransition,
         target_type: &OutputTypeDefinitionPosition,
         api_schema: &ValidFederationSchema,
         condition_resolver: &mut impl ConditionResolver,
-        override_conditions: &Arc<EnabledOverrideConditions>,
+        override_conditions: &Arc<OverrideConditions>,
     ) -> Result<
         Either<Vec<TransitionPathWithLazyIndirectPaths>, UnadvanceableClosures>,
         FederationError,

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hash;
+use std::ops::Deref;
+use std::ops::DerefMut;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
@@ -50,7 +52,6 @@ use crate::query_graph::condition_resolver::ConditionResolver;
 use crate::query_graph::graph_path::ExcludedConditions;
 use crate::query_graph::graph_path::ExcludedDestinations;
 use crate::query_plan::QueryPlanCost;
-use crate::query_plan::query_planner::EnabledOverrideConditions;
 use crate::query_plan::query_planning_traversal::non_local_selections_estimation;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -198,10 +199,7 @@ impl QueryGraphEdge {
         }
     }
 
-    fn satisfies_override_conditions(
-        &self,
-        conditions_to_check: &EnabledOverrideConditions,
-    ) -> bool {
+    fn satisfies_override_conditions(&self, conditions_to_check: &OverrideConditions) -> bool {
         if let Some(override_condition) = &self.override_condition {
             override_condition.check(conditions_to_check)
         } else {
@@ -234,15 +232,50 @@ impl Display for QueryGraphEdge {
         }
     }
 }
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct OverrideCondition {
-    pub(crate) label: String,
+    pub(crate) label: Arc<str>,
     pub(crate) condition: bool,
 }
 
 impl OverrideCondition {
-    pub(crate) fn check(&self, enabled_conditions: &EnabledOverrideConditions) -> bool {
-        self.condition == enabled_conditions.contains(&self.label)
+    pub(crate) fn check(&self, override_conditions: &OverrideConditions) -> bool {
+        override_conditions.get(&self.label) == Some(&self.condition)
+    }
+}
+
+/// For query planning, this is a map of all override condition labels to whether that label is set.
+/// For composition satisfiability, this is the same thing, but it's only some of the override
+/// conditions. Specifically, for top-level queries in satisfiability, this will only contain those
+/// override conditions encountered in the path. For conditions queries in satisfiability, this will
+/// be an empty map.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct OverrideConditions(IndexMap<Arc<str>, bool>);
+
+impl Deref for OverrideConditions {
+    type Target = IndexMap<Arc<str>, bool>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for OverrideConditions {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl OverrideConditions {
+    pub(crate) fn new(graph: &QueryGraph, enabled_conditions: &IndexSet<String>) -> Self {
+        Self(
+            graph
+                .override_condition_labels
+                .iter()
+                .map(|label| (label.clone(), enabled_conditions.contains(label.as_ref())))
+                .collect(),
+        )
     }
 }
 
@@ -463,6 +496,7 @@ pub struct QueryGraph {
     /// argument coordinates). This identifier is called the "context ID".
     arguments_to_context_ids_by_source:
         IndexMap<Arc<str>, IndexMap<ObjectFieldArgumentDefinitionPosition, Name>>,
+    override_condition_labels: IndexSet<Arc<str>>,
     /// To speed up the estimation of counting non-local selections, we precompute specific metadata
     /// about the query graph and store that here.
     non_local_selection_metadata: non_local_selections_estimation::QueryGraphMetadata,
@@ -524,7 +558,7 @@ impl QueryGraph {
             .ok_or_else(|| internal_error!("Edge unexpectedly missing"))
     }
 
-    fn schema(&self) -> Result<&ValidFederationSchema, FederationError> {
+    pub(crate) fn schema(&self) -> Result<&ValidFederationSchema, FederationError> {
         self.schema_by_source(&self.current_source)
     }
 
@@ -803,7 +837,7 @@ impl QueryGraph {
         &self,
         node: NodeIndex,
         field: &Field,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
     ) -> Option<EdgeIndex> {
         let mut candidates = self.out_edges(node).into_iter().filter_map(|edge_ref| {
             let edge_weight = edge_ref.weight();
@@ -885,7 +919,7 @@ impl QueryGraph {
         &self,
         node: NodeIndex,
         op_graph_path_trigger: &OpGraphPathTrigger,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
     ) -> Option<Option<EdgeIndex>> {
         let OpGraphPathTrigger::OpPathElement(op_path_element) = op_graph_path_trigger else {
             return None;
@@ -909,7 +943,7 @@ impl QueryGraph {
         &self,
         node: NodeIndex,
         transition_graph_path_trigger: &QueryGraphEdgeTransition,
-        override_conditions: &EnabledOverrideConditions,
+        override_conditions: &OverrideConditions,
     ) -> Result<Option<EdgeIndex>, FederationError> {
         for edge_ref in self.out_edges(node) {
             let edge_weight = edge_ref.weight();

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -1,7 +1,6 @@
 use std::cell::Cell;
 use std::num::NonZeroU32;
 use std::ops::ControlFlow;
-use std::ops::Deref;
 use std::sync::Arc;
 
 use apollo_compiler::ExecutableDocument;
@@ -27,6 +26,7 @@ use crate::operation::NormalizedDefer;
 use crate::operation::Operation;
 use crate::operation::SelectionSet;
 use crate::operation::normalize_operation;
+use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraph;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_graph::build_federated_query_graph;
@@ -232,17 +232,6 @@ impl std::fmt::Debug for QueryPlanOptions<'_> {
                 &self.non_local_selections_limit_enabled,
             )
             .finish()
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub(crate) struct EnabledOverrideConditions(IndexSet<String>);
-
-impl Deref for EnabledOverrideConditions {
-    type Target = IndexSet<String>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 
@@ -471,9 +460,10 @@ impl QueryPlanner {
                 .clone()
                 .into(),
             config: self.config.clone(),
-            override_conditions: EnabledOverrideConditions(IndexSet::from_iter(
-                options.override_conditions,
-            )),
+            override_conditions: OverrideConditions::new(
+                &self.federated_query_graph,
+                &IndexSet::from_iter(options.override_conditions),
+            ),
             check_for_cooperative_cancellation: options.check_for_cooperative_cancellation,
             fetch_id_generator: Arc::new(FetchIdGenerator::new()),
             disabled_subgraphs: self

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -15,6 +15,7 @@ use crate::error::SingleFederationError;
 use crate::operation::Operation;
 use crate::operation::Selection;
 use crate::operation::SelectionSet;
+use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraph;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_graph::condition_resolver::CachingConditionResolver;
@@ -41,7 +42,6 @@ use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphPro
 use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphToCostProcessor;
 use crate::query_plan::generate::PlanBuilder;
 use crate::query_plan::generate::generate_all_plans_and_find_best;
-use crate::query_plan::query_planner::EnabledOverrideConditions;
 use crate::query_plan::query_planner::QueryPlannerConfig;
 use crate::query_plan::query_planner::QueryPlanningStatistics;
 use crate::query_plan::query_planner::compute_root_fetch_groups;
@@ -87,7 +87,7 @@ pub(crate) struct QueryPlanningParameters<'a> {
     /// The configuration for the query planner.
     pub(crate) config: QueryPlannerConfig,
     pub(crate) statistics: &'a QueryPlanningStatistics,
-    pub(crate) override_conditions: EnabledOverrideConditions,
+    pub(crate) override_conditions: OverrideConditions,
     pub(crate) check_for_cooperative_cancellation: Option<&'a dyn Fn() -> ControlFlow<()>>,
     pub(crate) disabled_subgraphs: IndexSet<Arc<str>>,
 }

--- a/apollo-federation/src/utils/human_readable.rs
+++ b/apollo-federation/src/utils/human_readable.rs
@@ -91,6 +91,8 @@ pub(crate) struct HumanReadableListOptions<'a> {
     /// When displaying a list of something in a human-readable form, after what size (in number of
     /// characters) we start displaying only a subset of the list.
     pub(crate) output_length_limit: usize,
+    /// If there are no elements, this string will be used instead.
+    pub(crate) empty_output: &'a str,
 }
 
 pub(crate) struct HumanReadableListPrefix<'a> {
@@ -104,6 +106,7 @@ impl Default for HumanReadableListOptions<'_> {
             prefix: None,
             last_separator: Some(" and "),
             output_length_limit: 100,
+            empty_output: "",
         }
     }
 }
@@ -122,10 +125,7 @@ pub(crate) fn human_readable_list(
     options: HumanReadableListOptions,
 ) -> String {
     let Some(first) = iter.next() else {
-        // TODO: The JS code returns an empty string here, which we've ported accordingly. However,
-        // this probably isn't want the caller wants, and something like e.g. "no types" for prefix
-        // type/types may be better.
-        return "".to_owned();
+        return options.empty_output.to_owned();
     };
     let Some(second) = iter.next() else {
         return if let Some(prefix) = options.prefix {


### PR DESCRIPTION
This PR ports `ValidationState.validateTransition()` from the JS codebase. Note that:
1. During the query planner port, we converted the override conditions to a data structure that assumed that each label was either `true` or `false`. In composition, we need to support a third possibility (the JS `undefined`), so I've updated the query planning/composition code to all use a map from labels to booleans instead, as it was in the JS code.
    - As part of this, I updated the code to use `Arc<str>` instead of `String` for labels.
    - The actual `build_query_plan()` signature was not changed as part of this (the old data structure is just converted to the new one).
2. Downstream functions of `validate_transition()` have been switched to use `CompositionError` instead of `SingleFederationError` where appropriate (and new `CompositionError` variants have been added).

<!-- FED-578 -->
