### PR TITLE
Entity caching: fix inconsistency in cache-control header handling

### DIFF
--- a/.changesets/fix_simon_router_1200.md
+++ b/.changesets/fix_simon_router_1200.md
@@ -1,0 +1,9 @@
+### Entity caching: fix inconsistency in cache-control header handling ([PR #7987](https://github.com/apollographql/router/pull/7987))
+
+When the [Subgraph Entity Caching] feature is in use, it determines the `Cache-Control` HTTP response header sent to supergraph clients based on those received from subgraph servers.
+In this process, Apollo Router only emits the `max-age` [directive] and not `s-maxage`.
+This PR fixes a bug where, for a query that involved a single subgraph fetch that was not already cached, the subgraph response’s `Cache-Control` header would be forwarded as-is.
+Instead, it now goes through the same algorithm as other cases.
+
+[Subgraph Entity Caching]: https://www.apollographql.com/docs/graphos/routing/performance/caching/entity
+[directive]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#response_directives

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -937,10 +937,7 @@ async fn cache_lookup_root(
         Some(value) => {
             if value.0.control.can_use() {
                 let control = value.0.control.clone();
-                request
-                    .context
-                    .extensions()
-                    .with_lock(|lock| lock.insert(control));
+                update_cache_control(&request.context, &control);
                 if expose_keys_in_context {
                     let request_id = request.id.clone();
                     let cache_control_header = value.0.control.to_cache_control_header()?;

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -1121,8 +1121,10 @@ fn update_cache_control(context: &Context, cache_control: &CacheControl) {
         if let Some(c) = lock.get_mut::<CacheControl>() {
             *c = c.merge(cache_control);
         } else {
-            //FIXME: race condition. We need an Entry API for private entries
-            lock.insert(cache_control.clone());
+            // Go through the "merge" algorithm even with a single value
+            // in order to keep single-fetch queries consistent between cache hit and miss,
+            // and with multi-fetch queries.
+            lock.insert(cache_control.merge(cache_control));
         }
     })
 }

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -1681,7 +1681,10 @@ fn update_cache_control(context: &Context, cache_control: &CacheControl) {
         if let Some(c) = lock.get_mut::<CacheControl>() {
             *c = c.merge(cache_control);
         } else {
-            lock.insert(cache_control.clone());
+            // Go through the "merge" algorithm even with a single value
+            // in order to keep single-fetch queries consistent between cache hit and miss,
+            // and with multi-fetch queries.
+            lock.insert(cache_control.merge(cache_control));
         }
     })
 }

--- a/apollo-router/tests/integration/entity_cache.rs
+++ b/apollo-router/tests/integration/entity_cache.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use apollo_router::graphql;
 use apollo_router::services;
 use apollo_router::test_harness::HttpService;
 use http::HeaderMap;
@@ -104,17 +105,19 @@ async fn harness(
     (router, counters)
 }
 
-async fn make_graphql_request(
-    router: &mut HttpService,
-) -> (HeaderMap<String>, apollo_router::graphql::Response) {
+async fn make_graphql_request(router: &mut HttpService) -> (HeaderMap<String>, graphql::Response) {
     let query = "{ topProducts { reviews { id } } }";
-    let request: services::router::Request = services::supergraph::Request::fake_builder()
+    let request = graphql_request(query);
+    make_http_request(router, request.into()).await
+}
+
+fn graphql_request(query: &str) -> services::router::Request {
+    services::supergraph::Request::fake_builder()
         .query(query)
         .build()
         .unwrap()
         .try_into()
-        .unwrap();
-    make_http_request(router, request.into()).await
+        .unwrap()
 }
 
 async fn make_json_request(
@@ -281,4 +284,51 @@ async fn invalidate_with_endpoint() {
         products: 1
         reviews: 2
     "###);
+}
+
+/// For a supergraph query with a single subgraph fetch:
+///
+/// * In case of cache miss, the `cache-control` header is forwarded as-is with `s-maxage`
+///   (modulo parsing and reserialization)
+/// * In case of cache hit, `s-maxage` becomes `max-age`
+///
+/// This is inconsistent: the cache should be invisible to the client except for latency.
+/// For now, test the unexpected behavior.
+#[tokio::test]
+async fn cache_control_merging() {
+    if !graph_os_enabled() {
+        return;
+    }
+
+    let mut subgraphs = base_subgraphs();
+    subgraphs["products"]["headers"]["cache-control"] = "public, s-maxage=120".into();
+    subgraphs["reviews"]["headers"]["cache-control"] = "public, s-maxage=60".into();
+    let (mut router, _subgraph_request_counters) = harness(base_config(), subgraphs).await;
+
+    let query = "{ topProducts { upc } }";
+    let request = graphql_request(query);
+    let (headers, _body) =
+        make_http_request::<graphql::Response>(&mut router, request.into()).await;
+    insta::assert_snapshot!(&headers["cache-control"], @"s-maxage=120,public");
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let query = "{ topProducts { upc } }";
+    let request = graphql_request(query);
+    let (headers, _body) =
+        make_http_request::<graphql::Response>(&mut router, request.into()).await;
+    let cache_control = &headers["cache-control"];
+    let max_age: u32 = cache_control
+        .strip_prefix("max-age=")
+        .and_then(|s| s.strip_suffix(",public"))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("expected 'max-age={{seconds}},public', got '{cache_control}'"));
+    // Usually 120 - 2 = 118, but allow some slack in case CI CPUs are busy
+    assert!(max_age > 100 && max_age < 120, "got '{cache_control}'");
+
+    let query = "{ topProducts { reviews { id } } }";
+    let request = graphql_request(query);
+    let (headers, _body) =
+        make_http_request::<graphql::Response>(&mut router, request.into()).await;
+    insta::assert_snapshot!(&headers["cache-control"], @"max-age=60,public");
 }

--- a/apollo-router/tests/integration/entity_cache.rs
+++ b/apollo-router/tests/integration/entity_cache.rs
@@ -286,16 +286,8 @@ async fn invalidate_with_endpoint() {
     "###);
 }
 
-/// For a supergraph query with a single subgraph fetch:
-///
-/// * In case of cache miss, the `cache-control` header is forwarded as-is with `s-maxage`
-///   (modulo parsing and reserialization)
-/// * In case of cache hit, `s-maxage` becomes `max-age`
-///
-/// This is inconsistent: the cache should be invisible to the client except for latency.
-/// For now, test the unexpected behavior.
 #[tokio::test]
-async fn cache_control_merging() {
+async fn cache_control_merging_single_fetch() {
     if !graph_os_enabled() {
         return;
     }
@@ -304,31 +296,56 @@ async fn cache_control_merging() {
     subgraphs["products"]["headers"]["cache-control"] = "public, s-maxage=120".into();
     subgraphs["reviews"]["headers"]["cache-control"] = "public, s-maxage=60".into();
     let (mut router, _subgraph_request_counters) = harness(base_config(), subgraphs).await;
-
     let query = "{ topProducts { upc } }";
-    let request = graphql_request(query);
+
+    // Router responds with `max-age` even if a single subgraph used `s-maxage`
     let (headers, _body) =
-        make_http_request::<graphql::Response>(&mut router, request.into()).await;
-    insta::assert_snapshot!(&headers["cache-control"], @"s-maxage=120,public");
+        make_http_request::<graphql::Response>(&mut router, graphql_request(query).into()).await;
+    insta::assert_snapshot!(&headers["cache-control"], @"max-age=120,public");
 
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     let query = "{ topProducts { upc } }";
-    let request = graphql_request(query);
     let (headers, _body) =
-        make_http_request::<graphql::Response>(&mut router, request.into()).await;
+        make_http_request::<graphql::Response>(&mut router, graphql_request(query).into()).await;
     let cache_control = &headers["cache-control"];
-    let max_age: u32 = cache_control
+    let max_age = parse_max_age(cache_control);
+    // Usually 120 - 2 = 118, but allow some slack in case CI CPUs are busy
+    assert!(max_age > 100 && max_age < 120, "got '{cache_control}'");
+}
+
+#[tokio::test]
+async fn cache_control_merging_multi_fetch() {
+    if !graph_os_enabled() {
+        return;
+    }
+
+    let mut subgraphs = base_subgraphs();
+    subgraphs["products"]["headers"]["cache-control"] = "public, s-maxage=120".into();
+    subgraphs["reviews"]["headers"]["cache-control"] = "public, s-maxage=60".into();
+    let (mut router, _subgraph_request_counters) = harness(base_config(), subgraphs).await;
+    let query = "{ topProducts { reviews { id } } }";
+
+    // Router responds with `max-age` even if a subgraphs used `s-maxage`.
+    // The smaller value is used.
+    let (headers, _body) =
+        make_http_request::<graphql::Response>(&mut router, graphql_request(query).into()).await;
+    insta::assert_snapshot!(&headers["cache-control"], @"max-age=60,public");
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let (headers, _body) =
+        make_http_request::<graphql::Response>(&mut router, graphql_request(query).into()).await;
+    let cache_control = &headers["cache-control"];
+    let max_age = parse_max_age(cache_control);
+    // Usually 60 - 2 = 58, but allow some slack in case CI CPUs are busy
+    assert!(max_age > 40 && max_age < 60, "got '{cache_control}'");
+}
+
+fn parse_max_age(cache_control: &str) -> u32 {
+    cache_control
         .strip_prefix("max-age=")
         .and_then(|s| s.strip_suffix(",public"))
         .and_then(|s| s.parse().ok())
-        .unwrap_or_else(|| panic!("expected 'max-age={{seconds}},public', got '{cache_control}'"));
-    // Usually 120 - 2 = 118, but allow some slack in case CI CPUs are busy
-    assert!(max_age > 100 && max_age < 120, "got '{cache_control}'");
-
-    let query = "{ topProducts { reviews { id } } }";
-    let request = graphql_request(query);
-    let (headers, _body) =
-        make_http_request::<graphql::Response>(&mut router, request.into()).await;
-    insta::assert_snapshot!(&headers["cache-control"], @"max-age=60,public");
+        .unwrap_or_else(|| panic!("expected 'max-age={{seconds}},public', got '{cache_control}'"))
 }


### PR DESCRIPTION
When the [Subgraph Entity Caching] feature is in use, it determines the `Cache-Control` HTTP response header sent to supergraph clients based on those received from subgraph servers.
In this process, Apollo Router only emits the `max-age` [directive] and not `s-maxage`.
This PR fixes a bug where, for a query that involved a single subgraph fetch that was not already cached, the subgraph response’s `Cache-Control` header would be forwarded as-is.
Instead, it now goes through the same algorithm as other cases.

[Subgraph Entity Caching]: https://www.apollographql.com/docs/graphos/routing/performance/caching/entity
[directive]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#response_directives

<!-- start metadata -->

<!-- [ROUTER-1200] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1200]: https://apollographql.atlassian.net/browse/ROUTER-1200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ