### PR TITLE
chore: tweak renovate groups

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -104,28 +104,30 @@
         '/^opentelemetry/',
       ],
     },
-    // Our own `apollo-` packages deserve to get front-and-center treatment.
-    // We'll put them in their own PR to facilitate workflows that surface
-    // their changes earlier, and get us dog-fooding them quicker.
-    // They also have a small proclivity to require more hands-on changes
-    // since they're pre-0.x and we use them so extensively.
+    // Various monorepos / crates that are often released together
     {
       groupName: 'apollo-rs crates',
       groupSlug: 'rust-apollo-rs-updates',
-      matchManagers: [
-        'cargo',
-      ],
-      automerge: false,
-      matchPackageNames: [
-        '/^apollo-/',
-      ],
+      matchManagers: ['cargo'],
+      matchPackageNames: ['/^apollo-(parser|compiler|smith)$/'],
     },
-    // Not a monorepo, but belong together
     {
       groupName: 'rand crates',
       groupSlug: 'rust-rand',
       matchManagers: ['cargo'],
       matchPackageNames: ['/^rand$/', '/^rand[-_]/'],
+    },
+    {
+      groupName: 'nom crates',
+      groupSlug: 'rust-nom',
+      matchManagers: ['cargo'],
+      matchPackageNames: ['/^nom$/', '/^nom[-_]/'],
+    },
+    {
+      groupName: 'axum crates',
+      groupSlug: 'rust-axum',
+      matchManagers: ['cargo'],
+      matchPackageNames: ['/^axum$/', '/^axum-extra$/'],
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,35 +4,18 @@
     ':semanticCommits',
   ],
   customManagers: [
-    // Renovate Regex Manager Configuration
-    //
     // A slight variation on the pattern documented within Renovate's docs:
-    //
-    //   => https://docs.renovatebot.com/modules/manager/regex/
-    //
-    // This powers a mechanism that allows Renovate (the package dependency
-    // manager that we use within this repository) to bump packages that live
-    // outside of typical package manifests (e.g., `package.json`) and instead
-    // any number of files.
-    //
-    // This pattern can be conceivably adapted to any pattern to allow the
-    // "Renovation" of nearly anything.  This is largely what Renovate does
-    // behind the scenes for various datasources anyhow (e.g., Dockerfiles).
-    //
-    // You can find a list of data-source specific details on this page:
-    //
-    //   => https://docs.renovatebot.com/modules/datasource/
-    //
+    // => https://docs.renovatebot.com/modules/manager/regex/
     {
       customType: 'regex',
-      fileMatch: [
-        '^\\.tool-versions$',
-        '(^|/)Dockerfile[^/]*$',
-        '^rust-toolchain\\.toml$',
-        '^docs/.*?\\.mdx$',
-        '^.config/mise/.*?\\.toml$',
-        '^apollo-router/Cargo\\.toml$',
-        '^apollo-router/README\\.md$',
+      managerFilePatterns: [
+        '/^\\.tool-versions$/',
+        '/(^|/)Dockerfile[^/]*$/',
+        '/^rust-toolchain\\.toml$/',
+        '/^docs/.*?\\.mdx$/',
+        '/^.config/mise/.*?\\.toml$/',
+        '/^apollo-router/Cargo\\.toml$/',
+        '/^apollo-router/README\\.md$/',
       ],
       matchStrings: [
         '(#|<!--)\\s*renovate-automation: rustc version\\s*(?:-->)?\\n[^.]*?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\b',


### PR DESCRIPTION
- Add a group for axum crates (usually released together)
- Add a group for nom crates (versions usually interdependent)
- Narrow the apollo-rs group (apollo-environment-detector &
  apollo-federation are unrelated)<!-- start metadata -->

Also closes #7845 by renaming `fileMatch` -> `managerFilePatterns`