### PR TITLE
chore(deps): configure Renovate to handle exact version pins separately

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -112,5 +112,16 @@
       matchManagers: ['cargo'],
       matchPackageNames: ['/^axum$/', '/^axum-extra$/'],
     },
+    // Handle exact version pins (versions starting with =) in Cargo.toml files
+    // separately. Put them in individual PRs and require dashboard approval
+    // since they were explicitly pinned for a reason.
+    {
+      matchManagers: ['cargo'],
+      matchCurrentValue: '/^=/',
+      dependencyDashboardApproval: true,
+      automerge: false,
+      groupName: null,
+      groupSlug: null,
+    },
   ],
 }


### PR DESCRIPTION
Cargo dependencies pinned with an exact version (using '=' prefix) will now:
- Be handled in individual PRs (not grouped with other updates)
- Require dashboard approval before a PR is opened
- Never be automerged

This fixes an issue where pinned dependencies like 'rhai' were still being
included in dependency update PRs despite being explicitly pinned for stability
reasons (example: https://github.com/apollographql/router/pull/7863).
