### PR TITLE
refactor(federation): eliminated panics from `ArgumentComposition` implementations

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -8,6 +8,7 @@ use std::process::ExitCode;
 use apollo_compiler::ExecutableDocument;
 use apollo_federation::ApiSchemaOptions;
 use apollo_federation::Supergraph;
+use apollo_federation::bail;
 use apollo_federation::composition::validate_satisfiability;
 use apollo_federation::connectors::expand::ExpansionResult;
 use apollo_federation::connectors::expand::expand_connectors;
@@ -266,7 +267,7 @@ fn load_supergraph(
     file_paths: &[PathBuf],
 ) -> Result<apollo_federation::Supergraph, FederationError> {
     if file_paths.is_empty() {
-        panic!("Error: missing command arguments");
+        bail!("Error: missing command arguments");
     } else if file_paths.len() == 1 {
         load_supergraph_file(&file_paths[0])
     } else {

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -652,7 +652,7 @@ impl Merger {
                         })
                         .cloned()
                         .collect_vec();
-                    let merged_value = (merger.merge)(name, &values);
+                    let merged_value = (merger.merge)(name, &values)?;
                     let merged_arg = Argument {
                         name: arg_def.name.clone(),
                         value: Node::new(merged_value),


### PR DESCRIPTION
### Summary

* `ArgumentComposition` implementations shall return a default value, instead of `panic!`.
* The original JS code is here ([github](https://github.com/apollographql/federation/blob/4653320016ed4202a229d9ab5933ad3f13e5b6c0/internals-js/src/argumentCompositionStrategies.ts#L57)).
* Also, removed a panic in `ArgumentMerger` struct and CLI,

<!-- [FED-170] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This PR is just a refactoring. Those eliminated panic weren't expected to occur in practice.

[FED-170]: https://apollographql.atlassian.net/browse/FED-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ