### PR TITLE
fix(federation/query-planning): Fix bug where subgraph jump key fields are fetched from the wrong node

### DIFF
--- a/.changesets/fix_fix_sachin_fed_544.md
+++ b/.changesets/fix_fix_sachin_fed_544.md
@@ -1,0 +1,5 @@
+### Fix query planning error where `@requires` subgraph jump fetches `@key` from the wrong subgraph ([PR #8016](https://github.com/apollographql/router/pull/8016))
+
+During query planning, a subgraph jump added due to a `@requires` field may sometimes try to collect the necessary `@key` fields from an upstream subgraph fetch as an optimization, but it wasn't properly checking whether that subgraph had those fields. This is now fixed, and previously could cause query planning errors with messages that look like "InternalRebaseError(CannotRebase { field_position: Object(T.id), parent_type: Object(T) })".
+
+By [@sachindshinde](https://github.com/sachindshinde) in https://github.com/apollographql/router/pull/8016

--- a/.changesets/fix_fix_sachin_fed_544.md
+++ b/.changesets/fix_fix_sachin_fed_544.md
@@ -1,5 +1,0 @@
-### Fix query planning error where `@requires` subgraph jump fetches `@key` from the wrong subgraph ([PR #8016](https://github.com/apollographql/router/pull/8016))
-
-During query planning, a subgraph jump added due to a `@requires` field may sometimes try to collect the necessary `@key` fields from an upstream subgraph fetch as an optimization, but it wasn't properly checking whether that subgraph had those fields. This is now fixed, and previously could cause query planning errors with messages that look like "InternalRebaseError(CannotRebase { field_position: Object(T.id), parent_type: Object(T) })".
-
-By [@sachindshinde](https://github.com/sachindshinde) in https://github.com/apollographql/router/pull/8016

--- a/.changesets/fix_sachin_fed_544.md
+++ b/.changesets/fix_sachin_fed_544.md
@@ -1,0 +1,5 @@
+### Fix query planning error where `@requires` subgraph jump fetches `@key` from the wrong subgraph ([PR #8016](https://github.com/apollographql/router/pull/8016))
+
+During query planning, a subgraph jump added due to a `@requires` field may sometimes try to collect the necessary `@key` fields from an upstream subgraph fetch as an optimization, but it wasn't properly checking whether that subgraph had those fields. This is now fixed, and previously could cause query planning errors with messages that look like "Cannot add selection of field `T.id` to selection set of parent type `T`".
+
+By [@sachindshinde](https://github.com/sachindshinde) in https://github.com/apollographql/router/pull/8016

--- a/apollo-federation/tests/query_plan/supergraphs/avoids_selecting_inapplicable_key_from_parent_node.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/avoids_selecting_inapplicable_key_from_parent_node.graphql
@@ -1,0 +1,76 @@
+# Composed from subgraphs with hash: 7744f0ec3e7d0ca0b7427d4d80f066ec5650bfcb
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  A @join__graph(name: "A", url: "none")
+  B @join__graph(name: "B", url: "none")
+  C @join__graph(name: "C", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__type(graph: C)
+{
+  t: T @join__field(graph: A)
+}
+
+type T
+  @join__type(graph: A, key: "id1")
+  @join__type(graph: B, key: "id2")
+  @join__type(graph: B, key: "id1")
+  @join__type(graph: C, key: "id2")
+{
+  id1: ID! @join__field(graph: A) @join__field(graph: B)
+  id2: ID! @join__field(graph: B) @join__field(graph: C)
+  x: Int @join__field(graph: B, external: true) @join__field(graph: C)
+  req: Int @join__field(graph: B, requires: "x")
+}


### PR DESCRIPTION
When a `@requires` edge needs a subgraph jump during fetch dependency graph processing, this would sometimes cause the locally satisfiable key fields needed by that jump to be fetched from the parent node instead of the current node (which apparently was done as an optimization). This can be a problem, since `GraphPath::can_satisfy_conditions()` only really guarantees the current node has those key fields.

This PR updates the code using the parent node to now explicitly check whether the locally satisfiable key can be fetched from that node, and if not, falls back to the current node (adding it as a parent, if needed). This lets us keep the optimization and avoid unnecessarily changing query plans.

This PR mirrors its JS equivalent at https://github.com/apollographql/federation/pull/3293 , and fixes https://github.com/apollographql/router/issues/6004 .

<!-- FED-544 -->