### PR TITLE
Always use `graph_os_enabled` helper for GraphOS tests

### DIFF
--- a/apollo-router/tests/integration/batching.rs
+++ b/apollo-router/tests/integration/batching.rs
@@ -5,13 +5,10 @@ use tower::BoxError;
 use wiremock::ResponseTemplate;
 
 use crate::integration::ValueExt as _;
+use crate::integration::common::graph_os_enabled;
 
 const CONFIG: &str = include_str!("../fixtures/batching/all_enabled.router.yaml");
 const SHORT_TIMEOUTS_CONFIG: &str = include_str!("../fixtures/batching/short_timeouts.router.yaml");
-
-fn test_is_enabled() -> bool {
-    std::env::var("TEST_APOLLO_KEY").is_ok() && std::env::var("TEST_APOLLO_GRAPH_REF").is_ok()
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn it_supports_single_subgraph_batching() -> Result<(), BoxError> {
@@ -34,7 +31,7 @@ async fn it_supports_single_subgraph_batching() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         // Make sure that we got back what we wanted
         assert_yaml_snapshot!(responses, @r###"
     ---
@@ -88,7 +85,7 @@ async fn it_supports_multi_subgraph_batching() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         // Make sure that we got back what we wanted
         assert_yaml_snapshot!(responses, @r###"
     ---
@@ -137,7 +134,7 @@ async fn it_batches_with_errors_in_single_graph() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         // Make sure that we got back what we wanted
         assert_yaml_snapshot!(responses, @r###"
         ---
@@ -190,7 +187,7 @@ async fn it_batches_with_errors_in_multi_graph() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         assert_yaml_snapshot!(responses, @r###"
         ---
         - data:
@@ -251,7 +248,7 @@ async fn it_handles_short_timeouts() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         assert_yaml_snapshot!(responses, @r"
         - data:
             entryA:
@@ -321,7 +318,7 @@ async fn it_handles_indefinite_timeouts() -> Result<(), BoxError> {
 
     // verify the output
     let responses = [results_a, results_b].concat();
-    if test_is_enabled() {
+    if graph_os_enabled() {
         assert_yaml_snapshot!(responses, @r"
         - data:
             entryA:
@@ -387,7 +384,7 @@ async fn it_handles_cancelled_by_rhai() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         assert_yaml_snapshot!(responses, @r###"
     ---
     - data:
@@ -475,7 +472,7 @@ async fn it_handles_single_request_cancelled_by_rhai() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         assert_yaml_snapshot!(responses, @r###"
     ---
     - data:
@@ -569,7 +566,7 @@ async fn it_handles_cancelled_by_coprocessor() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         assert_yaml_snapshot!(responses, @r###"
         ---
         - errors:
@@ -716,7 +713,7 @@ async fn it_handles_single_request_cancelled_by_coprocessor() -> Result<(), BoxE
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         assert_yaml_snapshot!(responses, @r###"
         ---
         - data:
@@ -812,7 +809,7 @@ async fn it_handles_single_invalid_graphql() -> Result<(), BoxError> {
     )
     .await?;
 
-    if test_is_enabled() {
+    if graph_os_enabled() {
         // Make sure that we got back what we wanted
         assert_yaml_snapshot!(responses, @r###"
         ---
@@ -853,7 +850,7 @@ mod helper {
     use wiremock::ResponseTemplate;
     use wiremock::matchers;
 
-    use super::test_is_enabled;
+    use super::graph_os_enabled;
     use crate::integration::common::IntegrationTest;
     use crate::integration::common::Query;
 
@@ -891,7 +888,7 @@ mod helper {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if !test_is_enabled() {
+        if !graph_os_enabled() {
             return Ok(Vec::new());
         };
 

--- a/apollo-router/tests/integration/connectors.rs
+++ b/apollo-router/tests/integration/connectors.rs
@@ -4,15 +4,14 @@ mod apq {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -47,9 +46,7 @@ mod apq {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -87,9 +84,7 @@ mod apq {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -132,15 +127,14 @@ mod authentication {
 
     use crate::integration::IntegrationTest;
     use crate::integration::common::Query;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -183,9 +177,7 @@ mod authentication {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -226,9 +218,7 @@ mod authentication {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -280,9 +270,7 @@ mod authentication {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -372,15 +360,14 @@ mod batching {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -417,9 +404,7 @@ mod batching {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -459,9 +444,7 @@ mod batching {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -503,15 +486,14 @@ mod coprocessor {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -547,9 +529,7 @@ mod coprocessor {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -586,15 +566,14 @@ mod entity_cache {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -630,9 +609,7 @@ mod entity_cache {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -671,9 +648,7 @@ mod entity_cache {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -716,15 +691,14 @@ mod headers {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -762,9 +736,7 @@ mod headers {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -805,15 +777,14 @@ mod rhai {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -848,15 +819,14 @@ mod telemetry {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_all() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -893,9 +863,7 @@ mod telemetry {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -935,9 +903,7 @@ mod telemetry {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -977,9 +943,7 @@ mod telemetry {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -1022,15 +986,14 @@ mod tls {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_subgraph() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -1068,15 +1031,14 @@ mod traffic_shaping {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_subgraph() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 
@@ -1113,15 +1075,14 @@ mod url_override {
     use tower::BoxError;
 
     use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn incompatible_warnings_on_subgraph() -> Result<(), BoxError> {
         // Ensure that we have the test keys before running
         // Note: The [IntegrationTest] ensures that these test credentials get
         // set before running the router.
-        if std::env::var("TEST_APOLLO_KEY").is_err()
-            || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-        {
+        if !graph_os_enabled() {
             return Ok(());
         };
 

--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -1077,7 +1077,8 @@ mod helper {
     use tokio::net::TcpListener;
     use tokio_stream::Stream;
 
-    use super::super::common::IntegrationTest;
+    use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
 
     /// A helper server for testing multipart uploads.
     ///
@@ -1129,9 +1130,7 @@ mod helper {
             // Ensure that we have the test keys before running
             // Note: The [IntegrationTest] ensures that these test credentials get
             // set before running the router.
-            if std::env::var("TEST_APOLLO_KEY").is_err()
-                || std::env::var("TEST_APOLLO_GRAPH_REF").is_err()
-            {
+            if !graph_os_enabled() {
                 return Ok(());
             };
 

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -70,15 +70,13 @@ async fn test_metrics_reloading() {
         .assert_metrics_does_not_contain(r#"_total_total{"#)
         .await;
 
-    if std::env::var("TEST_APOLLO_KEY").is_ok() && std::env::var("TEST_APOLLO_GRAPH_REF").is_ok() {
-        router.assert_metrics_contains_multiple(vec![
-            r#"apollo_router_telemetry_studio_reports_total{report_type="metrics",otel_scope_name="apollo/router"} 2"#,
-            r#"apollo_router_telemetry_studio_reports_total{report_type="traces",otel_scope_name="apollo/router"} 2"#,
-            r#"apollo_router_uplink_fetch_duration_seconds_count{kind="unchanged",query="License",url="https://uplink.api.apollographql.com/",otel_scope_name="apollo/router"}"#,
-            r#"apollo_router_uplink_fetch_count_total{query="License",status="success",otel_scope_name="apollo/router"}"#
-            ], Some(Duration::from_secs(10)))
-            .await;
-    }
+    router.assert_metrics_contains_multiple(vec![
+        r#"apollo_router_telemetry_studio_reports_total{report_type="metrics",otel_scope_name="apollo/router"} 2"#,
+        r#"apollo_router_telemetry_studio_reports_total{report_type="traces",otel_scope_name="apollo/router"} 2"#,
+        r#"apollo_router_uplink_fetch_duration_seconds_count{kind="unchanged",query="License",url="https://uplink.api.apollographql.com/",otel_scope_name="apollo/router"}"#,
+        r#"apollo_router_uplink_fetch_count_total{query="License",status="success",otel_scope_name="apollo/router"}"#
+        ], Some(Duration::from_secs(10)))
+        .await;
 }
 
 #[track_caller]

--- a/apollo-router/tests/samples_tests.rs
+++ b/apollo-router/tests/samples_tests.rs
@@ -33,6 +33,7 @@ pub(crate) mod common;
 pub(crate) use common::IntegrationTest;
 
 use crate::common::Query;
+use crate::common::graph_os_enabled;
 
 fn main() -> Result<ExitCode, Box<dyn Error>> {
     let args = Arguments::from_args();
@@ -114,10 +115,7 @@ fn lookup_dir(
             };
 
             if let Some(plan) = plan {
-                if plan.enterprise
-                    && !(std::env::var("TEST_APOLLO_KEY").is_ok()
-                        && std::env::var("TEST_APOLLO_GRAPH_REF").is_ok())
-                {
+                if plan.enterprise && !graph_os_enabled() {
                     continue;
                 }
 


### PR DESCRIPTION
Cleanup.
