### PR TITLE
refactor(federation): simplified `GraphPath::add` using `GraphPathTriggerVariant` trait

### DIFF
--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -92,6 +92,13 @@ impl GraphPathTriggerVariant for OpGraphPathTrigger {
             _ => None,
         }
     }
+
+    fn get_op_path_element(&self) -> Option<&OpPathElement> {
+        match self {
+            OpGraphPathTrigger::OpPathElement(ele) => Some(ele),
+            OpGraphPathTrigger::Context(_) => None,
+        }
+    }
 }
 
 /// A path of operation elements within a GraphQL operation.

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -61,6 +61,10 @@ impl GraphPathTriggerVariant for QueryGraphEdgeTransition {
     fn get_field_mut(&mut self) -> Option<&mut Field> {
         None
     }
+
+    fn get_op_path_element(&self) -> Option<&super::operation::OpPathElement> {
+        None
+    }
 }
 
 /// Wraps a "composition validation" path (one built from `QueryGraphEdgeTransition`s) along with


### PR DESCRIPTION
#### Summary

- added `get_op_path_element` method to the `GraphPathTriggerVariant` trait.
- Using that trait method avoids a downcast from `TTrigger` to `GraphPathTrigger` type.
- removed `enum GraphPathTrigger`, which is no longer necessary.

<!-- start metadata -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is a pure refactoring.