### PR TITLE
Fix error when removing non-UTF-8 headers with Rhai plugin

### DIFF
--- a/.changesets/fix_fix_removing_non_utf_8_headers_with_rhai.md
+++ b/.changesets/fix_fix_removing_non_utf_8_headers_with_rhai.md
@@ -1,0 +1,7 @@
+### Fix error when removing non-UTF-8 headers with Rhai plugin ([PR #7801](https://github.com/apollographql/router/pull/7801))
+
+When trying to remove non-UTF-8 headers from a Rhai plugin, users were faced with an unhelpful error. Now, non-UTF-8 values will be lossy converted to UTF-8 when accessed from Rhai. This change affects `get`, `get_all`, and `remove` operations.
+
+[ROUTER-1291]: https://apollographql.atlassian.net/browse/ROUTER-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
+
+By [@Velfi](https://github.com/Velfi) in https://github.com/apollographql/router/pull/7801

--- a/.changesets/fix_fix_removing_non_utf_8_headers_with_rhai.md
+++ b/.changesets/fix_fix_removing_non_utf_8_headers_with_rhai.md
@@ -2,6 +2,4 @@
 
 When trying to remove non-UTF-8 headers from a Rhai plugin, users were faced with an unhelpful error. Now, non-UTF-8 values will be lossy converted to UTF-8 when accessed from Rhai. This change affects `get`, `get_all`, and `remove` operations.
 
-[ROUTER-1291]: https://apollographql.atlassian.net/browse/ROUTER-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
-
 By [@Velfi](https://github.com/Velfi) in https://github.com/apollographql/router/pull/7801

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -295,11 +295,7 @@ mod router_header_map {
         x: &mut HeaderMap,
         key: &str,
     ) -> Result<String, Box<EvalAltResult>> {
-        Ok(x.remove(key)
-            .ok_or("")?
-            .to_str()
-            .map_err(|e| e.to_string())?
-            .to_string())
+        Ok(String::from_utf8_lossy(x.remove(key).ok_or("")?.as_bytes()).to_string())
     }
 
     // Register a HeaderMap indexer so we can get/set headers
@@ -310,11 +306,7 @@ mod router_header_map {
     ) -> Result<String, Box<EvalAltResult>> {
         let search_name =
             HeaderName::from_str(key).map_err(|e: InvalidHeaderName| e.to_string())?;
-        Ok(x.get(search_name)
-            .ok_or("")?
-            .to_str()
-            .map_err(|e| e.to_string())?
-            .to_string())
+        Ok(String::from_utf8_lossy(x.get(search_name).ok_or("")?.as_bytes()).to_string())
     }
 
     #[rhai_fn(index_set, return_raw)]
@@ -363,13 +355,7 @@ mod router_header_map {
             HeaderName::from_str(key).map_err(|e: InvalidHeaderName| e.to_string())?;
         let mut response = Array::new();
         for value in x.get_all(search_name).iter() {
-            response.push(
-                value
-                    .to_str()
-                    .map_err(|e| e.to_string())?
-                    .to_string()
-                    .into(),
-            )
+            response.push(String::from_utf8_lossy(value.as_bytes()).to_string().into())
         }
         Ok(response)
     }

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -885,10 +885,7 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
 
     let mut service_response = router_service.ready().await?.call(supergraph_req).await?;
 
-    assert_eq!(
-        StatusCode::OK,
-        service_response.response.status()
-    );
+    assert_eq!(StatusCode::OK, service_response.response.status());
 
     // Removing a non-UTF-8 header should be OK
     let body = service_response.next_response().await.unwrap();
@@ -905,7 +902,10 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
 
     // Check that the header was actually removed
     let headers = service_response.response.headers().clone();
-    assert!(headers.get("x-binary-header").is_none(), "x-binary-header should have been removed but it's still present");
+    assert!(
+        headers.get("x-binary-header").is_none(),
+        "x-binary-header should have been removed but it's still present"
+    );
 
     Ok(())
 }

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -853,7 +853,7 @@ async fn it_can_access_demand_control_context() -> Result<(), BoxError> {
 async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError> {
     let bytes = b"\x80";
     // Prove that the bytes are not valid UTF-8
-    assert!(String::from_utf8(bytes.to_vec()).is_err());
+    assert!(str::from_utf8(bytes).is_err());
 
     let mut mock_service = MockSupergraphService::new();
     mock_service

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -896,7 +896,7 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
             .errors
             .iter()
             .find(|e| e.message.contains("rhai execution error"))
-            .expect("must have a rhai error");
+            .expect("unexpected non-rhai error");
         panic!("Got an unexpected rhai error: {:?}", rhai_error);
     }
 

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -853,7 +853,7 @@ async fn it_can_access_demand_control_context() -> Result<(), BoxError> {
 async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError> {
     let bytes = b"\x80";
     // Prove that the bytes are not valid UTF-8
-    assert!(str::from_utf8(bytes).is_err());
+    assert!(String::from_utf8(bytes.to_vec()).is_err());
 
     let mut mock_service = MockSupergraphService::new();
     mock_service

--- a/apollo-router/tests/fixtures/non_utf8_header_removal.rhai
+++ b/apollo-router/tests/fixtures/non_utf8_header_removal.rhai
@@ -1,0 +1,12 @@
+fn supergraph_service(service) {
+    print("registering callbacks for non-UTF-8 header removal test");
+
+    const response_callback = Fn("process_response");
+    service.map_response(response_callback);
+}
+
+fn process_response(response) {
+    // This will fail when trying to remove a non-UTF-8 header
+    // because the remove function calls .to_str() on the header value
+    response.headers.remove("x-binary-header")
+}


### PR DESCRIPTION
When trying to remove non-UTF-8 headers from a Rhai plugin, users were faced with an unhelpful error. Now, non-UTF-8 values will be lossy converted to UTF-8 when accessed from Rhai. This change affects `get`, `get_all`, and `remove` operations.

<!-- start metadata -->

<!-- [ROUTER-1291] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1291]: https://apollographql.atlassian.net/browse/ROUTER-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ