### PR TITLE
chore: pin serde_yaml to 0.8.x range

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -47,6 +47,16 @@
       groupName: 'rustc',
       branchName: '{{{branchPrefix}}}rustc',
     },
+    // Keep serde_yaml at 0.8.x - version 0.9.x has breaking changes and the
+    // underlying package is deprecated. The package works as-is and we can
+    // consider replacing it in the future. We'll allow 0.8.x just in case
+    // there HAPPEN to be any security updates that we need to be aware of.
+    // See: https://github.com/dtolnay/serde-yaml/releases/tag/0.9.34
+    {
+      matchManagers: ['cargo'],
+      matchPackageNames: ['serde_yaml'],
+      allowedVersions: '0.8.x',
+    },
     // Bunch up all non-major dependencies into a single PR.  In the common case
     // where the upgrades apply cleanly, this causes less noise and is resolved faster
     // than starting a bunch of upgrades in parallel for what may turn out to be


### PR DESCRIPTION
Version 0.9.x has breaking changes and the underlying package is deprecated. The package works as-is and we can consider replacing it in the future. We'll allow 0.8.x just in case there are any security updates that we need to be aware of.

See: https://github.com/dtolnay/serde-yaml/releases/tag/0.9.34

This resolves the Renovate complaints about this package on the [Dependency Dashboard](https://github.com/apollographql/router/issues/57).