### PR TITLE
fix(federation/composition): fixed `is_link_directive_definition` to be consistent with the JS version

### DIFF
--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -23,18 +23,26 @@ pub use crate::supergraph::Supergraph;
 pub fn compose(
     subgraphs: Vec<Subgraph<Initial>>,
 ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+    tracing::debug!("Expanding subgraphs...");
     let expanded_subgraphs = expand_subgraphs(subgraphs)?;
+    tracing::debug!("Upgrading subgraphs...");
     let mut upgraded_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)?;
+    tracing::debug!("Normalizing root types...");
     for subgraph in upgraded_subgraphs.iter_mut() {
         subgraph
             .normalize_root_types()
             .map_err(|e| e.to_composition_errors().collect_vec())?;
     }
+    tracing::debug!("Validating subgraphs...");
     let validated_subgraphs = validate_subgraphs(upgraded_subgraphs)?;
 
+    tracing::debug!("Pre-merge validations...");
     pre_merge_validations(&validated_subgraphs)?;
+    tracing::debug!("Merging subgraphs...");
     let supergraph = merge_subgraphs(validated_subgraphs)?;
+    tracing::debug!("Post-merge validations...");
     post_merge_validations(&supergraph)?;
+    tracing::debug!("Validating satisfiability...");
     validate_satisfiability(supergraph)
 }
 

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -218,7 +218,7 @@ impl Subgraph<Initial> {
     }
 
     pub fn expand_links(self) -> Result<Subgraph<Expanded>, SubgraphError> {
-        tracing::debug!("expand_links: expand_links start");
+        tracing::debug!("expand_links: expand subgraph `{}`", self.name);
         let subgraph_name = self.name.clone();
         self.expand_links_internal()
             .map_err(|e| SubgraphError::new_without_locations(subgraph_name, e))


### PR DESCRIPTION
Previously in `is_bootstrap_directive` function, `@link` directive recognition rule was more strict than `@core`.

```rust
/// Returns true if the given definition matches the @core definition.
///
/// Either of these definitions are accepted:
/// ```graphql
/// directive @_ANY_NAME_(feature: String!, as: String) repeatable on SCHEMA
/// directive @_ANY_NAME_(feature: String, as: String) repeatable on SCHEMA
/// directive @_ANY_NAME_(feature: String!) repeatable on SCHEMA
/// directive @_ANY_NAME_(feature: String) repeatable on SCHEMA
/// ```
fn is_core_directive_definition(definition: &DirectiveDefinition) -> bool {
```

```rust
/// Returns true if the given definition matches the @link definition.
///
/// Either of these definitions are accepted:
/// ```graphql
/// directive @_ANY_NAME_(url: String!, as: String) repeatable on SCHEMA
/// directive @_ANY_NAME_(url: String, as: String) repeatable on SCHEMA
/// ```
fn is_link_directive_definition(definition: &DirectiveDefinition) -> bool {
```

As commented, the `@link` directive is recognized only if `as` argument is defined. On the other hand, the JS implementation uses the same rule for both directives.  That discrepancy caused Rust composition errors with some customer subgraphs.

This PR updates `is_link_directive_definition` function to be consistent with the `is_core_directive_definition` and thus the JS implementation.

<!-- [FED-718] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is an incremental implementation of new native composition.

[FED-718]: https://apollographql.atlassian.net/browse/FED-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ