### PR TITLE
test(federation): updated the "compose" CLI command to use the new native composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
 name = "apollo-federation-cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "apollo-compiler",
  "apollo-federation",
  "clap",

--- a/apollo-federation/cli/Cargo.toml
+++ b/apollo-federation/cli/Cargo.toml
@@ -12,6 +12,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = { version = "1.0.114", features = [
     "preserve_order",
 ] }
+anyhow = "1"
 
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["json", "redactions"] }

--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -5,22 +5,24 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use anyhow::Error as AnyError;
+use anyhow::anyhow;
 use apollo_compiler::ExecutableDocument;
 use apollo_federation::ApiSchemaOptions;
 use apollo_federation::Supergraph;
 use apollo_federation::bail;
+use apollo_federation::composition;
 use apollo_federation::composition::validate_satisfiability;
 use apollo_federation::connectors::expand::ExpansionResult;
 use apollo_federation::connectors::expand::expand_connectors;
 use apollo_federation::correctness::CorrectnessError;
+use apollo_federation::error::CompositionError;
 use apollo_federation::error::FederationError;
 use apollo_federation::error::SingleFederationError;
 use apollo_federation::internal_composition_api;
-use apollo_federation::internal_error;
 use apollo_federation::query_graph;
 use apollo_federation::query_plan::query_planner::QueryPlanner;
 use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
-use apollo_federation::subgraph;
 use apollo_federation::subgraph::typestate;
 use apollo_federation::supergraph as new_supergraph;
 use clap::Parser;
@@ -229,7 +231,7 @@ fn read_input(input_path: &Path) -> String {
     }
 }
 
-fn cmd_api_schema(file_paths: &[PathBuf], enable_defer: bool) -> Result<(), FederationError> {
+fn cmd_api_schema(file_paths: &[PathBuf], enable_defer: bool) -> Result<(), AnyError> {
     let supergraph = load_supergraph(file_paths)?;
     let api_schema = supergraph.to_api_schema(apollo_federation::ApiSchemaOptions {
         include_defer: enable_defer,
@@ -239,19 +241,48 @@ fn cmd_api_schema(file_paths: &[PathBuf], enable_defer: bool) -> Result<(), Fede
     Ok(())
 }
 
+fn compose_files_inner(
+    file_paths: &[PathBuf],
+) -> Result<composition::Supergraph<composition::Satisfiable>, Vec<CompositionError>> {
+    let mut subgraphs = Vec::new();
+    let mut errors = Vec::new();
+    for path in file_paths {
+        let doc_str = std::fs::read_to_string(path).unwrap();
+        let url = format!("file://{}", path.to_str().unwrap());
+        let basename = path.file_stem().unwrap().to_str().unwrap();
+        let result = typestate::Subgraph::parse(basename, &url, &doc_str);
+        match result {
+            Ok(subgraph) => {
+                subgraphs.push(subgraph);
+            }
+            Err(err) => {
+                errors.push(err);
+            }
+        }
+    }
+    if !errors.is_empty() {
+        // Subgraph errors
+        return Err(errors.into_iter().map(CompositionError::from).collect());
+    }
+
+    composition::compose(subgraphs)
+}
+
 /// Compose a supergraph from multiple subgraph files.
-fn compose_files(file_paths: &[PathBuf]) -> Result<apollo_federation::Supergraph, FederationError> {
-    let schemas: Vec<_> = file_paths
-        .iter()
-        .map(|pathname| {
-            let doc_str = std::fs::read_to_string(pathname).unwrap();
-            let url = format!("file://{}", pathname.to_str().unwrap());
-            let basename = pathname.file_stem().unwrap().to_str().unwrap();
-            subgraph::Subgraph::parse_and_expand(basename, &url, &doc_str).unwrap()
-        })
-        .collect();
-    let supergraph = apollo_federation::Supergraph::compose(schemas.iter().collect()).unwrap();
-    Ok(supergraph)
+fn compose_files(
+    file_paths: &[PathBuf],
+) -> Result<composition::Supergraph<composition::Satisfiable>, AnyError> {
+    match compose_files_inner(file_paths) {
+        Ok(supergraph) => Ok(supergraph),
+        Err(errors) => {
+            // Print composition errors
+            let num_errors = errors.len();
+            for error in errors {
+                eprintln!("{error}");
+            }
+            Err(anyhow!("Composition failed with {num_errors} error(s)."))
+        }
+    }
 }
 
 fn load_supergraph_file(
@@ -263,19 +294,21 @@ fn load_supergraph_file(
 
 /// Load either single supergraph schema file or compose one from multiple subgraph files.
 /// If the single file is "-", read from stdin.
-fn load_supergraph(
-    file_paths: &[PathBuf],
-) -> Result<apollo_federation::Supergraph, FederationError> {
-    if file_paths.is_empty() {
+fn load_supergraph(file_paths: &[PathBuf]) -> Result<apollo_federation::Supergraph, AnyError> {
+    let supergraph = if file_paths.is_empty() {
         bail!("Error: missing command arguments");
     } else if file_paths.len() == 1 {
-        load_supergraph_file(&file_paths[0])
+        load_supergraph_file(&file_paths[0])?
     } else {
-        compose_files(file_paths)
-    }
+        let supergraph = compose_files(file_paths)?;
+        // Convert the new Supergraph struct into the old one.
+        let schema_doc = supergraph.schema().schema().to_string();
+        apollo_federation::Supergraph::new_with_router_specs(&schema_doc)?
+    };
+    Ok(supergraph)
 }
 
-fn cmd_query_graph(file_paths: &[PathBuf]) -> Result<(), FederationError> {
+fn cmd_query_graph(file_paths: &[PathBuf]) -> Result<(), AnyError> {
     let supergraph = load_supergraph(file_paths)?;
     let api_schema = supergraph.to_api_schema(Default::default())?;
     let query_graph = query_graph::build_supergraph_api_query_graph(supergraph.schema, api_schema)?;
@@ -283,7 +316,7 @@ fn cmd_query_graph(file_paths: &[PathBuf]) -> Result<(), FederationError> {
     Ok(())
 }
 
-fn cmd_federated_graph(file_paths: &[PathBuf]) -> Result<(), FederationError> {
+fn cmd_federated_graph(file_paths: &[PathBuf]) -> Result<(), AnyError> {
     let supergraph = load_supergraph(file_paths)?;
     let api_schema = supergraph.to_api_schema(Default::default())?;
     let query_graph =
@@ -297,7 +330,7 @@ fn cmd_plan(
     query_path: &Path,
     schema_paths: &[PathBuf],
     planner: QueryPlannerArgs,
-) -> Result<(), FederationError> {
+) -> Result<(), AnyError> {
     let query = read_input(query_path);
     let supergraph = load_supergraph(schema_paths)?;
 
@@ -305,7 +338,8 @@ fn cmd_plan(
     let planner = QueryPlanner::new(&supergraph, config)?;
 
     let query_doc =
-        ExecutableDocument::parse_and_validate(planner.api_schema().schema(), query, query_path)?;
+        ExecutableDocument::parse_and_validate(planner.api_schema().schema(), query, query_path)
+            .map_err(FederationError::from)?;
     let query_plan = planner.build_query_plan(&query_doc, None, Default::default())?;
     if use_json {
         println!("{}", serde_json::to_string_pretty(&query_plan).unwrap());
@@ -329,18 +363,18 @@ fn cmd_plan(
     );
     match result {
         Ok(_) => Ok(()),
-        Err(CorrectnessError::FederationError(e)) => Err(e),
-        Err(CorrectnessError::ComparisonError(e)) => Err(internal_error!("{}", e.description())),
+        Err(CorrectnessError::FederationError(e)) => Err(e.into()),
+        Err(CorrectnessError::ComparisonError(e)) => Err(anyhow!("{}", e.description())),
     }
 }
 
-fn cmd_validate(file_paths: &[PathBuf]) -> Result<(), FederationError> {
+fn cmd_validate(file_paths: &[PathBuf]) -> Result<(), AnyError> {
     load_supergraph(file_paths)?;
     println!("[SUCCESS]");
     Ok(())
 }
 
-fn cmd_subgraph(file_path: &Path) -> Result<(), FederationError> {
+fn cmd_subgraph(file_path: &Path) -> Result<(), AnyError> {
     let doc_str = read_input(file_path);
     let name = file_path
         .file_name()
@@ -370,20 +404,20 @@ fn cmd_subgraph(file_path: &Path) -> Result<(), FederationError> {
     Ok(())
 }
 
-fn cmd_satisfiability(file_path: &Path) -> Result<(), FederationError> {
+fn cmd_satisfiability(file_path: &Path) -> Result<(), AnyError> {
     let doc_str = read_input(file_path);
     let supergraph = new_supergraph::Supergraph::parse(&doc_str).unwrap();
     _ = validate_satisfiability(supergraph).expect("Supergraph should be satisfiable");
     Ok(())
 }
 
-fn cmd_compose(file_paths: &[PathBuf]) -> Result<(), FederationError> {
+fn cmd_compose(file_paths: &[PathBuf]) -> Result<(), AnyError> {
     let supergraph = compose_files(file_paths)?;
-    println!("{}", supergraph.schema.schema());
+    println!("{}", supergraph.schema().schema());
     Ok(())
 }
 
-fn cmd_extract(file_path: &Path, dest: Option<&PathBuf>) -> Result<(), FederationError> {
+fn cmd_extract(file_path: &Path, dest: Option<&PathBuf>) -> Result<(), AnyError> {
     let supergraph = load_supergraph_file(file_path)?;
     let subgraphs = supergraph.extract_subgraphs()?;
     if let Some(dest) = dest {
@@ -412,16 +446,14 @@ fn cmd_expand(
     file_path: &Path,
     dest: Option<&PathBuf>,
     filter_prefix: Option<&str>,
-) -> Result<(), FederationError> {
+) -> Result<(), AnyError> {
     let original_supergraph = load_supergraph_file(file_path)?;
     let ExpansionResult::Expanded { raw_sdl, .. } = expand_connectors(
         &original_supergraph.schema.schema().serialize().to_string(),
         &ApiSchemaOptions::default(),
     )?
     else {
-        return Err(FederationError::internal(
-            "supplied supergraph has no connectors to expand",
-        ));
+        bail!("supplied supergraph has no connectors to expand",);
     };
 
     // Validate the schema
@@ -490,7 +522,7 @@ fn cmd_bench(
     file_path: &Path,
     operations_dir: &PathBuf,
     planner: QueryPlannerArgs,
-) -> Result<(), FederationError> {
+) -> Result<(), AnyError> {
     let results = _cmd_bench(file_path, operations_dir, planner.into())?;
     println!("| operation_name | time (ms) | evaluated_plans (max 10000) | error |");
     println!("|----------------|----------------|-----------|-----------------------------|");


### PR DESCRIPTION
The `apollo-federation-cli` had "compose" command, but it used the old composition prototype.
This PR updates the command to use the new Rust composition implementation.

Additional changes:

* Since composition function returns `Vec<CompositionError>`, instead of `FederationError` as other functions do, this PR changed all command-line handles to return `anyhow::Error`.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This PR only updates the internal CLI command.