### PR TITLE
Unify `NamedSelection` enum variants into a single struct, without any grammar changes (yet)

### DIFF
--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@batch.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@batch.graphql.snap
@@ -54,18 +54,32 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/batch.g
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..2,
@@ -138,8 +152,8 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/batch.g
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Path {
-                                    alias: Some(
+                                NamedSelection {
+                                    prefix: Alias(
                                         Alias {
                                             name: WithRange {
                                                 node: Field(
@@ -154,7 +168,6 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/batch.g
                                             ),
                                         },
                                     ),
-                                    inline: false,
                                     path: PathSelection {
                                         path: WithRange {
                                             node: Var(
@@ -210,42 +223,84 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/batch.g
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "name",
-                                ),
-                                range: Some(
-                                    3..7,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "name",
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                7..7,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..7,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "username",
-                                ),
-                                range: Some(
-                                    8..16,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "username",
+                                            ),
+                                            range: Some(
+                                                8..16,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                16..16,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        8..16,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..16,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@carryover.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@carryover.graphql.snap
@@ -54,102 +54,214 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "tagged",
-                                ),
-                                range: Some(
-                                    3..9,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "tagged",
+                                            ),
+                                            range: Some(
+                                                3..9,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                9..9,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..9,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "hidden",
-                                ),
-                                range: Some(
-                                    10..16,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "hidden",
+                                            ),
+                                            range: Some(
+                                                10..16,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                16..16,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        10..16,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "custom",
-                                ),
-                                range: Some(
-                                    17..23,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "custom",
+                                            ),
+                                            range: Some(
+                                                17..23,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                23..23,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        17..23,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "authenticated",
-                                ),
-                                range: Some(
-                                    24..37,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "authenticated",
+                                            ),
+                                            range: Some(
+                                                24..37,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                37..37,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        24..37,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "requiresScopes",
-                                ),
-                                range: Some(
-                                    38..52,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "requiresScopes",
+                                            ),
+                                            range: Some(
+                                                38..52,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                52..52,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        38..52,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "policy",
-                                ),
-                                range: Some(
-                                    53..59,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "policy",
+                                            ),
+                                            range: Some(
+                                                53..59,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                59..59,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        53..59,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "overridden",
-                                ),
-                                range: Some(
-                                    60..70,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "overridden",
+                                            ),
+                                            range: Some(
+                                                60..70,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                70..70,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        60..70,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..70,
@@ -273,102 +385,214 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "tagged",
-                                ),
-                                range: Some(
-                                    3..9,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "tagged",
+                                            ),
+                                            range: Some(
+                                                3..9,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                9..9,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..9,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "hidden",
-                                ),
-                                range: Some(
-                                    10..16,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "hidden",
+                                            ),
+                                            range: Some(
+                                                10..16,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                16..16,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        10..16,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "custom",
-                                ),
-                                range: Some(
-                                    17..23,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "custom",
+                                            ),
+                                            range: Some(
+                                                17..23,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                23..23,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        17..23,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "authenticated",
-                                ),
-                                range: Some(
-                                    24..37,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "authenticated",
+                                            ),
+                                            range: Some(
+                                                24..37,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                37..37,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        24..37,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "requiresScopes",
-                                ),
-                                range: Some(
-                                    38..52,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "requiresScopes",
+                                            ),
+                                            range: Some(
+                                                38..52,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                52..52,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        38..52,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "policy",
-                                ),
-                                range: Some(
-                                    53..59,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "policy",
+                                            ),
+                                            range: Some(
+                                                53..59,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                59..59,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        53..59,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "overridden",
-                                ),
-                                range: Some(
-                                    60..70,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "overridden",
+                                            ),
+                                            range: Some(
+                                                60..70,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                70..70,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        60..70,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..70,
@@ -504,18 +728,32 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/carryov
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..2,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@interface-object.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@interface-object.graphql.snap
@@ -203,30 +203,58 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/interfa
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "c",
-                                ),
-                                range: Some(
-                                    3..4,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "c",
+                                            ),
+                                            range: Some(
+                                                3..4,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                4..4,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..4,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..4,
@@ -350,42 +378,84 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/interfa
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "c",
-                                ),
-                                range: Some(
-                                    3..4,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "c",
+                                            ),
+                                            range: Some(
+                                                3..4,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                4..4,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..4,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "d",
-                                ),
-                                range: Some(
-                                    5..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "d",
+                                            ),
+                                            range: Some(
+                                                5..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        5..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..6,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@keys.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@keys.graphql.snap
@@ -87,42 +87,84 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id2",
-                                ),
-                                range: Some(
-                                    3..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id2",
+                                            ),
+                                            range: Some(
+                                                3..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "unselected",
-                                ),
-                                range: Some(
-                                    7..17,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "unselected",
+                                            ),
+                                            range: Some(
+                                                7..17,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                17..17,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        7..17,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..17,
@@ -291,42 +333,84 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id2",
-                                ),
-                                range: Some(
-                                    3..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id2",
+                                            ),
+                                            range: Some(
+                                                3..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "unselected",
-                                ),
-                                range: Some(
-                                    7..17,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "unselected",
+                                            ),
+                                            range: Some(
+                                                7..17,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                17..17,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        7..17,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..17,
@@ -444,42 +528,84 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id2",
-                                ),
-                                range: Some(
-                                    3..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id2",
+                                            ),
+                                            range: Some(
+                                                3..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "accessibleByUnselected",
-                                ),
-                                range: Some(
-                                    7..29,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "accessibleByUnselected",
+                                            ),
+                                            range: Some(
+                                                7..29,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                29..29,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        7..29,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..29,
@@ -596,30 +722,58 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id2",
-                                ),
-                                range: Some(
-                                    3..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id2",
+                                            ),
+                                            range: Some(
+                                                3..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..6,
@@ -788,30 +942,58 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id2",
-                                ),
-                                range: Some(
-                                    3..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id2",
+                                            ),
+                                            range: Some(
+                                                3..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..6,
@@ -929,20 +1111,34 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Path {
-                            alias: Some(
+                        },
+                        NamedSelection {
+                            prefix: Alias(
                                 Alias {
                                     name: WithRange {
                                         node: Field(
@@ -957,7 +1153,6 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
                                     ),
                                 },
                             ),
-                            inline: false,
                             path: PathSelection {
                                 path: WithRange {
                                     node: Var(
@@ -1064,8 +1259,8 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Path {
-                                    alias: Some(
+                                NamedSelection {
+                                    prefix: Alias(
                                         Alias {
                                             name: WithRange {
                                                 node: Field(
@@ -1080,7 +1275,6 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
                                             ),
                                         },
                                     ),
-                                    inline: false,
                                     path: PathSelection {
                                         path: WithRange {
                                             node: Var(
@@ -1136,30 +1330,58 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id2",
-                                ),
-                                range: Some(
-                                    3..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id2",
+                                            ),
+                                            range: Some(
+                                                3..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..6,
@@ -1225,8 +1447,8 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Path {
-                                    alias: Some(
+                                NamedSelection {
+                                    prefix: Alias(
                                         Alias {
                                             name: WithRange {
                                                 node: Field(
@@ -1241,7 +1463,6 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
                                             ),
                                         },
                                     ),
-                                    inline: false,
                                     path: PathSelection {
                                         path: WithRange {
                                             node: Var(
@@ -1297,20 +1518,34 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Path {
-                            alias: Some(
+                        },
+                        NamedSelection {
+                            prefix: Alias(
                                 Alias {
                                     name: WithRange {
                                         node: Field(
@@ -1325,7 +1560,6 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/keys.gr
                                     ),
                                 },
                             ),
-                            inline: false,
                             path: PathSelection {
                                 path: WithRange {
                                     node: Var(

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@normalize_names.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@normalize_names.graphql.snap
@@ -54,30 +54,58 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/normali
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "a",
-                                ),
-                                range: Some(
-                                    3..4,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "a",
+                                            ),
+                                            range: Some(
+                                                3..4,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                4..4,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..4,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..4,
@@ -201,42 +229,84 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/normali
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "a",
-                                ),
-                                range: Some(
-                                    3..4,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "a",
+                                            ),
+                                            range: Some(
+                                                3..4,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                4..4,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..4,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "b",
-                                ),
-                                range: Some(
-                                    5..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "b",
+                                            ),
+                                            range: Some(
+                                                5..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        5..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..6,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@realistic.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@realistic.graphql.snap
@@ -70,166 +70,334 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
                                                 node: Selection(
                                                     SubSelection {
                                                         selections: [
-                                                            Field(
-                                                                None,
-                                                                WithRange {
-                                                                    node: Field(
-                                                                        "name",
-                                                                    ),
-                                                                    range: Some(
-                                                                        14..18,
-                                                                    ),
+                                                            NamedSelection {
+                                                                prefix: None,
+                                                                path: PathSelection {
+                                                                    path: WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "name",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    14..18,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Empty,
+                                                                                range: Some(
+                                                                                    18..18,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        range: Some(
+                                                                            14..18,
+                                                                        ),
+                                                                    },
                                                                 },
-                                                                None,
-                                                            ),
-                                                            Field(
-                                                                None,
-                                                                WithRange {
-                                                                    node: Field(
-                                                                        "username",
-                                                                    ),
-                                                                    range: Some(
-                                                                        19..27,
-                                                                    ),
+                                                            },
+                                                            NamedSelection {
+                                                                prefix: None,
+                                                                path: PathSelection {
+                                                                    path: WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "username",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    19..27,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Empty,
+                                                                                range: Some(
+                                                                                    27..27,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        range: Some(
+                                                                            19..27,
+                                                                        ),
+                                                                    },
                                                                 },
-                                                                None,
-                                                            ),
-                                                            Field(
-                                                                None,
-                                                                WithRange {
-                                                                    node: Field(
-                                                                        "email",
-                                                                    ),
-                                                                    range: Some(
-                                                                        28..33,
-                                                                    ),
+                                                            },
+                                                            NamedSelection {
+                                                                prefix: None,
+                                                                path: PathSelection {
+                                                                    path: WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "email",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    28..33,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Empty,
+                                                                                range: Some(
+                                                                                    33..33,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        range: Some(
+                                                                            28..33,
+                                                                        ),
+                                                                    },
                                                                 },
-                                                                None,
-                                                            ),
-                                                            Field(
-                                                                None,
-                                                                WithRange {
-                                                                    node: Field(
-                                                                        "status",
-                                                                    ),
-                                                                    range: Some(
-                                                                        34..40,
-                                                                    ),
+                                                            },
+                                                            NamedSelection {
+                                                                prefix: None,
+                                                                path: PathSelection {
+                                                                    path: WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "status",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    34..40,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Empty,
+                                                                                range: Some(
+                                                                                    40..40,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        range: Some(
+                                                                            34..40,
+                                                                        ),
+                                                                    },
                                                                 },
-                                                                None,
-                                                            ),
-                                                            Field(
-                                                                None,
-                                                                WithRange {
-                                                                    node: Field(
-                                                                        "address",
-                                                                    ),
-                                                                    range: Some(
-                                                                        41..48,
-                                                                    ),
-                                                                },
-                                                                Some(
-                                                                    SubSelection {
-                                                                        selections: [
-                                                                            Field(
-                                                                                None,
-                                                                                WithRange {
-                                                                                    node: Field(
-                                                                                        "street",
-                                                                                    ),
-                                                                                    range: Some(
-                                                                                        51..57,
-                                                                                    ),
-                                                                                },
-                                                                                None,
-                                                                            ),
-                                                                            Field(
-                                                                                None,
-                                                                                WithRange {
-                                                                                    node: Field(
-                                                                                        "suite",
-                                                                                    ),
-                                                                                    range: Some(
-                                                                                        58..63,
-                                                                                    ),
-                                                                                },
-                                                                                None,
-                                                                            ),
-                                                                            Field(
-                                                                                None,
-                                                                                WithRange {
-                                                                                    node: Field(
-                                                                                        "city",
-                                                                                    ),
-                                                                                    range: Some(
-                                                                                        64..68,
-                                                                                    ),
-                                                                                },
-                                                                                None,
-                                                                            ),
-                                                                            Field(
-                                                                                None,
-                                                                                WithRange {
-                                                                                    node: Field(
-                                                                                        "zipcode",
-                                                                                    ),
-                                                                                    range: Some(
-                                                                                        69..76,
-                                                                                    ),
-                                                                                },
-                                                                                None,
-                                                                            ),
-                                                                            Field(
-                                                                                None,
-                                                                                WithRange {
-                                                                                    node: Field(
-                                                                                        "geo",
-                                                                                    ),
-                                                                                    range: Some(
-                                                                                        77..80,
-                                                                                    ),
-                                                                                },
-                                                                                Some(
+                                                            },
+                                                            NamedSelection {
+                                                                prefix: None,
+                                                                path: PathSelection {
+                                                                    path: WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "address",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    41..48,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Selection(
                                                                                     SubSelection {
                                                                                         selections: [
-                                                                                            Field(
-                                                                                                None,
-                                                                                                WithRange {
-                                                                                                    node: Field(
-                                                                                                        "lat",
-                                                                                                    ),
-                                                                                                    range: Some(
-                                                                                                        83..86,
-                                                                                                    ),
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "street",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    51..57,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    57..57,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            51..57,
+                                                                                                        ),
+                                                                                                    },
                                                                                                 },
-                                                                                                None,
-                                                                                            ),
-                                                                                            Field(
-                                                                                                None,
-                                                                                                WithRange {
-                                                                                                    node: Field(
-                                                                                                        "lng",
-                                                                                                    ),
-                                                                                                    range: Some(
-                                                                                                        87..90,
-                                                                                                    ),
+                                                                                            },
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "suite",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    58..63,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    63..63,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            58..63,
+                                                                                                        ),
+                                                                                                    },
                                                                                                 },
-                                                                                                None,
-                                                                                            ),
+                                                                                            },
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "city",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    64..68,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    68..68,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            64..68,
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "zipcode",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    69..76,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    76..76,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            69..76,
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "geo",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    77..80,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Selection(
+                                                                                                                    SubSelection {
+                                                                                                                        selections: [
+                                                                                                                            NamedSelection {
+                                                                                                                                prefix: None,
+                                                                                                                                path: PathSelection {
+                                                                                                                                    path: WithRange {
+                                                                                                                                        node: Key(
+                                                                                                                                            WithRange {
+                                                                                                                                                node: Field(
+                                                                                                                                                    "lat",
+                                                                                                                                                ),
+                                                                                                                                                range: Some(
+                                                                                                                                                    83..86,
+                                                                                                                                                ),
+                                                                                                                                            },
+                                                                                                                                            WithRange {
+                                                                                                                                                node: Empty,
+                                                                                                                                                range: Some(
+                                                                                                                                                    86..86,
+                                                                                                                                                ),
+                                                                                                                                            },
+                                                                                                                                        ),
+                                                                                                                                        range: Some(
+                                                                                                                                            83..86,
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            NamedSelection {
+                                                                                                                                prefix: None,
+                                                                                                                                path: PathSelection {
+                                                                                                                                    path: WithRange {
+                                                                                                                                        node: Key(
+                                                                                                                                            WithRange {
+                                                                                                                                                node: Field(
+                                                                                                                                                    "lng",
+                                                                                                                                                ),
+                                                                                                                                                range: Some(
+                                                                                                                                                    87..90,
+                                                                                                                                                ),
+                                                                                                                                            },
+                                                                                                                                            WithRange {
+                                                                                                                                                node: Empty,
+                                                                                                                                                range: Some(
+                                                                                                                                                    90..90,
+                                                                                                                                                ),
+                                                                                                                                            },
+                                                                                                                                        ),
+                                                                                                                                        range: Some(
+                                                                                                                                            87..90,
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        range: Some(
+                                                                                                                            81..92,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    81..92,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            77..92,
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                            },
                                                                                         ],
                                                                                         range: Some(
-                                                                                            81..92,
+                                                                                            49..94,
                                                                                         ),
                                                                                     },
                                                                                 ),
-                                                                            ),
-                                                                        ],
+                                                                                range: Some(
+                                                                                    49..94,
+                                                                                ),
+                                                                            },
+                                                                        ),
                                                                         range: Some(
-                                                                            49..94,
+                                                                            41..94,
                                                                         ),
                                                                     },
-                                                                ),
-                                                            ),
+                                                                },
+                                                            },
                                                         ],
                                                         range: Some(
                                                             12..96,
@@ -264,18 +432,32 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..2,
@@ -352,8 +534,8 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Path {
-                                    alias: Some(
+                                NamedSelection {
+                                    prefix: Alias(
                                         Alias {
                                             name: WithRange {
                                                 node: Field(
@@ -368,7 +550,6 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
                                             ),
                                         },
                                     ),
-                                    inline: false,
                                     path: PathSelection {
                                         path: WithRange {
                                             node: Var(
@@ -424,30 +605,58 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "name",
-                                ),
-                                range: Some(
-                                    3..7,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "name",
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                7..7,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..7,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..7,
@@ -590,86 +799,170 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
-                            },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "name",
-                                ),
-                                range: Some(
-                                    3..7,
-                                ),
-                            },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "company",
-                                ),
-                                range: Some(
-                                    8..15,
-                                ),
-                            },
-                            Some(
-                                SubSelection {
-                                    selections: [
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "name",
-                                                ),
-                                                range: Some(
-                                                    20..24,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "catchPhrase",
-                                                ),
-                                                range: Some(
-                                                    27..38,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "bs",
-                                                ),
-                                                range: Some(
-                                                    41..43,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                    ],
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
                                     range: Some(
-                                        16..45,
+                                        0..2,
                                     ),
                                 },
-                            ),
-                        ),
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "name",
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                7..7,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..7,
+                                    ),
+                                },
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "company",
+                                            ),
+                                            range: Some(
+                                                8..15,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Selection(
+                                                SubSelection {
+                                                    selections: [
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "name",
+                                                                            ),
+                                                                            range: Some(
+                                                                                20..24,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                24..24,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        20..24,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "catchPhrase",
+                                                                            ),
+                                                                            range: Some(
+                                                                                27..38,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                38..38,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        27..38,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "bs",
+                                                                            ),
+                                                                            range: Some(
+                                                                                41..43,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                43..43,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        41..43,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                    range: Some(
+                                                        16..45,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                16..45,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        8..45,
+                                    ),
+                                },
+                            },
+                        },
                     ],
                     range: Some(
                         0..45,
@@ -797,258 +1090,524 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/realist
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "name",
-                                ),
-                                range: Some(
-                                    3..7,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "name",
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                7..7,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..7,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "username",
-                                ),
-                                range: Some(
-                                    8..16,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "username",
+                                            ),
+                                            range: Some(
+                                                8..16,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                16..16,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        8..16,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "email",
-                                ),
-                                range: Some(
-                                    17..22,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "email",
+                                            ),
+                                            range: Some(
+                                                17..22,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                22..22,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        17..22,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "address",
-                                ),
-                                range: Some(
-                                    23..30,
-                                ),
-                            },
-                            Some(
-                                SubSelection {
-                                    selections: [
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "street",
-                                                ),
-                                                range: Some(
-                                                    35..41,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "suite",
-                                                ),
-                                                range: Some(
-                                                    44..49,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "city",
-                                                ),
-                                                range: Some(
-                                                    52..56,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "zipcode",
-                                                ),
-                                                range: Some(
-                                                    59..66,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "geo",
-                                                ),
-                                                range: Some(
-                                                    69..72,
-                                                ),
-                                            },
-                                            Some(
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "address",
+                                            ),
+                                            range: Some(
+                                                23..30,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Selection(
                                                 SubSelection {
                                                     selections: [
-                                                        Field(
-                                                            None,
-                                                            WithRange {
-                                                                node: Field(
-                                                                    "lat",
-                                                                ),
-                                                                range: Some(
-                                                                    79..82,
-                                                                ),
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "street",
+                                                                            ),
+                                                                            range: Some(
+                                                                                35..41,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                41..41,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        35..41,
+                                                                    ),
+                                                                },
                                                             },
-                                                            None,
-                                                        ),
-                                                        Field(
-                                                            None,
-                                                            WithRange {
-                                                                node: Field(
-                                                                    "lng",
-                                                                ),
-                                                                range: Some(
-                                                                    87..90,
-                                                                ),
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "suite",
+                                                                            ),
+                                                                            range: Some(
+                                                                                44..49,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                49..49,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        44..49,
+                                                                    ),
+                                                                },
                                                             },
-                                                            None,
-                                                        ),
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "city",
+                                                                            ),
+                                                                            range: Some(
+                                                                                52..56,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                56..56,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        52..56,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "zipcode",
+                                                                            ),
+                                                                            range: Some(
+                                                                                59..66,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                66..66,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        59..66,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "geo",
+                                                                            ),
+                                                                            range: Some(
+                                                                                69..72,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Selection(
+                                                                                SubSelection {
+                                                                                    selections: [
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: PathSelection {
+                                                                                                path: WithRange {
+                                                                                                    node: Key(
+                                                                                                        WithRange {
+                                                                                                            node: Field(
+                                                                                                                "lat",
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                79..82,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Empty,
+                                                                                                            range: Some(
+                                                                                                                82..82,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        79..82,
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: PathSelection {
+                                                                                                path: WithRange {
+                                                                                                    node: Key(
+                                                                                                        WithRange {
+                                                                                                            node: Field(
+                                                                                                                "lng",
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                87..90,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Empty,
+                                                                                                            range: Some(
+                                                                                                                90..90,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        87..90,
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                    ],
+                                                                                    range: Some(
+                                                                                        73..94,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                73..94,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        69..94,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
                                                     ],
                                                     range: Some(
-                                                        73..94,
+                                                        31..96,
                                                     ),
                                                 },
                                             ),
-                                        ),
-                                    ],
+                                            range: Some(
+                                                31..96,
+                                            ),
+                                        },
+                                    ),
                                     range: Some(
-                                        31..96,
+                                        23..96,
                                     ),
                                 },
-                            ),
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "phone",
-                                ),
-                                range: Some(
-                                    97..102,
-                                ),
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "website",
-                                ),
-                                range: Some(
-                                    103..110,
-                                ),
-                            },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "company",
-                                ),
-                                range: Some(
-                                    111..118,
-                                ),
-                            },
-                            Some(
-                                SubSelection {
-                                    selections: [
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "name",
-                                                ),
-                                                range: Some(
-                                                    123..127,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "catchPhrase",
-                                                ),
-                                                range: Some(
-                                                    130..141,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "bs",
-                                                ),
-                                                range: Some(
-                                                    144..146,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "email",
-                                                ),
-                                                range: Some(
-                                                    149..154,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                    ],
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "phone",
+                                            ),
+                                            range: Some(
+                                                97..102,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                102..102,
+                                            ),
+                                        },
+                                    ),
                                     range: Some(
-                                        119..156,
+                                        97..102,
                                     ),
                                 },
-                            ),
-                        ),
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "website",
+                                            ),
+                                            range: Some(
+                                                103..110,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                110..110,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        103..110,
+                                    ),
+                                },
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "company",
+                                            ),
+                                            range: Some(
+                                                111..118,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Selection(
+                                                SubSelection {
+                                                    selections: [
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "name",
+                                                                            ),
+                                                                            range: Some(
+                                                                                123..127,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                127..127,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        123..127,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "catchPhrase",
+                                                                            ),
+                                                                            range: Some(
+                                                                                130..141,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                141..141,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        130..141,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "bs",
+                                                                            ),
+                                                                            range: Some(
+                                                                                144..146,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                146..146,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        144..146,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "email",
+                                                                            ),
+                                                                            range: Some(
+                                                                                149..154,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                154..154,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        149..154,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                    range: Some(
+                                                        119..156,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                119..156,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        111..156,
+                                    ),
+                                },
+                            },
+                        },
                     ],
                     range: Some(
                         0..156,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@sibling_fields.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@sibling_fields.graphql.snap
@@ -41,38 +41,66 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/sibling
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "k",
-                                ),
-                                range: Some(
-                                    0..1,
-                                ),
-                            },
-                            Some(
-                                SubSelection {
-                                    selections: [
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "id",
-                                                ),
-                                                range: Some(
-                                                    4..6,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                    ],
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "k",
+                                            ),
+                                            range: Some(
+                                                0..1,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Selection(
+                                                SubSelection {
+                                                    selections: [
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "id",
+                                                                            ),
+                                                                            range: Some(
+                                                                                4..6,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                6..6,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        4..6,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                    range: Some(
+                                                        2..8,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                2..8,
+                                            ),
+                                        },
+                                    ),
                                     range: Some(
-                                        2..8,
+                                        0..8,
                                     ),
                                 },
-                            ),
-                        ),
+                            },
+                        },
                     ],
                     range: Some(
                         0..8,
@@ -198,18 +226,32 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/sibling
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "b",
-                                ),
-                                range: Some(
-                                    0..1,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "b",
+                                            ),
+                                            range: Some(
+                                                0..1,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                1..1,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..1,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..1,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@simple.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@simple.graphql.snap
@@ -54,30 +54,58 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "a",
-                                ),
-                                range: Some(
-                                    3..4,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "a",
+                                            ),
+                                            range: Some(
+                                                3..4,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                4..4,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..4,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..4,
@@ -201,42 +229,84 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "a",
-                                ),
-                                range: Some(
-                                    3..4,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "a",
+                                            ),
+                                            range: Some(
+                                                3..4,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                4..4,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..4,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "b",
-                                ),
-                                range: Some(
-                                    5..6,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "b",
+                                            ),
+                                            range: Some(
+                                                5..6,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                6..6,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        5..6,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..6,
@@ -367,8 +437,8 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Path {
-                                    alias: Some(
+                                NamedSelection {
+                                    prefix: Alias(
                                         Alias {
                                             name: WithRange {
                                                 node: Field(
@@ -383,7 +453,6 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
                                             ),
                                         },
                                     ),
-                                    inline: false,
                                     path: PathSelection {
                                         path: WithRange {
                                             node: Var(

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@steelthread.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@steelthread.graphql.snap
@@ -54,30 +54,58 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "name",
-                                ),
-                                range: Some(
-                                    3..7,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "name",
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                7..7,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..7,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..7,
@@ -201,42 +229,84 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "name",
-                                ),
-                                range: Some(
-                                    3..7,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "name",
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                7..7,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..7,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "username",
-                                ),
-                                range: Some(
-                                    8..16,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "username",
+                                            ),
+                                            range: Some(
+                                                8..16,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                16..16,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        8..16,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..16,

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@types_used_twice.graphql.snap
@@ -54,90 +54,160 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/types_u
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "a",
-                                ),
-                                range: Some(
-                                    0..1,
-                                ),
-                            },
-                            Some(
-                                SubSelection {
-                                    selections: [
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "id",
-                                                ),
-                                                range: Some(
-                                                    4..6,
-                                                ),
-                                            },
-                                            None,
-                                        ),
-                                    ],
-                                    range: Some(
-                                        2..8,
-                                    ),
-                                },
-                            ),
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "b",
-                                ),
-                                range: Some(
-                                    9..10,
-                                ),
-                            },
-                            Some(
-                                SubSelection {
-                                    selections: [
-                                        Field(
-                                            None,
-                                            WithRange {
-                                                node: Field(
-                                                    "a",
-                                                ),
-                                                range: Some(
-                                                    13..14,
-                                                ),
-                                            },
-                                            Some(
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "a",
+                                            ),
+                                            range: Some(
+                                                0..1,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Selection(
                                                 SubSelection {
                                                     selections: [
-                                                        Field(
-                                                            None,
-                                                            WithRange {
-                                                                node: Field(
-                                                                    "id",
-                                                                ),
-                                                                range: Some(
-                                                                    17..19,
-                                                                ),
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "id",
+                                                                            ),
+                                                                            range: Some(
+                                                                                4..6,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                6..6,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        4..6,
+                                                                    ),
+                                                                },
                                                             },
-                                                            None,
-                                                        ),
+                                                        },
                                                     ],
                                                     range: Some(
-                                                        15..21,
+                                                        2..8,
                                                     ),
                                                 },
                                             ),
-                                        ),
-                                    ],
+                                            range: Some(
+                                                2..8,
+                                            ),
+                                        },
+                                    ),
                                     range: Some(
-                                        11..23,
+                                        0..8,
                                     ),
                                 },
-                            ),
-                        ),
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "b",
+                                            ),
+                                            range: Some(
+                                                9..10,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Selection(
+                                                SubSelection {
+                                                    selections: [
+                                                        NamedSelection {
+                                                            prefix: None,
+                                                            path: PathSelection {
+                                                                path: WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "a",
+                                                                            ),
+                                                                            range: Some(
+                                                                                13..14,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Selection(
+                                                                                SubSelection {
+                                                                                    selections: [
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: PathSelection {
+                                                                                                path: WithRange {
+                                                                                                    node: Key(
+                                                                                                        WithRange {
+                                                                                                            node: Field(
+                                                                                                                "id",
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                17..19,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Empty,
+                                                                                                            range: Some(
+                                                                                                                19..19,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        17..19,
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                    ],
+                                                                                    range: Some(
+                                                                                        15..21,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                15..21,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        13..21,
+                                                                    ),
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                    range: Some(
+                                                        11..23,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                11..23,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        9..23,
+                                    ),
+                                },
+                            },
+                        },
                     ],
                     range: Some(
                         0..23,

--- a/apollo-federation/src/connectors/header.rs
+++ b/apollo-federation/src/connectors/header.rs
@@ -294,38 +294,66 @@ mod test_header_value_parse {
                                                                 node: Selection(
                                                                     SubSelection {
                                                                         selections: [
-                                                                            Field(
-                                                                                None,
-                                                                                WithRange {
-                                                                                    node: Field(
-                                                                                        "two",
-                                                                                    ),
-                                                                                    range: Some(
-                                                                                        14..17,
-                                                                                    ),
-                                                                                },
-                                                                                Some(
-                                                                                    SubSelection {
-                                                                                        selections: [
-                                                                                            Field(
-                                                                                                None,
-                                                                                                WithRange {
-                                                                                                    node: Field(
-                                                                                                        "three",
-                                                                                                    ),
-                                                                                                    range: Some(
-                                                                                                        20..25,
-                                                                                                    ),
-                                                                                                },
-                                                                                                None,
-                                                                                            ),
-                                                                                        ],
+                                                                            NamedSelection {
+                                                                                prefix: None,
+                                                                                path: PathSelection {
+                                                                                    path: WithRange {
+                                                                                        node: Key(
+                                                                                            WithRange {
+                                                                                                node: Field(
+                                                                                                    "two",
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    14..17,
+                                                                                                ),
+                                                                                            },
+                                                                                            WithRange {
+                                                                                                node: Selection(
+                                                                                                    SubSelection {
+                                                                                                        selections: [
+                                                                                                            NamedSelection {
+                                                                                                                prefix: None,
+                                                                                                                path: PathSelection {
+                                                                                                                    path: WithRange {
+                                                                                                                        node: Key(
+                                                                                                                            WithRange {
+                                                                                                                                node: Field(
+                                                                                                                                    "three",
+                                                                                                                                ),
+                                                                                                                                range: Some(
+                                                                                                                                    20..25,
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                            WithRange {
+                                                                                                                                node: Empty,
+                                                                                                                                range: Some(
+                                                                                                                                    25..25,
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        range: Some(
+                                                                                                                            20..25,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            },
+                                                                                                        ],
+                                                                                                        range: Some(
+                                                                                                            18..27,
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    18..27,
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
                                                                                         range: Some(
-                                                                                            18..27,
+                                                                                            14..27,
                                                                                         ),
                                                                                     },
-                                                                                ),
-                                                                            ),
+                                                                                },
+                                                                            },
                                                                         ],
                                                                         range: Some(
                                                                             12..29,

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -378,91 +378,56 @@ impl ApplyToInternal for NamedSelection {
         let mut output: Option<JSON> = None;
         let mut errors = Vec::new();
 
-        match self {
-            Self::Field(alias, key, selection) => {
-                let input_path_with_key = input_path.append(key.to_json());
-                let name = key.as_str();
-                if let Some(child) = data.get(name) {
-                    let output_name = alias.as_ref().map_or(name, |alias| alias.name());
-                    if let Some(selection) = selection {
-                        let (value, apply_errors) =
-                            selection.apply_to_path(child, vars, &input_path_with_key, spec);
-                        errors.extend(apply_errors);
-                        if let Some(value) = value {
-                            output = Some(json!({ output_name: value }));
-                        }
-                    } else {
-                        output = Some(json!({ output_name: child.clone() }));
-                    }
-                } else {
-                    errors.push(ApplyToError::new(
-                        format!(
-                            "Property {} not found in {}",
-                            key.dotted(),
-                            json_type_name(data),
-                        ),
-                        input_path_with_key.to_vec(),
-                        key.range(),
-                        spec,
-                    ));
-                }
-            }
-            Self::Path {
-                alias,
-                path,
-                inline,
-            } => {
-                let (value_opt, apply_errors) = path.apply_to_path(data, vars, input_path, spec);
-                errors.extend(apply_errors);
+        let (value_opt, apply_errors) = self.path.apply_to_path(data, vars, input_path, spec);
+        errors.extend(apply_errors);
 
-                if let Some(alias) = alias {
-                    // Handle the NamedPathSelection case.
-                    if let Some(value) = value_opt {
-                        output = Some(json!({ alias.name(): value }));
+        match &self.prefix {
+            NamingPrefix::Alias(alias) => {
+                if let Some(value) = value_opt {
+                    output = Some(json!({ alias.name.as_str(): value }));
+                }
+            }
+
+            NamingPrefix::Spread(_) => {
+                match value_opt {
+                    Some(JSON::Object(_) | JSON::Null) => {
+                        // Objects and null are valid outputs for an
+                        // inline/spread NamedSelection.
+                        output = value_opt;
                     }
-                } else if *inline {
-                    match value_opt {
-                        Some(JSON::Object(map)) => {
-                            output = Some(JSON::Object(map));
-                        }
-                        Some(JSON::Null) => {
-                            output = Some(JSON::Null);
-                        }
-                        Some(value) => {
-                            errors.push(ApplyToError::new(
-                                format!("Expected object or null, not {}", json_type_name(&value)),
-                                input_path.to_vec(),
-                                path.range(),
-                                spec,
-                            ));
-                        }
-                        None => {
-                            errors.push(ApplyToError::new(
-                                "Expected object or null, not nothing".to_string(),
-                                input_path.to_vec(),
-                                path.range(),
-                                spec,
-                            ));
-                        }
+                    Some(value) => {
+                        errors.push(ApplyToError::new(
+                            format!("Expected object or null, not {}", json_type_name(&value)),
+                            input_path.to_vec(),
+                            self.path.range(),
+                            spec,
+                        ));
+                    }
+                    None => {
+                        errors.push(ApplyToError::new(
+                            "Named path must have an alias, a trailing subselection, or be inlined with ... and produce an object or null".to_string(),
+                            input_path.to_vec(),
+                            self.path.range(),
+                            spec,
+                        ));
+                    }
+                };
+            }
+
+            NamingPrefix::None => {
+                // Since there is no prefix (NamingPrefix::None), value_opt is
+                // usable as the output of NamedSelection::apply_to_path only if
+                // the NamedSelection has an implied single key, or by having a
+                // trailing SubSelection that guarantees object/null output.
+                if let Some(single_key) = self.path.get_single_key() {
+                    if let Some(value) = value_opt {
+                        output = Some(json!({ single_key.as_str(): value }));
                     }
                 } else {
-                    errors.push(ApplyToError::new(
-                        "Named path must have an alias, a trailing subselection, or be inlined with ... and produce an object or null".to_string(),
-                        input_path.to_vec(),
-                        path.range(),
-                        spec,
-                    ));
+                    output = value_opt;
                 }
             }
-            Self::Group(alias, sub_selection) => {
-                let (value_opt, apply_errors) =
-                    sub_selection.apply_to_path(data, vars, input_path, spec);
-                errors.extend(apply_errors);
-                if let Some(value) = value_opt {
-                    output = Some(json!({ alias.name(): value }));
-                }
-            }
-        };
+        }
 
         (output, errors)
     }
@@ -473,44 +438,17 @@ impl ApplyToInternal for NamedSelection {
         input_shape: Shape,
         dollar_shape: Shape,
     ) -> Shape {
-        let mut output = Shape::empty_map();
+        let path_shape = self
+            .path
+            .compute_output_shape(context, input_shape, dollar_shape);
 
-        match self {
-            Self::Field(alias_opt, key, selection) => {
-                let output_key = alias_opt
-                    .as_ref()
-                    .map_or(key.as_str(), |alias| alias.name());
-                let field_shape = field(&dollar_shape, key, context.source_id());
-                output.insert(
-                    output_key.to_string(),
-                    if let Some(selection) = selection {
-                        selection.compute_output_shape(context, field_shape, dollar_shape)
-                    } else {
-                        field_shape
-                    },
-                );
-            }
-            Self::Path { alias, path, .. } => {
-                let path_shape = path.compute_output_shape(context, input_shape, dollar_shape);
-                if let Some(alias) = alias {
-                    output.insert(alias.name().to_string(), path_shape);
-                } else {
-                    return path_shape;
-                }
-            }
-            Self::Group(alias, sub_selection) => {
-                output.insert(
-                    alias.name().to_string(),
-                    sub_selection.compute_output_shape(context, input_shape, dollar_shape),
-                );
-            }
-        };
-
-        Shape::object(
-            output,
-            Shape::none(),
-            self.shape_location(context.source_id()),
-        )
+        if let Some(single_output_key) = self.get_single_key() {
+            let mut map = Shape::empty_map();
+            map.insert(single_output_key.as_string(), path_shape);
+            Shape::record(map, self.shape_location(context.source_id()))
+        } else {
+            path_shape
+        }
     }
 }
 
@@ -784,8 +722,7 @@ impl ApplyToInternal for WithRange<PathList> {
             // ensuring that some.nested.path is equivalent to
             // $.some.nested.path.
             PathList::Key(key, tail) => {
-                let child_shape =
-                    input_shape.field(key.as_str(), key.shape_location(context.source_id()));
+                let child_shape = field(&input_shape, key, context.source_id());
 
                 // Here input_shape was not None, but input_shape.field(key) was
                 // None, so it's the responsibility of this PathList::Key node
@@ -1066,7 +1003,7 @@ impl ApplyToInternal for SubSelection {
 
         // Build up the merged object shape using Shape::all to merge the
         // individual named_selection object shapes.
-        let mut all_shape = Shape::empty_object(self.shape_location(context.source_id()));
+        let mut all_shape = Shape::none();
 
         for named_selection in self.selections.iter() {
             // Simplifying as we go with Shape::all keeps all_shape relatively
@@ -1093,7 +1030,11 @@ impl ApplyToInternal for SubSelection {
             }
         }
 
-        all_shape
+        if all_shape.is_none() {
+            Shape::empty_object(self.shape_location(context.source_id()))
+        } else {
+            all_shape
+        }
     }
 }
 
@@ -2507,7 +2448,7 @@ mod tests {
                         ConnectSpec::latest(),
                     ),
                     ApplyToError::new(
-                        "Expected object or null, not nothing".to_string(),
+                        "Named path must have an alias, a trailing subselection, or be inlined with ... and produce an object or null".to_string(),
                         vec![],
                         // This is the range of the whole
                         // `nested.path.nonexistent { name }` path selection.
@@ -2518,51 +2459,9 @@ mod tests {
             ),
         );
 
-        // We have to construct this invalid selection manually because we want
-        // to test an error case requiring a PathWithSubSelection that does not
-        // actually have a SubSelection, which should not be possible to
-        // construct through normal parsing.
-        let invalid_inline_path_selection = JSONSelection::named(SubSelection {
-            selections: vec![NamedSelection::Path {
-                alias: None,
-                inline: false,
-                path: PathSelection {
-                    path: PathList::Key(
-                        Key::field("some").into_with_range(),
-                        PathList::Key(
-                            Key::field("number").into_with_range(),
-                            PathList::Empty.into_with_range(),
-                        )
-                        .into_with_range(),
-                    )
-                    .into_with_range(),
-                },
-            }],
-            ..Default::default()
-        });
-
-        assert_eq!(
-            invalid_inline_path_selection.apply_to(&json!({
-                "some": {
-                    "number": 579,
-                },
-            })),
-            (
-                Some(json!({})),
-                vec![ApplyToError::new(
-                    "Named path must have an alias, a trailing subselection, or be inlined with ... and produce an object or null".to_string(),
-                    vec![],
-                    // No range because this is a manually constructed selection.
-                    None,
-                    ConnectSpec::latest(),
-                )],
-            ),
-        );
-
         let valid_inline_path_selection = JSONSelection::named(SubSelection {
-            selections: vec![NamedSelection::Path {
-                alias: None,
-                inline: true, // This makes it valid.
+            selections: vec![NamedSelection {
+                prefix: NamingPrefix::None,
                 path: PathSelection {
                     path: PathList::Key(
                         Key::field("some").into_with_range(),

--- a/apollo-federation/src/connectors/json_selection/location.rs
+++ b/apollo-federation/src/connectors/json_selection/location.rs
@@ -216,25 +216,13 @@ pub(crate) mod strip_ranges {
 
     impl StripRanges for NamedSelection {
         fn strip_ranges(&self) -> Self {
-            match self {
-                Self::Field(alias, key, sub) => Self::Field(
-                    alias.as_ref().map(|a| a.strip_ranges()),
-                    key.strip_ranges(),
-                    sub.as_ref().map(|s| s.strip_ranges()),
-                ),
-                Self::Path {
-                    alias,
-                    path,
-                    inline,
-                } => {
-                    let stripped_alias = alias.as_ref().map(|a| a.strip_ranges());
-                    Self::Path {
-                        alias: stripped_alias,
-                        path: path.strip_ranges(),
-                        inline: *inline,
-                    }
-                }
-                Self::Group(alias, sub) => Self::Group(alias.strip_ranges(), sub.strip_ranges()),
+            Self {
+                prefix: match &self.prefix {
+                    NamingPrefix::None => NamingPrefix::None,
+                    NamingPrefix::Alias(alias) => NamingPrefix::Alias(alias.strip_ranges()),
+                    NamingPrefix::Spread(_) => NamingPrefix::Spread(None),
+                },
+                path: self.path.strip_ranges(),
             }
         }
     }

--- a/apollo-federation/src/connectors/json_selection/pretty.rs
+++ b/apollo-federation/src/connectors/json_selection/pretty.rs
@@ -13,6 +13,7 @@ use super::parser::Key;
 use crate::connectors::json_selection::JSONSelection;
 use crate::connectors::json_selection::MethodArgs;
 use crate::connectors::json_selection::NamedSelection;
+use crate::connectors::json_selection::NamingPrefix;
 use crate::connectors::json_selection::PathList;
 use crate::connectors::json_selection::PathSelection;
 use crate::connectors::json_selection::SubSelection;
@@ -118,9 +119,9 @@ impl PrettyPrintable for PathSelection {
         // to indentation.
         let leading_space_count = inner.chars().take_while(|c| *c == ' ').count();
         let suffix = inner[leading_space_count..].to_string();
-        if suffix.starts_with('.') && !self.path.is_single_key() {
+        if let Some(after_dot) = suffix.strip_prefix('.') {
             // Strip the '.' but keep any leading spaces.
-            format!("{}{}", " ".repeat(leading_space_count), &suffix[1..])
+            format!("{}{}", " ".repeat(leading_space_count), after_dot)
         } else {
             inner
         }
@@ -300,47 +301,24 @@ impl PrettyPrintable for NamedSelection {
     fn pretty_print_with_indentation(&self, inline: bool, indentation: usize) -> String {
         let mut result = String::new();
 
-        match self {
-            Self::Field(alias, field_key, sub) => {
-                if let Some(alias) = alias {
-                    result.push_str(alias.pretty_print().as_str());
-                    result.push(' ');
-                }
-
-                result.push_str(field_key.pretty_print().as_str());
-
-                if let Some(sub) = sub {
-                    let sub = sub.pretty_print_with_indentation(inline, indentation);
-                    result.push(' ');
-                    result.push_str(sub.as_str());
-                }
-            }
-            Self::Path { alias, path, .. } => {
-                // TODO Once we reintroduce conditional selections, I believe we
-                // should print the ... even for PathWithSubSelection selections
-                // which were not originally written with the ... (but for which
-                // *inline is nevertheless true), because the version with ...
-                // will be equivalent to the version without, and using the ...
-                // makes it much more obvious that the output of the selection
-                // will be inlined into the parent object.
-                // if *inline {
-                //     result.push_str("...");
-                // }
-                if let Some(alias) = alias {
-                    result.push_str(alias.pretty_print().as_str());
-                    result.push(' ');
-                }
-                let path = path.pretty_print_with_indentation(inline, indentation);
-                result.push_str(path.trim_start());
-            }
-            Self::Group(alias, sub) => {
+        match &self.prefix {
+            NamingPrefix::None => {}
+            NamingPrefix::Alias(alias) => {
                 result.push_str(alias.pretty_print().as_str());
                 result.push(' ');
-
-                let sub = sub.pretty_print_with_indentation(inline, indentation);
-                result.push_str(sub.as_str());
+            }
+            NamingPrefix::Spread(token_range) => {
+                if token_range.is_some() {
+                    result.push_str("... ");
+                }
             }
         };
+
+        // The .trim_start() handles the case when self.path is just a
+        // SubSelection (i.e., a NamedGroupSelection), since that PathList
+        // variant typically prints a single leading space.
+        let pretty_path = self.path.pretty_print_with_indentation(inline, indentation);
+        result.push_str(pretty_path.trim_start());
 
         result
     }

--- a/apollo-federation/src/connectors/json_selection/selection_set.rs
+++ b/apollo-federation/src/connectors/json_selection/selection_set.rs
@@ -38,6 +38,7 @@ use crate::connectors::PathSelection;
 use crate::connectors::SubSelection;
 use crate::connectors::json_selection::Alias;
 use crate::connectors::json_selection::NamedSelection;
+use crate::connectors::json_selection::NamingPrefix;
 use crate::connectors::json_selection::TopLevelSelection;
 
 impl TryFrom<Valid<FieldSet>> for JSONSelection {
@@ -108,8 +109,8 @@ impl SubSelection {
         // TODO: this must change before we support interfaces and unions
         // because it will emit the abstract type's name which is invalid.
         if field_map.contains_key("__typename") && selection_set.ty != name!(_Entity) {
-            new_selections.push(NamedSelection::Path {
-                alias: Some(Alias::new("__typename")),
+            new_selections.push(NamedSelection {
+                prefix: NamingPrefix::Alias(Alias::new("__typename")),
                 path: PathSelection {
                     path: WithRange::new(
                         PathList::Var(
@@ -132,78 +133,62 @@ impl SubSelection {
                         None,
                     ),
                 },
-                inline: false,
             });
         }
 
         for selection in &self.selections {
-            match selection {
-                NamedSelection::Field(alias, name, sub) => {
-                    let key = alias
-                        .as_ref()
-                        .map(|a| a.name.as_str())
-                        .unwrap_or(name.as_str());
-                    if let Some(fields) = field_map.get_vec(key) {
-                        for field in fields {
-                            let field_response_key = field.response_key().as_str();
-                            new_selections.push(NamedSelection::Field(
-                                if field_response_key == name.as_str() {
-                                    None
-                                } else {
-                                    Some(Alias::new(field_response_key))
-                                },
-                                name.clone(),
-                                sub.as_ref().map(|sub| {
-                                    sub.apply_selection_set(document, &field.selection_set)
-                                }),
-                            ));
-                        }
-                    }
-                }
-                NamedSelection::Path {
-                    alias,
-                    path: path_selection,
-                    inline,
-                } => {
-                    let inline = *inline;
-                    if let Some(key) = alias.as_ref().map(|a| a.name.as_str()) {
-                        // If the NamedSelection::Path has an alias (meaning
-                        // it's a NamedPathSelection according to the grammar),
-                        // use the alias name to look up the corresponding
-                        // fields in the selection set.
-                        if let Some(fields) = field_map.get_vec(key) {
-                            for field in fields {
-                                new_selections.push(NamedSelection::Path {
-                                    alias: Some(Alias::new(field.response_key().as_str())),
-                                    path: path_selection
-                                        .apply_selection_set(document, &field.selection_set),
-                                    inline,
+            if let Some(single_key_for_selection) = selection.get_single_key() {
+                if let Some(fields) = field_map.get_vec(single_key_for_selection.as_str()) {
+                    for field in fields {
+                        let response_key = field.response_key().as_str();
+                        let applied_path = selection
+                            .path
+                            .apply_selection_set(document, &field.selection_set);
+
+                        if let Some(single_key_for_path_only) = applied_path.get_single_key() {
+                            if response_key == single_key_for_path_only.as_str() {
+                                // No need for an Alias if the path by
+                                // itself has a single key that equals
+                                // the desired response_key.
+                                new_selections.push(NamedSelection {
+                                    prefix: NamingPrefix::None,
+                                    path: applied_path,
                                 });
+                                continue;
+                            }
+
+                            if response_key == single_key_for_selection.as_str() {
+                                // The response_key matched the existing alias,
+                                // so we don't need to change the alias.
+                                new_selections.push(NamedSelection {
+                                    prefix: selection.prefix.clone(),
+                                    path: applied_path,
+                                });
+                                continue;
                             }
                         }
-                    } else {
-                        // If the NamedSelection::Path has no alias (meaning
-                        // it's a PathWithSubSelection according to the
-                        // grammar), apply the selection set to the path and add
-                        // the new PathWithSubSelection to the new_selections.
-                        new_selections.push(NamedSelection::Path {
-                            alias: None,
-                            path: path_selection.apply_selection_set(document, selection_set),
-                            inline,
+
+                        // The response_key is different from both the
+                        // alias and single_key_for_path_only, so we
+                        // need a new explicit alias to ensure
+                        // response_key is generated.
+                        new_selections.push(NamedSelection {
+                            prefix: NamingPrefix::Alias(Alias::new(response_key)),
+                            path: applied_path,
                         });
                     }
                 }
-                NamedSelection::Group(alias, sub) => {
-                    let key = alias.name.as_str();
-                    if let Some(fields) = field_map.get_vec(key) {
-                        for field in fields {
-                            new_selections.push(NamedSelection::Group(
-                                Alias::new(field.response_key().as_str()),
-                                sub.apply_selection_set(document, &field.selection_set),
-                            ));
-                        }
-                    }
-                }
+            } else {
+                // If the NamedSelection::Path does not have a single
+                // output key (has no alias and is not a single field
+                // selection), then the path's output will be inlined
+                // into the parent, which means we care only about the
+                // intersection between the path's output and the
+                // incoming selection_set.
+                new_selections.push(NamedSelection {
+                    prefix: NamingPrefix::None,
+                    path: selection.path.apply_selection_set(document, selection_set),
+                });
             }
         }
 

--- a/apollo-federation/src/connectors/json_selection/selection_trie.rs
+++ b/apollo-federation/src/connectors/json_selection/selection_trie.rs
@@ -8,8 +8,8 @@ use apollo_compiler::collections::IndexSet;
 
 use super::JSONSelection;
 use super::Key;
-use super::NamedSelection;
 use super::PathList;
+use super::PathSelection;
 use super::Ranged;
 use super::SubSelection;
 use super::helpers::quote_if_necessary;
@@ -33,8 +33,8 @@ impl JSONSelection {
         use crate::connectors::json_selection::TopLevelSelection;
         for path in self.external_var_paths() {
             if let PathList::Var(known_var, tail) = path.path.as_ref() {
-                trie.add_str(known_var.as_str())
-                    .add_path_list(tail.as_ref());
+                trie.add_str_with_ranges(known_var.as_str(), path.range())
+                    .add_path_list(tail);
             } else {
                 // The self.external_var_paths() method should only return
                 // PathSelection elements whose path starts with PathList::Var.
@@ -44,7 +44,7 @@ impl JSONSelection {
         let mut root_trie = SelectionTrie::new();
         match &self.inner {
             TopLevelSelection::Path(path) => {
-                root_trie.add_path_list(path.path.as_ref());
+                root_trie.add_path_list(&path.path);
             }
             TopLevelSelection::Named(selection) => {
                 root_trie.add_subselection(selection);
@@ -56,8 +56,8 @@ impl JSONSelection {
     }
 }
 
-impl PathList {
-    pub(crate) fn compute_selection_trie(&self) -> SelectionTrie {
+impl WithRange<PathList> {
+    pub(super) fn compute_selection_trie(&self) -> SelectionTrie {
         let mut trie = SelectionTrie::new();
         trie.add_path_list(self);
         trie
@@ -181,9 +181,13 @@ impl SelectionTrie {
             .set_leaf()
     }
 
-    pub(super) fn add_path_list(&mut self, path_list: &PathList) -> &mut Self {
-        match path_list {
-            PathList::Key(key, tail) => self.add_key(key).add_path_list(tail.as_ref()),
+    pub(crate) fn add_path_selection(&mut self, path: &PathSelection) -> &mut Self {
+        self.add_path_list(&path.path)
+    }
+
+    fn add_path_list(&mut self, path_list: &WithRange<PathList>) -> &mut Self {
+        match path_list.as_ref() {
+            PathList::Key(key, tail) => self.add_key(key).add_path_list(tail),
             PathList::Selection(sub) => self.add_subselection(sub),
             // If we get to the end of the PathList, mark the path used.
             PathList::Empty => self.set_leaf(),
@@ -196,22 +200,7 @@ impl SelectionTrie {
 
     pub(crate) fn add_subselection(&mut self, sub: &SubSelection) -> &mut Self {
         for selection in sub.selections_iter() {
-            match selection {
-                NamedSelection::Field(_, key, nested_selection) => {
-                    let result = self.add_key(key);
-                    if let Some(nested) = nested_selection {
-                        result.add_subselection(nested);
-                    } else {
-                        result.set_leaf();
-                    }
-                }
-                NamedSelection::Path { path, .. } => {
-                    self.add_path_list(path.path.as_ref());
-                }
-                NamedSelection::Group(_, sub) => {
-                    self.add_subselection(sub);
-                }
-            }
+            self.add_path_selection(&selection.path);
         }
         self
     }

--- a/apollo-federation/src/connectors/json_selection/snapshots/arrow_path_ranges.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/arrow_path_ranges.snap
@@ -6,8 +6,8 @@ JSONSelection {
     inner: Named(
         SubSelection {
             selections: [
-                Path {
-                    alias: Some(
+                NamedSelection {
+                    prefix: Alias(
                         Alias {
                             name: WithRange {
                                 node: Field(
@@ -22,7 +22,6 @@ JSONSelection {
                             ),
                         },
                     ),
-                    inline: false,
                     path: PathSelection {
                         path: WithRange {
                             node: Var(

--- a/apollo-federation/src/connectors/json_selection/snapshots/expr_path_selections.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/expr_path_selections.snap
@@ -6,8 +6,8 @@ JSONSelection {
     inner: Named(
         SubSelection {
             selections: [
-                Path {
-                    alias: Some(
+                NamedSelection {
+                    prefix: Alias(
                         Alias {
                             name: WithRange {
                                 node: Field(
@@ -22,7 +22,6 @@ JSONSelection {
                             ),
                         },
                     ),
-                    inline: false,
                     path: PathSelection {
                         path: WithRange {
                             node: Key(

--- a/apollo-federation/src/connectors/json_selection/snapshots/naked_literal_path_for_connect_v0_2-2.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/naked_literal_path_for_connect_v0_2-2.snap
@@ -6,8 +6,8 @@ JSONSelection {
     inner: Named(
         SubSelection {
             selections: [
-                Path {
-                    alias: Some(
+                NamedSelection {
+                    prefix: Alias(
                         Alias {
                             name: WithRange {
                                 node: Field(
@@ -22,7 +22,6 @@ JSONSelection {
                             ),
                         },
                     ),
-                    inline: false,
                     path: PathSelection {
                         path: WithRange {
                             node: Expr(

--- a/apollo-federation/src/connectors/json_selection/snapshots/parse_with_range_snapshots.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/parse_with_range_snapshots.snap
@@ -6,8 +6,8 @@ JSONSelection {
     inner: Named(
         SubSelection {
             selections: [
-                Path {
-                    alias: Some(
+                NamedSelection {
+                    prefix: Alias(
                         Alias {
                             name: WithRange {
                                 node: Field(
@@ -22,7 +22,6 @@ JSONSelection {
                             ),
                         },
                     ),
-                    inline: false,
                     path: PathSelection {
                         path: WithRange {
                             node: Key(
@@ -58,50 +57,92 @@ JSONSelection {
                                                     node: Selection(
                                                         SubSelection {
                                                             selections: [
-                                                                Field(
-                                                                    None,
-                                                                    WithRange {
-                                                                        node: Field(
-                                                                            "isbn",
-                                                                        ),
-                                                                        range: Some(
-                                                                            34..38,
-                                                                        ),
-                                                                    },
-                                                                    None,
-                                                                ),
-                                                                Field(
-                                                                    None,
-                                                                    WithRange {
-                                                                        node: Field(
-                                                                            "author",
-                                                                        ),
-                                                                        range: Some(
-                                                                            39..45,
-                                                                        ),
-                                                                    },
-                                                                    Some(
-                                                                        SubSelection {
-                                                                            selections: [
-                                                                                Field(
-                                                                                    None,
-                                                                                    WithRange {
-                                                                                        node: Field(
-                                                                                            "name",
-                                                                                        ),
-                                                                                        range: Some(
-                                                                                            48..52,
-                                                                                        ),
-                                                                                    },
-                                                                                    None,
-                                                                                ),
-                                                                            ],
+                                                                NamedSelection {
+                                                                    prefix: None,
+                                                                    path: PathSelection {
+                                                                        path: WithRange {
+                                                                            node: Key(
+                                                                                WithRange {
+                                                                                    node: Field(
+                                                                                        "isbn",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        34..38,
+                                                                                    ),
+                                                                                },
+                                                                                WithRange {
+                                                                                    node: Empty,
+                                                                                    range: Some(
+                                                                                        38..38,
+                                                                                    ),
+                                                                                },
+                                                                            ),
                                                                             range: Some(
-                                                                                46..54,
+                                                                                34..38,
                                                                             ),
                                                                         },
-                                                                    ),
-                                                                ),
+                                                                    },
+                                                                },
+                                                                NamedSelection {
+                                                                    prefix: None,
+                                                                    path: PathSelection {
+                                                                        path: WithRange {
+                                                                            node: Key(
+                                                                                WithRange {
+                                                                                    node: Field(
+                                                                                        "author",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        39..45,
+                                                                                    ),
+                                                                                },
+                                                                                WithRange {
+                                                                                    node: Selection(
+                                                                                        SubSelection {
+                                                                                            selections: [
+                                                                                                NamedSelection {
+                                                                                                    prefix: None,
+                                                                                                    path: PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "name",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        48..52,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        52..52,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                48..52,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                            ],
+                                                                                            range: Some(
+                                                                                                46..54,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        46..54,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                39..54,
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                },
                                                             ],
                                                             range: Some(
                                                                 32..55,
@@ -129,8 +170,8 @@ JSONSelection {
                         },
                     },
                 },
-                Field(
-                    Some(
+                NamedSelection {
+                    prefix: Alias(
                         Alias {
                             name: WithRange {
                                 node: Field(
@@ -145,322 +186,400 @@ JSONSelection {
                             ),
                         },
                     ),
-                    WithRange {
-                        node: Quoted(
-                            "not an identifier",
-                        ),
-                        range: Some(
-                            71..90,
-                        ),
-                    },
-                    Some(
-                        SubSelection {
-                            selections: [
-                                Path {
-                                    alias: Some(
-                                        Alias {
-                                            name: WithRange {
-                                                node: Field(
-                                                    "__typename",
-                                                ),
-                                                range: Some(
-                                                    151..161,
-                                                ),
-                                            },
-                                            range: Some(
-                                                151..162,
-                                            ),
-                                        },
+                    path: PathSelection {
+                        path: WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Quoted(
+                                        "not an identifier",
                                     ),
-                                    inline: false,
-                                    path: PathSelection {
-                                        path: WithRange {
-                                            node: Var(
-                                                WithRange {
-                                                    node: @,
-                                                    range: Some(
-                                                        163..164,
-                                                    ),
-                                                },
-                                                WithRange {
-                                                    node: Method(
-                                                        WithRange {
-                                                            node: "echo",
-                                                            range: Some(
-                                                                166..170,
-                                                            ),
-                                                        },
-                                                        Some(
-                                                            MethodArgs {
-                                                                args: [
-                                                                    WithRange {
-                                                                        node: String(
-                                                                            "Frog",
-                                                                        ),
-                                                                        range: Some(
-                                                                            172..178,
-                                                                        ),
-                                                                    },
-                                                                ],
+                                    range: Some(
+                                        71..90,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Selection(
+                                        SubSelection {
+                                            selections: [
+                                                NamedSelection {
+                                                    prefix: Alias(
+                                                        Alias {
+                                                            name: WithRange {
+                                                                node: Field(
+                                                                    "__typename",
+                                                                ),
                                                                 range: Some(
-                                                                    170..182,
+                                                                    151..161,
                                                                 ),
                                                             },
-                                                        ),
-                                                        WithRange {
-                                                            node: Empty,
                                                             range: Some(
-                                                                182..182,
+                                                                151..162,
                                                             ),
                                                         },
                                                     ),
-                                                    range: Some(
-                                                        164..182,
-                                                    ),
-                                                },
-                                            ),
-                                            range: Some(
-                                                163..182,
-                                            ),
-                                        },
-                                    },
-                                },
-                                Path {
-                                    alias: Some(
-                                        Alias {
-                                            name: WithRange {
-                                                node: Field(
-                                                    "wrapped",
-                                                ),
-                                                range: Some(
-                                                    195..202,
-                                                ),
-                                            },
-                                            range: Some(
-                                                195..203,
-                                            ),
-                                        },
-                                    ),
-                                    inline: false,
-                                    path: PathSelection {
-                                        path: WithRange {
-                                            node: Var(
-                                                WithRange {
-                                                    node: $,
-                                                    range: Some(
-                                                        204..205,
-                                                    ),
-                                                },
-                                                WithRange {
-                                                    node: Method(
-                                                        WithRange {
-                                                            node: "echo",
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Var(
+                                                                WithRange {
+                                                                    node: @,
+                                                                    range: Some(
+                                                                        163..164,
+                                                                    ),
+                                                                },
+                                                                WithRange {
+                                                                    node: Method(
+                                                                        WithRange {
+                                                                            node: "echo",
+                                                                            range: Some(
+                                                                                166..170,
+                                                                            ),
+                                                                        },
+                                                                        Some(
+                                                                            MethodArgs {
+                                                                                args: [
+                                                                                    WithRange {
+                                                                                        node: String(
+                                                                                            "Frog",
+                                                                                        ),
+                                                                                        range: Some(
+                                                                                            172..178,
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                range: Some(
+                                                                                    170..182,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                182..182,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        164..182,
+                                                                    ),
+                                                                },
+                                                            ),
                                                             range: Some(
-                                                                207..211,
+                                                                163..182,
                                                             ),
                                                         },
-                                                        Some(
-                                                            MethodArgs {
-                                                                args: [
-                                                                    WithRange {
-                                                                        node: Object(
-                                                                            {
-                                                                                WithRange {
-                                                                                    node: Field(
-                                                                                        "wrapped",
-                                                                                    ),
-                                                                                    range: Some(
-                                                                                        214..221,
-                                                                                    ),
-                                                                                }: WithRange {
-                                                                                    node: Path(
-                                                                                        PathSelection {
-                                                                                            path: WithRange {
-                                                                                                node: Var(
-                                                                                                    WithRange {
-                                                                                                        node: @,
-                                                                                                        range: Some(
-                                                                                                            224..225,
-                                                                                                        ),
-                                                                                                    },
-                                                                                                    WithRange {
-                                                                                                        node: Empty,
-                                                                                                        range: Some(
-                                                                                                            225..225,
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                                range: Some(
-                                                                                                    224..225,
-                                                                                                ),
+                                                    },
+                                                },
+                                                NamedSelection {
+                                                    prefix: Alias(
+                                                        Alias {
+                                                            name: WithRange {
+                                                                node: Field(
+                                                                    "wrapped",
+                                                                ),
+                                                                range: Some(
+                                                                    195..202,
+                                                                ),
+                                                            },
+                                                            range: Some(
+                                                                195..203,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Var(
+                                                                WithRange {
+                                                                    node: $,
+                                                                    range: Some(
+                                                                        204..205,
+                                                                    ),
+                                                                },
+                                                                WithRange {
+                                                                    node: Method(
+                                                                        WithRange {
+                                                                            node: "echo",
+                                                                            range: Some(
+                                                                                207..211,
+                                                                            ),
+                                                                        },
+                                                                        Some(
+                                                                            MethodArgs {
+                                                                                args: [
+                                                                                    WithRange {
+                                                                                        node: Object(
+                                                                                            {
+                                                                                                WithRange {
+                                                                                                    node: Field(
+                                                                                                        "wrapped",
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        214..221,
+                                                                                                    ),
+                                                                                                }: WithRange {
+                                                                                                    node: Path(
+                                                                                                        PathSelection {
+                                                                                                            path: WithRange {
+                                                                                                                node: Var(
+                                                                                                                    WithRange {
+                                                                                                                        node: @,
+                                                                                                                        range: Some(
+                                                                                                                            224..225,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                    WithRange {
+                                                                                                                        node: Empty,
+                                                                                                                        range: Some(
+                                                                                                                            225..225,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    224..225,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        224..225,
+                                                                                                    ),
+                                                                                                },
                                                                                             },
+                                                                                        ),
+                                                                                        range: Some(
+                                                                                            212..229,
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                range: Some(
+                                                                                    211..230,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                230..230,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        205..230,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                204..230,
+                                                            ),
+                                                        },
+                                                    },
+                                                },
+                                                NamedSelection {
+                                                    prefix: Alias(
+                                                        Alias {
+                                                            name: WithRange {
+                                                                node: Field(
+                                                                    "group",
+                                                                ),
+                                                                range: Some(
+                                                                    243..248,
+                                                                ),
+                                                            },
+                                                            range: Some(
+                                                                243..249,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Selection(
+                                                                SubSelection {
+                                                                    selections: [
+                                                                        NamedSelection {
+                                                                            prefix: None,
+                                                                            path: PathSelection {
+                                                                                path: WithRange {
+                                                                                    node: Key(
+                                                                                        WithRange {
+                                                                                            node: Field(
+                                                                                                "a",
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                252..253,
+                                                                                            ),
+                                                                                        },
+                                                                                        WithRange {
+                                                                                            node: Empty,
+                                                                                            range: Some(
+                                                                                                253..253,
+                                                                                            ),
                                                                                         },
                                                                                     ),
                                                                                     range: Some(
-                                                                                        224..225,
+                                                                                        252..253,
                                                                                     ),
                                                                                 },
                                                                             },
-                                                                        ),
-                                                                        range: Some(
-                                                                            212..229,
-                                                                        ),
-                                                                    },
-                                                                ],
+                                                                        },
+                                                                        NamedSelection {
+                                                                            prefix: None,
+                                                                            path: PathSelection {
+                                                                                path: WithRange {
+                                                                                    node: Key(
+                                                                                        WithRange {
+                                                                                            node: Field(
+                                                                                                "b",
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                254..255,
+                                                                                            ),
+                                                                                        },
+                                                                                        WithRange {
+                                                                                            node: Empty,
+                                                                                            range: Some(
+                                                                                                255..255,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        254..255,
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        NamedSelection {
+                                                                            prefix: None,
+                                                                            path: PathSelection {
+                                                                                path: WithRange {
+                                                                                    node: Key(
+                                                                                        WithRange {
+                                                                                            node: Field(
+                                                                                                "c",
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                256..257,
+                                                                                            ),
+                                                                                        },
+                                                                                        WithRange {
+                                                                                            node: Empty,
+                                                                                            range: Some(
+                                                                                                257..257,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        256..257,
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                    range: Some(
+                                                                        250..259,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                250..259,
+                                                            ),
+                                                        },
+                                                    },
+                                                },
+                                                NamedSelection {
+                                                    prefix: Alias(
+                                                        Alias {
+                                                            name: WithRange {
+                                                                node: Field(
+                                                                    "arg",
+                                                                ),
                                                                 range: Some(
-                                                                    211..230,
+                                                                    272..275,
                                                                 ),
                                                             },
-                                                        ),
-                                                        WithRange {
-                                                            node: Empty,
                                                             range: Some(
-                                                                230..230,
+                                                                272..276,
                                                             ),
                                                         },
                                                     ),
-                                                    range: Some(
-                                                        205..230,
-                                                    ),
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Var(
+                                                                WithRange {
+                                                                    node: $args,
+                                                                    range: Some(
+                                                                        277..282,
+                                                                    ),
+                                                                },
+                                                                WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "arg",
+                                                                            ),
+                                                                            range: Some(
+                                                                                285..288,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Empty,
+                                                                            range: Some(
+                                                                                288..288,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        283..288,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                277..288,
+                                                            ),
+                                                        },
+                                                    },
                                                 },
-                                            ),
+                                                NamedSelection {
+                                                    prefix: None,
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Key(
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "field",
+                                                                    ),
+                                                                    range: Some(
+                                                                        301..306,
+                                                                    ),
+                                                                },
+                                                                WithRange {
+                                                                    node: Empty,
+                                                                    range: Some(
+                                                                        306..306,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                301..306,
+                                                            ),
+                                                        },
+                                                    },
+                                                },
+                                            ],
                                             range: Some(
-                                                204..230,
-                                            ),
-                                        },
-                                    },
-                                },
-                                Group(
-                                    Alias {
-                                        name: WithRange {
-                                            node: Field(
-                                                "group",
-                                            ),
-                                            range: Some(
-                                                243..248,
-                                            ),
-                                        },
-                                        range: Some(
-                                            243..249,
-                                        ),
-                                    },
-                                    SubSelection {
-                                        selections: [
-                                            Field(
-                                                None,
-                                                WithRange {
-                                                    node: Field(
-                                                        "a",
-                                                    ),
-                                                    range: Some(
-                                                        252..253,
-                                                    ),
-                                                },
-                                                None,
-                                            ),
-                                            Field(
-                                                None,
-                                                WithRange {
-                                                    node: Field(
-                                                        "b",
-                                                    ),
-                                                    range: Some(
-                                                        254..255,
-                                                    ),
-                                                },
-                                                None,
-                                            ),
-                                            Field(
-                                                None,
-                                                WithRange {
-                                                    node: Field(
-                                                        "c",
-                                                    ),
-                                                    range: Some(
-                                                        256..257,
-                                                    ),
-                                                },
-                                                None,
-                                            ),
-                                        ],
-                                        range: Some(
-                                            250..259,
-                                        ),
-                                    },
-                                ),
-                                Path {
-                                    alias: Some(
-                                        Alias {
-                                            name: WithRange {
-                                                node: Field(
-                                                    "arg",
-                                                ),
-                                                range: Some(
-                                                    272..275,
-                                                ),
-                                            },
-                                            range: Some(
-                                                272..276,
+                                                91..316,
                                             ),
                                         },
                                     ),
-                                    inline: false,
-                                    path: PathSelection {
-                                        path: WithRange {
-                                            node: Var(
-                                                WithRange {
-                                                    node: $args,
-                                                    range: Some(
-                                                        277..282,
-                                                    ),
-                                                },
-                                                WithRange {
-                                                    node: Key(
-                                                        WithRange {
-                                                            node: Field(
-                                                                "arg",
-                                                            ),
-                                                            range: Some(
-                                                                285..288,
-                                                            ),
-                                                        },
-                                                        WithRange {
-                                                            node: Empty,
-                                                            range: Some(
-                                                                288..288,
-                                                            ),
-                                                        },
-                                                    ),
-                                                    range: Some(
-                                                        283..288,
-                                                    ),
-                                                },
-                                            ),
-                                            range: Some(
-                                                277..288,
-                                            ),
-                                        },
-                                    },
+                                    range: Some(
+                                        91..316,
+                                    ),
                                 },
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "field",
-                                        ),
-                                        range: Some(
-                                            301..306,
-                                        ),
-                                    },
-                                    None,
-                                ),
-                            ],
+                            ),
                             range: Some(
-                                91..316,
+                                71..316,
                             ),
                         },
-                    ),
-                ),
+                    },
+                },
             ],
             range: Some(
                 9..316,

--- a/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-2.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-2.snap
@@ -6,33 +6,62 @@ JSONSelection {
     inner: Named(
         SubSelection {
             selections: [
-                Field(
-                    None,
-                    WithRange {
-                        node: Field(
-                            "id",
-                        ),
-                        range: Some(
-                            13..15,
-                        ),
+                NamedSelection {
+                    prefix: None,
+                    path: PathSelection {
+                        path: WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "id",
+                                    ),
+                                    range: Some(
+                                        13..15,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        15..15,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                13..15,
+                            ),
+                        },
                     },
-                    None,
-                ),
-                Field(
-                    None,
-                    WithRange {
-                        node: Field(
-                            "created",
-                        ),
-                        range: Some(
-                            28..35,
-                        ),
+                },
+                NamedSelection {
+                    prefix: None,
+                    path: PathSelection {
+                        path: WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "created",
+                                    ),
+                                    range: Some(
+                                        28..35,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        35..35,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                28..35,
+                            ),
+                        },
                     },
-                    None,
-                ),
-                Path {
-                    alias: None,
-                    inline: true,
+                },
+                NamedSelection {
+                    prefix: Spread(
+                        None,
+                    ),
                     path: PathSelection {
                         path: WithRange {
                             node: Key(
@@ -67,30 +96,58 @@ JSONSelection {
                                                     node: Selection(
                                                         SubSelection {
                                                             selections: [
-                                                                Field(
-                                                                    None,
-                                                                    WithRange {
-                                                                        node: Field(
-                                                                            "content",
-                                                                        ),
-                                                                        range: Some(
-                                                                            73..80,
-                                                                        ),
+                                                                NamedSelection {
+                                                                    prefix: None,
+                                                                    path: PathSelection {
+                                                                        path: WithRange {
+                                                                            node: Key(
+                                                                                WithRange {
+                                                                                    node: Field(
+                                                                                        "content",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        73..80,
+                                                                                    ),
+                                                                                },
+                                                                                WithRange {
+                                                                                    node: Empty,
+                                                                                    range: Some(
+                                                                                        80..80,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                73..80,
+                                                                            ),
+                                                                        },
                                                                     },
-                                                                    None,
-                                                                ),
-                                                                Field(
-                                                                    None,
-                                                                    WithRange {
-                                                                        node: Field(
-                                                                            "role",
-                                                                        ),
-                                                                        range: Some(
-                                                                            81..85,
-                                                                        ),
+                                                                },
+                                                                NamedSelection {
+                                                                    prefix: None,
+                                                                    path: PathSelection {
+                                                                        path: WithRange {
+                                                                            node: Key(
+                                                                                WithRange {
+                                                                                    node: Field(
+                                                                                        "role",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        81..85,
+                                                                                    ),
+                                                                                },
+                                                                                WithRange {
+                                                                                    node: Empty,
+                                                                                    range: Some(
+                                                                                        85..85,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                81..85,
+                                                                            ),
+                                                                        },
                                                                     },
-                                                                    None,
-                                                                ),
+                                                                },
                                                             ],
                                                             range: Some(
                                                                 71..87,
@@ -118,18 +175,32 @@ JSONSelection {
                         },
                     },
                 },
-                Field(
-                    None,
-                    WithRange {
-                        node: Field(
-                            "model",
-                        ),
-                        range: Some(
-                            100..105,
-                        ),
+                NamedSelection {
+                    prefix: None,
+                    path: PathSelection {
+                        path: WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "model",
+                                    ),
+                                    range: Some(
+                                        100..105,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        105..105,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                100..105,
+                            ),
+                        },
                     },
-                    None,
-                ),
+                },
             ],
             range: Some(
                 13..105,

--- a/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-3.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-3.snap
@@ -6,33 +6,62 @@ JSONSelection {
     inner: Named(
         SubSelection {
             selections: [
-                Field(
-                    None,
-                    WithRange {
-                        node: Field(
-                            "id",
-                        ),
-                        range: Some(
-                            13..15,
-                        ),
+                NamedSelection {
+                    prefix: None,
+                    path: PathSelection {
+                        path: WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "id",
+                                    ),
+                                    range: Some(
+                                        13..15,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        15..15,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                13..15,
+                            ),
+                        },
                     },
-                    None,
-                ),
-                Field(
-                    None,
-                    WithRange {
-                        node: Field(
-                            "created",
-                        ),
-                        range: Some(
-                            28..35,
-                        ),
+                },
+                NamedSelection {
+                    prefix: None,
+                    path: PathSelection {
+                        path: WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "created",
+                                    ),
+                                    range: Some(
+                                        28..35,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        35..35,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                28..35,
+                            ),
+                        },
                     },
-                    None,
-                ),
-                Path {
-                    alias: None,
-                    inline: true,
+                },
+                NamedSelection {
+                    prefix: Spread(
+                        None,
+                    ),
                     path: PathSelection {
                         path: WithRange {
                             node: Key(
@@ -67,30 +96,58 @@ JSONSelection {
                                                     node: Selection(
                                                         SubSelection {
                                                             selections: [
-                                                                Field(
-                                                                    None,
-                                                                    WithRange {
-                                                                        node: Field(
-                                                                            "content",
-                                                                        ),
-                                                                        range: Some(
-                                                                            73..80,
-                                                                        ),
+                                                                NamedSelection {
+                                                                    prefix: None,
+                                                                    path: PathSelection {
+                                                                        path: WithRange {
+                                                                            node: Key(
+                                                                                WithRange {
+                                                                                    node: Field(
+                                                                                        "content",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        73..80,
+                                                                                    ),
+                                                                                },
+                                                                                WithRange {
+                                                                                    node: Empty,
+                                                                                    range: Some(
+                                                                                        80..80,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                73..80,
+                                                                            ),
+                                                                        },
                                                                     },
-                                                                    None,
-                                                                ),
-                                                                Field(
-                                                                    None,
-                                                                    WithRange {
-                                                                        node: Field(
-                                                                            "role",
-                                                                        ),
-                                                                        range: Some(
-                                                                            81..85,
-                                                                        ),
+                                                                },
+                                                                NamedSelection {
+                                                                    prefix: None,
+                                                                    path: PathSelection {
+                                                                        path: WithRange {
+                                                                            node: Key(
+                                                                                WithRange {
+                                                                                    node: Field(
+                                                                                        "role",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        81..85,
+                                                                                    ),
+                                                                                },
+                                                                                WithRange {
+                                                                                    node: Empty,
+                                                                                    range: Some(
+                                                                                        85..85,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                81..85,
+                                                                            ),
+                                                                        },
                                                                     },
-                                                                    None,
-                                                                ),
+                                                                },
                                                             ],
                                                             range: Some(
                                                                 71..87,
@@ -118,21 +175,36 @@ JSONSelection {
                         },
                     },
                 },
-                Field(
-                    None,
-                    WithRange {
-                        node: Field(
-                            "model",
-                        ),
-                        range: Some(
-                            100..105,
-                        ),
+                NamedSelection {
+                    prefix: None,
+                    path: PathSelection {
+                        path: WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "model",
+                                    ),
+                                    range: Some(
+                                        100..105,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Empty,
+                                    range: Some(
+                                        105..105,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                100..105,
+                            ),
+                        },
                     },
-                    None,
-                ),
-                Path {
-                    alias: None,
-                    inline: true,
+                },
+                NamedSelection {
+                    prefix: Spread(
+                        None,
+                    ),
                     path: PathSelection {
                         path: WithRange {
                             node: Key(
@@ -167,8 +239,8 @@ JSONSelection {
                                                     node: Selection(
                                                         SubSelection {
                                                             selections: [
-                                                                Field(
-                                                                    Some(
+                                                                NamedSelection {
+                                                                    prefix: Alias(
                                                                         Alias {
                                                                             name: WithRange {
                                                                                 node: Field(
@@ -183,16 +255,30 @@ JSONSelection {
                                                                             ),
                                                                         },
                                                                     ),
-                                                                    WithRange {
-                                                                        node: Field(
-                                                                            "content",
-                                                                        ),
-                                                                        range: Some(
-                                                                            155..162,
-                                                                        ),
+                                                                    path: PathSelection {
+                                                                        path: WithRange {
+                                                                            node: Key(
+                                                                                WithRange {
+                                                                                    node: Field(
+                                                                                        "content",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        155..162,
+                                                                                    ),
+                                                                                },
+                                                                                WithRange {
+                                                                                    node: Empty,
+                                                                                    range: Some(
+                                                                                        162..162,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                155..162,
+                                                                            ),
+                                                                        },
                                                                     },
-                                                                    None,
-                                                                ),
+                                                                },
                                                             ],
                                                             range: Some(
                                                                 140..164,

--- a/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-5.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-5.snap
@@ -7,8 +7,8 @@ Ok(
         inner: Named(
             SubSelection {
                 selections: [
-                    Path {
-                        alias: Some(
+                    NamedSelection {
+                        prefix: Alias(
                             Alias {
                                 name: WithRange {
                                     node: Field(
@@ -23,7 +23,6 @@ Ok(
                                 ),
                             },
                         ),
-                        inline: false,
                         path: PathSelection {
                             path: WithRange {
                                 node: Var(
@@ -61,9 +60,10 @@ Ok(
                             },
                         },
                     },
-                    Path {
-                        alias: None,
-                        inline: true,
+                    NamedSelection {
+                        prefix: Spread(
+                            None,
+                        ),
                         path: PathSelection {
                             path: WithRange {
                                 node: Var(
@@ -87,30 +87,58 @@ Ok(
                                                 node: Selection(
                                                     SubSelection {
                                                         selections: [
-                                                            Field(
-                                                                None,
-                                                                WithRange {
-                                                                    node: Field(
-                                                                        "title",
-                                                                    ),
-                                                                    range: Some(
-                                                                        68..73,
-                                                                    ),
+                                                            NamedSelection {
+                                                                prefix: None,
+                                                                path: PathSelection {
+                                                                    path: WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "title",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    68..73,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Empty,
+                                                                                range: Some(
+                                                                                    73..73,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        range: Some(
+                                                                            68..73,
+                                                                        ),
+                                                                    },
                                                                 },
-                                                                None,
-                                                            ),
-                                                            Field(
-                                                                None,
-                                                                WithRange {
-                                                                    node: Field(
-                                                                        "body",
-                                                                    ),
-                                                                    range: Some(
-                                                                        90..94,
-                                                                    ),
+                                                            },
+                                                            NamedSelection {
+                                                                prefix: None,
+                                                                path: PathSelection {
+                                                                    path: WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "body",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    90..94,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Empty,
+                                                                                range: Some(
+                                                                                    94..94,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        range: Some(
+                                                                            90..94,
+                                                                        ),
+                                                                    },
                                                                 },
-                                                                None,
-                                                            ),
+                                                            },
                                                         ],
                                                         range: Some(
                                                             50..108,

--- a/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-6.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-6.snap
@@ -7,9 +7,10 @@ Ok(
         inner: Named(
             SubSelection {
                 selections: [
-                    Path {
-                        alias: None,
-                        inline: true,
+                    NamedSelection {
+                        prefix: Spread(
+                            None,
+                        ),
                         path: PathSelection {
                             path: WithRange {
                                 node: Var(
@@ -23,18 +24,32 @@ Ok(
                                         node: Selection(
                                             SubSelection {
                                                 selections: [
-                                                    Field(
-                                                        None,
-                                                        WithRange {
-                                                            node: Field(
-                                                                "id",
-                                                            ),
-                                                            range: Some(
-                                                                21..23,
-                                                            ),
+                                                    NamedSelection {
+                                                        prefix: None,
+                                                        path: PathSelection {
+                                                            path: WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "id",
+                                                                        ),
+                                                                        range: Some(
+                                                                            21..23,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            23..23,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    21..23,
+                                                                ),
+                                                            },
                                                         },
-                                                        None,
-                                                    ),
+                                                    },
                                                 ],
                                                 range: Some(
                                                     19..25,
@@ -52,9 +67,10 @@ Ok(
                             },
                         },
                     },
-                    Path {
-                        alias: None,
-                        inline: true,
+                    NamedSelection {
+                        prefix: Spread(
+                            None,
+                        ),
                         path: PathSelection {
                             path: WithRange {
                                 node: Var(
@@ -68,9 +84,10 @@ Ok(
                                         node: Selection(
                                             SubSelection {
                                                 selections: [
-                                                    Path {
-                                                        alias: None,
-                                                        inline: true,
+                                                    NamedSelection {
+                                                        prefix: Spread(
+                                                            None,
+                                                        ),
                                                         path: PathSelection {
                                                             path: WithRange {
                                                                 node: Var(
@@ -94,30 +111,58 @@ Ok(
                                                                                 node: Selection(
                                                                                     SubSelection {
                                                                                         selections: [
-                                                                                            Field(
-                                                                                                None,
-                                                                                                WithRange {
-                                                                                                    node: Field(
-                                                                                                        "title",
-                                                                                                    ),
-                                                                                                    range: Some(
-                                                                                                        56..61,
-                                                                                                    ),
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "title",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    56..61,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    61..61,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            56..61,
+                                                                                                        ),
+                                                                                                    },
                                                                                                 },
-                                                                                                None,
-                                                                                            ),
-                                                                                            Field(
-                                                                                                None,
-                                                                                                WithRange {
-                                                                                                    node: Field(
-                                                                                                        "body",
-                                                                                                    ),
-                                                                                                    range: Some(
-                                                                                                        62..66,
-                                                                                                    ),
+                                                                                            },
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "body",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    62..66,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    66..66,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            62..66,
+                                                                                                        ),
+                                                                                                    },
                                                                                                 },
-                                                                                                None,
-                                                                                            ),
+                                                                                            },
                                                                                         ],
                                                                                         range: Some(
                                                                                             54..68,

--- a/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-7.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection-7.snap
@@ -7,9 +7,10 @@ Ok(
         inner: Named(
             SubSelection {
                 selections: [
-                    Path {
-                        alias: None,
-                        inline: true,
+                    NamedSelection {
+                        prefix: Spread(
+                            None,
+                        ),
                         path: PathSelection {
                             path: WithRange {
                                 node: Var(
@@ -23,18 +24,32 @@ Ok(
                                         node: Selection(
                                             SubSelection {
                                                 selections: [
-                                                    Field(
-                                                        None,
-                                                        WithRange {
-                                                            node: Field(
-                                                                "id",
-                                                            ),
-                                                            range: Some(
-                                                                62..64,
-                                                            ),
+                                                    NamedSelection {
+                                                        prefix: None,
+                                                        path: PathSelection {
+                                                            path: WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "id",
+                                                                        ),
+                                                                        range: Some(
+                                                                            62..64,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            64..64,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    62..64,
+                                                                ),
+                                                            },
                                                         },
-                                                        None,
-                                                    ),
+                                                    },
                                                 ],
                                                 range: Some(
                                                     60..66,
@@ -52,9 +67,10 @@ Ok(
                             },
                         },
                     },
-                    Path {
-                        alias: None,
-                        inline: true,
+                    NamedSelection {
+                        prefix: Spread(
+                            None,
+                        ),
                         path: PathSelection {
                             path: WithRange {
                                 node: Var(
@@ -68,8 +84,8 @@ Ok(
                                         node: Selection(
                                             SubSelection {
                                                 selections: [
-                                                    Path {
-                                                        alias: Some(
+                                                    NamedSelection {
+                                                        prefix: Alias(
                                                             Alias {
                                                                 name: WithRange {
                                                                     node: Field(
@@ -84,7 +100,6 @@ Ok(
                                                                 ),
                                                             },
                                                         ),
-                                                        inline: false,
                                                         path: PathSelection {
                                                             path: WithRange {
                                                                 node: Expr(
@@ -109,9 +124,10 @@ Ok(
                                                             },
                                                         },
                                                     },
-                                                    Path {
-                                                        alias: None,
-                                                        inline: true,
+                                                    NamedSelection {
+                                                        prefix: Spread(
+                                                            None,
+                                                        ),
                                                         path: PathSelection {
                                                             path: WithRange {
                                                                 node: Var(
@@ -135,30 +151,58 @@ Ok(
                                                                                 node: Selection(
                                                                                     SubSelection {
                                                                                         selections: [
-                                                                                            Field(
-                                                                                                None,
-                                                                                                WithRange {
-                                                                                                    node: Field(
-                                                                                                        "title",
-                                                                                                    ),
-                                                                                                    range: Some(
-                                                                                                        287..292,
-                                                                                                    ),
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "title",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    287..292,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    292..292,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            287..292,
+                                                                                                        ),
+                                                                                                    },
                                                                                                 },
-                                                                                                None,
-                                                                                            ),
-                                                                                            Field(
-                                                                                                None,
-                                                                                                WithRange {
-                                                                                                    node: Field(
-                                                                                                        "body",
-                                                                                                    ),
-                                                                                                    range: Some(
-                                                                                                        293..297,
-                                                                                                    ),
+                                                                                            },
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "body",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    293..297,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    297..297,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            293..297,
+                                                                                                        ),
+                                                                                                    },
                                                                                                 },
-                                                                                                None,
-                                                                                            ),
+                                                                                            },
                                                                                         ],
                                                                                         range: Some(
                                                                                             285..299,
@@ -181,18 +225,32 @@ Ok(
                                                             },
                                                         },
                                                     },
-                                                    Field(
-                                                        None,
-                                                        WithRange {
-                                                            node: Field(
-                                                                "extra",
-                                                            ),
-                                                            range: Some(
-                                                                317..322,
-                                                            ),
+                                                    NamedSelection {
+                                                        prefix: None,
+                                                        path: PathSelection {
+                                                            path: WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "extra",
+                                                                        ),
+                                                                        range: Some(
+                                                                            317..322,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            322..322,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    317..322,
+                                                                ),
+                                                            },
                                                         },
-                                                        None,
-                                                    ),
+                                                    },
                                                 ],
                                                 range: Some(
                                                     86..336,
@@ -210,8 +268,8 @@ Ok(
                             },
                         },
                     },
-                    Path {
-                        alias: Some(
+                    NamedSelection {
+                        prefix: Alias(
                             Alias {
                                 name: WithRange {
                                     node: Field(
@@ -226,7 +284,6 @@ Ok(
                                 ),
                             },
                         ),
-                        inline: false,
                         path: PathSelection {
                             path: WithRange {
                                 node: Var(

--- a/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/path_with_subselection.snap
@@ -38,30 +38,58 @@ JSONSelection {
                                         node: Selection(
                                             SubSelection {
                                                 selections: [
-                                                    Field(
-                                                        None,
-                                                        WithRange {
-                                                            node: Field(
-                                                                "content",
-                                                            ),
-                                                            range: Some(
-                                                                38..45,
-                                                            ),
+                                                    NamedSelection {
+                                                        prefix: None,
+                                                        path: PathSelection {
+                                                            path: WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "content",
+                                                                        ),
+                                                                        range: Some(
+                                                                            38..45,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            45..45,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    38..45,
+                                                                ),
+                                                            },
                                                         },
-                                                        None,
-                                                    ),
-                                                    Field(
-                                                        None,
-                                                        WithRange {
-                                                            node: Field(
-                                                                "role",
-                                                            ),
-                                                            range: Some(
-                                                                46..50,
-                                                            ),
+                                                    },
+                                                    NamedSelection {
+                                                        prefix: None,
+                                                        path: PathSelection {
+                                                            path: WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "role",
+                                                                        ),
+                                                                        range: Some(
+                                                                            46..50,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            50..50,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    46..50,
+                                                                ),
+                                                            },
                                                         },
-                                                        None,
-                                                    ),
+                                                    },
                                                 ],
                                                 range: Some(
                                                     36..52,

--- a/apollo-federation/src/connectors/json_selection/snapshots/selection.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/selection.snap
@@ -6,8 +6,8 @@ JSONSelection {
     inner: Named(
         SubSelection {
             selections: [
-                Field(
-                    Some(
+                NamedSelection {
+                    prefix: Alias(
                         Alias {
                             name: WithRange {
                                 node: Field(
@@ -22,263 +22,399 @@ JSONSelection {
                             ),
                         },
                     ),
-                    WithRange {
-                        node: Field(
-                            "topLevelField",
-                        ),
-                        range: Some(
-                            101..114,
-                        ),
-                    },
-                    Some(
-                        SubSelection {
-                            selections: [
-                                Field(
-                                    Some(
-                                        Alias {
-                                            name: WithRange {
-                                                node: Field(
-                                                    "identifier",
-                                                ),
-                                                range: Some(
-                                                    133..143,
-                                                ),
-                                            },
-                                            range: Some(
-                                                133..144,
-                                            ),
-                                        },
+                    path: PathSelection {
+                        path: WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "topLevelField",
                                     ),
-                                    WithRange {
-                                        node: Quoted(
-                                            "property name with spaces",
-                                        ),
-                                        range: Some(
-                                            145..172,
-                                        ),
-                                    },
-                                    None,
-                                ),
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Quoted(
-                                            "unaliased non-identifier property",
-                                        ),
-                                        range: Some(
-                                            189..224,
-                                        ),
-                                    },
-                                    None,
-                                ),
-                                Field(
-                                    Some(
-                                        Alias {
-                                            name: WithRange {
-                                                node: Quoted(
-                                                    "non-identifier alias",
-                                                ),
-                                                range: Some(
-                                                    241..263,
-                                                ),
-                                            },
-                                            range: Some(
-                                                241..264,
-                                            ),
-                                        },
+                                    range: Some(
+                                        101..114,
                                     ),
-                                    WithRange {
-                                        node: Field(
-                                            "identifier",
-                                        ),
-                                        range: Some(
-                                            265..275,
-                                        ),
-                                    },
-                                    None,
-                                ),
-                                Path {
-                                    alias: Some(
-                                        Alias {
-                                            name: WithRange {
-                                                node: Field(
-                                                    "pathSelection",
-                                                ),
-                                                range: Some(
-                                                    457..470,
-                                                ),
-                                            },
-                                            range: Some(
-                                                457..471,
-                                            ),
-                                        },
-                                    ),
-                                    inline: false,
-                                    path: PathSelection {
-                                        path: WithRange {
-                                            node: Key(
-                                                WithRange {
-                                                    node: Field(
-                                                        "some",
-                                                    ),
-                                                    range: Some(
-                                                        472..476,
-                                                    ),
-                                                },
-                                                WithRange {
-                                                    node: Key(
-                                                        WithRange {
-                                                            node: Field(
-                                                                "nested",
-                                                            ),
+                                },
+                                WithRange {
+                                    node: Selection(
+                                        SubSelection {
+                                            selections: [
+                                                NamedSelection {
+                                                    prefix: Alias(
+                                                        Alias {
+                                                            name: WithRange {
+                                                                node: Field(
+                                                                    "identifier",
+                                                                ),
+                                                                range: Some(
+                                                                    133..143,
+                                                                ),
+                                                            },
                                                             range: Some(
-                                                                477..483,
+                                                                133..144,
                                                             ),
                                                         },
-                                                        WithRange {
+                                                    ),
+                                                    path: PathSelection {
+                                                        path: WithRange {
                                                             node: Key(
                                                                 WithRange {
-                                                                    node: Field(
-                                                                        "path",
+                                                                    node: Quoted(
+                                                                        "property name with spaces",
                                                                     ),
                                                                     range: Some(
-                                                                        484..488,
+                                                                        145..172,
                                                                     ),
                                                                 },
                                                                 WithRange {
-                                                                    node: Selection(
-                                                                        SubSelection {
-                                                                            selections: [
-                                                                                Field(
-                                                                                    Some(
-                                                                                        Alias {
-                                                                                            name: WithRange {
-                                                                                                node: Field(
-                                                                                                    "still",
-                                                                                                ),
-                                                                                                range: Some(
-                                                                                                    511..516,
-                                                                                                ),
-                                                                                            },
+                                                                    node: Empty,
+                                                                    range: Some(
+                                                                        172..172,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                145..172,
+                                                            ),
+                                                        },
+                                                    },
+                                                },
+                                                NamedSelection {
+                                                    prefix: None,
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Key(
+                                                                WithRange {
+                                                                    node: Quoted(
+                                                                        "unaliased non-identifier property",
+                                                                    ),
+                                                                    range: Some(
+                                                                        189..224,
+                                                                    ),
+                                                                },
+                                                                WithRange {
+                                                                    node: Empty,
+                                                                    range: Some(
+                                                                        224..224,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                189..224,
+                                                            ),
+                                                        },
+                                                    },
+                                                },
+                                                NamedSelection {
+                                                    prefix: Alias(
+                                                        Alias {
+                                                            name: WithRange {
+                                                                node: Quoted(
+                                                                    "non-identifier alias",
+                                                                ),
+                                                                range: Some(
+                                                                    241..263,
+                                                                ),
+                                                            },
+                                                            range: Some(
+                                                                241..264,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Key(
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "identifier",
+                                                                    ),
+                                                                    range: Some(
+                                                                        265..275,
+                                                                    ),
+                                                                },
+                                                                WithRange {
+                                                                    node: Empty,
+                                                                    range: Some(
+                                                                        275..275,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                265..275,
+                                                            ),
+                                                        },
+                                                    },
+                                                },
+                                                NamedSelection {
+                                                    prefix: Alias(
+                                                        Alias {
+                                                            name: WithRange {
+                                                                node: Field(
+                                                                    "pathSelection",
+                                                                ),
+                                                                range: Some(
+                                                                    457..470,
+                                                                ),
+                                                            },
+                                                            range: Some(
+                                                                457..471,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Key(
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "some",
+                                                                    ),
+                                                                    range: Some(
+                                                                        472..476,
+                                                                    ),
+                                                                },
+                                                                WithRange {
+                                                                    node: Key(
+                                                                        WithRange {
+                                                                            node: Field(
+                                                                                "nested",
+                                                                            ),
+                                                                            range: Some(
+                                                                                477..483,
+                                                                            ),
+                                                                        },
+                                                                        WithRange {
+                                                                            node: Key(
+                                                                                WithRange {
+                                                                                    node: Field(
+                                                                                        "path",
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        484..488,
+                                                                                    ),
+                                                                                },
+                                                                                WithRange {
+                                                                                    node: Selection(
+                                                                                        SubSelection {
+                                                                                            selections: [
+                                                                                                NamedSelection {
+                                                                                                    prefix: Alias(
+                                                                                                        Alias {
+                                                                                                            name: WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "still",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    511..516,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            range: Some(
+                                                                                                                511..517,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    path: PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "yet",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        518..521,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        521..521,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                518..521,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                NamedSelection {
+                                                                                                    prefix: None,
+                                                                                                    path: PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "more",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        542..546,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        546..546,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                542..546,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                NamedSelection {
+                                                                                                    prefix: None,
+                                                                                                    path: PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "properties",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        567..577,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        577..577,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                567..577,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                            ],
                                                                                             range: Some(
-                                                                                                511..517,
+                                                                                                489..595,
                                                                                             ),
                                                                                         },
                                                                                     ),
-                                                                                    WithRange {
-                                                                                        node: Field(
-                                                                                            "yet",
-                                                                                        ),
-                                                                                        range: Some(
-                                                                                            518..521,
-                                                                                        ),
-                                                                                    },
-                                                                                    None,
-                                                                                ),
-                                                                                Field(
-                                                                                    None,
-                                                                                    WithRange {
-                                                                                        node: Field(
-                                                                                            "more",
-                                                                                        ),
-                                                                                        range: Some(
-                                                                                            542..546,
-                                                                                        ),
-                                                                                    },
-                                                                                    None,
-                                                                                ),
-                                                                                Field(
-                                                                                    None,
-                                                                                    WithRange {
-                                                                                        node: Field(
-                                                                                            "properties",
-                                                                                        ),
-                                                                                        range: Some(
-                                                                                            567..577,
-                                                                                        ),
-                                                                                    },
-                                                                                    None,
-                                                                                ),
-                                                                            ],
+                                                                                    range: Some(
+                                                                                        489..595,
+                                                                                    ),
+                                                                                },
+                                                                            ),
                                                                             range: Some(
-                                                                                489..595,
+                                                                                483..595,
                                                                             ),
                                                                         },
                                                                     ),
                                                                     range: Some(
-                                                                        489..595,
+                                                                        476..595,
                                                                     ),
                                                                 },
                                                             ),
                                                             range: Some(
-                                                                483..595,
+                                                                472..595,
+                                                            ),
+                                                        },
+                                                    },
+                                                },
+                                                NamedSelection {
+                                                    prefix: Alias(
+                                                        Alias {
+                                                            name: WithRange {
+                                                                node: Field(
+                                                                    "siblingGroup",
+                                                                ),
+                                                                range: Some(
+                                                                    731..743,
+                                                                ),
+                                                            },
+                                                            range: Some(
+                                                                731..744,
                                                             ),
                                                         },
                                                     ),
-                                                    range: Some(
-                                                        476..595,
-                                                    ),
+                                                    path: PathSelection {
+                                                        path: WithRange {
+                                                            node: Selection(
+                                                                SubSelection {
+                                                                    selections: [
+                                                                        NamedSelection {
+                                                                            prefix: None,
+                                                                            path: PathSelection {
+                                                                                path: WithRange {
+                                                                                    node: Key(
+                                                                                        WithRange {
+                                                                                            node: Field(
+                                                                                                "brother",
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                747..754,
+                                                                                            ),
+                                                                                        },
+                                                                                        WithRange {
+                                                                                            node: Empty,
+                                                                                            range: Some(
+                                                                                                754..754,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        747..754,
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        NamedSelection {
+                                                                            prefix: None,
+                                                                            path: PathSelection {
+                                                                                path: WithRange {
+                                                                                    node: Key(
+                                                                                        WithRange {
+                                                                                            node: Field(
+                                                                                                "sister",
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                755..761,
+                                                                                            ),
+                                                                                        },
+                                                                                        WithRange {
+                                                                                            node: Empty,
+                                                                                            range: Some(
+                                                                                                761..761,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        755..761,
+                                                                                    ),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                    range: Some(
+                                                                        745..763,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                745..763,
+                                                            ),
+                                                        },
+                                                    },
                                                 },
-                                            ),
+                                            ],
                                             range: Some(
-                                                472..595,
+                                                115..777,
                                             ),
                                         },
-                                    },
+                                    ),
+                                    range: Some(
+                                        115..777,
+                                    ),
                                 },
-                                Group(
-                                    Alias {
-                                        name: WithRange {
-                                            node: Field(
-                                                "siblingGroup",
-                                            ),
-                                            range: Some(
-                                                731..743,
-                                            ),
-                                        },
-                                        range: Some(
-                                            731..744,
-                                        ),
-                                    },
-                                    SubSelection {
-                                        selections: [
-                                            Field(
-                                                None,
-                                                WithRange {
-                                                    node: Field(
-                                                        "brother",
-                                                    ),
-                                                    range: Some(
-                                                        747..754,
-                                                    ),
-                                                },
-                                                None,
-                                            ),
-                                            Field(
-                                                None,
-                                                WithRange {
-                                                    node: Field(
-                                                        "sister",
-                                                    ),
-                                                    range: Some(
-                                                        755..761,
-                                                    ),
-                                                },
-                                                None,
-                                            ),
-                                        ],
-                                        range: Some(
-                                            745..763,
-                                        ),
-                                    },
-                                ),
-                            ],
+                            ),
                             range: Some(
-                                115..777,
+                                101..777,
                             ),
                         },
-                    ),
-                ),
+                    },
+                },
             ],
             range: Some(
                 86..777,

--- a/apollo-federation/src/connectors/json_selection/snapshots/single_key_paths-2.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/single_key_paths-2.snap
@@ -1,0 +1,140 @@
+---
+source: apollo-federation/src/connectors/json_selection/parser.rs
+expression: mul_with_dollars
+---
+JSONSelection {
+    inner: Path(
+        PathSelection {
+            path: WithRange {
+                node: Key(
+                    WithRange {
+                        node: Field(
+                            "a",
+                        ),
+                        range: Some(
+                            0..1,
+                        ),
+                    },
+                    WithRange {
+                        node: Method(
+                            WithRange {
+                                node: "mul",
+                                range: Some(
+                                    3..6,
+                                ),
+                            },
+                            Some(
+                                MethodArgs {
+                                    args: [
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $,
+                                                                range: Some(
+                                                                    7..8,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "b",
+                                                                        ),
+                                                                        range: Some(
+                                                                            9..10,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            10..10,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    8..10,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            7..10,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                7..10,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $,
+                                                                range: Some(
+                                                                    12..13,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "c",
+                                                                        ),
+                                                                        range: Some(
+                                                                            14..15,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            15..15,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    13..15,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            12..15,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                12..15,
+                                            ),
+                                        },
+                                    ],
+                                    range: Some(
+                                        6..16,
+                                    ),
+                                },
+                            ),
+                            WithRange {
+                                node: Empty,
+                                range: Some(
+                                    16..16,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            1..16,
+                        ),
+                    },
+                ),
+                range: Some(
+                    0..16,
+                ),
+            },
+        },
+    ),
+    spec: V0_3,
+}

--- a/apollo-federation/src/connectors/json_selection/snapshots/single_key_paths-3.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/single_key_paths-3.snap
@@ -1,0 +1,114 @@
+---
+source: apollo-federation/src/connectors/json_selection/parser.rs
+expression: selection
+---
+JSONSelection {
+    inner: Path(
+        PathSelection {
+            path: WithRange {
+                node: Key(
+                    WithRange {
+                        node: Field(
+                            "a",
+                        ),
+                        range: Some(
+                            0..1,
+                        ),
+                    },
+                    WithRange {
+                        node: Method(
+                            WithRange {
+                                node: "add",
+                                range: Some(
+                                    3..6,
+                                ),
+                            },
+                            Some(
+                                MethodArgs {
+                                    args: [
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Key(
+                                                            WithRange {
+                                                                node: Field(
+                                                                    "b",
+                                                                ),
+                                                                range: Some(
+                                                                    7..8,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Empty,
+                                                                range: Some(
+                                                                    8..8,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            7..8,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                7..8,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Key(
+                                                            WithRange {
+                                                                node: Field(
+                                                                    "c",
+                                                                ),
+                                                                range: Some(
+                                                                    10..11,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Empty,
+                                                                range: Some(
+                                                                    11..11,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            10..11,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                10..11,
+                                            ),
+                                        },
+                                    ],
+                                    range: Some(
+                                        6..12,
+                                    ),
+                                },
+                            ),
+                            WithRange {
+                                node: Empty,
+                                range: Some(
+                                    12..12,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            1..12,
+                        ),
+                    },
+                ),
+                range: Some(
+                    0..12,
+                ),
+            },
+        },
+    ),
+    spec: V0_3,
+}

--- a/apollo-federation/src/connectors/json_selection/snapshots/single_key_paths.snap
+++ b/apollo-federation/src/connectors/json_selection/snapshots/single_key_paths.snap
@@ -1,0 +1,140 @@
+---
+source: apollo-federation/src/connectors/json_selection/parser.rs
+expression: mul_with_dollars
+---
+JSONSelection {
+    inner: Path(
+        PathSelection {
+            path: WithRange {
+                node: Key(
+                    WithRange {
+                        node: Field(
+                            "a",
+                        ),
+                        range: Some(
+                            0..1,
+                        ),
+                    },
+                    WithRange {
+                        node: Method(
+                            WithRange {
+                                node: "mul",
+                                range: Some(
+                                    3..6,
+                                ),
+                            },
+                            Some(
+                                MethodArgs {
+                                    args: [
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $,
+                                                                range: Some(
+                                                                    7..8,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "b",
+                                                                        ),
+                                                                        range: Some(
+                                                                            9..10,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            10..10,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    8..10,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            7..10,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                7..10,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $,
+                                                                range: Some(
+                                                                    12..13,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "c",
+                                                                        ),
+                                                                        range: Some(
+                                                                            14..15,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            15..15,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    13..15,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            12..15,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                12..15,
+                                            ),
+                                        },
+                                    ],
+                                    range: Some(
+                                        6..16,
+                                    ),
+                                },
+                            ),
+                            WithRange {
+                                node: Empty,
+                                range: Some(
+                                    16..16,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            1..16,
+                        ),
+                    },
+                ),
+                range: Some(
+                    0..16,
+                ),
+            },
+        },
+    ),
+    spec: V0_2,
+}

--- a/apollo-federation/src/connectors/models.rs
+++ b/apollo-federation/src/connectors/models.rs
@@ -487,7 +487,7 @@ mod tests {
         let subgraphs = get_subgraphs(SIMPLE_SUPERGRAPH);
         let subgraph = subgraphs.get("connectors").unwrap();
         let connectors = Connector::from_schema(subgraph.schema.schema(), "connectors").unwrap();
-        assert_debug_snapshot!(&connectors, @r#"
+        assert_debug_snapshot!(&connectors, @r###"
         [
             Connector {
                 id: ConnectId {
@@ -563,30 +563,58 @@ mod tests {
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "id",
-                                        ),
-                                        range: Some(
-                                            0..2,
-                                        ),
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "name",
-                                        ),
-                                        range: Some(
-                                            3..7,
-                                        ),
+                                },
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "name",
+                                                    ),
+                                                    range: Some(
+                                                        3..7,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        7..7,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
+                                },
                             ],
                             range: Some(
                                 0..7,
@@ -688,42 +716,84 @@ mod tests {
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "id",
-                                        ),
-                                        range: Some(
-                                            0..2,
-                                        ),
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "title",
-                                        ),
-                                        range: Some(
-                                            3..8,
-                                        ),
+                                },
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "title",
+                                                    ),
+                                                    range: Some(
+                                                        3..8,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        8..8,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..8,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "body",
-                                        ),
-                                        range: Some(
-                                            9..13,
-                                        ),
+                                },
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "body",
+                                                    ),
+                                                    range: Some(
+                                                        9..13,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        13..13,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                9..13,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
+                                },
                             ],
                             range: Some(
                                 0..13,
@@ -752,7 +822,7 @@ mod tests {
                 ),
             },
         ]
-        "#);
+        "###);
     }
 
     #[test]

--- a/apollo-federation/src/connectors/snapshots/apollo_federation__connectors__models__tests__from_schema_v0_2.snap
+++ b/apollo-federation/src/connectors/snapshots/apollo_federation__connectors__models__tests__from_schema_v0_2.snap
@@ -77,42 +77,84 @@ expression: "&connectors"
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "title",
-                                ),
-                                range: Some(
-                                    3..8,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "title",
+                                            ),
+                                            range: Some(
+                                                3..8,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                8..8,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..8,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "body",
-                                ),
-                                range: Some(
-                                    9..13,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "body",
+                                            ),
+                                            range: Some(
+                                                9..13,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                13..13,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        9..13,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..13,
@@ -209,8 +251,8 @@ expression: "&connectors"
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Path {
-                                    alias: Some(
+                                NamedSelection {
+                                    prefix: Alias(
                                         Alias {
                                             name: WithRange {
                                                 node: Field(
@@ -225,7 +267,6 @@ expression: "&connectors"
                                             ),
                                         },
                                     ),
-                                    inline: false,
                                     path: PathSelection {
                                         path: WithRange {
                                             node: Var(
@@ -281,42 +322,84 @@ expression: "&connectors"
             inner: Named(
                 SubSelection {
                     selections: [
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "id",
-                                ),
-                                range: Some(
-                                    0..2,
-                                ),
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                2..2,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        0..2,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "title",
-                                ),
-                                range: Some(
-                                    3..8,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "title",
+                                            ),
+                                            range: Some(
+                                                3..8,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                8..8,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        3..8,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
-                        Field(
-                            None,
-                            WithRange {
-                                node: Field(
-                                    "body",
-                                ),
-                                range: Some(
-                                    9..13,
-                                ),
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: PathSelection {
+                                path: WithRange {
+                                    node: Key(
+                                        WithRange {
+                                            node: Field(
+                                                "body",
+                                            ),
+                                            range: Some(
+                                                9..13,
+                                            ),
+                                        },
+                                        WithRange {
+                                            node: Empty,
+                                            range: Some(
+                                                13..13,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        9..13,
+                                    ),
+                                },
                             },
-                            None,
-                        ),
+                        },
                     ],
                     range: Some(
                         0..13,

--- a/apollo-federation/src/connectors/snapshots/apollo_federation__connectors__string_template__test_parse__expressions_with_nested_braces.snap
+++ b/apollo-federation/src/connectors/snapshots/apollo_federation__connectors__string_template__test_parse__expressions_with_nested_braces.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/connectors/string_template.rs
-expression: "StringTemplate::from_str(\"const{$config.one { two { three } }}another-const\").unwrap()"
+expression: "StringTemplate::parse_with_spec(\"const{$config.one { two { three } }}another-const\",\nConnectSpec::latest()).unwrap()"
 ---
 StringTemplate {
     parts: [
@@ -37,38 +37,66 @@ StringTemplate {
                                                 node: Selection(
                                                     SubSelection {
                                                         selections: [
-                                                            Field(
-                                                                None,
-                                                                WithRange {
-                                                                    node: Field(
-                                                                        "two",
-                                                                    ),
-                                                                    range: Some(
-                                                                        14..17,
-                                                                    ),
-                                                                },
-                                                                Some(
-                                                                    SubSelection {
-                                                                        selections: [
-                                                                            Field(
-                                                                                None,
-                                                                                WithRange {
-                                                                                    node: Field(
-                                                                                        "three",
-                                                                                    ),
-                                                                                    range: Some(
-                                                                                        20..25,
-                                                                                    ),
-                                                                                },
-                                                                                None,
-                                                                            ),
-                                                                        ],
+                                                            NamedSelection {
+                                                                prefix: None,
+                                                                path: PathSelection {
+                                                                    path: WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "two",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    14..17,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Selection(
+                                                                                    SubSelection {
+                                                                                        selections: [
+                                                                                            NamedSelection {
+                                                                                                prefix: None,
+                                                                                                path: PathSelection {
+                                                                                                    path: WithRange {
+                                                                                                        node: Key(
+                                                                                                            WithRange {
+                                                                                                                node: Field(
+                                                                                                                    "three",
+                                                                                                                ),
+                                                                                                                range: Some(
+                                                                                                                    20..25,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                            WithRange {
+                                                                                                                node: Empty,
+                                                                                                                range: Some(
+                                                                                                                    25..25,
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            20..25,
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                        ],
+                                                                                        range: Some(
+                                                                                            18..27,
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    18..27,
+                                                                                ),
+                                                                            },
+                                                                        ),
                                                                         range: Some(
-                                                                            18..27,
+                                                                            14..27,
                                                                         ),
                                                                     },
-                                                                ),
-                                                            ),
+                                                                },
+                                                            },
                                                         ],
                                                         range: Some(
                                                             12..29,

--- a/apollo-federation/src/connectors/spec/connect.rs
+++ b/apollo-federation/src/connectors/spec/connect.rs
@@ -547,30 +547,58 @@ mod tests {
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "id",
-                                        ),
-                                        range: Some(
-                                            0..2,
-                                        ),
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "name",
-                                        ),
-                                        range: Some(
-                                            3..7,
-                                        ),
+                                },
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "name",
+                                                    ),
+                                                    range: Some(
+                                                        3..7,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        7..7,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
+                                },
                             ],
                             range: Some(
                                 0..7,
@@ -615,42 +643,84 @@ mod tests {
                     inner: Named(
                         SubSelection {
                             selections: [
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "id",
-                                        ),
-                                        range: Some(
-                                            0..2,
-                                        ),
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "title",
-                                        ),
-                                        range: Some(
-                                            3..8,
-                                        ),
+                                },
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "title",
+                                                    ),
+                                                    range: Some(
+                                                        3..8,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        8..8,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..8,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
-                                Field(
-                                    None,
-                                    WithRange {
-                                        node: Field(
-                                            "body",
-                                        ),
-                                        range: Some(
-                                            9..13,
-                                        ),
+                                },
+                                NamedSelection {
+                                    prefix: None,
+                                    path: PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "body",
+                                                    ),
+                                                    range: Some(
+                                                        9..13,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        13..13,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                9..13,
+                                            ),
+                                        },
                                     },
-                                    None,
-                                ),
+                                },
                             ],
                             range: Some(
                                 0..13,

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@errors.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@errors.graphql.snap
@@ -9,7 +9,6 @@ input_file: apollo-federation/src/connectors/validation/test_data/errors.graphql
         message: "In `@source(name: \"invalid_source_message_not_string\" errors.message:)`: object values aren't valid here",
         locations: [
             13:25..13:47,
-            13:25..13:47,
         ],
     },
     Message {
@@ -44,7 +43,6 @@ input_file: apollo-federation/src/connectors/validation/test_data/errors.graphql
         code: InvalidErrorsMessage,
         message: "In `@connect(errors.message:)` on `Query.invalid_sourceless_message_not_string`: object values aren't valid here",
         locations: [
-            86:27..86:49,
             86:27..86:49,
         ],
     },

--- a/apollo-federation/tests/dhat_profiling/connectors_validation.rs
+++ b/apollo-federation/tests/dhat_profiling/connectors_validation.rs
@@ -10,7 +10,7 @@ fn valid_large_body() {
     const SCHEMA: &str = "src/connectors/validation/test_data/valid_large_body.graphql";
 
     const MAX_BYTES: usize = 204_800; // 200 KiB
-    const MAX_ALLOCATIONS: u64 = 22_300;
+    const MAX_ALLOCATIONS: u64 = 22_500;
 
     let schema = std::fs::read_to_string(SCHEMA).unwrap();
 


### PR DESCRIPTION
After attempting to write the description for my PR #7934, I thought it might be helpful to break those changes up into separate PRs, as mentioned in https://github.com/apollographql/router/pull/7934#issuecomment-3097080630.

This PR contains just the internal unification of the `NamedSelection` enum into a struct of the same name. All the existing parsing logic has been updated to generate an AST in the new format, so no changes to parsing behavior are necessary, and no version gating is needed.

Of course, this change of representation triggered a whole bunch of snapshot updates, which I've kept in their own commit for ease of reviewing.

The first part of the #7934 description is still accurate/appropriate for this PR:

> Builds on PR #7933 as well as transitive dependencies including PRs #7932 and #7927, all targeting the `benjamn/JSONSelection-abstract-types` branch from PR #7926.
>
> This PR implements a significant simplification to the JSONSelection ~formal EBNF grammar and~ parser implementation, based around the insight that `NamedFieldSelection` was essentially a single-`Key` `NamedPathSelection`, so it makes sense to represent them in a common way, rather than representing/handling them separately. Internally, the `NamedSelection` enum has become a struct that always has a `path: PathSelection` field, so we can reuse all the usual `PathSelection` and `PathList` machinery for every kind of `NamedSelection` element. This internal refactoring was possible without changing the grammar, since the new `NamedSelection` struct represents the previous grammar's AST structure in the same way it represents the new grammar's simplified structure.
>
> Technical note: besides `path`, the other field of the new `NamedSelection` struct is `prefix: NamingPrefix`, where `NamingPrefix` is a private enum type that can represent the no-prefix case (`NamingPrefix::None`), the `Alias` case (`NamingPrefix::Alias(Alias)`), as well as a `NamingPrefix::Spread(Option<Range<usize>>)` variant, which is currently used to represent the former `PathWithSubSelection ::= Path SubSelection` case as `NamingPrefix::Spread(None)`, since existing behavior dictates the `SubSelection` gets inlined/spread into the larger selection, even without the `...` syntax that we're planning to introduce soon. Once we do introduce the explicit `...` spread operator, we can represent that with `NamingPrefix::Spread(Some(start..end))` where the range identifies the location of the `...` token in the source, when present. Of course we don't want there to be a functional difference between `NamingPrefix::Spread(None)` and `::Spread(Some(_))` (both get spread), but tracking the optional range of the `...` token seemed useful for tooling.