### PR TITLE
Use Arc

### DIFF
--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -221,7 +221,7 @@ async fn init(
             None,
             vec![],
             MultiMap::new(),
-            LicenseState::Unlicensed,
+            Arc::new(LicenseState::Unlicensed),
             all_connections_stopped_sender,
         )
         .await
@@ -279,7 +279,7 @@ pub(super) async fn init_with_config(
             None,
             vec![],
             web_endpoints,
-            LicenseState::Unlicensed,
+            Arc::new(LicenseState::Unlicensed),
             all_connections_stopped_sender,
         )
         .await?;
@@ -346,7 +346,7 @@ async fn init_unix(
             None,
             vec![],
             MultiMap::new(),
-            LicenseState::Unlicensed,
+            Arc::new(LicenseState::Unlicensed),
             all_connections_stopped_sender,
         )
         .await
@@ -1833,7 +1833,7 @@ async fn it_supports_server_restart() {
             None,
             vec![],
             MultiMap::new(),
-            LicenseState::default(),
+            Arc::new(LicenseState::default()),
             all_connections_stopped_sender,
         )
         .await
@@ -1862,7 +1862,7 @@ async fn it_supports_server_restart() {
             supergraph_service_factory,
             new_configuration,
             MultiMap::new(),
-            LicenseState::default(),
+            Arc::new(LicenseState::default()),
         )
         .await
         .unwrap();

--- a/apollo-router/src/axum_factory/utils.rs
+++ b/apollo-router/src/axum_factory/utils.rs
@@ -1,6 +1,7 @@
 //! Utilities used for [`super::AxumHttpServerFactory`]
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use opentelemetry::global;
 use opentelemetry::trace::TraceContextExt;
@@ -16,7 +17,7 @@ use crate::uplink::license_enforcement::LicenseState;
 
 #[derive(Clone, Default)]
 pub(crate) struct PropagatingMakeSpan {
-    pub(crate) license: LicenseState,
+    pub(crate) license: Arc<LicenseState>,
     pub(crate) span_mode: SpanMode,
 }
 
@@ -38,20 +39,20 @@ impl<B> MakeSpan<B> for PropagatingMakeSpan {
             // We have a valid remote span, attach it to the current thread before creating the root span.
             let _context_guard = context.attach();
             if use_legacy_request_span {
-                self.span_mode.create_request(request, self.license.clone())
+                self.span_mode.create_request(request, &self.license)
             } else {
                 self.span_mode.create_router(request)
             }
         } else {
             // No remote span, we can go ahead and create the span without context.
             if use_legacy_request_span {
-                self.span_mode.create_request(request, self.license.clone())
+                self.span_mode.create_request(request, &self.license)
             } else {
                 self.span_mode.create_router(request)
             }
         };
         if matches!(
-            self.license,
+            &*self.license,
             LicenseState::LicensedWarn { limits: _ } | LicenseState::LicensedHalt { limits: _ }
         ) {
             span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -31,7 +31,7 @@ pub(crate) trait HttpServerFactory {
         main_listener: Option<Listener>,
         previous_listeners: ExtraListeners,
         extra_endpoints: MultiMap<ListenAddr, Endpoint>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
         all_connections_stopped_sender: mpsc::Sender<()>,
     ) -> Self::Future
     where
@@ -127,7 +127,7 @@ impl HttpServerHandle {
         router: RF,
         configuration: Arc<Configuration>,
         web_endpoints: MultiMap<ListenAddr, Endpoint>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
     ) -> Result<Self, ApolloRouterError>
     where
         SF: HttpServerFactory,

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -101,7 +101,7 @@ impl RouterSuperServiceFactory for OrbiterRouterSuperServiceFactory {
         schema: Arc<Schema>,
         previous_router: Option<&'a Self::RouterFactory>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
     ) -> Result<Self::RouterFactory, BoxError> {
         self.delegate
             .create(

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -85,7 +85,7 @@ pub struct PluginInit<T> {
     pub(crate) notify: Notify<String, graphql::Response>,
 
     /// User's license's state, including any limits of use
-    pub(crate) license: LicenseState,
+    pub(crate) license: Arc<LicenseState>,
 
     /// The full router configuration json for use by the telemetry plugin ONLY.
     /// NEVER use this in any other plugin. Plugins should only ever access their pre-defined
@@ -113,7 +113,7 @@ where
             .supergraph_schema(supergraph_schema)
             .launch_id(Arc::new("launch_id".to_string()))
             .notify(Notify::for_tests())
-            .license(LicenseState::default())
+            .license(Arc::new(LicenseState::default()))
             .build()
     }
 }
@@ -136,7 +136,7 @@ where
         subgraph_schemas: Option<Arc<HashMap<String, Arc<Valid<Schema>>>>>,
         launch_id: Option<Option<Arc<String>>>,
         notify: Notify<String, graphql::Response>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
         full_config: Option<Value>,
     ) -> Self {
         PluginInit {
@@ -165,7 +165,7 @@ where
         subgraph_schemas: Option<Arc<HashMap<String, Arc<Valid<Schema>>>>>,
         launch_id: Option<Arc<String>>,
         notify: Notify<String, graphql::Response>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
         full_config: Option<Value>,
     ) -> Result<Self, BoxError> {
         let config: T = serde_json::from_value(config)?;
@@ -192,7 +192,7 @@ where
         subgraph_schemas: Option<Arc<HashMap<String, Arc<Valid<Schema>>>>>,
         launch_id: Option<Arc<String>>,
         notify: Option<Notify<String, graphql::Response>>,
-        license: Option<LicenseState>,
+        license: Option<Arc<LicenseState>>,
         full_config: Option<Value>,
     ) -> Self {
         PluginInit {

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -2280,7 +2280,7 @@ async fn execute(
             Arc::new(crate::spec::Schema::parse(schema, &config).unwrap()),
             None,
             None,
-            LicenseState::default(),
+            Arc::new(LicenseState::default()),
         )
         .await
         .unwrap();

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -764,6 +764,7 @@ fn ensure_id_consistency(
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use futures::StreamExt;
     use serde_json::Value;
@@ -949,7 +950,7 @@ mod tests {
                         .unwrap(),
                     )
                     .notify(notify.clone())
-                    .license(LicenseState::default())
+                    .license(Arc::new(LicenseState::default()))
                     .build(),
             )
             .await
@@ -1039,7 +1040,7 @@ mod tests {
                         .unwrap(),
                     )
                     .notify(notify.clone())
-                    .license(LicenseState::default())
+                    .license(Arc::new(LicenseState::default()))
                     .build(),
             )
             .await

--- a/apollo-router/src/plugins/telemetry/span_factory.rs
+++ b/apollo-router/src/plugins/telemetry/span_factory.rs
@@ -31,7 +31,7 @@ impl SpanMode {
     pub(crate) fn create_request<B>(
         &self,
         request: &http::Request<B>,
-        license_state: LicenseState,
+        license_state: &LicenseState,
     ) -> ::tracing::span::Span {
         match self {
             SpanMode::Deprecated => {
@@ -307,7 +307,7 @@ mod tests {
                 let (subscriber, handle) =
                     subscriber::mock().new_span(expected_span).run_with_handle();
                 tracing::subscriber::with_default(subscriber, || {
-                    let span = span_mode.create_request(&request, license_state.clone());
+                    let span = span_mode.create_request(&request, license_state);
                     let _guard = span.enter();
                 });
                 handle.assert_finished();

--- a/apollo-router/src/plugins/test/mod.rs
+++ b/apollo-router/src/plugins/test/mod.rs
@@ -149,7 +149,7 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
                     .collect(),
             ))
             .notify(Notify::default())
-            .license(license.unwrap_or_default())
+            .license(Arc::new(license.unwrap_or_default()))
             .full_config(full_config)
             .build();
 

--- a/apollo-router/src/router/event/mod.rs
+++ b/apollo-router/src/router/event/mod.rs
@@ -42,7 +42,7 @@ pub(crate) enum Event {
     NoMoreSchema,
 
     /// Update license {}
-    UpdateLicense(LicenseState),
+    UpdateLicense(Arc<LicenseState>),
 
     /// There were no more updates to license.
     NoMoreLicense,

--- a/apollo-router/src/router/mod.rs
+++ b/apollo-router/src/router/mod.rs
@@ -422,7 +422,7 @@ mod tests {
             .await
             .unwrap();
         router_handle
-            .send_event(UpdateLicense(LicenseState::Unlicensed))
+            .send_event(UpdateLicense(Arc::new(LicenseState::Unlicensed)))
             .await
             .unwrap();
 
@@ -468,7 +468,7 @@ mod tests {
             .await
             .unwrap();
         router_handle
-            .send_event(UpdateLicense(LicenseState::Unlicensed))
+            .send_event(UpdateLicense(Arc::new(LicenseState::Unlicensed)))
             .await
             .unwrap();
 

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -129,7 +129,7 @@ pub(crate) trait RouterSuperServiceFactory: Send + Sync + 'static {
         schema: Arc<Schema>,
         previous_router: Option<&'a Self::RouterFactory>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
     ) -> Result<Self::RouterFactory, BoxError>;
 }
 
@@ -148,7 +148,7 @@ impl RouterSuperServiceFactory for YamlRouterFactory {
         schema: Arc<Schema>,
         previous_router: Option<&'a Self::RouterFactory>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
     ) -> Result<Self::RouterFactory, BoxError> {
         // we have to create a telemetry plugin before creating everything else, to generate a trace
         // of router and plugin creation
@@ -218,7 +218,7 @@ impl YamlRouterFactory {
         previous_router: Option<&'a RouterCreator>,
         initial_telemetry_plugin: Option<Box<dyn DynPlugin>>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
     ) -> Result<RouterCreator, BoxError> {
         let mut supergraph_creator = self
             .inner_create_supergraph(
@@ -286,7 +286,7 @@ impl YamlRouterFactory {
         schema: Arc<Schema>,
         initial_telemetry_plugin: Option<Box<dyn DynPlugin>>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
     ) -> Result<SupergraphCreator, BoxError> {
         let query_planner_span = tracing::info_span!("query_planner_creation");
         // QueryPlannerService takes an UnplannedRequest and outputs PlannedRequest
@@ -530,7 +530,7 @@ pub(crate) async fn add_plugin(
     notify: &crate::notification::Notify<String, crate::graphql::Response>,
     plugin_instances: &mut Plugins,
     errors: &mut Vec<ConfigurationError>,
-    license: LicenseState,
+    license: Arc<LicenseState>,
     full_config: Option<Value>,
 ) {
     match factory
@@ -565,7 +565,7 @@ pub(crate) async fn create_plugins(
     subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
     initial_telemetry_plugin: Option<Box<dyn DynPlugin>>,
     extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-    license: LicenseState,
+    license: Arc<LicenseState>,
 ) -> Result<Plugins, BoxError> {
     let supergraph_schema = Arc::new(schema.supergraph_schema().clone());
     let supergraph_schema_id = schema.schema_id.clone().into_inner();
@@ -908,7 +908,7 @@ mod test {
                 Arc::new(schema),
                 None,
                 None,
-                LicenseState::default(),
+                Arc::new(LicenseState::default()),
             )
             .await;
         service.map(|_| ())

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -60,14 +60,14 @@ enum State<FA: RouterSuperServiceFactory> {
     Startup {
         configuration: Option<Arc<Configuration>>,
         schema: Option<Arc<SchemaState>>,
-        license: Option<LicenseState>,
+        license: Option<Arc<LicenseState>>,
         listen_addresses_guard: OwnedRwLockWriteGuard<ListenAddresses>,
     },
     Running {
         configuration: Arc<Configuration>,
         _metrics: Option<Metrics>,
         schema: Arc<SchemaState>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
         server_handle: Option<HttpServerHandle>,
         router_service_factory: FA::RouterFactory,
         all_connections_stopped_signals: Vec<mpsc::Receiver<()>>,
@@ -125,7 +125,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         state_machine: &mut StateMachine<S, FA>,
         new_schema: Option<Arc<SchemaState>>,
         new_configuration: Option<Arc<Configuration>>,
-        new_license: Option<LicenseState>,
+        new_license: Option<Arc<LicenseState>>,
         force_reload: bool,
     ) -> Self
     where
@@ -173,8 +173,8 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             } => {
                 // When we get an unlicensed event, if we were licensed before then just carry on.
                 // This means that users can delete and then undelete their graphs in studio while having their routers continue to run.
-                if new_license == Some(LicenseState::Unlicensed)
-                    && *license != LicenseState::Unlicensed
+                if new_license == Some(LicenseState::Unlicensed.into())
+                    && *license != LicenseState::Unlicensed.into()
                 {
                     tracing::info!(
                         event = STATE_CHANGE,
@@ -321,7 +321,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         previous_router_service_factory: Option<&FA::RouterFactory>,
         configuration: Arc<Configuration>,
         schema_state: Arc<SchemaState>,
-        license: LicenseState,
+        license: Arc<LicenseState>,
         listen_addresses_guard: &mut OwnedRwLockWriteGuard<ListenAddresses>,
         mut all_connections_stopped_signals: Vec<mpsc::Receiver<()>>,
     ) -> Result<(State<FA>, Arc<Schema>), ApolloRouterError>
@@ -336,19 +336,19 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         // Check the license
         let report = LicenseEnforcementReport::build(&configuration, &schema);
 
-        let license_limits = match license {
-            LicenseState::Licensed { ref limits } => {
+        let license_limits = match &*license {
+            LicenseState::Licensed { limits } => {
                 tracing::debug!("A valid Apollo license has been detected.");
                 limits
             }
-            LicenseState::LicensedWarn { ref limits } if report.uses_restricted_features() => {
+            LicenseState::LicensedWarn { limits } if report.uses_restricted_features() => {
                 tracing::error!(
                     "License has expired. The Router will soon stop serving requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
                     report
                 );
                 limits
             }
-            LicenseState::LicensedHalt { ref limits } if report.uses_restricted_features() => {
+            LicenseState::LicensedHalt { limits } if report.uses_restricted_features() => {
                 tracing::error!(
                     "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
                     report
@@ -384,9 +384,9 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
 
         // If there are no restricted featured in use then the effective license is Licensed as we don't need warn or halt behavior.
         let effective_license = if !report.uses_restricted_features() {
-            LicenseState::Licensed {
+            Arc::new(LicenseState::Licensed {
                 limits: license_limits.clone(),
-            }
+            })
         } else {
             license.clone()
         };
@@ -461,8 +461,8 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             discussed.log_preview_used(yaml);
         }
 
-        let metrics =
-            apollo_opentelemetry_initialized().then(|| Metrics::new(&configuration, &license));
+        let metrics = apollo_opentelemetry_initialized()
+            .then(|| Metrics::new(&configuration, Arc::as_ref(&license)));
 
         Ok((
             Running {
@@ -755,9 +755,9 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateLicense(LicenseState::Licensed {
+                    UpdateLicense(Arc::new(LicenseState::Licensed {
                         limits: Some(LicenseLimits::default())
-                    }),
+                    })),
                     Shutdown
                 ])
             )
@@ -779,9 +779,9 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateLicense(LicenseState::LicensedHalt {
+                    UpdateLicense(Arc::new(LicenseState::LicensedHalt {
                         limits: Some(LicenseLimits::default())
-                    }),
+                    })),
                     Shutdown
                 ])
             )
@@ -803,9 +803,9 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateLicense(LicenseState::LicensedWarn {
+                    UpdateLicense(Arc::new(LicenseState::LicensedWarn {
                         limits: Some(LicenseLimits::default())
-                    }),
+                    })),
                     Shutdown
                 ])
             )
@@ -828,10 +828,10 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateLicense(LicenseState::Licensed {
+                    UpdateLicense(Arc::new(LicenseState::Licensed {
                         limits: Some(LicenseLimits::default())
-                    }),
-                    UpdateLicense(LicenseState::Unlicensed),
+                    })),
+                    UpdateLicense(Arc::new(LicenseState::Unlicensed)),
                     UpdateConfiguration(test_config_restricted()),
                     Shutdown
                 ])
@@ -854,7 +854,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateLicense(LicenseState::Unlicensed),
+                    UpdateLicense(Arc::new(LicenseState::Unlicensed)),
                     Shutdown
                 ])
             )
@@ -876,11 +876,11 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Arc::new(Configuration::builder().build().unwrap())),
                     UpdateSchema(example_schema()),
-                    UpdateLicense(LicenseState::Unlicensed),
+                    UpdateLicense(Arc::new(LicenseState::Unlicensed)),
                     UpdateConfiguration(test_config_restricted()),
-                    UpdateLicense(LicenseState::Licensed {
+                    UpdateLicense(Arc::new(LicenseState::Licensed {
                         limits: Some(LicenseLimits::default())
-                    }),
+                    })),
                     Shutdown
                 ])
             )
@@ -1003,9 +1003,9 @@ mod tests {
                         launch_id: None
                     }),
                     UpdateLicense(Default::default()),
-                    UpdateLicense(LicenseState::Licensed {
+                    UpdateLicense(Arc::new(LicenseState::Licensed {
                         limits: Some(LicenseLimits::default())
-                    }),
+                    })),
                     Shutdown
                 ])
             )
@@ -1215,7 +1215,7 @@ mod tests {
                 schema: Arc<Schema>,
                 previous_router_service_factory: Option<&'a MockMyRouterFactory>,
                 extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-                license: LicenseState
+                license: Arc<LicenseState>
             ) -> Result<MockMyRouterFactory, BoxError>;
         }
     }
@@ -1261,7 +1261,7 @@ mod tests {
             _extra_listeners: Vec<(ListenAddr, Listener)>,
             _web_endpoints: MultiMap<ListenAddr, Endpoint>,
 
-            _license: LicenseState,
+            _license: Arc<LicenseState>,
             _all_connections_stopped_sender: mpsc::Sender<()>,
         ) -> Self::Future
         where

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -389,7 +389,7 @@ impl<'a> TestHarness<'a> {
             router_creator,
             &config,
             web_endpoints,
-            LicenseState::Unlicensed,
+            Arc::new(LicenseState::Unlicensed),
         )?;
         let ListenAddrAndRouter(_listener, router) = routers.main;
         Ok(router.boxed())


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-####] -->
---
Uses `Arc<LicenseState>` instead of `LicenseState` to avoid expensive clones

**Why do we need this?**
In https://github.com/apollographql/router/pull/7917 we added a new field, `allowed_features`, to `LicenseLimits` which is part of `LicenseState` that was previously `Copy`.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
