### PR TITLE
Include base version in nightly versioning scheme (backport #8009)

### DIFF
--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -175,6 +175,18 @@ impl Prepare {
         Ok(())
     }
 
+    /// Read the current apollo-router version number from `Cargo.toml`.
+    fn cargo_toml_version() -> Result<String> {
+        let metadata = MetadataCommand::new()
+            .manifest_path("./apollo-router/Cargo.toml")
+            .exec()?;
+        Ok(metadata
+            .root_package()
+            .expect("root package missing")
+            .version
+            .to_string())
+    }
+
     /// Update the `apollo-router` version in the `dependencies` sections of the `Cargo.toml` files in `apollo-router-scaffold/templates/**`.
     fn update_cargo_tomls(&self, version: &Version) -> Result<String> {
         println!("updating Cargo.toml files");
@@ -212,13 +224,14 @@ impl Prepare {
                 // Just get the first 8 characters, for brevity.
                 let head_commit = head_commit.chars().take(8).collect::<String>();
 
+                let base_version = Self::cargo_toml_version()?;
+                let date = Utc::now().format("%Y%m%d");
+
                 replace_in_file!(
                     "./apollo-router/Cargo.toml",
                     r#"^(?P<existingVersion>version\s*=\s*)"[^"]+""#,
                     format!(
-                        "${{existingVersion}}\"0.0.0-nightly.{}+{}\"",
-                        Utc::now().format("%Y%m%d"),
-                        head_commit
+                        r#"${{existingVersion}}"0.0.0-nightly-{base_version}.{date}+{head_commit}""#
                     )
                 );
             }
@@ -230,15 +243,7 @@ impl Prepare {
             }
         }
 
-        let metadata = MetadataCommand::new()
-            .manifest_path("./apollo-router/Cargo.toml")
-            .exec()?;
-        let resolved_version = metadata
-            .root_package()
-            .expect("root package missing")
-            .version
-            .to_string();
-
+        let resolved_version = Self::cargo_toml_version()?;
         if let Version::Nightly = version {
             println!("Not changing `apollo-router-scaffold` or `apollo-router-benchmarks` because of nightly build mode.");
         } else {


### PR DESCRIPTION
Changes nightly versions from:
```
0.0.0-nightly.<date>+<commithash>
```
to:
```
0.0.0-nightly-<version>.<date>+<commithash>
```

This will make it easier to identify versions in the big list of
nightlies. The version number is appended in the prerelease
metadata part of the semver version, because nightlies actually do _not_
have to be in any way semver-compatible with that version (they can even
include major breaking changes).
<hr>This is an automatic backport of pull request #8009 done by [Mergify](https://mergify.com).