### PR TITLE
ci: enable `xtask check-compliance` on windows again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ commands:
             # TODO: remove this workaround once we update to Xcode >= 15.1.0
             # See: https://github.com/apollographql/router/pull/5462
             RUST_LIB_BACKTRACE: 0
-          command: cargo xtask test --workspace --locked --features ci,snapshot
+          command: cargo xtask check-compliance
       - run:
           name: Delete large files from cache
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ commands:
             # TODO: remove this workaround once we update to Xcode >= 15.1.0
             # See: https://github.com/apollographql/router/pull/5462
             RUST_LIB_BACKTRACE: 0
-          command: cargo xtask check-compliance
+          command: cargo xtask test --workspace --locked --features ci,snapshot
       - run:
           name: Delete large files from cache
           command: |

--- a/xtask/src/commands/compliance.rs
+++ b/xtask/src/commands/compliance.rs
@@ -6,11 +6,6 @@ pub struct Compliance {}
 
 impl Compliance {
     pub fn run(&self) -> Result<()> {
-        // Cargo deny is triggering `git credential-manager-core get`
-        // On windows CI this will hang as it requires user input.
-        // The root cause seems to be the krates step in cargo-deny but did not manage to figure it out.
-        // Disabling as a temporary measure, but we must fix this soon. https://github.com/apollographql/router/issues/3237
-        #[cfg(not(windows))]
         cargo!(["deny", "-L", "error", "check"]);
         Ok(())
     }


### PR DESCRIPTION
Fixes #3237

Maybe it Just Works now.

Tested in: https://app.circleci.com/pipelines/github/apollographql/router/37218/workflows/3b46e66a-bb19-48da-8849-73d876070dee/jobs/277603 ("Run tests" job is actually `xtask check-compliance`).

<!-- start metadata -->
