### PR TITLE
fix(federation/composition): Fix the failing test `test_satisfiability_basic()`

### DIFF
--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -198,10 +198,6 @@ type T implements I
     "#;
 
     #[test]
-    // TODO: fix this panic
-    #[should_panic(
-        expected = r#"Supergraph should be satisfiable: [InternalError { message: "An internal error has occurred, please report this bug to Apollo.\n\nDetails: Unexpectedly missing entry for Query(supergraph) -> I(supergraph) (start) in non-trivial followup edges map" }]"#
-    )]
     fn test_satisfiability_basic() {
         let supergraph = Supergraph::parse(TEST_SUPERGRAPH).unwrap();
         _ = validate_satisfiability(supergraph).expect("Supergraph should be satisfiable");

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -285,6 +285,83 @@ impl BaseQueryGraphBuilder {
         root_kinds_to_nodes.insert(root_kind, node);
         Ok(())
     }
+
+    /// Precompute which followup edges for a given edge are non-trivial.
+    fn precompute_non_trivial_followup_edges(&mut self) -> Result<(), FederationError> {
+        for edge in self.query_graph.graph.edge_indices() {
+            let edge_weight = self.query_graph.edge_weight(edge)?;
+            let (_, tail) = self.query_graph.edge_endpoints(edge)?;
+            let out_edges = self.query_graph.out_edges(tail);
+            let mut non_trivial_followups = Vec::with_capacity(out_edges.len());
+            for followup_edge_ref in out_edges {
+                let followup_edge_weight = followup_edge_ref.weight();
+                match edge_weight.transition {
+                    QueryGraphEdgeTransition::KeyResolution => {
+                        // After taking a key from subgraph A to B, there is no point of following
+                        // that up with another key to subgraph C if that key has the same
+                        // conditions. This is because, due to the way key edges are created, if we
+                        // have a key (with some conditions X) from B to C, then we are guaranteed
+                        // to also have a key (with the same conditions X) from A to C, and so it's
+                        // that later key we should be using in the first place. In other words,
+                        // it's never better to do 2 hops rather than 1.
+                        if matches!(
+                            followup_edge_weight.transition,
+                            QueryGraphEdgeTransition::KeyResolution
+                        ) {
+                            let Some(conditions) = &edge_weight.conditions else {
+                                return Err(SingleFederationError::Internal {
+                                    message: "Key resolution edge unexpectedly missing conditions"
+                                        .to_owned(),
+                                }
+                                .into());
+                            };
+                            let Some(followup_conditions) = &followup_edge_weight.conditions else {
+                                return Err(SingleFederationError::Internal {
+                                    message: "Key resolution edge unexpectedly missing conditions"
+                                        .to_owned(),
+                                }
+                                .into());
+                            };
+
+                            if conditions == followup_conditions {
+                                continue;
+                            }
+                        }
+                    }
+                    QueryGraphEdgeTransition::RootTypeResolution { .. } => {
+                        // A 'RootTypeResolution' means that a query reached the query type (or
+                        // another root type) in some subgraph A and we're looking at jumping to
+                        // another subgraph B. But like for keys, there is no point in trying to
+                        // jump directly to yet another subpraph C from B, since we can always jump
+                        // directly from A to C and it's better.
+                        if matches!(
+                            followup_edge_weight.transition,
+                            QueryGraphEdgeTransition::RootTypeResolution { .. }
+                        ) {
+                            continue;
+                        }
+                    }
+                    QueryGraphEdgeTransition::SubgraphEnteringTransition => {
+                        // This is somewhat similar to 'RootTypeResolution' except that we're
+                        // starting the query. Still, we shouldn't do "start of query" -> B -> C,
+                        // since we can do "start of query" -> C and that's always better.
+                        if matches!(
+                            followup_edge_weight.transition,
+                            QueryGraphEdgeTransition::RootTypeResolution { .. }
+                        ) {
+                            continue;
+                        }
+                    }
+                    _ => {}
+                }
+                non_trivial_followups.push(followup_edge_ref.id());
+            }
+            self.query_graph
+                .non_trivial_followup_edges
+                .insert(edge, non_trivial_followups);
+        }
+        Ok(())
+    }
 }
 
 struct SchemaQueryGraphBuilder {
@@ -348,6 +425,8 @@ impl SchemaQueryGraphBuilder {
         if self.for_query_planning {
             self.add_additional_abstract_type_edges()?;
         }
+        // This method adds no nodes/edges, but just precomputes followup edge information.
+        self.base.precompute_non_trivial_followup_edges()?;
         Ok(self.base.build())
     }
 
@@ -1094,7 +1173,7 @@ impl FederatedQueryGraphBuilder {
         // more details).
         self.handle_interface_object()?;
         // This method adds no nodes/edges, but just precomputes followup edge information.
-        self.precompute_non_trivial_followup_edges()?;
+        self.base.precompute_non_trivial_followup_edges()?;
         // This method adds no nodes/edges, but just precomputes metadata for estimating the count
         // of non_local_selections.
         self.base.query_graph.non_local_selection_metadata =
@@ -2254,84 +2333,6 @@ impl FederatedQueryGraphBuilder {
         }
         for new_edge in new_edges {
             new_edge.add_to(&mut self.base)?;
-        }
-        Ok(())
-    }
-
-    /// Precompute which followup edges for a given edge are non-trivial.
-    fn precompute_non_trivial_followup_edges(&mut self) -> Result<(), FederationError> {
-        for edge in self.base.query_graph.graph.edge_indices() {
-            let edge_weight = self.base.query_graph.edge_weight(edge)?;
-            let (_, tail) = self.base.query_graph.edge_endpoints(edge)?;
-            let out_edges = self.base.query_graph.out_edges(tail);
-            let mut non_trivial_followups = Vec::with_capacity(out_edges.len());
-            for followup_edge_ref in out_edges {
-                let followup_edge_weight = followup_edge_ref.weight();
-                match edge_weight.transition {
-                    QueryGraphEdgeTransition::KeyResolution => {
-                        // After taking a key from subgraph A to B, there is no point of following
-                        // that up with another key to subgraph C if that key has the same
-                        // conditions. This is because, due to the way key edges are created, if we
-                        // have a key (with some conditions X) from B to C, then we are guaranteed
-                        // to also have a key (with the same conditions X) from A to C, and so it's
-                        // that later key we should be using in the first place. In other words,
-                        // it's never better to do 2 hops rather than 1.
-                        if matches!(
-                            followup_edge_weight.transition,
-                            QueryGraphEdgeTransition::KeyResolution
-                        ) {
-                            let Some(conditions) = &edge_weight.conditions else {
-                                return Err(SingleFederationError::Internal {
-                                    message: "Key resolution edge unexpectedly missing conditions"
-                                        .to_owned(),
-                                }
-                                .into());
-                            };
-                            let Some(followup_conditions) = &followup_edge_weight.conditions else {
-                                return Err(SingleFederationError::Internal {
-                                    message: "Key resolution edge unexpectedly missing conditions"
-                                        .to_owned(),
-                                }
-                                .into());
-                            };
-
-                            if conditions == followup_conditions {
-                                continue;
-                            }
-                        }
-                    }
-                    QueryGraphEdgeTransition::RootTypeResolution { .. } => {
-                        // A 'RootTypeResolution' means that a query reached the query type (or
-                        // another root type) in some subgraph A and we're looking at jumping to
-                        // another subgraph B. But like for keys, there is no point in trying to
-                        // jump directly to yet another subpraph C from B, since we can always jump
-                        // directly from A to C and it's better.
-                        if matches!(
-                            followup_edge_weight.transition,
-                            QueryGraphEdgeTransition::RootTypeResolution { .. }
-                        ) {
-                            continue;
-                        }
-                    }
-                    QueryGraphEdgeTransition::SubgraphEnteringTransition => {
-                        // This is somewhat similar to 'RootTypeResolution' except that we're
-                        // starting the query. Still, we shouldn't do "start of query" -> B -> C,
-                        // since we can do "start of query" -> C and that's always better.
-                        if matches!(
-                            followup_edge_weight.transition,
-                            QueryGraphEdgeTransition::RootTypeResolution { .. }
-                        ) {
-                            continue;
-                        }
-                    }
-                    _ => {}
-                }
-                non_trivial_followups.push(followup_edge_ref.id());
-            }
-            self.base
-                .query_graph
-                .non_trivial_followup_edges
-                .insert(edge, non_trivial_followups);
         }
         Ok(())
     }

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -18,7 +18,7 @@ use petgraph::graph::EdgeReference;
 use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
 
-use crate::bail;
+use crate::ensure;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::internal_error;
@@ -363,6 +363,11 @@ impl QueryGraphEdgeTransition {
         &self,
         other: &Self,
     ) -> Result<bool, FederationError> {
+        ensure!(
+            other.collect_operation_elements(),
+            "Supergraphs shouldn't have a transition that doesn't collect elements; got {}",
+            other,
+        );
         Ok(match self {
             QueryGraphEdgeTransition::FieldCollection {
                 field_definition_position,
@@ -400,12 +405,7 @@ impl QueryGraphEdgeTransition {
                 };
                 to_type_name == other_to_type_name
             }
-            _ => {
-                bail!(
-                    "Supergraphs shouldn't have a transition that doesn't collect elements; got {}",
-                    other,
-                );
-            }
+            _ => false,
         })
     }
 }


### PR DESCRIPTION
This PR fixes the failing satisfiability test `test_satisfiability_basic()` in `satisfiability.rs`. The specific bugs being fixed are:
1. The `QueryGraph::non_trivial_followup_edges` map was only being computed for federated query graphs and not API schema/supergraph query graphs (the JS code computes it for both).
2. The `QueryGraphEdgeTransition::matches_supergraph_transition()` function was mistakenly bailing when the `self` transition did not collect elements, when it should have been bailing when the `other` transition did not collect elements (as the JS code does).

<!-- FED-710 -->