### PR TITLE
(feat) Enhance chaos plugin (backport #8083)

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -53,6 +53,8 @@ use crate::configuration::schema::Mode;
 use crate::graphql;
 use crate::notification::Notify;
 use crate::plugin::plugins;
+use crate::plugins::chaos;
+use crate::plugins::chaos::Config;
 use crate::plugins::limits;
 use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN;
 use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN_NAME;
@@ -168,7 +170,7 @@ pub struct Configuration {
     /// Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions.
     /// You probably don’t want this in production!
     #[serde(default)]
-    pub(crate) experimental_chaos: Chaos,
+    pub(crate) experimental_chaos: Config,
 
     /// Plugin configuration
     #[serde(default)]
@@ -224,7 +226,7 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             apq: Apq,
             persisted_queries: PersistedQueries,
             limits: limits::Config,
-            experimental_chaos: Chaos,
+            experimental_chaos: chaos::Config,
             batching: Batching,
             experimental_type_conditioned_fetching: bool,
         }
@@ -295,7 +297,7 @@ impl Configuration {
         apq: Option<Apq>,
         persisted_query: Option<PersistedQueries>,
         operation_limits: Option<limits::Config>,
-        chaos: Option<Chaos>,
+        chaos: Option<chaos::Config>,
         uplink: Option<UplinkConfig>,
         experimental_type_conditioned_fetching: Option<bool>,
         batching: Option<Batching>,
@@ -432,7 +434,7 @@ impl Configuration {
         apq: Option<Apq>,
         persisted_query: Option<PersistedQueries>,
         operation_limits: Option<limits::Config>,
-        chaos: Option<Chaos>,
+        chaos: Option<chaos::Config>,
         uplink: Option<UplinkConfig>,
         batching: Option<Batching>,
         experimental_type_conditioned_fetching: Option<bool>,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -522,19 +522,6 @@ expression: "&schema"
       ],
       "type": "object"
     },
-    "Chaos": {
-      "additionalProperties": false,
-      "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions. You probably don’t want this in production!",
-      "properties": {
-        "force_reload": {
-          "default": null,
-          "description": "Force a hot reload of the Router (as if the schema or configuration had changed) at a regular time interval.",
-          "nullable": true,
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
     "Client": {
       "additionalProperties": false,
       "properties": {
@@ -1189,8 +1176,8 @@ expression: "&schema"
           "nullable": true
         },
         "subgraph": {
-          "$ref": "#/definitions/Config4",
-          "description": "#/definitions/Config4",
+          "$ref": "#/definitions/Config5",
+          "description": "#/definitions/Config5",
           "nullable": true
         }
       },
@@ -1296,8 +1283,8 @@ expression: "&schema"
       "description": "Telemetry configuration",
       "properties": {
         "apollo": {
-          "$ref": "#/definitions/Config9",
-          "description": "#/definitions/Config9"
+          "$ref": "#/definitions/Config10",
+          "description": "#/definitions/Config10"
         },
         "exporters": {
           "$ref": "#/definitions/Exporters",
@@ -1396,342 +1383,6 @@ expression: "&schema"
           "$ref": "#/definitions/BatchProcessorConfig",
           "description": "#/definitions/BatchProcessorConfig"
         },
-        "enabled": {
-          "description": "Enable otlp",
-          "type": "boolean"
-        },
-        "endpoint": {
-          "$ref": "#/definitions/UriEndpoint",
-          "description": "#/definitions/UriEndpoint"
-        },
-        "grpc": {
-          "$ref": "#/definitions/GrpcExporter",
-          "description": "#/definitions/GrpcExporter"
-        },
-        "http": {
-          "$ref": "#/definitions/HttpExporter",
-          "description": "#/definitions/HttpExporter"
-        },
-        "protocol": {
-          "$ref": "#/definitions/Protocol",
-          "description": "#/definitions/Protocol"
-        },
-        "temporality": {
-          "$ref": "#/definitions/Temporality",
-          "description": "#/definitions/Temporality"
-        }
-      },
-      "required": [
-        "enabled"
-      ],
-      "type": "object"
-    },
-    "Config11": {
-      "additionalProperties": false,
-      "description": "Prometheus configuration",
-      "properties": {
-        "enabled": {
-          "default": false,
-          "description": "Set to true to enable",
-          "type": "boolean"
-        },
-        "listen": {
-          "$ref": "#/definitions/ListenAddr",
-          "description": "#/definitions/ListenAddr"
-        },
-        "path": {
-          "default": "/metrics",
-          "description": "The path where prometheus will be exposed",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "Config12": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "agent": {
-              "$ref": "#/definitions/AgentConfig",
-              "description": "#/definitions/AgentConfig"
-            },
-            "batch_processor": {
-              "$ref": "#/definitions/BatchProcessorConfig",
-              "description": "#/definitions/BatchProcessorConfig"
-            },
-            "enabled": {
-              "description": "Enable Jaeger",
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "enabled"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "batch_processor": {
-              "$ref": "#/definitions/BatchProcessorConfig",
-              "description": "#/definitions/BatchProcessorConfig"
-            },
-            "collector": {
-              "$ref": "#/definitions/CollectorConfig",
-              "description": "#/definitions/CollectorConfig"
-            },
-            "enabled": {
-              "description": "Enable Jaeger",
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "enabled"
-          ],
-          "type": "object"
-        }
-      ]
-    },
-    "Config13": {
-      "additionalProperties": false,
-      "properties": {
-        "batch_processor": {
-          "$ref": "#/definitions/BatchProcessorConfig",
-          "description": "#/definitions/BatchProcessorConfig"
-        },
-        "enabled": {
-          "description": "Enable zipkin",
-          "type": "boolean"
-        },
-        "endpoint": {
-          "$ref": "#/definitions/UriEndpoint",
-          "description": "#/definitions/UriEndpoint"
-        }
-      },
-      "required": [
-        "enabled"
-      ],
-      "type": "object"
-    },
-    "Config14": {
-      "additionalProperties": false,
-      "properties": {
-        "batch_processor": {
-          "$ref": "#/definitions/BatchProcessorConfig",
-          "description": "#/definitions/BatchProcessorConfig"
-        },
-        "enable_span_mapping": {
-          "default": true,
-          "description": "Enable datadog span mapping for span name and resource name.",
-          "type": "boolean"
-        },
-        "enabled": {
-          "description": "Enable datadog",
-          "type": "boolean"
-        },
-        "endpoint": {
-          "$ref": "#/definitions/UriEndpoint",
-          "description": "#/definitions/UriEndpoint"
-        },
-        "fixed_span_names": {
-          "default": true,
-          "description": "Fixes the span names, this means that the APM view will show the original span names in the operation dropdown.",
-          "type": "boolean"
-        },
-        "resource_mapping": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "default": {},
-          "description": "Custom mapping to be used as the resource field in spans, defaults to: router -> http.route supergraph -> graphql.operation.name query_planning -> graphql.operation.name subgraph -> subgraph.name subgraph_request -> subgraph.name http_request -> http.route",
-          "type": "object"
-        },
-        "span_metrics": {
-          "additionalProperties": {
-            "type": "boolean"
-          },
-          "default": {
-            "execution": true,
-            "http_request": true,
-            "parse_query": true,
-            "query_planning": true,
-            "request": true,
-            "router": true,
-            "subgraph": true,
-            "subgraph_request": true,
-            "supergraph": true
-          },
-          "description": "Which spans will be eligible for span stats to be collected for viewing in the APM view. Defaults to true for `request`, `router`, `query_parsing`, `supergraph`, `execution`, `query_planning`, `subgraph`, `subgraph_request` and `http_request`.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "enabled"
-      ],
-      "type": "object"
-    },
-    "Config15": {
-      "additionalProperties": false,
-      "description": "Configuration for the experimental traffic shaping plugin",
-      "properties": {
-        "all": {
-          "$ref": "#/definitions/SubgraphShaping",
-          "description": "#/definitions/SubgraphShaping",
-          "nullable": true
-        },
-        "deduplicate_variables": {
-          "default": null,
-          "description": "DEPRECATED, now always enabled: Enable variable deduplication optimization when sending requests to subgraphs (https://github.com/apollographql/router/issues/87)",
-          "nullable": true,
-          "type": "boolean"
-        },
-        "router": {
-          "$ref": "#/definitions/RouterShaping",
-          "description": "#/definitions/RouterShaping",
-          "nullable": true
-        },
-        "subgraphs": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SubgraphShaping",
-            "description": "#/definitions/SubgraphShaping"
-          },
-          "description": "Applied on specific subgraphs",
-          "type": "object"
-        }
-      },
-      "type": "object"
-    },
-    "Config2": {
-      "description": "This is a broken plugin for testing purposes only.",
-      "properties": {
-        "enabled": {
-          "description": "Enable the broken plugin.",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "enabled"
-      ],
-      "type": "object"
-    },
-    "Config3": {
-      "description": "Restricted plugin (for testing purposes only)",
-      "properties": {
-        "enabled": {
-          "description": "Enable the restricted plugin (for testing purposes only)",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "enabled"
-      ],
-      "type": "object"
-    },
-    "Config4": {
-      "additionalProperties": false,
-      "description": "Configure subgraph authentication",
-      "properties": {
-        "all": {
-          "$ref": "#/definitions/AuthConfig",
-          "description": "#/definitions/AuthConfig",
-          "nullable": true
-        },
-        "subgraphs": {
-          "additionalProperties": {
-            "$ref": "#/definitions/AuthConfig",
-            "description": "#/definitions/AuthConfig"
-          },
-          "description": "Create a configuration that will apply only to a specific subgraph.",
-          "type": "object"
-        }
-      },
-      "type": "object"
-    },
-    "Config5": {
-      "additionalProperties": false,
-      "description": "Configuration for header propagation",
-      "properties": {
-        "all": {
-          "$ref": "#/definitions/HeadersLocation",
-          "description": "#/definitions/HeadersLocation",
-          "nullable": true
-        },
-        "subgraphs": {
-          "additionalProperties": {
-            "$ref": "#/definitions/HeadersLocation",
-            "description": "#/definitions/HeadersLocation"
-          },
-          "description": "Rules to specific subgraphs",
-          "type": "object"
-        }
-      },
-      "type": "object"
-    },
-    "Config6": {
-      "additionalProperties": false,
-      "description": "Configuration for exposing errors that originate from subgraphs",
-      "properties": {
-        "all": {
-          "default": false,
-          "description": "Include errors from all subgraphs",
-          "type": "boolean"
-        },
-        "subgraphs": {
-          "additionalProperties": {
-            "type": "boolean"
-          },
-          "default": {},
-          "description": "Include errors from specific subgraphs",
-          "type": "object"
-        }
-      },
-      "type": "object"
-    },
-    "Config7": {
-      "additionalProperties": false,
-      "description": "Configuration for entity caching",
-      "properties": {
-        "enabled": {
-          "default": false,
-          "description": "Enable or disable the entity caching feature",
-          "type": "boolean"
-        },
-        "expose_keys_in_context": {
-          "default": false,
-          "description": "Expose cache keys in context",
-          "type": "boolean"
-        },
-        "invalidation": {
-          "$ref": "#/definitions/InvalidationEndpointConfig",
-          "description": "#/definitions/InvalidationEndpointConfig",
-          "nullable": true
-        },
-        "metrics": {
-          "$ref": "#/definitions/Metrics",
-          "description": "#/definitions/Metrics"
-        },
-        "subgraph": {
-          "$ref": "#/definitions/SubgraphConfiguration_for_Subgraph",
-          "description": "#/definitions/SubgraphConfiguration_for_Subgraph"
-        }
-      },
-      "required": [
-        "subgraph"
-      ],
-      "type": "object"
-    },
-    "Config8": {
-      "description": "Configuration for the progressive override plugin",
-      "type": "object"
-    },
-    "Config9": {
-      "additionalProperties": false,
-      "properties": {
-        "batch_processor": {
-          "$ref": "#/definitions/BatchProcessorConfig",
-          "description": "#/definitions/BatchProcessorConfig"
-        },
         "buffer_size": {
           "default": 10000,
           "description": "The buffer size for sending traces to Apollo. Increase this if you are experiencing lost traces.",
@@ -1799,6 +1450,361 @@ expression: "&schema"
           "description": "#/definitions/ApolloSignatureNormalizationAlgorithm"
         }
       },
+      "type": "object"
+    },
+    "Config11": {
+      "additionalProperties": false,
+      "properties": {
+        "batch_processor": {
+          "$ref": "#/definitions/BatchProcessorConfig",
+          "description": "#/definitions/BatchProcessorConfig"
+        },
+        "enabled": {
+          "description": "Enable otlp",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "$ref": "#/definitions/UriEndpoint",
+          "description": "#/definitions/UriEndpoint"
+        },
+        "grpc": {
+          "$ref": "#/definitions/GrpcExporter",
+          "description": "#/definitions/GrpcExporter"
+        },
+        "http": {
+          "$ref": "#/definitions/HttpExporter",
+          "description": "#/definitions/HttpExporter"
+        },
+        "protocol": {
+          "$ref": "#/definitions/Protocol",
+          "description": "#/definitions/Protocol"
+        },
+        "temporality": {
+          "$ref": "#/definitions/Temporality",
+          "description": "#/definitions/Temporality"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": "object"
+    },
+    "Config12": {
+      "additionalProperties": false,
+      "description": "Prometheus configuration",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Set to true to enable",
+          "type": "boolean"
+        },
+        "listen": {
+          "$ref": "#/definitions/ListenAddr",
+          "description": "#/definitions/ListenAddr"
+        },
+        "path": {
+          "default": "/metrics",
+          "description": "The path where prometheus will be exposed",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Config13": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "agent": {
+              "$ref": "#/definitions/AgentConfig",
+              "description": "#/definitions/AgentConfig"
+            },
+            "batch_processor": {
+              "$ref": "#/definitions/BatchProcessorConfig",
+              "description": "#/definitions/BatchProcessorConfig"
+            },
+            "enabled": {
+              "description": "Enable Jaeger",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "batch_processor": {
+              "$ref": "#/definitions/BatchProcessorConfig",
+              "description": "#/definitions/BatchProcessorConfig"
+            },
+            "collector": {
+              "$ref": "#/definitions/CollectorConfig",
+              "description": "#/definitions/CollectorConfig"
+            },
+            "enabled": {
+              "description": "Enable Jaeger",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Config14": {
+      "additionalProperties": false,
+      "properties": {
+        "batch_processor": {
+          "$ref": "#/definitions/BatchProcessorConfig",
+          "description": "#/definitions/BatchProcessorConfig"
+        },
+        "enabled": {
+          "description": "Enable zipkin",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "$ref": "#/definitions/UriEndpoint",
+          "description": "#/definitions/UriEndpoint"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": "object"
+    },
+    "Config15": {
+      "additionalProperties": false,
+      "properties": {
+        "batch_processor": {
+          "$ref": "#/definitions/BatchProcessorConfig",
+          "description": "#/definitions/BatchProcessorConfig"
+        },
+        "enable_span_mapping": {
+          "default": true,
+          "description": "Enable datadog span mapping for span name and resource name.",
+          "type": "boolean"
+        },
+        "enabled": {
+          "description": "Enable datadog",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "$ref": "#/definitions/UriEndpoint",
+          "description": "#/definitions/UriEndpoint"
+        },
+        "fixed_span_names": {
+          "default": true,
+          "description": "Fixes the span names, this means that the APM view will show the original span names in the operation dropdown.",
+          "type": "boolean"
+        },
+        "resource_mapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Custom mapping to be used as the resource field in spans, defaults to: router -> http.route supergraph -> graphql.operation.name query_planning -> graphql.operation.name subgraph -> subgraph.name subgraph_request -> subgraph.name http_request -> http.route",
+          "type": "object"
+        },
+        "span_metrics": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "default": {
+            "execution": true,
+            "http_request": true,
+            "parse_query": true,
+            "query_planning": true,
+            "request": true,
+            "router": true,
+            "subgraph": true,
+            "subgraph_request": true,
+            "supergraph": true
+          },
+          "description": "Which spans will be eligible for span stats to be collected for viewing in the APM view. Defaults to true for `request`, `router`, `query_parsing`, `supergraph`, `execution`, `query_planning`, `subgraph`, `subgraph_request` and `http_request`.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": "object"
+    },
+    "Config16": {
+      "additionalProperties": false,
+      "description": "Configuration for the experimental traffic shaping plugin",
+      "properties": {
+        "all": {
+          "$ref": "#/definitions/SubgraphShaping",
+          "description": "#/definitions/SubgraphShaping",
+          "nullable": true
+        },
+        "deduplicate_variables": {
+          "default": null,
+          "description": "DEPRECATED, now always enabled: Enable variable deduplication optimization when sending requests to subgraphs (https://github.com/apollographql/router/issues/87)",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "router": {
+          "$ref": "#/definitions/RouterShaping",
+          "description": "#/definitions/RouterShaping",
+          "nullable": true
+        },
+        "subgraphs": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphShaping",
+            "description": "#/definitions/SubgraphShaping"
+          },
+          "description": "Applied on specific subgraphs",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Config2": {
+      "additionalProperties": false,
+      "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions. You probably don't want this in production!\n\n## How Chaos Reloading Works\n\nThe chaos system automatically captures and replays the last known schema and configuration events to force hot reloads even when the underlying content hasn't actually changed. This is particularly useful for memory leak detection during hot reload scenarios. If configured, it will activate upon the first config event that is encountered.\n\n### Schema Reloading (`force_schema_reload`) When enabled, the router will periodically replay the last schema event with a timestamp comment injected into the SDL (e.g., `# Chaos reload timestamp: 1234567890`). This ensures the schema is seen as \"different\" and triggers a full hot reload, even though the functional schema content is identical.\n\n### Configuration Reloading (`force_config_reload`) When enabled, the router will periodically replay the last configuration event. The configuration is cloned and re-emitted, which triggers the router's configuration change detection and reload logic.\n\n### Example Usage ```yaml experimental_chaos: force_schema_reload: \"30s\"    # Trigger schema reload every 30 seconds force_config_reload: \"2m\"     # Trigger config reload every 2 minutes ```",
+      "properties": {
+        "force_config_reload": {
+          "default": null,
+          "description": "Force a hot reload of the configuration at regular intervals by replaying the last configuration event. This triggers the router's configuration change detection even when the configuration content hasn't actually changed.\n\nThe system automatically captures the last configuration event and replays it to force configuration reload processing.",
+          "nullable": true,
+          "type": "string"
+        },
+        "force_schema_reload": {
+          "default": null,
+          "description": "Force a hot reload of the schema at regular intervals by injecting a timestamp comment into the SDL. This ensures schema reloads occur even when the functional schema content hasn't changed, which is useful for testing memory leaks during schema hot reloads.\n\nThe system automatically captures the last schema event and replays it with a timestamp comment added to make it appear \"different\" to the reload detection logic.",
+          "nullable": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Config3": {
+      "description": "This is a broken plugin for testing purposes only.",
+      "properties": {
+        "enabled": {
+          "description": "Enable the broken plugin.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": "object"
+    },
+    "Config4": {
+      "description": "Restricted plugin (for testing purposes only)",
+      "properties": {
+        "enabled": {
+          "description": "Enable the restricted plugin (for testing purposes only)",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": "object"
+    },
+    "Config5": {
+      "additionalProperties": false,
+      "description": "Configure subgraph authentication",
+      "properties": {
+        "all": {
+          "$ref": "#/definitions/AuthConfig",
+          "description": "#/definitions/AuthConfig",
+          "nullable": true
+        },
+        "subgraphs": {
+          "additionalProperties": {
+            "$ref": "#/definitions/AuthConfig",
+            "description": "#/definitions/AuthConfig"
+          },
+          "description": "Create a configuration that will apply only to a specific subgraph.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Config6": {
+      "additionalProperties": false,
+      "description": "Configuration for header propagation",
+      "properties": {
+        "all": {
+          "$ref": "#/definitions/HeadersLocation",
+          "description": "#/definitions/HeadersLocation",
+          "nullable": true
+        },
+        "subgraphs": {
+          "additionalProperties": {
+            "$ref": "#/definitions/HeadersLocation",
+            "description": "#/definitions/HeadersLocation"
+          },
+          "description": "Rules to specific subgraphs",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Config7": {
+      "additionalProperties": false,
+      "description": "Configuration for exposing errors that originate from subgraphs",
+      "properties": {
+        "all": {
+          "default": false,
+          "description": "Include errors from all subgraphs",
+          "type": "boolean"
+        },
+        "subgraphs": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "default": {},
+          "description": "Include errors from specific subgraphs",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Config8": {
+      "additionalProperties": false,
+      "description": "Configuration for entity caching",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable or disable the entity caching feature",
+          "type": "boolean"
+        },
+        "expose_keys_in_context": {
+          "default": false,
+          "description": "Expose cache keys in context",
+          "type": "boolean"
+        },
+        "invalidation": {
+          "$ref": "#/definitions/InvalidationEndpointConfig",
+          "description": "#/definitions/InvalidationEndpointConfig",
+          "nullable": true
+        },
+        "metrics": {
+          "$ref": "#/definitions/Metrics",
+          "description": "#/definitions/Metrics"
+        },
+        "subgraph": {
+          "$ref": "#/definitions/SubgraphConfiguration_for_Subgraph",
+          "description": "#/definitions/SubgraphConfiguration_for_Subgraph"
+        }
+      },
+      "required": [
+        "subgraph"
+      ],
+      "type": "object"
+    },
+    "Config9": {
+      "description": "Configuration for the progressive override plugin",
       "type": "object"
     },
     "ContextForward": {
@@ -3916,12 +3922,12 @@ expression: "&schema"
           "description": "#/definitions/MetricsCommon"
         },
         "otlp": {
-          "$ref": "#/definitions/Config10",
-          "description": "#/definitions/Config10"
-        },
-        "prometheus": {
           "$ref": "#/definitions/Config11",
           "description": "#/definitions/Config11"
+        },
+        "prometheus": {
+          "$ref": "#/definitions/Config12",
+          "description": "#/definitions/Config12"
         }
       },
       "type": "object"
@@ -4206,8 +4212,8 @@ expression: "&schema"
       "additionalProperties": false,
       "properties": {
         "experimental.broken": {
-          "$ref": "#/definitions/Config2",
-          "description": "#/definitions/Config2"
+          "$ref": "#/definitions/Config3",
+          "description": "#/definitions/Config3"
         },
         "experimental.expose_query_plan": {
           "$ref": "#/definitions/ExposeQueryPlanConfig",
@@ -4218,8 +4224,8 @@ expression: "&schema"
           "description": "#/definitions/RecordConfig"
         },
         "experimental.restricted": {
-          "$ref": "#/definitions/Config3",
-          "description": "#/definitions/Config3"
+          "$ref": "#/definitions/Config4",
+          "description": "#/definitions/Config4"
         },
         "test.always_fails_to_start": {
           "$ref": "#/definitions/Conf",
@@ -7278,28 +7284,28 @@ expression: "&schema"
           "description": "#/definitions/TracingCommon"
         },
         "datadog": {
-          "$ref": "#/definitions/Config14",
-          "description": "#/definitions/Config14"
+          "$ref": "#/definitions/Config15",
+          "description": "#/definitions/Config15"
         },
         "experimental_response_trace_id": {
           "$ref": "#/definitions/ExposeTraceId",
           "description": "#/definitions/ExposeTraceId"
         },
         "jaeger": {
-          "$ref": "#/definitions/Config12",
-          "description": "#/definitions/Config12"
+          "$ref": "#/definitions/Config13",
+          "description": "#/definitions/Config13"
         },
         "otlp": {
-          "$ref": "#/definitions/Config10",
-          "description": "#/definitions/Config10"
+          "$ref": "#/definitions/Config11",
+          "description": "#/definitions/Config11"
         },
         "propagation": {
           "$ref": "#/definitions/Propagation",
           "description": "#/definitions/Propagation"
         },
         "zipkin": {
-          "$ref": "#/definitions/Config13",
-          "description": "#/definitions/Config13"
+          "$ref": "#/definitions/Config14",
+          "description": "#/definitions/Config14"
         }
       },
       "type": "object"
@@ -8321,8 +8327,8 @@ expression: "&schema"
       "description": "#/definitions/DemandControlConfig"
     },
     "experimental_chaos": {
-      "$ref": "#/definitions/Chaos",
-      "description": "#/definitions/Chaos"
+      "$ref": "#/definitions/Config2",
+      "description": "#/definitions/Config2"
     },
     "experimental_type_conditioned_fetching": {
       "default": false,
@@ -8338,8 +8344,8 @@ expression: "&schema"
       "description": "#/definitions/ForbidMutationsConfig"
     },
     "headers": {
-      "$ref": "#/definitions/Config5",
-      "description": "#/definitions/Config5"
+      "$ref": "#/definitions/Config6",
+      "description": "#/definitions/Config6"
     },
     "health_check": {
       "$ref": "#/definitions/HealthCheck",
@@ -8350,8 +8356,8 @@ expression: "&schema"
       "description": "#/definitions/Homepage"
     },
     "include_subgraph_errors": {
-      "$ref": "#/definitions/Config6",
-      "description": "#/definitions/Config6"
+      "$ref": "#/definitions/Config7",
+      "description": "#/definitions/Config7"
     },
     "limits": {
       "$ref": "#/definitions/Config",
@@ -8370,16 +8376,16 @@ expression: "&schema"
       "description": "#/definitions/Plugins"
     },
     "preview_entity_cache": {
-      "$ref": "#/definitions/Config7",
-      "description": "#/definitions/Config7"
+      "$ref": "#/definitions/Config8",
+      "description": "#/definitions/Config8"
     },
     "preview_file_uploads": {
       "$ref": "#/definitions/FileUploadsConfig",
       "description": "#/definitions/FileUploadsConfig"
     },
     "progressive_override": {
-      "$ref": "#/definitions/Config8",
-      "description": "#/definitions/Config8"
+      "$ref": "#/definitions/Config9",
+      "description": "#/definitions/Config9"
     },
     "rhai": {
       "$ref": "#/definitions/Conf7",
@@ -8410,8 +8416,8 @@ expression: "&schema"
       "description": "#/definitions/Tls"
     },
     "traffic_shaping": {
-      "$ref": "#/definitions/Config15",
-      "description": "#/definitions/Config15"
+      "$ref": "#/definitions/Config16",
+      "description": "#/definitions/Config16"
     }
   },
   "title": "Configuration",

--- a/apollo-router/src/plugins/chaos/mod.rs
+++ b/apollo-router/src/plugins/chaos/mod.rs
@@ -1,0 +1,127 @@
+//! Chaos testing plugin for the Apollo Router.
+//!
+//! This plugin provides chaos testing capabilities to help reproduce bugs that require uncommon conditions.
+//! You probably don't want this in production!
+
+use std::time::Duration;
+
+use futures::Stream;
+use futures::StreamExt;
+use futures::stream;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+pub(crate) mod reload;
+
+// Re-export reload functionality
+pub(crate) use reload::ReloadState;
+
+use crate::router::Event;
+
+/// Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions.
+/// You probably don't want this in production!
+///
+/// ## How Chaos Reloading Works
+///
+/// The chaos system automatically captures and replays the last known schema and configuration
+/// events to force hot reloads even when the underlying content hasn't actually changed. This
+/// is particularly useful for memory leak detection during hot reload scenarios.
+/// If configured, it will activate upon the first config event that is encountered.
+///
+/// ### Schema Reloading (`force_schema_reload`)
+/// When enabled, the router will periodically replay the last schema event with a timestamp
+/// comment injected into the SDL (e.g., `# Chaos reload timestamp: 1234567890`). This ensures
+/// the schema is seen as "different" and triggers a full hot reload, even though the functional
+/// schema content is identical.
+///
+/// ### Configuration Reloading (`force_config_reload`)
+/// When enabled, the router will periodically replay the last configuration event. The
+/// configuration is cloned and re-emitted, which triggers the router's configuration change
+/// detection and reload logic.
+///
+/// ### Example Usage
+/// ```yaml
+/// experimental_chaos:
+///   force_schema_reload: "30s"    # Trigger schema reload every 30 seconds
+///   force_config_reload: "2m"     # Trigger config reload every 2 minutes
+/// ```
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[serde(default)]
+pub(crate) struct Config {
+    /// Force a hot reload of the schema at regular intervals by injecting a timestamp comment
+    /// into the SDL. This ensures schema reloads occur even when the functional schema content
+    /// hasn't changed, which is useful for testing memory leaks during schema hot reloads.
+    ///
+    /// The system automatically captures the last schema event and replays it with a timestamp
+    /// comment added to make it appear "different" to the reload detection logic.
+    #[serde(with = "humantime_serde")]
+    #[schemars(with = "Option<String>")]
+    pub(crate) force_schema_reload: Option<Duration>,
+
+    /// Force a hot reload of the configuration at regular intervals by replaying the last
+    /// configuration event. This triggers the router's configuration change detection even
+    /// when the configuration content hasn't actually changed.
+    ///
+    /// The system automatically captures the last configuration event and replays it to
+    /// force configuration reload processing.
+    #[serde(with = "humantime_serde")]
+    #[schemars(with = "Option<String>")]
+    pub(crate) force_config_reload: Option<Duration>,
+}
+
+impl Config {
+    #[cfg(test)]
+    fn new(force_schema_reload: Option<Duration>, force_config_reload: Option<Duration>) -> Self {
+        Self {
+            force_schema_reload,
+            force_config_reload,
+        }
+    }
+}
+
+/// Extension trait to add chaos reload functionality to event streams.
+pub(crate) trait ChaosEventStream: Stream<Item = Event> + Sized {
+    /// Add chaos reload functionality to an event stream.
+    ///
+    /// This method wraps the event stream to automatically capture schema and configuration
+    /// events for later replay during chaos testing. The reload source will emit modified
+    /// versions of these events at configured intervals to force hot reloads.
+    ///
+    /// The chaos reload timers are automatically configured when configuration events
+    /// flow through the stream.
+    fn with_chaos_reload_state(self, reload_source: ReloadState) -> impl Stream<Item = Event> {
+        let reload_source_for_events = reload_source.clone();
+        let watched_upstream = self.map(move |event| {
+            match &event {
+                Event::UpdateSchema(schema_state) => {
+                    reload_source_for_events.update_last_schema(schema_state);
+                }
+                Event::UpdateConfiguration(config) => {
+                    // Update the reload source with the latest configuration
+                    reload_source_for_events.set_periods(&config.experimental_chaos);
+                    reload_source_for_events.update_last_configuration(config);
+                }
+                _ => {}
+            }
+            event
+        });
+
+        // Combine upstream events with reload source events
+        stream::select(watched_upstream, reload_source.into_stream())
+    }
+    /// Add chaos reload functionality to an event stream.
+    ///
+    /// This method wraps the event stream to automatically capture schema and configuration
+    /// events for later replay during chaos testing. The reload source will emit modified
+    /// versions of these events at configured intervals to force hot reloads.
+    ///
+    /// The chaos reload timers are automatically configured when configuration events
+    /// flow through the stream - no manual setup is required.
+    fn with_chaos_reload(self) -> impl Stream<Item = Event> {
+        self.with_chaos_reload_state(ReloadState::default())
+    }
+}
+
+impl<S> ChaosEventStream for S where S: Stream<Item = Event> {}

--- a/apollo-router/src/plugins/chaos/reload.rs
+++ b/apollo-router/src/plugins/chaos/reload.rs
@@ -1,0 +1,514 @@
+//! Chaos reload source for schema and configuration events.
+//!
+//! This module provides the ReloadSource for chaos testing, which automatically captures
+//! and replays schema/configuration events to force hot reloads at configurable intervals.
+
+use std::sync::Arc;
+use std::task::Poll;
+use std::time::Duration;
+
+use futures::prelude::*;
+use parking_lot::Mutex;
+use tokio_util::time::DelayQueue;
+
+use super::Config;
+use crate::configuration::Configuration;
+use crate::router::Event;
+use crate::uplink::schema::SchemaState;
+
+#[derive(Clone)]
+enum ChaosEvent {
+    Schema,
+    Configuration,
+}
+
+#[derive(Default)]
+struct ReloadStateInner {
+    queue: DelayQueue<ChaosEvent>,
+    force_schema_reload_period: Option<Duration>,
+    force_config_reload_period: Option<Duration>,
+    last_schema: Option<SchemaState>,
+    last_configuration: Option<Arc<Configuration>>,
+}
+
+/// Chaos testing event source that automatically captures and replays schema/configuration events
+/// to force hot reloads at configurable intervals.
+///
+/// This is used for memory leak detection during hot reload scenarios. The ReloadSource:
+/// 1. Automatically captures the last schema and configuration events as they flow through the system
+/// 2. Replays these events at configured intervals with modifications to ensure they're seen as "different"
+/// 3. For schema events: injects a timestamp comment into the SDL
+/// 4. For configuration events: clones and re-emits the configuration
+///
+/// The ReloadSource requires no manual setup - it automatically configures itself when the first
+/// configuration event (containing chaos settings) flows through the event stream.
+#[derive(Clone, Default)]
+pub(crate) struct ReloadState {
+    inner: Arc<Mutex<ReloadStateInner>>,
+}
+
+impl ReloadState {
+    /// Configure chaos reload periods from the router configuration.
+    /// This is called automatically when configuration events flow through the system.
+    pub(crate) fn set_periods(&self, config: &Config) {
+        let mut inner = self.inner.lock();
+        // Clear the queue before setting the periods
+        inner.queue.clear();
+
+        inner.force_schema_reload_period = config.force_schema_reload;
+        inner.force_config_reload_period = config.force_config_reload;
+
+        if let Some(period) = config.force_schema_reload {
+            inner.queue.insert(ChaosEvent::Schema, period);
+        }
+        if let Some(period) = config.force_config_reload {
+            inner.queue.insert(ChaosEvent::Configuration, period);
+        }
+    }
+
+    /// Store the most recent schema event for later replay during chaos testing.
+    /// This is called automatically when schema events flow through the system.
+    pub(crate) fn update_last_schema(&self, schema: &SchemaState) {
+        let mut inner = self.inner.lock();
+        inner.last_schema = Some(schema.clone());
+    }
+
+    /// Store the most recent configuration event for later replay during chaos testing.
+    /// This is called automatically when configuration events flow through the system.
+    pub(crate) fn update_last_configuration(&self, config: &Arc<Configuration>) {
+        let mut inner = self.inner.lock();
+        inner.last_configuration = Some(config.clone());
+    }
+
+    pub(crate) fn into_stream(self) -> impl Stream<Item = Event> {
+        futures::stream::poll_fn(move |cx| {
+            let mut inner = self.inner.lock();
+            match inner.queue.poll_expired(cx) {
+                Poll::Ready(Some(expired)) => {
+                    let event_type = expired.into_inner();
+
+                    // Re-schedule the event
+                    match &event_type {
+                        ChaosEvent::Schema => {
+                            if let Some(period) = inner.force_schema_reload_period {
+                                inner.queue.insert(ChaosEvent::Schema, period);
+                            }
+                        }
+                        ChaosEvent::Configuration => {
+                            if let Some(period) = inner.force_config_reload_period {
+                                inner.queue.insert(ChaosEvent::Configuration, period);
+                            }
+                        }
+                    }
+
+                    // Generate the appropriate event
+                    let event = match event_type {
+                        ChaosEvent::Schema => {
+                            if let Some(mut schema) = inner.last_schema.clone() {
+                                // Inject a timestamp comment into the schema SDL to make it appear "different"
+                                // This ensures the router's change detection will trigger a hot reload even
+                                // though the functional schema content is identical
+                                let timestamp = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_secs();
+                                schema.sdl = format!(
+                                    "# Chaos reload timestamp: {}\n{}",
+                                    timestamp, schema.sdl
+                                );
+                                Some(Event::UpdateSchema(schema))
+                            } else {
+                                // No schema available yet - skip this chaos event
+                                None
+                            }
+                        }
+                        ChaosEvent::Configuration => {
+                            if let Some(config) = inner.last_configuration.clone() {
+                                // Clone and re-emit the configuration to trigger reload processing
+                                // The router's change detection will process this as a new configuration event
+                                // even though the content is identical, forcing configuration reload logic
+                                let config_clone = (*config).clone();
+                                Some(Event::UpdateConfiguration(Arc::new(config_clone)))
+                            } else {
+                                // No configuration available yet - skip this chaos event
+                                None
+                            }
+                        }
+                    };
+
+                    match event {
+                        Some(event) => Poll::Ready(Some(event)),
+                        None => Poll::Pending, // Skip this event and wait for the next one
+                    }
+                }
+                // We must return pending even if the queue is empty, otherwise the stream will never be polled again
+                // The waker will still be used, so this won't end up in a hot loop.
+                Poll::Ready(None) => Poll::Pending,
+                Poll::Pending => Poll::Pending,
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use futures::pin_mut;
+
+    use super::*;
+    use crate::configuration::Configuration;
+    use crate::plugins::chaos::ChaosEventStream;
+
+    fn create_test_schema() -> SchemaState {
+        SchemaState {
+            sdl: "type Query { hello: String }".to_string(),
+            launch_id: Some("test-launch".to_string()),
+        }
+    }
+
+    fn create_test_config() -> Arc<Configuration> {
+        Arc::new(Configuration::default())
+    }
+
+    #[test]
+    fn test_reload_source_default() {
+        let source = ReloadState::default();
+        let inner = source.inner.lock();
+        assert!(inner.force_schema_reload_period.is_none());
+        assert!(inner.force_config_reload_period.is_none());
+        assert!(inner.last_schema.is_none());
+        assert!(inner.last_configuration.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_set_periods_configures_reload_intervals() {
+        let source = ReloadState::default();
+        let schema_period = Duration::from_secs(5);
+        let config_period = Duration::from_secs(10);
+
+        let chaos_config = Config::new(Some(schema_period), Some(config_period));
+        source.set_periods(&chaos_config);
+
+        let inner = source.inner.lock();
+        assert_eq!(inner.force_schema_reload_period, Some(schema_period));
+        assert_eq!(inner.force_config_reload_period, Some(config_period));
+    }
+
+    #[tokio::test]
+    async fn test_set_periods_clears_existing_queue() {
+        let source = ReloadState::default();
+
+        // Set initial periods
+        let chaos_config1 = Config::new(Some(Duration::from_secs(5)), None);
+        source.set_periods(&chaos_config1);
+
+        // Verify queue has an entry
+        assert_eq!(source.inner.lock().queue.len(), 1);
+        // Set different periods - should clear queue
+        let chaos_config2 = Config::new(None, Some(Duration::from_secs(10)));
+        source.set_periods(&chaos_config2);
+
+        let inner = source.inner.lock();
+        assert_eq!(inner.force_schema_reload_period, None);
+        assert_eq!(
+            inner.force_config_reload_period,
+            Some(Duration::from_secs(10))
+        );
+        assert_eq!(inner.queue.len(), 1);
+    }
+
+    #[test]
+    fn test_set_periods_with_none_values() {
+        let source = ReloadState::default();
+        let chaos_config = Config::new(None, None);
+
+        source.set_periods(&chaos_config);
+
+        let inner = source.inner.lock();
+        assert!(inner.force_schema_reload_period.is_none());
+        assert!(inner.force_config_reload_period.is_none());
+        assert!(inner.queue.is_empty());
+    }
+
+    #[test]
+    fn test_update_last_schema() {
+        let source = ReloadState::default();
+        let schema = create_test_schema();
+
+        // Initially no schema stored
+        {
+            let inner = source.inner.lock();
+            assert!(inner.last_schema.is_none());
+        }
+
+        // Update with schema
+        source.update_last_schema(&schema);
+
+        // Verify schema is stored
+        let inner = source.inner.lock();
+        let stored_schema = inner.last_schema.as_ref().unwrap();
+        assert_eq!(stored_schema.sdl, schema.sdl);
+        assert_eq!(stored_schema.launch_id, schema.launch_id);
+    }
+
+    #[test]
+    fn test_update_last_configuration() {
+        let source = ReloadState::default();
+        let config = create_test_config();
+
+        // Initially no configuration stored
+        {
+            let inner = source.inner.lock();
+            assert!(inner.last_configuration.is_none());
+        }
+
+        // Update with configuration
+        source.update_last_configuration(&config);
+
+        // Verify configuration is stored
+        let inner = source.inner.lock();
+        let stored_config = inner.last_configuration.as_ref().unwrap();
+        assert!(Arc::ptr_eq(stored_config, &config));
+    }
+
+    #[test]
+    fn test_update_methods_replace_previous_values() {
+        let source = ReloadState::default();
+
+        // Set initial schema and config
+        let schema1 = create_test_schema();
+        let config1 = create_test_config();
+        source.update_last_schema(&schema1);
+        source.update_last_configuration(&config1);
+
+        // Create new schema and config
+        let mut schema2 = create_test_schema();
+        schema2.sdl = "type Query { goodbye: String }".to_string();
+        schema2.launch_id = Some("new-launch".to_string());
+        let config2 = Arc::new(Configuration::default());
+
+        // Update with new values
+        source.update_last_schema(&schema2);
+        source.update_last_configuration(&config2);
+
+        // Verify new values are stored
+        let inner = source.inner.lock();
+        let stored_schema = inner.last_schema.as_ref().unwrap();
+        assert_eq!(stored_schema.sdl, schema2.sdl);
+        assert_eq!(stored_schema.launch_id, schema2.launch_id);
+
+        let stored_config = inner.last_configuration.as_ref().unwrap();
+        assert!(Arc::ptr_eq(stored_config, &config2));
+        assert!(!Arc::ptr_eq(stored_config, &config1));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stream_with_no_chaos_periods_is_empty() {
+        let source = ReloadState::default();
+        let mut stream = source.into_stream();
+
+        // Stream should not produce events without periods configured
+        let result = tokio::time::timeout(Duration::from_millis(50), stream.next()).await;
+        assert!(result.is_err()); // Timeout expected
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stream_skips_events_when_no_data_available() {
+        let source = ReloadState::default();
+        let chaos_config = Config::new(Some(Duration::from_millis(10)), None);
+        source.set_periods(&chaos_config);
+
+        let mut stream = source.into_stream();
+
+        // Stream should not produce events since no schema is stored
+        let result = tokio::time::timeout(Duration::from_millis(50), stream.next()).await;
+        assert!(result.is_err()); // Timeout expected
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_schema_reload_stream_generates_events() {
+        let source = ReloadState::default();
+        let schema = create_test_schema();
+        source.update_last_schema(&schema);
+
+        let chaos_config = Config::new(Some(Duration::from_millis(10)), None);
+        source.set_periods(&chaos_config);
+
+        let mut stream = source.into_stream();
+
+        // Should get a schema reload event
+        let event = tokio::time::timeout(Duration::from_millis(100), stream.next())
+            .await
+            .expect("Should receive event within timeout")
+            .expect("Stream should produce an event");
+
+        match event {
+            Event::UpdateSchema(reloaded_schema) => {
+                // Should contain timestamp comment
+                assert!(reloaded_schema.sdl.contains("# Chaos reload timestamp:"));
+                assert!(reloaded_schema.sdl.contains(&schema.sdl));
+                assert_eq!(reloaded_schema.launch_id, schema.launch_id);
+            }
+            _ => panic!("Expected UpdateSchema event, got {:?}", event),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_config_reload_stream_generates_events() {
+        let source = ReloadState::default();
+        let config = create_test_config();
+        source.update_last_configuration(&config);
+
+        let chaos_config = Config::new(None, Some(Duration::from_millis(10)));
+        source.set_periods(&chaos_config);
+
+        let mut stream = source.into_stream();
+
+        // Should get a config reload event
+        let event = tokio::time::timeout(Duration::from_millis(100), stream.next())
+            .await
+            .expect("Should receive event within timeout")
+            .expect("Stream should produce an event");
+
+        match event {
+            Event::UpdateConfiguration(reloaded_config) => {
+                // Should be a clone of the original config (different Arc but same contents)
+                assert!(!Arc::ptr_eq(&reloaded_config, &config));
+            }
+            _ => panic!("Expected UpdateConfiguration event, got {:?}", event),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_reloadable_event_stream_captures_schema_events() {
+        let reload_source = ReloadState::default();
+        let schema = create_test_schema();
+        let schema_event = Event::UpdateSchema(schema.clone());
+
+        let upstream = futures::stream::once(async move { schema_event });
+        let stream = upstream.with_chaos_reload_state(reload_source.clone());
+        pin_mut!(stream);
+
+        // Get the upstream event
+        let event = stream.next().await.unwrap();
+        match event {
+            Event::UpdateSchema(received_schema) => {
+                assert_eq!(received_schema.sdl, schema.sdl);
+                assert_eq!(received_schema.launch_id, schema.launch_id);
+            }
+            _ => panic!("Expected UpdateSchema event"),
+        }
+
+        // Verify the schema was captured by reload source
+        let inner = reload_source.inner.lock();
+        let stored_schema = inner.last_schema.as_ref().unwrap();
+        assert_eq!(stored_schema.sdl, schema.sdl);
+        assert_eq!(stored_schema.launch_id, schema.launch_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_reloadable_event_stream_configures_and_captures_config_events() {
+        let reload_source = ReloadState::default();
+        let config = Configuration {
+            experimental_chaos: Config::new(Some(Duration::from_secs(30)), None),
+            ..Default::default()
+        };
+        let config_arc = Arc::new(config);
+        let config_event = Event::UpdateConfiguration(config_arc.clone());
+
+        let upstream = futures::stream::once(async move { config_event });
+        let stream = upstream.with_chaos_reload_state(reload_source.clone());
+        pin_mut!(stream);
+
+        // Get the upstream event
+        let event = stream.next().await.unwrap();
+        match event {
+            Event::UpdateConfiguration(received_config) => {
+                assert!(Arc::ptr_eq(&received_config, &config_arc));
+            }
+            _ => panic!("Expected UpdateConfiguration event"),
+        }
+
+        // Verify the configuration was captured and periods were set
+        let inner = reload_source.inner.lock();
+        let stored_config = inner.last_configuration.as_ref().unwrap();
+        assert!(Arc::ptr_eq(stored_config, &config_arc));
+        assert_eq!(
+            inner.force_schema_reload_period,
+            Some(Duration::from_secs(30))
+        );
+        assert!(inner.force_config_reload_period.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_reloadable_event_stream_ignores_other_events() {
+        let reload_source = ReloadState::default();
+        let other_event = Event::NoMoreSchema;
+
+        let upstream = futures::stream::once(async move { other_event });
+        let stream = upstream.with_chaos_reload_state(reload_source.clone());
+        pin_mut!(stream);
+
+        // Get the upstream event
+        let event = stream.next().await.unwrap();
+        match event {
+            Event::NoMoreSchema => {
+                // Expected - this should pass through unchanged
+            }
+            _ => panic!("Expected NoMoreSchema event"),
+        }
+
+        // Verify no data was captured
+        let inner = reload_source.inner.lock();
+        assert!(inner.last_schema.is_none());
+        assert!(inner.last_configuration.is_none());
+        assert!(inner.force_schema_reload_period.is_none());
+        assert!(inner.force_config_reload_period.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_reloadable_event_stream_merges_upstream_and_chaos_events() {
+        let reload_source = ReloadState::default();
+        let schema = create_test_schema();
+        reload_source.update_last_schema(&schema);
+
+        let chaos_config = Config::new(Some(Duration::from_millis(10)), None);
+        reload_source.set_periods(&chaos_config);
+
+        // Create upstream with a single event, then end
+        let schema_event = Event::UpdateSchema(schema.clone());
+        let upstream = futures::stream::once(async move { schema_event });
+
+        let stream = upstream.with_chaos_reload_state(reload_source);
+        pin_mut!(stream);
+
+        // Should get the original upstream event first
+        let first_event = stream.next().await.unwrap();
+        match first_event {
+            Event::UpdateSchema(received_schema) => {
+                // This should be the original schema without timestamp
+                assert_eq!(received_schema.sdl, schema.sdl);
+                assert!(!received_schema.sdl.contains("# Chaos reload timestamp:"));
+            }
+            _ => panic!("Expected UpdateSchema event"),
+        }
+
+        // Should then get chaos reload events
+        let second_event = tokio::time::timeout(Duration::from_millis(100), stream.next())
+            .await
+            .expect("Should receive chaos event within timeout")
+            .expect("Stream should produce an event");
+
+        match second_event {
+            Event::UpdateSchema(chaos_schema) => {
+                // This should contain the timestamp comment
+                assert!(chaos_schema.sdl.contains("# Chaos reload timestamp:"));
+                assert!(chaos_schema.sdl.contains(&schema.sdl));
+            }
+            _ => panic!("Expected UpdateSchema chaos event"),
+        }
+    }
+}

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -23,6 +23,7 @@ macro_rules! schemar_fn {
 pub(crate) mod authentication;
 pub(crate) mod authorization;
 pub(crate) mod cache;
+pub(crate) mod chaos;
 mod coprocessor;
 pub(crate) mod csrf;
 mod demand_control;

--- a/apollo-router/src/router/event/mod.rs
+++ b/apollo-router/src/router/event/mod.rs
@@ -1,15 +1,15 @@
 mod configuration;
 mod license;
-mod reload;
+pub(crate) mod reload;
 mod schema;
 mod shutdown;
 
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::sync::Arc;
 
 pub use configuration::ConfigurationSource;
 pub use license::LicenseSource;
-pub(crate) use reload::ReloadSource;
 pub use schema::SchemaSource;
 pub use shutdown::ShutdownSource;
 
@@ -28,7 +28,7 @@ use crate::uplink::schema::SchemaState;
 /// Messages that are broadcast across the app.
 pub(crate) enum Event {
     /// The configuration was updated.
-    UpdateConfiguration(Configuration),
+    UpdateConfiguration(Arc<Configuration>),
 
     /// There are no more updates to the configuration
     NoMoreConfiguration,

--- a/apollo-router/src/router/event/reload.rs
+++ b/apollo-router/src/router/event/reload.rs
@@ -1,36 +1,15 @@
-use std::sync::Arc;
-use std::sync::Mutex;
+#[cfg(unix)]
 use std::task::Poll;
-use std::time::Duration;
 
 use futures::prelude::*;
-use tokio_util::time::DelayQueue;
 
 use crate::router::Event;
 
-#[derive(Default)]
-struct ReloadSourceInner {
-    queue: DelayQueue<()>,
-    period: Option<Duration>,
-}
-
-/// Reload source is an internal event emitter for the state machine that will send reload events on SIGUP and/or on a timer.
+/// Reload source is an internal event emitter for the state machine that will send reload events on SIGHUP
 #[derive(Clone, Default)]
-pub(crate) struct ReloadSource {
-    inner: Arc<Mutex<ReloadSourceInner>>,
-}
+pub(crate) struct ReloadSource;
 
 impl ReloadSource {
-    pub(crate) fn set_period(&self, period: &Option<Duration>) {
-        let mut inner = self.inner.lock().unwrap();
-        // Clear the queue before setting the period
-        inner.queue.clear();
-        inner.period = *period;
-        if let Some(period) = period {
-            inner.queue.insert((), *period);
-        }
-    }
-
     pub(crate) fn into_stream(self) -> impl Stream<Item = Event> {
         #[cfg(unix)]
         let signal_stream = {
@@ -47,22 +26,18 @@ impl ReloadSource {
         #[cfg(not(unix))]
         let signal_stream = futures::stream::empty().boxed();
 
-        let periodic_reload = futures::stream::poll_fn(move |cx| {
-            let mut inner = self.inner.lock().unwrap();
-            match inner.queue.poll_expired(cx) {
-                Poll::Ready(Some(_expired)) => {
-                    if let Some(period) = inner.period {
-                        inner.queue.insert((), period);
-                    }
-                    Poll::Ready(Some(Event::Reload))
-                }
-                // We must return pending even if the queue is empty, otherwise the stream will never be polled again
-                // The waker will still be used, so this won't end up in a hot loop.
-                Poll::Ready(None) => Poll::Pending,
-                Poll::Pending => Poll::Pending,
-            }
-        });
-
-        futures::stream::select(signal_stream, periodic_reload)
+        signal_stream
     }
 }
+
+/// Extension trait to add chaos reload functionality to event streams.
+///
+/// This trait provides the `.with_sighub_reload()` method that automatically triggers a reload event when SIGHUP is received.
+pub(crate) trait ReloadableEventStream: Stream<Item = Event> + Sized {
+    /// Adds sighub reload to the event stream.
+    fn with_sighup_reload(self) -> impl Stream<Item = Event> {
+        stream::select(self, ReloadSource.into_stream())
+    }
+}
+
+impl<S> ReloadableEventStream for S where S: Stream<Item = Event> {}

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -564,7 +564,7 @@ where
             state = match event {
                 UpdateConfiguration(configuration) => {
                     state
-                        .update_inputs(&mut self, None, Some(Arc::new(configuration)), None)
+                        .update_inputs(&mut self, None, Some(configuration), None)
                         .await
                 }
                 NoMoreConfiguration => state.no_more_configuration().await,
@@ -716,11 +716,11 @@ mod tests {
             Err(NoLicense)
         );
     }
-    fn test_config_restricted() -> Configuration {
+    fn test_config_restricted() -> Arc<Configuration> {
         let mut config = Configuration::builder().build().unwrap();
         config.validated_yaml =
             Some(json!({"plugins":{"experimental.restricted":{"enabled":true}}}));
-        config
+        config.into()
     }
 
     #[test(tokio::test)]
@@ -846,7 +846,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(example_schema()),
                     UpdateLicense(LicenseState::Unlicensed),
                     UpdateConfiguration(test_config_restricted()),
@@ -890,7 +890,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(example_schema()),
                     UpdateLicense(LicenseState::default()),
                     Shutdown
@@ -912,7 +912,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(SchemaState {
                         sdl: minimal_schema.to_owned(),
                         launch_id: None
@@ -938,7 +938,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(SchemaState {
                         sdl: minimal_schema.to_owned(),
                         launch_id: None
@@ -967,7 +967,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(SchemaState {
                         sdl: minimal_schema.to_owned(),
                         launch_id: None
@@ -993,7 +993,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(example_schema()),
                     UpdateLicense(LicenseState::default()),
                     UpdateConfiguration(
@@ -1005,6 +1005,7 @@ mod tests {
                             )
                             .build()
                             .unwrap()
+                            .into()
                     ),
                     Shutdown
                 ])
@@ -1025,7 +1026,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(example_schema()),
                     UpdateLicense(LicenseState::default()),
                     Shutdown
@@ -1052,7 +1053,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(example_schema()),
                     UpdateLicense(LicenseState::default()),
                 ])
@@ -1091,7 +1092,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(example_schema()),
                     UpdateLicense(LicenseState::default()),
                     UpdateSchema(SchemaState {
@@ -1146,7 +1147,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    UpdateConfiguration(Configuration::builder().build().unwrap()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().into()),
                     UpdateSchema(example_schema()),
                     UpdateLicense(LicenseState::default()),
                     UpdateConfiguration(
@@ -1154,6 +1155,7 @@ mod tests {
                             .homepage(Homepage::builder().enabled(true).build())
                             .build()
                             .unwrap()
+                            .into()
                     ),
                     UpdateSchema(SchemaState {
                         sdl: minimal_schema.to_owned(),

--- a/apollo-router/src/uplink/schema.rs
+++ b/apollo-router/src/uplink/schema.rs
@@ -2,7 +2,7 @@ use std::convert::Infallible;
 use std::str::FromStr;
 
 /// Represents the new state of a schema after an update.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub(crate) struct SchemaState {
     pub(crate) sdl: String,
     pub(crate) launch_id: Option<String>,

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -138,18 +138,35 @@ async fn test_graceful_shutdown() -> Result<(), BoxError> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_force_reload() -> Result<(), BoxError> {
+async fn test_force_config_reload_via_chaos() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(
             "experimental_chaos:
-                force_reload: 1s",
+                force_config_reload: 1s",
         )
         .build()
         .await;
     router.start().await;
     router.assert_started().await;
     tokio::time::sleep(Duration::from_secs(2)).await;
-    router.assert_no_reload_necessary().await;
+    router.assert_reloaded().await;
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_force_schema_reload_via_chaos() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(
+            "experimental_chaos:
+                force_schema_reload: 1s",
+        )
+        .build()
+        .await;
+    router.start().await;
+    router.assert_started().await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    router.assert_reloaded().await;
     router.graceful_shutdown().await;
     Ok(())
 }


### PR DESCRIPTION
The experimental chaos plugin was not actually useful because the router detects that a schema reload event is the same as the last seen schema and skips reloading.

This PR fixes and enhances the chaos plugin so that we can actually use it for testing.

Changes:
- Split out chaos reload and sighup reload into separate units of functionality.
- Chaos plugin:
  - Fix ineffective schema reload.
  - Add force_schema_reload and force_config_reload with independent timers
  - Automatically capture and replay events with modifications to force reloads:
    - Schema events: inject timestamp comments into SDL
    - Config events: clone and re-emit configuration

As experimental chaos is not officially supported there is no changeset, documentation and the config is allowed to have breaking changes.



---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #8083 done by [Mergify](https://mergify.com).