### PR TITLE
Added an error code for CompositionError::SubgraphError

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -159,9 +159,12 @@ pub enum CompositionError {
 impl CompositionError {
     pub fn code(&self) -> ErrorCode {
         match self {
-            Self::SubgraphError { error, .. } => {
-                error.errors().first().expect("At least one error").code()
-            }
+            Self::SubgraphError { error, .. } => error
+                .errors()
+                .into_iter()
+                .next()
+                .map(SingleFederationError::code)
+                .unwrap_or(ErrorCode::ErrorCodeMissing),
             Self::EmptyMergedEnumType { .. } => ErrorCode::EmptyMergedEnumType,
             Self::EnumValueMismatch { .. } => ErrorCode::EnumValueMismatch,
             Self::InvalidGraphQL { .. } => ErrorCode::InvalidGraphQL,
@@ -1868,6 +1871,14 @@ static INTERNAL: LazyLock<ErrorCodeDefinition> = LazyLock::new(|| {
     )
 });
 
+static ERROR_CODE_MISSING: LazyLock<ErrorCodeDefinition> = LazyLock::new(|| {
+    ErrorCodeDefinition::new(
+        "ERROR_CODE_MISSING".to_owned(),
+        "An internal federation error occurred when translating a federation error into an error code".to_owned(),
+        None,
+    )
+});
+
 static UNSUPPORTED_FEDERATION_VERSION: LazyLock<ErrorCodeDefinition> = LazyLock::new(|| {
     ErrorCodeDefinition::new(
         "UNSUPPORTED_FEDERATION_VERSION".to_owned(),
@@ -2049,6 +2060,7 @@ static INVALID_TAG_NAME: LazyLock<ErrorCodeDefinition> = LazyLock::new(|| {
 
 #[derive(Debug, PartialEq, strum_macros::EnumIter)]
 pub enum ErrorCode {
+    ErrorCodeMissing,
     Internal,
     InvalidGraphQL,
     DirectiveDefinitionInvalid,
@@ -2149,7 +2161,6 @@ pub enum ErrorCode {
 impl ErrorCode {
     pub fn definition(&self) -> &'static ErrorCodeDefinition {
         match self {
-            // TODO: We should determine the code and doc info for internal errors.
             ErrorCode::Internal => &INTERNAL,
             ErrorCode::InvalidGraphQL => &INVALID_GRAPHQL,
             ErrorCode::DirectiveDefinitionInvalid => &DIRECTIVE_DEFINITION_INVALID,
@@ -2261,6 +2272,7 @@ impl ErrorCode {
             ErrorCode::ContextNoResolvableKey => &CONTEXT_NO_RESOLVABLE_KEY,
             ErrorCode::ContextSelectionInvalid => &CONTEXT_SELECTION_INVALID,
             ErrorCode::InvalidTagName => &INVALID_TAG_NAME,
+            ErrorCode::ErrorCodeMissing => &ERROR_CODE_MISSING,
         }
     }
 }

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -159,7 +159,9 @@ pub enum CompositionError {
 impl CompositionError {
     pub fn code(&self) -> ErrorCode {
         match self {
-            Self::SubgraphError { error, .. } => error.code(),
+            Self::SubgraphError { error, .. } => {
+                error.errors().first().expect("At least one error").code()
+            }
             Self::EmptyMergedEnumType { .. } => ErrorCode::EmptyMergedEnumType,
             Self::EnumValueMismatch { .. } => ErrorCode::EnumValueMismatch,
             Self::InvalidGraphQL { .. } => ErrorCode::InvalidGraphQL,

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -159,7 +159,7 @@ pub enum CompositionError {
 impl CompositionError {
     pub fn code(&self) -> ErrorCode {
         match self {
-            Self::SubgraphError { .. } => todo!(),
+            Self::SubgraphError { error, .. } => error.code(),
             Self::EmptyMergedEnumType { .. } => ErrorCode::EmptyMergedEnumType,
             Self::EnumValueMismatch { .. } => ErrorCode::EnumValueMismatch,
             Self::InvalidGraphQL { .. } => ErrorCode::InvalidGraphQL,


### PR DESCRIPTION
This PR adds an error code for the `SubgraphError` variant of `CompositionError` rather than panicking.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
