### PR TITLE
fix(response_cache): add content-type header in invalidation responses

### DIFF
--- a/apollo-router/src/plugins/response_cache/invalidation_endpoint.rs
+++ b/apollo-router/src/plugins/response_cache/invalidation_endpoint.rs
@@ -3,9 +3,11 @@ use std::task::Poll;
 
 use bytes::Buf;
 use futures::future::BoxFuture;
+use http::HeaderValue;
 use http::Method;
 use http::StatusCode;
 use http::header::AUTHORIZATION;
+use http::header::CONTENT_TYPE;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -87,6 +89,8 @@ impl Service<router::Request> for InvalidationService {
     }
 
     fn call(&mut self, req: router::Request) -> Self::Future {
+        const APPLICATION_JSON_HEADER_VALUE: HeaderValue =
+            HeaderValue::from_static("application/json");
         let invalidation = self.invalidation.clone();
         let config = self.config.clone();
         Box::pin(
@@ -96,6 +100,7 @@ impl Service<router::Request> for InvalidationService {
                     Span::current().record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                     return router::Response::error_builder()
                         .status_code(StatusCode::UNAUTHORIZED)
+                        .header(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE)
                         .error(
                             graphql::Error::builder()
                                 .message(String::from("Missing authorization header"))
@@ -149,6 +154,7 @@ impl Service<router::Request> for InvalidationService {
                                         .record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                                     return router::Response::error_builder()
                                         .status_code(StatusCode::UNAUTHORIZED)
+                                        .header(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE)
                                         .error(
                                             graphql::Error::builder()
                                                 .message(String::from(
@@ -171,6 +177,7 @@ impl Service<router::Request> for InvalidationService {
                                         .response(
                                             http::Response::builder()
                                                 .status(StatusCode::ACCEPTED)
+                                                .header(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE)
                                                 .body(router::body::from_bytes(
                                                     serde_json::to_string(&json!({
                                                         "count": count
@@ -185,6 +192,7 @@ impl Service<router::Request> for InvalidationService {
                                             .record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                                         router::Response::error_builder()
                                             .status_code(StatusCode::BAD_REQUEST)
+                                            .header(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE)
                                             .error(
                                                 graphql::Error::builder()
                                                     .message(err.to_string())
@@ -202,6 +210,7 @@ impl Service<router::Request> for InvalidationService {
                                 Span::current().record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                                 router::Response::error_builder()
                                     .status_code(StatusCode::BAD_REQUEST)
+                                    .header(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE)
                                     .error(
                                         graphql::Error::builder()
                                             .message(err)
@@ -217,6 +226,7 @@ impl Service<router::Request> for InvalidationService {
                         Span::current().record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                         router::Response::error_builder()
                             .status_code(StatusCode::METHOD_NOT_ALLOWED)
+                            .header(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE)
                             .error(
                                 graphql::Error::builder()
                                     .message("".to_string())

--- a/apollo-router/src/plugins/response_cache/invalidation_endpoint.rs
+++ b/apollo-router/src/plugins/response_cache/invalidation_endpoint.rs
@@ -336,6 +336,10 @@ mod tests {
             .build()
             .unwrap();
         let res = service.oneshot(req).await.unwrap();
+        assert_eq!(
+            res.response.headers().get(&CONTENT_TYPE).unwrap(),
+            &HeaderValue::from_static("application/json")
+        );
         assert_eq!(res.response.status(), StatusCode::UNAUTHORIZED);
     }
 
@@ -403,6 +407,10 @@ mod tests {
             .build()
             .unwrap();
         let res = service.oneshot(req).await.unwrap();
+        assert_eq!(
+            res.response.headers().get(&CONTENT_TYPE).unwrap(),
+            &HeaderValue::from_static("application/json")
+        );
         assert_eq!(res.response.status(), StatusCode::UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
Make sure to return `content-type: application/json` in response headers from the invalidation endpoint.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
