### PR TITLE
Allow deserialization of multiple audiences from string with delimiter

### DIFF
--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -1,6 +1,7 @@
 //! Authentication plugin
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ops::ControlFlow;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -17,7 +18,9 @@ use jsonwebtoken::decode_header;
 use once_cell::sync::Lazy;
 use reqwest::Client;
 use schemars::JsonSchema;
+use schemars::SchemaGenerator;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
@@ -131,6 +134,9 @@ struct JwksConf {
     /// Expected audiences for tokens verified by that JWKS
     ///
     /// If not specified, the audience will not be checked.
+    /// Accepts either a single string or an array of strings.
+    #[serde(default, deserialize_with = "deserialize_audiences")]
+    #[schemars(schema_with = "audiences_schema")]
     audiences: Option<Audiences>,
     /// List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`
     #[schemars(with = "Option<Vec<String>>", default)]
@@ -205,6 +211,69 @@ fn default_header_value_prefix() -> String {
 
 fn default_poll_interval() -> Duration {
     DEFAULT_AUTHENTICATION_DOWNLOAD_INTERVAL
+}
+
+/// Custom deserializer for the `audiences` field.
+///
+/// Accepts either:
+/// - a single `String` value (e.g., `"aud1;aud2"`) that is split by `;` into multiple entries, or
+/// - an array of strings (e.g., `["aud1", "aud2"]`).
+///
+/// Returns an `Option<HashSet<String>>` where:
+/// - `None` means the field was not present.
+/// - `Some(set)` contains the parsed and normalized audience values.
+fn deserialize_audiences<'de, D>(deserializer: D) -> Result<Option<HashSet<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    // Deserialize into either a single string or a vector of strings.
+    let value = Option::<OneOrMany>::deserialize(deserializer)?;
+
+    // Convert the parsed value into a HashSet<String>, handling splitting and trimming.
+    let result = match value {
+        None => None,
+        Some(OneOrMany::One(s)) => {
+            let set = s
+                .split(';')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect::<HashSet<_>>();
+            Some(set)
+        }
+        Some(OneOrMany::Many(vec)) => Some(vec.into_iter().collect::<HashSet<_>>()),
+    };
+
+    Ok(result)
+}
+
+/// Custom schema generator for the `audiences` field, used by `schemars`.
+///
+/// Produces a JSON Schema that accepts:
+/// - either a string (e.g., `"aud1;aud2"`)
+/// - or an array of strings (e.g., `["aud1", "aud2"]`)
+fn audiences_schema(generator: &mut SchemaGenerator) -> schemars::schema::Schema {
+    use schemars::schema::*;
+
+    // Generate schemas for a string and a list of strings
+    let string_subschema = generator.subschema_for::<String>();
+    let array_of_string_subschema = generator.subschema_for::<Vec<String>>();
+
+    // Return a union type schema allowing either
+    Schema::Object(SchemaObject {
+        subschemas: Some(Box::new(SubschemaValidation {
+            any_of: Some(vec![string_subschema, array_of_string_subschema]),
+            ..Default::default()
+        })),
+        ..Default::default()
+    })
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-7986] -->
---

#7986 

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests (not necessary?)
    - [x] Manual tests, as necessary

**Exceptions**

N/A

**Notes**

This pull request implements the feature proposed in:  
**Issue**: *Support delimited string for audiences to allow dynamic configuration via environment variables*  
(Submitted by me)

---

### 🧭 Motivation

In dynamic environments like staging, QA, or production, we rely on injecting runtime configuration via environment variables rather than rebuilding Docker images. However, the current `audiences` configuration requires a YAML list, which cannot be passed directly as a string environment variable without complex workarounds.

This PR allows audiences to be configured as either:
- A list (status quo)
- A single string delimited by `;`, e.g., `"aud1;aud2"`

This enables clean runtime injection from variables like:

```yaml
audiences: ${env.PROVIDER_AUDIENCES}
```

Where `PROVIDER_AUDIENCES="aud1;aud2"`.

---

### 🔧 What’s changed

- Added a custom `deserialize_audiences` function to allow `audiences` to be:
  - a single string (split on `;` into multiple values)
  - or an array of strings (as currently supported)
- Added a `#[schemars(schema_with = "audiences_schema")]` override to document this in the generated OpenAPI schema.
- Added a test `deserializes_audiences_configuration` covering all supported YAML formats.

---

### 📋 Example config support

```yaml
# Supported:
audiences: "aud1;aud2"
audiences:
  - aud1
  - aud2

# Not supported (still): JSON-like string list
audiences: "[\"aud1\", \"aud2\"]"
```

---

### ✅ Compatibility

This change is backward-compatible and non-breaking. Existing YAML lists continue to work as-is. This only enhances input flexibility.

---

Let me know if Apollo prefers a different delimiter than `;` or would like this feature gated behind a flag.

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

