### PR TITLE
Revert "Revert "Add _dd.measured to spans when agent sampling is enabled""

### DIFF
--- a/.changesets/fix_bryn_otlp_export_dd_measured.md
+++ b/.changesets/fix_bryn_otlp_export_dd_measured.md
@@ -1,0 +1,5 @@
+### OTLP trace exporter does not correctly display resources in Datadog APM view ([PR #7344](https://github.com/apollographql/router/pull/7344))
+
+Router 2.x Datadog APM view is now fixed when using `preview_datadog_agent_sampling`. This was underreporting requests due to missing `_dd.measured` attributes.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/7344

--- a/apollo-router/src/plugins/telemetry/tracing/datadog/span_processor.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog/span_processor.rs
@@ -1,4 +1,5 @@
 use opentelemetry::Context;
+use opentelemetry::KeyValue;
 use opentelemetry::trace::SpanContext;
 use opentelemetry::trace::TraceResult;
 use opentelemetry_sdk::Resource;
@@ -36,6 +37,7 @@ impl<T: SpanProcessor> SpanProcessor for DatadogSpanProcessor<T> {
             span.span_context.is_remote(),
             span.span_context.trace_state().clone(),
         );
+        span.attributes.push(KeyValue::new("_dd.measured", 1));
         self.delegate.on_end(span)
     }
 

--- a/apollo-router/tests/integration/telemetry/otlp.rs
+++ b/apollo-router/tests/integration/telemetry/otlp.rs
@@ -386,6 +386,7 @@ async fn test_untraced_request_sample_datadog_agent() -> Result<(), BoxError> {
         .services(["router", "subgraph"].into())
         .priority_sampled("1")
         .subgraph_sampled(true)
+        .measured_spans(["router", "supergraph"].into())
         .build()
         .validate_otlp_trace(
             &mut router,
@@ -792,20 +793,13 @@ impl Verifier for OtlpTraceSpec<'_> {
     }
 
     fn measured_span(&self, trace: &Value, name: &str) -> Result<bool, BoxError> {
-        let binding1 = trace.select_path(&format!(
-            "$..[?(@.meta.['otel.original_name'] == '{}')].metrics.['_dd.measured']",
+        let binding = trace.select_path(&format!(
+            "$..[?(@.attributes[?(@.key == 'otel.original_name' && @.value.stringValue == '{}')])].attributes[?(@.key == '_dd.measured')].value.intValue",
             name
         ))?;
-        let binding2 = trace.select_path(&format!(
-            "$..[?(@.name == '{}')].metrics.['_dd.measured']",
-            name
-        ))?;
-        Ok(binding1
-            .first()
-            .or(binding2.first())
-            .and_then(|v| v.as_f64())
-            .map(|v| v == 1.0)
-            .unwrap_or_default())
+
+        let measured = binding.first().and_then(|v| v.as_i64()).unwrap_or_default();
+        Ok(measured == 1)
     }
 
     async fn find_valid_metrics(&self) -> Result<(), BoxError> {


### PR DESCRIPTION
Reverts apollographql/router#7403

Reopening this PR so that we can see if there are conflicts while we get clarification from datadog.

The current situation where the APM view is not functional is unsustainable and adding yet another config to allow users to set measured on a per span basis is complicated. 

Given that the behaviour in Router 1.x is that all spans are measured this feels like a regression rather than a nice to have.