### PR TITLE
fix: @context locations should match JS definition

### DIFF
--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -140,8 +140,8 @@ impl SpecDefinition for ContextSpecDefinition {
             }],
             true,
             &[
-                DirectiveLocation::Object,
                 DirectiveLocation::Interface,
+                DirectiveLocation::Object,
                 DirectiveLocation::Union,
             ],
             true,

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -679,7 +679,7 @@ directive @federation__interfaceObject on OBJECT
 directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 directive @federation__policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
-directive @federation__context(name: String!) repeatable on OBJECT | INTERFACE | UNION
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
 directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
 directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION


### PR DESCRIPTION
Currently we rely on `apollo-rs` to compare directive locations. While semantically the same, current implementation compares ordered Vec which means we have to match the same order in the args and location definitions.
