### PR TITLE
response cache: suggestions for #7797

### DIFF
--- a/apollo-router/src/plugins/response_cache/postgres.rs
+++ b/apollo-router/src/plugins/response_cache/postgres.rs
@@ -489,8 +489,9 @@ impl TryFrom<&TimeDelta> for Cron {
 
 #[cfg(test)]
 mod tests {
-    use chrono::TimeDelta;
     use std::time::Duration;
+
+    use chrono::TimeDelta;
 
     use super::Cron;
 


### PR DESCRIPTION
These changes were a bit cumbersome to add as suggestions on #7797, so I created a separate branch. Feel free to reject (they're mostly stylistic)!

* Make use of `rstest` to create simpler parameterized tests. I hadn't used this crate before but it seems to be in use in federation and I think it makes it easier to see what's being tested - but happy to revert if you prefer the existing style.
* Nit: I believe the existing implementation would not work if the user specified `12 months` - `humantime` would convert that to 365 days and the router would reject it with the error `interval bigger than 1 year is not supported` as the current upper bound is `12*28=336`.