### PR TITLE
Include base version in nightly versioning scheme

### DIFF
--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -231,7 +231,9 @@ impl Prepare {
                 replace_in_file!(
                     "./apollo-router/Cargo.toml",
                     r#"^(?P<existingVersion>version\s*=\s*)"[^"]+""#,
-                    format!(r#"${{existingVersion}}"0.0.0-nightly-{base_version}.{date}+{head_commit}""#)
+                    format!(
+                        r#"${{existingVersion}}"0.0.0-nightly-{base_version}.{date}+{head_commit}""#
+                    )
                 );
             }
             Version::Custom(version) => {


### PR DESCRIPTION
Changes nightly versions from:
```
0.0.0-nightly.<date>+<commithash>
```
to:
```
0.0.0-nightly-<version>.<date>+<commithash>
```

This will make it easier to identify versions in the big list of
nightlies. The version number is appended in the prerelease
metadata part of the semver version, because nightlies actually do _not_
have to be in any way semver-compatible with that version (they can even
include major breaking changes).
