### PR TITLE
[Connectors] Add isSuccess logic to connector HTTP error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "multimap 0.10.1",
  "nom",
  "nom_locate",
+ "once_cell",
  "parking_lot",
  "percent-encoding",
  "petgraph 0.8.2",

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -51,6 +51,7 @@ shape = "0.5.2"
 form_urlencoded = "1.2.1"
 parking_lot = "0.12.4"
 mime = "0.3.17"
+once_cell = "1.21.3"
 
 [dev-dependencies]
 diff = "0.1.13"

--- a/apollo-federation/src/connectors/models/problem_location.rs
+++ b/apollo-federation/src/connectors/models/problem_location.rs
@@ -12,6 +12,7 @@ pub enum ProblemLocation {
     ConnectQueryParams,
     SourceHeaders,
     ConnectHeaders,
+    IsSuccessMapping,
     Selection,
     ErrorsMessage,
     SourceErrorsExtensions,

--- a/apollo-federation/src/connectors/runtime/debug.rs
+++ b/apollo-federation/src/connectors/runtime/debug.rs
@@ -264,6 +264,11 @@ impl ConnectorDebugHttpRequest {
     }
 }
 
+pub type DebugRequest = (
+    Option<Box<ConnectorDebugHttpRequest>>,
+    Vec<(ProblemLocation, Problem)>,
+);
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConnectorDebugHttpResponse {
     status: u16,

--- a/apollo-federation/src/connectors/runtime/http_json_transport.rs
+++ b/apollo-federation/src/connectors/runtime/http_json_transport.rs
@@ -21,6 +21,7 @@ use crate::connectors::OriginatingDirective;
 use crate::connectors::ProblemLocation;
 use crate::connectors::runtime::debug::ConnectorContext;
 use crate::connectors::runtime::debug::ConnectorDebugHttpRequest;
+use crate::connectors::runtime::debug::DebugRequest;
 use crate::connectors::runtime::debug::SelectionData;
 use crate::connectors::runtime::mapping::Problem;
 use crate::connectors::runtime::mapping::aggregate_apply_to_errors;
@@ -30,10 +31,7 @@ use crate::connectors::runtime::mapping::aggregate_apply_to_errors_with_problem_
 #[derive(Debug)]
 pub struct HttpRequest {
     pub inner: http::Request<String>,
-    pub debug: (
-        Option<Box<ConnectorDebugHttpRequest>>,
-        Vec<(ProblemLocation, Problem)>,
-    ),
+    pub debug: DebugRequest,
 }
 
 /// Response from an HTTP transport


### PR DESCRIPTION
<!-- start metadata -->

<!-- [CNN-900] -->

Adds the core error handling functionality for the `isSuccess` parameter. 

The `isSuccess` parameter allows users to set custom success condition that overrides the default error condition (i.e. checking that status is 2XX). This allows users to get data from an error response (for example a 404).

Note that deserialization and rate limiting errors are not mapped by this logic and will always be marked as internal connector failures.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
