### PR TITLE
chore: use multer to test subscription responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4226,6 +4226,8 @@ dependencies = [
  "log",
  "memchr",
  "mime",
+ "serde",
+ "serde_json",
  "spin",
  "version_check",
 ]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -326,6 +326,7 @@ test-log = { version = "0.2.16", default-features = false, features = [
 ] }
 basic-toml = "0.1.9"
 tower-test = "0.4.0"
+multer = { version = "2.1.0", features = ["json"] }
 
 # See note above in this file about `^tracing` packages which also applies to
 # these dev dependencies.

--- a/apollo-router/tests/integration/subscription_load_test.rs
+++ b/apollo-router/tests/integration/subscription_load_test.rs
@@ -14,7 +14,9 @@ const SUB_QUERY: &str =
 const UNFEDERATED_SUB_QUERY: &str = r#"subscription {  userWasCreated { name username }}"#;
 
 fn is_json_field(field: &multer::Field<'_>) -> bool {
-    field.content_type().is_some_and(|mime| mime.essence_str() == "application/json")
+    field
+        .content_type()
+        .is_some_and(|mime| mime.essence_str() == "application/json")
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -30,7 +32,11 @@ async fn test_subscription() -> Result<(), BoxError> {
         // Use `multipart/form-data` parsing. The router actually responds with `multipart/mixed`, but
         // the formats are compatible.
         let mut multipart = multer::Multipart::new(response.bytes_stream(), "graphql");
-        while let Some(field) = multipart.next_field().await.expect("could not read next chunk") {
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .expect("could not read next chunk")
+        {
             assert!(is_json_field(&field), "all response chunks must be JSON");
             let _: serde_json::Value = field.json().await.expect("invalid JSON chunk");
         }

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -219,7 +219,7 @@ pub async fn verify_subscription_events(
         );
     });
 
-    _ = timeout.await.expect("Subscription test timed out");
+    timeout.await.expect("Subscription test timed out");
 
     assert!(
         subscription_events.len() == expected_events.len(),

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -12,7 +12,6 @@ use axum::http::StatusCode;
 use axum::response::Response;
 use axum::routing::get;
 use axum::routing::post;
-use futures::StreamExt;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::json;
@@ -72,8 +71,6 @@ pub fn create_sub_query(interval_ms: u64, nb_events: usize) -> String {
         interval_ms, nb_events
     )
 }
-
-const MULTIPART_CHUNK_SEPARATOR: &str = "\r\n--graphql\r\ncontent-type: application/json\r\n\r\n";
 
 pub async fn start_subscription_server_with_payloads(
     payloads: Vec<serde_json::Value>,
@@ -177,42 +174,34 @@ pub async fn start_coprocessor_server() -> wiremock::MockServer {
     coprocessor_server
 }
 
+fn is_json_field(field: &multer::Field<'_>) -> bool {
+    field.content_type().is_some_and(|mime| mime.essence_str() == "application/json")
+}
+
 pub async fn verify_subscription_events(
-    mut stream: impl futures::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Unpin,
+    stream: impl futures::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send,
     expected_events: Vec<serde_json::Value>,
     include_heartbeats: bool,
 ) -> Result<Vec<serde_json::Value>, String> {
     use pretty_assertions::assert_eq;
 
+    // Use `multipart/form-data` parsing. The router actually responds with `multipart/mixed`, but
+    // the formats are compatible.
+    let mut multipart = multer::Multipart::new(stream, "graphql");
+
     let mut subscription_events = Vec::new();
     // Set a longer timeout for receiving all events
     let timeout = tokio::time::timeout(tokio::time::Duration::from_secs(60), async {
-        let mut chunk_string = String::new();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|e| format!("Stream error: {}", e))?;
-            chunk_string += &String::from_utf8_lossy(&chunk);
+        while let Some(field) = multipart.next_field().await.expect("could not read next chunk") {
+            assert!(is_json_field(&field), "all response chunks must be JSON");
+
+            let parsed: serde_json::Value = field.json().await.expect("invalid JSON chunk");
+            if parsed == serde_json::json!({}) && !include_heartbeats {
+                continue;
+            }
+
+            subscription_events.push(parsed);
         }
-        let events = chunk_string
-            .split(MULTIPART_CHUNK_SEPARATOR)
-            .filter_map(|s| {
-                let parsed = serde_json::from_str::<serde_json::Value>(
-                    s.trim_end_matches("\r\n--graphql--\r\n"), // If it's the last event
-                )
-                .ok()?;
-                if s.is_empty() {
-                    return None;
-                }
-                if parsed == serde_json::json!({}) {
-                    if include_heartbeats {
-                        Some(parsed)
-                    } else {
-                        None
-                    }
-                } else {
-                    Some(parsed)
-                }
-            });
-        subscription_events.extend(events);
 
         // If we've received more events than expected, that's an error
         if subscription_events.len() > expected_events.len() {
@@ -246,43 +235,27 @@ pub async fn verify_subscription_events(
     let termination_timeout = tokio::time::timeout(
         tokio::time::Duration::from_millis(1000),
         async {
-            while let Some(chunk) = stream.next().await {
-                let chunk = chunk.map_err(|e| format!("Stream error: {}", e))?;
-                let chunk_str = String::from_utf8_lossy(&chunk);
+            while let Some(field) = multipart.next_field().await.expect("could not read next chunk") {
+                assert!(is_json_field(&field), "all response chunks must be JSON");
 
-                // Only check for actual data events, ignore heartbeats/keep-alives
-                if chunk_str.contains("content-type: application/json") {
-                    if let Some(json_start) = chunk_str.find('{') {
-                        if let Some(json_end) = chunk_str.rfind('}') {
-                            let json_str = &chunk_str[json_start..=json_end];
-                            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str)
-                            {
-                                let data = parsed
-                                    .get("data")
-                                    .or_else(|| parsed.get("payload").and_then(|p| p.get("data")));
-                                if data.is_some() {
-                                    return Err(format!(
-                                        "Unexpected additional event received after {} expected events: {}",
-                                        expected_events.len(),
-                                        chunk_str
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
+                let parsed: serde_json::Value = field.json().await.expect("invalid JSON chunk");
+                let data = parsed
+                    .get("data")
+                    .or_else(|| parsed.get("payload").and_then(|p| p.get("data")));
 
-                if chunk_str.contains("--graphql--") {
-                    debug!("Stream properly terminated with completion marker");
-                    break;
+                if data.is_some() {
+                    return Err(format!(
+                        "Unexpected additional event received after {} expected events: {}",
+                        expected_events.len(),
+                        parsed,
+                    ));
                 }
             }
             Ok::<(), String>(())
         },
     );
 
-    // It's OK if this times out - it means no additional events arrived
-    let _ = termination_timeout.await;
+    assert!(termination_timeout.await.is_ok(), "subscription should have closed cleanly");
     // Simple equality comparison using pretty_assertions
     assert_eq!(
         subscription_events, expected_events,

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -175,7 +175,9 @@ pub async fn start_coprocessor_server() -> wiremock::MockServer {
 }
 
 fn is_json_field(field: &multer::Field<'_>) -> bool {
-    field.content_type().is_some_and(|mime| mime.essence_str() == "application/json")
+    field
+        .content_type()
+        .is_some_and(|mime| mime.essence_str() == "application/json")
 }
 
 pub async fn verify_subscription_events(
@@ -192,7 +194,11 @@ pub async fn verify_subscription_events(
     let mut subscription_events = Vec::new();
     // Set a longer timeout for receiving all events
     let timeout = tokio::time::timeout(tokio::time::Duration::from_secs(60), async {
-        while let Some(field) = multipart.next_field().await.expect("could not read next chunk") {
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .expect("could not read next chunk")
+        {
             assert!(is_json_field(&field), "all response chunks must be JSON");
 
             let parsed: serde_json::Value = field.json().await.expect("invalid JSON chunk");
@@ -232,10 +238,13 @@ pub async fn verify_subscription_events(
     }
 
     // Give the stream a moment to ensure it's properly terminated and no more events arrive
-    let termination_timeout = tokio::time::timeout(
-        tokio::time::Duration::from_millis(1000),
-        async {
-            while let Some(field) = multipart.next_field().await.expect("could not read next chunk") {
+    let termination_timeout =
+        tokio::time::timeout(tokio::time::Duration::from_millis(1000), async {
+            while let Some(field) = multipart
+                .next_field()
+                .await
+                .expect("could not read next chunk")
+            {
                 assert!(is_json_field(&field), "all response chunks must be JSON");
 
                 let parsed: serde_json::Value = field.json().await.expect("invalid JSON chunk");
@@ -252,10 +261,12 @@ pub async fn verify_subscription_events(
                 }
             }
             Ok::<(), String>(())
-        },
-    );
+        });
 
-    assert!(termination_timeout.await.is_ok(), "subscription should have closed cleanly");
+    assert!(
+        termination_timeout.await.is_ok(),
+        "subscription should have closed cleanly"
+    );
     // Simple equality comparison using pretty_assertions
     assert_eq!(
         subscription_events, expected_events,

--- a/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
+++ b/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
@@ -244,9 +244,7 @@ async fn test_subscription_ws_passthrough() -> Result<(), BoxError> {
         create_expected_user_payload(1),
         create_expected_user_payload(2),
     ];
-    let _subscription_events = verify_subscription_events(stream, expected_events, true)
-        .await
-        .map_err(|e| format!("Event verification failed: {}", e))?;
+    let _subscription_events = verify_subscription_events(stream, expected_events, true).await;
 
     // Check for errors in router logs
     router.assert_no_error_logs();
@@ -315,9 +313,7 @@ async fn test_subscription_ws_passthrough_with_coprocessor() -> Result<(), BoxEr
         create_expected_user_payload(2),
     ];
 
-    let _subscription_events = verify_subscription_events(stream, expected_events, true)
-        .await
-        .map_err(|e| format!("Event verification failed: {}", e))?;
+    let _subscription_events = verify_subscription_events(stream, expected_events, true).await;
 
     // Check for errors in router logs (allow expected coprocessor error)
     router.assert_no_error_logs();
@@ -390,9 +386,7 @@ async fn test_subscription_ws_passthrough_error_payload() -> Result<(), BoxError
         create_expected_user_payload(1),
         create_expected_user_payload_missing_reviews(2),
     ];
-    let _subscription_events = verify_subscription_events(stream, expected_events, true)
-        .await
-        .map_err(|e| format!("Event verification failed: {}", e))?;
+    let _subscription_events = verify_subscription_events(stream, expected_events, true).await;
 
     // Check for errors in router logs
     router.assert_no_error_logs();
@@ -470,9 +464,7 @@ async fn test_subscription_ws_passthrough_pure_error_payload() -> Result<(), Box
         create_expected_partial_error_payload(2),
         create_expected_error_payload(),
     ];
-    let _subscription_events = verify_subscription_events(stream, expected_events, true)
-        .await
-        .map_err(|e| format!("Event verification failed: {}", e))?;
+    let _subscription_events = verify_subscription_events(stream, expected_events, true).await;
 
     // Check for errors in router logs
     router.assert_no_error_logs();
@@ -566,9 +558,7 @@ async fn test_subscription_ws_passthrough_pure_error_payload_with_coprocessor()
         create_expected_partial_error_payload(3),
         create_expected_error_payload(),
     ];
-    let _subscription_events = verify_subscription_events(stream, expected_events, true)
-        .await
-        .map_err(|e| format!("Event verification failed: {}", e))?;
+    let _subscription_events = verify_subscription_events(stream, expected_events, true).await;
 
     // Check for errors in router logs
     router.assert_no_error_logs();
@@ -653,16 +643,7 @@ async fn test_subscription_ws_passthrough_on_config_reload() -> Result<(), BoxEr
     assert_eq!(total_active, 1);
     assert_eq!(total_active + total_terminating, 1);
 
-    match verify_subscription_events(stream, expected_events, true)
-        .await
-        .map_err(|e| format!("Event verification failed: {}", e))
-    {
-        Ok(_events) => {}
-        Err(err) if err.contains("unexpected EOF") => {
-            log::warn!("{}", err)
-        }
-        Err(err) => return Err(err.into()),
-    }
+    verify_subscription_events(stream, expected_events, true).await;
 
     router.graceful_shutdown().await;
     // router.assert_shutdown().await;
@@ -755,16 +736,7 @@ async fn test_subscription_ws_passthrough_on_schema_reload() -> Result<(), BoxEr
     assert_eq!(total_active, 1);
     assert_eq!(total_active + total_terminating, 1);
 
-    match verify_subscription_events(stream, expected_events, true)
-        .await
-        .map_err(|e| format!("Event verification failed: {}", e))
-    {
-        Ok(_events) => {}
-        Err(err) if err.contains("unexpected EOF") => {
-            log::warn!("{}", err)
-        }
-        Err(err) => return Err(err.into()),
-    }
+    verify_subscription_events(stream, expected_events, true).await;
 
     router.graceful_shutdown().await;
     // router.assert_shutdown().await;


### PR DESCRIPTION
Follow-up to #7731.

Use the multer crate for parsing subscription `multipart/mixed` streams
instead of a hand-rolled implementation. multer technically is for
`multipart/form-data`, which is sort of the successor format to
`multipart/mixed` if i understand the RFCs correctly. But the format is
essentially identical.

This implementation is mostly stricter than before. These things now
cause test failures:
- Final `--graphql--` boundaries in the middle of the stream
- Omitting the final `--graphql--` boundary
- Not draining the entire subscription
- Non-JSON response chunks

But these benign things will not:
- Having multiple headers on a chunk (we don't do this, but it sounds
  valid)
- A chunk boundary occurring at the edge of an HTTP frame from hyper