### PR TITLE
update router metric names (underscore -> dot separator) in docs

### DIFF
--- a/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/routing/observability/telemetry/instrumentation/standard-instruments.mdx
@@ -128,13 +128,13 @@ The `apollo.router.cache.redis.errors` metric also includes an `error_type` attr
 
 </Tip>
 
-- `apollo_router_uplink_fetch_duration_seconds` - Uplink request duration, attributes:
+- `apollo.router.uplink.fetch.duration.seconds` - Uplink request duration, attributes:
   - `url`: The Uplink URL that was polled
   - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `License`)
   - `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`)
   - `code`: The error code depending on type (if an error occurred)
   - `error`: The error message (if an error occurred)
-- `apollo_router_uplink_fetch_count_total`
+- `apollo.router.uplink.fetch.count.total`
   - `status`: (`success`, `failure`)
   - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `License`)
 


### PR DESCRIPTION
see [DXM-215](https://apollographql.atlassian.net/browse/DXM-215)


[DXM-215]: https://apollographql.atlassian.net/browse/DXM-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ