### PR TITLE
Enable jemalloc on MacOS

### DIFF
--- a/.changesets/feat_zelda_enable_jemalloc_on_macos.md
+++ b/.changesets/feat_zelda_enable_jemalloc_on_macos.md
@@ -1,0 +1,3 @@
+### Enable jemalloc on MacOS ([PR #8046](https://github.com/apollographql/router/pull/8046))
+
+This PR enables the jemalloc allocator on MacOS by default. Previously, this was only done for Linux. We're making this change because it will make memory profiling easier than it currently is.

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -34,7 +34,7 @@ default = ["global-allocator"]
 # [dependencies]
 # apollo-router = {version = "1.20", default-features = false}
 # ```
-global-allocator = ["dep:tikv-jemallocator", "tikv-jemalloc-ctl/stats"]
+global-allocator = ["tikv-jemallocator/profiling", "tikv-jemalloc-ctl/stats", "tikv-jemalloc-ctl/profiling"]
 
 # if you are doing heap profiling
 dhat-heap = ["dhat"]
@@ -286,18 +286,13 @@ log = "0.4.22"
 scopeguard = "1.2.0"
 chrono = "0.4.41"
 
-[target.'cfg(macos)'.dependencies]
-uname = "0.1.1"
-
 [target.'cfg(unix)'.dependencies]
 uname = "0.1.1"
 hyperlocal = { version = "0.9.1", default-features = false, features = [
     "client",
 ] }
-
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", optional = true }
-tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"], optional = true }
+tikv-jemallocator = { version = "0.6.0", features = ["profiling"], optional = true }
+tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats", "profiling"], optional = true }
 
 [dev-dependencies]
 axum = { version = "0.8.1", features = ["http2", "ws"] }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -295,7 +295,7 @@ hyperlocal = { version = "0.9.1", default-features = false, features = [
     "client",
 ] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(macos, target_os = "linux"))'.dependencies]
 tikv-jemallocator = { version = "0.6.0", optional = true }
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"], optional = true }
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -295,7 +295,7 @@ hyperlocal = { version = "0.9.1", default-features = false, features = [
     "client",
 ] }
 
-[target.'cfg(any(macos, target_os = "linux"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 tikv-jemallocator = { version = "0.6.0", optional = true }
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"], optional = true }
 

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -84,7 +84,7 @@ fn session_count_instrument() -> ObservableGauge<u64> {
 #[cfg(all(
     feature = "global-allocator",
     not(feature = "dhat-heap"),
-    target_os = "linux"
+    any(target_os = "linux", target_os = "macos")
 ))]
 fn jemalloc_metrics_instruments() -> (tokio::task::JoinHandle<()>, Vec<ObservableGauge<u64>>) {
     use crate::axum_factory::metrics::jemalloc;
@@ -506,7 +506,7 @@ where
     #[cfg(all(
         feature = "global-allocator",
         not(feature = "dhat-heap"),
-        target_os = "linux"
+        any(target_os = "linux", target_os = "macos")
     ))]
     let (_epoch_advance_loop, jemalloc_instrument) = jemalloc_metrics_instruments();
     // Tie the lifetime of the various instruments to the lifetime of the router
@@ -516,7 +516,7 @@ where
         #[cfg(all(
             feature = "global-allocator",
             not(feature = "dhat-heap"),
-            target_os = "linux"
+            any(target_os = "linux", target_os = "macos")
         ))]
         let _jemalloc_instrument = &jemalloc_instrument;
         service

--- a/apollo-router/src/axum_factory/metrics.rs
+++ b/apollo-router/src/axum_factory/metrics.rs
@@ -1,8 +1,4 @@
-#[cfg(all(
-    feature = "global-allocator",
-    not(feature = "dhat-heap"),
-    any(target_os = "linux", target_os = "macos")
-))]
+#[cfg(all(feature = "global-allocator", not(feature = "dhat-heap"), unix))]
 pub(crate) mod jemalloc {
     use std::time::Duration;
 

--- a/apollo-router/src/axum_factory/metrics.rs
+++ b/apollo-router/src/axum_factory/metrics.rs
@@ -1,7 +1,7 @@
 #[cfg(all(
     feature = "global-allocator",
     not(feature = "dhat-heap"),
-    target_os = "linux"
+    any(target_os = "linux", target_os = "macos")
 ))]
 pub(crate) mod jemalloc {
     use std::time::Duration;

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -43,7 +43,7 @@ use crate::uplink::UplinkConfig;
 #[cfg(all(
     feature = "global-allocator",
     not(feature = "dhat-heap"),
-    target_os = "linux"
+    any(target_os = "linux", target_os = "macos")
 ))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -40,11 +40,7 @@ use crate::router::ShutdownSource;
 use crate::uplink::Endpoints;
 use crate::uplink::UplinkConfig;
 
-#[cfg(all(
-    feature = "global-allocator",
-    not(feature = "dhat-heap"),
-    any(target_os = "linux", target_os = "macos")
-))]
+#[cfg(all(feature = "global-allocator", not(feature = "dhat-heap"), unix))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/apollo-router/tests/integration/metrics.rs
+++ b/apollo-router/tests/integration/metrics.rs
@@ -1,8 +1,4 @@
-#[cfg(all(
-    feature = "global-allocator",
-    not(feature = "dhat-heap"),
-    any(target_os = "linux", target_os = "macos")
-))]
+#[cfg(all(feature = "global-allocator", not(feature = "dhat-heap"), unix))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_jemalloc_metrics_are_emitted() {
     use super::common::IntegrationTest;

--- a/apollo-router/tests/integration/metrics.rs
+++ b/apollo-router/tests/integration/metrics.rs
@@ -1,7 +1,7 @@
 #[cfg(all(
     feature = "global-allocator",
     not(feature = "dhat-heap"),
-    target_os = "linux"
+    any(target_os = "linux", target_os = "macos")
 ))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_jemalloc_metrics_are_emitted() {


### PR DESCRIPTION
This PR enables the jemalloc allocator on MacOS by default. Previously, this was only done for Linux. We're making this change because it will make memory profiling easier than it currently is.

<!-- start metadata -->

<!-- [ROUTER-1409] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1409]: https://apollographql.atlassian.net/browse/ROUTER-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ