### PR TITLE
Fix the subscription duplication problem when the client terminates the original subscription. (backport #7879)

### DIFF
--- a/.changesets/fix_bnjjj_rh_924.md
+++ b/.changesets/fix_bnjjj_rh_924.md
@@ -1,0 +1,7 @@
+### Fix deduplicated subscriptions hanging when one subscription closes ([PR #7879](https://github.com/apollographql/router/pull/7879))
+
+Fixes a regression introduced in v1.50.0. When multiple client subscriptions are deduped onto a single subgraph subscription in WebSocket passthrough mode, and the first client subscription closes, the Router would close the subgraph subscription. The other deduplicated subscriptions would then silently stop receiving events.
+
+Now outgoing subscriptions to subgraphs are kept open as long as _any_ client subscription uses them.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/7879

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -27,7 +27,6 @@ use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use rustls::RootCertStore;
 use serde::Serialize;
-use tokio::select;
 use tokio::sync::oneshot;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::connect_async_tls_with_config;
@@ -501,7 +500,6 @@ async fn call_websocket(
     let SubgraphRequest {
         subgraph_request,
         subscription_stream,
-        connection_closed_signal,
         id: subgraph_request_id,
         ..
     } = request;
@@ -726,26 +724,16 @@ async fn call_websocket(
 
     let (handle_sink, handle_stream) = handle.split();
 
+    // Forward GraphQL subscription stream to WebSocket handle
+    // Connection lifecycle is managed by the WebSocket infrastructure,
+    // so we don't need to handle connection_closed_signal here
     tokio::task::spawn(async move {
-        match connection_closed_signal {
-            Some(mut connection_closed_signal) => select! {
-                // We prefer to specify the order of checks within the select
-                biased;
-                _ = gql_stream
-                    .map(Ok::<_, graphql::Error>)
-                    .forward(handle_sink) => {
-                    tracing::debug!("gql_stream empty");
-                },
-                _ = connection_closed_signal.recv() => {
-                    tracing::debug!("connection_closed_signal triggered");
-                }
-            },
-            None => {
-                let _ = gql_stream
-                    .map(Ok::<_, graphql::Error>)
-                    .forward(handle_sink)
-                    .await;
-            }
+        if let Err(e) = gql_stream
+            .map(Ok::<_, graphql::Error>)
+            .forward(handle_sink)
+            .await
+        {
+            tracing::debug!("WebSocket subscription stream ended: {}", e);
         }
     });
 

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -279,12 +279,8 @@ async fn websocket_handler(
 ) -> Response {
     debug!("WebSocket upgrade requested");
     debug!("Headers: {:?}", headers);
-<<<<<<< HEAD
-    ws.on_upgrade(move |socket| handle_websocket(socket, config))
-=======
     ws.protocols(["graphql-ws"])
         .on_upgrade(move |socket| handle_websocket(socket, config, is_closed))
->>>>>>> b92f3097 (Fix the subscription duplication problem when the client terminates the original subscription. (#7879))
 }
 
 async fn handle_websocket(


### PR DESCRIPTION
Address a regression in subscription deduplication introduced in #5505. The client connection close event does not need handling in this task because it is managed elsewhere. Additionally, part of #5505 resolved the issue related to closing the websocket connection. This PR also includes tests to ensure no future regressions related to subscription deduplication and websocket close events.



---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1371]: https://apollographql.atlassian.net/browse/ROUTER-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #7879 done by [Mergify](https://mergify.com).