### PR TITLE
fix: Add validation for incompatible Datadog and trace context propagation

### DIFF
--- a/.changesets/fix_yoke_houseboat_peppermint_radish.md
+++ b/.changesets/fix_yoke_houseboat_peppermint_radish.md
@@ -1,0 +1,5 @@
+### Add validation for incompatible Datadog and trace context propagation
+
+Prevents simultaneous activation of Datadog tracing and W3C trace context propagation to avoid trace ID format conflicts. When both are enabled, the router now returns a clear configuration error explaining the incompatibility between Datadog's 64-bit trace IDs and W3C trace context's 128-bit trace IDs.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/7848

--- a/apollo-router/tests/integration/telemetry/fixtures/compatible_datadog_propagation.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/compatible_datadog_propagation.router.yaml
@@ -1,0 +1,8 @@
+telemetry:
+  exporters:
+    tracing:
+      propagation:
+        datadog: true
+        trace_context: false
+      datadog:
+        enabled: true

--- a/apollo-router/tests/integration/telemetry/fixtures/incompatible_datadog_propagation.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/incompatible_datadog_propagation.router.yaml
@@ -1,0 +1,19 @@
+include_subgraph_errors:
+  all: true # Propagate errors from all subgraphs
+
+homepage:
+  enabled: false
+
+supergraph:
+  listen: 127.0.0.1:4000
+
+telemetry:
+  exporters:
+    tracing:
+      # Enable both Datadog and trace context propagation - this should fail validation
+      datadog:
+        enabled: true
+        endpoint: http://localhost:8126/v0.5/traces
+      propagation:
+        datadog: true
+        trace_context: true

--- a/docs/source/routing/observability/telemetry/trace-exporters/overview.mdx
+++ b/docs/source/routing/observability/telemetry/trace-exporters/overview.mdx
@@ -181,6 +181,12 @@ telemetry:
            format: uuid
 ```
 
+<Note>
+
+**Incompatible propagation types**: Datadog propagation and W3C trace context propagation cannot be used simultaneously. Datadog uses a 64-bit trace ID format while W3C trace context uses a 128-bit format, which causes conflicts in trace ID handling. If you attempt to enable both, the router will return a configuration error at startup.
+
+</Note>
+
 #### `request` configuration reference
 
 | Option        | Values                                                        | Default                           | Description                         |


### PR DESCRIPTION
Prevents simultaneous activation of Datadog tracing and W3C trace context propagation to avoid trace ID format conflicts.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests, as necessary
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
