### PR TITLE
Move `deserialize_response` to `apollo-federation`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "dhat",
  "diff",
  "either",
+ "encoding_rs",
  "form_urlencoded",
  "hashbrown 0.15.4",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ apollo-compiler = "1.28.0"
 apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"
+encoding_rs = "0.8.35"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "1.1.0"
 insta = { version = "1.38.0", features = [

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -24,6 +24,7 @@ time = { version = "0.3.34", default-features = false, features = [
     "local-offset",
 ] }
 derive_more = { version = "2.0.0", features = ["display", "from", "is_variant"] }
+encoding_rs.workspace = true
 http.workspace = true
 hashbrown = "0.15.1"
 indexmap = { version = "2.2.6", features = ["serde"] }

--- a/apollo-federation/src/connectors/runtime/errors.rs
+++ b/apollo-federation/src/connectors/runtime/errors.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use serde_json_bytes::ByteString;
 use serde_json_bytes::Map;
 use serde_json_bytes::Value;
@@ -5,7 +6,7 @@ use serde_json_bytes::Value;
 use crate::connectors::Connector;
 use crate::connectors::runtime::key::ResponseKey;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct RuntimeError {
     pub message: String,
     code: Option<String>,

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -282,7 +282,6 @@ itoa = "1.0.9"
 ryu = "1.0.15"
 apollo-environment-detector = "0.1.0"
 log = "0.4.22"
-encoding_rs = "0.8.35"
 scopeguard = "1.2.0"
 chrono = "0.4.41"
 
@@ -304,6 +303,7 @@ axum = { version = "0.8.1", features = ["http2", "ws"] }
 axum-server = "0.7.1"
 ctor = "0.4.0"
 ecdsa = { version = "0.16.9", features = ["signing", "pem", "pkcs8"] }
+encoding_rs.workspace = true
 fred = { version = "10.1.0", features = [
     "enable-rustls-ring",
     "mocks",


### PR DESCRIPTION
This way response handling can be shared with other projects. Also adjusts some error handling to expose to new consumers.

<!-- [CNN-926] -->

[CNN-926]: https://apollographql.atlassian.net/browse/CNN-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ