### PR TITLE
Revert #7879 to fix a subscriptions regression in v2.5.0

### DIFF
--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -27,6 +27,7 @@ use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use rustls::RootCertStore;
 use serde::Serialize;
+use tokio::select;
 use tokio::sync::oneshot;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::connect_async_tls_with_config;
@@ -494,6 +495,7 @@ async fn call_websocket(
     let SubgraphRequest {
         subgraph_request,
         subscription_stream,
+        connection_closed_signal,
         id: subgraph_request_id,
         ..
     } = request;
@@ -686,16 +688,26 @@ async fn call_websocket(
 
     let (handle_sink, handle_stream) = handle.split();
 
-    // Forward GraphQL subscription stream to WebSocket handle
-    // Connection lifecycle is managed by the WebSocket infrastructure,
-    // so we don't need to handle connection_closed_signal here
     tokio::task::spawn(async move {
-        if let Err(e) = gql_stream
-            .map(Ok::<_, graphql::Error>)
-            .forward(handle_sink)
-            .await
-        {
-            tracing::debug!("WebSocket subscription stream ended: {}", e);
+        match connection_closed_signal {
+            Some(mut connection_closed_signal) => select! {
+                // We prefer to specify the order of checks within the select
+                biased;
+                _ = gql_stream
+                    .map(Ok::<_, graphql::Error>)
+                    .forward(handle_sink) => {
+                    tracing::debug!("gql_stream empty");
+                },
+                _ = connection_closed_signal.recv() => {
+                    tracing::debug!("connection_closed_signal triggered");
+                }
+            },
+            None => {
+                let _ = gql_stream
+                    .map(Ok::<_, graphql::Error>)
+                    .forward(handle_sink)
+                    .await;
+            }
         }
     });
 

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -16,6 +16,7 @@ use axum::routing::post;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::json;
+use tokio::time::Duration;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -110,7 +111,7 @@ pub async fn start_subscription_server_with_payloads(
     });
 
     // Wait a moment for the server to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     info!("Axum server running on {}", ws_addr);
 
@@ -197,7 +198,7 @@ pub async fn verify_subscription_events(
 
     let mut subscription_events = Vec::new();
     // Set a longer timeout for receiving all events
-    let timeout = tokio::time::timeout(tokio::time::Duration::from_secs(60), async {
+    let timeout = tokio::time::timeout(Duration::from_secs(60), async {
         while let Some(field) = multipart
             .next_field()
             .await
@@ -232,28 +233,27 @@ pub async fn verify_subscription_events(
     );
 
     // Give the stream a moment to ensure it's properly terminated and no more events arrive
-    let termination_timeout =
-        tokio::time::timeout(tokio::time::Duration::from_millis(1000), async {
-            while let Some(field) = multipart
-                .next_field()
-                .await
-                .expect("could not read next chunk")
-            {
-                assert!(is_json_field(&field), "all response chunks must be JSON");
+    let termination_timeout = tokio::time::timeout(Duration::from_millis(1000), async {
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .expect("could not read next chunk")
+        {
+            assert!(is_json_field(&field), "all response chunks must be JSON");
 
-                let parsed: serde_json::Value = field.json().await.expect("invalid JSON chunk");
-                let data = parsed
-                    .get("data")
-                    .or_else(|| parsed.get("payload").and_then(|p| p.get("data")));
+            let parsed: serde_json::Value = field.json().await.expect("invalid JSON chunk");
+            let data = parsed
+                .get("data")
+                .or_else(|| parsed.get("payload").and_then(|p| p.get("data")));
 
-                assert!(
-                    data.is_none(),
-                    "Unexpected additional event received after {} expected events: {}",
-                    expected_events.len(),
-                    parsed
-                );
-            }
-        });
+            assert!(
+                data.is_none(),
+                "Unexpected additional event received after {} expected events: {}",
+                expected_events.len(),
+                parsed
+            );
+        }
+    });
 
     assert!(
         termination_timeout.await.is_ok(),
@@ -279,6 +279,11 @@ async fn websocket_handler(
         .on_upgrade(move |socket| handle_websocket(socket, config, is_closed))
 }
 
+/// Create a WebSocket message from a JSON value.
+fn json_message<T: serde::Serialize>(data: &T) -> axum::extract::ws::Message {
+    axum::extract::ws::Message::text(serde_json::to_string(data).unwrap())
+}
+
 async fn handle_websocket(
     mut socket: WebSocket,
     config: SubscriptionServerConfig,
@@ -286,127 +291,96 @@ async fn handle_websocket(
 ) {
     info!("WebSocket connection established");
     'global: while let Some(msg) = socket.recv().await {
-        if let Ok(msg) = msg {
-            match msg {
-                axum::extract::ws::Message::Text(text) => {
-                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
-                        match parsed.get("type").and_then(|t| t.as_str()) {
-                            Some("connection_init") => {
-                                // Send connection_ack
-                                let ack = json!({
-                                    "type": "connection_ack"
-                                });
-                                if socket
-                                    .send(axum::extract::ws::Message::text(
-                                        serde_json::to_string(&ack).unwrap(),
-                                    ))
-                                    .await
-                                    .is_err()
-                                {
-                                    break 'global;
-                                }
-                            }
-                            Some("start") => {
-                                let id = parsed.get("id").and_then(|i| i.as_str()).unwrap_or("1");
+        match msg.expect("error receiving websocket message from the router") {
+            axum::extract::ws::Message::Text(text) => {
+                let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) else {
+                    panic!("router sent non-JSON subscription message: {text}");
+                };
 
-                                // Handle subscription
-                                if let Some(payload) = parsed.get("payload") {
-                                    if let Some(query) =
-                                        payload.get("query").and_then(|q| q.as_str())
-                                    {
-                                        if query.contains("userWasCreated") {
-                                            let interval_ms = config.interval_ms;
-                                            let payloads = &config.payloads;
-
-                                            info!(
-                                                "Starting subscription with {} events, interval {}ms (configured)",
-                                                payloads.len(),
-                                                interval_ms
-                                            );
-
-                                            // Give the router time to fully establish the subscription stream
-                                            tokio::time::sleep(tokio::time::Duration::from_millis(
-                                                100,
-                                            ))
-                                            .await;
-
-                                            // Send multiple subscription events
-                                            for (i, custom_payload) in payloads.iter().enumerate() {
-                                                // Always send exactly what we're given - no transformation
-                                                let event_data = json!({
-                                                    "id": id,
-                                                    "type": "data",
-                                                    "payload": custom_payload
-                                                });
-
-                                                if socket
-                                                    .send(axum::extract::ws::Message::text(
-                                                        serde_json::to_string(&event_data).unwrap(),
-                                                    ))
-                                                    .await
-                                                    .is_err()
-                                                {
-                                                    break 'global;
-                                                }
-
-                                                debug!(
-                                                    "Sent subscription event {}/{}",
-                                                    i + 1,
-                                                    payloads.len()
-                                                );
-
-                                                // Wait between events
-                                                if i < payloads.len() - 1 {
-                                                    tokio::time::sleep(
-                                                        tokio::time::Duration::from_millis(
-                                                            interval_ms,
-                                                        ),
-                                                    )
-                                                    .await;
-                                                }
-                                            }
-
-                                            if config.terminate_subscription {
-                                                // Send completion
-                                                let complete = json!({
-                                                    "id": id,
-                                                    "type": "complete"
-                                                });
-                                                if socket
-                                                    .send(axum::extract::ws::Message::text(
-                                                        serde_json::to_string(&complete).unwrap(),
-                                                    ))
-                                                    .await
-                                                    .is_err()
-                                                {
-                                                    break 'global;
-                                                }
-
-                                                info!(
-                                                    "Completed subscription with {} events",
-                                                    payloads.len()
-                                                );
-                                            } else {
-                                                info!(
-                                                    "Sent {} subscription events but did not send `complete` message",
-                                                    payloads.len()
-                                                );
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            Some("stop") => {
-                                // Handle stop message
-                                break 'global;
-                            }
-                            _ => {}
+                match parsed.get("type").and_then(|t| t.as_str()) {
+                    Some("connection_init") => {
+                        // Send connection_ack
+                        let ack = json!({
+                            "type": "connection_ack"
+                        });
+                        if socket.send(json_message(&ack)).await.is_err() {
+                            break 'global;
                         }
                     }
+                    Some("start") => {
+                        let id = parsed.get("id").and_then(|i| i.as_str()).unwrap_or("1");
+
+                        let Some(query) = parsed
+                            .get("payload")
+                            .and_then(|payload| payload.get("query"))
+                            .and_then(|query| query.as_str())
+                        else {
+                            panic!(r#"router sent invalid "start" message: {parsed}"#);
+                        };
+
+                        // actual implementation for our test subscription
+                        if query.contains("userWasCreated") {
+                            let interval_ms = config.interval_ms;
+                            let payloads = &config.payloads;
+
+                            info!(
+                                "Starting subscription with {} events, interval {}ms (configured)",
+                                payloads.len(),
+                                interval_ms
+                            );
+
+                            // Give the router time to fully establish the subscription stream
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+
+                            // Send multiple subscription events
+                            for (i, custom_payload) in payloads.iter().enumerate() {
+                                // Always send exactly what we're given - no transformation
+                                let event_data = json!({
+                                    "id": id,
+                                    "type": "data",
+                                    "payload": custom_payload
+                                });
+
+                                if socket.send(json_message(&event_data)).await.is_err() {
+                                    break 'global;
+                                }
+
+                                debug!("Sent subscription event {}/{}", i + 1, payloads.len());
+
+                                // Wait between events
+                                if i < payloads.len() - 1 {
+                                    tokio::time::sleep(Duration::from_millis(interval_ms)).await;
+                                }
+                            }
+
+                            if config.terminate_subscription {
+                                // Send completion
+                                let complete = json!({
+                                    "id": id,
+                                    "type": "complete"
+                                });
+                                if socket.send(json_message(&complete)).await.is_err() {
+                                    break 'global;
+                                }
+
+                                info!("Completed subscription with {} events", payloads.len());
+                            } else {
+                                info!(
+                                    "Sent {} subscription events but did not send `complete` message",
+                                    payloads.len()
+                                );
+                            }
+                        }
+                    }
+                    Some("stop") => {
+                        // Handle stop message
+                        break 'global;
+                    }
+                    _ => {}
                 }
-                axum::extract::ws::Message::Close(_) => break 'global,
-                _ => {}
             }
+            axum::extract::ws::Message::Close(_) => break 'global,
+            _ => {}
         }
     }
     is_closed.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -430,7 +404,7 @@ pub async fn start_callback_server() -> (SocketAddr, CallbackTestState) {
         axum::serve(listener, app).await.unwrap();
     });
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
     info!("Callback server running on {}", addr);
 
     (addr, state)
@@ -622,7 +596,7 @@ async fn send_callback_events_with_payloads(
 ) {
     let client = reqwest::Client::new();
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     for (i, custom_payload) in payloads.iter().enumerate() {
         let payload = CallbackPayload {
@@ -648,7 +622,7 @@ async fn send_callback_events_with_payloads(
         }
 
         if i < payloads.len() - 1 {
-            tokio::time::sleep(tokio::time::Duration::from_millis(interval_ms)).await;
+            tokio::time::sleep(Duration::from_millis(interval_ms)).await;
         }
     }
 


### PR DESCRIPTION
This PR is _not_ intended to be merged, but just to cut a nightly release for select customers who require a quick fix.

## Problem

#7879 fixed a bug where deduplicated subscription connections to the subgraph were closed too early, leading to clients having a subscription open but not receiving any events.

Unfortunately, it introduced a regression the other way around: now when a client disconnects, the router doesn't close the subgraph connection, or at least, not cleanly. This can cause resource leakage in subgraphs.

## Workarounds

We're still working on a proper fix to the problem. In the mean time, there are some workarounds for affected users:

- Stay on 2.4.0. This means missing out on hot reload and deduplication fixes. You can disable subscription deduplication and hot reload. Both issues existed for a long time, so if you haven't experienced problems, you can also just wait it out.
- Update to the nightly released from this branch. This reverts a subscription deduplication fix, so the recommendation would be to disable subscription deduplication when using this branch.

Subscription deduplication is enabled by default. You can check if you're actually _using_ it heavily in production using the `subscriptions.deduplicated` attribute on the `apollo.router.operations.subscriptions` metric. If it's only `true` for a small or zero amount of subscriptions, you can safely disable subscription deduplication without increasing the load on subgraph services. If you _do_ have many deduplicated subscriptions, then consider if your subgraphs can handle increased load from disabling the feature. Otherwise you may have to wait it out until the next 2.5.x patch release.