### PR TITLE
response_cache: add private entries in debugger data and make data consistent

### DIFF
--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -18,6 +18,8 @@ use http::header;
 use http::header::CACHE_CONTROL;
 use itertools::Itertools;
 use multimap::MultiMap;
+use opentelemetry::Key;
+use opentelemetry::StringValue;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -103,6 +105,7 @@ pub(crate) struct ResponseCache {
     enabled: bool,
     metrics: Metrics,
     debug: bool,
+    // TODO make it LRU
     private_queries: Arc<RwLock<HashSet<String>>>,
     pub(crate) invalidation: Invalidation,
     supergraph_schema: Arc<Valid<Schema>>,
@@ -843,7 +846,67 @@ impl CacheService {
 
         // the response will have a private scope but we don't have a way to differentiate users, so we know we will not get or store anything in the cache
         if is_known_private && private_id.is_none() {
-            return self.service.call(request).await;
+            let mut debug_subgraph_request = None;
+            let mut root_operation_fields = Vec::new();
+            if self.debug {
+                root_operation_fields = request
+                    .executable_document
+                    .as_ref()
+                    .and_then(|executable_document| {
+                        let operation_name =
+                            request.subgraph_request.body().operation_name.as_deref();
+                        Some(
+                            executable_document
+                                .operations
+                                .get(operation_name)
+                                .ok()?
+                                .root_fields(executable_document)
+                                .map(|f| f.name.to_string())
+                                .collect(),
+                        )
+                    })
+                    .unwrap_or_default();
+                debug_subgraph_request = Some(request.subgraph_request.body().clone());
+            }
+            let is_entity = request
+                .subgraph_request
+                .body()
+                .variables
+                .contains_key(REPRESENTATIONS);
+            let resp = self.service.call(request).await?;
+            if self.debug {
+                let cache_control = CacheControl::new(resp.response.headers(), None)?;
+                let kind = if is_entity {
+                    CacheEntryKind::Entity {
+                        typename: "".to_string(),
+                        entity_key: Default::default(),
+                    }
+                } else {
+                    CacheEntryKind::RootFields {
+                        root_fields: root_operation_fields,
+                    }
+                };
+                resp.context.upsert::<_, CacheKeysContext>(
+                    CONTEXT_DEBUG_CACHE_KEYS,
+                    |mut val| {
+                        val.push(CacheKeyContext {
+                            key: "-".to_string(),
+                            invalidation_keys: vec![],
+                            kind,
+                            subgraph_name: self.name.clone(),
+                            subgraph_request: debug_subgraph_request.unwrap_or_default(),
+                            status: CacheKeyStatus::New,
+                            cache_control,
+                            data: serde_json_bytes::to_value(resp.response.body().clone())
+                                .unwrap_or_default(),
+                        });
+
+                        val
+                    },
+                )?;
+            }
+
+            return Ok(resp);
         }
 
         if !request
@@ -941,7 +1004,13 @@ impl CacheService {
                                     |mut val| {
                                         val.push(CacheKeyContext {
                                             key: root_cache_key.clone(),
-                                            invalidation_keys: invalidation_keys.clone(),
+                                            invalidation_keys: invalidation_keys
+                                                .clone()
+                                                .into_iter()
+                                                .filter(|k| {
+                                                    !k.starts_with(INTERNAL_CACHE_TAG_PREFIX)
+                                                })
+                                                .collect(),
                                             kind: CacheEntryKind::RootFields {
                                                 root_fields: root_operation_fields,
                                             },
@@ -1031,7 +1100,6 @@ impl CacheService {
             .instrument(tracing::info_span!(
                 "response_cache.lookup",
                 kind = "entity",
-                "graphql.type" = self.entity_type.as_deref().unwrap_or_default(),
                 debug = self.debug,
                 private = is_known_private
             ))
@@ -1219,6 +1287,7 @@ async fn cache_lookup_root(
                             )
                         })
                         .unwrap_or_default();
+
                     request.context.upsert::<_, CacheKeysContext>(
                         CONTEXT_DEBUG_CACHE_KEYS,
                         |mut val| {
@@ -1279,6 +1348,7 @@ async fn cache_lookup_root(
                     "code" = err.code()
                 );
             }
+
             span.set_span_dyn_attribute(
                 opentelemetry::Key::new("cache.status"),
                 opentelemetry::Value::String("miss".into()),
@@ -1521,7 +1591,7 @@ async fn cache_lookup_entities(
                     subgraph_request: request.subgraph_request.body().clone(),
                     status: CacheKeyStatus::Cached,
                     cache_control: cache_entry.control.clone(),
-                    data: serde_json_bytes::to_value(cache_entry.data.clone()).unwrap_or_default(),
+                    data: serde_json_bytes::json!({"data": cache_entry.data.clone()}),
                 })
             });
             request.context.upsert::<_, CacheKeysContext>(
@@ -1865,6 +1935,7 @@ fn extract_cache_keys(
     // Get entity key to only get the right fields in representations
     let mut res = Vec::with_capacity(representations.len());
     let mut entities = HashMap::new();
+    let mut typenames = HashSet::new();
     for representation in representations {
         let representation =
             representation
@@ -1884,6 +1955,7 @@ fn extract_cache_keys(
             .ok_or_else(|| FetchError::MalformedRequest {
                 reason: "__typename in representation is not a string".to_string(),
             })?;
+        typenames.insert(typename.to_string());
         match entities.get_mut(typename) {
             Some(entity_nb) => *entity_nb += 1,
             None => {
@@ -1948,6 +2020,17 @@ fn extract_cache_keys(
         };
         res.push(cache_key_metadata);
     }
+
+    Span::current().set_span_dyn_attribute(
+        Key::from_static_str("graphql.types"),
+        opentelemetry::Value::Array(
+            typenames
+                .into_iter()
+                .map(StringValue::from)
+                .collect::<Vec<StringValue>>()
+                .into(),
+        ),
+    );
 
     for (typename, entity_nb) in entities {
         u64_histogram_with_unit!(
@@ -2410,7 +2493,7 @@ async fn insert_entities_in_result(
                         subgraph_request: subgraph_request.clone(),
                         status: CacheKeyStatus::New,
                         cache_control: cache_control.clone(),
-                        data: value.clone(),
+                        data: serde_json_bytes::json!({"data": value.clone()}),
                     });
                 }
                 if !has_errors && cache_control.should_store() && should_cache_private {

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__failure_mode_reconnect-2.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__failure_mode_reconnect-2.snap
@@ -66,9 +66,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__failure_mode_reconnect-4.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__failure_mode_reconnect-4.snap
@@ -61,9 +61,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert-3.snap
@@ -61,9 +61,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert.snap
@@ -66,9 +66,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_nested_field_set-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_nested_field_set-3.snap
@@ -69,7 +69,9 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "name": "test"
+      "data": {
+        "name": "test"
+      }
     }
   }
 ]

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_nested_field_set.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_nested_field_set.snap
@@ -77,7 +77,9 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "name": "test"
+      "data": {
+        "name": "test"
+      }
     }
   }
 ]

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_requires-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_requires-3.snap
@@ -30,7 +30,9 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "shippingEstimate": 15
+      "data": {
+        "shippingEstimate": 15
+      }
     }
   },
   {

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_requires.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_requires.snap
@@ -37,7 +37,9 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "shippingEstimate": 15
+      "data": {
+        "shippingEstimate": 15
+      }
     }
   },
   {

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag-3.snap
@@ -60,9 +60,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag.snap
@@ -65,9 +65,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type-3.snap
@@ -60,9 +60,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type-5.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type-5.snap
@@ -65,9 +65,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type.snap
@@ -65,9 +65,11 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__no_data.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__no_data.snap
@@ -75,7 +75,9 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "name": "Organization 1"
+      "data": {
+        "name": "Organization 1"
+      }
     }
   },
   {
@@ -113,7 +115,9 @@ expression: cache_keys
       "public": true
     },
     "data": {
-      "name": "Organization 3"
+      "data": {
+        "name": "Organization 3"
+      }
     }
   }
 ]

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private-5.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private-5.snap
@@ -6,7 +6,6 @@ expression: cache_keys
   {
     "key": "version:1.0:subgraph:user:type:Query:hash:26ab4118dbabffe5dfbef4462513caa8b6c8941363cf2eafa874bf1d47a3c468:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:f8638b979b2f4f793ddb6dbd197e0ee25a7a6ea32b0ae22f5e3c5d119d839e75",
     "invalidationKeys": [
-      "__apollo_internal::version:1.0:subgraph:user:type:Query",
       "currentUser"
     ],
     "kind": {
@@ -66,9 +65,11 @@ expression: cache_keys
       "private": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private.snap
@@ -6,7 +6,6 @@ expression: cache_keys
   {
     "key": "version:1.0:subgraph:user:type:Query:hash:26ab4118dbabffe5dfbef4462513caa8b6c8941363cf2eafa874bf1d47a3c468:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "invalidationKeys": [
-      "__apollo_internal::version:1.0:subgraph:user:type:Query",
       "currentUser"
     ],
     "kind": {
@@ -66,9 +65,11 @@ expression: cache_keys
       "private": true
     },
     "data": {
-      "creatorUser": {
-        "__typename": "User",
-        "id": 2
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_without_private_id-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_without_private_id-3.snap
@@ -4,10 +4,8 @@ expression: cache_keys
 ---
 [
   {
-    "key": "test_invalidate_by_cache_tag-version:1.0:subgraph:user:type:Query:hash:26ab4118dbabffe5dfbef4462513caa8b6c8941363cf2eafa874bf1d47a3c468:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
-    "invalidationKeys": [
-      "currentUser"
-    ],
+    "key": "-",
+    "invalidationKeys": [],
     "kind": {
       "rootFields": [
         "currentUser"
@@ -17,11 +15,10 @@ expression: cache_keys
     "subgraphRequest": {
       "query": "{ currentUser { activeOrganization { __typename id } } }"
     },
-    "status": "cached",
+    "status": "new",
     "cacheControl": {
       "created": 0,
-      "maxAge": 86400,
-      "public": true
+      "private": true
     },
     "data": {
       "data": {
@@ -35,16 +32,11 @@ expression: cache_keys
     }
   },
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:a7ccf1576978c6598f6d10d8855fc683f71242533dc6d5a706743bd9bbfa554c:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
-    "invalidationKeys": [
-      "organization",
-      "organization-1"
-    ],
+    "key": "-",
+    "invalidationKeys": [],
     "kind": {
-      "typename": "Organization",
-      "entityKey": {
-        "id": "1"
-      }
+      "typename": "",
+      "entityKey": {}
     },
     "subgraphName": "orga",
     "subgraphRequest": {
@@ -52,8 +44,8 @@ expression: cache_keys
       "variables": {
         "representations": [
           {
-            "id": "1",
-            "__typename": "Organization"
+            "__typename": "Organization",
+            "id": "1"
           }
         ]
       }
@@ -61,15 +53,18 @@ expression: cache_keys
     "status": "new",
     "cacheControl": {
       "created": 0,
-      "maxAge": 86400,
-      "public": true
+      "private": true
     },
     "data": {
       "data": {
-        "creatorUser": {
-          "__typename": "User",
-          "id": 2
-        }
+        "_entities": [
+          {
+            "creatorUser": {
+              "__typename": "User",
+              "id": 2
+            }
+          }
+        ]
       }
     }
   }

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_without_private_id.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_without_private_id.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "private-version:1.0:subgraph:user:type:Query:hash:26ab4118dbabffe5dfbef4462513caa8b6c8941363cf2eafa874bf1d47a3c468:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:user:type:Query:hash:26ab4118dbabffe5dfbef4462513caa8b6c8941363cf2eafa874bf1d47a3c468:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -17,7 +17,7 @@ expression: cache_keys
     "subgraphRequest": {
       "query": "{ currentUser { activeOrganization { __typename id } } }"
     },
-    "status": "cached",
+    "status": "new",
     "cacheControl": {
       "created": 0,
       "maxAge": 86400,
@@ -35,7 +35,7 @@ expression: cache_keys
     }
   },
   {
-    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:a7ccf1576978c6598f6d10d8855fc683f71242533dc6d5a706743bd9bbfa554c:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.0:subgraph:orga:type:Organization:entity:bcc0a4a9f8c595510c0ff8849bc36b402ac3f52506392d67107c623528ff11f4:representation::hash:a7ccf1576978c6598f6d10d8855fc683f71242533dc6d5a706743bd9bbfa554c:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "invalidationKeys": [
       "organization",
       "organization-1"
@@ -50,10 +50,15 @@ expression: cache_keys
     "subgraphRequest": {
       "query": "query($representations: [_Any!]!) { _entities(representations: $representations) { ... on Organization { creatorUser { __typename id } } } }",
       "variables": {
-        "representations": []
+        "representations": [
+          {
+            "id": "1",
+            "__typename": "Organization"
+          }
+        ]
       }
     },
-    "status": "cached",
+    "status": "new",
     "cacheControl": {
       "created": 0,
       "maxAge": 86400,

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__postgres__entity_cache_basic-4.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__postgres__entity_cache_basic-4.snap
@@ -107,11 +107,13 @@ expression: response
             "public": true
           },
           "data": {
-            "reviews": [
-              {
-                "body": "I can sit on it"
-              }
-            ]
+            "data": {
+              "reviews": [
+                {
+                  "body": "I can sit on it"
+                }
+              ]
+            }
           }
         },
         {
@@ -137,14 +139,16 @@ expression: response
             "public": true
           },
           "data": {
-            "reviews": [
-              {
-                "body": "I can sit on it"
-              },
-              {
-                "body": "I can sit on it2"
-              }
-            ]
+            "data": {
+              "reviews": [
+                {
+                  "body": "I can sit on it"
+                },
+                {
+                  "body": "I can sit on it2"
+                }
+              ]
+            }
           }
         },
         {
@@ -170,17 +174,19 @@ expression: response
             "public": true
           },
           "data": {
-            "reviews": [
-              {
-                "body": "I can sit on it"
-              },
-              {
-                "body": "I can sit on it2"
-              },
-              {
-                "body": "I can sit on it3"
-              }
-            ]
+            "data": {
+              "reviews": [
+                {
+                  "body": "I can sit on it"
+                },
+                {
+                  "body": "I can sit on it2"
+                },
+                {
+                  "body": "I can sit on it3"
+                }
+              ]
+            }
           }
         }
       ]

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__postgres__entity_cache_basic.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__postgres__entity_cache_basic.snap
@@ -120,11 +120,13 @@ expression: response
             "public": true
           },
           "data": {
-            "reviews": [
-              {
-                "body": "I can sit on it"
-              }
-            ]
+            "data": {
+              "reviews": [
+                {
+                  "body": "I can sit on it"
+                }
+              ]
+            }
           }
         },
         {
@@ -163,14 +165,16 @@ expression: response
             "public": true
           },
           "data": {
-            "reviews": [
-              {
-                "body": "I can sit on it"
-              },
-              {
-                "body": "I can sit on it2"
-              }
-            ]
+            "data": {
+              "reviews": [
+                {
+                  "body": "I can sit on it"
+                },
+                {
+                  "body": "I can sit on it2"
+                }
+              ]
+            }
           }
         },
         {
@@ -209,17 +213,19 @@ expression: response
             "public": true
           },
           "data": {
-            "reviews": [
-              {
-                "body": "I can sit on it"
-              },
-              {
-                "body": "I can sit on it2"
-              },
-              {
-                "body": "I can sit on it3"
-              }
-            ]
+            "data": {
+              "reviews": [
+                {
+                  "body": "I can sit on it"
+                },
+                {
+                  "body": "I can sit on it2"
+                },
+                {
+                  "body": "I can sit on it3"
+                }
+              ]
+            }
           }
         }
       ]


### PR DESCRIPTION
Make sure the data passed in debugger data is always consistent and contains `data` field. And add debugger data even if it's a known private query.


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
