### PR TITLE
fix(federation/composition): fixed `CompositionError::location` to return subgraph error locations

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -279,6 +279,22 @@ fn compose_files(
             let num_errors = errors.len();
             for error in errors {
                 eprintln!("{error}");
+                if error.locations().is_empty() {
+                    eprintln!("locations: <unknown>");
+                } else {
+                    eprintln!("locations:");
+                    for loc in error.locations() {
+                        eprintln!(
+                            "  [{subgraph}] {start_line}:{start_column} - {end_line}:{end_column}",
+                            subgraph = loc.subgraph,
+                            start_line = loc.range.start.line,
+                            start_column = loc.range.start.column,
+                            end_line = loc.range.end.line,
+                            end_column = loc.range.end.column,
+                        );
+                    }
+                }
+                eprintln!(); // line break
             }
             Err(anyhow!("Composition failed with {num_errors} error(s)."))
         }

--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -297,7 +297,7 @@ fn compose_files(
                 }
                 eprintln!(); // line break
             }
-            Err(anyhow!("Composition failed with {num_errors} error(s)."))
+            Err(anyhow!("Error: found {num_errors} composition error(s)."))
         }
     }
 }
@@ -428,7 +428,7 @@ fn cmd_subgraph(file_path: &Path) -> Result<(), AnyError> {
                 }
             }
             eprintln!(); // line break
-            return Err(anyhow!("Failed to parse and validate subgraph schema"));
+            return Err(anyhow!("Error: found an error in subgraph schema"));
         }
     };
 
@@ -453,7 +453,10 @@ fn cmd_subgraph(file_path: &Path) -> Result<(), AnyError> {
             }
             eprintln!(); // line break
         }
-        return Err(anyhow!("Failed to validate @cacheTag directive"));
+        let num_errors = result.errors.len();
+        return Err(anyhow!(
+            "Error: found {num_errors} error(s) in subgraph schema"
+        ));
     }
 
     println!("{}", subgraph.schema_string());

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -302,6 +302,7 @@ impl CompositionError {
 
     pub fn locations(&self) -> &[SubgraphLocation] {
         match self {
+            Self::SubgraphError { locations, .. } => locations,
             Self::EmptyMergedEnumType { locations, .. } => locations,
             _ => &[],
         }

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -366,6 +366,10 @@ impl SubgraphError {
         *self.error
     }
 
+    pub fn locations(&self) -> &[Range<LineColumn>] {
+        &self.locations
+    }
+
     // Format subgraph errors in the same way as `Rover` does.
     // And return them as a vector of (error_code, error_message) tuples
     // - Gather associated errors from the validation error.


### PR DESCRIPTION
This is a minor bug fix in the `CompositionError::location` method.
Also, this PR updates `subgraph` and `compose` CLI commands to print the location information.

<!-- start metadata -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is an incremental implementation of unreleased composition feature.