### PR TITLE
feat(federation/composition): prep adding location info to errors and hints

### DIFF
--- a/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
+++ b/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
@@ -161,6 +161,7 @@ pub(super) fn shareable_field_mismatched_runtime_types_hint(
     hints.push(CompositionHint {
         message,
         code: "INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN".to_owned(),
+        locations: Default::default(), // TODO
     });
     Ok(())
 }

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -127,7 +127,7 @@ pub struct SubgraphLocation {
     pub range: Range<LineColumn>,
 }
 
-type Locations = Vec<SubgraphLocation>;
+pub type Locations = Vec<SubgraphLocation>;
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum CompositionError {

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -135,6 +135,7 @@ pub enum CompositionError {
     SubgraphError {
         subgraph: String,
         error: FederationError,
+        locations: Locations,
     },
     #[error("{message}")]
     EmptyMergedEnumType {
@@ -308,8 +309,20 @@ impl CompositionError {
 }
 
 impl From<SubgraphError> for CompositionError {
-    fn from(SubgraphError { subgraph, error }: SubgraphError) -> Self {
-        Self::SubgraphError { subgraph, error }
+    fn from(value: SubgraphError) -> Self {
+        let locations = value
+            .locations
+            .into_iter()
+            .map(|range| SubgraphLocation {
+                subgraph: value.subgraph.clone(),
+                range,
+            })
+            .collect();
+        Self::SubgraphError {
+            subgraph: value.subgraph,
+            error: *value.error,
+            locations,
+        }
     }
 }
 

--- a/apollo-federation/src/merger/error_reporter.rs
+++ b/apollo-federation/src/merger/error_reporter.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::ops::Range;
+
+use apollo_compiler::parser::LineColumn;
 
 use crate::error::CompositionError;
 use crate::error::FederationError;
@@ -27,11 +30,16 @@ impl ErrorReporter {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn add_subgraph_error(&mut self, name: &str, error: impl Into<FederationError>) {
-        let error = error.into();
+    pub(crate) fn add_subgraph_error(
+        &mut self,
+        name: &str,
+        error: impl Into<FederationError>,
+        locations: Vec<Range<LineColumn>>,
+    ) {
         let error = SubgraphError {
             subgraph: name.into(),
-            error,
+            error: Box::new(error.into()),
+            locations,
         };
         self.errors.push(error.into());
     }

--- a/apollo-federation/src/merger/error_reporter.rs
+++ b/apollo-federation/src/merger/error_reporter.rs
@@ -116,6 +116,7 @@ impl ErrorReporter {
                 myself.add_hint(CompositionHint {
                     code: code.code().to_string(),
                     message: format!("{message}{distribution_str}"),
+                    locations: Default::default(), // TODO
                 });
             },
             Some(|elt: Option<&T>| elt.is_none()),

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -73,6 +73,7 @@ impl Merger {
                     "Enum type \"{}\" is defined but unused. It will be included in the supergraph with all the values appearing in any subgraph (\"as if\" it was only used as an output type).",
                     dest.type_name
                 ),
+                locations: Default::default(), // PORT_NOTE: No locations in JS implementation.
             });
             usage
         });

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -100,6 +100,7 @@ impl Merger {
                     "None of the values of enum type \"{}\" are defined consistently in all the subgraphs defining that type. As only values common to all subgraphs are merged, this would result in an empty type.",
                     dest.type_name
                 ),
+                locations: self.source_locations(&sources),
             });
         }
 

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -273,6 +273,7 @@ impl Merger {
                         linked_federation_version,
                         spec.minimum_federation_version()
                     ),
+                    locations: Default::default(), // TODO: need @link directive application AST node
                 });
                 return spec.minimum_federation_version();
             }
@@ -799,7 +800,8 @@ impl Merger {
                     message: format!(
                         "Directive @{name} is applied to \"{pos}\" in multiple subgraphs with different arguments. Merging strategies used by arguments: {}",
                         directive_in_supergraph.arguments_merger.as_ref().map_or("undefined".to_string(), |m| (m.to_string)())
-                    )
+                    ),
+                    locations: Default::default(), // PORT_NOTE: No locations in JS implementation.
                 });
             } else if let Some(most_used_directive) = directive_counts
                 .into_iter()
@@ -1280,8 +1282,8 @@ impl Merger {
         &mut self,
         code: HintCode,
         message: String,
-        sources: &Sources<T>,
-        accessor: impl Fn(&Option<T>) -> bool,
+        sources: &Sources<Node<T>>,
+        accessor: impl Fn(&Option<Node<T>>) -> bool,
     ) {
         // Build detailed hint message showing which subgraphs have/don't have the element
         let mut has_subgraphs = Vec::new();
@@ -1312,6 +1314,7 @@ impl Merger {
         let hint = CompositionHint {
             code: code.definition().code().to_string(),
             message: detailed_message,
+            locations: self.source_locations(sources),
         };
         self.error_reporter.add_hint(hint);
     }

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -1,6 +1,7 @@
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::ops::Deref;
+use std::ops::Range;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
@@ -11,6 +12,7 @@ use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::FieldSet;
+use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::ComponentOrigin;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::ExtensionId;
@@ -1076,6 +1078,13 @@ impl FederationSchema {
         }
 
         Ok(features)
+    }
+
+    pub(crate) fn node_locations<T>(
+        &self,
+        node: &Node<T>,
+    ) -> impl Iterator<Item = Range<LineColumn>> {
+        node.line_column_range(&self.schema().sources).into_iter()
     }
 }
 

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -103,7 +103,7 @@ impl SchemaUpgrader {
     ) -> Result<Subgraph<Upgraded>, SubgraphError> {
         let subgraph_name = subgraph.name.clone();
         self.upgrade_inner(subgraph)
-            .map_err(|e| SubgraphError::new(subgraph_name, e))
+            .map_err(|e| SubgraphError::new(subgraph_name, e, vec![]))
     }
 
     pub(crate) fn upgrade_inner(
@@ -163,7 +163,7 @@ impl SchemaUpgrader {
             Subgraph::new(subgraph.name.as_str(), subgraph.url.as_str(), schema.schema)
                 // This error will be wrapped up as a SubgraphError in `Self::upgrade`
                 .assume_expanded()
-                .map_err(|err| err.error)?
+                .map_err(|err| *err.error)?
                 .assume_upgraded();
         Ok(upgraded_subgraph)
     }
@@ -916,7 +916,7 @@ pub fn upgrade_subgraphs_if_necessary(
                 schema_upgrader.upgrade(subgraph)
             } else {
                 if is_interface_object_used(&subgraph)
-                    .map_err(|e| SubgraphError::new(subgraph.name.clone(), e))?
+                    .map_err(|e| SubgraphError::new(subgraph.name.clone(), e, vec![]))?
                 {
                     subgraphs_using_interface_object.push(subgraph.name.clone())
                 };

--- a/apollo-federation/src/schema/validators/cache_tag.rs
+++ b/apollo-federation/src/schema/validators/cache_tag.rs
@@ -392,7 +392,7 @@ impl Message {
     ) -> Self {
         Self {
             error,
-            locations: make_locations(node, schema),
+            locations: schema.node_locations(node).collect(),
         }
     }
 
@@ -409,15 +409,6 @@ impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.error)
     }
-}
-
-fn make_locations<T>(
-    node: &apollo_compiler::Node<T>,
-    schema: &FederationSchema,
-) -> Vec<Range<LineColumn>> {
-    node.line_column_range(&schema.schema().sources)
-        .into_iter()
-        .collect()
 }
 
 /// `@cacheTag` validation errors

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -1,11 +1,13 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::ops::Range;
 
 use apollo_compiler::Node;
 use apollo_compiler::Schema;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::name;
+use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::ComponentName;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::ObjectType;
@@ -331,18 +333,29 @@ impl From<ValidFederationSubgraph> for ValidSubgraph {
 /// it's idiomatic to have strongly typed errors which defer conversion to strings via `thiserror`, so
 /// for now we wrap the underlying error until we figure out a longer-term replacement that accounts
 /// for missing error codes and the like.
+// Note: The `error` field's type is boxed, since the size of struct is warned to be too large
+//       without boxing it.
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct SubgraphError {
     pub(crate) subgraph: String,
-    pub(crate) error: FederationError,
+    pub(crate) error: Box<FederationError>,
+    pub(crate) locations: Vec<Range<LineColumn>>,
 }
 
 impl SubgraphError {
-    pub fn new(subgraph: impl Into<String>, error: impl Into<FederationError>) -> Self {
+    pub fn new(
+        subgraph: impl Into<String>,
+        error: impl Into<FederationError>,
+        locations: Vec<Range<LineColumn>>,
+    ) -> Self {
         let subgraph = subgraph.into();
         let error = error.into();
-        SubgraphError { subgraph, error }
+        SubgraphError {
+            subgraph,
+            error: Box::new(error),
+            locations,
+        }
     }
 
     pub fn error(&self) -> &FederationError {
@@ -350,7 +363,7 @@ impl SubgraphError {
     }
 
     pub fn into_inner(self) -> FederationError {
-        self.error
+        *self.error
     }
 
     // Format subgraph errors in the same way as `Rover` does.

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -47,6 +47,7 @@ pub use self::subgraph::ValidFederationSubgraphs;
 use crate::ApiSchemaOptions;
 use crate::api_schema;
 use crate::error::FederationError;
+use crate::error::Locations;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
 use crate::link::context_spec_definition::ContextSpecDefinition;
@@ -231,6 +232,7 @@ pub struct SupergraphMetadata {
 pub struct CompositionHint {
     pub message: String,
     pub code: String,
+    pub locations: Locations,
 }
 
 impl CompositionHint {


### PR DESCRIPTION
### Summary

* added `locations` field to `CompositionError::EmptyMergedEnumType` variant.
* added `locations` field to `SubgraphError`
* added `locations` field to `CompositionHint`

This is just a prep work. Not all construction sites have been updated to actually add locations. There will be follow-up tasks to fill them in.

<!-- [FED-610] -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This PR is an incremental implementation of new composition feature.