### PR TITLE
chore: pin `rand` version used for fuzzing

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,8 @@ apollo-smith.workspace = true
 bnf = "0.5.0"
 env_logger = "0.11.0"
 log = "0.4"
-rand = "0.8.0"
+# Required until https://github.com/shnewto/bnf/pull/175, remove when bnf 0.6 is out
+rand = "=0.8.5"
 reqwest = { workspace = true, features = ["json", "blocking"] }
 serde_json.workspace = true
 


### PR DESCRIPTION
This `rand` version must be aligned with the `bnf` version used, as we pass a random number generator to `bnf::Grammar::generate`.

In the next version of `bnf`, we can remove our `rand` dependency thanks to https://github.com/shnewto/bnf/pull/175.

Until then, we should pin it with `=` syntax so renovate stops making PRs for it that can't be merged.

https://github.com/apollographql/router/pull/7857 should be closed by renovate after landing this

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
