### PR TITLE
fix: make `cargo test` work again after #7860

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -361,6 +361,8 @@ walkdir = "2.5.0"
 wiremock = "0.6"
 libtest-mimic = "0.8.0"
 rstest = "0.25.0"
+# Optional in `[dependencies]` behind a feature flag, but always used in our tests
+serde_regex = "1.1.0"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 rstack = { version = "0.3.3", features = ["dw"], default-features = false }


### PR DESCRIPTION
It turns out that `serde_regex` is sneakily used behind a
`cfg(any(test, feature = "snapshot"))`, so it actually must also be
listed in `[dev-dependencies]` and not only as an optional
feature-flagged dependency.

Add it back & add a comment so we know this for the future

<!-- start metadata -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- Tests added and passing
    - [x] Manual tests, as necessary
