### PR TITLE
Add isSuccess argument to @source and @connect directives

### DIFF
--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@batch.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@batch.graphql.snap
@@ -84,6 +84,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/batch.g
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_User_0": Connector {
@@ -260,6 +261,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/batch.g
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@carryover.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@carryover.graphql.snap
@@ -168,6 +168,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_Query_t_0": Connector {
@@ -383,6 +384,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_T_r_0": Connector {
@@ -520,6 +522,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@interface-object.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@interface-object.graphql.snap
@@ -141,6 +141,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/interfa
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_Query_itfs_0": Connector {
@@ -235,6 +236,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/interfa
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_Query_itf_0": Connector {
@@ -390,6 +392,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/interfa
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@keys.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@keys.graphql.snap
@@ -144,6 +144,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_Query_t2_0": Connector {
@@ -336,6 +337,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_Query_unselected_0": Connector {
@@ -478,6 +480,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_T_r1_0": Connector {
@@ -608,6 +611,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_T_r2_0": Connector {
@@ -788,6 +792,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_T_r3_0": Connector {
@@ -964,6 +969,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_T_r4_0": Connector {
@@ -1115,6 +1121,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "one_T_r5_0": Connector {
@@ -1312,6 +1319,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@nested_inputs.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@nested_inputs.graphql.snap
@@ -278,6 +278,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/nested_
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@normalize_names.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@normalize_names.graphql.snap
@@ -96,6 +96,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/normali
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors-subgraph_Query_user_0": Connector {
@@ -251,6 +252,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/normali
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@realistic.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@realistic.graphql.snap
@@ -295,6 +295,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_Query_filterUsersByEmailDomain_0": Connector {
@@ -457,6 +458,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_Query_usersByCompany_0": Connector {
@@ -669,6 +671,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_Query_user_0": Connector {
@@ -1040,6 +1043,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@sibling_fields.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@sibling_fields.graphql.snap
@@ -91,6 +91,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/sibling
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_T_b_0": Connector {
@@ -224,6 +225,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/sibling
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@simple.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@simple.graphql.snap
@@ -96,6 +96,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_Query_user_0": Connector {
@@ -251,6 +252,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_User_d_1": Connector {
@@ -455,6 +457,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@steelthread.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@steelthread.graphql.snap
@@ -96,6 +96,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_Query_user_0": Connector {
@@ -251,6 +252,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     "connectors_User_d_1": Connector {
@@ -399,6 +401,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
@@ -156,6 +156,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/types_u
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 }

--- a/apollo-federation/src/connectors/models.rs
+++ b/apollo-federation/src/connectors/models.rs
@@ -77,12 +77,14 @@ pub struct ConnectorErrorsSettings {
     pub message: Option<JSONSelection>,
     pub source_extensions: Option<JSONSelection>,
     pub connect_extensions: Option<JSONSelection>,
+    pub connect_is_success: Option<JSONSelection>,
 }
 
 impl ConnectorErrorsSettings {
     fn from_directive(
         connect_errors: Option<&ErrorsArguments>,
         source_errors: Option<&ErrorsArguments>,
+        connect_is_success: Option<&JSONSelection>,
     ) -> Self {
         let message = connect_errors
             .and_then(|e| e.message.as_ref())
@@ -90,11 +92,12 @@ impl ConnectorErrorsSettings {
             .cloned();
         let source_extensions = source_errors.and_then(|e| e.extensions.as_ref()).cloned();
         let connect_extensions = connect_errors.and_then(|e| e.extensions.as_ref()).cloned();
-
+        let connect_is_success = connect_is_success.cloned();
         Self {
             message,
             source_extensions,
             connect_extensions,
+            connect_is_success,
         }
     }
 
@@ -111,6 +114,12 @@ impl ConnectorErrorsSettings {
             )
             .chain(
                 self.connect_extensions
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|m| m.variable_references()),
+            )
+            .chain(
+                self.connect_is_success
                     .as_ref()
                     .into_iter()
                     .flat_map(|m| m.variable_references()),
@@ -192,7 +201,14 @@ impl Connector {
         let batch_settings = connect.batch;
         let connect_errors = connect.errors.as_ref();
         let source_errors = source.and_then(|s| s.errors.as_ref());
-        let error_settings = ConnectorErrorsSettings::from_directive(connect_errors, source_errors);
+        // Use the connector setting if available, otherwise, use source setting
+        let is_success = connect
+            .is_success
+            .as_ref()
+            .or_else(|| source.and_then(|s| s.is_success.as_ref()));
+
+        let error_settings =
+            ConnectorErrorsSettings::from_directive(connect_errors, source_errors, is_success);
 
         // Collect all variables and subselections used in the request mappings
         let request_references: IndexSet<VariableReference<Namespace>> =
@@ -441,7 +457,7 @@ mod tests {
         let connectors =
             Connector::from_schema(subgraph.schema.schema(), "connectors", ConnectSpec::V0_1)
                 .unwrap();
-        assert_debug_snapshot!(&connectors, @r###"
+        assert_debug_snapshot!(&connectors, @r#"
         [
             Connector {
                 id: ConnectId {
@@ -559,6 +575,7 @@ mod tests {
                     message: None,
                     source_extensions: None,
                     connect_extensions: None,
+                    connect_is_success: None,
                 },
             },
             Connector {
@@ -689,10 +706,11 @@ mod tests {
                     message: None,
                     source_extensions: None,
                     connect_extensions: None,
+                    connect_is_success: None,
                 },
             },
         ]
-        "###);
+        "#);
     }
 
     #[test]

--- a/apollo-federation/src/connectors/snapshots/apollo_federation__connectors__models__tests__from_schema_v0_2.snap
+++ b/apollo-federation/src/connectors/snapshots/apollo_federation__connectors__models__tests__from_schema_v0_2.snap
@@ -131,6 +131,7 @@ expression: "&connectors"
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
     Connector {
@@ -331,6 +332,7 @@ expression: "&connectors"
             message: None,
             source_extensions: None,
             connect_extensions: None,
+            connect_is_success: None,
         },
     },
 ]

--- a/apollo-federation/src/connectors/spec/connect.rs
+++ b/apollo-federation/src/connectors/spec/connect.rs
@@ -31,6 +31,7 @@ pub(crate) const CONNECT_HTTP_NAME_IN_SPEC: Name = name!("ConnectHTTP");
 pub(crate) const CONNECT_BATCH_NAME_IN_SPEC: Name = name!("ConnectBatch");
 pub(crate) const CONNECT_BODY_ARGUMENT_NAME: Name = name!("body");
 pub(crate) const BATCH_ARGUMENT_NAME: Name = name!("batch");
+pub(crate) const IS_SUCCESS_ARGUMENT_NAME: Name = name!("isSuccess");
 
 pub(crate) fn extract_connect_directive_arguments(
     schema: &Schema,
@@ -146,6 +147,12 @@ pub(crate) struct ConnectDirectiveArguments {
 
     /// Configure the error mapping functionality for this connect
     pub(crate) errors: Option<ErrorsArguments>,
+
+    /// Criteria to use to determine if a request is a success.
+    ///
+    /// Uses the JSONSelection to define a success criteria. This JSON Selection
+    /// _must_ resolve to a boolean value.
+    pub(crate) is_success: Option<JSONSelection>,
 }
 
 impl ConnectDirectiveArguments {
@@ -163,6 +170,7 @@ impl ConnectDirectiveArguments {
         let mut entity = None;
         let mut batch = None;
         let mut errors = None;
+        let mut is_success = None;
         for arg in args {
             let arg_name = arg.name.as_str();
 
@@ -216,6 +224,16 @@ impl ConnectDirectiveArguments {
                 })?;
 
                 entity = Some(entity_value);
+            } else if arg_name == IS_SUCCESS_ARGUMENT_NAME.as_str() {
+                let selection_value = arg.value.as_str().ok_or_else(|| {
+                    FederationError::internal(format!(
+                        "`is_success` field in `@{directive_name}` directive is not a string"
+                    ))
+                })?;
+                is_success = Some(
+                    JSONSelection::parse(selection_value)
+                        .map_err(|e| FederationError::internal(e.message))?,
+                );
             }
         }
 
@@ -231,6 +249,7 @@ impl ConnectDirectiveArguments {
             entity: entity.unwrap_or_default(),
             batch,
             errors,
+            is_success,
         })
     }
 }
@@ -395,6 +414,7 @@ mod tests {
     use crate::supergraph::extract_subgraphs_from_supergraph;
 
     static SIMPLE_SUPERGRAPH: &str = include_str!("../tests/schemas/simple.graphql");
+    static IS_SUCCESS_SUPERGRAPH: &str = include_str!("../tests/schemas/is-success.graphql");
 
     fn get_subgraphs(supergraph_sdl: &str) -> ValidFederationSubgraphs {
         let schema = Schema::parse(supergraph_sdl, "supergraph.graphql").unwrap();
@@ -416,7 +436,7 @@ mod tests {
 
         insta::assert_snapshot!(
             actual_definition.to_string(),
-            @"directive @connect(source: String, http: connect__ConnectHTTP, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, selection: connect__JSONSelection!, entity: Boolean = false) repeatable on FIELD_DEFINITION | OBJECT"
+            @"directive @connect(source: String, http: connect__ConnectHTTP, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection, selection: connect__JSONSelection!, entity: Boolean = false) repeatable on FIELD_DEFINITION | OBJECT"
         );
 
         let fields = schema
@@ -513,6 +533,7 @@ mod tests {
                 entity: false,
                 batch: None,
                 errors: None,
+                is_success: None,
             },
             ConnectDirectiveArguments {
                 position: Field(
@@ -588,9 +609,25 @@ mod tests {
                 entity: false,
                 batch: None,
                 errors: None,
+                is_success: None,
             },
         ]
         "#
         );
+    }
+
+    #[test]
+    fn it_supports_is_success_in_connect() {
+        let subgraphs = get_subgraphs(IS_SUCCESS_SUPERGRAPH);
+        let subgraph = subgraphs.get("connectors").unwrap();
+        let schema = &subgraph.schema;
+
+        // Extract the connects from the schema definition and map them to their `Connect` equivalent
+        let connects =
+            extract_connect_directive_arguments(schema.schema(), &name!(connect)).unwrap();
+        for connect in connects {
+            // Unwrap and fail if is_success doesn't exist on all as expected.
+            connect.is_success.unwrap();
+        }
     }
 }

--- a/apollo-federation/src/connectors/spec/type_and_directive_specifications.rs
+++ b/apollo-federation/src/connectors/spec/type_and_directive_specifications.rs
@@ -366,12 +366,7 @@ fn connect_directive_spec() -> DirectiveSpecification {
                 base_spec: ArgumentSpecification {
                     name: IS_SUCCESS_ARGUMENT_NAME,
                     get_type: |s, _| {
-                        let name = s
-                            .metadata()
-                            .ok_or_else(|| internal!("missing metadata"))?
-                            .for_identity(&ConnectSpec::identity())
-                            .ok_or_else(|| internal!("missing connect spec"))?
-                            .type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
+                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
                         Ok(Type::Named(name))
                     },
                     default_value: None,
@@ -452,12 +447,7 @@ fn source_directive_spec() -> DirectiveSpecification {
                 base_spec: ArgumentSpecification {
                     name: IS_SUCCESS_ARGUMENT_NAME,
                     get_type: |s, _| {
-                        let name = s
-                            .metadata()
-                            .ok_or_else(|| internal!("missing metadata"))?
-                            .for_identity(&ConnectSpec::identity())
-                            .ok_or_else(|| internal!("missing connect spec"))?
-                            .type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
+                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
                         Ok(Type::Named(name))
                     },
                     default_value: None,

--- a/apollo-federation/src/connectors/tests/schemas/is-success-source.graphql
+++ b/apollo-federation/src/connectors/tests/schemas/is-success-source.graphql
@@ -1,0 +1,126 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @join__directive(
+    graphs: [CONNECTORS]
+    name: "link"
+    args: {
+      url: "https://specs.apollo.dev/connect/v0.1"
+      import: ["@connect", "@source"]
+    }
+  )
+  @join__directive(
+    graphs: [CONNECTORS]
+    name: "source"
+    args: {
+      name: "json"
+      isSuccess: "$status->eq(202)"
+      http: {
+        baseURL: "https://jsonplaceholder.typicode.com/"
+        headers: [
+          { name: "AuthToken", from: "X-Auth-Token" }
+          { name: "user-agent", value: "Firefox" }
+        ]
+      }
+    }
+  ) {
+  query: Query
+}
+
+directive @join__directive(
+  graphs: [join__Graph!]
+  name: String!
+  args: join__DirectiveArguments
+) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "http://unused")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Post @join__type(graph: CONNECTORS) {
+  id: ID!
+  title: String
+  body: String
+}
+
+type Query @join__type(graph: CONNECTORS) {
+  users: [User]
+    @join__directive(
+      graphs: [CONNECTORS]
+      name: "connect"
+      args: { source: "json", http: { GET: "/users" }, selection: "id name" }
+    )
+  posts: [Post]
+    @join__directive(
+      graphs: [CONNECTORS]
+      name: "connect"
+      args: {
+        source: "json"
+        http: { GET: "/posts" }
+        selection: "id title body"
+      }
+    )
+}
+
+type User @join__type(graph: CONNECTORS, key: "id", resolvable: false) {
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/tests/schemas/is-success-source.yaml
+++ b/apollo-federation/src/connectors/tests/schemas/is-success-source.yaml
@@ -1,0 +1,48 @@
+# rover supergraph compose --config src/connectors/tests/schemas/simple.yaml > src/connectors/tests/schemas/simple.graphql
+federation_version: =2.7.3-testing.0
+subgraphs:
+  connectors:
+    routing_url: http://unused
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"])
+          @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"])
+          @source(
+            name: "json"
+            isSuccess: "$status->eq(202)"
+            http: {
+              baseURL: "https://jsonplaceholder.typicode.com/"
+              headers: [
+                { name: "AuthToken", from: "X-Auth-Token" }
+                { name: "user-agent", value: "Firefox" }
+              ]
+            }
+          )
+
+        type Query {
+          users: [User]
+            @connect(
+              source: "json"
+              http: { GET: "/users" }
+              selection: "id name"
+            )
+
+          posts: [Post]
+            @connect(
+              source: "json"
+              http: { GET: "/posts" }
+              selection: "id title body"
+            )
+        }
+
+        type User @key(fields: "id", resolvable: false) {
+          id: ID!
+          name: String
+        }
+
+        type Post {
+          id: ID!
+          title: String
+          body: String
+        }

--- a/apollo-federation/src/connectors/tests/schemas/is-success.graphql
+++ b/apollo-federation/src/connectors/tests/schemas/is-success.graphql
@@ -1,0 +1,126 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @join__directive(
+    graphs: [CONNECTORS]
+    name: "link"
+    args: {
+      url: "https://specs.apollo.dev/connect/v0.1"
+      import: ["@connect", "@source"]
+    }
+  )
+  @join__directive(
+    graphs: [CONNECTORS]
+    name: "source"
+    args: {
+      name: "json"
+      http: {
+        baseURL: "https://jsonplaceholder.typicode.com/"
+        headers: [
+          { name: "AuthToken", from: "X-Auth-Token" }
+          { name: "user-agent", value: "Firefox" }
+        ]
+      }
+    }
+  ) {
+  query: Query
+}
+
+directive @join__directive(
+  graphs: [join__Graph!]
+  name: String!
+  args: join__DirectiveArguments
+) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "http://unused")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Post @join__type(graph: CONNECTORS) {
+  id: ID!
+  title: String
+  body: String
+}
+
+type Query @join__type(graph: CONNECTORS) {
+  users: [User]
+    @join__directive(
+      graphs: [CONNECTORS]
+      name: "connect"
+      args: { source: "json", http: { GET: "/users" }, selection: "id name", isSuccess:"id->eq('yay')" }
+    )
+  posts: [Post]
+    @join__directive(
+      graphs: [CONNECTORS]
+      name: "connect"
+      args: {
+        source: "json"
+        http: { GET: "/posts" }
+        selection: "id title body"
+        isSuccess: "id->eq('cool')"
+      }
+    )
+}
+
+type User @join__type(graph: CONNECTORS, key: "id", resolvable: false) {
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/tests/schemas/is-success.yaml
+++ b/apollo-federation/src/connectors/tests/schemas/is-success.yaml
@@ -1,0 +1,49 @@
+# rover supergraph compose --config src/connectors/tests/schemas/simple.yaml > src/connectors/tests/schemas/simple.graphql
+federation_version: =2.7.3-testing.0
+subgraphs:
+  connectors:
+    routing_url: http://unused
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"])
+          @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"])
+          @source(
+            name: "json"
+            http: {
+              baseURL: "https://jsonplaceholder.typicode.com/"
+              headers: [
+                { name: "AuthToken", from: "X-Auth-Token" }
+                { name: "user-agent", value: "Firefox" }
+              ]
+            }
+          )
+
+        type Query {
+          users: [User]
+            @connect(
+              source: "json"
+              http: { GET: "/users" }
+              selection: "id name"
+              isSuccess: "id->eq('yay')"
+            )
+
+          posts: [Post]
+            @connect(
+              source: "json"
+              http: { GET: "/posts" }
+              selection: "id title body"
+              isSuccess: "id->eq('cool')"
+            )
+        }
+
+        type User @key(fields: "id", resolvable: false) {
+          id: ID!
+          name: String
+        }
+
+        type Post {
+          id: ID!
+          title: String
+          body: String
+        }


### PR DESCRIPTION
<!-- start metadata -->

<!-- [CNN-900] -->

Adds a new `isSuccess` argument to the `@source` and `@connect` directive definitions. 

This parameter will allow users to override the success conditions for connector responses. For example, a user might want to include 404 response data in the data returned from the connector rather than treating the response as an error.

Note: Validation and Error handling functionality related to this argument will be added in separate PR to keep the reviews relatively small.
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-900]: https://apollographql.atlassian.net/browse/CNN-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ