### PR TITLE
dep(composition/preview) bump up apollo-compiler to 1.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "1.28.0"
+apollo-compiler = "1.29.0"
 apollo-parser = "0.8.4"
 apollo-smith = "0.15.0"
 async-trait = "0.1.77"


### PR DESCRIPTION
`apollo-compiler` 1.29 has a few bug fixes and a new feature that will be used by composition.