### PR TITLE
Docker build improvements (sha256sums and `BASE_VERSION`),  (backport #8056, #7634)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,13 +707,42 @@ jobs:
                   # See: https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-a-container-image-using-the-command-line
 
                   BASE_VERSION=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[0].version')
-                  ARTIFACT_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/artifacts/router-v${BASE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+                  ARTIFACT_FILENAME="router-v${BASE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+                  ARTIFACT_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/artifacts/${ARTIFACT_FILENAME}"
                   VERSION="v$(echo "${BASE_VERSION}" | tr "+" "-")"
                   ROUTER_TAG=ghcr.io/apollographql/nightly/router
 
+                  # Validate local artifact exists and calculate its checksum as a safety net
+                  if [ ! -f "artifacts/${ARTIFACT_FILENAME}" ]; then
+                    echo "Error: Local artifact not found: artifacts/${ARTIFACT_FILENAME}"
+                    exit 1
+                  fi
+                  LOCAL_ARTIFACT_SHA256SUM=$(sha256sum "artifacts/${ARTIFACT_FILENAME}" | cut -d' ' -f1)
+                  echo "Local artifact checksum: ${LOCAL_ARTIFACT_SHA256SUM}"
+
+                  # Download the artifact and calculate its checksum
+                  echo "Downloading artifact to calculate checksum..."
+                  curl -sSL -H "Circle-Token: ${CIRCLE_TOKEN}" -o "router-artifact.tar.gz" "${ARTIFACT_URL}"
+
+                  # Calculate checksum of the tarball (not the binary inside)
+                  ARTIFACT_URL_SHA256SUM=$(sha256sum "router-artifact.tar.gz" | cut -d' ' -f1)
+                  rm -f router-artifact.tar.gz
+
+                  # Compare local vs remote artifact checksums
+                  if [ "${LOCAL_ARTIFACT_SHA256SUM}" != "${ARTIFACT_URL_SHA256SUM}" ]; then
+                    echo "Error: Local and remote artifact checksums don't match!"
+                    echo "Local:      ${LOCAL_ARTIFACT_SHA256SUM}"
+                    echo "Remote: ${ARTIFACT_URL_SHA256SUM}"
+                    exit 1
+                  fi
+                  echo "Local and remote artifact checksums match: ${LOCAL_ARTIFACT_SHA256SUM}"
+
                   echo "REPO_URL: ${REPO_URL}"
                   echo "BASE_VERSION: ${BASE_VERSION}"
+                  echo "ARTIFACT_FILENAME: ${ARTIFACT_FILENAME}"
                   echo "ARTIFACT_URL: ${ARTIFACT_URL}"
+                  echo "ARTIFACT_URL_SHA256SUM: ${ARTIFACT_URL_SHA256SUM}"
+                  echo "LOCAL_ARTIFACT_SHA256SUM: ${LOCAL_ARTIFACT_SHA256SUM}"
                   echo "VERSION: ${VERSION}"
                   echo "ROUTER_TAG: ${ROUTER_TAG}"
 
@@ -726,10 +755,10 @@ jobs:
                   echo ${GITHUB_OCI_TOKEN} | docker login ghcr.io -u apollo-bot2 --password-stdin
                   # TODO: Can't figure out how to build multi-arch image from ARTIFACT_URL right now. Figure out later...
                   # Build and push debug image
-                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug .
+                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug dockerfiles/.
                   docker push ${ROUTER_TAG}:${VERSION}-debug
                   # Build and push release image
-                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} .
+                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} dockerfiles/.
                   docker push ${ROUTER_TAG}:${VERSION}
                   # save containers for analysis
                   mkdir built-containers
@@ -893,9 +922,9 @@ jobs:
                   docker manifest inspect ${ROUTER_TAG}:${VERSION}  > /dev/null && exit 1
                   docker manifest inspect ${ROUTER_TAG}:${VERSION}-debug  > /dev/null && exit 1
                   # Build and push debug image
-                  docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug .
+                  docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug dockerfiles/.
                   # Build and push release image
-                  docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} .
+                  docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} dockerfiles/.
             - run:
                 name: Helm build
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -755,10 +755,10 @@ jobs:
                   echo ${GITHUB_OCI_TOKEN} | docker login ghcr.io -u apollo-bot2 --password-stdin
                   # TODO: Can't figure out how to build multi-arch image from ARTIFACT_URL right now. Figure out later...
                   # Build and push debug image
-                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug dockerfiles/.
+                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug dockerfiles/.
                   docker push ${ROUTER_TAG}:${VERSION}-debug
                   # Build and push release image
-                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} dockerfiles/.
+                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} dockerfiles/.
                   docker push ${ROUTER_TAG}:${VERSION}
                   # save containers for analysis
                   mkdir built-containers

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -19,6 +19,7 @@ RUN chmod +x /tmp/download_and_validate_router.sh && /tmp/download_and_validate_
 FROM debian:bookworm-slim AS distro
 ARG DEBUG_IMAGE=false
 ARG REPO_URL=https://github.com/apollographql/router
+ARG BASE_VERSION
 
 # Add a user to run the router as
 RUN useradd -m router
@@ -48,10 +49,11 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN mkdir config schema
 
 # Copy configuration for docker image
-COPY dockerfiles/router.yaml config
+COPY router.yaml config
 
 LABEL org.opencontainers.image.authors="Apollo Graph, Inc. ${REPO_URL}"
 LABEL org.opencontainers.image.source="${REPO_URL}"
+LABEL org.opencontainers.image.version="${BASE_VERSION}"
 
 ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -2,23 +2,19 @@ FROM debian:bookworm-slim AS downloader
 ARG ROUTER_RELEASE=latest
 ARG ARTIFACT_URL=
 ARG CIRCLE_TOKEN=
+ARG ARTIFACT_URL_SHA256SUM=
 
-# Install curl
 RUN \
   apt-get update -y \
   && apt-get install -y \
     curl
 
-WORKDIR /dist
+# We work in /, and the tarball produces /dist/router after extraction.
+WORKDIR /
 
-# Run the Router downloader which puts Router into current working directory
-RUN if [ -z "${ARTIFACT_URL}"]; then \
-    curl -sSL "https://router.apollo.dev/download/nix/${ROUTER_RELEASE}"/ | sh; \
-  else \
-    cd /; \
-    curl -sSL -H "Circle-Token: ${CIRCLE_TOKEN}" -o - "${ARTIFACT_URL}" | tar -xzf -; \
-    cd -; \
-  fi
+# Copy and run the router download script
+COPY download_and_validate_router.sh /tmp/download_and_validate_router.sh
+RUN chmod +x /tmp/download_and_validate_router.sh && /tmp/download_and_validate_router.sh
 
 FROM debian:bookworm-slim AS distro
 ARG DEBUG_IMAGE=false

--- a/dockerfiles/diy/build_docker_image.sh
+++ b/dockerfiles/diy/build_docker_image.sh
@@ -173,6 +173,7 @@ cd "$(dirname "${0}")" || terminate "Couldn't cd to source location";
 mkdir "${BUILD_DIR}/dockerfiles"
 cp dockerfiles/Dockerfile.repo "${BUILD_DIR}" || terminate "Couldn't copy dockerfiles to ${BUILD_DIR}"
 cp ../Dockerfile.router "${BUILD_DIR}" || terminate "Couldn't copy dockerfiles to ${BUILD_DIR}"
+cp ../download_and_validate_router.sh "${BUILD_DIR}" || terminate "Couldn't copy random sidecar download and validate script to ${BUILD_DIR}"
 cp ../router.yaml "${BUILD_DIR}/dockerfiles" || terminate "Couldn't copy ../router.yaml to ${BUILD_DIR}"
 
 # Change to our build directory

--- a/dockerfiles/download_and_validate_router.sh
+++ b/dockerfiles/download_and_validate_router.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+# Download and validate Router binary This script handles both release downloads
+# and artifact downloads with checksum validation NOTE: This script is only
+# intended to be executed from inside Dockerfile.router which lives besides
+# this.
+
+# Validate required environment variables early
+if [ -z "${ARTIFACT_URL}" ]; then
+    # Release build path - requires ROUTER_RELEASE
+    if [ -z "${ROUTER_RELEASE}" ]; then
+        echo "Error: ROUTER_RELEASE environment variable is required for release builds"
+        exit 1
+    fi
+else
+    # Artifact build path - requires CIRCLE_TOKEN.
+    if [ -z "${CIRCLE_TOKEN}" ]; then
+        echo "Error: CIRCLE_TOKEN environment variable is required when ARTIFACT_URL is set"
+        exit 1
+    fi
+    # ARTIFACT_URL_SHA256SUM is optional but recommended
+fi
+
+# MOTIVATION
+#
+# Once upon a time, we encountered a case where the Router binary which was
+# inside the built Docker container was corrupted.  This script supports
+# downloading the Router binary and validating it against a provided checksum
+# which is calculated out of band (in CircleCI, typically) and passed into the
+# Docker build as an optional environment variables.
+
+# ARTIFACT_URL is used for nightly builds, which are built in CircleCI and
+# downloaded from the CircleCI API.  If ARTIFACT_URL is not set, we assume we
+# are building a release and will download the Router binary from the official
+# release URL.
+
+if [ -z "${ARTIFACT_URL}" ]; then
+    echo "Downloading Router release: ${ROUTER_RELEASE}"
+    # Download router tarball directly instead of using installer
+    TARBALL_NAME="router-${ROUTER_RELEASE}-x86_64-unknown-linux-gnu.tar.gz"
+
+    # We use the rover-plugin service to download the Router tarball, rather
+    # than the actual executable which is what our usual curl installer does.
+    #
+    # Expanding on that with a couple notes:
+    #
+    # - There is, as of the time of this writing, NO fixed Apollo-controlled URL
+    #   that lets you download a specific Router release tarball.
+    #   - We currently only have the curl installer which downloads and extracts
+    #     the tarballs.
+    #   - This approach is acceptable and defensive since rover is guaranteed to
+    #     have this in order for it to download the router, and that's not going
+    #     away. They also go through the same Orbiter endpoint/code anyhow.
+    #   - It IS possible to fix orbiter to also serve on the router domain and w
+    #     could do that, but this seemed more than acceptable, and is a well-tested
+    #     and monitored endpoint.
+    #   - The hard-coding of the x86_64 bit (rather than letting the install script
+    #     decide) also seems acceptable because this Docker container is built
+    #     with --platform linux/amd64 in the CircleCI config where this is called.
+
+    # Download the router tarball from the rover service
+    curl -sSL \
+      "https://rover.apollo.dev/tar/router/x86_64-unknown-linux-gnu/${ROUTER_RELEASE}" \
+        -o "${TARBALL_NAME}"
+
+    # Download and validate checksum
+    curl -sSL \
+      "https://github.com/apollographql/router/releases/download/${ROUTER_RELEASE}/sha256sums.txt" \
+        -o sha256sums.txt
+
+    # Extract the expected checksum for the tarball
+    EXPECTED_SHA256SUM=$(grep "${TARBALL_NAME}" sha256sums.txt | cut -d' ' -f1)
+    if [ -z "${EXPECTED_SHA256SUM}" ]; then
+        echo "ERROR: Could not find checksum for ${TARBALL_NAME} in sha256sums.txt"
+        exit 1
+    fi
+
+    # Calculate actual checksum of downloaded tarball
+    ACTUAL_SHA256SUM=$(sha256sum "${TARBALL_NAME}" | cut -d' ' -f1)
+
+    if [ "${EXPECTED_SHA256SUM}" != "${ACTUAL_SHA256SUM}" ]; then
+        echo "Error: Tarball checksum validation failed!"
+        echo "Expected: ${EXPECTED_SHA256SUM}"
+        echo "Actual: ${ACTUAL_SHA256SUM}"
+        exit 1
+    fi
+
+    echo "Tarball checksum validation passed: ${ACTUAL_SHA256SUM}"
+
+    # Extract the tarball, which literally drops a dist/ directory.
+    tar -xzf "${TARBALL_NAME}"
+else
+    echo "Downloading Router artifact: ${ARTIFACT_URL}"
+
+    curl -sSL -H "Circle-Token: ${CIRCLE_TOKEN}" -o "artifact.tar.gz" "${ARTIFACT_URL}"
+
+    # Validate checksum if ARTIFACT_URL_SHA256SUM is provided
+    if [ -n "${ARTIFACT_URL_SHA256SUM}" ]; then
+        ACTUAL_SHA256SUM=$(sha256sum "artifact.tar.gz" | cut -d' ' -f1)
+        if [ "${ARTIFACT_URL_SHA256SUM}" != "${ACTUAL_SHA256SUM}" ]; then
+            echo "Error: Artifact tarball checksum validation failed!"
+            echo "Expected: ${ARTIFACT_URL_SHA256SUM}"
+            echo "Actual: ${ACTUAL_SHA256SUM}"
+            exit 1
+        fi
+        echo "Artifact tarball checksum validation passed: ${ACTUAL_SHA256SUM}"
+    else
+        echo "WARN: No checksum provided for artifact validation"
+    fi
+
+    # Extract the tarball, which literally drops a dist/ directory.
+    tar -xzf "artifact.tar.gz"
+fi
+
+echo "Router download and validation completed successfully"


### PR DESCRIPTION
## Motivation
We recently encountered data corruption where a file in a Docker build had the correct size but wrong checksum, resulting in a broken Router image. This adds checksum validation to prevent such issues.

## Changes
Adds SHA256 validation for both nightly and release builds:

* Nightly builds: Validates local artifacts, remote artifacts in more than one way — inside CI, and within the Docker build
* Release builds: Downloads and validates against published sha256sums.txt from GitHub releases

Both paths fail with error messages if checksums don't match.

## Additional Backport

- https://github.com/apollographql/router/pull/7634

## Manual Testing

- [See this run](https://app.circleci.com/pipelines/github/apollographql/router/38179/workflows/b8012ab2-be5a-435c-8832-95b9baa2c020/jobs/286527/parallel-runs/0/steps/0-116)
- I'm also just starting another.
- I also manually tested building the Docker container (`Dockerfile.router`) with a bad `ARTIFACT_URL_SHA256` value passed as a build argument, which is how it's invoked from the CircleCI script and it correctly failed:
    ```
	docker build --progress=plain --platform linux/amd64 -t "jesse-new-router" \
	   --build-arg BASE_VERSION="0.0.0-nightly-2.5.0.20250806-6e56c771" \
	   --build-arg ROUTER_RELEASE="v0.0.0-nightly-2.5.0.20250806-6e56c771" \
	   --build-arg ARTIFACT_URL="https://github.com/apollographql/router/releases/download/v2.5.0/router-v2.5.0-x86_64-unknown-linux-gnu.tar.gz" \
	   --build-arg ARTIFACT_URL_SHA256SUM="🐑" \
	   --no-cache -f ../Dockerfile.router .
    ```
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] ~Changeset is included for user-facing changes~
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] ~Metrics and logs are added[^3] and documented~
- Tests added and passing[^4]
    - [ ] ~Unit tests~
    - [ ] ~Integration tests~
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #8056 done by [Mergify](https://mergify.com).