### PR TITLE
feat(response_cache): add support for cache-control header in request

### DIFF
--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -651,6 +651,37 @@ impl CacheService {
         {
             return self.service.call(request).await;
         }
+        // Don't use cache at all if no-store is set in cache-control header
+        if request
+            .subgraph_request
+            .headers()
+            .get_all(&CACHE_CONTROL)
+            .iter()
+            .next()
+            .is_some()
+        {
+            let cache_control = match CacheControl::new(request.subgraph_request.headers(), None) {
+                Ok(cache_control) => cache_control,
+                Err(err) => {
+                    return Ok(subgraph::Response::builder()
+                        .subgraph_name(request.subgraph_name)
+                        .context(request.context)
+                        .error(
+                            graphql::Error::builder()
+                                .message(format!("cannot get cache-control header: {err}"))
+                                .extension_code("INVALID_CACHE_CONTROL_HEADER")
+                                .build(),
+                        )
+                        .extensions(Object::default())
+                        .build());
+                }
+            };
+            if cache_control.no_store {
+                let mut resp = self.service.call(request).await?;
+                cache_control.to_headers(resp.response.headers_mut())?;
+                return Ok(resp);
+            }
+        }
         let query = request
             .subgraph_request
             .body()


### PR DESCRIPTION
If a client doesn't want to interact with the cache they can set the header `cache-control` to `no-store` and it won't use response cache plugin. This is an opt-in feature from the configuration because the router admin will have to propagate the header from supergraph request to subgraph request. Without this configuration nothing will happen if the cache-control is set to anything.

<!-- [ROUTER-1364] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
