### PR TITLE
Bump to Rust 1.88

### DIFF
--- a/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
+++ b/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
@@ -76,7 +76,7 @@ pub(super) fn shareable_field_non_intersecting_runtime_types_error(
                 human_readable_list(
                     runtime_types
                         .iter()
-                        .map(|runtime_type| format!("\"{}\"", runtime_type)),
+                        .map(|runtime_type| format!("\"{runtime_type}\"")),
                     HumanReadableListOptions {
                         prefix: Some(HumanReadableListPrefix {
                             singular: "type",

--- a/apollo-federation/src/connectors/expand/carryover.rs
+++ b/apollo-federation/src/connectors/expand/carryover.rs
@@ -473,7 +473,7 @@ impl Link {
 
                                 if let Some(alias) = &i.alias {
                                     let alias = if i.is_directive {
-                                        format!("@{}", alias)
+                                        format!("@{alias}")
                                     } else {
                                         alias.to_string()
                                     };

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -1139,7 +1139,6 @@ impl ApplyToInternal for SubSelection {
 
         // The SubSelection rebinds the $ variable to the selected input object,
         // so we can ignore _previous_dollar_shape.
-        #[expect(clippy::redundant_clone)]
         let dollar_shape = input_shape.clone();
 
         // Build up the merged object shape using Shape::all to merge the

--- a/apollo-federation/src/connectors/json_selection/fixtures.rs
+++ b/apollo-federation/src/connectors/json_selection/fixtures.rs
@@ -15,7 +15,7 @@ impl FromStr for Namespace {
         match s {
             "$args" => Ok(Self::Args),
             "$this" => Ok(Self::This),
-            _ => Err(format!("Unknown variable namespace: {}", s)),
+            _ => Err(format!("Unknown variable namespace: {s}")),
         }
     }
 }

--- a/apollo-federation/src/connectors/json_selection/helpers.rs
+++ b/apollo-federation/src/connectors/json_selection/helpers.rs
@@ -221,7 +221,7 @@ mod tests {
                     assert_eq!(*remainder.fragment(), exp_remainder);
                     assert_eq!(*parsed.as_ref(), exp_spaces);
                 }
-                Err(e) => panic!("error: {:?}", e),
+                Err(e) => panic!("error: {e:?}"),
             }
         }
 

--- a/apollo-federation/src/connectors/json_selection/lit_expr.rs
+++ b/apollo-federation/src/connectors/json_selection/lit_expr.rs
@@ -474,7 +474,7 @@ mod tests {
                 assert!(span_is_all_spaces_or_comments(remainder));
                 assert_eq!(parsed.strip_ranges(), WithRange::new(expected, None));
             }
-            Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
+            Err(e) => panic!("Failed to parse '{input}': {e:?}"),
         };
     }
 
@@ -826,7 +826,7 @@ mod tests {
                     assert_eq!(parsed.pretty_print_with_indentation(true, 0), input);
                     assert_eq!(expected_inline, input);
                 }
-                Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
+                Err(e) => panic!("Failed to parse '{input}': {e:?}"),
             };
         }
 
@@ -1158,11 +1158,10 @@ mod tests {
         let err = result.expect_err("Expected parse error for mixed operators ?? and ?!");
 
         // Verify the error message contains information about mixed operators
-        let error_msg = format!("{:?}", err);
+        let error_msg = format!("{err:?}");
         assert!(
             error_msg.contains("Found mixed operators ?? and ?!"),
-            "Expected mixed operators error message, got: {}",
-            error_msg
+            "Expected mixed operators error message, got: {error_msg}"
         );
     }
 
@@ -1173,7 +1172,7 @@ mod tests {
                 assert!(span_is_all_spaces_or_comments(remainder));
                 assert_eq!(parsed.strip_ranges(), WithRange::new(expected, None));
             }
-            Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
+            Err(e) => panic!("Failed to parse '{input}': {e:?}"),
         }
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/join_not_null.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/join_not_null.rs
@@ -229,7 +229,7 @@ mod tests {
         #[case] expected: JSON,
     ) {
         assert_eq!(
-            selection!(&format!("$->joinNotNull('{}')", separator)).apply_to(&input),
+            selection!(&format!("$->joinNotNull('{separator}')")).apply_to(&input),
             (Some(expected), vec![]),
         );
     }

--- a/apollo-federation/src/connectors/json_selection/methods/public/or.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/or.rs
@@ -202,7 +202,7 @@ mod method_tests {
             "a": true,
         }));
 
-        println!("result: {:?}", result);
+        println!("result: {result:?}");
 
         assert_eq!(result.0, None);
         assert!(!result.1.is_empty());

--- a/apollo-federation/src/connectors/json_selection/mod.rs
+++ b/apollo-federation/src/connectors/json_selection/mod.rs
@@ -78,7 +78,7 @@ mod test {
         let (result, errors) = JSONSelection::parse_with_spec(selection, version)
             .unwrap()
             .apply_to(&data);
-        println!("errors: {:?}", errors);
+        println!("errors: {errors:?}");
         assert!(errors.is_empty());
         assert_eq!(result, expected);
     }

--- a/apollo-federation/src/connectors/json_selection/parser.rs
+++ b/apollo-federation/src/connectors/json_selection/parser.rs
@@ -3996,9 +3996,7 @@ mod tests {
             );
             assert_debug_snapshot!(selection);
         } else {
-            panic!(
-                "Expected a valid selection, got error: {a_plus_b_plus_c:?}"
-            );
+            panic!("Expected a valid selection, got error: {a_plus_b_plus_c:?}");
         }
     }
 
@@ -4019,16 +4017,12 @@ mod tests {
                     }
                 },
                 |path| {
-                    panic!(
-                        "Expected any number of named selections, got path: {path:?}"
-                    );
+                    panic!("Expected any number of named selections, got path: {path:?}");
                 },
             );
             assert_debug_snapshot!(selection);
         } else {
-            panic!(
-                "Expected a valid selection, got error: {sum_a_plus_b_plus_c:?}"
-            );
+            panic!("Expected a valid selection, got error: {sum_a_plus_b_plus_c:?}");
         }
     }
 

--- a/apollo-federation/src/connectors/json_selection/parser.rs
+++ b/apollo-federation/src/connectors/json_selection/parser.rs
@@ -2560,8 +2560,7 @@ mod tests {
             match PathSelection::parse(new_span_with_spec(input, ConnectSpec::latest())) {
                 Ok((remainder, path)) => {
                     panic!(
-                        "Expected error at offset {} with message '{}', but got path {:?} and remainder {:?}",
-                        expected_offset, expected_message, path, remainder,
+                        "Expected error at offset {expected_offset} with message '{expected_message}', but got path {path:?} and remainder {remainder:?}",
                     );
                 }
                 Err(nom::Err::Error(e) | nom::Err::Failure(e)) => {
@@ -2578,7 +2577,7 @@ mod tests {
                     );
                 }
                 Err(e) => {
-                    panic!("Unexpected error {:?}", e);
+                    panic!("Unexpected error {e:?}");
                 }
             }
         }
@@ -3704,7 +3703,7 @@ mod tests {
         let mul_with_dollars = selection!("a->mul($.b, $.c)", spec);
         mul_with_dollars.if_named_else_path(
             |named| {
-                panic!("Expected a path selection, got named: {:?}", named);
+                panic!("Expected a path selection, got named: {named:?}");
             },
             |path| {
                 assert_eq!(path.get_single_key(), None);
@@ -3969,7 +3968,7 @@ mod tests {
         let mul_with_dollars = selection!("a->mul($.b, $.c)", spec);
         mul_with_dollars.if_named_else_path(
             |named| {
-                panic!("Expected a path selection, got named: {:?}", named);
+                panic!("Expected a path selection, got named: {named:?}");
             },
             |path| {
                 assert_eq!(path.get_single_key(), None);
@@ -3988,7 +3987,7 @@ mod tests {
         if let Ok(selection) = a_plus_b_plus_c {
             selection.if_named_else_path(
                 |named| {
-                    panic!("Expected a path selection, got named: {:?}", named);
+                    panic!("Expected a path selection, got named: {named:?}");
                 },
                 |path| {
                     assert_eq!(path.pretty_print(), "a->add(b, c)");
@@ -3998,8 +3997,7 @@ mod tests {
             assert_debug_snapshot!(selection);
         } else {
             panic!(
-                "Expected a valid selection, got error: {:?}",
-                a_plus_b_plus_c
+                "Expected a valid selection, got error: {a_plus_b_plus_c:?}"
             );
         }
     }
@@ -4022,16 +4020,14 @@ mod tests {
                 },
                 |path| {
                     panic!(
-                        "Expected any number of named selections, got path: {:?}",
-                        path
+                        "Expected any number of named selections, got path: {path:?}"
                     );
                 },
             );
             assert_debug_snapshot!(selection);
         } else {
             panic!(
-                "Expected a valid selection, got error: {:?}",
-                sum_a_plus_b_plus_c
+                "Expected a valid selection, got error: {sum_a_plus_b_plus_c:?}"
             );
         }
     }

--- a/apollo-federation/src/connectors/runtime/debug.rs
+++ b/apollo-federation/src/connectors/runtime/debug.rs
@@ -76,7 +76,7 @@ impl ConnectorContext {
                         .collect(),
                     body: ConnectorDebugBody {
                         kind: "invalid".to_string(),
-                        content: format!("{:?}", body).into(),
+                        content: format!("{body:?}").into(),
                         selection: None,
                     },
                     errors: if error_settings.message.is_some()

--- a/apollo-federation/src/connectors/spec/connect.rs
+++ b/apollo-federation/src/connectors/spec/connect.rs
@@ -369,8 +369,7 @@ impl TryFrom<(&ObjectNode, &Name, ConnectSpec)> for ConnectHTTPArguments {
             } else if name == PATH_ARGUMENT_NAME.as_str() {
                 let value = value.as_str().ok_or_else(|| {
                     FederationError::internal(format!(
-                        "`{}` field in `@{directive_name}` directive's `http` field is not a string",
-                        PATH_ARGUMENT_NAME
+                        "`{PATH_ARGUMENT_NAME}` field in `@{directive_name}` directive's `http` field is not a string"
                     ))
                 })?;
                 path = Some(
@@ -380,8 +379,7 @@ impl TryFrom<(&ObjectNode, &Name, ConnectSpec)> for ConnectHTTPArguments {
             } else if name == QUERY_PARAMS_ARGUMENT_NAME.as_str() {
                 let value = value.as_str().ok_or_else(|| {
                     FederationError::internal(format!(
-                        "`{}` field in `@{directive_name}` directive's `http` field is not a string",
-                        QUERY_PARAMS_ARGUMENT_NAME
+                        "`{QUERY_PARAMS_ARGUMENT_NAME}` field in `@{directive_name}` directive's `http` field is not a string"
                     ))
                 })?;
                 query_params = Some(

--- a/apollo-federation/src/connectors/spec/source.rs
+++ b/apollo-federation/src/connectors/spec/source.rs
@@ -164,8 +164,7 @@ impl SourceHTTPArguments {
             if name == PATH_ARGUMENT_NAME.as_str() {
                 let value = value.as_str().ok_or_else(|| {
                     FederationError::internal(format!(
-                        "`{}` field in `@{directive_name}` directive's `http.path` field is not a string",
-                        PATH_ARGUMENT_NAME
+                        "`{PATH_ARGUMENT_NAME}` field in `@{directive_name}` directive's `http.path` field is not a string"
                     ))
                 })?;
                 path = Some(
@@ -174,8 +173,7 @@ impl SourceHTTPArguments {
                 );
             } else if name == QUERY_PARAMS_ARGUMENT_NAME.as_str() {
                 let value = value.as_str().ok_or_else(|| FederationError::internal(format!(
-                    "`{}` field in `@{directive_name}` directive's `http.queryParams` field is not a string",
-                    QUERY_PARAMS_ARGUMENT_NAME
+                    "`{QUERY_PARAMS_ARGUMENT_NAME}` field in `@{directive_name}` directive's `http.queryParams` field is not a string"
                 )))?;
                 query = Some(
                     JSONSelection::parse_with_spec(value, spec)

--- a/apollo-federation/src/connectors/string_template.rs
+++ b/apollo-federation/src/connectors/string_template.rs
@@ -199,7 +199,7 @@ impl StringTemplate {
             PathAndQuery::from_str(result.as_ref()).map(Uri::from)
         }
         .map_err(|err| Error {
-            message: format!("Invalid URI: {}", err),
+            message: format!("Invalid URI: {err}"),
             location: 0..result.as_ref().len(),
         })?;
 
@@ -213,8 +213,8 @@ impl Display for StringTemplate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for part in &self.parts {
             match part {
-                Part::Constant(Constant { value, .. }) => write!(f, "{}", value)?,
-                Part::Expression(Expression { expression, .. }) => write!(f, "{{{}}}", expression)?,
+                Part::Constant(Constant { value, .. }) => write!(f, "{value}")?,
+                Part::Expression(Expression { expression, .. }) => write!(f, "{{{expression}}}")?,
             }
         }
         Ok(())

--- a/apollo-federation/src/correctness/mod.rs
+++ b/apollo-federation/src/correctness/mod.rs
@@ -42,7 +42,7 @@ impl fmt::Display for CorrectnessError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CorrectnessError::FederationError(err) => {
-                write!(f, "Correctness check failed to complete: {}", err)
+                write!(f, "Correctness check failed to complete: {err}")
             }
             CorrectnessError::ComparisonError(err) => {
                 write!(f, "Correctness error found:\n{}", err.description())

--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -52,8 +52,8 @@ impl AnalysisError {
 impl fmt::Display for AnalysisErrorMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AnalysisErrorMessage::FederationError(err) => write!(f, "{}", err),
-            AnalysisErrorMessage::QueryPlanError(err) => write!(f, "{}", err),
+            AnalysisErrorMessage::FederationError(err) => write!(f, "{err}"),
+            AnalysisErrorMessage::QueryPlanError(err) => write!(f, "{err}"),
         }
     }
 }

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -1346,8 +1346,8 @@ impl fmt::Display for Clause {
                     write!(f, " ∧ ")?;
                 }
                 match l {
-                    Literal::Pos(v) => write!(f, "{}", v)?,
-                    Literal::Neg(v) => write!(f, "¬{}", v)?,
+                    Literal::Pos(v) => write!(f, "{v}")?,
+                    Literal::Neg(v) => write!(f, "¬{v}")?,
                 }
             }
             Ok(())
@@ -1433,7 +1433,7 @@ impl PossibleDefinitions {
         for (type_condition, per_type_cond) in &self.0 {
             for variant in &per_type_cond.conditional_variants {
                 let field_display = &variant.representative_field;
-                let type_cond_str = format!(" on {}", type_condition);
+                let type_cond_str = format!(" on {type_condition}");
                 let boolean_str = if !variant.boolean_clause.is_always_true() {
                     format!(" if {}", variant.boolean_clause)
                 } else {
@@ -1478,7 +1478,7 @@ impl ResponseShape {
                 for variant in &per_type_cond.conditional_variants {
                     let field_display = &variant.representative_field;
                     let type_cond_str = if has_type_cond {
-                        format!(" on {}", type_condition)
+                        format!(" on {type_condition}")
                     } else {
                         "".to_string()
                     };

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -1297,8 +1297,7 @@ static FIELDS_HAS_ARGS: LazyLock<ErrorCodeCategory<String>> = LazyLock::new(|| {
         "FIELDS_HAS_ARGS".to_owned(),
         Box::new(|directive| {
             format!(
-                "The `fields` argument of a `@{}` directive includes a field defined with arguments (which is not currently supported).",
-                directive
+                "The `fields` argument of a `@{directive}` directive includes a field defined with arguments (which is not currently supported)."
             )
         }),
         None,
@@ -1317,8 +1316,7 @@ static DIRECTIVE_FIELDS_MISSING_EXTERNAL: LazyLock<ErrorCodeCategory<String>> = 
             "FIELDS_MISSING_EXTERNAL".to_owned(),
             Box::new(|directive| {
                 format!(
-                    "The `fields` argument of a `@{}` directive includes a field that is not marked as `@external`.",
-                    directive
+                    "The `fields` argument of a `@{directive}` directive includes a field that is not marked as `@external`."
                 )
             }),
             Some(ErrorCodeMetadata {
@@ -1345,8 +1343,7 @@ static DIRECTIVE_UNSUPPORTED_ON_INTERFACE: LazyLock<ErrorCodeCategory<String>> =
                     "not (yet) supported"
                 };
                 format!(
-                    "A `@{}` directive is used on an interface, which is {}.",
-                    directive, suffix
+                    "A `@{directive}` directive is used on an interface, which is {suffix}."
                 )
             }),
             None,
@@ -1365,8 +1362,7 @@ static DIRECTIVE_IN_FIELDS_ARG: LazyLock<ErrorCodeCategory<String>> = LazyLock::
         "DIRECTIVE_IN_FIELDS_ARG".to_owned(),
         Box::new(|directive| {
             format!(
-                "The `fields` argument of a `@{}` directive includes some directive applications. This is not supported",
-                directive
+                "The `fields` argument of a `@{directive}` directive includes some directive applications. This is not supported"
             )
         }),
         Some(ErrorCodeMetadata {
@@ -1420,8 +1416,7 @@ static DIRECTIVE_INVALID_FIELDS_TYPE: LazyLock<ErrorCodeCategory<String>> = Lazy
         "INVALID_FIELDS_TYPE".to_owned(),
         Box::new(|directive| {
             format!(
-                "The value passed to the `fields` argument of a `@{}` directive is not a string.",
-                directive
+                "The value passed to the `fields` argument of a `@{directive}` directive is not a string."
             )
         }),
         None,
@@ -1440,8 +1435,7 @@ static DIRECTIVE_INVALID_FIELDS: LazyLock<ErrorCodeCategory<String>> = LazyLock:
         "INVALID_FIELDS".to_owned(),
         Box::new(|directive| {
             format!(
-                "The `fields` argument of a `@{}` directive is invalid (it has invalid syntax, includes unknown fields, ...).",
-                directive
+                "The `fields` argument of a `@{directive}` directive is invalid (it has invalid syntax, includes unknown fields, ...)."
             )
         }),
         None,
@@ -1475,8 +1469,7 @@ static ROOT_TYPE_USED: LazyLock<ErrorCodeCategory<SchemaRootKind>> = LazyLock::n
         Box::new(|element| {
             let kind: String = element.into();
             format!(
-                "A subgraph's schema defines a type with the name `{}`, while also specifying a _different_ type name as the root query object. This is not allowed.",
-                kind
+                "A subgraph's schema defines a type with the name `{kind}`, while also specifying a _different_ type name as the root query object. This is not allowed."
             )
         }),
         Some(ErrorCodeMetadata {

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -1342,9 +1342,7 @@ static DIRECTIVE_UNSUPPORTED_ON_INTERFACE: LazyLock<ErrorCodeCategory<String>> =
                 } else {
                     "not (yet) supported"
                 };
-                format!(
-                    "A `@{directive}` directive is used on an interface, which is {suffix}."
-                )
+                format!("A `@{directive}` directive is used on an interface, which is {suffix}.")
             }),
             None,
         )

--- a/apollo-federation/src/error/suggestion.rs
+++ b/apollo-federation/src/error/suggestion.rs
@@ -35,7 +35,7 @@ pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> Str
         suggestions
             .into_iter()
             .take(MAX_SUGGESTIONS)
-            .map(|s| format!("\"{}\"", s)),
+            .map(|s| format!("\"{s}\"")),
         human_readable::JoinStringsOptions {
             separator: ", ",
             first_separator: None,
@@ -43,5 +43,5 @@ pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> Str
             output_length_limit: None,
         },
     );
-    format!("{}{}?", MESSAGE, suggestion_str)
+    format!("{MESSAGE}{suggestion_str}?")
 }

--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -680,7 +680,7 @@ mod tests {
             let schema_doc = format!("{schema_prefix}\n{link_def}");
             let schema = Schema::parse(&schema_doc, "test.graphql").unwrap();
             let meta = links_metadata(&schema)?;
-            assert!(meta.is_some(), "should have metadata for: {}", link_def);
+            assert!(meta.is_some(), "should have metadata for: {link_def}");
         }
         Ok(())
     }

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -175,8 +175,7 @@ impl FederationSpecDefinition {
             None => Ok(None),
             _ => Err(SingleFederationError::Internal {
                 message: format!(
-                    "Unexpectedly found non-union for federation spec's \"{}\" type definition",
-                    FEDERATION_ENTITY_TYPE_NAME_IN_SPEC
+                    "Unexpectedly found non-union for federation spec's \"{FEDERATION_ENTITY_TYPE_NAME_IN_SPEC}\" type definition"
                 ),
             }
             .into()),
@@ -191,8 +190,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }
                 .into()
@@ -253,8 +251,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -289,8 +286,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                 ))
             })
     }
@@ -310,8 +306,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -360,8 +355,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -396,8 +390,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -451,8 +444,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -503,8 +495,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                 ))
             })
     }
@@ -531,8 +522,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                 ))
             })
     }
@@ -586,8 +576,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC,
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC}\" directive definition",
                 ))
             })
     }
@@ -635,8 +624,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC,
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC}\" directive definition",
                 ))
             })
     }
@@ -692,8 +680,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_CACHE_TAG_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_CACHE_TAG_DIRECTIVE_NAME_IN_SPEC,
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_CACHE_TAG_DIRECTIVE_NAME_IN_SPEC}\" directive definition",
                 ))
             })
     }

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -1037,7 +1037,7 @@ fn validate_inaccessible(
                     .collect::<Vec<_>>()
                     .join(", ");
                 errors.push(SingleFederationError::DisallowedInaccessible {
-                    message: format!("Directive `{position}` cannot use @inaccessible because it may be applied to these type-system locations: {}", type_system_locations),
+                    message: format!("Directive `{position}` cannot use @inaccessible because it may be applied to these type-system locations: {type_system_locations}"),
                 }.into());
             }
         } else {

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -251,8 +251,7 @@ impl JoinSpecDefinition {
         } else {
             Err(SingleFederationError::Internal {
                 message: format!(
-                    "Unexpectedly found non-enum for join spec's \"{}\" enum definition",
-                    JOIN_GRAPH_ENUM_NAME_IN_SPEC,
+                    "Unexpectedly found non-enum for join spec's \"{JOIN_GRAPH_ENUM_NAME_IN_SPEC}\" enum definition",
                 ),
             }
             .into())
@@ -1028,7 +1027,7 @@ impl JoinSpecDefinition {
                     sanitized_name.clone()
                 } else {
                     // Subsequent subgraphs get _1, _2, etc.
-                    format!("{}_{}", sanitized_name, index)
+                    format!("{sanitized_name}_{index}")
                 };
 
                 let enum_value_name = Name::new(enum_name.as_str())?;

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -433,12 +433,12 @@ impl fmt::Display for Link {
         let alias = self
             .spec_alias
             .as_ref()
-            .map(|a| format!(r#", as: "{}""#, a))
+            .map(|a| format!(r#", as: "{a}""#))
             .unwrap_or("".to_string());
         let purpose = self
             .purpose
             .as_ref()
-            .map(|p| format!(r#", for: {}"#, p))
+            .map(|p| format!(r#", for: {p}"#))
             .unwrap_or("".to_string());
         write!(f, r#"@link(url: "{}"{alias}{imports}{purpose})"#, self.url)
     }

--- a/apollo-federation/src/link/spec.rs
+++ b/apollo-federation/src/link/spec.rs
@@ -175,10 +175,10 @@ impl str::FromStr for Version {
         ))?;
 
         let major = major.parse::<u32>().map_err(|_| {
-            SpecError::ParseError(format!("invalid major version number '{}'", major))
+            SpecError::ParseError(format!("invalid major version number '{major}'"))
         })?;
         let minor = minor.parse::<u32>().map_err(|_| {
-            SpecError::ParseError(format!("invalid minor version number '{}'", minor))
+            SpecError::ParseError(format!("invalid minor version number '{minor}'"))
         })?;
 
         Ok(Version { major, minor })
@@ -285,7 +285,7 @@ impl str::FromStr for Url {
                 ))?;
                 let path_remainder = segments.collect::<Vec<&str>>();
                 let domain = if path_remainder.is_empty() {
-                    format!("{}://{}", scheme, url_domain)
+                    format!("{scheme}://{url_domain}")
                 } else {
                     format!("{}://{}/{}", scheme, url_domain, path_remainder.join("/"))
                 };
@@ -295,8 +295,7 @@ impl str::FromStr for Url {
                 })
             }
             Err(e) => Err(SpecError::ParseError(format!(
-                "invalid specification url: {}",
-                e
+                "invalid specification url: {e}"
             ))),
         }
     }

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -106,8 +106,7 @@ pub(crate) trait SpecDefinition {
                 .ok_or_else(|| {
                     SingleFederationError::Internal {
                         message: format!(
-                            "Unexpectedly could not find spec directive \"@{}\" in schema",
-                            name
+                            "Unexpectedly could not find spec directive \"@{name}\" in schema"
                         ),
                     }
                     .into()
@@ -130,8 +129,7 @@ pub(crate) trait SpecDefinition {
                 .ok_or_else(|| {
                     SingleFederationError::Internal {
                         message: format!(
-                            "Unexpectedly could not find spec type \"{}\" in schema",
-                            name
+                            "Unexpectedly could not find spec type \"{name}\" in schema"
                         ),
                     }
                     .into()

--- a/apollo-federation/src/merge/tests.rs
+++ b/apollo-federation/src/merge/tests.rs
@@ -38,7 +38,7 @@ fn test_steel_thread() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -54,7 +54,7 @@ fn test_basic() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -70,7 +70,7 @@ fn test_inaccessible() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -87,7 +87,7 @@ fn test_interface_object() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -102,7 +102,7 @@ fn test_input_types() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -117,7 +117,7 @@ fn test_interface_implementing_interface() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }

--- a/apollo-federation/src/merger/error_reporter.rs
+++ b/apollo-federation/src/merger/error_reporter.rs
@@ -84,7 +84,7 @@ impl ErrorReporter {
             subgraph_elements,
             mismatch_accessor,
             |elt, names| format!("{} in {}", elt, names.unwrap_or("undefined".to_string())),
-            |elt, names| format!("{} in {}", elt, names),
+            |elt, names| format!("{elt} in {names}"),
             |myself, distribution, _: Vec<U>| {
                 let distribution_str = join_strings(
                     distribution.iter(),

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -252,8 +252,7 @@ impl Merger {
                 self.report_mismatch_hint(
                     HintCode::InconsistentEnumValueForOutputEnum,
                     format!(
-                        "Value \"{}\" of enum type \"{}\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"{}\": ",
-                        value_name, dest_name, dest_name
+                        "Value \"{value_name}\" of enum type \"{dest_name}\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"{dest_name}\": "
                     ),
                     sources,
                     |source| {

--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -598,13 +598,12 @@ impl Merger {
             self.error_reporter.report_mismatch_error::<FieldDefinitionPosition, ()>(
                 CompositionError::ExternalTypeMismatch {
                     message: format!(
-                        "Type of field \"{}\" is incompatible across subgraphs (where marked @external): it has ",
-                        dest,
+                        "Type of field \"{dest}\" is incompatible across subgraphs (where marked @external): it has ",
                     ),
                 },
                 dest,
                 sources,
-                |source, _| Some(format!("type \"{}\"", source)),
+                |source, _| Some(format!("type \"{source}\"")),
             );
         }
 
@@ -612,8 +611,7 @@ impl Merger {
             self.report_mismatch_error_with_specifics(
                 CompositionError::ExternalArgumentMissing {
                     message: format!(
-                        "Field \"{}\" is missing argument \"{}\" in some subgraphs where it is marked @external: ",
-                        dest, arg_name
+                        "Field \"{dest}\" is missing argument \"{arg_name}\" in some subgraphs where it is marked @external: "
                     ),
                 },
                 &self.argument_sources(sources, arg_name)?,
@@ -630,14 +628,12 @@ impl Merger {
             self.error_reporter.report_mismatch_error::<ObjectFieldArgumentDefinitionPosition, ()>(
                 CompositionError::ExternalArgumentTypeMismatch {
                     message: format!(
-                        "Type of argument \"{}\" is incompatible across subgraphs (where \"{}\" is marked @external): it has ",
-                        argument_pos,
-                        dest,
+                        "Type of argument \"{argument_pos}\" is incompatible across subgraphs (where \"{dest}\" is marked @external): it has ",
                     ),
                 },
                 &argument_pos,
                 &self.argument_sources(sources, arg_name)?,
-                |source, _| Some(format!("type \"{}\"", source)),
+                |source, _| Some(format!("type \"{source}\"")),
             );
         }
 
@@ -650,14 +646,12 @@ impl Merger {
             self.error_reporter.report_mismatch_error::<ObjectFieldArgumentDefinitionPosition, ()>(
                 CompositionError::ExternalArgumentDefaultMismatch {
                     message: format!(
-                        "Argument \"{}\" has incompatible defaults across subgraphs (where \"{}\" is marked @external): it has ",
-                        argument_pos,
-                        dest,
+                        "Argument \"{argument_pos}\" has incompatible defaults across subgraphs (where \"{dest}\" is marked @external): it has ",
                     ),
                 },
                 &argument_pos,
                 &self.argument_sources(sources, arg_name)?,
-                |source, _| Some(format!("default value {:?}", source)), // TODO: Need proper value formatting
+                |source, _| Some(format!("default value {source:?}")), // TODO: Need proper value formatting
             );
         }
 
@@ -1125,7 +1119,7 @@ impl Merger {
                 continue;
             };
 
-            let prefixed_context = format!("{}__{}", subgraph_name, context);
+            let prefixed_context = format!("{subgraph_name}__{context}");
 
             context_args.push(Node::new(Value::Object(vec![
                 (name!("context"), Node::new(Value::String(prefixed_context))),

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -845,7 +845,7 @@ impl Merger {
                         Some(format!("arguments: [{}]", elt.arguments.iter().map(|arg| format!("{}: {}", arg.name, arg.value)).join(", ")))
                     },
                     |application, subgraphs| format!("The supergraph will use {} (from {}), but found ", application, subgraphs.unwrap_or_else(|| "undefined".to_string())),
-                    |application, subgraphs| format!("{} in {}", application, subgraphs),
+                    |application, subgraphs| format!("{application} in {subgraphs}"),
                     None::<fn(Option<&Directive>) -> bool>,
                     false,
                     false,
@@ -1005,7 +1005,7 @@ impl Merger {
                 error,
                 typ,
                 sources,
-                |typ, _is_supergraph| Some(format!("type \"{}\"", typ)),
+                |typ, _is_supergraph| Some(format!("type \"{typ}\"")),
             );
 
             Ok(false)
@@ -1032,7 +1032,7 @@ impl Merger {
                 ),
                 typ,
                 sources,
-                |typ, _is_supergraph| Some(format!("type \"{}\"", typ)),
+                |typ, _is_supergraph| Some(format!("type \"{typ}\"")),
                 |elt, subgraphs| {
                     format!(
                         "will use type \"{}\" (from {}) in supergraph but \"{}\" has ",
@@ -1041,7 +1041,7 @@ impl Merger {
                         dest.coordinate(parent_type_name)
                     )
                 },
-                |elt, subgraphs| format!("{} \"{}\" in {}", type_class, elt, subgraphs),
+                |elt, subgraphs| format!("{type_class} \"{elt}\" in {subgraphs}"),
                 None::<fn(Option<&Type>) -> bool>,
                 false,
                 false,
@@ -1224,7 +1224,7 @@ impl Merger {
         if !target_schema.types.contains_key(name) {
             self.error_reporter_mut()
                 .add_error(CompositionError::InternalError {
-                    message: format!("Cannot find type '{}' in target schema", name),
+                    message: format!("Cannot find type '{name}' in target schema"),
                 });
         }
 
@@ -1931,7 +1931,7 @@ pub(crate) mod tests {
                 assert_eq!(input_example.coordinate, "Parent.status_filter");
                 assert_eq!(output_example.coordinate, "Parent.user_status");
             }
-            _ => panic!("Expected Both usage, got {:?}", usage),
+            _ => panic!("Expected Both usage, got {usage:?}"),
         }
     }
 
@@ -2016,7 +2016,7 @@ pub(crate) mod tests {
         match result {
             Ok(false) => {} // Expected
             Ok(true) => panic!("Expected Ok(false), got Ok(true)"),
-            Err(e) => panic!("Expected Ok(false), got Err: {:?}", e),
+            Err(e) => panic!("Expected Ok(false), got Err: {e:?}"),
         }
         assert!(
             merger.has_errors(),
@@ -2049,7 +2049,7 @@ pub(crate) mod tests {
         match result {
             Ok(false) => {} // Expected
             Ok(true) => panic!("Expected Ok(false), got Ok(true)"),
-            Err(e) => panic!("Expected Ok(false), got Err: {:?}", e),
+            Err(e) => panic!("Expected Ok(false), got Err: {e:?}"),
         }
         assert!(
             merger.has_errors(),

--- a/apollo-federation/src/operation/merging.rs
+++ b/apollo-federation/src/operation/merging.rs
@@ -190,8 +190,7 @@ impl SelectionSet {
                                     .type_condition_position
                                     .clone()
                                     .map_or_else(String::new, |cond| format!(
-                                        "(type condition: {}) ",
-                                        cond
+                                        "(type condition: {cond}) "
                                     ),),
                             );
                         };

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2506,7 +2506,6 @@ impl InlineFragmentSelection {
         };
 
         let mut remove_defer = false;
-        #[expect(clippy::redundant_clone)]
         let mut args_copy = args.clone();
         if let Some(BooleanOrVariable::Boolean(b)) = &args.if_ {
             if *b {

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -888,8 +888,7 @@ impl SchemaQueryGraphBuilder {
                 _ => {
                     return Err(SingleFederationError::Internal {
                         message: format!(
-                            "Type \"{}\" was abstract in subgraph but not in API schema",
-                            type_name,
+                            "Type \"{type_name}\" was abstract in subgraph but not in API schema",
                         ),
                     }
                     .into());
@@ -1299,8 +1298,7 @@ impl FederatedQueryGraphBuilder {
                 .get(type_pos.type_name())
                 .ok_or_else(|| SingleFederationError::Internal {
                     message: format!(
-                        "Type \"{}\" unexpectedly missing from subgraph \"{}\"",
-                        type_pos, source,
+                        "Type \"{type_pos}\" unexpectedly missing from subgraph \"{source}\"",
                     ),
                 })?
                 .directives();
@@ -1329,9 +1327,7 @@ impl FederatedQueryGraphBuilder {
                 else {
                     return Err(SingleFederationError::Internal {
                             message: format!(
-                                "Invalid \"@key\" application on non-object/interface type \"{}\" in subgraph \"{}\"",
-                                type_pos,
-                                source,
+                                "Invalid \"@key\" application on non-object/interface type \"{type_pos}\" in subgraph \"{source}\"",
                             )
                         }.into());
                 };
@@ -1358,9 +1354,7 @@ impl FederatedQueryGraphBuilder {
                         let head = other_nodes.first().ok_or_else(|| {
                             SingleFederationError::Internal {
                                 message: format!(
-                                    "Types-to-nodes set unexpectedly empty for type \"{}\" in subgraph \"{}\"",
-                                    type_pos,
-                                    other_source,
+                                    "Types-to-nodes set unexpectedly empty for type \"{type_pos}\" in subgraph \"{other_source}\"",
                                 ),
                             }
                         })?;
@@ -1371,9 +1365,7 @@ impl FederatedQueryGraphBuilder {
                             return Err(
                                 SingleFederationError::Internal {
                                     message: format!(
-                                        "Types-to-nodes set unexpectedly had more than one element for type \"{}\" in subgraph \"{}\"",
-                                        type_pos,
-                                        other_source,
+                                        "Types-to-nodes set unexpectedly had more than one element for type \"{type_pos}\" in subgraph \"{other_source}\"",
                                     ),
                                 }
                                     .into()
@@ -1402,9 +1394,7 @@ impl FederatedQueryGraphBuilder {
                         else {
                             return Err(SingleFederationError::Internal {
                                     message: format!(
-                                        "Type \"{}\" was marked with \"@interfaceObject\" in subgraph \"{}\", but was non-interface in supergraph",
-                                        type_pos,
-                                        other_source,
+                                        "Type \"{type_pos}\" was marked with \"@interfaceObject\" in subgraph \"{other_source}\", but was non-interface in supergraph",
                                     )
                                 }.into());
                         };
@@ -1429,9 +1419,7 @@ impl FederatedQueryGraphBuilder {
                             let head = implementation_nodes.first().ok_or_else(|| {
                                 SingleFederationError::Internal {
                                     message: format!(
-                                        "Types-to-nodes set unexpectedly empty for type \"{}\" in subgraph \"{}\"",
-                                        implementation_type_in_supergraph_pos,
-                                        other_source,
+                                        "Types-to-nodes set unexpectedly empty for type \"{implementation_type_in_supergraph_pos}\" in subgraph \"{other_source}\"",
                                     ),
                                 }
                             })?;
@@ -1439,9 +1427,7 @@ impl FederatedQueryGraphBuilder {
                                 return Err(
                                     SingleFederationError::Internal {
                                         message: format!(
-                                            "Types-to-nodes set unexpectedly had more than one element for type \"{}\" in subgraph \"{}\"",
-                                            implementation_type_in_supergraph_pos,
-                                            other_source,
+                                            "Types-to-nodes set unexpectedly had more than one element for type \"{implementation_type_in_supergraph_pos}\" in subgraph \"{other_source}\"",
                                         ),
                                     }.into()
                                 );
@@ -1510,8 +1496,7 @@ impl FederatedQueryGraphBuilder {
             if edge_weight.conditions.is_some() {
                 return Err(SingleFederationError::Internal {
                     message: format!(
-                        "Field-collection edge for field \"{}\" unexpectedly had conditions",
-                        field_definition_position,
+                        "Field-collection edge for field \"{field_definition_position}\" unexpectedly had conditions",
                     ),
                 }
                 .into());
@@ -2007,8 +1992,7 @@ impl FederatedQueryGraphBuilder {
                                 .get(tail_type)
                                 .ok_or_else(|| SingleFederationError::Internal {
                                     message: format!(
-                                        "Types-to-nodes map missing type \"{}\" in subgraph \"{}\"",
-                                        tail_type, source,
+                                        "Types-to-nodes map missing type \"{tail_type}\" in subgraph \"{source}\"",
                                     ),
                                 })?;
                             // Note because this is an IndexSet, the non-provides should be first
@@ -2027,9 +2011,7 @@ impl FederatedQueryGraphBuilder {
                                 return Err(
                                     SingleFederationError::Internal {
                                         message: format!(
-                                            "Missing non-provides node for type \"{}\" in subgraph \"{}\"",
-                                            tail_type,
-                                            source,
+                                            "Missing non-provides node for type \"{tail_type}\" in subgraph \"{source}\"",
                                         )
                                     }.into()
                                 );
@@ -2097,8 +2079,7 @@ impl FederatedQueryGraphBuilder {
                                 .ok_or_else(|| {
                                     SingleFederationError::Internal {
                                         message: format!(
-                                            "Shouldn't have selection \"{}\" in an @provides, as its type condition has no query graph edge",
-                                            inline_fragment_selection,
+                                            "Shouldn't have selection \"{inline_fragment_selection}\" in an @provides, as its type condition has no query graph edge",
                                         )
                                     }
                                 })?;
@@ -2156,8 +2137,7 @@ impl FederatedQueryGraphBuilder {
             .get_mut(type_pos.type_name())
             .ok_or_else(|| SingleFederationError::Internal {
                 message: format!(
-                    "Unexpectedly missing @provides type \"{}\" in types-to-nodes map",
-                    type_pos,
+                    "Unexpectedly missing @provides type \"{type_pos}\" in types-to-nodes map",
                 ),
             })?
             .insert(new_node);
@@ -2266,8 +2246,7 @@ impl FederatedQueryGraphBuilder {
                     .get(&type_pos.type_name)
                     .ok_or_else(|| SingleFederationError::Internal {
                         message: format!(
-                            "Types-to-nodes map missing type \"{}\" in subgraph \"{}\"",
-                            type_pos, source,
+                            "Types-to-nodes map missing type \"{type_pos}\" in subgraph \"{source}\"",
                         ),
                     })?;
                 // Note because this is an IndexSet, the non-provides should be first since it was
@@ -2284,8 +2263,7 @@ impl FederatedQueryGraphBuilder {
                 let Some(node) = node else {
                     return Err(SingleFederationError::Internal {
                         message: format!(
-                            "Missing non-provides node for type \"{}\" in subgraph \"{}\"",
-                            type_pos, source,
+                            "Missing non-provides node for type \"{type_pos}\" in subgraph \"{source}\"",
                         ),
                     }
                     .into());
@@ -2298,9 +2276,7 @@ impl FederatedQueryGraphBuilder {
                 else {
                     return Err(SingleFederationError::Internal {
                             message: format!(
-                                "Type \"{}\" was marked with \"@interfaceObject\" in subgraph \"{}\", but was non-interface in supergraph",
-                                type_pos,
-                                source,
+                                "Type \"{type_pos}\" was marked with \"@interfaceObject\" in subgraph \"{source}\", but was non-interface in supergraph",
                             )
                         }.into());
                 };
@@ -2374,8 +2350,7 @@ impl FederatedQueryGraphBuilderSubgraphs {
                     // means they should include an @interfaceObject definition.
                     SingleFederationError::Internal {
                         message: format!(
-                            "Subgraph \"{}\" unexpectedly missing @interfaceObject definition",
-                            source,
+                            "Subgraph \"{source}\" unexpectedly missing @interfaceObject definition",
                         ),
                     }
                 })?;

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -72,7 +72,7 @@ impl std::fmt::Display for ConditionResolution {
                 Ok(())
             }
             ConditionResolution::Unsatisfied { reason } => {
-                writeln!(f, "Unsatisfied: reason={:?}", reason)
+                writeln!(f, "Unsatisfied: reason={reason:?}")
             }
         }
     }

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -643,15 +643,13 @@ where
         let tail_weight = self.graph.node_weight(self.tail)?;
         if self.tail != edge_head {
             return Err(FederationError::internal(format!(
-                "Cannot add edge {} to path ending at {}",
-                edge_weight, tail_weight
+                "Cannot add edge {edge_weight} to path ending at {tail_weight}"
             )));
         }
         if let Some(path_tree) = &condition_path_tree {
             if edge_weight.conditions.is_none() {
                 return Err(FederationError::internal(format!(
-                    "Unexpectedly got conditions paths {} for edge {} without conditions",
-                    path_tree, edge_weight,
+                    "Unexpectedly got conditions paths {path_tree} for edge {edge_weight} without conditions",
                 )));
             }
         }
@@ -1710,8 +1708,7 @@ where
                         )?;
                         let extra_message = if has_overridden_field {
                             format!(
-                                " (note that some of those key fields are overridden in \"{}\")",
-                                from_subgraph,
+                                " (note that some of those key fields are overridden in \"{from_subgraph}\")",
                             )
                         } else {
                             "".to_owned()

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -229,8 +229,7 @@ impl OpPathElement {
             if let Some(application) = self.directives().get(directive_name) {
                 let Some(arg) = application.specified_argument_by_name("if") else {
                     return Err(FederationError::internal(format!(
-                        "@{} missing required argument \"if\"",
-                        directive_name
+                        "@{directive_name} missing required argument \"if\""
                     )));
                 };
                 let value = match arg.deref() {
@@ -1182,8 +1181,7 @@ impl OpGraphPath {
                             {
                                 let edge_weight = self.graph.edge_weight(edge)?;
                                 return Err(FederationError::internal(format!(
-                                    "Unexpectedly missing {} for {} from path {}",
-                                    operation_field, edge_weight, self,
+                                    "Unexpectedly missing {operation_field} for {edge_weight} from path {self}",
                                 )));
                             }
                             operation_field = Field {
@@ -1252,8 +1250,7 @@ impl OpGraphPath {
                                 let interface_edge_weight =
                                     self.graph.edge_weight(*interface_edge)?;
                                 return Err(FederationError::internal(format!(
-                                    "Interface edge {} unexpectedly had conditions",
-                                    interface_edge_weight
+                                    "Interface edge {interface_edge_weight} unexpectedly had conditions"
                                 )));
                             }
                             field_path
@@ -1456,8 +1453,7 @@ impl OpGraphPath {
                                 // condition (only fragments can).
                                 if field_options_for_implementation.is_empty() {
                                     return Err(FederationError::internal(format!(
-                                        "Unexpected unsatisfiable path after {}",
-                                        operation_field
+                                        "Unexpected unsatisfiable path after {operation_field}"
                                     )));
                                 }
                                 debug!(
@@ -1529,8 +1525,7 @@ impl OpGraphPath {
                         // the query should have been flagged invalid if a field was selected on
                         // something else.
                         Err(FederationError::internal(format!(
-                            "Unexpectedly found field {} on non-composite type {}",
-                            operation_field, tail_type_pos,
+                            "Unexpectedly found field {operation_field} on non-composite type {tail_type_pos}",
                         )))
                     }
                 }
@@ -1772,8 +1767,7 @@ impl OpGraphPath {
                     _ => {
                         // We shouldn't have a fragment on a non-composite type.
                         Err(FederationError::internal(format!(
-                            "Unexpectedly found inline fragment {} on non-composite type {}",
-                            operation_inline_fragment, tail_type_pos,
+                            "Unexpectedly found inline fragment {operation_inline_fragment} on non-composite type {tail_type_pos}",
                         )))
                     }
                 }
@@ -2194,8 +2188,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
                         // exited the method early).
                         if advance_options.is_empty() {
                             return Err(FederationError::internal(format!(
-                                "Unexpected empty options after non-collecting path {} for {}",
-                                path_with_non_collecting_edges, operation_element,
+                                "Unexpected empty options after non-collecting path {path_with_non_collecting_edges} for {operation_element}",
                             )));
                         }
                         // There is a special case we can deal with now. Namely, suppose we have a

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -182,8 +182,7 @@ impl TransitionGraphPath {
             },
         );
         Ok(format!(
-            " (please ensure that this is not due to key {} being accidentally marked @external)",
-            fields_list
+            " (please ensure that this is not due to key {fields_list} being accidentally marked @external)"
         ))
     }
 
@@ -412,8 +411,7 @@ impl TransitionGraphPath {
                                     }
                                     Some(UnsatisfiedConditionReason::NoSetContext) => {
                                         format!(
-                                            "could not find a match for required context for field \"{}\"",
-                                            field_definition_position,
+                                            "could not find a match for required context for field \"{field_definition_position}\"",
                                         )
                                     }
                                     None => {
@@ -523,32 +521,28 @@ impl TransitionGraphPath {
                             // subgraph not having that implementation because it uses
                             // @interfaceObject on an interface of that implementation.
                             break 'details format!(
-                                "cannot find implementation type \"{}\" (supergraph interface \"{}\" is declared with @interfaceObject in \"{}\")",
-                                parent_type_pos, tail_type_pos, subgraph,
+                                "cannot find implementation type \"{parent_type_pos}\" (supergraph interface \"{tail_type_pos}\" is declared with @interfaceObject in \"{subgraph}\")",
                             );
                         }
                         let Some(Ok(parent_type_pos_in_subgraph)) = parent_type_pos_in_subgraph
                             .map(CompositeTypeDefinitionPosition::try_from)
                         else {
                             break 'details format!(
-                                "cannot find field \"{}\"",
-                                field_definition_position,
+                                "cannot find field \"{field_definition_position}\"",
                             );
                         };
                         let Ok(field_pos_in_subgraph) = parent_type_pos_in_subgraph
                             .field(field_definition_position.field_name().clone())
                         else {
                             break 'details format!(
-                                "cannot find field \"{}\"",
-                                field_definition_position,
+                                "cannot find field \"{field_definition_position}\"",
                             );
                         };
                         let Ok(field_in_subgraph) =
                             field_pos_in_subgraph.get(subgraph_schema.schema())
                         else {
                             break 'details format!(
-                                "cannot find field \"{}\"",
-                                field_definition_position,
+                                "cannot find field \"{field_definition_position}\"",
                             );
                         };
                         // The subgraph has the field but no corresponding edge. This should only
@@ -583,8 +577,7 @@ impl TransitionGraphPath {
                         };
                         if overriding_subgraphs.is_empty() {
                             format!(
-                                "field \"{}\" is not resolvable because marked @external",
-                                field_definition_position,
+                                "field \"{field_definition_position}\" is not resolvable because marked @external",
                             )
                         } else {
                             format!(
@@ -597,7 +590,7 @@ impl TransitionGraphPath {
                     QueryGraphEdgeTransition::Downcast {
                         to_type_position, ..
                     } => {
-                        format!("cannot find type \"{}\"", to_type_position)
+                        format!("cannot find type \"{to_type_position}\"")
                     }
                     _ => {
                         bail!("Unhandled direct transition {}", transition);
@@ -978,13 +971,11 @@ impl TransitionPathWithLazyIndirectPaths {
                                 };
                             let explanation = if key_resolvables.is_empty() {
                                 format!(
-                                    "{} \"{}\" has no @key defined in subgraph \"{}\"",
-                                    kind_of_type, tail_type_pos, subgraph,
+                                    "{kind_of_type} \"{tail_type_pos}\" has no @key defined in subgraph \"{subgraph}\"",
                                 )
                             } else {
                                 format!(
-                                    "none of the @key defined on {} \"{}\" in subgraph \"{}\" are resolvable (they are all declared with their \"resolvable\" argument set to false)",
-                                    kind_of_type, tail_type_pos, subgraph,
+                                    "none of the @key defined on {kind_of_type} \"{tail_type_pos}\" in subgraph \"{subgraph}\" are resolvable (they are all declared with their \"resolvable\" argument set to false)",
                                 )
                             };
                             all_dead_ends.push(Arc::new(Unadvanceable {
@@ -992,10 +983,7 @@ impl TransitionPathWithLazyIndirectPaths {
                                 from_subgraph: tail_weight.source.clone(),
                                 to_subgraph: subgraph.clone(),
                                 details: format!(
-                                    "cannot move to subgraph \"{}\", which has field \"{}\", because {}",
-                                    subgraph,
-                                    field_definition_position,
-                                    explanation,
+                                    "cannot move to subgraph \"{subgraph}\", which has field \"{field_definition_position}\", because {explanation}",
                                 ),
                             }))
                         } else {
@@ -1011,12 +999,7 @@ impl TransitionPathWithLazyIndirectPaths {
                                 from_subgraph: tail_weight.source.clone(),
                                 to_subgraph: subgraph.clone(),
                                 details: format!(
-                                    "cannot move to subgraph \"{}\", which has field \"{}\", because interface \"{}\" is not defined in this subgraph (to jump to \"{}\", it would need to both define interface \"{}\" and have a @key on it)",
-                                    subgraph,
-                                    field_definition_position,
-                                    tail_type_pos,
-                                    subgraph,
-                                    tail_type_pos,
+                                    "cannot move to subgraph \"{subgraph}\", which has field \"{field_definition_position}\", because interface \"{tail_type_pos}\" is not defined in this subgraph (to jump to \"{subgraph}\", it would need to both define interface \"{tail_type_pos}\" and have a @key on it)",
                                 ),
                             }))
                         }

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -86,7 +86,7 @@ impl Display for QueryGraphNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}({})", self.type_, self.source)?;
         if let Some(provide_id) = self.provide_id {
-            write!(f, "-{}", provide_id)?;
+            write!(f, "-{provide_id}")?;
         }
         if self.is_root_node() {
             write!(f, "*")?;
@@ -428,13 +428,13 @@ impl Display for QueryGraphEdgeTransition {
                 write!(f, "key()")
             }
             QueryGraphEdgeTransition::RootTypeResolution { root_kind } => {
-                write!(f, "{}()", root_kind)
+                write!(f, "{root_kind}()")
             }
             QueryGraphEdgeTransition::SubgraphEnteringTransition => {
                 write!(f, "∅")
             }
             QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { to_type_name, .. } => {
-                write!(f, "... on {}", to_type_name)
+                write!(f, "... on {to_type_name}")
             }
         }
     }
@@ -1127,8 +1127,7 @@ impl QueryGraph {
         let schema = self.schema_by_source(source)?;
         let Some(metadata) = schema.subgraph_metadata() else {
             return Err(FederationError::internal(format!(
-                "Interface should have come from a federation subgraph {}",
-                source
+                "Interface should have come from a federation subgraph {source}"
             )));
         };
 

--- a/apollo-federation/src/query_graph/output.rs
+++ b/apollo-federation/src/query_graph/output.rs
@@ -23,7 +23,7 @@ fn label_edge(edge: &QueryGraphEdge) -> String {
     if label.is_empty() {
         String::new()
     } else {
-        format!("label=\"{}\"", edge)
+        format!("label=\"{edge}\"")
     }
 }
 
@@ -67,7 +67,7 @@ fn to_dot_federated(graph: &QueryGraph) -> Result<String, std::fmt::Error> {
 
     fn label_cluster_node(node: &QueryGraphNode) -> String {
         let provide_id = match node.provide_id {
-            Some(id) => format!("#{}", id),
+            Some(id) => format!("#{id}"),
             None => String::new(),
         };
         format!(r#"label="{}{}@{}""#, node.type_, provide_id, node.source)

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2359,8 +2359,7 @@ impl FetchDependencyGraph {
                         .map_or_else(
                             |_| {
                                 Err(FederationError::internal(format!(
-                                    "Invalid call from {} starting at {}: {} is not composite",
-                                    path, parent_type, field_position
+                                    "Invalid call from {path} starting at {parent_type}: {field_position} is not composite"
                                 )))
                             },
                             Ok,
@@ -2374,8 +2373,7 @@ impl FetchDependencyGraph {
                             .map_or_else(
                                 |_| {
                                     Err(FederationError::internal(format!(
-                                        "Invalid call from {} starting at {}: {} is not composite",
-                                        path, parent_type, type_condition_position
+                                        "Invalid call from {path} starting at {parent_type}: {type_condition_position} is not composite"
                                     )))
                                 },
                                 Ok,
@@ -3313,7 +3311,7 @@ impl std::fmt::Display for FetchInputs {
                 // We can safely unwrap because we know the len >= 1.
                 write!(f, "{}", iter.next().unwrap())?;
                 for x in iter {
-                    write!(f, ",{}", x)?;
+                    write!(f, ",{x}")?;
                 }
                 write!(f, "]")
             }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -446,8 +446,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 if new_options.len() > options_limit as usize {
                     return Err(SingleFederationError::QueryPlanComplexityExceeded {
                         message: format!(
-                            "Too many options generated for {}, reached the limit of {}.",
-                            selection, options_limit,
+                            "Too many options generated for {selection}, reached the limit of {options_limit}.",
                         ),
                     }
                     .into());
@@ -525,8 +524,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             return if self.is_top_level {
                 if self.parameters.disabled_subgraphs.is_empty() {
                     Err(FederationError::internal(format!(
-                        "Was not able to find any options for {}: This shouldn't have happened.",
-                        selection,
+                        "Was not able to find any options for {selection}: This shouldn't have happened.",
                     )))
                 } else {
                     // If subgraphs were disabled, this could be expected, and we indicate this in

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -184,7 +184,7 @@ impl FederationBlueprint {
             return Self::on_unknown_directive_validation_error(schema, directive_name, &message);
         }
 
-        let did_you_mean = did_you_mean(suggestions.iter().map(|s| format!("@{}", s)));
+        let did_you_mean = did_you_mean(suggestions.iter().map(|s| format!("@{s}")));
         SingleFederationError::InvalidGraphQL {
             message: format!("{message}{did_you_mean}\n"),
         }
@@ -254,7 +254,7 @@ impl FederationBlueprint {
                 all_directive_names.iter().map(|name| name.to_string()),
             );
             if !suggestions.is_empty() {
-                let did_you_mean = did_you_mean(suggestions.iter().map(|s| format!("@{}", s)));
+                let did_you_mean = did_you_mean(suggestions.iter().map(|s| format!("@{s}")));
                 let note = if suggestions.len() == 1 {
                     "it is a federation 2 directive"
                 } else {

--- a/apollo-federation/src/schema/definitions.rs
+++ b/apollo-federation/src/schema/definitions.rs
@@ -11,7 +11,7 @@ fn is_composite_type(ty: &NamedType, schema: &Schema) -> Result<bool, Federation
             .types
             .get(ty)
             .ok_or_else(|| SingleFederationError::Internal {
-                message: format!("Cannot find type `'{}\'", ty),
+                message: format!("Cannot find type `'{ty}\'"),
             })?,
         apollo_compiler::schema::ExtendedType::Object(_)
             | apollo_compiler::schema::ExtendedType::Interface(_)

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -160,7 +160,7 @@ impl FederationSchema {
                 .types
                 .get(&type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema has no type \"{}\"", type_name),
+                    message: format!("Schema has no type \"{type_name}\""),
                 })?;
         Ok(match type_ {
             ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition { type_name }.into(),
@@ -282,8 +282,7 @@ impl FederationSchema {
                 type_name: FEDERATION_ENTITY_TYPE_NAME_IN_SPEC,
             })),
             Some(_) => Err(FederationError::internal(format!(
-                "Unexpectedly found non-union for federation spec's `{}` type definition",
-                FEDERATION_ENTITY_TYPE_NAME_IN_SPEC
+                "Unexpectedly found non-union for federation spec's `{FEDERATION_ENTITY_TYPE_NAME_IN_SPEC}` type definition"
             ))),
             None => Ok(None),
         }

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -1289,8 +1289,7 @@ impl SchemaDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Schema definition's directive application \"@{}\" does not refer to an existing directive.",
-                    name,
+                    "Schema definition's directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -1447,14 +1446,14 @@ impl SchemaRootDefinitionPosition {
         match self.root_kind {
             SchemaRootDefinitionKind::Query => schema_definition.query.as_ref().ok_or_else(|| {
                 SingleFederationError::Internal {
-                    message: format!("Schema definition has no root {} type", self),
+                    message: format!("Schema definition has no root {self} type"),
                 }
                 .into()
             }),
             SchemaRootDefinitionKind::Mutation => {
                 schema_definition.mutation.as_ref().ok_or_else(|| {
                     SingleFederationError::Internal {
-                        message: format!("Schema definition has no root {} type", self),
+                        message: format!("Schema definition has no root {self} type"),
                     }
                     .into()
                 })
@@ -1462,7 +1461,7 @@ impl SchemaRootDefinitionPosition {
             SchemaRootDefinitionKind::Subscription => {
                 schema_definition.subscription.as_ref().ok_or_else(|| {
                     SingleFederationError::Internal {
-                        message: format!("Schema definition has no root {} type", self),
+                        message: format!("Schema definition has no root {self} type"),
                     }
                     .into()
                 })
@@ -1484,7 +1483,7 @@ impl SchemaRootDefinitionPosition {
     ) -> Result<(), FederationError> {
         if self.try_get(&schema.schema).is_some() {
             return Err(SingleFederationError::Internal {
-                message: format!("Root {} already exists on schema definition", self),
+                message: format!("Root {self} already exists on schema definition"),
             }
             .into());
         }
@@ -1759,7 +1758,7 @@ impl ScalarTypeDefinitionPosition {
                 .scalar_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -1826,9 +1825,7 @@ impl ScalarTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Scalar type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Scalar type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -2158,7 +2155,7 @@ impl ObjectTypeDefinitionPosition {
                 .object_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -2315,9 +2312,7 @@ impl ObjectTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Object type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Object type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -2340,9 +2335,7 @@ impl ObjectTypeDefinitionPosition {
         let interface_type_referencers = referencers.interface_types.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Object type \"{}\"'s implements \"{}\" does not refer to an existing interface.",
-                    self,
-                    name,
+                    "Object type \"{self}\"'s implements \"{name}\" does not refer to an existing interface.",
                 ),
             }
         })?;
@@ -2807,9 +2800,7 @@ impl ObjectFieldDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Object field \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Object field \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -3095,9 +3086,7 @@ impl ObjectFieldArgumentDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Object field argument \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Object field argument \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -3474,7 +3463,7 @@ impl InterfaceTypeDefinitionPosition {
                 .interface_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -3601,9 +3590,7 @@ impl InterfaceTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Interface type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Interface type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -3626,9 +3613,7 @@ impl InterfaceTypeDefinitionPosition {
         let interface_type_referencers = referencers.interface_types.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Interface type \"{}\"'s implements \"{}\" does not refer to an existing interface.",
-                    self,
-                    name,
+                    "Interface type \"{self}\"'s implements \"{name}\" does not refer to an existing interface.",
                 ),
             }
         })?;
@@ -4040,9 +4025,7 @@ impl InterfaceFieldDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Interface field \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Interface field \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -4336,9 +4319,7 @@ impl InterfaceFieldArgumentDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Interface field argument \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Interface field argument \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -4608,7 +4589,7 @@ impl UnionTypeDefinitionPosition {
                 .union_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -4720,9 +4701,7 @@ impl UnionTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Union type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Union type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -4745,8 +4724,7 @@ impl UnionTypeDefinitionPosition {
         let object_type_referencers = referencers.object_types.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Union type \"{}\"'s member \"{}\" does not refer to an existing object.",
-                    self, name,
+                    "Union type \"{self}\"'s member \"{name}\" does not refer to an existing object.",
                 ),
             }
         })?;
@@ -4919,8 +4897,7 @@ impl UnionTypenameFieldDefinitionPosition {
             scalar_type_referencers.union_fields.insert(self.clone());
         } else {
             return Err(FederationError::internal(format!(
-                "Schema missing referencers for type \"{}\"",
-                output_type_reference
+                "Schema missing referencers for type \"{output_type_reference}\""
             )));
         }
         Ok(())
@@ -5097,7 +5074,7 @@ impl EnumTypeDefinitionPosition {
                 .enum_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -5177,9 +5154,7 @@ impl EnumTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Enum type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Enum type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -5490,9 +5465,7 @@ impl EnumValueDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Enum value \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Enum value \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -5694,7 +5667,7 @@ impl InputObjectTypeDefinitionPosition {
                 .input_object_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -5774,9 +5747,7 @@ impl InputObjectTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Input object type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Input object type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -6102,9 +6073,7 @@ impl InputObjectFieldDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Input object field \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Input object field \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -6348,7 +6317,7 @@ impl DirectiveDefinitionPosition {
                 .directives
                 .shift_remove(&self.directive_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for directive \"{}\"", self),
+                    message: format!("Schema missing referencers for directive \"{self}\""),
                 })?,
         ))
     }
@@ -6555,9 +6524,7 @@ impl DirectiveArgumentDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Directive argument \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Directive argument \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -473,7 +473,7 @@ impl TypeAndDirectiveSpecification for InputObjectTypeSpecification {
                 new_definition_fields.as_slice(),
                 existing_definition_fields.as_slice(),
                 schema,
-                format!("input object type {}", actual_name).as_str(),
+                format!("input object type {actual_name}").as_str(),
                 |s| SingleFederationError::TypeDefinitionInvalid {
                     message: s.to_string(),
                 },
@@ -821,7 +821,7 @@ fn is_valid_input_type_redefinition(
 fn default_value_message(value: Option<&Value>) -> String {
     match value {
         None => "no default value".to_string(),
-        Some(value) => format!("default value {}", value),
+        Some(value) => format!("default value {value}"),
     }
 }
 
@@ -913,8 +913,7 @@ fn ensure_same_fields(
         let Some(existing_field) = existing_field else {
             errors.push(SingleFederationError::TypeDefinitionInvalid {
                 message: format!(
-                    "Invalid definition of type {}: missing field {}",
-                    obj_type_name, field_name
+                    "Invalid definition of type {obj_type_name}: missing field {field_name}"
                 ),
             });
             continue;

--- a/apollo-federation/src/schema/validators/from_context.rs
+++ b/apollo-federation/src/schema/validators/from_context.rs
@@ -219,8 +219,7 @@ fn validate_selection_format(
                     errors.push(
                         SingleFederationError::ContextSelectionInvalid {
                             message: format!(
-                                "Context \"{}\" is used in \"{}\" but the selection is invalid: inline fragments must have type conditions",
-                                context, from_context_parent
+                                "Context \"{context}\" is used in \"{from_context_parent}\" but the selection is invalid: inline fragments must have type conditions"
                             ),
                         }
                         .into(),
@@ -232,8 +231,7 @@ fn validate_selection_format(
                 errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: fragment spreads are not allowed",
-                            context, from_context_parent
+                            "Context \"{context}\" is used in \"{from_context_parent}\" but the selection is invalid: fragment spreads are not allowed"
                         ),
                     }
                     .into(),
@@ -246,7 +244,7 @@ fn validate_selection_format(
     if has_field && has_inline_fragment {
         errors.push(
             SingleFederationError::ContextSelectionInvalid {
-                message: format!("Context \"{}\" is used in \"{}\" but the selection is invalid: multiple fields could be selected", context, from_context_parent),
+                message: format!("Context \"{context}\" is used in \"{from_context_parent}\" but the selection is invalid: multiple fields could be selected"),
             }
             .into(),
         );
@@ -259,8 +257,7 @@ fn validate_selection_format(
         errors.push(
             SingleFederationError::ContextSelectionInvalid {
                 message: format!(
-                    "Context \"{}\" is used in \"{}\" but the selection is invalid: type conditions have the same name",
-                    context, from_context_parent
+                    "Context \"{context}\" is used in \"{from_context_parent}\" but the selection is invalid: type conditions have the same name"
                 ),
             }
             .into(),
@@ -353,8 +350,7 @@ fn validate_field_value(
             errors.push(
             SingleFederationError::ContextSelectionInvalid {
                 message: format!(
-                    "Context \"{}\" is used in \"{}\" but the selection is invalid: multiple selections are made",
-                    context, target
+                    "Context \"{context}\" is used in \"{target}\" but the selection is invalid: multiple selections are made"
                 ),
             }
             .into(),
@@ -380,8 +376,7 @@ fn validate_field_value(
                     errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: the type of the selection does not match the expected type \"{}\"",
-                            context, target, expected_type
+                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection does not match the expected type \"{expected_type}\""
                         ),
                     }
                     .into(),
@@ -392,8 +387,7 @@ fn validate_field_value(
                     errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: the type of the selection \"{}\" does not match the expected type \"{}\"",
-                            context, target, resolved_type, expected_type
+                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection \"{resolved_type}\" does not match the expected type \"{expected_type}\""
                         ),
                     }
                     .into(),
@@ -446,8 +440,7 @@ fn validate_field_value(
                                     errors.push(
                                     SingleFederationError::ContextSelectionInvalid {
                                         message: format!(
-                                            "Context \"{}\" is used in \"{}\" but the selection is invalid: the type of the selection \"{}\" does not match the expected type \"{}\"",
-                                            context, target, resolved_type, expected_type
+                                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection \"{resolved_type}\" does not match the expected type \"{expected_type}\""
                                         ),
                                     }
                                     .into(),
@@ -459,8 +452,7 @@ fn validate_field_value(
                                 errors.push(
                                 SingleFederationError::ContextSelectionInvalid {
                                     message: format!(
-                                        "Context \"{}\" is used in \"{}\" but the selection is invalid: the type of the selection does not match the expected type \"{}\"",
-                                        context, target, expected_type
+                                        "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection does not match the expected type \"{expected_type}\""
                                     ),
                                 }
                                 .into(),
@@ -521,8 +513,7 @@ fn validate_field_value(
                     errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: no type condition matches the location \"{}\"",
-                            context, target, context_locations_str
+                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: no type condition matches the location \"{context_locations_str}\""
                         ),
                     }
                     .into(),
@@ -540,8 +531,7 @@ fn validate_field_value(
                 errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: type condition \"{}\" is never used",
-                            context, target, type_condition
+                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: type condition \"{type_condition}\" is never used"
                         ),
                     }
                     .into(),
@@ -627,8 +617,7 @@ impl FromContextValidator for DenyOnAbstractType {
             errors.push(
             SingleFederationError::ContextNotSet {
                 message: format!(
-                    "@fromContext argument cannot be used on a field that exists on an abstract type \"{}\".",
-                    target
+                    "@fromContext argument cannot be used on a field that exists on an abstract type \"{target}\"."
                 ),
                 }
                 .into(),
@@ -669,8 +658,7 @@ impl FromContextValidator for DenyOnInterfaceImplementation {
                     errors.push(
                         SingleFederationError::ContextNotSet {
                             message: format!(
-                                "@fromContext argument cannot be used on a field implementing an interface field \"{}\".",
-                                target
+                                "@fromContext argument cannot be used on a field implementing an interface field \"{target}\"."
                             ),
                         }
                         .into(),
@@ -709,8 +697,7 @@ impl<'a> FromContextValidator for RequireContextExists<'a> {
             errors.push(
                 SingleFederationError::NoContextReferenced {
                     message: format!(
-                        "@fromContext argument does not reference a context \"${} {}\".",
-                        context, selection
+                        "@fromContext argument does not reference a context \"${context} {selection}\"."
                     ),
                 }
                 .into(),
@@ -719,8 +706,7 @@ impl<'a> FromContextValidator for RequireContextExists<'a> {
             errors.push(
                 SingleFederationError::ContextNotSet {
                     message: format!(
-                        "Context \"{}\" is used at location \"{}\" but is never set.",
-                        context, target
+                        "Context \"{context}\" is used at location \"{target}\" but is never set."
                     ),
                 }
                 .into(),
@@ -729,8 +715,7 @@ impl<'a> FromContextValidator for RequireContextExists<'a> {
             errors.push(
                 SingleFederationError::NoSelectionForContext {
                     message: format!(
-                        "@fromContext directive in field \"{}\" has no selection",
-                        target
+                        "@fromContext directive in field \"{target}\" has no selection"
                     ),
                 }
                 .into(),
@@ -779,8 +764,7 @@ impl FromContextValidator for RequireResolvableKey {
                 errors.push(
                     SingleFederationError::ContextNoResolvableKey {
                         message: format!(
-                            "Object \"{}\" has no resolvable key but has a field with a contextual argument.",
-                            parent
+                            "Object \"{parent}\" has no resolvable key but has a field with a contextual argument."
                         ),
                     }
                     .into(),
@@ -832,8 +816,7 @@ impl FromContextValidator for DenyDefaultValues {
             errors.push(
                 SingleFederationError::ContextSelectionInvalid {
                     message: format!(
-                        "@fromContext arguments may not have a default value: \"{}\".",
-                        target
+                        "@fromContext arguments may not have a default value: \"{target}\"."
                     ),
                 }
                 .into(),

--- a/apollo-federation/src/schema/validators/interface_object.rs
+++ b/apollo-federation/src/schema/validators/interface_object.rs
@@ -80,7 +80,7 @@ fn validate_keys_on_interfaces_are_also_on_all_implementations(
                 let types_list = human_readable_list(
                     implementations_with_missing_keys
                         .iter()
-                        .map(|pos| format!("\"{}\"", pos)),
+                        .map(|pos| format!("\"{pos}\"")),
                     HumanReadableListOptions {
                         prefix: Some(HumanReadableListPrefix {
                             singular: "type",
@@ -103,7 +103,7 @@ fn validate_keys_on_interfaces_are_also_on_all_implementations(
                 let types_list = human_readable_list(
                     implementations_with_non_resolvable_keys
                         .iter()
-                        .map(|pos| format!("\"{}\"", pos)),
+                        .map(|pos| format!("\"{pos}\"")),
                     HumanReadableListOptions {
                         prefix: Some(HumanReadableListPrefix {
                             singular: "type",
@@ -156,8 +156,7 @@ fn validate_interface_objects_are_on_entities(
             error_collector.errors.push(
                 SingleFederationError::InterfaceObjectUsageError {
                     message: format!(
-                        "The @interfaceObject directive can only be applied to entity types but type \"{}\" has no @key in this subgraph.",
-                        type_pos
+                        "The @interfaceObject directive can only be applied to entity types but type \"{type_pos}\" has no @key in this subgraph."
                     )
                 }
             )

--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -231,8 +231,7 @@ pub(crate) fn validate_merged_schema(
                         },
                         |incompatible_subgraphs| {
                             Ok(format!(
-                                "cannot provide a value for argument \"{}\" of field \"{}\" as argument \"{}\" is not defined in {}",
-                                argument_name, field_name, argument_name, incompatible_subgraphs,
+                                "cannot provide a value for argument \"{argument_name}\" of field \"{field_name}\" as argument \"{argument_name}\" is not defined in {incompatible_subgraphs}",
                             ))
                         },
                         subgraphs,
@@ -266,8 +265,7 @@ pub(crate) fn validate_merged_schema(
                         },
                         |incompatible_subgraphs| {
                             Ok(format!(
-                                "no value provided for argument \"{}\" of field \"{}\" but a value is mandatory as \"{}\" is required in {}",
-                                argument_name, field_name, argument_name, incompatible_subgraphs,
+                                "no value provided for argument \"{argument_name}\" of field \"{field_name}\" but a value is mandatory as \"{argument_name}\" is required in {incompatible_subgraphs}",
                             ))
                         },
                         subgraphs,

--- a/apollo-federation/src/schema/validators/tag.rs
+++ b/apollo-federation/src/schema/validators/tag.rs
@@ -36,8 +36,7 @@ pub(crate) fn validate_tag_directives(
         if tag_name.len() > MAX_TAG_LENGTH || !TAG_NAME_PATTERN.is_match(tag_name) {
             let message = if matches!(tag_directive.target, TagDirectiveTargetPosition::Schema(_)) {
                 format!(
-                    "Schema root has invalid @tag directive value '{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                    tag_name
+                    "Schema root has invalid @tag directive value '{tag_name}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                 )
             } else {
                 format!(

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -558,11 +558,11 @@ pub mod test_utils {
                 b.len(),
                 a.len(),
                 b.iter()
-                    .map(|(code, msg)| { format!("- {}: {}", code, msg) })
+                    .map(|(code, msg)| { format!("- {code}: {msg}") })
                     .collect::<Vec<_>>()
                     .join("\n"),
                 a.iter()
-                    .map(|(code, msg)| { format!("+ {}: {}", code, msg) })
+                    .map(|(code, msg)| { format!("+ {code}: {msg}") })
                     .collect::<Vec<_>>()
                     .join("\n"),
             ));

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -621,7 +621,7 @@ fn find_unused_name_for_directive(
     // The schema already defines a directive named `@link` so we need to use an alias. To keep it
     // simple, we add a number in the end (so we try `@link1`, and if that's taken `@link2`, ...)
     for i in 1..=1000 {
-        let candidate = Name::try_from(format!("{}{}", directive_name, i))?;
+        let candidate = Name::try_from(format!("{directive_name}{i}"))?;
         if schema.get_directive_definition(&candidate).is_none() {
             return Ok(Some(candidate));
         }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -367,8 +367,7 @@ fn collect_empty_subgraphs(
             .get(&graph_directive_definition.name)
             .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
                 message: format!(
-                    "Value \"{}\" of join__Graph enum has no @join__graph directive",
-                    enum_value_name
+                    "Value \"{enum_value_name}\" of join__Graph enum has no @join__graph directive"
                 ),
             })?;
         let graph_arguments = join_spec_definition.graph_directive_arguments(graph_application)?;
@@ -648,7 +647,7 @@ fn add_empty_type(
     // In fed2, we always mark all types with `@join__type` but making sure.
     if type_directive_applications.is_empty() {
         return Err(SingleFederationError::InvalidFederationSupergraph {
-            message: format!("Missing @join__type on \"{}\"", type_definition_position),
+            message: format!("Missing @join__type on \"{type_definition_position}\""),
         }
         .into());
     }
@@ -1009,10 +1008,7 @@ fn extract_object_type_content(
                         return Err(
                             SingleFederationError::InvalidFederationSupergraph {
                                 message: format!(
-                                    "@join__field cannot exist on {}.{} for subgraph {} without type-level @join__type",
-                                    type_name,
-                                    field_name,
-                                    graph_enum_value,
+                                    "@join__field cannot exist on {type_name}.{field_name} for subgraph {graph_enum_value} without type-level @join__type",
                                 ),
                             }.into()
                         );
@@ -1070,9 +1066,7 @@ fn extract_interface_type_content(
             let is_interface_object = *subgraph_info.get(graph_enum_value).ok_or_else(|| {
                 SingleFederationError::InvalidFederationSupergraph {
                     message: format!(
-                        "@join__implements cannot exist on {} for subgraph {} without type-level @join__type",
-                        type_name,
-                        graph_enum_value,
+                        "@join__implements cannot exist on {type_name} for subgraph {graph_enum_value} without type-level @join__type",
                     ),
                 }
             })?;
@@ -1198,10 +1192,7 @@ fn extract_interface_type_content(
                         return Err(
                             SingleFederationError::InvalidFederationSupergraph {
                                 message: format!(
-                                    "@join__field cannot exist on {}.{} for subgraph {} without type-level @join__type",
-                                    type_name,
-                                    field_name,
-                                    graph_enum_value,
+                                    "@join__field cannot exist on {type_name}.{field_name} for subgraph {graph_enum_value} without type-level @join__type",
                                 ),
                             }.into()
                         );
@@ -1475,10 +1466,7 @@ fn extract_input_object_type_content(
                         return Err(
                             SingleFederationError::InvalidFederationSupergraph {
                                 message: format!(
-                                    "@join__field cannot exist on {}.{} for subgraph {} without type-level @join__type",
-                                    type_name,
-                                    input_field_name,
-                                    graph_enum_value,
+                                    "@join__field cannot exist on {type_name}.{input_field_name} for subgraph {graph_enum_value} without type-level @join__type",
                                 ),
                             }.into()
                         );
@@ -1611,11 +1599,11 @@ fn add_subgraph_field(
             } = args;
             let (_, context_name_in_subgraph) = context.rsplit_once("__").ok_or_else(|| {
                 SingleFederationError::InvalidFederationSupergraph {
-                    message: format!(r#"Invalid context "{}" in supergraph schema"#, context),
+                    message: format!(r#"Invalid context "{context}" in supergraph schema"#),
                 }
             })?;
 
-            let arg = format!("${} {}", context_name_in_subgraph, selection);
+            let arg = format!("${context_name_in_subgraph} {selection}");
             let from_context_directive =
                 federation_spec_definition.from_context_directive(&subgraph.schema, arg)?;
             let directives = std::iter::once(from_context_directive).collect();
@@ -1702,8 +1690,7 @@ fn get_subgraph<'subgraph>(
         .ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Invalid graph enum_value \"{}\": does not match an enum value defined in the @join__Graph enum",
-                    graph_enum_value,
+                    "Invalid graph enum_value \"{graph_enum_value}\": does not match an enum value defined in the @join__Graph enum",
                 ),
             }
         })?;
@@ -2278,8 +2265,7 @@ fn maybe_dump_subgraph_schema(subgraph: FederationSubgraph, message: &mut String
         }
         _ => write!(
             message,
-            "Re-run with environment variable '{}' set to 'true' to extract the invalid subgraph",
-            DEBUG_SUBGRAPHS_ENV_VARIABLE_NAME
+            "Re-run with environment variable '{DEBUG_SUBGRAPHS_ENV_VARIABLE_NAME}' set to 'true' to extract the invalid subgraph"
         ),
     };
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -116,7 +116,7 @@ pub(crate) fn compose(
         .map(|(name, schema)| {
             (
                 *name,
-                format!("extend schema {DEFAULT_LINK_DIRECTIVE}\n\n{}", schema,),
+                format!("extend schema {DEFAULT_LINK_DIRECTIVE}\n\n{schema}",),
             )
         })
         .collect();

--- a/apollo-federation/tests/subgraph/parse_expand_tests.rs
+++ b/apollo-federation/tests/subgraph/parse_expand_tests.rs
@@ -17,7 +17,7 @@ fn can_parse_and_expand() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("T"));
@@ -48,7 +48,7 @@ fn can_parse_and_expand_with_renames() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.directive_definitions.contains_key("myKey"));
@@ -78,7 +78,7 @@ fn can_parse_and_expand_with_namespace() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.directive_definitions.contains_key("key"));
@@ -118,7 +118,7 @@ fn can_parse_and_expand_preserves_user_definitions() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("Purpose"));
@@ -139,7 +139,7 @@ fn can_parse_and_expand_works_with_fed_v1() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("T"));

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -101,7 +101,7 @@ mod fieldset_based_directives {
             let schema_str = format!(
                 r#"
                 extend schema
-                @link(url: "https://specs.apollo.dev/federation/v{}", import: ["@key"])
+                @link(url: "https://specs.apollo.dev/federation/v{version}", import: ["@key"])
 
                 type Query {{
                 t: T
@@ -110,8 +110,7 @@ mod fieldset_based_directives {
                 interface T @key(fields: "f") {{
                 f: Int
                 }}
-            "#,
-                version
+            "#
             );
             let err = build_for_errors_with_option(&schema_str, BuildOption::AsIs);
 
@@ -2119,127 +2118,109 @@ mod tag_tests {
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema root has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema root has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Foo has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Foo has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Foo.foo1 has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Foo.foo1 has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Foo.foo2(arg:) has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Foo.foo2(arg:) has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Bar has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Bar has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Query.foo has invalid @tag directive value '{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Query.foo has invalid @tag directive value '{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Query.bar has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Query.bar has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Query.baz has invalid @tag directive value 'test{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Query.baz has invalid @tag directive value 'test{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Bar.bar1 has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Bar.bar1 has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Bar.bar2(arg:) has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Bar.bar2(arg:) has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Baz has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Baz has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element CustomScalar has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element CustomScalar has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestEnum has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestEnum has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestEnum.VALUE1 has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestEnum.VALUE1 has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestInput has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestInput has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestInput.inputField1 has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestInput.inputField1 has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestInput.inputField3 has invalid @tag directive value '{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestInput.inputField3 has invalid @tag directive value '{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element @custom(arg:) has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element @custom(arg:) has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                 ]
@@ -2261,15 +2242,13 @@ mod tag_tests {
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Query.foo has invalid @tag directive value '{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Query.foo has invalid @tag directive value '{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestInput.inputField3 has invalid @tag directive value '{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestInput.inputField3 has invalid @tag directive value '{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                 ]
@@ -2320,8 +2299,7 @@ mod tag_tests {
             [(
                 "INVALID_TAG_NAME",
                 &format!(
-                    "[S] Schema element T has invalid @tag directive value '{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                    invalid
+                    "[S] Schema element T has invalid @tag directive value '{invalid}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                 )
             )]
         );

--- a/apollo-router/benches/deeply_nested.rs
+++ b/apollo-router/benches/deeply_nested.rs
@@ -123,7 +123,7 @@ async fn spawn_router(graphql_recursion_limit: usize) -> tokio::process::Child {
                 }
             }
             if VERBOSE {
-                println!("{}", line);
+                println!("{line}");
             }
         }
     });
@@ -183,9 +183,9 @@ async fn spawn_subgraph() -> ShutdownOnDrop {
 
                     tokio::spawn(async move {
                         if let Err(err) = conn.await {
-                            eprintln!("connection error: {}", err);
+                            eprintln!("connection error: {err}");
                         }
-                        eprintln!("connection dropped: {}", peer_addr);
+                        eprintln!("connection dropped: {peer_addr}");
                     });
                 }
                 _ = rx.recv() => {

--- a/apollo-router/benches/huge_requests.rs
+++ b/apollo-router/benches/huge_requests.rs
@@ -76,7 +76,7 @@ async fn one_request(string_variable_bytes: usize) {
                 }
             }
             if VERBOSE {
-                println!("{}", line);
+                println!("{line}");
             }
         }
     });
@@ -166,9 +166,9 @@ async fn spawn_subgraph() -> ShutdownOnDrop {
 
                     tokio::spawn(async move {
                         if let Err(err) = conn.await {
-                            eprintln!("connection error: {}", err);
+                            eprintln!("connection error: {err}");
                         }
-                        eprintln!("connection dropped: {}", peer_addr);
+                        eprintln!("connection dropped: {peer_addr}");
                     });
                 }
                 _ = rx.recv() => {

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -194,7 +194,7 @@ impl UsageReportingOperationDetails {
             .as_deref()
             .unwrap_or("")
             .to_string();
-        format!("# {}\n{}", op_name, op_sig)
+        format!("# {op_name}\n{op_sig}")
     }
 }
 
@@ -242,7 +242,7 @@ impl UsageReporting {
                 operation_details.get_signature_and_operation()
             }
             UsageReporting::Error(error_key) => {
-                format!("## {}\n", error_key)
+                format!("## {error_key}\n")
             }
             UsageReporting::PersistedQuery {
                 operation_details,
@@ -267,7 +267,7 @@ impl UsageReporting {
                 operation_details, ..
             } => operation_details.get_signature_and_operation(),
             UsageReporting::Error(error_key) => {
-                format!("# # {}\n", error_key)
+                format!("# # {error_key}\n")
             }
         };
         Self::hash_string(&string_to_hash)
@@ -279,7 +279,7 @@ impl UsageReporting {
             | UsageReporting::PersistedQuery {
                 operation_details, ..
             } => operation_details.operation_name_or_default(),
-            UsageReporting::Error(error_key) => format!("# {}", error_key),
+            UsageReporting::Error(error_key) => format!("# {error_key}"),
         }
     }
 
@@ -951,7 +951,7 @@ fn format_operation(
     if !shorthand {
         f.write_str(operation.operation_type.name())?;
         if let Some(name) = &operation.name {
-            write!(f, " {}", name)?;
+            write!(f, " {name}")?;
         }
 
         // print variables sorted by name
@@ -1034,7 +1034,7 @@ fn format_selection_set(
                 formatter: &ApolloReportingSignatureFormatter::Field(field),
                 normalization_algorithm,
             };
-            let field_str = format!("{}", formatter);
+            let field_str = format!("{formatter}");
             f.write_str(&field_str)?;
 
             // We need to insert a space if this is not the last field and it ends in an alphanumeric character.
@@ -1111,7 +1111,7 @@ fn format_field(
                     formatter: &ApolloReportingSignatureFormatter::Argument(a),
                     normalization_algorithm,
                 };
-                format!("{}", formatter)
+                format!("{formatter}")
             })
             .collect();
 
@@ -1129,7 +1129,7 @@ fn format_field(
                         .last()
                         .is_none_or(|c| c.is_alphanumeric() || c == '_'))
             {
-                write!(f, "{}", separator)?;
+                write!(f, "{separator}")?;
             }
         }
         f.write_str(")")?;
@@ -1146,7 +1146,7 @@ fn format_inline_fragment(
     f: &mut fmt::Formatter,
 ) -> fmt::Result {
     if let Some(type_name) = &inline_fragment.type_condition {
-        write!(f, "...on {}", type_name)?;
+        write!(f, "...on {type_name}")?;
     } else {
         f.write_str("...")?;
     }
@@ -1205,7 +1205,7 @@ fn format_directives(
                     formatter: &ApolloReportingSignatureFormatter::Argument(argument),
                     normalization_algorithm,
                 };
-                write!(f, "{}", formatter)?;
+                write!(f, "{formatter}")?;
             }
 
             f.write_str(")")?;
@@ -1230,7 +1230,7 @@ fn format_value(
                     if index != 0 {
                         f.write_str(",")?;
                     }
-                    write!(f, "{}:", name)?;
+                    write!(f, "{name}:")?;
                     format_value(val, normalization_algorithm, f)?;
                 }
                 f.write_str("}")

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1638,10 +1638,10 @@ async fn assert_cors_origin(response: reqwest::Response, origin: &str) {
             .text()
             .await
             .unwrap_or_else(|_| "Failed to get response body".to_string());
-        println!("Response status: {}", status);
-        println!("Response headers: {:?}", headers);
-        println!("Response body: {}", body);
-        panic!("Response status is not success: {}", status);
+        println!("Response status: {status}");
+        println!("Response headers: {headers:?}");
+        println!("Response body: {body}");
+        panic!("Response status is not success: {status}");
     }
     let headers = response.headers();
     assert_headers_valid(&response);
@@ -2286,7 +2286,7 @@ async fn send_to_unix_socket(addr: &ListenAddr, method: Method, body: &str) -> S
     let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
     tokio::task::spawn(async move {
         if let Err(err) = conn.await {
-            println!("Connection failed: {:?}", err);
+            println!("Connection failed: {err:?}");
         }
     });
 

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -227,7 +227,7 @@ where
             tracing::error!("couldn't serialize value to redis {}. This is a bug in the router, please file an issue: https://github.com/apollographql/router/issues/new", e);
             RedisError::new(
                 RedisErrorKind::Parse,
-                format!("couldn't serialize value to redis {}", e),
+                format!("couldn't serialize value to redis {e}"),
             )
         })?;
 
@@ -448,8 +448,7 @@ impl RedisCacheStorage {
                     return Err(RedisError::new(
                         RedisErrorKind::Config,
                         format!(
-                            "invalid Redis URL scheme, expected a scheme from {SUPPORTED_REDIS_SCHEMES:?}, got: {}",
-                            scheme
+                            "invalid Redis URL scheme, expected a scheme from {SUPPORTED_REDIS_SCHEMES:?}, got: {scheme}"
                         ),
                     ));
                 }
@@ -759,7 +758,7 @@ mod test {
     fn it_preprocesses_redis_schemas_correctly() {
         // Base Format
         for scheme in ["redis", "rediss"] {
-            let url_s = format!("{}://username:password@host:6666/database", scheme);
+            let url_s = format!("{scheme}://username:password@host:6666/database");
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
             assert!(super::RedisCacheStorage::preprocess_urls(urls).is_ok());
@@ -767,8 +766,7 @@ mod test {
         // Cluster Format
         for scheme in ["redis-cluster", "rediss-cluster"] {
             let url_s = format!(
-                "{}://username:password@host:6666?node=host1:6667&node=host2:6668",
-                scheme
+                "{scheme}://username:password@host:6666?node=host1:6667&node=host2:6668"
             );
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
@@ -777,8 +775,7 @@ mod test {
         // Sentinel Format
         for scheme in ["redis-sentinel", "rediss-sentinel"] {
             let url_s = format!(
-                "{}://username:password@host:6666?node=host1:6667&node=host2:6668&sentinelServiceName=myservice&sentinelUserName=username2&sentinelPassword=password2",
-                scheme
+                "{scheme}://username:password@host:6666?node=host1:6667&node=host2:6668&sentinelServiceName=myservice&sentinelUserName=username2&sentinelPassword=password2"
             );
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
@@ -786,7 +783,7 @@ mod test {
         }
         // Make sure it fails on sample invalid schemes
         for scheme in ["wrong", "something"] {
-            let url_s = format!("{}://username:password@host:6666/database", scheme);
+            let url_s = format!("{scheme}://username:password@host:6666/database");
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
             assert!(super::RedisCacheStorage::preprocess_urls(urls).is_err());

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -765,9 +765,8 @@ mod test {
         }
         // Cluster Format
         for scheme in ["redis-cluster", "rediss-cluster"] {
-            let url_s = format!(
-                "{scheme}://username:password@host:6666?node=host1:6667&node=host2:6668"
-            );
+            let url_s =
+                format!("{scheme}://username:password@host:6666?node=host1:6667&node=host2:6668");
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
             assert!(super::RedisCacheStorage::preprocess_urls(urls).is_ok());

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -594,7 +594,7 @@ fn gen_schema(
                 .unwrap_or_default()
                 .into_iter()
                 // Wrap plugin name with regex start/end to enforce exact match
-                .map(|(k, v)| (format!("^{}$", k), v))
+                .map(|(k, v)| (format!("^{k}$"), v))
                 .collect(),
             ..Default::default()
         })),

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -126,7 +126,7 @@ pub(crate) fn validate_yaml_configuration(
         match result {
             Ok(schema) => schema,
             Err(e) => {
-                panic!("failed to compile configuration schema: {}", e)
+                panic!("failed to compile configuration schema: {e}")
             }
         }
     });

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -960,7 +960,7 @@ fn test_deserialize_derive_default() {
             if deserialize_regex.is_match(line) {
                 // Get the struct name
                 if let Some(struct_name) = find_struct_name(&lines, line_number) {
-                    let manual_implementation = format!("impl Default for {} ", struct_name);
+                    let manual_implementation = format!("impl Default for {struct_name} ");
 
                     let has_field_level_defaults =
                         has_field_level_serde_defaults(&lines, line_number);

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -84,7 +84,7 @@ pub(crate) fn upgrade_configuration(
         if let Some(migration) = Asset::get(&filename) {
             let parsed_migration = serde_yaml::from_slice(&migration.data).map_err(|error| {
                 ConfigurationError::MigrationFailure {
-                    error: format!("Failed to parse migration {}: {}", filename, error),
+                    error: format!("Failed to parse migration {filename}: {error}"),
                 }
             })?;
             migrations.push(parsed_migration);
@@ -207,12 +207,12 @@ fn apply_migration(config: &Value, migration: &Migration) -> Result<Value, Confi
 pub(crate) fn generate_upgrade(config: &str, diff: bool) -> Result<String, ConfigurationError> {
     let parsed_config =
         serde_yaml::from_str(config).map_err(|error| ConfigurationError::MigrationFailure {
-            error: format!("Failed to parse config: {}", error),
+            error: format!("Failed to parse config: {error}"),
         })?;
     let upgraded_config = upgrade_configuration(&parsed_config, true, UpgradeMode::Major)?;
     let upgraded_config = serde_yaml::to_string(&upgraded_config).map_err(|error| {
         ConfigurationError::MigrationFailure {
-            error: format!("Failed to serialize upgraded config: {}", error),
+            error: format!("Failed to serialize upgraded config: {error}"),
         }
     })?;
     generate_upgrade_output(config, &upgraded_config, diff)

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -523,7 +523,7 @@ impl std::fmt::Display for ParseErrors {
             if i > 0 {
                 f.write_str("\n")?;
             }
-            write!(f, "{}", error)?;
+            write!(f, "{error}")?;
         }
         let remaining = errors.count();
         if remaining > 0 {

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -447,7 +447,7 @@ impl Executable {
                 )?
                 .validate()?;
 
-                println!("Configuration at path {:?} is valid!", config_path);
+                println!("Configuration at path {config_path:?} is valid!");
 
                 Ok(())
             }

--- a/apollo-router/src/graphql/mod.rs
+++ b/apollo-router/src/graphql/mod.rs
@@ -160,13 +160,13 @@ impl Error {
 
     pub(crate) fn from_value(value: Value) -> Result<Error, MalformedResponseError> {
         let mut object = ensure_object!(value).map_err(|error| MalformedResponseError {
-            reason: format!("invalid error within `errors`: {}", error),
+            reason: format!("invalid error within `errors`: {error}"),
         })?;
 
         let extensions =
             extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
                 .map_err(|err| MalformedResponseError {
-                    reason: format!("invalid `extensions` within error: {}", err),
+                    reason: format!("invalid `extensions` within error: {err}"),
                 })?
                 .unwrap_or_default();
         let message = match extract_key_value_from_object!(object, "message", Value::String(s) => s)
@@ -176,7 +176,7 @@ impl Error {
                 reason: "missing required `message` property within error".to_owned(),
             }),
             Err(err) => Err(MalformedResponseError {
-                reason: format!("invalid `message` within error: {}", err),
+                reason: format!("invalid `message` within error: {err}"),
             }),
         }?;
         let locations = extract_key_value_from_object!(object, "locations")
@@ -184,14 +184,14 @@ impl Error {
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| MalformedResponseError {
-                reason: format!("invalid `locations` within error: {}", err),
+                reason: format!("invalid `locations` within error: {err}"),
             })?
             .unwrap_or_default();
         let path = extract_key_value_from_object!(object, "path")
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| MalformedResponseError {
-                reason: format!("invalid `path` within error: {}", err),
+                reason: format!("invalid `path` within error: {err}"),
             })?;
         let apollo_id: Option<Uuid> = extract_key_value_from_object!(
             object,
@@ -199,11 +199,11 @@ impl Error {
             Value::String(s) => s
         )
         .map_err(|err| MalformedResponseError {
-            reason: format!("invalid `apolloId` within error: {}", err),
+            reason: format!("invalid `apolloId` within error: {err}"),
         })?
         .map(|s| {
             Uuid::from_str(s.as_str()).map_err(|err| MalformedResponseError {
-                reason: format!("invalid `apolloId` within error: {}", err),
+                reason: format!("invalid `apolloId` within error: {err}"),
             })
         })
         .transpose()?;

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -876,7 +876,7 @@ where
     } else {
         "".to_string()
     };
-    let res = format!("@{}", tc_string);
+    let res = format!("@{tc_string}");
     serializer.serialize_str(res.as_str())
 }
 
@@ -920,7 +920,7 @@ where
     } else {
         "".to_string()
     };
-    let res = format!("{}{}", key, tc_string);
+    let res = format!("{key}{tc_string}");
     serializer.serialize_str(res.as_str())
 }
 
@@ -1060,7 +1060,7 @@ impl Path {
                 if let Some(c) = type_conditions {
                     tc = format!("|[{}]", c.join(","));
                 };
-                Some(format!("{}{}", key, tc))
+                Some(format!("{key}{tc}"))
             }
             _ => None,
         })

--- a/apollo-router/src/plugins/authentication/subgraph.rs
+++ b/apollo-router/src/plugins/authentication/subgraph.rs
@@ -355,7 +355,7 @@ impl SigningParamsConfig {
         let (signing_instructions, _signature) = sign(signable_request, &signing_params.into())
             .map_err(|err| {
                 increment_failure_counter(subgraph_name);
-                let error = format!("failed to sign GraphQL body for AWS SigV4: {}", err);
+                let error = format!("failed to sign GraphQL body for AWS SigV4: {err}");
                 tracing::error!("{}", error);
                 error
             })?
@@ -394,7 +394,7 @@ impl SigningParamsConfig {
         let (signing_instructions, _signature) = sign(signable_request, &signing_params.into())
             .map_err(|err| {
                 increment_failure_counter(subgraph_name);
-                let error = format!("failed to sign GraphQL body for AWS SigV4: {}", err);
+                let error = format!("failed to sign GraphQL body for AWS SigV4: {err}");
                 tracing::error!("{}", error);
                 error
             })?
@@ -425,7 +425,7 @@ impl SigningParamsConfig {
             .await
             .map_err(|err| {
                 increment_failure_counter(self.subgraph_name.as_str());
-                let error = format!("failed to get credentials for AWS SigV4 signing: {}", err);
+                let error = format!("failed to get credentials for AWS SigV4 signing: {err}");
                 tracing::error!("{}", error);
                 error.into()
             })

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -168,7 +168,7 @@ async fn build_a_test_harness(
         .await
     {
         Ok(test_harness) => test_harness,
-        Err(e) => panic!("Failed to build test harness: {}", e),
+        Err(e) => panic!("Failed to build test harness: {e}"),
     }
 }
 
@@ -692,7 +692,7 @@ async fn it_inserts_success_jwt_status_into_context() {
             assert_eq!(r#type, "header");
             assert!(name.eq_ignore_ascii_case("Authorization"));
         }
-        JwtStatus::Failure { .. } => panic!("expected a success but got {:?}", jwt_context),
+        JwtStatus::Failure { .. } => panic!("expected a success but got {jwt_context:?}"),
     }
 
     let response: graphql::Response = serde_json::from_slice(
@@ -1742,7 +1742,7 @@ async fn jwks_send_headers() {
     let got_header = Arc::new(AtomicBool::new(false));
     let gh = got_header.clone();
     let service = move |headers: HeaderMap| {
-        println!("got re: {:?}", headers);
+        println!("got re: {headers:?}");
         let gh: Arc<AtomicBool> = gh.clone();
         async move {
             if headers.get("jwks-authz").and_then(|v| v.to_str().ok()) == Some("user1") {

--- a/apollo-router/src/plugins/chaos/reload.rs
+++ b/apollo-router/src/plugins/chaos/reload.rs
@@ -352,7 +352,7 @@ mod tests {
                 assert!(reloaded_schema.sdl.contains(&schema.sdl));
                 assert_eq!(reloaded_schema.launch_id, schema.launch_id);
             }
-            _ => panic!("Expected UpdateSchema event, got {:?}", event),
+            _ => panic!("Expected UpdateSchema event, got {event:?}"),
         }
     }
 
@@ -378,7 +378,7 @@ mod tests {
                 // Should be a clone of the original config (different Arc but same contents)
                 assert!(!Arc::ptr_eq(&reloaded_config, &config));
             }
-            _ => panic!("Expected UpdateConfiguration event, got {:?}", event),
+            _ => panic!("Expected UpdateConfiguration event, got {event:?}"),
         }
     }
 

--- a/apollo-router/src/plugins/connectors/request_limit.rs
+++ b/apollo-router/src/plugins/connectors/request_limit.rs
@@ -25,10 +25,10 @@ impl Display for RequestLimitKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             RequestLimitKey::SourceName(source_name) => {
-                write!(f, "connector source {}", source_name)
+                write!(f, "connector source {source_name}")
             }
             RequestLimitKey::ConnectorLabel(connector_label) => {
-                write!(f, "connector {}", connector_label)
+                write!(f, "connector {connector_label}")
             }
         }
     }

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -553,8 +553,7 @@ async fn basic_connection_errors() {
         msg.starts_with(
             "Connector error: HTTP fetch failed from 'connectors.json': tcp connect error:" // *nix: Connection refused, Windows: No connection could be made
         ),
-        "got message: {}",
-        msg
+        "got message: {msg}"
     );
     assert_eq!(err.get("path").unwrap(), &serde_json::json!(["users"]));
     assert_eq!(
@@ -2248,8 +2247,8 @@ async fn execute(
     config: Option<serde_json_bytes::Value>,
     mut request_mutator: impl FnMut(&mut Request),
 ) -> serde_json::Value {
-    let connector_uri = format!("{}/", uri);
-    let subgraph_uri = format!("{}/graphql", uri);
+    let connector_uri = format!("{uri}/");
+    let subgraph_uri = format!("{uri}/graphql");
 
     // we cannot use Testharness because the subgraph connectors are actually extracted in YamlRouterFactory
     let mut factory = YamlRouterFactory;

--- a/apollo-router/src/plugins/connectors/tests/req_asserts.rs
+++ b/apollo-router/src/plugins/connectors/tests/req_asserts.rs
@@ -190,7 +190,7 @@ impl Plan {
                             continue 'requests;
                         }
                     }
-                    panic!("No plan matched request {:?}", request);
+                    panic!("No plan matched request {request:?}");
                 }
             }
         }

--- a/apollo-router/src/plugins/cors.rs
+++ b/apollo-router/src/plugins/cors.rs
@@ -53,8 +53,7 @@ impl CorsLayer {
                 for origin in &policy.origins {
                     http::HeaderValue::from_str(origin).map_err(|_| {
                         format!(
-                            "origin '{}' is not valid: failed to parse header value",
-                            origin
+                            "origin '{origin}' is not valid: failed to parse header value"
                         )
                     })?;
                 }
@@ -349,7 +348,7 @@ impl<S> CorsService<S> {
                 let mut existing_values = existing_str.split(',').map(|v| v.trim());
 
                 if !existing_values.any(|existing| existing.eq_ignore_ascii_case(value.as_str())) {
-                    let new_vary = format!("{}, {}", existing_str, value);
+                    let new_vary = format!("{existing_str}, {value}");
                     let new_header_value = http::HeaderValue::from_str(&new_vary)
                         .expect("combining pre-existing header + hardcoded valid value can not produce an invalid result");
                     headers.insert(VARY, new_header_value);

--- a/apollo-router/src/plugins/cors.rs
+++ b/apollo-router/src/plugins/cors.rs
@@ -52,9 +52,7 @@ impl CorsLayer {
                 // Validate origin URLs
                 for origin in &policy.origins {
                     http::HeaderValue::from_str(origin).map_err(|_| {
-                        format!(
-                            "origin '{origin}' is not valid: failed to parse header value"
-                        )
+                        format!("origin '{origin}' is not valid: failed to parse header value")
                     })?;
                 }
 

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -429,8 +429,7 @@ impl StaticCostCalculator {
 
         let schema = self.subgraph_schemas.get(subgraph).ok_or_else(|| {
             DemandControlError::QueryParseFailure(format!(
-                "Query planner did not provide a schema for service {}",
-                subgraph
+                "Query planner did not provide a schema for service {subgraph}"
             ))
         })?;
 

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -208,7 +208,7 @@ impl DemandControlError {
 
 impl<T> From<WithErrors<T>> for DemandControlError {
     fn from(value: WithErrors<T>) -> Self {
-        DemandControlError::QueryParseFailure(format!("{}", value))
+        DemandControlError::QueryParseFailure(format!("{value}"))
     }
 }
 
@@ -220,8 +220,7 @@ impl From<FieldLookupError<'_>> for DemandControlError {
             ),
             FieldLookupError::NoSuchField(type_name, _) => {
                 DemandControlError::QueryParseFailure(format!(
-                    "Attempted to look up a field on type {}, but the field does not exist",
-                    type_name
+                    "Attempted to look up a field on type {type_name}, but the field does not exist"
                 ))
             }
         }

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -233,7 +233,7 @@ async fn supergraph_layer(mut req: supergraph::Request) -> Result<supergraph::Re
                         variables,
                         variable_path,
                         serde_json_bytes::Value::String(
-                            format!("<Placeholder for file '{}'>", filename).into(),
+                            format!("<Placeholder for file '{filename}'>").into(),
                         ),
                     )
                     .map_err(|path| FileUploadError::InputValueNotFound(path.join(".")))?;

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -174,7 +174,7 @@ where
             let filename = field
                 .file_name()
                 .or_else(|| field.name())
-                .map(|name| format!("'{}'", name))
+                .map(|name| format!("'{name}'"))
                 .unwrap_or_else(|| "unknown".to_owned());
 
             let field = Pin::new(field);
@@ -228,7 +228,7 @@ where
                     return Poll::Ready(Some(Err(FileUploadError::MissingFiles(
                         files
                             .into_iter()
-                            .map(|file| format!("'{}'", file))
+                            .map(|file| format!("'{file}'"))
                             .join(", "),
                     ))));
                 }

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -226,10 +226,7 @@ where
 
                     let files = mem::take(&mut self.file_names);
                     return Poll::Ready(Some(Err(FileUploadError::MissingFiles(
-                        files
-                            .into_iter()
-                            .map(|file| format!("'{file}'"))
-                            .join(", "),
+                        files.into_iter().map(|file| format!("'{file}'")).join(", "),
                     ))));
                 }
                 Poll::Ready(Ok(Some(field))) => {

--- a/apollo-router/src/plugins/file_uploads/rearrange_query_plan.rs
+++ b/apollo-router/src/plugins/file_uploads/rearrange_query_plan.rs
@@ -109,7 +109,7 @@ fn rearrange_plan_node<'a>(
                     return Err(FileUploadError::VariablesForbiddenInsideSubscription(
                         rest_variables
                             .into_keys()
-                            .map(|name| format!("${}", name))
+                            .map(|name| format!("${name}"))
                             .join(", "),
                     ));
                 }
@@ -146,7 +146,7 @@ fn rearrange_plan_node<'a>(
                 return Err(FileUploadError::VariablesForbiddenInsideDefer(
                     deferred_variables
                         .into_keys()
-                        .map(|name| format!("${}", name))
+                        .map(|name| format!("${name}"))
                         .join(", "),
                 ));
             }
@@ -193,7 +193,7 @@ fn rearrange_plan_node<'a>(
                 return Err(FileUploadError::DuplicateVariableUsages(
                     duplicate_variables
                         .iter()
-                        .map(|name| format!("${}", name))
+                        .map(|name| format!("${name}"))
                         .join(", "),
                 ));
             }
@@ -241,7 +241,7 @@ fn rearrange_plan_node<'a>(
                 return Err(FileUploadError::DuplicateVariableUsages(
                     duplicate_variables
                         .iter()
-                        .map(|name| format!("${}", name))
+                        .map(|name| format!("${name}"))
                         .join(", "),
                 ));
             }

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -1776,7 +1776,7 @@ mod test {
                     if let Some(header) = headers.get(*name) {
                         assert_eq!(header.to_str().unwrap(), *value);
                     } else {
-                        panic!("missing header {}", name);
+                        panic!("missing header {name}");
                     }
                 }
                 Ok(subgraph::Response::fake_builder().build())

--- a/apollo-router/src/plugins/healthcheck/mod.rs
+++ b/apollo-router/src/plugins/healthcheck/mod.rs
@@ -404,7 +404,7 @@ mod test {
             get_axum_router(listen_addr, config, response_status_code).await;
 
         let request = http::Request::builder()
-            .uri(format!("http://{}/health?ready=", router_addr))
+            .uri(format!("http://{router_addr}/health?ready="))
             .body(http_body_util::Empty::new())
             .expect("valid request");
 

--- a/apollo-router/src/plugins/include_subgraph_errors/tests.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/tests.rs
@@ -71,7 +71,7 @@ async fn run_test_case(
         .collect::<Vec<Value>>();
     let request = serde_json::to_string_pretty(&parsed_responses).expect("request to json");
 
-    let description = format!("CONFIG:\n{}\n\nREQUEST:\n{}", config, request);
+    let description = format!("CONFIG:\n{config}\n\nREQUEST:\n{request}");
     with_settings!({
         description => description,
     }, {

--- a/apollo-router/src/plugins/progressive_override/tests.rs
+++ b/apollo-router/src/plugins/progressive_override/tests.rs
@@ -32,11 +32,10 @@ fn test_progressive_overrides_are_recognised_vor_join_v0_4_and_above() {
         format!(
             r#"schema
                 @link(url: "https://specs.apollo.dev/link/v1.0")
-                @link(url: "https://specs.apollo.dev/join/{}", for: EXECUTION)
+                @link(url: "https://specs.apollo.dev/join/{version}", for: EXECUTION)
                 @link(url: "https://specs.apollo.dev/context/v0.1", for: SECURITY)
 
-                directive @join__field repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION"#,
-            version
+                directive @join__field repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION"#
         )
     };
 

--- a/apollo-router/src/plugins/record_replay/recording.rs
+++ b/apollo-router/src/plugins/record_replay/recording.rs
@@ -34,7 +34,7 @@ impl Recording {
         digest.update(req);
         let hash = hex::encode(digest.finalize().as_slice());
 
-        PathBuf::from(format!("{}-{}.json", operation_name, hash))
+        PathBuf::from(format!("{operation_name}-{hash}.json"))
     }
 }
 

--- a/apollo-router/src/plugins/record_replay/replay.rs
+++ b/apollo-router/src/plugins/record_replay/replay.rs
@@ -347,9 +347,9 @@ impl ReplayReport {
         print_line(width);
 
         if !old.is_empty() {
-            println!("{}", style(format_args!("-{}", old_hint)).red());
+            println!("{}", style(format_args!("-{old_hint}")).red());
         }
-        println!("{}", style(format_args!("+{}", new_hint)).green());
+        println!("{}", style(format_args!("+{new_hint}")).green());
 
         println!("────────────┬{:─^1$}", "", width.saturating_sub(13));
         let mut has_changes = false;

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -633,7 +633,7 @@ struct Position {
 impl fmt::Display for Position {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some((line, pos)) = self.line.zip(self.pos) {
-            write!(f, "line {}, position {}", line, pos)
+            write!(f, "line {line}, position {pos}")
         } else {
             write!(f, "none")
         }

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -900,7 +900,7 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
             .iter()
             .find(|e| e.message.contains("rhai execution error"))
             .expect("unexpected non-rhai error");
-        panic!("Got an unexpected rhai error: {:?}", rhai_error);
+        panic!("Got an unexpected rhai error: {rhai_error:?}");
     }
 
     // Check that the header was actually removed

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -257,7 +257,7 @@ impl TraceIdFormat {
     pub(crate) fn format(&self, trace_id: TraceId) -> String {
         match self {
             TraceIdFormat::Hexadecimal | TraceIdFormat::OpenTelemetry => {
-                format!("{:032x}", trace_id)
+                format!("{trace_id:032x}")
             }
             TraceIdFormat::Decimal => format!("{}", u128::from_be_bytes(trace_id.to_bytes())),
             TraceIdFormat::Datadog => trace_id.to_datadog(),

--- a/apollo-router/src/plugins/telemetry/config_new/conditions.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditions.rs
@@ -100,8 +100,7 @@ where
                         Ok(())
                     } else {
                         Err(format!(
-                            "the 'exists' condition use a selector applied at the wrong stage, this condition will be executed at the {} stage",
-                            stage
+                            "the 'exists' condition use a selector applied at the wrong stage, this condition will be executed at the {stage} stage"
                         ))
                     }
                 }

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -98,9 +98,7 @@ where
                             let mut temp_attributes: Map<String, Value> = Map::new();
                             temp_attributes.insert(key.clone(), value.clone());
                             Att::deserialize(Value::Object(temp_attributes)).map_err(|e| {
-                                A::Error::custom(format!(
-                                    "failed to parse attribute '{key}': {e}"
-                                ))
+                                A::Error::custom(format!("failed to parse attribute '{key}': {e}"))
                             })?;
                             attributes.insert(key, value);
                         }

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -99,8 +99,7 @@ where
                             temp_attributes.insert(key.clone(), value.clone());
                             Att::deserialize(Value::Object(temp_attributes)).map_err(|e| {
                                 A::Error::custom(format!(
-                                    "failed to parse attribute '{}': {}",
-                                    key, e
+                                    "failed to parse attribute '{key}': {e}"
                                 ))
                             })?;
                             attributes.insert(key, value);

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -2848,7 +2848,7 @@ mod tests {
             // There's no async in this test, but introducing an async block allows us to separate metrics for each fixture.
             async move {
                 if fixture.ends_with("test.yaml") {
-                    println!("Running test for fixture: {}", fixture);
+                    println!("Running test for fixture: {fixture}");
                     let path = PathBuf::from_str(&fixture).unwrap();
                     let fixture_name = path
                         .parent()

--- a/apollo-router/src/plugins/telemetry/config_new/logging.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/logging.rs
@@ -244,7 +244,7 @@ impl<'de> Deserialize<'de> for Format {
                 match value {
                     "json" => Ok(Format::Json(JsonFormat::default())),
                     "text" => Ok(Format::Text(TextFormat::default())),
-                    _ => Err(E::custom(format!("unknown log format: {}", value))),
+                    _ => Err(E::custom(format!("unknown log format: {value}"))),
                 }
             }
 
@@ -258,8 +258,7 @@ impl<'de> Deserialize<'de> for Format {
                     Some("json") => Ok(Format::Json(map.next_value::<JsonFormat>()?)),
                     Some("text") => Ok(Format::Text(map.next_value::<TextFormat>()?)),
                     Some(value) => Err(serde::de::Error::custom(format!(
-                        "unknown log format: {}",
-                        value
+                        "unknown log format: {value}"
                     ))),
                     _ => Err(serde::de::Error::custom("unknown log format")),
                 }

--- a/apollo-router/src/plugins/telemetry/config_new/router/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/events.rs
@@ -71,7 +71,7 @@ impl CustomEvents<router::Request, router::Response, (), RouterAttributes, Route
                 let headers = response.response.headers();
                 attrs.push(KeyValue::new(
                     HTTP_RESPONSE_HEADERS,
-                    opentelemetry::Value::String(format!("{:?}", headers).into()),
+                    opentelemetry::Value::String(format!("{headers:?}").into()),
                 ));
                 attrs.push(KeyValue::new(
                     HTTP_RESPONSE_STATUS,

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
@@ -58,7 +58,7 @@ impl
                 let headers = request.supergraph_request.headers();
                 attrs.push(KeyValue::new(
                     HTTP_REQUEST_HEADERS,
-                    opentelemetry::Value::String(format!("{:?}", headers).into()),
+                    opentelemetry::Value::String(format!("{headers:?}").into()),
                 ));
                 attrs.push(KeyValue::new(
                     HTTP_REQUEST_METHOD,

--- a/apollo-router/src/plugins/telemetry/endpoint.rs
+++ b/apollo-router/src/plugins/telemetry/endpoint.rs
@@ -45,7 +45,7 @@ impl UriEndpoint {
 
                     if let Some(port) = port {
                         parts.authority = Some(
-                            Authority::from_str(format!("{}:{}", host, port).as_str())
+                            Authority::from_str(format!("{host}:{port}").as_str())
                                 .expect("host and port must have come from a valid uri, qed"),
                         )
                     } else {
@@ -93,8 +93,7 @@ impl<'de> Deserialize<'de> for UriEndpoint {
                 match Uri::from_str(v) {
                     Ok(uri) => Ok(UriEndpoint { uri: Some(uri) }),
                     Err(_) => Err(Error::custom(format!(
-                        "invalid endpoint: {}. Expected a valid uri or 'default'",
-                        v
+                        "invalid endpoint: {v}. Expected a valid uri or 'default'"
                     ))),
                 }
             }
@@ -151,8 +150,7 @@ impl<'de> Deserialize<'de> for SocketEndpoint {
                         socket: Some(socket),
                     }),
                     Err(_) => Err(Error::custom(format!(
-                        "invalid endpoint: {}. Expected a valid socket or 'default'",
-                        v
+                        "invalid endpoint: {v}. Expected a valid socket or 'default'"
                     ))),
                 }
             }

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -247,11 +247,11 @@ impl field::Visit for FieldsVisitor<'_, '_> {
         match field_name {
             name if name.starts_with("r#") => {
                 self.values
-                    .insert(&name[2..], serde_json::Value::from(format!("{:?}", value)));
+                    .insert(&name[2..], serde_json::Value::from(format!("{value:?}")));
             }
             name => {
                 self.values
-                    .insert(name, serde_json::Value::from(format!("{:?}", value)));
+                    .insert(name, serde_json::Value::from(format!("{value:?}")));
             }
         };
     }

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -344,10 +344,10 @@ where
                     DisplayTraceIdFormat::Bool(false) => None,
                 };
                 if let Some(trace_id) = trace_id {
-                    write!(writer, "trace_id: {} ", trace_id)?;
+                    write!(writer, "trace_id: {trace_id} ")?;
                 }
                 if self.config.display_span_id {
-                    write!(writer, "span_id: {} ", span_id)?;
+                    write!(writer, "span_id: {span_id} ")?;
                 }
             }
         }
@@ -552,7 +552,7 @@ impl<'a> DefaultVisitor<'a> {
 
         self.maybe_pad();
         self.result = match field_name {
-            "message" => write!(self.writer, "{:?}", value),
+            "message" => write!(self.writer, "{value:?}"),
             name if name.starts_with("r#") => write!(
                 self.writer,
                 "{}{}{:?}",
@@ -578,7 +578,7 @@ impl field::Visit for DefaultVisitor<'_> {
         }
 
         if field.name() == "message" {
-            self.record_debug(field, &format_args!("{}", value))
+            self.record_debug(field, &format_args!("{value}"))
         } else {
             self.record_debug(field, &value)
         }
@@ -599,7 +599,7 @@ impl field::Visit for DefaultVisitor<'_> {
                 ),
             )
         } else {
-            self.record_debug(field, &format_args!("{}", value))
+            self.record_debug(field, &format_args!("{value}"))
         }
     }
 
@@ -628,7 +628,7 @@ impl std::fmt::Display for ErrorSourceList<'_> {
         let mut list = f.debug_list();
         let mut curr = Some(self.0);
         while let Some(curr_err) = curr {
-            list.entry(&format_args!("{}", curr_err));
+            list.entry(&format_args!("{curr_err}"));
             curr = curr_err.source();
         }
         list.finish()

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/histogram/list_length.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/histogram/list_length.rs
@@ -58,16 +58,16 @@ mod test {
         assert_eq!(v.len(), MAXIMUM_SIZE);
 
         for (i, item) in v.iter().enumerate().take(100) {
-            assert_eq!(*item, 1, "testing contents of bucket {}", i);
+            assert_eq!(*item, 1, "testing contents of bucket {i}");
         }
         for (i, item) in v.iter().enumerate().take(190).skip(100) {
-            assert_eq!(*item, 10, "testing contents of bucket {}", i);
+            assert_eq!(*item, 10, "testing contents of bucket {i}");
         }
         for (i, item) in v.iter().enumerate().take(280).skip(190) {
-            assert_eq!(*item, 100, "testing contents of bucket {}", i);
+            assert_eq!(*item, 100, "testing contents of bucket {i}");
         }
         for (i, item) in v.iter().enumerate().take(382).skip(280) {
-            assert_eq!(*item, 1000, "testing contents of bucket {}", i);
+            assert_eq!(*item, 1000, "testing contents of bucket {i}");
         }
         assert_eq!(v[MAXIMUM_SIZE - 1], 7000, "testing contents of last bucket");
     }

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -580,15 +580,14 @@ mod test {
             r#"
             telemetry:
               apollo:
-                endpoint: "{endpoint}"
+                endpoint: "{ENDPOINT_DEFAULT}"
                 apollo_key: "key"
                 apollo_graph_ref: "ref"
                 client_name_header: "name_header"
                 client_version_header: "version_header"
                 buffer_size: 10000
                 schema_id: "schema_sha"
-            "#,
-            endpoint = ENDPOINT_DEFAULT
+            "#
         );
 
         async move { create_telemetry_plugin(&config).await }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -738,7 +738,7 @@ impl PluginPrivate for Telemetry {
                 let format_id = |trace_id: TraceId| {
                     let id = match config.exporters.tracing.response_trace_id.format {
                         TraceIdFormat::Hexadecimal | TraceIdFormat::OpenTelemetry => {
-                            format!("{:032x}", trace_id)
+                            format!("{trace_id:032x}")
                         }
                         TraceIdFormat::Decimal => {
                             format!("{}", u128::from_be_bytes(trace_id.to_bytes()))

--- a/apollo-router/src/plugins/telemetry/otel/layer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/layer.rs
@@ -216,14 +216,14 @@ impl field::Visit for SpanEventVisitor<'_, '_> {
     /// [`Span`]: opentelemetry::trace::Span
     fn record_debug(&mut self, field: &field::Field, value: &dyn fmt::Debug) {
         match field.name() {
-            "message" => self.event_builder.name = format!("{:?}", value).into(),
+            "message" => self.event_builder.name = format!("{value:?}").into(),
             name => {
                 if name == "kind" {
                     self.custom_event = true;
                 }
                 self.event_builder
                     .attributes
-                    .push(KeyValue::new(name, format!("{:?}", value)));
+                    .push(KeyValue::new(name, format!("{value:?}")));
             }
         }
     }
@@ -362,13 +362,13 @@ impl field::Visit for SpanAttributeVisitor<'_> {
     /// [`Span`]: opentelemetry::trace::Span
     fn record_debug(&mut self, field: &field::Field, value: &dyn fmt::Debug) {
         match field.name() {
-            OTEL_NAME => self.span_builder.name = format!("{:?}", value).into(),
-            OTEL_KIND => self.span_builder.span_kind = str_to_span_kind(&format!("{:?}", value)),
-            OTEL_STATUS_CODE => self.span_builder.status = str_to_status(&format!("{:?}", value)),
+            OTEL_NAME => self.span_builder.name = format!("{value:?}").into(),
+            OTEL_KIND => self.span_builder.span_kind = str_to_span_kind(&format!("{value:?}")),
+            OTEL_STATUS_CODE => self.span_builder.status = str_to_status(&format!("{value:?}")),
             OTEL_STATUS_MESSAGE => {
-                self.span_builder.status = otel::Status::error(format!("{:?}", value))
+                self.span_builder.status = otel::Status::error(format!("{value:?}"))
             }
-            _ => self.record(Key::new(field.name()).string(format!("{:?}", value))),
+            _ => self.record(Key::new(field.name()).string(format!("{value:?}"))),
         }
     }
 
@@ -1096,7 +1096,7 @@ impl Timings {
 }
 
 fn thread_id_integer(id: thread::ThreadId) -> u64 {
-    let thread_id = format!("{:?}", id);
+    let thread_id = format!("{id:?}");
     thread_id
         .trim_start_matches("ThreadId(")
         .trim_end_matches(')')

--- a/apollo-router/src/plugins/telemetry/otel/named_runtime_channel.rs
+++ b/apollo-router/src/plugins/telemetry/otel/named_runtime_channel.rs
@@ -70,12 +70,10 @@ impl<T: Send> NamedSender<T> {
         NamedSender {
             name,
             channel_full_message: format!(
-                "cannot send message to batch processor '{}' as the channel is full",
-                name
+                "cannot send message to batch processor '{name}' as the channel is full"
             ),
             channel_closed_message: format!(
-                "cannot send message to batch processor '{}' as the channel is closed",
-                name
+                "cannot send message to batch processor '{name}' as the channel is closed"
             ),
             sender,
         }

--- a/apollo-router/src/plugins/telemetry/otel/tracer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/tracer.rs
@@ -227,8 +227,7 @@ mod tests {
             assert_eq!(
                 sampled.span().span_context().is_sampled(),
                 is_sampled,
-                "{}",
-                name
+                "{name}"
             )
         }
     }

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -237,7 +237,7 @@ impl GrpcExporter {
         let endpoint = endpoint
             .to_string()
             .parse::<Url>()
-            .map_err(|e| BoxError::from(format!("invalid GRPC endpoint {}, {}", endpoint, e)))?;
+            .map_err(|e| BoxError::from(format!("invalid GRPC endpoint {endpoint}, {e}")))?;
         let domain_name = self.default_tls_domain(&endpoint);
 
         if let (Some(ca), Some(key), Some(cert), Some(domain_name)) =

--- a/apollo-router/src/plugins/telemetry/resource.rs
+++ b/apollo-router/src/plugins/telemetry/resource.rs
@@ -81,7 +81,7 @@ pub trait ConfigResource {
             resource.merge(&Resource::new(vec![KeyValue::new(
                 opentelemetry_semantic_conventions::resource::SERVICE_NAME,
                 executable_name
-                    .map(|executable_name| format!("{}:{}", UNKNOWN_SERVICE, executable_name))
+                    .map(|executable_name| format!("{UNKNOWN_SERVICE}:{executable_name}"))
                     .unwrap_or_else(|| UNKNOWN_SERVICE.to_string()),
             )]))
         } else {

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/intern.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/intern.rs
@@ -452,13 +452,13 @@ mod tests {
 
         f1.write_to(&mut buffer);
 
-        assert_eq!(&buffer[..], format!("{}", f1).as_bytes());
+        assert_eq!(&buffer[..], format!("{f1}").as_bytes());
 
         buffer.clear();
 
         f2.write_to(&mut buffer);
 
-        assert_eq!(&buffer[..], format!("{}", f2).as_bytes());
+        assert_eq!(&buffer[..], format!("{f2}").as_bytes());
     }
 
     #[test]
@@ -470,13 +470,13 @@ mod tests {
 
         s1.write_to(&mut buffer);
 
-        assert_eq!(&buffer[..], format!("\"{}\"", s1).as_bytes());
+        assert_eq!(&buffer[..], format!("\"{s1}\"").as_bytes());
 
         buffer.clear();
 
         s2.write_to(&mut buffer);
 
-        assert_eq!(&buffer[..], format!("\"{}\"", s2).as_bytes());
+        assert_eq!(&buffer[..], format!("\"{s2}\"").as_bytes());
     }
 
     fn test_encoding_intern_value(value: InternValue<'_>) {

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/mod.rs
@@ -309,7 +309,7 @@ pub(crate) mod propagator {
                 SamplingPriority::AutoKeep => 1,
                 SamplingPriority::UserKeep => 2,
             };
-            write!(f, "{}", value)
+            write!(f, "{value}")
         }
     }
 

--- a/apollo-router/src/plugins/test/router_ext.rs
+++ b/apollo-router/src/plugins/test/router_ext.rs
@@ -56,13 +56,13 @@ impl RequestTestExt<router::Request, router::Response> for RouterRequest {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -71,7 +71,7 @@ impl RequestTestExt<router::Request, router::Response> for RouterRequest {
             .router_request
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 
@@ -118,13 +118,13 @@ impl ResponseTestExt for RouterResponse {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -133,7 +133,7 @@ impl ResponseTestExt for RouterResponse {
             .response
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 

--- a/apollo-router/src/plugins/test/subgraph_ext.rs
+++ b/apollo-router/src/plugins/test/subgraph_ext.rs
@@ -69,13 +69,13 @@ impl RequestTestExt<subgraph::Request, subgraph::Response> for SubgraphRequest {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -84,7 +84,7 @@ impl RequestTestExt<subgraph::Request, subgraph::Response> for SubgraphRequest {
             .subgraph_request
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 
@@ -118,13 +118,13 @@ impl ResponseTestExt for SubgraphResponse {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -133,7 +133,7 @@ impl ResponseTestExt for SubgraphResponse {
             .response
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 

--- a/apollo-router/src/plugins/test/supergraph_ext.rs
+++ b/apollo-router/src/plugins/test/supergraph_ext.rs
@@ -67,13 +67,13 @@ impl RequestTestExt<supergraph::Request, supergraph::Response> for SupergraphReq
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -82,7 +82,7 @@ impl RequestTestExt<supergraph::Request, supergraph::Response> for SupergraphReq
             .supergraph_request
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 
@@ -117,13 +117,13 @@ impl ResponseTestExt for SupergraphResponse {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -132,7 +132,7 @@ impl ResponseTestExt for SupergraphResponse {
             .response
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 

--- a/apollo-router/src/protocols/websocket.rs
+++ b/apollo-router/src/protocols/websocket.rs
@@ -282,7 +282,7 @@ where
             })?;
         if !matches!(resp, Some(Ok(ServerMessage::ConnectionAck))) {
             return Err(graphql::Error::builder()
-                .message(format!("didn't receive the connection ack from websocket connection but instead got: {:?}", resp))
+                .message(format!("didn't receive the connection ack from websocket connection but instead got: {resp:?}"))
                 .extension_code("WEBSOCKET_ACK_ERROR")
                 .build());
         }
@@ -953,7 +953,7 @@ mod tests {
         let socket_addr =
             emulate_correct_websocket_server_new_protocol(send_ping, heartbeat_interval, port)
                 .await;
-        let url = format!("ws://{}/ws", socket_addr);
+        let url = format!("ws://{socket_addr}/ws");
         let mut request = url.into_client_request().unwrap();
         request.headers_mut().insert(
             http::header::SEC_WEBSOCKET_PROTOCOL,
@@ -1020,7 +1020,7 @@ mod tests {
 
     async fn test_ws_connection_old_proto(send_ping: bool, port: Option<u16>) {
         let socket_addr = emulate_correct_websocket_server_old_protocol(send_ping, port).await;
-        let url = format!("ws://{}/ws", socket_addr);
+        let url = format!("ws://{socket_addr}/ws");
         let mut request = url.into_client_request().unwrap();
         request.headers_mut().insert(
             http::header::SEC_WEBSOCKET_PROTOCOL,

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -917,7 +917,7 @@ mod tests {
 
                 fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
                     self.map
-                        .insert(field.name().to_string(), format!("{:?}", value));
+                        .insert(field.name().to_string(), format!("{value:?}"));
                 }
             }
 
@@ -1255,7 +1255,7 @@ mod tests {
             Ok(_) => panic!(
                 "Expected the task to be aborted due to client drop, but it completed successfully"
             ),
-            Err(e) => assert!(e.is_cancelled(), "Task should be cancelled, got: {:?}", e),
+            Err(e) => assert!(e.is_cancelled(), "Task should be cancelled, got: {e:?}"),
         }
 
         // Give a small delay to ensure the span is recorded

--- a/apollo-router/src/query_planner/subgraph_context.rs
+++ b/apollo-router/src/query_planner/subgraph_context.rs
@@ -175,7 +175,7 @@ impl<'a> SubgraphContext<'a> {
                     // append _<index> to each of the arguments and push all the values into hash_map
                     hash_map.extend(item.iter().map(|(k, v)| {
                         let mut new_named_param = k.clone();
-                        new_named_param.push_str(&format!("_{}", index));
+                        new_named_param.push_str(&format!("_{index}"));
                         (new_named_param, v.clone())
                     }));
                 }
@@ -284,7 +284,7 @@ fn transform_operation(
         // it is a field selection for _entities, so it's ok to reach in and give it an alias
         let mut cloned = field_selection.clone();
         let cfs = cloned.make_mut();
-        cfs.alias = Some(Name::new_unchecked(&format!("_{}", i)));
+        cfs.alias = Some(Name::new_unchecked(&format!("_{i}")));
 
         transform_field_arguments(&mut cfs.arguments, arguments, i);
         transform_selection_set(&mut cfs.selection_set, arguments, i);

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -308,7 +308,7 @@ mod tests {
         if let LayerMissingTitle = result {
             // Expected error
         } else {
-            panic!("Expected OCILayerMissingTitle error, got {:?}", result);
+            panic!("Expected OCILayerMissingTitle error, got {result:?}");
         }
     }
 }

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -315,7 +315,7 @@ fn log_request(
 
         attrs.push(KeyValue::new(
             HTTP_REQUEST_HEADERS,
-            opentelemetry::Value::String(format!("{:?}", headers).into()),
+            opentelemetry::Value::String(format!("{headers:?}").into()),
         ));
         attrs.push(KeyValue::new(
             HTTP_REQUEST_METHOD,

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -81,11 +81,11 @@ impl FromStr for ConnectorSourceRef {
         let mut parts = s.split('.');
         let subgraph_name = parts
             .next()
-            .ok_or(format!("Invalid connector source reference '{}'", s))?
+            .ok_or(format!("Invalid connector source reference '{s}'"))?
             .to_string();
         let source_name = parts
             .next()
-            .ok_or(format!("Invalid connector source reference '{}'", s))?;
+            .ok_or(format!("Invalid connector source reference '{s}'"))?;
         Ok(Self::new(subgraph_name, SourceName::cast(source_name)))
     }
 }

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -305,7 +305,7 @@ where
                 0
             }
         });
-        let otel_name = format!("POST {}", schema_uri);
+        let otel_name = format!("POST {schema_uri}");
 
         let http_req_span = tracing::info_span!(HTTP_REQUEST_SPAN_NAME,
             "otel.kind" = "CLIENT",

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -457,8 +457,7 @@ impl FetchService {
                     vec![
                         Error::builder()
                             .message(format!(
-                                "subscription mode is not configured for subgraph {:?}",
-                                service_name
+                                "subscription mode is not configured for subgraph {service_name:?}"
                             ))
                             .extension_code("INVALID_SUBSCRIPTION_MODE")
                             .build(),

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -111,7 +111,7 @@ where
                 .serve_connection_with_upgrades(io, svc)
                 .await
             {
-                eprintln!("server error: {}", err);
+                eprintln!("server error: {err}");
             }
         });
     }
@@ -136,7 +136,7 @@ where
                 .serve_connection_with_upgrades(io, svc)
                 .await
             {
-                eprintln!("server error: {}", err);
+                eprintln!("server error: {err}");
             }
         });
     }
@@ -852,7 +852,7 @@ async fn test_unix_socket() {
     async fn handle(mut req: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
         let data = router::body::into_bytes(req.body_mut()).await.unwrap();
         let body = std::str::from_utf8(&data).unwrap();
-        println!("{:?}", body);
+        println!("{body:?}");
         let response = http::Response::builder()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, "application/json")

--- a/apollo-router/src/services/layers/persisted_queries/manifest.rs
+++ b/apollo-router/src/services/layers/persisted_queries/manifest.rs
@@ -52,7 +52,7 @@ impl SignedUrlChunk {
     pub(crate) fn parse_and_validate(raw_chunk: &str) -> Result<Self, BoxError> {
         let parsed_chunk =
             serde_json::from_str::<SignedUrlChunk>(raw_chunk).map_err(|e| -> BoxError {
-                format!("Could not parse persisted query manifest chunk: {}", e).into()
+                format!("Could not parse persisted query manifest chunk: {e}").into()
             })?;
 
         parsed_chunk.validate()

--- a/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
+++ b/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
@@ -214,18 +214,13 @@ async fn fetch_chunk(http_client: Client, chunk_url: &String) -> Result<SignedUr
         .await
         .and_then(|r| r.error_for_status())
         .map_err(|e| -> BoxError {
-            format!(
-                "error fetching persisted queries manifest chunk from {chunk_url}: {e}"
-            )
-            .into()
+            format!("error fetching persisted queries manifest chunk from {chunk_url}: {e}").into()
         })?
         .json::<SignedUrlChunk>()
         .await
         .map_err(|e| -> BoxError {
-            format!(
-                "error reading body of persisted queries manifest chunk from {chunk_url}: {e}"
-            )
-            .into()
+            format!("error reading body of persisted queries manifest chunk from {chunk_url}: {e}")
+                .into()
         })?;
 
     chunk.validate()
@@ -336,10 +331,7 @@ async fn load_local_manifests(paths: Vec<String>) -> Result<PersistedQueryManife
 
     for path in paths.iter() {
         let raw_file_contents = read_to_string(path).await.map_err(|e| -> BoxError {
-            format!(
-                "Failed to read persisted query list file at path: {path}, {e}"
-            )
-            .into()
+            format!("Failed to read persisted query list file at path: {path}, {e}").into()
         })?;
 
         let chunk = SignedUrlChunk::parse_and_validate(&raw_file_contents)?;

--- a/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
+++ b/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
@@ -215,8 +215,7 @@ async fn fetch_chunk(http_client: Client, chunk_url: &String) -> Result<SignedUr
         .and_then(|r| r.error_for_status())
         .map_err(|e| -> BoxError {
             format!(
-                "error fetching persisted queries manifest chunk from {}: {}",
-                chunk_url, e
+                "error fetching persisted queries manifest chunk from {chunk_url}: {e}"
             )
             .into()
         })?
@@ -224,8 +223,7 @@ async fn fetch_chunk(http_client: Client, chunk_url: &String) -> Result<SignedUr
         .await
         .map_err(|e| -> BoxError {
             format!(
-                "error reading body of persisted queries manifest chunk from {}: {}",
-                chunk_url, e
+                "error reading body of persisted queries manifest chunk from {chunk_url}: {e}"
             )
             .into()
         })?;
@@ -339,8 +337,7 @@ async fn load_local_manifests(paths: Vec<String>) -> Result<PersistedQueryManife
     for path in paths.iter() {
         let raw_file_contents = read_to_string(path).await.map_err(|e| -> BoxError {
             format!(
-                "Failed to read persisted query list file at path: {}, {}",
-                path, e
+                "Failed to read persisted query list file at path: {path}, {e}"
             )
             .into()
         })?;

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -465,7 +465,7 @@ pub(crate) fn get_operation(
 
 impl Display for ParsedDocumentInner {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -772,7 +772,7 @@ impl RouterService {
 
                     attrs.push(KeyValue::new(
                         HTTP_REQUEST_HEADERS,
-                        opentelemetry::Value::String(format!("{:?}", headers).into()),
+                        opentelemetry::Value::String(format!("{headers:?}").into()),
                     ));
                     attrs.push(KeyValue::new(
                         HTTP_REQUEST_METHOD,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1427,12 +1427,10 @@ fn get_graphql_content_type(service_name: &str, parts: &Parts) -> Result<Content
                 Ok(ContentType::ApplicationGraphqlResponseJson)
             }
             Some(mime) => Err(format!(
-                "subgraph response contains unsupported content-type: {}",
-                mime,
+                "subgraph response contains unsupported content-type: {mime}",
             )),
             None => Err(format!(
-                "subgraph response contains invalid 'content-type' header value {:?}",
-                raw_content_type,
+                "subgraph response contains invalid 'content-type' header value {raw_content_type:?}",
             )),
         }
     } else {
@@ -1710,7 +1708,7 @@ mod tests {
                     .serve_connection_with_upgrades(io, svc)
                     .await
                 {
-                    eprintln!("server error: {}", err);
+                    eprintln!("server error: {err}");
                 }
             });
         }

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -2851,9 +2851,7 @@ async fn no_typename_on_interface() {
             .unwrap()
             .get("name")
             .unwrap(),
-        "{:?}\n{:?}",
-        with_typename,
-        no_typename
+        "{with_typename:?}\n{no_typename:?}"
     );
     insta::assert_json_snapshot!(with_typename);
 
@@ -2894,9 +2892,7 @@ async fn no_typename_on_interface() {
             .unwrap()
             .get("name")
             .unwrap(),
-        "{:?}\n{:?}",
-        with_reversed_fragments,
-        no_typename
+        "{with_reversed_fragments:?}\n{no_typename:?}"
     );
     insta::assert_json_snapshot!(with_reversed_fragments);
 }

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -800,8 +800,7 @@ impl Query {
                         parameters.errors.push(
                             Error::builder()
                                 .message(format!(
-                                    "Cannot return null for non-nullable field {}.{field_name_str}",
-                                    root_type_name
+                                    "Cannot return null for non-nullable field {root_type_name}.{field_name_str}"
                                 ))
                                 .path(Path::from_response_slice(path))
                                 .build(),

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -1829,7 +1829,7 @@ fn variable_validation() {
         }}",
         json!({"input":{}})
     );
-    assert!(res.is_ok(), "validation should have succeeded: {:?}", res);
+    assert!(res.is_ok(), "validation should have succeeded: {res:?}");
 }
 
 #[test]

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -317,7 +317,7 @@ impl Schema {
                     };
 
                     let Some(version_in_url) =
-                        Version::parse(format!("{}.0", version_in_link).as_str()).ok()
+                        Version::parse(format!("{version_in_link}.0").as_str()).ok()
                     else {
                         return false;
                     };
@@ -355,7 +355,7 @@ impl Schema {
                     };
 
                     let Some(version_in_url) =
-                        Version::parse(format!("{}.0", version_in_link).as_str()).ok()
+                        Version::parse(format!("{version_in_link}.0").as_str()).ok()
                     else {
                         return false;
                     };

--- a/apollo-router/src/uplink/feature_gate_enforcement.rs
+++ b/apollo-router/src/uplink/feature_gate_enforcement.rs
@@ -177,8 +177,7 @@ impl Display for FeatureGateViolation {
             } => {
                 write!(
                     f,
-                    "* {} @link(url: \"{}\")\n  To enable:\n\n{}",
-                    name, url, to_enable
+                    "* {name} @link(url: \"{url}\")\n  To enable:\n\n{to_enable}"
                 )
             }
         }

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -683,7 +683,7 @@ impl Display for SchemaViolation {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             SchemaViolation::Spec { name, url } => {
-                write!(f, "* @{}\n  {}", name, url)
+                write!(f, "* @{name}\n  {url}")
             }
             SchemaViolation::DirectiveArgument {
                 name,
@@ -691,7 +691,7 @@ impl Display for SchemaViolation {
                 argument,
                 explanation,
             } => {
-                write!(f, "* @{}.{}\n  {}\n\n{}", name, argument, url, explanation)
+                write!(f, "* @{name}.{argument}\n  {url}\n\n{explanation}")
             }
         }
     }

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -966,7 +966,7 @@ mod test {
 
     fn to_friendly<R: std::fmt::Debug>(r: Result<R, Error>) -> Result<String, String> {
         match r {
-            Ok(e) => Ok(format!("result {:?}", e)),
+            Ok(e) => Ok(format!("result {e:?}")),
             Err(e) => Err(e.to_string()),
         }
     }

--- a/apollo-router/src/uplink/parsed_link_spec.rs
+++ b/apollo-router/src/uplink/parsed_link_spec.rs
@@ -96,7 +96,7 @@ impl ParsedLinkSpec {
     // 3. Otherwise, use the spec name as the prefix.
     pub(super) fn directive_name(&self, default_name: &str) -> String {
         if let Some(imported_as) = &self.imported_as {
-            format!("{}__{}", imported_as, default_name)
+            format!("{imported_as}__{default_name}")
         } else if self.spec_name == default_name {
             default_name.to_string()
         } else {

--- a/apollo-router/src/uplink/persisted_queries_manifest_stream.rs
+++ b/apollo-router/src/uplink/persisted_queries_manifest_stream.rs
@@ -147,9 +147,9 @@ mod test {
 
                 let persisted_query_manifest = results
                     .first()
-                    .unwrap_or_else(|| panic!("expected one result from {}", url))
+                    .unwrap_or_else(|| panic!("expected one result from {url}"))
                     .as_ref()
-                    .unwrap_or_else(|_| panic!("schema should be OK from {}", url))
+                    .unwrap_or_else(|_| panic!("schema should be OK from {url}"))
                     .as_ref()
                     .unwrap();
                 assert!(!persisted_query_manifest.is_empty())

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -135,9 +135,9 @@ mod test {
 
                 let schema = results
                     .first()
-                    .unwrap_or_else(|| panic!("expected one result from {}", url))
+                    .unwrap_or_else(|| panic!("expected one result from {url}"))
                     .as_ref()
-                    .unwrap_or_else(|_| panic!("schema should be OK from {}", url));
+                    .unwrap_or_else(|_| panic!("schema should be OK from {url}"));
                 assert!(schema.contains("type Product"))
             }
         }

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -236,17 +236,16 @@ impl IntegrationTest {
             .expect("Failed to read config file");
 
         // Check if placeholder exists in config
-        let placeholder_pattern = format!("{{{{{}}}}}", placeholder_name);
-        let port_pattern = format!(":{{{{{}}}}}", placeholder_name);
-        let addr_pattern = format!("127.0.0.1:{{{{{}}}}}", placeholder_name);
+        let placeholder_pattern = format!("{{{{{placeholder_name}}}}}");
+        let port_pattern = format!(":{{{{{placeholder_name}}}}}");
+        let addr_pattern = format!("127.0.0.1:{{{{{placeholder_name}}}}}");
 
         if !current_config.contains(&placeholder_pattern)
             && !current_config.contains(&port_pattern)
             && !current_config.contains(&addr_pattern)
         {
             panic!(
-                "Placeholder '{}' not found in config file. Expected one of: '{}', '{}', or '{}'",
-                placeholder_name, placeholder_pattern, port_pattern, addr_pattern
+                "Placeholder '{placeholder_name}' not found in config file. Expected one of: '{placeholder_pattern}', '{port_pattern}', or '{addr_pattern}'"
             );
         }
 
@@ -1098,7 +1097,7 @@ impl IntegrationTest {
     #[allow(dead_code)]
     pub fn print_logs(&self) {
         for line in &self.logs {
-            println!("{}", line);
+            println!("{line}");
         }
     }
 
@@ -1221,7 +1220,7 @@ impl IntegrationTest {
         let now = Instant::now();
         let mut last_metrics = String::new();
         let text = regex::escape(text).replace("<any>", ".+");
-        let re = Regex::new(&format!("(?m)^{}", text)).expect("Invalid regex");
+        let re = Regex::new(&format!("(?m)^{text}")).expect("Invalid regex");
         while now.elapsed() < duration.unwrap_or_else(|| Duration::from_secs(15)) {
             if let Ok(metrics) = self
                 .get_metrics_response()
@@ -1464,17 +1463,17 @@ fn merge_overrides(
     if let Some(port_replacements) = port_replacements {
         for (placeholder, port) in port_replacements {
             // Replace placeholder patterns like {{PLACEHOLDER_NAME}} with the actual port
-            let placeholder_pattern = format!("{{{{{}}}}}", placeholder);
+            let placeholder_pattern = format!("{{{{{placeholder}}}}}");
             yaml_with_ports = yaml_with_ports.replace(&placeholder_pattern, &port.to_string());
 
             // Also replace patterns like :{{PLACEHOLDER_NAME}} with :port
-            let port_pattern = format!(":{{{{{}}}}}", placeholder);
-            yaml_with_ports = yaml_with_ports.replace(&port_pattern, &format!(":{}", port));
+            let port_pattern = format!(":{{{{{placeholder}}}}}");
+            yaml_with_ports = yaml_with_ports.replace(&port_pattern, &format!(":{port}"));
 
             // Replace full address patterns like 127.0.0.1:{{PLACEHOLDER_NAME}}
-            let addr_pattern = format!("127.0.0.1:{{{{{}}}}}", placeholder);
+            let addr_pattern = format!("127.0.0.1:{{{{{placeholder}}}}}");
             yaml_with_ports =
-                yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{}", port));
+                yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{port}"));
         }
     }
 
@@ -1510,7 +1509,7 @@ fn merge_overrides(
         for (name, url) in overrides2 {
             let mut obj = serde_json::Map::new();
             obj.insert("override_url".to_string(), url.clone());
-            sources.insert(format!("connectors.{}", name), Value::Object(obj));
+            sources.insert(format!("connectors.{name}"), Value::Object(obj));
         }
     }
 

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1472,8 +1472,7 @@ fn merge_overrides(
 
             // Replace full address patterns like 127.0.0.1:{{PLACEHOLDER_NAME}}
             let addr_pattern = format!("127.0.0.1:{{{{{placeholder}}}}}");
-            yaml_with_ports =
-                yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{port}"));
+            yaml_with_ports = yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{port}"));
         }
     }
 

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -192,8 +192,7 @@ async fn test_full_pipeline(
     assert_eq!(
         response.status(),
         response_status,
-        "Failed at stage {}",
-        stage
+        "Failed at stage {stage}"
     );
 
     router.graceful_shutdown().await;

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -298,7 +298,7 @@ async fn test_plugin_ordering() {
         });
         tokio::spawn(async move {
             if let Err(e) = server.await {
-                eprintln!("coprocessor server error: {}", e);
+                eprintln!("coprocessor server error: {e}");
             }
         });
         (coprocessor_url, shutdown_on_drop)

--- a/apollo-router/tests/integration/rhai.rs
+++ b/apollo-router/tests/integration/rhai.rs
@@ -111,7 +111,7 @@ async fn test_rhai_hot_reload_works() {
     ] {
         // We should see 1. and 2. versions of the expected logs
         for i in 1..3 {
-            let expected = format!("{}. {}", i, expected_log);
+            let expected = format!("{i}. {expected_log}");
             assert!(logs.contains(&expected));
         }
     }

--- a/apollo-router/tests/integration/subscriptions/callback.rs
+++ b/apollo-router/tests/integration/subscriptions/callback.rs
@@ -19,7 +19,7 @@ async fn test_subscription_callback() -> Result<(), BoxError> {
 
     // Start callback server to receive router callbacks
     let (callback_addr, callback_state) = start_callback_server().await;
-    let callback_url = format!("http://{}/callback", callback_addr);
+    let callback_url = format!("http://{callback_addr}/callback");
 
     // Start mock subgraph server that will send callbacks
     let subgraph_server =
@@ -161,7 +161,7 @@ async fn test_subscription_callback_error_scenarios() -> Result<(), BoxError> {
     let (callback_addr, callback_state) = start_callback_server().await;
 
     let client = reqwest::Client::new();
-    let callback_url = format!("http://{}/callback/test-id", callback_addr);
+    let callback_url = format!("http://{callback_addr}/callback/test-id");
 
     // Test invalid payload - missing required fields
     let invalid_payload = serde_json::json!({
@@ -320,7 +320,7 @@ async fn test_subscription_callback_error_payload() -> Result<(), BoxError> {
 
     // Start callback server to receive router callbacks
     let (callback_addr, callback_state) = start_callback_server().await;
-    let callback_url = format!("http://{}/callback", callback_addr);
+    let callback_url = format!("http://{callback_addr}/callback");
 
     // Start mock subgraph server with custom payloads
     let subgraph_server = start_callback_subgraph_server_with_payloads(
@@ -426,7 +426,7 @@ async fn test_subscription_callback_pure_error_payload() -> Result<(), BoxError>
 
     // Start callback server to receive router callbacks
     let (callback_addr, callback_state) = start_callback_server().await;
-    let callback_url = format!("http://{}/callback", callback_addr);
+    let callback_url = format!("http://{callback_addr}/callback");
 
     // Start mock subgraph server with custom payloads
     let subgraph_server = start_callback_subgraph_server_with_payloads(

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -68,8 +68,7 @@ pub const SUBSCRIPTION_COPROCESSOR_CONFIG: &str =
 pub const CALLBACK_CONFIG: &str = include_str!("fixtures/callback.router.yaml");
 pub fn create_sub_query(interval_ms: u64, nb_events: usize) -> String {
     format!(
-        r#"subscription {{  userWasCreated(intervalMs: {}, nbEvents: {}) {{    name reviews {{ body }} }}}}"#,
-        interval_ms, nb_events
+        r#"subscription {{  userWasCreated(intervalMs: {interval_ms}, nbEvents: {nb_events}) {{    name reviews {{ body }} }}}}"#
     )
 }
 

--- a/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
+++ b/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
@@ -225,7 +225,7 @@ async fn test_subscription_ws_passthrough() -> Result<(), BoxError> {
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -291,7 +291,7 @@ async fn test_subscription_ws_passthrough_with_coprocessor() -> Result<(), BoxEr
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string(
@@ -369,7 +369,7 @@ async fn test_subscription_ws_passthrough_error_payload() -> Result<(), BoxError
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -452,7 +452,7 @@ async fn test_subscription_ws_passthrough_pure_error_payload() -> Result<(), Box
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -540,7 +540,7 @@ async fn test_subscription_ws_passthrough_pure_error_payload_with_coprocessor()
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string(
@@ -633,7 +633,7 @@ async fn test_subscription_ws_passthrough_on_config_reload() -> Result<(), BoxEr
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -734,7 +734,7 @@ async fn test_subscription_ws_passthrough_on_schema_reload() -> Result<(), BoxEr
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -834,7 +834,7 @@ async fn test_subscription_ws_passthrough_dedup() -> Result<(), BoxError> {
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");

--- a/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
+++ b/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
@@ -771,7 +771,7 @@ async fn test_failed_connector_request_emits_histogram() {
 fn assert_metrics_contain(actual_metrics: &[ExportMetricsServiceRequest], expected_metric: Metric) {
     let expected_name = &expected_metric.name.clone();
     let actual_metric = find_metric(expected_name, actual_metrics)
-        .unwrap_or_else(|| panic!("Metric '{}' not found", expected_name));
+        .unwrap_or_else(|| panic!("Metric '{expected_name}' not found"));
 
     let actual_metrics: Vec<Metric> = match &actual_metric.data {
         Some(metric::Data::Sum(sum)) => sum
@@ -784,7 +784,7 @@ fn assert_metrics_contain(actual_metrics: &[ExportMetricsServiceRequest], expect
             .iter()
             .map(|dp| Metric::from_histogram_datapoint(expected_name, dp))
             .collect(),
-        _ => panic!("Metric type for '{}' is not yet implemented", expected_name),
+        _ => panic!("Metric type for '{expected_name}' is not yet implemented"),
     };
 
     let metric_found = actual_metrics.iter().any(|m| {
@@ -903,10 +903,10 @@ impl Display for Metric {
                     BoolValue(b) => b.to_string(),
                     IntValue(n) => n.to_string(),
                     DoubleValue(d) => d.to_string(),
-                    other => format!("{:?}", other),
+                    other => format!("{other:?}"),
                 })
                 .unwrap_or_else(|| "nil".into());
-            write!(f, "\n\t{}={}", key, value)?;
+            write!(f, "\n\t{key}={value}")?;
         }
         write!(f, "\n]")
     }

--- a/apollo-router/tests/integration/telemetry/propagation.rs
+++ b/apollo-router/tests/integration/telemetry/propagation.rs
@@ -27,12 +27,12 @@ async fn test_trace_id_via_header() -> Result<(), BoxError> {
     router.assert_started().await;
     make_call(&mut router, trace_id).await;
     router
-        .wait_for_log_message(&format!("trace_id: {}", trace_id))
+        .wait_for_log_message(&format!("trace_id: {trace_id}"))
         .await;
 
     make_call(&mut router, trace_id).await;
     router
-        .wait_for_log_message(&format!("\"id_from_header\": \"{}\"", trace_id))
+        .wait_for_log_message(&format!("\"id_from_header\": \"{trace_id}\""))
         .await;
 
     router.graceful_shutdown().await;

--- a/apollo-router/tests/integration/telemetry/verifier.rs
+++ b/apollo-router/tests/integration/telemetry/verifier.rs
@@ -86,7 +86,7 @@ pub trait Verifier {
 
         // For now just validate service name.
         let trace: Value = self.get_trace(trace_id).await?;
-        println!("trace: {}", trace_id);
+        println!("trace: {trace_id}");
         self.verify_services(&trace)?;
         println!("services verified");
         self.verify_spans_present(&trace)?;

--- a/apollo-router/tests/samples_tests.rs
+++ b/apollo-router/tests/samples_tests.rs
@@ -555,7 +555,7 @@ impl TestExecution {
         }
 
         writeln!(out, "query: {}\n", serde_json::to_string(&request).unwrap()).unwrap();
-        writeln!(out, "header: {:?}\n", headers).unwrap();
+        writeln!(out, "header: {headers:?}\n").unwrap();
 
         let (_, response) = router
             .execute_query(
@@ -571,7 +571,7 @@ impl TestExecution {
         for (key, value) in expected_headers {
             if !response.headers().contains_key(key) {
                 failed = true;
-                writeln!(out, "expected header {} to be present", key).unwrap();
+                writeln!(out, "expected header {key} to be present").unwrap();
             } else if response.headers().get(key).unwrap() != value {
                 failed = true;
                 writeln!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # renovate-automation: rustc version
-channel = "1.87.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR bumps the rust toolchain version to 1.88 and fixes the lints.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
