### PR TITLE
refactor(federation): expose `override_condition_labels` from `QueryPlanner`

### DIFF
--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -513,6 +513,10 @@ impl QueryGraph {
         &self.graph
     }
 
+    pub(crate) fn override_condition_labels(&self) -> &IndexSet<Arc<str>> {
+        &self.override_condition_labels
+    }
+
     pub(crate) fn supergraph_schema(&self) -> Result<ValidFederationSchema, FederationError> {
         self.supergraph_schema
             .clone()

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -570,6 +570,10 @@ impl QueryPlanner {
     pub fn supergraph_schema(&self) -> &ValidFederationSchema {
         &self.supergraph_schema
     }
+
+    pub fn override_condition_labels(&self) -> &IndexSet<Arc<str>> {
+        self.federated_query_graph.override_condition_labels()
+    }
 }
 
 fn compute_root_serial_dependency_graph(


### PR DESCRIPTION
`QueryPlanner`'s `override_condition_labels` field contains all override labels in the supergraph. This PR just make it publicly readable. The field is going to be used by test harness and other tools in the future.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is a minor refactoring.