### PR TITLE
Add DockerHub References To The Documentation

### DIFF
--- a/.changesets/docs_add_dockerhub_runtime_container.md
+++ b/.changesets/docs_add_dockerhub_runtime_container.md
@@ -1,0 +1,6 @@
+### Update Documentation To Add DockerHub References
+
+Now that we have a DockerHub account we have published the Runtime Container to that account.
+This fix simply adds a reference to that to the documentation
+
+By [@jonathanrainer](https://github.com/jonathanrainer) in https://github.com/apollographql/router/pull/8054

--- a/docs/source/routing/self-hosted/index.mdx
+++ b/docs/source/routing/self-hosted/index.mdx
@@ -36,10 +36,10 @@ Follow our [Kubernetes quickstart](/graphos/routing/kubernetes/quickstart) to de
 
 Apollo provides the [Apollo Runtime Container](https://github.com/apollographql/apollo-runtime), which bundles all that's required to run the Apollo Runtime in one place. This includes the Apollo Router and the [Apollo MCP Server](/apollo-mcp-server).
 
-The images are downloadable from:
+You can download the images from:
 
-* [DockerHub](https://hub.docker.com/r/apollograph/apollo-runtime) (recommended)
-* [GitHub Container Registry](https://github.com/apollographql/apollo-runtime/pkgs/container/apollo-runtime)
+- [Docker Hub](https://hub.docker.com/r/apollograph/apollo-runtime) (recommended)
+- [GitHub Container Registry](https://github.com/apollographql/apollo-runtime/pkgs/container/apollo-runtime)
 
 For more information on deploying using your container environment:
 

--- a/docs/source/routing/self-hosted/index.mdx
+++ b/docs/source/routing/self-hosted/index.mdx
@@ -36,8 +36,8 @@ Follow our [Kubernetes quickstart](/graphos/routing/kubernetes/quickstart) to de
 
 Apollo provides the Apollo Runtime Container, which bundles all that's required to run the Apollo Runtime in one place. This includes the Apollo Router and the [Apollo MCP Server](/apollo-mcp-server).
 
-The images are available via GitHub, downloadable from `ghcr.io/apollographql/apollo-runtime` and the [Apollo Runtime Container repository](https://github.com/apollographql/apollo-runtime).
-Alternatively you can download the images from DockerHub at `apollograph/apollo-runtime`.
+The images are available via GitHub, downloadable from [`ghcr.io/apollographql/apollo-runtime`](https://github.com/apollographql/apollo-runtime/pkgs/container/apollo-runtime) and the [Apollo Runtime Container repository](https://github.com/apollographql/apollo-runtime).
+Alternatively you can download the images from DockerHub at [`apollograph/apollo-runtime`](https://hub.docker.com/r/apollograph/apollo-runtime).
 
 For more information on deploying using your container environment:
 

--- a/docs/source/routing/self-hosted/index.mdx
+++ b/docs/source/routing/self-hosted/index.mdx
@@ -37,6 +37,7 @@ Follow our [Kubernetes quickstart](/graphos/routing/kubernetes/quickstart) to de
 Apollo provides the Apollo Runtime Container, which bundles all that's required to run the Apollo Runtime in one place. This includes the Apollo Router and the [Apollo MCP Server](/apollo-mcp-server).
 
 The images are available via GitHub, downloadable from `ghcr.io/apollographql/apollo-runtime` and the [Apollo Runtime Container repository](https://github.com/apollographql/apollo-runtime).
+Alternatively you can download the images from DockerHub at `apollograph/apollo-runtime`.
 
 For more information on deploying using your container environment:
 

--- a/docs/source/routing/self-hosted/index.mdx
+++ b/docs/source/routing/self-hosted/index.mdx
@@ -34,10 +34,12 @@ Follow our [Kubernetes quickstart](/graphos/routing/kubernetes/quickstart) to de
 
 ### Apollo Runtime Container (Recommended)
 
-Apollo provides the Apollo Runtime Container, which bundles all that's required to run the Apollo Runtime in one place. This includes the Apollo Router and the [Apollo MCP Server](/apollo-mcp-server).
+Apollo provides the [Apollo Runtime Container](https://github.com/apollographql/apollo-runtime), which bundles all that's required to run the Apollo Runtime in one place. This includes the Apollo Router and the [Apollo MCP Server](/apollo-mcp-server).
 
-The images are available via GitHub, downloadable from [`ghcr.io/apollographql/apollo-runtime`](https://github.com/apollographql/apollo-runtime/pkgs/container/apollo-runtime) and the [Apollo Runtime Container repository](https://github.com/apollographql/apollo-runtime).
-Alternatively you can download the images from DockerHub at [`apollograph/apollo-runtime`](https://hub.docker.com/r/apollograph/apollo-runtime).
+The images are downloadable from:
+
+* [DockerHub](https://hub.docker.com/r/apollograph/apollo-runtime) (recommended)
+* [GitHub Container Registry](https://github.com/apollographql/apollo-runtime/pkgs/container/apollo-runtime)
 
 For more information on deploying using your container environment:
 


### PR DESCRIPTION
As per title, updates the documentation to add reference to our new DockerHub repo for the Runtime Container