### PR TITLE
Loosen encoding_rs dep version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ apollo-compiler = "1.28.0"
 apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"
-encoding_rs = "0.8.35"
+encoding_rs = "0.8"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "1.1.0"
 insta = { version = "1.38.0", features = [


### PR DESCRIPTION
This PR loosens the version requirement of the `encoding_rs` dependency from "0.8.35" to "0.8". The prior version conflicts with fed-core's testing harness.