### PR TITLE
ci: update mise version (backport #7965)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ common_job_environment: &common_job_environment
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   RUST_BACKTRACE: full
   CARGO_INCREMENTAL: 0
+  MISE_VERSION: v2025.7.26
 commands:
 
   setup_environment:


### PR DESCRIPTION
Fixes 404s during mise install.<hr>This is an automatic backport of pull request #7965 done by [Mergify](https://mergify.com).