### PR TITLE
fix(federation/composition): fixed `validate_federation_imports` to use the actual federation spec

### DIFF
--- a/apollo-federation/src/link/authenticated_spec_definition.rs
+++ b/apollo-federation/src/link/authenticated_spec_definition.rs
@@ -80,18 +80,8 @@ pub(crate) static AUTHENTICATED_VERSIONS: LazyLock<SpecDefinitions<Authenticated
 
 #[cfg(test)]
 mod test {
-    use apollo_compiler::Node;
-    use apollo_compiler::ast::Argument;
-    use apollo_compiler::ast::Directive;
-    use apollo_compiler::ast::Value;
-    use apollo_compiler::name;
     use itertools::Itertools;
 
-    use super::*;
-    use crate::link::DEFAULT_LINK_NAME;
-    use crate::link::link_spec_definition::LINK_DIRECTIVE_FOR_ARGUMENT_NAME;
-    use crate::link::link_spec_definition::LINK_DIRECTIVE_URL_ARGUMENT_NAME;
-    use crate::schema::position::SchemaDefinitionPosition;
     use crate::subgraph::test_utils::BuildOption;
     use crate::subgraph::test_utils::build_inner_expanded;
 
@@ -100,29 +90,6 @@ mod test {
             .unwrap()
             .schema()
             .to_owned()
-    }
-
-    fn get_schema_with_authenticated(version: Version) -> crate::schema::FederationSchema {
-        let mut schema = trivial_schema();
-        let spec = AUTHENTICATED_VERSIONS.find(&version).unwrap();
-        let link = Directive {
-            name: DEFAULT_LINK_NAME,
-            arguments: vec![
-                Node::new(Argument {
-                    name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
-                    value: spec.url().to_string().into(),
-                }),
-                Node::new(Argument {
-                    name: LINK_DIRECTIVE_FOR_ARGUMENT_NAME,
-                    value: Node::new(Value::Enum(name!("SECURITY"))),
-                }),
-            ],
-        };
-        SchemaDefinitionPosition
-            .insert_directive(&mut schema, link.into())
-            .unwrap();
-        spec.add_elements_to_schema(&mut schema).unwrap();
-        schema
     }
 
     fn authenticated_spec_directives_snapshot(schema: &crate::schema::FederationSchema) -> String {
@@ -142,7 +109,7 @@ mod test {
 
     #[test]
     fn authenticated_spec_v0_1_definitions() {
-        let schema = get_schema_with_authenticated(Version { major: 0, minor: 1 });
+        let schema = trivial_schema();
         let snapshot = authenticated_spec_directives_snapshot(&schema);
         let expected =
             r#"directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM"#;

--- a/apollo-federation/src/link/policy_spec_definition.rs
+++ b/apollo-federation/src/link/policy_spec_definition.rs
@@ -108,19 +108,9 @@ pub(crate) static POLICY_VERSIONS: LazyLock<SpecDefinitions<PolicySpecDefinition
 
 #[cfg(test)]
 mod test {
-    use apollo_compiler::Node;
-    use apollo_compiler::ast::Argument;
-    use apollo_compiler::ast::Directive;
-    use apollo_compiler::ast::Value;
-    use apollo_compiler::name;
     use itertools::Itertools;
 
-    use super::*;
-    use crate::link::DEFAULT_LINK_NAME;
-    use crate::link::link_spec_definition::LINK_DIRECTIVE_FOR_ARGUMENT_NAME;
-    use crate::link::link_spec_definition::LINK_DIRECTIVE_URL_ARGUMENT_NAME;
     use crate::schema::FederationSchema;
-    use crate::schema::position::SchemaDefinitionPosition;
     use crate::subgraph::test_utils::BuildOption;
     use crate::subgraph::test_utils::build_inner_expanded;
 
@@ -129,29 +119,6 @@ mod test {
             .unwrap()
             .schema()
             .to_owned()
-    }
-
-    fn get_schema_with_policy(version: Version) -> FederationSchema {
-        let mut schema = trivial_schema();
-        let spec = POLICY_VERSIONS.find(&version).unwrap();
-        let link = Directive {
-            name: DEFAULT_LINK_NAME,
-            arguments: vec![
-                Node::new(Argument {
-                    name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
-                    value: spec.url().to_string().into(),
-                }),
-                Node::new(Argument {
-                    name: LINK_DIRECTIVE_FOR_ARGUMENT_NAME,
-                    value: Node::new(Value::Enum(name!("SECURITY"))),
-                }),
-            ],
-        };
-        SchemaDefinitionPosition
-            .insert_directive(&mut schema, link.into())
-            .unwrap();
-        spec.add_elements_to_schema(&mut schema).unwrap();
-        schema
     }
 
     fn policy_spec_directives_snapshot(schema: &FederationSchema) -> String {
@@ -175,7 +142,7 @@ mod test {
             .types
             .iter()
             .filter_map(|(name, ty)| {
-                if name.as_str().starts_with("policy__") {
+                if name.as_str().ends_with("__Policy") {
                     Some(ty.to_string())
                 } else {
                     None
@@ -186,13 +153,13 @@ mod test {
 
     #[test]
     fn policy_spec_v0_1_definitions() {
-        let schema = get_schema_with_policy(Version { major: 0, minor: 1 });
+        let schema = trivial_schema();
         let types_snapshot = policy_spec_types_snapshot(&schema);
-        let expected_types = r#"scalar policy__Policy"#;
+        let expected_types = r#"scalar federation__Policy"#;
         assert_eq!(types_snapshot.trim(), expected_types.trim());
 
         let directives_snapshot = policy_spec_directives_snapshot(&schema);
-        let expected_directives = r#"directive @policy(policies: [[policy__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM"#;
+        let expected_directives = r#"directive @policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM"#;
         assert_eq!(directives_snapshot.trim(), expected_directives.trim());
     }
 }

--- a/apollo-federation/src/link/requires_scopes_spec_definition.rs
+++ b/apollo-federation/src/link/requires_scopes_spec_definition.rs
@@ -111,19 +111,9 @@ pub(crate) static REQUIRES_SCOPES_VERSIONS: LazyLock<
 
 #[cfg(test)]
 mod test {
-    use apollo_compiler::Node;
-    use apollo_compiler::ast::Argument;
-    use apollo_compiler::ast::Directive;
-    use apollo_compiler::ast::Value;
-    use apollo_compiler::name;
     use itertools::Itertools;
 
-    use super::*;
-    use crate::link::DEFAULT_LINK_NAME;
-    use crate::link::link_spec_definition::LINK_DIRECTIVE_FOR_ARGUMENT_NAME;
-    use crate::link::link_spec_definition::LINK_DIRECTIVE_URL_ARGUMENT_NAME;
     use crate::schema::FederationSchema;
-    use crate::schema::position::SchemaDefinitionPosition;
     use crate::subgraph::test_utils::BuildOption;
     use crate::subgraph::test_utils::build_inner_expanded;
 
@@ -132,29 +122,6 @@ mod test {
             .unwrap()
             .schema()
             .to_owned()
-    }
-
-    fn get_schema_with_requires_scopes(version: Version) -> FederationSchema {
-        let mut schema = trivial_schema();
-        let spec = REQUIRES_SCOPES_VERSIONS.find(&version).unwrap();
-        let link = Directive {
-            name: DEFAULT_LINK_NAME,
-            arguments: vec![
-                Node::new(Argument {
-                    name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
-                    value: spec.url().to_string().into(),
-                }),
-                Node::new(Argument {
-                    name: LINK_DIRECTIVE_FOR_ARGUMENT_NAME,
-                    value: Node::new(Value::Enum(name!("SECURITY"))),
-                }),
-            ],
-        };
-        SchemaDefinitionPosition
-            .insert_directive(&mut schema, link.into())
-            .unwrap();
-        spec.add_elements_to_schema(&mut schema).unwrap();
-        schema
     }
 
     fn requires_scopes_spec_directives_snapshot(schema: &FederationSchema) -> String {
@@ -178,7 +145,7 @@ mod test {
             .types
             .iter()
             .filter_map(|(name, ty)| {
-                if name.as_str().starts_with("requiresScopes__") {
+                if name.as_str().ends_with("__Scope") {
                     Some(ty.to_string())
                 } else {
                     None
@@ -189,13 +156,13 @@ mod test {
 
     #[test]
     fn requires_scopes_spec_v0_1_definitions() {
-        let schema = get_schema_with_requires_scopes(Version { major: 0, minor: 1 });
+        let schema = trivial_schema();
         let types_snapshot = requires_scopes_spec_types_snapshot(&schema);
-        let expected_types = r#"scalar requiresScopes__Scope"#;
+        let expected_types = r#"scalar federation__Scope"#;
         assert_eq!(types_snapshot.trim(), expected_types.trim());
 
         let directives_snapshot: String = requires_scopes_spec_directives_snapshot(&schema);
-        let expected_directives = r#"directive @requiresScopes(scopes: [[requiresScopes__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM"#;
+        let expected_directives = r#"directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM"#;
         assert_eq!(directives_snapshot.trim(), expected_directives.trim());
     }
 }

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -264,7 +264,6 @@ pub(crate) mod tests {
     use crate::schema::FederationSchema;
     use crate::schema::position::EnumTypeDefinitionPosition;
     use crate::schema::position::PositionLookupError;
-    use crate::subgraph::typestate::expand_schema;
 
     fn insert_enum_type(schema: &mut FederationSchema, name: Name) -> Result<(), FederationError> {
         let status_pos = EnumTypeDefinitionPosition {
@@ -295,14 +294,31 @@ pub(crate) mod tests {
             schema
                 @link(url: "https://specs.apollo.dev/link/v1.0")
                 @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
-            
+
+            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
             directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
             directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+            enum join__Graph {
+                A @join__graph(name: "A", url: "http://localhost:4002/")
+                B @join__graph(name: "B", url: "http://localhost:4003/")
+            }
+
+            scalar link__Import
+
+            enum link__Purpose {
+                SECURITY
+                EXECUTION
+            }
             "#,
                 "",
             )
             .build()?;
-        let mut schema = expand_schema(schema)?;
+        let mut schema = FederationSchema::new(schema)?;
         insert_enum_type(&mut schema, name!("Status"))?;
         insert_enum_type(&mut schema, name!("UnusedStatus"))?;
 

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -18,6 +18,7 @@ use crate::link::federation_spec_definition::FEDERATION_KEY_DIRECTIVE_NAME_IN_SP
 use crate::link::federation_spec_definition::FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
+use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::link::link_spec_definition::LinkSpecDefinition;
 use crate::link::spec::Identity;
@@ -38,7 +39,6 @@ use crate::schema::validators::provides::validate_provides_directives;
 use crate::schema::validators::requires::validate_requires_directives;
 use crate::schema::validators::shareable::validate_shareable_directives;
 use crate::schema::validators::tag::validate_tag_directives;
-use crate::subgraph;
 use crate::supergraph::FEDERATION_ENTITIES_FIELD_NAME;
 use crate::supergraph::FEDERATION_SERVICE_FIELD_NAME;
 
@@ -353,9 +353,9 @@ pub(crate) const FEDERATION_OPERATION_FIELDS: [Name; 2] = [
 ];
 
 fn all_default_federation_directive_names() -> HashSet<Name> {
-    subgraph::spec::FEDERATION_V1_DIRECTIVE_NAMES
+    FederationSpecDefinition::latest()
+        .directive_specs()
         .iter()
-        .chain(subgraph::spec::FEDERATION_V2_DIRECTIVE_NAMES.iter())
-        .cloned()
+        .map(|spec| spec.name().clone())
         .collect()
 }

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -397,7 +397,7 @@ pub mod test_utils {
         let subgraph =
             Subgraph::parse(name, &format!("http://{name}"), schema_str).expect("valid schema");
         let subgraph = if matches!(build_option, BuildOption::AsFed2) {
-            subgraph.into_fed2_test_subgraph()?
+            subgraph.into_fed2_test_subgraph(true)?
         } else {
             subgraph
         };
@@ -414,7 +414,7 @@ pub mod test_utils {
         let subgraph =
             Subgraph::parse(name, &format!("http://{name}"), schema_str).expect("valid schema");
         let subgraph = if matches!(build_option, BuildOption::AsFed2) {
-            subgraph.into_fed2_test_subgraph()?
+            subgraph.into_fed2_test_subgraph(true)?
         } else {
             subgraph
         };

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -85,6 +85,7 @@ pub const FEDERATION_V2_DIRECTIVE_NAMES: [Name; 13] = [
     TAG_DIRECTIVE_NAME,
 ];
 
+#[allow(dead_code)]
 pub(crate) const FEDERATION_V2_ELEMENT_NAMES: [Name; 2] =
     [FIELDSET_SCALAR_NAME, CONTEXTFIELDVALUE_SCALAR_NAME];
 

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -174,9 +174,13 @@ impl Subgraph<Initial> {
     /// - Returns an equivalent subgraph with a `@link` to the auto expanded federation spec.
     /// - This is mainly for testing and not optimized.
     // PORT_NOTE: Corresponds to `asFed2SubgraphDocument` function in JS, but simplified.
-    pub fn into_fed2_test_subgraph(self) -> Result<Self, SubgraphError> {
+    pub fn into_fed2_test_subgraph(self, use_latest: bool) -> Result<Self, SubgraphError> {
         let mut schema = self.state.schema;
-        let federation_spec = FederationSpecDefinition::auto_expanded_federation_spec();
+        let federation_spec = if use_latest {
+            FederationSpecDefinition::latest()
+        } else {
+            FederationSpecDefinition::auto_expanded_federation_spec()
+        };
         add_federation_link_to_schema(&mut schema, federation_spec.version())
             .map_err(|e| SubgraphError::new(self.name.clone(), e))?;
         Ok(Self::new(&self.name, &self.url, schema))

--- a/apollo-federation/tests/dhat_profiling/supergraph.rs
+++ b/apollo-federation/tests/dhat_profiling/supergraph.rs
@@ -15,8 +15,8 @@ fn valid_supergraph_schema() {
     const MAX_BYTES_SUPERGRAPH: usize = 135_050; // ~135 KiB. actual number: 128605
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 4889.
-    const MAX_ALLOCATIONS_SUPERGRAPH: u64 = 5_150; // number of allocations. actual number: 4889
+    // Actual number: 4929.
+    const MAX_ALLOCATIONS_SUPERGRAPH: u64 = 5_150; // number of allocations.
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
     // Actual number: 188_420.
@@ -25,10 +25,10 @@ fn valid_supergraph_schema() {
     const MAX_BYTES_API_SCHEMA: usize = 197_900; // ~200 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 5_535.
+    // Actual number: 5584.
     //
-    // API schema has an additional 646 allocations (5_535-4_889=646).
-    const MAX_ALLOCATIONS_API_SCHEMA: u64 = 5_800;
+    // API schema has an additional 655 allocations (= 5584 - 4929).
+    const MAX_ALLOCATIONS_API_SCHEMA: u64 = 5863;
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
     // Actual number: 552_781.
@@ -37,10 +37,10 @@ fn valid_supergraph_schema() {
     const MAX_BYTES_SUBGRAPHS: usize = 580_420; // ~600 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 12_185.
+    // Actual number: 13205.
     //
-    // Extract subgraphs from supergraph has an additional 6_650 allocations (12_185-5_535=6_650).
-    const MAX_ALLOCATIONS_SUBGRAPHS: u64 = 12_800;
+    // Extract subgraphs from supergraph has an additional 7621 allocations (= 13205 - 5584).
+    const MAX_ALLOCATIONS_SUBGRAPHS: u64 = 13865;
 
     let schema = std::fs::read_to_string(SCHEMA).unwrap();
 
@@ -49,12 +49,14 @@ fn valid_supergraph_schema() {
     let supergraph =
         apollo_federation::Supergraph::new(&schema).expect("supergraph should be valid");
     let stats = dhat::HeapStats::get();
+    println!("Supergraph::new: {stats:?}");
     dhat::assert!(stats.max_bytes < MAX_BYTES_SUPERGRAPH);
     dhat::assert!(stats.total_blocks < MAX_ALLOCATIONS_SUPERGRAPH);
 
     let api_options = apollo_federation::ApiSchemaOptions::default();
     let _api_schema = supergraph.to_api_schema(api_options);
     let stats = dhat::HeapStats::get();
+    println!("supergraph.to_api_schema: {stats:?}");
     dhat::assert!(stats.max_bytes < MAX_BYTES_API_SCHEMA);
     dhat::assert!(stats.total_blocks < MAX_ALLOCATIONS_API_SCHEMA);
 
@@ -62,6 +64,7 @@ fn valid_supergraph_schema() {
         .extract_subgraphs()
         .expect("subgraphs should be extracted");
     let stats = dhat::HeapStats::get();
+    println!("supergraph.extract_subgraphs: {stats:?}");
     dhat::assert!(stats.max_bytes < MAX_BYTES_SUBGRAPHS);
     dhat::assert!(stats.total_blocks < MAX_ALLOCATIONS_SUBGRAPHS);
 }

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -1814,9 +1814,6 @@ mod cost_tests {
     #[test]
     fn rejects_cost_applications_on_interfaces() {
         let doc = r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@cost"])
-
             type Query {
                 a: A
             }
@@ -1842,9 +1839,6 @@ mod list_size_tests {
     #[test]
     fn rejects_applications_on_non_lists_unless_it_uses_sized_fields() {
         let doc = r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
             type Query {
                 a1: A @listSize(assumedSize: 5)
                 a2: A @listSize(assumedSize: 10, sizedFields: ["ints"])
@@ -1867,9 +1861,6 @@ mod list_size_tests {
     #[test]
     fn rejects_negative_assumed_size() {
         let doc = r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
             type Query {
                 a: [Int] @listSize(assumedSize: -5)
                 b: [Int] @listSize(assumedSize: 0)
@@ -1888,9 +1879,6 @@ mod list_size_tests {
     #[test]
     fn rejects_slicing_arguments_not_in_field_arguments() {
         let doc = r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
             type Query {
                 myField(something: Int): [String]
                     @listSize(slicingArguments: ["missing1", "missing2"])
@@ -1921,9 +1909,6 @@ mod list_size_tests {
     #[test]
     fn rejects_slicing_arguments_not_int_or_int_non_null() {
         let doc = r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
             type Query {
                 sliced(
                     first: String
@@ -1960,9 +1945,6 @@ mod list_size_tests {
     #[test]
     fn rejects_sized_fields_when_output_type_is_not_object() {
         let doc = r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
             type Query {
                 notObject: Int @listSize(assumedSize: 1, sizedFields: ["anything"])
                 a: A @listSize(assumedSize: 5, sizedFields: ["ints"])
@@ -1990,9 +1972,6 @@ mod list_size_tests {
     #[test]
     fn rejects_sized_fields_not_in_output_type() {
         let doc = r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
             type Query {
                 a: A @listSize(assumedSize: 5, sizedFields: ["notOnA"])
             }
@@ -2014,9 +1993,6 @@ mod list_size_tests {
     #[test]
     fn rejects_sized_fields_not_lists() {
         let doc = r#"
-            extend schema
-                @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
-
             type Query {
                 a: A
                     @listSize(


### PR DESCRIPTION
This PR fixes a bug where Rust composition does not accept newer federation directives like `@authenticated`.

* Fixed validate_federation_imports to use the actual federation spec, instead of hardcoded names.
* Also fixed subgraph tests to auto-import all latest federation directives and not to use supergraph spec links.
  * `into_fed2_test_subgraph` was updated to have a `bool` argument that allow auto-importing all federation directives into test subgraph schemas.
  * With that, subgraph tests don't need to have spec `@links` any more.

<!-- start metadata -->
<!-- FED-666 -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary