### PR TITLE
response_cache: add support for private_id in cache debugger

### DIFF
--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -893,6 +893,7 @@ impl CacheService {
                             key: "-".to_string(),
                             invalidation_keys: vec![],
                             kind,
+                            hashed_private_id: private_id.clone(),
                             subgraph_name: self.name.clone(),
                             subgraph_request: debug_subgraph_request.unwrap_or_default(),
                             status: CacheKeyStatus::New,
@@ -1004,6 +1005,7 @@ impl CacheService {
                                     |mut val| {
                                         val.push(CacheKeyContext {
                                             key: root_cache_key.clone(),
+                                            hashed_private_id: private_id.clone(),
                                             invalidation_keys: invalidation_keys
                                                 .clone()
                                                 .into_iter()
@@ -1041,6 +1043,7 @@ impl CacheService {
                                 |mut val| {
                                     val.push(CacheKeyContext {
                                         key: root_cache_key.clone(),
+                                        hashed_private_id: private_id.clone(),
                                         invalidation_keys: invalidation_keys
                                             .clone()
                                             .into_iter()
@@ -1113,6 +1116,7 @@ impl CacheService {
                         debug_subgraph_request = Some(request.subgraph_request.body().clone());
                         let debug_cache_keys_ctx = cache_result.0.iter().filter_map(|ir| {
                             ir.cache_entry.as_ref().map(|cache_entry| CacheKeyContext {
+                                hashed_private_id: private_id.clone(),
                                 key: cache_entry.cache_key.clone(),
                                 invalidation_keys: ir.invalidation_keys.clone().into_iter()
                                 .filter(|k| !k.starts_with(INTERNAL_CACHE_TAG_PREFIX))
@@ -1293,6 +1297,7 @@ async fn cache_lookup_root(
                         |mut val| {
                             val.push(CacheKeyContext {
                                 key: value.cache_key.clone(),
+                                hashed_private_id: private_id.map(ToString::to_string),
                                 invalidation_keys: invalidation_keys
                                     .clone()
                                     .into_iter()
@@ -1577,6 +1582,7 @@ async fn cache_lookup_entities(
             let debug_cache_keys_ctx = cache_result.iter().filter_map(|ir| {
                 ir.cache_entry.as_ref().map(|cache_entry| CacheKeyContext {
                     key: ir.key.clone(),
+                    hashed_private_id: private_id.map(ToString::to_string),
                     invalidation_keys: ir
                         .invalidation_keys
                         .clone()
@@ -2480,6 +2486,7 @@ async fn insert_entities_in_result(
                 if let Some(subgraph_request) = &subgraph_request {
                     debug_ctx_entries.push(CacheKeyContext {
                         key: key.clone(),
+                        hashed_private_id: update_key_private.clone(),
                         invalidation_keys: invalidation_keys
                             .clone()
                             .into_iter()
@@ -2654,6 +2661,8 @@ pub(crate) struct CacheKeyContext {
     pub(super) subgraph_request: graphql::Request,
     pub(super) status: CacheKeyStatus,
     pub(super) cache_control: CacheControl,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) hashed_private_id: Option<String>,
     pub(super) data: serde_json_bytes::Value,
 }
 

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private-3.snap
@@ -23,6 +23,7 @@ expression: cache_keys
       "maxAge": 86400,
       "private": true
     },
+    "hashedPrivateId": "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "data": {
       "data": {
         "currentUser": {
@@ -59,6 +60,7 @@ expression: cache_keys
       "maxAge": 86400,
       "private": true
     },
+    "hashedPrivateId": "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "data": {
       "data": {
         "creatorUser": {

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private-5.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private-5.snap
@@ -23,6 +23,7 @@ expression: cache_keys
       "maxAge": 86400,
       "private": true
     },
+    "hashedPrivateId": "f8638b979b2f4f793ddb6dbd197e0ee25a7a6ea32b0ae22f5e3c5d119d839e75",
     "data": {
       "data": {
         "currentUser": {

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private.snap
@@ -23,6 +23,7 @@ expression: cache_keys
       "maxAge": 86400,
       "private": true
     },
+    "hashedPrivateId": "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "data": {
       "data": {
         "currentUser": {
@@ -64,6 +65,7 @@ expression: cache_keys
       "maxAge": 86400,
       "private": true
     },
+    "hashedPrivateId": "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "data": {
       "data": {
         "creatorUser": {


### PR DESCRIPTION
Add field `hashedPrivateId` in debugger data. This field is useful to know if any private data has been used to create the unique cache key. In case the cache-control response header is set to private it will use this data.

<!-- [ROUTER-1394] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
