### PR TITLE
Reliably distinguish GraphQL errors and transport errors in subscriptions

### DIFF
--- a/.changesets/fix_renee_router_1343.md
+++ b/.changesets/fix_renee_router_1343.md
@@ -1,0 +1,5 @@
+### Reliably distinguish GraphQL errors and transport errors in subscriptions ([PR #7901](https://github.com/apollographql/router/pull/7901))
+
+The [Multipart HTTP protocol for GraphQL Subscriptions](https://www.apollographql.com/docs/graphos/routing/operations/subscriptions/multipart-protocol) distinguishes between GraphQL-level errors and fatal transport-level errors. The router previously used a heuristic to determine if a given error was fatal or not, which could sometimes cause errors to be wrongly classified. For example, if a subgraph returned a GraphQL-level error for a subscription and then immediately ended the subscription, the router might propagate this as a fatal transport-level error.
+
+This is now fixed. Fatal transport-level errors are tagged as such when they are constructed, so the router can reliably know how to serialize errors when sending them to the client.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -104,8 +104,6 @@ or ( binary_id(=apollo-router::integration_tests) & test(=integration::rhai::tes
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_invalid_error_locations_contains_negative_one_location) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_for_subgraph_error) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_is_preserved_for_subgraph_error) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback_pure_error_payload) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_pure_error_payload) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::telemetry::datadog::test_basic) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::telemetry::datadog::test_priority_sampling_no_parent_propagated) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::telemetry::datadog::test_resource_mapping_default) )

--- a/apollo-router/src/protocols/multipart.rs
+++ b/apollo-router/src/protocols/multipart.rs
@@ -116,9 +116,15 @@ impl Stream for Multipart {
 
                     match self.mode {
                         ProtocolMode::Subscription => {
-                            let is_transport_error = response.extensions.remove(SUBSCRIPTION_ERROR_EXTENSION_KEY) == Some(true.into());
+                            let is_transport_error =
+                                response.extensions.remove(SUBSCRIPTION_ERROR_EXTENSION_KEY)
+                                    == Some(true.into());
                             // Magic empty response (that we create internally) means the connection was gracefully closed at the server side
-                            if !is_still_open && response.data.is_none() && response.errors.is_empty() && response.extensions.is_empty() {
+                            if !is_still_open
+                                && response.data.is_none()
+                                && response.errors.is_empty()
+                                && response.extensions.is_empty()
+                            {
                                 self.is_terminated = true;
                                 return Poll::Ready(Some(Ok(Bytes::from_static(&b"--\r\n"[..]))));
                             }

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -56,12 +56,17 @@ impl QueryPlan {
         &self,
         context: &'a Context,
         service_factory: &'a Arc<FetchServiceFactory>,
+        // The original supergraph request is used to populate variable values and for plugin
+        // features like propagating headers or subgraph telemetry based on supergraph request
+        // values.
         supergraph_request: &'a Arc<http::Request<Request>>,
         schema: &'a Arc<Schema>,
         subgraph_schemas: &'a Arc<SubgraphSchemas>,
+        // Sender for additional responses past the first one (@defer, @stream, subscriptions)
         sender: mpsc::Sender<Response>,
         subscription_handle: Option<SubscriptionHandle>,
         subscription_config: &'a Option<SubscriptionConfig>,
+        // Query plan execution builds up a JSON result value, use this as the initial data.
         initial_value: Option<Value>,
     ) -> Response {
         let root = Path::empty();

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_callback_schema_reload-3.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_callback_schema_reload-3.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/src/services/supergraph/tests.rs
 expression: "tokio::time::timeout(Duration::from_secs(1),\nstream.next_response()).await.unwrap().unwrap()"
+snapshot_kind: text
 ---
 {
   "data": null,
@@ -11,5 +12,8 @@ expression: "tokio::time::timeout(Duration::from_secs(1),\nstream.next_response(
         "code": "SUBSCRIPTION_SCHEMA_RELOAD"
       }
     }
-  ]
+  ],
+  "extensions": {
+    "apollo::subscriptions::fatal_error": true
+  }
 }

--- a/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
+++ b/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
@@ -17,106 +17,106 @@ use crate::integration::subscriptions::verify_subscription_events;
 /// Creates an expected subscription event payload for a schema reload
 fn create_expected_schema_reload_payload() -> serde_json::Value {
     serde_json::json!({
-    "payload": null,
-    "errors": [
-        {
-            "message": "subscription has been closed due to a schema reload",
-            "extensions": {
-                "code": "SUBSCRIPTION_SCHEMA_RELOAD"
+        "payload": null,
+        "errors": [
+            {
+                "message": "subscription has been closed due to a schema reload",
+                "extensions": {
+                    "code": "SUBSCRIPTION_SCHEMA_RELOAD"
+                }
             }
-        }
-    ]
+        ]
     })
 }
 
 /// Creates an expected subscription event payload for a configuration reload
 fn create_expected_config_reload_payload() -> serde_json::Value {
     serde_json::json!({
-    "payload": null,
-    "errors": [
-        {
-            "message": "subscription has been closed due to a configuration reload",
-            "extensions": {
-                "code": "SUBSCRIPTION_CONFIG_RELOAD"
+        "payload": null,
+        "errors": [
+            {
+                "message": "subscription has been closed due to a configuration reload",
+                "extensions": {
+                    "code": "SUBSCRIPTION_CONFIG_RELOAD"
+                }
             }
-        }
-    ]
+        ]
     })
 }
 
 /// Creates an expected subscription event payload for the given user number
 fn create_expected_user_payload(user_num: u32) -> serde_json::Value {
     serde_json::json!({
-    "payload": {
-        "data": {
-            "userWasCreated": {
-                "name": format!("User {}", user_num),
-                "reviews": [{"body": format!("Review {} from user {}", user_num, user_num)}]
+        "payload": {
+            "data": {
+                "userWasCreated": {
+                    "name": format!("User {}", user_num),
+                    "reviews": [{"body": format!("Review {} from user {}", user_num, user_num)}]
+                }
             }
         }
-    }
     })
 }
 
 /// Creates an expected subscription event payload with null userWasCreated (for empty/error payloads)
 fn create_expected_null_payload() -> serde_json::Value {
     serde_json::json!({
-    "payload": {
-        "data": {
-            "userWasCreated": null
+        "payload": {
+            "data": {
+                "userWasCreated": null
+            }
         }
-    }
     })
 }
 
 /// Creates an expected subscription event payload for a user with missing reviews field (becomes null)
 fn create_expected_user_payload_missing_reviews(user_num: u32) -> serde_json::Value {
     serde_json::json!({
-    "payload": {
-        "data": {
-            "userWasCreated": {
-                "name": format!("User {}", user_num),
-                "reviews": null // Missing reviews field gets transformed to null
+        "payload": {
+            "data": {
+                "userWasCreated": {
+                    "name": format!("User {}", user_num),
+                    "reviews": null // Missing reviews field gets transformed to null
+                }
             }
         }
-    }
     })
 }
 
 /// Creates an expected subscription event payload for a user with missing reviews field (becomes null) and error
 fn create_expected_partial_error_payload(user_num: u32) -> serde_json::Value {
     serde_json::json!({
-    "payload": {
-        "data": {
-            "userWasCreated": {
-                "name": format!("User {}", user_num),
-                "reviews": null // Missing reviews field gets transformed to null
-            }
-        },
-        "errors": [
-            {
-                "message": "Internal error handling deferred response",
-                "extensions": {
-                    "code": "INTERNAL_ERROR"
+        "payload": {
+            "data": {
+                "userWasCreated": {
+                    "name": format!("User {}", user_num),
+                    "reviews": null // Missing reviews field gets transformed to null
                 }
-            }
-        ]
-    }
+            },
+            "errors": [
+                {
+                    "message": "Internal error handling deferred response",
+                    "extensions": {
+                        "code": "INTERNAL_ERROR"
+                    }
+                }
+            ]
+        }
     })
 }
 
 /// Creates an expected subscription event payload for a user with missing reviews field (becomes null) and error
 fn create_expected_error_payload() -> serde_json::Value {
     serde_json::json!({
-    "payload": {
-        "data": {
-            "userWasCreated": null
-        }
-    },
-    "errors": [{
-        "message": "Internal error handling deferred response",
-        "extensions": {"code": "INTERNAL_ERROR"}
-    }]
+        "payload": {
+            "data": {
+                "userWasCreated": null
+            },
+            "errors": [{
+                "message": "Internal error handling deferred response",
+                "extensions": {"code": "INTERNAL_ERROR"}
+            }]
+        },
     })
 }
 
@@ -130,27 +130,27 @@ fn create_initial_empty_response() -> serde_json::Value {
 /// Creates a GraphQL data payload for a user (sent to mock server)
 fn create_user_data_payload(user_num: u32) -> serde_json::Value {
     serde_json::json!({
-    "data": {
-        "userWasCreated": {
-            "name": format!("User {}", user_num),
-            "reviews": [{
-                "body": format!("Review {} from user {}", user_num, user_num)
-            }]
+        "data": {
+            "userWasCreated": {
+                "name": format!("User {}", user_num),
+                "reviews": [{
+                    "body": format!("Review {} from user {}", user_num, user_num)
+                }]
+            }
         }
-    }
     })
 }
 
 /// Creates a GraphQL data payload with missing reviews field (sent to mock server)
 fn create_user_data_payload_missing_reviews(user_num: u32) -> serde_json::Value {
     serde_json::json!({
-    "data": {
-        "userWasCreated": {
-            "name": format!("User {}", user_num)
-            // Missing reviews field to test error handling
-        }
-    },
-    "errors": []
+        "data": {
+            "userWasCreated": {
+                "name": format!("User {}", user_num)
+                // Missing reviews field to test error handling
+            }
+        },
+        "errors": []
     })
 }
 
@@ -164,36 +164,36 @@ fn create_empty_data_payload() -> serde_json::Value {
 /// Creates an expected error response payload (sent to mock server)
 fn create_partial_error_payload(user_num: u32) -> serde_json::Value {
     serde_json::json!({
-    "data": {
-        "userWasCreated": {
-            "name": format!("User {}", user_num),
-        }
-    },
-    "errors": [
-        {
-            "message": "Internal error handling deferred response",
-            "extensions": {
-                "code": "INTERNAL_ERROR"
+        "data": {
+            "userWasCreated": {
+                "name": format!("User {}", user_num),
             }
-        }
-    ]
+        },
+        "errors": [
+            {
+                "message": "Internal error handling deferred response",
+                "extensions": {
+                    "code": "INTERNAL_ERROR"
+                }
+            }
+        ]
     })
 }
 
 /// Creates an expected error response payload (sent to mock server)
 fn create_error_payload() -> serde_json::Value {
     serde_json::json!({
-    "data": {
-        "userWasCreated": null
-    },
-    "errors": [
-        {
-            "message": "Internal error handling deferred response",
-            "extensions": {
-                "code": "INTERNAL_ERROR"
+        "data": {
+            "userWasCreated": null
+        },
+        "errors": [
+            {
+                "message": "Internal error handling deferred response",
+                "extensions": {
+                    "code": "INTERNAL_ERROR"
+                }
             }
-        }
-    ]
+        ]
     })
 }
 

--- a/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
+++ b/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
@@ -420,7 +420,6 @@ async fn test_subscription_ws_passthrough_error_payload() -> Result<(), BoxError
 
 // We have disabled this test because this test is failing for reasons that are understood, but are now preventing us from doing other fixes. We will ensure this is fixed by tracking this in the attached ticket as a follow up on its own PR.
 // The bug is basically an inconsistency in the way we're returning an error, sometimes it's consider as a critical error, sometimes not.
-#[ignore = "ROUTER-1343"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscription_ws_passthrough_pure_error_payload() -> Result<(), BoxError> {
     if !graph_os_enabled() {
@@ -505,7 +504,6 @@ async fn test_subscription_ws_passthrough_pure_error_payload() -> Result<(), Box
 
 // We have disabled this test because this test is failing for reasons that are understood, but are now preventing us from doing other fixes. We will ensure this is fixed by tracking this in the attached ticket as a follow up on its own PR.
 // The bug is basically an inconsistency in the way we're returning an error, sometimes it's consider as a critical error, sometimes not.
-#[ignore = "ROUTER-1343"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscription_ws_passthrough_pure_error_payload_with_coprocessor()
 -> Result<(), BoxError> {


### PR DESCRIPTION
Using a GraphQL response extension to mark "fatal" errors that should be reported as a top-level `{errors}` key in the subscriptions chunk, while letting non-fatal errors through as `{payload: {errors}}` chunks. In the past, we tried to detect this "magically" by seeing if the error is the _final_ response in the stream, which isn't 100% accurate and can also be flaky depending on when the subgraph closes the connection.

I wanted to use a `Result` type here to enforce that fatal errors would be marked and handled correctly, but that would be a breaking change to our response types and every plugin. So instead, responses that are subscription fatal errors have a GraphQL extension `apollo::subscriptions::fatal_error`. The multipart serialisation code uses only that extension to decide how to format the response.

**Todos**
- [x] Update the test expectations
- [x] `test_subscription_ws_passthrough_pure_error_payload` appears to (still) be flaky with these changes

<!-- [ROUTER-1343] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1343]: https://apollographql.atlassian.net/browse/ROUTER-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ