### PR TITLE
ci: beefier windows machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,14 +72,14 @@ executors:
   windows_build: &windows_build_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
-    resource_class: windows.xlarge
+    resource_class: windows.2xlarge
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
   windows_test: &windows_test_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
-    resource_class: windows.xlarge
+    resource_class: windows.2xlarge
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows


### PR DESCRIPTION
We have a lot of OOMs happening on windows CI. the easiest way to fix it would seem to be to just download a bunch more ram.

https://www.youtube.com/watch?v=MbclRNm_ANY
