### PR TITLE
response_cache: add units on instruments + consistency + missing metric

### DIFF
--- a/apollo-router/src/plugins/response_cache/invalidation.rs
+++ b/apollo-router/src/plugins/response_cache/invalidation.rs
@@ -69,9 +69,10 @@ impl Invalidation {
         &self,
         requests: Vec<InvalidationRequest>,
     ) -> Result<u64, BoxError> {
-        u64_counter!(
+        u64_counter_with_unit!(
             "apollo.router.operations.response_cache.invalidation.event",
             "Response cache received a batch of invalidation requests",
+            "{request}",
             1u64
         );
 
@@ -91,18 +92,19 @@ impl Invalidation {
             "got invalidation request: {request:?}, will invalidate: {}",
             invalidation_key
         );
-        let count = match request {
+        let (count, subgraphs) = match request {
             InvalidationRequest::Subgraph { subgraph } => {
                 let count = pg_storage
                     .invalidate_by_subgraphs(vec![subgraph.clone()])
                     .await?;
-                u64_counter!(
+                u64_counter_with_unit!(
                     "apollo.router.operations.response_cache.invalidation.entry",
                     "Response cache counter for invalidated entries",
+                    "{entry}",
                     count,
                     "subgraph.name" = subgraph.clone()
                 );
-                count
+                (count, vec![subgraph.clone()])
             }
             InvalidationRequest::Entity { subgraph, .. }
             | InvalidationRequest::Type { subgraph, .. } => {
@@ -112,15 +114,16 @@ impl Invalidation {
                 let mut total_count = 0;
                 for (subgraph_name, count) in subgraph_counts {
                     total_count += count;
-                    u64_counter!(
+                    u64_counter_with_unit!(
                         "apollo.router.operations.response_cache.invalidation.entry",
                         "Response cache counter for invalidated entries",
+                        "{entry}",
                         count,
                         "subgraph.name" = subgraph_name
                     );
                 }
 
-                total_count
+                (total_count, vec![subgraph.clone()])
             }
             InvalidationRequest::CacheTag {
                 subgraphs,
@@ -135,23 +138,31 @@ impl Invalidation {
                 let mut total_count = 0;
                 for (subgraph_name, count) in subgraph_counts {
                     total_count += count;
-                    u64_counter!(
+                    u64_counter_with_unit!(
                         "apollo.router.operations.response_cache.invalidation.entry",
                         "Response cache counter for invalidated entries",
+                        "{entry}",
                         count,
                         "subgraph.name" = subgraph_name
                     );
                 }
 
-                total_count
+                (
+                    total_count,
+                    subgraphs.clone().into_iter().collect::<Vec<String>>(),
+                )
             }
         };
 
-        u64_histogram!(
-            "apollo.router.operations.response_cache.invalidation.keys",
-            "Number of invalidated keys per invalidation request.",
-            count
-        );
+        for subgraph in subgraphs {
+            u64_histogram_with_unit!(
+                "apollo.router.operations.response_cache.invalidation.request.entry",
+                "Number of invalidated entries per invalidation request.",
+                "{entry}",
+                count,
+                "subgraph.name" = subgraph
+            );
+        }
 
         Ok(count)
     }
@@ -189,9 +200,10 @@ impl Invalidation {
                         .instrument(tracing::info_span!("cache.invalidation.request"))
                         .await;
 
-                    f64_histogram!(
+                    f64_histogram_with_unit!(
                         "apollo.router.operations.response_cache.invalidation.duration",
                         "Duration of the invalidation event execution, in seconds.",
+                        "s",
                         start.elapsed().as_secs_f64()
                     );
                     if let Err(err) = &res {

--- a/apollo-router/src/plugins/response_cache/metrics.rs
+++ b/apollo-router/src/plugins/response_cache/metrics.rs
@@ -31,7 +31,7 @@ use crate::services::subgraph;
 use crate::spec::TYPENAME;
 
 pub(crate) const CACHE_INFO_SUBGRAPH_CONTEXT_KEY: &str =
-    "apollo::router::plugin_cache_info_subgraph";
+    "apollo::router::response_cache::cache_info_subgraph";
 
 impl CacheMetricsService {
     pub(crate) fn create(
@@ -257,9 +257,10 @@ impl CacheCounter {
 
         for (typename, (cache_hit, total_entities)) in seen.into_iter() {
             if separate_metrics_per_type {
-                f64_histogram!(
+                f64_histogram_with_unit!(
                     "apollo.router.operations.response_cache.cache_hit",
                     "Hit rate percentage of cached entities",
+                    "percent",
                     (cache_hit as f64 / total_entities as f64) * 100f64,
                     // Can't just `Arc::clone` these because they're `Arc<String>`,
                     // while opentelemetry supports `Arc<str>`
@@ -267,9 +268,10 @@ impl CacheCounter {
                     subgraph = subgraph_name.to_string()
                 );
             } else {
-                f64_histogram!(
+                f64_histogram_with_unit!(
                     "apollo.router.operations.response_cache.cache_hit",
                     "Hit rate percentage of cached entities",
+                    "percent",
                     (cache_hit as f64 / total_entities as f64) * 100f64,
                     subgraph = subgraph_name.to_string()
                 );

--- a/apollo-router/src/plugins/response_cache/tests.rs
+++ b/apollo-router/src/plugins/response_cache/tests.rs
@@ -2222,6 +2222,8 @@ async fn invalidate() {
           }
         }
         "###);
+        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 1u64, "subgraph.name" = "orga", "graphql.type" = "Organization");
+
 
         // Now testing without any mock subgraphs, all the data should come from the cache
         let service = TestHarness::builder()
@@ -2279,6 +2281,7 @@ async fn invalidate() {
                 .remove(CACHE_DEBUG_EXTENSIONS_KEY)
                 .is_some()
         );
+        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 2u64, "subgraph.name" = "orga", "graphql.type" = "Organization");
 
         insta::assert_json_snapshot!(response, @r###"
         {
@@ -2379,6 +2382,7 @@ async fn invalidate() {
           }
         }
         "###);
+        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 3u64, "subgraph.name" = "orga", "graphql.type" = "Organization");
 
     }.with_metrics().await;
 }


### PR DESCRIPTION
This PR add units on all metrics in response_cache. It also check the consistency in span/instrument naming and attributes. It also adds a new histogram to know how much entities we have per subgraph fetch node.

<!-- [ROUTER-1376] -->
<!-- [ROUTER-1384] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1376]: https://apollographql.atlassian.net/browse/ROUTER-1376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROUTER-1384]: https://apollographql.atlassian.net/browse/ROUTER-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ