### PR TITLE
Bump toolchain to Rust 1.89

### DIFF
--- a/.config/mise/config.ci-mac.toml
+++ b/.config/mise/config.ci-mac.toml
@@ -1,5 +1,5 @@
 [tools]
 # renovate-automation: rustc version
-rust = { version = "1.87.0", targets = "x86_64-apple-darwin,aarch64-apple-darwin", profile = "default", components = "llvm-tools" }
+rust = { version = "1.89.0", targets = "x86_64-apple-darwin,aarch64-apple-darwin", profile = "default", components = "llvm-tools" }
 "cargo:cargo-llvm-cov" = "0.6.16"
 "ubi:codecov/codecov-cli" = "10.4.0"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,6 +1,6 @@
 [tools]
 # renovate-automation: rustc version
-rust = "1.87.0"
+rust = "1.89.0"
 "aqua:cargo-bins/cargo-binstall" = "1.14.4"
 "cargo:cargo-nextest" = "0.9.70"
 "cargo:cargo-deny" = "0.18.2"

--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -556,10 +556,10 @@ fn cmd_expand(
         })?;
         for (name, subgraph) in subgraphs {
             // Skip any files not matching the prefix, if specified
-            if let Some(prefix) = filter_prefix {
-                if !name.starts_with(prefix) {
-                    continue;
-                }
+            if let Some(prefix) = filter_prefix
+                && !name.starts_with(prefix)
+            {
+                continue;
             }
 
             let subgraph_path = dest.join(format!("{}.graphql", name));
@@ -576,10 +576,10 @@ fn cmd_expand(
         println!("subgraphs:");
         for (name, subgraph) in subgraphs {
             // Skip any files not matching the prefix, if specified
-            if let Some(prefix) = filter_prefix {
-                if !name.starts_with(prefix) {
-                    continue;
-                }
+            if let Some(prefix) = filter_prefix
+                && !name.starts_with(prefix)
+            {
+                continue;
             }
 
             let schema_str = subgraph.schema.schema().serialize().initial_indent_level(4);

--- a/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
+++ b/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
@@ -76,7 +76,7 @@ pub(super) fn shareable_field_non_intersecting_runtime_types_error(
                 human_readable_list(
                     runtime_types
                         .iter()
-                        .map(|runtime_type| format!("\"{}\"", runtime_type)),
+                        .map(|runtime_type| format!("\"{runtime_type}\"")),
                     HumanReadableListOptions {
                         prefix: Some(HumanReadableListPrefix {
                             singular: "type",

--- a/apollo-federation/src/composition/satisfiability/validation_state.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_state.rs
@@ -356,11 +356,10 @@ impl ValidationState {
             // If we see a type here that is not included in the list of all runtime types, it is
             // safe to assume that it is an interface behaving like a runtime type (i.e. an
             // @interfaceObject) and we should allow it to stand in for any runtime type.
-            if let Some(type_name) = iter_into_single_item(type_names.iter()) {
-                if !all_runtime_types.contains(type_name) {
+            if let Some(type_name) = iter_into_single_item(type_names.iter())
+                && !all_runtime_types.contains(type_name) {
                     continue;
                 }
-            }
             runtime_types_per_subgraphs.insert(subgraph.clone(), type_names.clone());
             // PORT_NOTE: The JS code couldn't really use sets as map keys, so it instead used the
             // formatted output text as the map key. We instead use a `BTreeSet<Name>`, and move

--- a/apollo-federation/src/composition/satisfiability/validation_state.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_state.rs
@@ -357,9 +357,10 @@ impl ValidationState {
             // safe to assume that it is an interface behaving like a runtime type (i.e. an
             // @interfaceObject) and we should allow it to stand in for any runtime type.
             if let Some(type_name) = iter_into_single_item(type_names.iter())
-                && !all_runtime_types.contains(type_name) {
-                    continue;
-                }
+                && !all_runtime_types.contains(type_name)
+            {
+                continue;
+            }
             runtime_types_per_subgraphs.insert(subgraph.clone(), type_names.clone());
             // PORT_NOTE: The JS code couldn't really use sets as map keys, so it instead used the
             // formatted output text as the map key. We instead use a `BTreeSet<Name>`, and move

--- a/apollo-federation/src/composition/satisfiability/validation_traversal.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_traversal.rs
@@ -221,19 +221,19 @@ impl ValidationTraversal {
                 && state
                     .selected_override_conditions()
                     .contains_key(&override_condition.label)
-                    && !override_condition.check(state.selected_override_conditions())
-                {
-                    debug!(
-                        "Edge {} doesn't satisfy label condition: {}({}), no need to validate further",
-                        edge_weight,
-                        override_condition.label,
-                        state
-                            .selected_override_conditions()
-                            .get(&override_condition.label)
-                            .map_or("unset".to_owned(), |x| x.to_string()),
-                    );
-                    continue;
-                }
+                && !override_condition.check(state.selected_override_conditions())
+            {
+                debug!(
+                    "Edge {} doesn't satisfy label condition: {}({}), no need to validate further",
+                    edge_weight,
+                    override_condition.label,
+                    state
+                        .selected_override_conditions()
+                        .get(&override_condition.label)
+                        .map_or("unset".to_owned(), |x| x.to_string()),
+                );
+                continue;
+            }
 
             let matching_contexts = edge_head_type_name
                 .and_then(|name| self.context.matching_contexts(name))
@@ -266,14 +266,14 @@ impl ValidationTraversal {
                     .supergraph_path()
                     .graph()
                     .is_terminal(new_state.supergraph_path().tail())
-                {
-                    drop(guard);
-                    debug!("Reached new state {}", new_state);
-                    if let Some(error) = self.push_stack(new_state) {
-                        return Ok(Some(error));
-                    }
-                    continue;
+            {
+                drop(guard);
+                debug!("Reached new state {}", new_state);
+                if let Some(error) = self.push_stack(new_state) {
+                    return Ok(Some(error));
                 }
+                continue;
+            }
             drop(guard);
             debug!("Reached terminal node/cycle")
         }

--- a/apollo-federation/src/composition/satisfiability/validation_traversal.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_traversal.rs
@@ -217,8 +217,8 @@ impl ValidationTraversal {
             // conditions) that we've selected/assumed so far in our traversal (i.e. "foo" -> true).
             // There's no need to validate edges that share the same label with the opposite
             // condition since they're unreachable during query planning.
-            if let Some(override_condition) = &edge_weight.override_condition {
-                if state
+            if let Some(override_condition) = &edge_weight.override_condition
+                && state
                     .selected_override_conditions()
                     .contains_key(&override_condition.label)
                     && !override_condition.check(state.selected_override_conditions())
@@ -234,7 +234,6 @@ impl ValidationTraversal {
                     );
                     continue;
                 }
-            }
 
             let matching_contexts = edge_head_type_name
                 .and_then(|name| self.context.matching_contexts(name))
@@ -262,8 +261,8 @@ impl ValidationTraversal {
             // The check for `is_terminal()` is not strictly necessary, since if we add a terminal
             // state to the stack, then `handle_state()` will do nothing later. But it's worth
             // checking it now and saving some memory/cycles.
-            if let Some(new_state) = new_state {
-                if !new_state
+            if let Some(new_state) = new_state
+                && !new_state
                     .supergraph_path()
                     .graph()
                     .is_terminal(new_state.supergraph_path().tail())
@@ -275,7 +274,6 @@ impl ValidationTraversal {
                     }
                     continue;
                 }
-            }
             drop(guard);
             debug!("Reached terminal node/cycle")
         }

--- a/apollo-federation/src/connectors/expand/carryover.rs
+++ b/apollo-federation/src/connectors/expand/carryover.rs
@@ -473,7 +473,7 @@ impl Link {
 
                                 if let Some(alias) = &i.alias {
                                     let alias = if i.is_directive {
-                                        format!("@{}", alias)
+                                        format!("@{alias}")
                                     } else {
                                         alias.to_string()
                                     };

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -1139,7 +1139,6 @@ impl ApplyToInternal for SubSelection {
 
         // The SubSelection rebinds the $ variable to the selected input object,
         // so we can ignore _previous_dollar_shape.
-        #[expect(clippy::redundant_clone)]
         let dollar_shape = input_shape.clone();
 
         // Build up the merged object shape using Shape::all to merge the

--- a/apollo-federation/src/connectors/json_selection/fixtures.rs
+++ b/apollo-federation/src/connectors/json_selection/fixtures.rs
@@ -15,7 +15,7 @@ impl FromStr for Namespace {
         match s {
             "$args" => Ok(Self::Args),
             "$this" => Ok(Self::This),
-            _ => Err(format!("Unknown variable namespace: {}", s)),
+            _ => Err(format!("Unknown variable namespace: {s}")),
         }
     }
 }

--- a/apollo-federation/src/connectors/json_selection/helpers.rs
+++ b/apollo-federation/src/connectors/json_selection/helpers.rs
@@ -221,7 +221,7 @@ mod tests {
                     assert_eq!(*remainder.fragment(), exp_remainder);
                     assert_eq!(*parsed.as_ref(), exp_spaces);
                 }
-                Err(e) => panic!("error: {:?}", e),
+                Err(e) => panic!("error: {e:?}"),
             }
         }
 

--- a/apollo-federation/src/connectors/json_selection/helpers.rs
+++ b/apollo-federation/src/connectors/json_selection/helpers.rs
@@ -35,7 +35,7 @@ macro_rules! selection {
 
 // Consumes any amount of whitespace and/or comments starting with # until the
 // end of the line.
-pub(crate) fn spaces_or_comments(input: Span) -> ParseResult<WithRange<&str>> {
+pub(crate) fn spaces_or_comments(input: Span<'_>) -> ParseResult<'_, WithRange<&str>> {
     let mut suffix = input.clone();
     loop {
         let mut made_progress = false;

--- a/apollo-federation/src/connectors/json_selection/lit_expr.rs
+++ b/apollo-federation/src/connectors/json_selection/lit_expr.rs
@@ -474,7 +474,7 @@ mod tests {
                 assert!(span_is_all_spaces_or_comments(remainder));
                 assert_eq!(parsed.strip_ranges(), WithRange::new(expected, None));
             }
-            Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
+            Err(e) => panic!("Failed to parse '{input}': {e:?}"),
         };
     }
 
@@ -826,7 +826,7 @@ mod tests {
                     assert_eq!(parsed.pretty_print_with_indentation(true, 0), input);
                     assert_eq!(expected_inline, input);
                 }
-                Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
+                Err(e) => panic!("Failed to parse '{input}': {e:?}"),
             };
         }
 
@@ -1158,11 +1158,10 @@ mod tests {
         let err = result.expect_err("Expected parse error for mixed operators ?? and ?!");
 
         // Verify the error message contains information about mixed operators
-        let error_msg = format!("{:?}", err);
+        let error_msg = format!("{err:?}");
         assert!(
             error_msg.contains("Found mixed operators ?? and ?!"),
-            "Expected mixed operators error message, got: {}",
-            error_msg
+            "Expected mixed operators error message, got: {error_msg}"
         );
     }
 
@@ -1173,7 +1172,7 @@ mod tests {
                 assert!(span_is_all_spaces_or_comments(remainder));
                 assert_eq!(parsed.strip_ranges(), WithRange::new(expected, None));
             }
-            Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
+            Err(e) => panic!("Failed to parse '{input}': {e:?}"),
         }
     }
 }

--- a/apollo-federation/src/connectors/json_selection/location.rs
+++ b/apollo-federation/src/connectors/json_selection/location.rs
@@ -29,7 +29,7 @@ pub(crate) struct SpanExtra {
 }
 
 #[cfg(test)]
-pub(crate) fn new_span(input: &str) -> Span {
+pub(crate) fn new_span(input: &str) -> Span<'_> {
     Span::new_extra(
         input,
         SpanExtra {
@@ -39,7 +39,7 @@ pub(crate) fn new_span(input: &str) -> Span {
     )
 }
 
-pub(crate) fn new_span_with_spec(input: &str, spec: ConnectSpec) -> Span {
+pub(crate) fn new_span_with_spec(input: &str, spec: ConnectSpec) -> Span<'_> {
     Span::new_extra(
         input,
         SpanExtra {

--- a/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
@@ -29,67 +29,60 @@ fn contains_method(
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args
-        && let [arg] = args.as_slice() {
-            let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
-            let mut apply_to_errors = arg_errors;
+        && let [arg] = args.as_slice()
+    {
+        let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
+        let mut apply_to_errors = arg_errors;
 
-            let matches = value_opt.and_then(|search_value| {
-                if let JSON::Array(array) = data {
-                    for item in array {
-                        let is_equal = match (item, &search_value) {
-                            // Number comparisons: Always convert to float so 1 == 1.0
-                            (JSON::Number(left), JSON::Number(right)) => {
-                                let left = match number_value_as_float(
-                                    left,
-                                    method_name,
-                                    input_path,
-                                    spec,
-                                ) {
+        let matches = value_opt.and_then(|search_value| {
+            if let JSON::Array(array) = data {
+                for item in array {
+                    let is_equal = match (item, &search_value) {
+                        // Number comparisons: Always convert to float so 1 == 1.0
+                        (JSON::Number(left), JSON::Number(right)) => {
+                            let left =
+                                match number_value_as_float(left, method_name, input_path, spec) {
                                     Ok(f) => f,
                                     Err(err) => {
                                         apply_to_errors.push(err);
                                         return None;
                                     }
                                 };
-                                let right = match number_value_as_float(
-                                    right,
-                                    method_name,
-                                    input_path,
-                                    spec,
-                                ) {
+                            let right =
+                                match number_value_as_float(right, method_name, input_path, spec) {
                                     Ok(f) => f,
                                     Err(err) => {
                                         apply_to_errors.push(err);
                                         return None;
                                     }
                                 };
-                                left == right
-                            }
-                            // Everything else
-                            _ => item == &search_value,
-                        };
-
-                        if is_equal {
-                            return Some(JSON::Bool(true));
+                            left == right
                         }
-                    }
-                    Some(JSON::Bool(false))
-                } else {
-                    apply_to_errors.push(ApplyToError::new(
-                        format!(
-                            "Method ->{} requires an array input, but got: {data}",
-                            method_name.as_ref(),
-                        ),
-                        input_path.to_vec(),
-                        method_name.range(),
-                        spec,
-                    ));
-                    None
-                }
-            });
+                        // Everything else
+                        _ => item == &search_value,
+                    };
 
-            return (matches, apply_to_errors);
-        }
+                    if is_equal {
+                        return Some(JSON::Bool(true));
+                    }
+                }
+                Some(JSON::Bool(false))
+            } else {
+                apply_to_errors.push(ApplyToError::new(
+                    format!(
+                        "Method ->{} requires an array input, but got: {data}",
+                        method_name.as_ref(),
+                    ),
+                    input_path.to_vec(),
+                    method_name.range(),
+                    spec,
+                ));
+                None
+            }
+        });
+
+        return (matches, apply_to_errors);
+    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
@@ -28,8 +28,8 @@ fn contains_method(
     input_path: &InputPath<JSON>,
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
-    if let Some(MethodArgs { args, .. }) = method_args {
-        if let [arg] = args.as_slice() {
+    if let Some(MethodArgs { args, .. }) = method_args
+        && let [arg] = args.as_slice() {
             let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
             let mut apply_to_errors = arg_errors;
 
@@ -90,7 +90,6 @@ fn contains_method(
 
             return (matches, apply_to_errors);
         }
-    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/echo.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/echo.rs
@@ -35,9 +35,10 @@ fn echo_method(
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args
-        && let Some(arg) = args.first() {
-            return arg.apply_to_path(data, vars, input_path, spec);
-        }
+        && let Some(arg) = args.first()
+    {
+        return arg.apply_to_path(data, vars, input_path, spec);
+    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/echo.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/echo.rs
@@ -34,11 +34,10 @@ fn echo_method(
     input_path: &InputPath<JSON>,
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
-    if let Some(MethodArgs { args, .. }) = method_args {
-        if let Some(arg) = args.first() {
+    if let Some(MethodArgs { args, .. }) = method_args
+        && let Some(arg) = args.first() {
             return arg.apply_to_path(data, vars, input_path, spec);
         }
-    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
@@ -28,35 +28,36 @@ fn eq_method(
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args
-        && let [arg] = args.as_slice() {
-            let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
-            let mut apply_to_errors = arg_errors;
-            let matches = value_opt.and_then(|value| match (data, &value) {
-                // Number comparisons: Always convert to float so 1 == 1.0
-                (JSON::Number(left), JSON::Number(right)) => {
-                    let left = match number_value_as_float(left, method_name, input_path, spec) {
-                        Ok(f) => f,
-                        Err(err) => {
-                            apply_to_errors.push(err);
-                            return None;
-                        }
-                    };
-                    let right = match number_value_as_float(right, method_name, input_path, spec) {
-                        Ok(f) => f,
-                        Err(err) => {
-                            apply_to_errors.push(err);
-                            return None;
-                        }
-                    };
+        && let [arg] = args.as_slice()
+    {
+        let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
+        let mut apply_to_errors = arg_errors;
+        let matches = value_opt.and_then(|value| match (data, &value) {
+            // Number comparisons: Always convert to float so 1 == 1.0
+            (JSON::Number(left), JSON::Number(right)) => {
+                let left = match number_value_as_float(left, method_name, input_path, spec) {
+                    Ok(f) => f,
+                    Err(err) => {
+                        apply_to_errors.push(err);
+                        return None;
+                    }
+                };
+                let right = match number_value_as_float(right, method_name, input_path, spec) {
+                    Ok(f) => f,
+                    Err(err) => {
+                        apply_to_errors.push(err);
+                        return None;
+                    }
+                };
 
-                    Some(JSON::Bool(left == right))
-                }
-                // Everything else
-                _ => Some(JSON::Bool(&value == data)),
-            });
+                Some(JSON::Bool(left == right))
+            }
+            // Everything else
+            _ => Some(JSON::Bool(&value == data)),
+        });
 
-            return (matches, apply_to_errors);
-        }
+        return (matches, apply_to_errors);
+    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
@@ -27,8 +27,8 @@ fn eq_method(
     input_path: &InputPath<JSON>,
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
-    if let Some(MethodArgs { args, .. }) = method_args {
-        if let [arg] = args.as_slice() {
+    if let Some(MethodArgs { args, .. }) = method_args
+        && let [arg] = args.as_slice() {
             let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
             let mut apply_to_errors = arg_errors;
             let matches = value_opt.and_then(|value| match (data, &value) {
@@ -57,7 +57,6 @@ fn eq_method(
 
             return (matches, apply_to_errors);
         }
-    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/get.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/get.rs
@@ -463,7 +463,7 @@ fn handle_array_shape(
     } else if !tail.is_none() {
         // If we have a tail, we cannot know for sure if the item exists at the index or not
         // This is because a tail implies that there are 0 to many items of that type
-        return input_shape.any_item(method_name.shape_location(source_id));
+        input_shape.any_item(method_name.shape_location(source_id))
     } else {
         out_of_bounds_error()
     }
@@ -503,16 +503,16 @@ fn handle_object_shape(
     } else if !rest.is_none() {
         // If we have a rest, we cannot know for sure if the item exists at the index or not
         // This is because a rest implies that there are 0 to many items of that type
-        return input_shape.any_field(method_name.shape_location(source_id));
+        input_shape.any_field(method_name.shape_location(source_id))
     } else {
-        return Shape::error(
+        Shape::error(
             format!(
                 "Method ->{} property {index_value} not found in object",
                 method_name.as_ref()
             )
             .as_str(),
             method_name.shape_location(source_id),
-        );
+        )
     }
 }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/in.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/in.rs
@@ -28,8 +28,8 @@ fn in_method(
     input_path: &InputPath<JSON>,
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
-    if let Some(MethodArgs { args, .. }) = method_args {
-        if let [arg] = args.as_slice() {
+    if let Some(MethodArgs { args, .. }) = method_args
+        && let [arg] = args.as_slice() {
             let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
             let mut apply_to_errors = arg_errors;
 
@@ -90,7 +90,6 @@ fn in_method(
 
             return (matches, apply_to_errors);
         }
-    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/in.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/in.rs
@@ -29,67 +29,60 @@ fn in_method(
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args
-        && let [arg] = args.as_slice() {
-            let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
-            let mut apply_to_errors = arg_errors;
+        && let [arg] = args.as_slice()
+    {
+        let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
+        let mut apply_to_errors = arg_errors;
 
-            let matches = value_opt.and_then(|value| {
-                if let JSON::Array(array) = &value {
-                    for item in array {
-                        let is_equal = match (data, item) {
-                            // Number comparisons: Always convert to float so 1 == 1.0
-                            (JSON::Number(left), JSON::Number(right)) => {
-                                let left = match number_value_as_float(
-                                    left,
-                                    method_name,
-                                    input_path,
-                                    spec,
-                                ) {
+        let matches = value_opt.and_then(|value| {
+            if let JSON::Array(array) = &value {
+                for item in array {
+                    let is_equal = match (data, item) {
+                        // Number comparisons: Always convert to float so 1 == 1.0
+                        (JSON::Number(left), JSON::Number(right)) => {
+                            let left =
+                                match number_value_as_float(left, method_name, input_path, spec) {
                                     Ok(f) => f,
                                     Err(err) => {
                                         apply_to_errors.push(err);
                                         return None;
                                     }
                                 };
-                                let right = match number_value_as_float(
-                                    right,
-                                    method_name,
-                                    input_path,
-                                    spec,
-                                ) {
+                            let right =
+                                match number_value_as_float(right, method_name, input_path, spec) {
                                     Ok(f) => f,
                                     Err(err) => {
                                         apply_to_errors.push(err);
                                         return None;
                                     }
                                 };
-                                left == right
-                            }
-                            // Everything else
-                            _ => item == data,
-                        };
-
-                        if is_equal {
-                            return Some(JSON::Bool(true));
+                            left == right
                         }
-                    }
-                    Some(JSON::Bool(false))
-                } else {
-                    apply_to_errors.push(ApplyToError::new(
-                        format!(
-                            "Method ->{} requires an array argument, but got: {value}",
-                            method_name.as_ref(),
-                        ),
-                        input_path.to_vec(),
-                        method_name.range(),
-                        spec,
-                    ));
-                    None
-                }
-            });
+                        // Everything else
+                        _ => item == data,
+                    };
 
-            return (matches, apply_to_errors);
-        }
+                    if is_equal {
+                        return Some(JSON::Bool(true));
+                    }
+                }
+                Some(JSON::Bool(false))
+            } else {
+                apply_to_errors.push(ApplyToError::new(
+                    format!(
+                        "Method ->{} requires an array argument, but got: {value}",
+                        method_name.as_ref(),
+                    ),
+                    input_path.to_vec(),
+                    method_name.range(),
+                    spec,
+                ));
+                None
+            }
+        });
+
+        return (matches, apply_to_errors);
+    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/join_not_null.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/join_not_null.rs
@@ -229,7 +229,7 @@ mod tests {
         #[case] expected: JSON,
     ) {
         assert_eq!(
-            selection!(&format!("$->joinNotNull('{}')", separator)).apply_to(&input),
+            selection!(&format!("$->joinNotNull('{separator}')")).apply_to(&input),
             (Some(expected), vec![]),
         );
     }

--- a/apollo-federation/src/connectors/json_selection/methods/public/match.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/match.rs
@@ -52,11 +52,12 @@ fn match_method(
                 errors.extend(candidate_errors);
 
                 if let Some(candidate) = candidate_opt
-                    && candidate == *data {
-                        return value
-                            .apply_to_path(data, vars, input_path, spec)
-                            .prepend_errors(errors);
-                    };
+                    && candidate == *data
+                {
+                    return value
+                        .apply_to_path(data, vars, input_path, spec)
+                        .prepend_errors(errors);
+                };
             }
         }
     }
@@ -100,9 +101,10 @@ pub(crate) fn match_shape(
                 };
                 if let LitExpr::Path(path) = pattern.as_ref()
                     && let PathList::Var(known_var, _tail) = path.path.as_ref()
-                        && known_var.as_ref() == &KnownVariable::AtSign {
-                            has_infallible_case = true;
-                        };
+                    && known_var.as_ref() == &KnownVariable::AtSign
+                {
+                    has_infallible_case = true;
+                };
 
                 let value_shape =
                     value.compute_output_shape(context, input_shape.clone(), dollar_shape.clone());

--- a/apollo-federation/src/connectors/json_selection/methods/public/match.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/match.rs
@@ -51,13 +51,12 @@ fn match_method(
                     pattern.apply_to_path(data, vars, input_path, spec);
                 errors.extend(candidate_errors);
 
-                if let Some(candidate) = candidate_opt {
-                    if candidate == *data {
+                if let Some(candidate) = candidate_opt
+                    && candidate == *data {
                         return value
                             .apply_to_path(data, vars, input_path, spec)
                             .prepend_errors(errors);
-                    }
-                };
+                    };
             }
         }
     }
@@ -99,13 +98,11 @@ pub(crate) fn match_shape(
                     [pattern, value] => (pattern, value),
                     _ => continue,
                 };
-                if let LitExpr::Path(path) = pattern.as_ref() {
-                    if let PathList::Var(known_var, _tail) = path.path.as_ref() {
-                        if known_var.as_ref() == &KnownVariable::AtSign {
+                if let LitExpr::Path(path) = pattern.as_ref()
+                    && let PathList::Var(known_var, _tail) = path.path.as_ref()
+                        && known_var.as_ref() == &KnownVariable::AtSign {
                             has_infallible_case = true;
-                        }
-                    }
-                };
+                        };
 
                 let value_shape =
                     value.compute_output_shape(context, input_shape.clone(), dollar_shape.clone());

--- a/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
@@ -27,8 +27,8 @@ fn ne_method(
     input_path: &InputPath<JSON>,
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
-    if let Some(MethodArgs { args, .. }) = method_args {
-        if let [arg] = args.as_slice() {
+    if let Some(MethodArgs { args, .. }) = method_args
+        && let [arg] = args.as_slice() {
             let (value_opt, mut apply_to_errors) = arg.apply_to_path(data, vars, input_path, spec);
             let matches = value_opt.and_then(|value| match (data, &value) {
                 // Number comparisons: Always convert to float so 1 == 1.0
@@ -56,7 +56,6 @@ fn ne_method(
 
             return (matches, apply_to_errors);
         }
-    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
@@ -28,34 +28,35 @@ fn ne_method(
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(MethodArgs { args, .. }) = method_args
-        && let [arg] = args.as_slice() {
-            let (value_opt, mut apply_to_errors) = arg.apply_to_path(data, vars, input_path, spec);
-            let matches = value_opt.and_then(|value| match (data, &value) {
-                // Number comparisons: Always convert to float so 1 == 1.0
-                (JSON::Number(left), JSON::Number(right)) => {
-                    let left = match number_value_as_float(left, method_name, input_path, spec) {
-                        Ok(f) => f,
-                        Err(err) => {
-                            apply_to_errors.push(err);
-                            return None;
-                        }
-                    };
-                    let right = match number_value_as_float(right, method_name, input_path, spec) {
-                        Ok(f) => f,
-                        Err(err) => {
-                            apply_to_errors.push(err);
-                            return None;
-                        }
-                    };
+        && let [arg] = args.as_slice()
+    {
+        let (value_opt, mut apply_to_errors) = arg.apply_to_path(data, vars, input_path, spec);
+        let matches = value_opt.and_then(|value| match (data, &value) {
+            // Number comparisons: Always convert to float so 1 == 1.0
+            (JSON::Number(left), JSON::Number(right)) => {
+                let left = match number_value_as_float(left, method_name, input_path, spec) {
+                    Ok(f) => f,
+                    Err(err) => {
+                        apply_to_errors.push(err);
+                        return None;
+                    }
+                };
+                let right = match number_value_as_float(right, method_name, input_path, spec) {
+                    Ok(f) => f,
+                    Err(err) => {
+                        apply_to_errors.push(err);
+                        return None;
+                    }
+                };
 
-                    Some(JSON::Bool(left != right))
-                }
-                // Everything else
-                _ => Some(JSON::Bool(&value != data)),
-            });
+                Some(JSON::Bool(left != right))
+            }
+            // Everything else
+            _ => Some(JSON::Bool(&value != data)),
+        });
 
-            return (matches, apply_to_errors);
-        }
+        return (matches, apply_to_errors);
+    }
     (
         None,
         vec![ApplyToError::new(

--- a/apollo-federation/src/connectors/json_selection/methods/public/or.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/or.rs
@@ -202,7 +202,7 @@ mod method_tests {
             "a": true,
         }));
 
-        println!("result: {:?}", result);
+        println!("result: {result:?}");
 
         assert_eq!(result.0, None);
         assert!(!result.1.is_empty());

--- a/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
@@ -76,8 +76,8 @@ fn parse_int_method(
         }
     };
 
-    if let Some(args) = method_args {
-        if args.args.len() > 1 {
+    if let Some(args) = method_args
+        && args.args.len() > 1 {
             return (
                 None,
                 vec![ApplyToError::new(
@@ -92,7 +92,6 @@ fn parse_int_method(
                 )],
             );
         }
-    }
 
     // Parse base argument or use default (10)
     let base = match method_args

--- a/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
@@ -77,21 +77,22 @@ fn parse_int_method(
     };
 
     if let Some(args) = method_args
-        && args.args.len() > 1 {
-            return (
-                None,
-                vec![ApplyToError::new(
-                    format!(
-                        "Method ->{} accepts at most one argument (base), but {} were provided",
-                        method_name.as_ref(),
-                        args.args.len()
-                    ),
-                    input_path.to_vec(),
-                    method_name.range(),
-                    spec,
-                )],
-            );
-        }
+        && args.args.len() > 1
+    {
+        return (
+            None,
+            vec![ApplyToError::new(
+                format!(
+                    "Method ->{} accepts at most one argument (base), but {} were provided",
+                    method_name.as_ref(),
+                    args.args.len()
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+                spec,
+            )],
+        );
+    }
 
     // Parse base argument or use default (10)
     let base = match method_args

--- a/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
@@ -31,21 +31,22 @@ fn to_string_method(
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
     if let Some(args) = method_args
-        && !args.args.is_empty() {
-            return (
-                None,
-                vec![ApplyToError::new(
-                    format!(
-                        "Method ->{} does not accept any arguments, but {} were provided",
-                        method_name.as_ref(),
-                        args.args.len()
-                    ),
-                    input_path.to_vec(),
-                    method_name.range(),
-                    spec,
-                )],
-            );
-        }
+        && !args.args.is_empty()
+    {
+        return (
+            None,
+            vec![ApplyToError::new(
+                format!(
+                    "Method ->{} does not accept any arguments, but {} were provided",
+                    method_name.as_ref(),
+                    args.args.len()
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+                spec,
+            )],
+        );
+    }
 
     let string_value = match json_to_string(data) {
         Ok(result) => result.unwrap_or_default(),

--- a/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
@@ -30,8 +30,8 @@ fn to_string_method(
     input_path: &InputPath<JSON>,
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
-    if let Some(args) = method_args {
-        if !args.args.is_empty() {
+    if let Some(args) = method_args
+        && !args.args.is_empty() {
             return (
                 None,
                 vec![ApplyToError::new(
@@ -46,7 +46,6 @@ fn to_string_method(
                 )],
             );
         }
-    }
 
     let string_value = match json_to_string(data) {
         Ok(result) => result.unwrap_or_default(),

--- a/apollo-federation/src/connectors/json_selection/mod.rs
+++ b/apollo-federation/src/connectors/json_selection/mod.rs
@@ -78,7 +78,7 @@ mod test {
         let (result, errors) = JSONSelection::parse_with_spec(selection, version)
             .unwrap()
             .apply_to(&data);
-        println!("errors: {:?}", errors);
+        println!("errors: {errors:?}");
         assert!(errors.is_empty());
         assert_eq!(result, expected);
     }

--- a/apollo-federation/src/connectors/json_selection/parser.rs
+++ b/apollo-federation/src/connectors/json_selection/parser.rs
@@ -3996,9 +3996,7 @@ mod tests {
             );
             assert_debug_snapshot!(selection);
         } else {
-            panic!(
-                "Expected a valid selection, got error: {a_plus_b_plus_c:?}"
-            );
+            panic!("Expected a valid selection, got error: {a_plus_b_plus_c:?}");
         }
     }
 
@@ -4019,16 +4017,12 @@ mod tests {
                     }
                 },
                 |path| {
-                    panic!(
-                        "Expected any number of named selections, got path: {path:?}"
-                    );
+                    panic!("Expected any number of named selections, got path: {path:?}");
                 },
             );
             assert_debug_snapshot!(selection);
         } else {
-            panic!(
-                "Expected a valid selection, got error: {sum_a_plus_b_plus_c:?}"
-            );
+            panic!("Expected a valid selection, got error: {sum_a_plus_b_plus_c:?}");
         }
     }
 

--- a/apollo-federation/src/connectors/json_selection/parser.rs
+++ b/apollo-federation/src/connectors/json_selection/parser.rs
@@ -2560,8 +2560,7 @@ mod tests {
             match PathSelection::parse(new_span_with_spec(input, ConnectSpec::latest())) {
                 Ok((remainder, path)) => {
                     panic!(
-                        "Expected error at offset {} with message '{}', but got path {:?} and remainder {:?}",
-                        expected_offset, expected_message, path, remainder,
+                        "Expected error at offset {expected_offset} with message '{expected_message}', but got path {path:?} and remainder {remainder:?}",
                     );
                 }
                 Err(nom::Err::Error(e) | nom::Err::Failure(e)) => {
@@ -2578,7 +2577,7 @@ mod tests {
                     );
                 }
                 Err(e) => {
-                    panic!("Unexpected error {:?}", e);
+                    panic!("Unexpected error {e:?}");
                 }
             }
         }
@@ -3704,7 +3703,7 @@ mod tests {
         let mul_with_dollars = selection!("a->mul($.b, $.c)", spec);
         mul_with_dollars.if_named_else_path(
             |named| {
-                panic!("Expected a path selection, got named: {:?}", named);
+                panic!("Expected a path selection, got named: {named:?}");
             },
             |path| {
                 assert_eq!(path.get_single_key(), None);
@@ -3969,7 +3968,7 @@ mod tests {
         let mul_with_dollars = selection!("a->mul($.b, $.c)", spec);
         mul_with_dollars.if_named_else_path(
             |named| {
-                panic!("Expected a path selection, got named: {:?}", named);
+                panic!("Expected a path selection, got named: {named:?}");
             },
             |path| {
                 assert_eq!(path.get_single_key(), None);
@@ -3988,7 +3987,7 @@ mod tests {
         if let Ok(selection) = a_plus_b_plus_c {
             selection.if_named_else_path(
                 |named| {
-                    panic!("Expected a path selection, got named: {:?}", named);
+                    panic!("Expected a path selection, got named: {named:?}");
                 },
                 |path| {
                     assert_eq!(path.pretty_print(), "a->add(b, c)");
@@ -3998,8 +3997,7 @@ mod tests {
             assert_debug_snapshot!(selection);
         } else {
             panic!(
-                "Expected a valid selection, got error: {:?}",
-                a_plus_b_plus_c
+                "Expected a valid selection, got error: {a_plus_b_plus_c:?}"
             );
         }
     }
@@ -4022,16 +4020,14 @@ mod tests {
                 },
                 |path| {
                     panic!(
-                        "Expected any number of named selections, got path: {:?}",
-                        path
+                        "Expected any number of named selections, got path: {path:?}"
                     );
                 },
             );
             assert_debug_snapshot!(selection);
         } else {
             panic!(
-                "Expected a valid selection, got error: {:?}",
-                sum_a_plus_b_plus_c
+                "Expected a valid selection, got error: {sum_a_plus_b_plus_c:?}"
             );
         }
     }

--- a/apollo-federation/src/connectors/runtime/debug.rs
+++ b/apollo-federation/src/connectors/runtime/debug.rs
@@ -76,7 +76,7 @@ impl ConnectorContext {
                         .collect(),
                     body: ConnectorDebugBody {
                         kind: "invalid".to_string(),
-                        content: format!("{:?}", body).into(),
+                        content: format!("{body:?}").into(),
                         selection: None,
                     },
                     errors: if error_settings.message.is_some()

--- a/apollo-federation/src/connectors/runtime/inputs.rs
+++ b/apollo-federation/src/connectors/runtime/inputs.rs
@@ -46,7 +46,7 @@ impl RequestInputs {
     pub fn merger(
         self,
         variables_used: &IndexMap<Namespace, IndexSet<String>>,
-    ) -> MappingContextMerger {
+    ) -> MappingContextMerger<'_> {
         MappingContextMerger {
             inputs: self,
             variables_used,

--- a/apollo-federation/src/connectors/spec/connect.rs
+++ b/apollo-federation/src/connectors/spec/connect.rs
@@ -369,8 +369,7 @@ impl TryFrom<(&ObjectNode, &Name, ConnectSpec)> for ConnectHTTPArguments {
             } else if name == PATH_ARGUMENT_NAME.as_str() {
                 let value = value.as_str().ok_or_else(|| {
                     FederationError::internal(format!(
-                        "`{}` field in `@{directive_name}` directive's `http` field is not a string",
-                        PATH_ARGUMENT_NAME
+                        "`{PATH_ARGUMENT_NAME}` field in `@{directive_name}` directive's `http` field is not a string"
                     ))
                 })?;
                 path = Some(
@@ -380,8 +379,7 @@ impl TryFrom<(&ObjectNode, &Name, ConnectSpec)> for ConnectHTTPArguments {
             } else if name == QUERY_PARAMS_ARGUMENT_NAME.as_str() {
                 let value = value.as_str().ok_or_else(|| {
                     FederationError::internal(format!(
-                        "`{}` field in `@{directive_name}` directive's `http` field is not a string",
-                        QUERY_PARAMS_ARGUMENT_NAME
+                        "`{QUERY_PARAMS_ARGUMENT_NAME}` field in `@{directive_name}` directive's `http` field is not a string"
                     ))
                 })?;
                 query_params = Some(

--- a/apollo-federation/src/connectors/spec/source.rs
+++ b/apollo-federation/src/connectors/spec/source.rs
@@ -164,8 +164,7 @@ impl SourceHTTPArguments {
             if name == PATH_ARGUMENT_NAME.as_str() {
                 let value = value.as_str().ok_or_else(|| {
                     FederationError::internal(format!(
-                        "`{}` field in `@{directive_name}` directive's `http.path` field is not a string",
-                        PATH_ARGUMENT_NAME
+                        "`{PATH_ARGUMENT_NAME}` field in `@{directive_name}` directive's `http.path` field is not a string"
                     ))
                 })?;
                 path = Some(
@@ -174,8 +173,7 @@ impl SourceHTTPArguments {
                 );
             } else if name == QUERY_PARAMS_ARGUMENT_NAME.as_str() {
                 let value = value.as_str().ok_or_else(|| FederationError::internal(format!(
-                    "`{}` field in `@{directive_name}` directive's `http.queryParams` field is not a string",
-                    QUERY_PARAMS_ARGUMENT_NAME
+                    "`{QUERY_PARAMS_ARGUMENT_NAME}` field in `@{directive_name}` directive's `http.queryParams` field is not a string"
                 )))?;
                 query = Some(
                     JSONSelection::parse_with_spec(value, spec)

--- a/apollo-federation/src/connectors/string_template.rs
+++ b/apollo-federation/src/connectors/string_template.rs
@@ -199,7 +199,7 @@ impl StringTemplate {
             PathAndQuery::from_str(result.as_ref()).map(Uri::from)
         }
         .map_err(|err| Error {
-            message: format!("Invalid URI: {}", err),
+            message: format!("Invalid URI: {err}"),
             location: 0..result.as_ref().len(),
         })?;
 
@@ -213,8 +213,8 @@ impl Display for StringTemplate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for part in &self.parts {
             match part {
-                Part::Constant(Constant { value, .. }) => write!(f, "{}", value)?,
-                Part::Expression(Expression { expression, .. }) => write!(f, "{{{}}}", expression)?,
+                Part::Constant(Constant { value, .. }) => write!(f, "{value}")?,
+                Part::Expression(Expression { expression, .. }) => write!(f, "{{{expression}}}")?,
             }
         }
         Ok(())

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -279,7 +279,7 @@ impl SelectionValidator<'_> {
             .into_iter()
     }
 
-    fn path_with_root(&self) -> impl Iterator<Item = PathPart> {
+    fn path_with_root(&self) -> impl Iterator<Item = PathPart<'_>> {
         once(self.root).chain(self.path.iter().copied())
     }
 
@@ -293,7 +293,7 @@ impl SelectionValidator<'_> {
             .join(".")
     }
 
-    fn last_field(&self) -> &PathPart {
+    fn last_field(&self) -> &PathPart<'_> {
         self.path.last().unwrap_or(&self.root)
     }
 }

--- a/apollo-federation/src/connectors/validation/schema.rs
+++ b/apollo-federation/src/connectors/validation/schema.rs
@@ -246,8 +246,8 @@ fn fields_seen_by_resolvable_keys(schema: &SchemaInfo) -> IndexSet<(Name, Name)>
         })
         .collect();
     while !selections.is_empty() {
-        if let Some((type_name, selection)) = selections.pop() {
-            if let Some(field) = selection.as_field() {
+        if let Some((type_name, selection)) = selections.pop()
+            && let Some(field) = selection.as_field() {
                 let t = (type_name, field.name.clone());
                 if !seen_fields.contains(&t) {
                     seen_fields.insert(t);
@@ -256,7 +256,6 @@ fn fields_seen_by_resolvable_keys(schema: &SchemaInfo) -> IndexSet<(Name, Name)>
                     });
                 }
             }
-        }
     }
 
     seen_fields
@@ -479,8 +478,8 @@ impl<'walker> ShapeVisitor for SelectionSetWalker<'walker> {
             };
 
             // Check that next shape doesn't come from a non-`$root` field.
-            if let ShapeCase::Name(root, _) = next_shape.case() {
-                if root.value != Self::ROOT_SHAPE {
+            if let ShapeCase::Name(root, _) = next_shape.case()
+                && root.value != Self::ROOT_SHAPE {
                     return Err(ShapeVisitorError::NonRootBatch(
                         self.name
                             .line_column_range(&self.schema.sources)
@@ -488,7 +487,6 @@ impl<'walker> ShapeVisitor for SelectionSetWalker<'walker> {
                             .collect(),
                     ));
                 }
-            }
 
             // If key has no nested selections, then we can stop walking down this branch.
             if sub_selection.is_empty() {

--- a/apollo-federation/src/connectors/validation/schema.rs
+++ b/apollo-federation/src/connectors/validation/schema.rs
@@ -247,15 +247,16 @@ fn fields_seen_by_resolvable_keys(schema: &SchemaInfo) -> IndexSet<(Name, Name)>
         .collect();
     while !selections.is_empty() {
         if let Some((type_name, selection)) = selections.pop()
-            && let Some(field) = selection.as_field() {
-                let t = (type_name, field.name.clone());
-                if !seen_fields.contains(&t) {
-                    seen_fields.insert(t);
-                    field.selection_set.selections.iter().for_each(|selection| {
-                        selections.push((field.ty().inner_named_type().clone(), selection.clone()));
-                    });
-                }
+            && let Some(field) = selection.as_field()
+        {
+            let t = (type_name, field.name.clone());
+            if !seen_fields.contains(&t) {
+                seen_fields.insert(t);
+                field.selection_set.selections.iter().for_each(|selection| {
+                    selections.push((field.ty().inner_named_type().clone(), selection.clone()));
+                });
             }
+        }
     }
 
     seen_fields
@@ -479,14 +480,15 @@ impl<'walker> ShapeVisitor for SelectionSetWalker<'walker> {
 
             // Check that next shape doesn't come from a non-`$root` field.
             if let ShapeCase::Name(root, _) = next_shape.case()
-                && root.value != Self::ROOT_SHAPE {
-                    return Err(ShapeVisitorError::NonRootBatch(
-                        self.name
-                            .line_column_range(&self.schema.sources)
-                            .into_iter()
-                            .collect(),
-                    ));
-                }
+                && root.value != Self::ROOT_SHAPE
+            {
+                return Err(ShapeVisitorError::NonRootBatch(
+                    self.name
+                        .line_column_range(&self.schema.sources)
+                        .into_iter()
+                        .collect(),
+                ));
+            }
 
             // If key has no nested selections, then we can stop walking down this branch.
             if sub_selection.is_empty() {

--- a/apollo-federation/src/correctness/mod.rs
+++ b/apollo-federation/src/correctness/mod.rs
@@ -42,7 +42,7 @@ impl fmt::Display for CorrectnessError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CorrectnessError::FederationError(err) => {
-                write!(f, "Correctness check failed to complete: {}", err)
+                write!(f, "Correctness check failed to complete: {err}")
             }
             CorrectnessError::ComparisonError(err) => {
                 write!(f, "Correctness error found:\n{}", err.description())

--- a/apollo-federation/src/correctness/query_plan_analysis.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis.rs
@@ -291,11 +291,12 @@ fn rename_at_path(
             let mut target_defs = PossibleDefinitions::default(); // for the new name
             for (type_cond, defs_per_type_cond) in defs.iter() {
                 if let Some(type_filter) = &type_filter
-                    && !type_filter.implies(type_cond) {
-                        // Not applicable => same as before
-                        updated_defs.insert(type_cond.clone(), defs_per_type_cond.clone());
-                        continue;
-                    }
+                    && !type_filter.implies(type_cond)
+                {
+                    // Not applicable => same as before
+                    updated_defs.insert(type_cond.clone(), defs_per_type_cond.clone());
+                    continue;
+                }
                 if rename_here {
                     // move all definitions to the target_defs
                     target_defs.insert(type_cond.clone(), defs_per_type_cond.clone());

--- a/apollo-federation/src/correctness/query_plan_analysis.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis.rs
@@ -290,13 +290,12 @@ fn rename_at_path(
             let mut updated_defs = PossibleDefinitions::default(); // for the old name
             let mut target_defs = PossibleDefinitions::default(); // for the new name
             for (type_cond, defs_per_type_cond) in defs.iter() {
-                if let Some(type_filter) = &type_filter {
-                    if !type_filter.implies(type_cond) {
+                if let Some(type_filter) = &type_filter
+                    && !type_filter.implies(type_cond) {
                         // Not applicable => same as before
                         updated_defs.insert(type_cond.clone(), defs_per_type_cond.clone());
                         continue;
                     }
-                }
                 if rename_here {
                     // move all definitions to the target_defs
                     target_defs.insert(type_cond.clone(), defs_per_type_cond.clone());

--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -52,8 +52,8 @@ impl AnalysisError {
 impl fmt::Display for AnalysisErrorMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AnalysisErrorMessage::FederationError(err) => write!(f, "{}", err),
-            AnalysisErrorMessage::QueryPlanError(err) => write!(f, "{}", err),
+            AnalysisErrorMessage::FederationError(err) => write!(f, "{err}"),
+            AnalysisErrorMessage::QueryPlanError(err) => write!(f, "{err}"),
         }
     }
 }

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -326,11 +326,10 @@ impl NormalizedTypeCondition {
         }
 
         // Simple case #1 - The collected types is just a single named type.
-        if types.len() == 1 {
-            if let Some(first) = types.first() {
+        if types.len() == 1
+            && let Some(first) = types.first() {
                 return NormalizedTypeCondition::from_type_name(first.clone(), schema);
             }
-        }
 
         // Grind the type names into object types.
         let mut ground_types = IndexSet::default();
@@ -346,8 +345,7 @@ impl NormalizedTypeCondition {
         // Simple case #2 - `declared_type` is same as the collected types.
         if let Some(declared_type_cond) =
             NormalizedTypeCondition::from_type_name(declared_type.clone(), schema)?
-        {
-            if declared_type_cond.ground_set.len() == ground_types.len()
+            && declared_type_cond.ground_set.len() == ground_types.len()
                 && declared_type_cond
                     .ground_set
                     .iter()
@@ -355,7 +353,6 @@ impl NormalizedTypeCondition {
             {
                 return Ok(Some(declared_type_cond));
             }
-        }
 
         Ok(Some(NormalizedTypeCondition::from_object_types(
             ground_types.into_iter(),

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -327,9 +327,10 @@ impl NormalizedTypeCondition {
 
         // Simple case #1 - The collected types is just a single named type.
         if types.len() == 1
-            && let Some(first) = types.first() {
-                return NormalizedTypeCondition::from_type_name(first.clone(), schema);
-            }
+            && let Some(first) = types.first()
+        {
+            return NormalizedTypeCondition::from_type_name(first.clone(), schema);
+        }
 
         // Grind the type names into object types.
         let mut ground_types = IndexSet::default();
@@ -346,13 +347,13 @@ impl NormalizedTypeCondition {
         if let Some(declared_type_cond) =
             NormalizedTypeCondition::from_type_name(declared_type.clone(), schema)?
             && declared_type_cond.ground_set.len() == ground_types.len()
-                && declared_type_cond
-                    .ground_set
-                    .iter()
-                    .all(|t| ground_types.contains(t))
-            {
-                return Ok(Some(declared_type_cond));
-            }
+            && declared_type_cond
+                .ground_set
+                .iter()
+                .all(|t| ground_types.contains(t))
+        {
+            return Ok(Some(declared_type_cond));
+        }
 
         Ok(Some(NormalizedTypeCondition::from_object_types(
             ground_types.into_iter(),

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -1346,8 +1346,8 @@ impl fmt::Display for Clause {
                     write!(f, " ∧ ")?;
                 }
                 match l {
-                    Literal::Pos(v) => write!(f, "{}", v)?,
-                    Literal::Neg(v) => write!(f, "¬{}", v)?,
+                    Literal::Pos(v) => write!(f, "{v}")?,
+                    Literal::Neg(v) => write!(f, "¬{v}")?,
                 }
             }
             Ok(())
@@ -1433,7 +1433,7 @@ impl PossibleDefinitions {
         for (type_condition, per_type_cond) in &self.0 {
             for variant in &per_type_cond.conditional_variants {
                 let field_display = &variant.representative_field;
-                let type_cond_str = format!(" on {}", type_condition);
+                let type_cond_str = format!(" on {type_condition}");
                 let boolean_str = if !variant.boolean_clause.is_always_true() {
                     format!(" if {}", variant.boolean_clause)
                 } else {
@@ -1478,7 +1478,7 @@ impl ResponseShape {
                 for variant in &per_type_cond.conditional_variants {
                     let field_display = &variant.representative_field;
                     let type_cond_str = if has_type_cond {
-                        format!(" on {}", type_condition)
+                        format!(" on {type_condition}")
                     } else {
                         "".to_string()
                     };

--- a/apollo-federation/src/correctness/response_shape_compare.rs
+++ b/apollo-federation/src/correctness/response_shape_compare.rs
@@ -188,8 +188,8 @@ fn compare_possible_definitions<T: PathConstraint>(
         let updated_constraint = path_constraint.under_type_condition(this_cond);
 
         // First try: Use the single exact match (common case).
-        if let Some(other_def) = other.get(this_cond) {
-            if let Ok(result) = compare_possible_definitions_per_type_condition(
+        if let Some(other_def) = other.get(this_cond)
+            && let Ok(result) = compare_possible_definitions_per_type_condition(
                 &updated_constraint,
                 assumption,
                 this_def,
@@ -198,7 +198,6 @@ fn compare_possible_definitions<T: PathConstraint>(
                 return Ok(result);
             }
             // fall through
-        }
 
         // Second try: Collect all definitions implied by the `this_cond`.
         if let Some(other_def) = collect_definitions_for_type_condition(other, this_cond)? {

--- a/apollo-federation/src/correctness/response_shape_compare.rs
+++ b/apollo-federation/src/correctness/response_shape_compare.rs
@@ -194,10 +194,11 @@ fn compare_possible_definitions<T: PathConstraint>(
                 assumption,
                 this_def,
                 other_def,
-            ) {
-                return Ok(result);
-            }
-            // fall through
+            )
+        {
+            return Ok(result);
+        }
+        // fall through
 
         // Second try: Collect all definitions implied by the `this_cond`.
         if let Some(other_def) = collect_definitions_for_type_condition(other, this_cond)? {

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -1359,9 +1359,7 @@ static DIRECTIVE_UNSUPPORTED_ON_INTERFACE: LazyLock<ErrorCodeCategory<String>> =
                 } else {
                     "not (yet) supported"
                 };
-                format!(
-                    "A `@{directive}` directive is used on an interface, which is {suffix}."
-                )
+                format!("A `@{directive}` directive is used on an interface, which is {suffix}.")
             }),
             None,
         )

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -1314,8 +1314,7 @@ static FIELDS_HAS_ARGS: LazyLock<ErrorCodeCategory<String>> = LazyLock::new(|| {
         "FIELDS_HAS_ARGS".to_owned(),
         Box::new(|directive| {
             format!(
-                "The `fields` argument of a `@{}` directive includes a field defined with arguments (which is not currently supported).",
-                directive
+                "The `fields` argument of a `@{directive}` directive includes a field defined with arguments (which is not currently supported)."
             )
         }),
         None,
@@ -1334,8 +1333,7 @@ static DIRECTIVE_FIELDS_MISSING_EXTERNAL: LazyLock<ErrorCodeCategory<String>> = 
             "FIELDS_MISSING_EXTERNAL".to_owned(),
             Box::new(|directive| {
                 format!(
-                    "The `fields` argument of a `@{}` directive includes a field that is not marked as `@external`.",
-                    directive
+                    "The `fields` argument of a `@{directive}` directive includes a field that is not marked as `@external`."
                 )
             }),
             Some(ErrorCodeMetadata {
@@ -1362,8 +1360,7 @@ static DIRECTIVE_UNSUPPORTED_ON_INTERFACE: LazyLock<ErrorCodeCategory<String>> =
                     "not (yet) supported"
                 };
                 format!(
-                    "A `@{}` directive is used on an interface, which is {}.",
-                    directive, suffix
+                    "A `@{directive}` directive is used on an interface, which is {suffix}."
                 )
             }),
             None,
@@ -1382,8 +1379,7 @@ static DIRECTIVE_IN_FIELDS_ARG: LazyLock<ErrorCodeCategory<String>> = LazyLock::
         "DIRECTIVE_IN_FIELDS_ARG".to_owned(),
         Box::new(|directive| {
             format!(
-                "The `fields` argument of a `@{}` directive includes some directive applications. This is not supported",
-                directive
+                "The `fields` argument of a `@{directive}` directive includes some directive applications. This is not supported"
             )
         }),
         Some(ErrorCodeMetadata {
@@ -1437,8 +1433,7 @@ static DIRECTIVE_INVALID_FIELDS_TYPE: LazyLock<ErrorCodeCategory<String>> = Lazy
         "INVALID_FIELDS_TYPE".to_owned(),
         Box::new(|directive| {
             format!(
-                "The value passed to the `fields` argument of a `@{}` directive is not a string.",
-                directive
+                "The value passed to the `fields` argument of a `@{directive}` directive is not a string."
             )
         }),
         None,
@@ -1457,8 +1452,7 @@ static DIRECTIVE_INVALID_FIELDS: LazyLock<ErrorCodeCategory<String>> = LazyLock:
         "INVALID_FIELDS".to_owned(),
         Box::new(|directive| {
             format!(
-                "The `fields` argument of a `@{}` directive is invalid (it has invalid syntax, includes unknown fields, ...).",
-                directive
+                "The `fields` argument of a `@{directive}` directive is invalid (it has invalid syntax, includes unknown fields, ...)."
             )
         }),
         None,
@@ -1492,8 +1486,7 @@ static ROOT_TYPE_USED: LazyLock<ErrorCodeCategory<SchemaRootKind>> = LazyLock::n
         Box::new(|element| {
             let kind: String = element.into();
             format!(
-                "A subgraph's schema defines a type with the name `{}`, while also specifying a _different_ type name as the root query object. This is not allowed.",
-                kind
+                "A subgraph's schema defines a type with the name `{kind}`, while also specifying a _different_ type name as the root query object. This is not allowed."
             )
         }),
         Some(ErrorCodeMetadata {

--- a/apollo-federation/src/error/suggestion.rs
+++ b/apollo-federation/src/error/suggestion.rs
@@ -35,7 +35,7 @@ pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> Str
         suggestions
             .into_iter()
             .take(MAX_SUGGESTIONS)
-            .map(|s| format!("\"{}\"", s)),
+            .map(|s| format!("\"{s}\"")),
         human_readable::JoinStringsOptions {
             separator: ", ",
             first_separator: None,
@@ -43,5 +43,5 @@ pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> Str
             output_length_limit: None,
         },
     );
-    format!("{}{}?", MESSAGE, suggestion_str)
+    format!("{MESSAGE}{suggestion_str}?")
 }

--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -150,14 +150,15 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
                 // directive of the same name. So one cannot import a direcitive with the
                 // same name than a linked spec.
                 if let Some(other) = by_name_in_schema.get(imported_name)
-                    && !Arc::ptr_eq(other, link) {
-                        return Err(LinkError::BootstrapError(format!(
-                            "import for '{}' of {} conflicts with spec {}",
-                            import.imported_display_name(),
-                            link.url,
-                            other.url
-                        )));
-                    }
+                    && !Arc::ptr_eq(other, link)
+                {
+                    return Err(LinkError::BootstrapError(format!(
+                        "import for '{}' of {} conflicts with spec {}",
+                        import.imported_display_name(),
+                        link.url,
+                        other.url
+                    )));
+                }
                 &mut directives_by_imported_name
             } else {
                 &mut types_by_imported_name

--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -680,7 +680,7 @@ mod tests {
             let schema_doc = format!("{schema_prefix}\n{link_def}");
             let schema = Schema::parse(&schema_doc, "test.graphql").unwrap();
             let meta = links_metadata(&schema)?;
-            assert!(meta.is_some(), "should have metadata for: {}", link_def);
+            assert!(meta.is_some(), "should have metadata for: {link_def}");
         }
         Ok(())
     }

--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -149,8 +149,8 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
                 // the name of each spec (in the schema) acts as an implicit import for a
                 // directive of the same name. So one cannot import a direcitive with the
                 // same name than a linked spec.
-                if let Some(other) = by_name_in_schema.get(imported_name) {
-                    if !Arc::ptr_eq(other, link) {
+                if let Some(other) = by_name_in_schema.get(imported_name)
+                    && !Arc::ptr_eq(other, link) {
                         return Err(LinkError::BootstrapError(format!(
                             "import for '{}' of {} conflicts with spec {}",
                             import.imported_display_name(),
@@ -158,7 +158,6 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
                             other.url
                         )));
                     }
-                }
                 &mut directives_by_imported_name
             } else {
                 &mut types_by_imported_name

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -966,9 +966,10 @@ impl SpecDefinition for FederationSpecDefinition {
         }
 
         if self.version().satisfies(&Version { major: 2, minor: 6 })
-            && let Some(policy_spec) = POLICY_VERSIONS.find(&Version { major: 0, minor: 1 }) {
-                specs.extend(policy_spec.directive_specs());
-            }
+            && let Some(policy_spec) = POLICY_VERSIONS.find(&Version { major: 0, minor: 1 })
+        {
+            specs.extend(policy_spec.directive_specs());
+        }
 
         if self.version().satisfies(&Version { major: 2, minor: 8 }) {
             let context_spec_definitions =
@@ -978,9 +979,10 @@ impl SpecDefinition for FederationSpecDefinition {
         }
 
         if self.version().satisfies(&Version { major: 2, minor: 9 })
-            && let Some(cost_spec) = COST_VERSIONS.find(&Version { major: 0, minor: 1 }) {
-                specs.extend(cost_spec.directive_specs());
-            }
+            && let Some(cost_spec) = COST_VERSIONS.find(&Version { major: 0, minor: 1 })
+        {
+            specs.extend(cost_spec.directive_specs());
+        }
 
         if self.version().satisfies(&Version {
             major: 2,
@@ -1001,14 +1003,15 @@ impl SpecDefinition for FederationSpecDefinition {
         if self.version().satisfies(&Version { major: 2, minor: 5 })
             && let Some(requires_scopes_spec) =
                 REQUIRES_SCOPES_VERSIONS.find(&Version { major: 0, minor: 1 })
-            {
-                type_specs.extend(requires_scopes_spec.type_specs());
-            }
+        {
+            type_specs.extend(requires_scopes_spec.type_specs());
+        }
 
         if self.version().satisfies(&Version { major: 2, minor: 6 })
-            && let Some(policy_spec) = POLICY_VERSIONS.find(&Version { major: 0, minor: 1 }) {
-                type_specs.extend(policy_spec.type_specs());
-            }
+            && let Some(policy_spec) = POLICY_VERSIONS.find(&Version { major: 0, minor: 1 })
+        {
+            type_specs.extend(policy_spec.type_specs());
+        }
 
         if self.version().satisfies(&Version { major: 2, minor: 8 }) {
             type_specs.extend(

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -175,8 +175,7 @@ impl FederationSpecDefinition {
             None => Ok(None),
             _ => Err(SingleFederationError::Internal {
                 message: format!(
-                    "Unexpectedly found non-union for federation spec's \"{}\" type definition",
-                    FEDERATION_ENTITY_TYPE_NAME_IN_SPEC
+                    "Unexpectedly found non-union for federation spec's \"{FEDERATION_ENTITY_TYPE_NAME_IN_SPEC}\" type definition"
                 ),
             }
             .into()),
@@ -191,8 +190,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }
                 .into()
@@ -253,8 +251,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -289,8 +286,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                 ))
             })
     }
@@ -310,8 +306,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -360,8 +355,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -396,8 +390,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -451,8 +444,7 @@ impl FederationSpecDefinition {
             .ok_or_else(|| {
                 SingleFederationError::Internal {
                     message: format!(
-                        "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                        FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC
+                        "Unexpectedly could not find federation spec's \"@{FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                     ),
                 }.into()
             })
@@ -503,8 +495,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                 ))
             })
     }
@@ -531,8 +522,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC}\" directive definition"
                 ))
             })
     }
@@ -586,8 +576,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC,
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC}\" directive definition",
                 ))
             })
     }
@@ -635,8 +624,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC,
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC}\" directive definition",
                 ))
             })
     }
@@ -692,8 +680,7 @@ impl FederationSpecDefinition {
         self.directive_definition(schema, &FEDERATION_CACHE_TAG_DIRECTIVE_NAME_IN_SPEC)?
             .ok_or_else(|| {
                 FederationError::internal(format!(
-                    "Unexpectedly could not find federation spec's \"@{}\" directive definition",
-                    FEDERATION_CACHE_TAG_DIRECTIVE_NAME_IN_SPEC,
+                    "Unexpectedly could not find federation spec's \"@{FEDERATION_CACHE_TAG_DIRECTIVE_NAME_IN_SPEC}\" directive definition",
                 ))
             })
     }

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -965,11 +965,10 @@ impl SpecDefinition for FederationSpecDefinition {
             }
         }
 
-        if self.version().satisfies(&Version { major: 2, minor: 6 }) {
-            if let Some(policy_spec) = POLICY_VERSIONS.find(&Version { major: 0, minor: 1 }) {
+        if self.version().satisfies(&Version { major: 2, minor: 6 })
+            && let Some(policy_spec) = POLICY_VERSIONS.find(&Version { major: 0, minor: 1 }) {
                 specs.extend(policy_spec.directive_specs());
             }
-        }
 
         if self.version().satisfies(&Version { major: 2, minor: 8 }) {
             let context_spec_definitions =
@@ -978,11 +977,10 @@ impl SpecDefinition for FederationSpecDefinition {
             specs.extend(context_spec_definitions);
         }
 
-        if self.version().satisfies(&Version { major: 2, minor: 9 }) {
-            if let Some(cost_spec) = COST_VERSIONS.find(&Version { major: 0, minor: 1 }) {
+        if self.version().satisfies(&Version { major: 2, minor: 9 })
+            && let Some(cost_spec) = COST_VERSIONS.find(&Version { major: 0, minor: 1 }) {
                 specs.extend(cost_spec.directive_specs());
             }
-        }
 
         if self.version().satisfies(&Version {
             major: 2,
@@ -1000,19 +998,17 @@ impl SpecDefinition for FederationSpecDefinition {
                 name: FEDERATION_FIELDSET_TYPE_NAME_IN_SPEC,
             })];
 
-        if self.version().satisfies(&Version { major: 2, minor: 5 }) {
-            if let Some(requires_scopes_spec) =
+        if self.version().satisfies(&Version { major: 2, minor: 5 })
+            && let Some(requires_scopes_spec) =
                 REQUIRES_SCOPES_VERSIONS.find(&Version { major: 0, minor: 1 })
             {
                 type_specs.extend(requires_scopes_spec.type_specs());
             }
-        }
 
-        if self.version().satisfies(&Version { major: 2, minor: 6 }) {
-            if let Some(policy_spec) = POLICY_VERSIONS.find(&Version { major: 0, minor: 1 }) {
+        if self.version().satisfies(&Version { major: 2, minor: 6 })
+            && let Some(policy_spec) = POLICY_VERSIONS.find(&Version { major: 0, minor: 1 }) {
                 type_specs.extend(policy_spec.type_specs());
             }
-        }
 
         if self.version().satisfies(&Version { major: 2, minor: 8 }) {
             type_specs.extend(

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -1037,7 +1037,7 @@ fn validate_inaccessible(
                     .collect::<Vec<_>>()
                     .join(", ");
                 errors.push(SingleFederationError::DisallowedInaccessible {
-                    message: format!("Directive `{position}` cannot use @inaccessible because it may be applied to these type-system locations: {}", type_system_locations),
+                    message: format!("Directive `{position}` cannot use @inaccessible because it may be applied to these type-system locations: {type_system_locations}"),
                 }.into());
             }
         } else {

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -381,16 +381,16 @@ fn validate_inaccessible_in_arguments(
         if !arg_inaccessible
             && let (Some(default_value), Some(arg_type)) =
                 (&arg.default_value, types.get(arg.ty.inner_named_type()))
-            {
-                validate_inaccessible_in_default_value(
-                    schema,
-                    inaccessible_directive,
-                    arg_type,
-                    default_value,
-                    format!("{usage_position}({arg_name}:)"),
-                    errors,
-                )?;
-            }
+        {
+            validate_inaccessible_in_default_value(
+                schema,
+                inaccessible_directive,
+                arg_type,
+                default_value,
+                format!("{usage_position}({arg_name}:)"),
+                errors,
+            )?;
+        }
     }
     Ok(())
 }
@@ -949,16 +949,17 @@ fn validate_inaccessible(
                             && let (Some(default_value), Some(field_type)) = (
                                 &field.default_value,
                                 schema.schema().types.get(field.ty.inner_named_type()),
-                            ) {
-                                validate_inaccessible_in_default_value(
-                                    schema,
-                                    &inaccessible_directive,
-                                    field_type,
-                                    default_value,
-                                    input_object_position.field(field.name.clone()).to_string(),
-                                    &mut errors,
-                                )?;
-                            }
+                            )
+                        {
+                            validate_inaccessible_in_default_value(
+                                schema,
+                                &inaccessible_directive,
+                                field_type,
+                                default_value,
+                                input_object_position.field(field.name.clone()).to_string(),
+                                &mut errors,
+                            )?;
+                        }
                     }
 
                     if has_inaccessible_field && !has_accessible_field {

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -378,8 +378,8 @@ fn validate_inaccessible_in_arguments(
             }.into());
         }
 
-        if !arg_inaccessible {
-            if let (Some(default_value), Some(arg_type)) =
+        if !arg_inaccessible
+            && let (Some(default_value), Some(arg_type)) =
                 (&arg.default_value, types.get(arg.ty.inner_named_type()))
             {
                 validate_inaccessible_in_default_value(
@@ -391,7 +391,6 @@ fn validate_inaccessible_in_arguments(
                     errors,
                 )?;
             }
-        }
     }
     Ok(())
 }
@@ -946,8 +945,8 @@ fn validate_inaccessible(
                             }.into());
                         }
 
-                        if !field_inaccessible {
-                            if let (Some(default_value), Some(field_type)) = (
+                        if !field_inaccessible
+                            && let (Some(default_value), Some(field_type)) = (
                                 &field.default_value,
                                 schema.schema().types.get(field.ty.inner_named_type()),
                             ) {
@@ -960,7 +959,6 @@ fn validate_inaccessible(
                                     &mut errors,
                                 )?;
                             }
-                        }
                     }
 
                     if has_inaccessible_field && !has_accessible_field {

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -648,14 +648,13 @@ impl JoinSpecDefinition {
             }
         }
 
-        if *self.version() >= (Version { major: 0, minor: 3 }) {
-            if let Some(is_interface_object) = is_interface_object {
+        if *self.version() >= (Version { major: 0, minor: 3 })
+            && let Some(is_interface_object) = is_interface_object {
                 args.push(Node::new(Argument {
                     name: JOIN_ISINTERFACEOBJECT_ARGUMENT_NAME,
                     value: Node::new(Value::Boolean(is_interface_object)),
                 }));
             }
-        }
 
         Directive {
             name: JOIN_TYPE_DIRECTIVE_NAME_IN_SPEC,

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -251,8 +251,7 @@ impl JoinSpecDefinition {
         } else {
             Err(SingleFederationError::Internal {
                 message: format!(
-                    "Unexpectedly found non-enum for join spec's \"{}\" enum definition",
-                    JOIN_GRAPH_ENUM_NAME_IN_SPEC,
+                    "Unexpectedly found non-enum for join spec's \"{JOIN_GRAPH_ENUM_NAME_IN_SPEC}\" enum definition",
                 ),
             }
             .into())
@@ -1096,7 +1095,7 @@ impl JoinSpecDefinition {
                     sanitized_name.clone()
                 } else {
                     // Subsequent subgraphs get _1, _2, etc.
-                    format!("{}_{}", sanitized_name, index)
+                    format!("{sanitized_name}_{index}")
                 };
 
                 let enum_value_name = Name::new(enum_name.as_str())?;

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -649,12 +649,13 @@ impl JoinSpecDefinition {
         }
 
         if *self.version() >= (Version { major: 0, minor: 3 })
-            && let Some(is_interface_object) = is_interface_object {
-                args.push(Node::new(Argument {
-                    name: JOIN_ISINTERFACEOBJECT_ARGUMENT_NAME,
-                    value: Node::new(Value::Boolean(is_interface_object)),
-                }));
-            }
+            && let Some(is_interface_object) = is_interface_object
+        {
+            args.push(Node::new(Argument {
+                name: JOIN_ISINTERFACEOBJECT_ARGUMENT_NAME,
+                value: Node::new(Value::Boolean(is_interface_object)),
+            }));
+        }
 
         Directive {
             name: JOIN_TYPE_DIRECTIVE_NAME_IN_SPEC,

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -211,23 +211,22 @@ impl LinkSpecDefinition {
         let url =
             directive_optional_string_argument(application, &LINK_DIRECTIVE_URL_ARGUMENT_NAME)?;
         if let Some(url) = url
-            && url.starts_with(&LinkSpecDefinition::latest().url.identity.to_string()) {
-                let alias = directive_optional_string_argument(
-                    application,
-                    &LINK_DIRECTIVE_AS_ARGUMENT_NAME,
-                )?
-                .map(Name::new)
-                .transpose()?;
-                let imports = directive_optional_list_argument(
-                    application,
-                    &LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
-                )?
-                .into_iter()
-                .flatten()
-                .map(|value| Ok::<_, FederationError>(Arc::new(Import::from_value(value)?)))
-                .process_results(|r| r.collect::<Vec<_>>())?;
-                return Ok((alias, imports));
-            }
+            && url.starts_with(&LinkSpecDefinition::latest().url.identity.to_string())
+        {
+            let alias =
+                directive_optional_string_argument(application, &LINK_DIRECTIVE_AS_ARGUMENT_NAME)?
+                    .map(Name::new)
+                    .transpose()?;
+            let imports = directive_optional_list_argument(
+                application,
+                &LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
+            )?
+            .into_iter()
+            .flatten()
+            .map(|value| Ok::<_, FederationError>(Arc::new(Import::from_value(value)?)))
+            .process_results(|r| r.collect::<Vec<_>>())?;
+            return Ok((alias, imports));
+        }
         Ok((None, vec![]))
     }
 
@@ -307,23 +306,24 @@ impl LinkSpecDefinition {
             }
         }
         if let Some(imports) = imports
-            && !imports.is_empty() {
-                if self.supports_import() {
-                    directive.arguments.push(Node::new(Argument {
-                        name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
-                        value: Node::new(Value::List(
-                            imports.into_iter().map(|i| Node::new(i.into())).collect(),
-                        )),
-                    }))
-                } else {
-                    return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+            && !imports.is_empty()
+        {
+            if self.supports_import() {
+                directive.arguments.push(Node::new(Argument {
+                    name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
+                    value: Node::new(Value::List(
+                        imports.into_iter().map(|i| Node::new(i.into())).collect(),
+                    )),
+                }))
+            } else {
+                return Err(SingleFederationError::InvalidLinkDirectiveUsage {
                         message: format!(
                             "Cannot apply feature {} with imports since the schema's @core/@link version does not support it.",
                             feature.to_string()
                         ),
                     }.into());
-                }
             }
+        }
 
         SchemaDefinitionPosition.insert_directive(schema, Component::new(directive))?;
         feature.add_elements_to_schema(schema)?;

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -210,8 +210,8 @@ impl LinkSpecDefinition {
         // problems with it in a later version bump.
         let url =
             directive_optional_string_argument(application, &LINK_DIRECTIVE_URL_ARGUMENT_NAME)?;
-        if let Some(url) = url {
-            if url.starts_with(&LinkSpecDefinition::latest().url.identity.to_string()) {
+        if let Some(url) = url
+            && url.starts_with(&LinkSpecDefinition::latest().url.identity.to_string()) {
                 let alias = directive_optional_string_argument(
                     application,
                     &LINK_DIRECTIVE_AS_ARGUMENT_NAME,
@@ -228,7 +228,6 @@ impl LinkSpecDefinition {
                 .process_results(|r| r.collect::<Vec<_>>())?;
                 return Ok((alias, imports));
             }
-        }
         Ok((None, vec![]))
     }
 
@@ -307,8 +306,8 @@ impl LinkSpecDefinition {
                 }.into());
             }
         }
-        if let Some(imports) = imports {
-            if !imports.is_empty() {
+        if let Some(imports) = imports
+            && !imports.is_empty() {
                 if self.supports_import() {
                     directive.arguments.push(Node::new(Argument {
                         name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
@@ -325,7 +324,6 @@ impl LinkSpecDefinition {
                     }.into());
                 }
             }
-        }
 
         SchemaDefinitionPosition.insert_directive(schema, Component::new(directive))?;
         feature.add_elements_to_schema(schema)?;

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -192,14 +192,13 @@ impl Import {
                         alias: alias.map(Name::new).transpose()?,
                     })
                 } else {
-                    if let Some(alias) = &alias {
-                        if alias.starts_with('@') {
+                    if let Some(alias) = &alias
+                        && alias.starts_with('@') {
                             return Err(LinkError::BootstrapError(format!(
                                 r#"in "{}", invalid alias '{alias}' for import name '{element}': should not start with '@' (or, if {element} is a directive, then the name should start with '@')"#,
                                 value.serialize().no_indent()
                             )));
                         }
-                    }
                     Ok(Import {
                         element: Name::new(element)?,
                         is_directive: false,

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -193,12 +193,13 @@ impl Import {
                     })
                 } else {
                     if let Some(alias) = &alias
-                        && alias.starts_with('@') {
-                            return Err(LinkError::BootstrapError(format!(
-                                r#"in "{}", invalid alias '{alias}' for import name '{element}': should not start with '@' (or, if {element} is a directive, then the name should start with '@')"#,
-                                value.serialize().no_indent()
-                            )));
-                        }
+                        && alias.starts_with('@')
+                    {
+                        return Err(LinkError::BootstrapError(format!(
+                            r#"in "{}", invalid alias '{alias}' for import name '{element}': should not start with '@' (or, if {element} is a directive, then the name should start with '@')"#,
+                            value.serialize().no_indent()
+                        )));
+                    }
                     Ok(Import {
                         element: Name::new(element)?,
                         is_directive: false,

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -433,12 +433,12 @@ impl fmt::Display for Link {
         let alias = self
             .spec_alias
             .as_ref()
-            .map(|a| format!(r#", as: "{}""#, a))
+            .map(|a| format!(r#", as: "{a}""#))
             .unwrap_or("".to_string());
         let purpose = self
             .purpose
             .as_ref()
-            .map(|p| format!(r#", for: {}"#, p))
+            .map(|p| format!(r#", for: {p}"#))
             .unwrap_or("".to_string());
         write!(f, r#"@link(url: "{}"{alias}{imports}{purpose})"#, self.url)
     }

--- a/apollo-federation/src/link/spec.rs
+++ b/apollo-federation/src/link/spec.rs
@@ -175,10 +175,10 @@ impl str::FromStr for Version {
         ))?;
 
         let major = major.parse::<u32>().map_err(|_| {
-            SpecError::ParseError(format!("invalid major version number '{}'", major))
+            SpecError::ParseError(format!("invalid major version number '{major}'"))
         })?;
         let minor = minor.parse::<u32>().map_err(|_| {
-            SpecError::ParseError(format!("invalid minor version number '{}'", minor))
+            SpecError::ParseError(format!("invalid minor version number '{minor}'"))
         })?;
 
         Ok(Version { major, minor })
@@ -285,7 +285,7 @@ impl str::FromStr for Url {
                 ))?;
                 let path_remainder = segments.collect::<Vec<&str>>();
                 let domain = if path_remainder.is_empty() {
-                    format!("{}://{}", scheme, url_domain)
+                    format!("{scheme}://{url_domain}")
                 } else {
                     format!("{}://{}/{}", scheme, url_domain, path_remainder.join("/"))
                 };
@@ -295,8 +295,7 @@ impl str::FromStr for Url {
                 })
             }
             Err(e) => Err(SpecError::ParseError(format!(
-                "invalid specification url: {}",
-                e
+                "invalid specification url: {e}"
             ))),
         }
     }

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -216,7 +216,7 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
         self.definitions.get(requested)
     }
 
-    pub(crate) fn versions(&self) -> Keys<Version, T> {
+    pub(crate) fn versions(&self) -> Keys<'_, Version, T> {
         self.definitions.keys()
     }
 

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -106,8 +106,7 @@ pub(crate) trait SpecDefinition {
                 .ok_or_else(|| {
                     SingleFederationError::Internal {
                         message: format!(
-                            "Unexpectedly could not find spec directive \"@{}\" in schema",
-                            name
+                            "Unexpectedly could not find spec directive \"@{name}\" in schema"
                         ),
                     }
                     .into()
@@ -130,8 +129,7 @@ pub(crate) trait SpecDefinition {
                 .ok_or_else(|| {
                     SingleFederationError::Internal {
                         message: format!(
-                            "Unexpectedly could not find spec type \"{}\" in schema",
-                            name
+                            "Unexpectedly could not find spec type \"{name}\" in schema"
                         ),
                     }
                     .into()

--- a/apollo-federation/src/merge/tests.rs
+++ b/apollo-federation/src/merge/tests.rs
@@ -38,7 +38,7 @@ fn test_steel_thread() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -54,7 +54,7 @@ fn test_basic() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -70,7 +70,7 @@ fn test_inaccessible() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -87,7 +87,7 @@ fn test_interface_object() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -102,7 +102,7 @@ fn test_input_types() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }
@@ -117,7 +117,7 @@ fn test_interface_implementing_interface() {
 
     let schema = result.schema.into_inner();
     let validation = schema.clone().validate();
-    assert!(validation.is_ok(), "{:?}", validation);
+    assert!(validation.is_ok(), "{validation:?}");
 
     assert_snapshot!(schema.serialize());
 }

--- a/apollo-federation/src/merger/error_reporter.rs
+++ b/apollo-federation/src/merger/error_reporter.rs
@@ -84,7 +84,7 @@ impl ErrorReporter {
             subgraph_elements,
             mismatch_accessor,
             |elt, names| format!("{} in {}", elt, names.unwrap_or("undefined".to_string())),
-            |elt, names| format!("{} in {}", elt, names),
+            |elt, names| format!("{elt} in {names}"),
             |myself, distribution, _: Vec<U>| {
                 let distribution_str = join_strings(
                     distribution.iter(),

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -252,8 +252,7 @@ impl Merger {
                 self.report_mismatch_hint(
                     HintCode::InconsistentEnumValueForOutputEnum,
                     format!(
-                        "Value \"{}\" of enum type \"{}\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"{}\": ",
-                        value_name, dest_name, dest_name
+                        "Value \"{value_name}\" of enum type \"{dest_name}\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"{dest_name}\": "
                     ),
                     sources,
                     |source| {

--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -1017,50 +1017,41 @@ impl Merger {
             let overridden = merge_context.is_unused_overridden(idx);
             match source_opt {
                 Some(source_pos) => {
-                    if !overridden
-                        && let Some(subgraph) = self.subgraphs.get(idx) {
-                            // Check if field is external
-                            let is_external = match source_pos {
-                                DirectiveTargetPosition::ObjectField(pos) => self
-                                    .is_field_external(
-                                        idx,
-                                        &FieldDefinitionPosition::Object(pos.clone()),
-                                    ),
-                                DirectiveTargetPosition::InterfaceField(pos) => self
-                                    .is_field_external(
-                                        idx,
-                                        &FieldDefinitionPosition::Interface(pos.clone()),
-                                    ),
-                                _ => false, // Non-field positions can't be external
-                            };
-                            if is_external {
-                                return Ok(true);
-                            }
-
-                            // Check for requires and provides directives using subgraph-specific metadata
-                            if let Ok(Some(provides_directive_name)) =
-                                subgraph.provides_directive_name()
-                                && !source_pos
-                                    .get_applied_directives(
-                                        subgraph.schema(),
-                                        &provides_directive_name,
-                                    )
-                                    .is_empty()
-                                {
-                                    return Ok(true);
-                                }
-                            if let Ok(Some(requires_directive_name)) =
-                                subgraph.requires_directive_name()
-                                && !source_pos
-                                    .get_applied_directives(
-                                        subgraph.schema(),
-                                        &requires_directive_name,
-                                    )
-                                    .is_empty()
-                                {
-                                    return Ok(true);
-                                }
+                    if !overridden && let Some(subgraph) = self.subgraphs.get(idx) {
+                        // Check if field is external
+                        let is_external = match source_pos {
+                            DirectiveTargetPosition::ObjectField(pos) => self.is_field_external(
+                                idx,
+                                &FieldDefinitionPosition::Object(pos.clone()),
+                            ),
+                            DirectiveTargetPosition::InterfaceField(pos) => self.is_field_external(
+                                idx,
+                                &FieldDefinitionPosition::Interface(pos.clone()),
+                            ),
+                            _ => false, // Non-field positions can't be external
+                        };
+                        if is_external {
+                            return Ok(true);
                         }
+
+                        // Check for requires and provides directives using subgraph-specific metadata
+                        if let Ok(Some(provides_directive_name)) =
+                            subgraph.provides_directive_name()
+                            && !source_pos
+                                .get_applied_directives(subgraph.schema(), &provides_directive_name)
+                                .is_empty()
+                        {
+                            return Ok(true);
+                        }
+                        if let Ok(Some(requires_directive_name)) =
+                            subgraph.requires_directive_name()
+                            && !source_pos
+                                .get_applied_directives(subgraph.schema(), &requires_directive_name)
+                                .is_empty()
+                        {
+                            return Ok(true);
+                        }
+                    }
                 }
                 None => {
                     // This subgraph does not have the field, so if it has the field type, we need a join__field.
@@ -1069,9 +1060,9 @@ impl Merger {
                             .schema()
                             .try_get_type(parent_name.clone())
                             .is_some()
-                        {
-                            return Ok(true);
-                        }
+                    {
+                        return Ok(true);
+                    }
                 }
             }
         }

--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -598,13 +598,12 @@ impl Merger {
             self.error_reporter.report_mismatch_error::<FieldDefinitionPosition, ()>(
                 CompositionError::ExternalTypeMismatch {
                     message: format!(
-                        "Type of field \"{}\" is incompatible across subgraphs (where marked @external): it has ",
-                        dest,
+                        "Type of field \"{dest}\" is incompatible across subgraphs (where marked @external): it has ",
                     ),
                 },
                 dest,
                 sources,
-                |source, _| Some(format!("type \"{}\"", source)),
+                |source, _| Some(format!("type \"{source}\"")),
             );
         }
 
@@ -612,8 +611,7 @@ impl Merger {
             self.report_mismatch_error_with_specifics(
                 CompositionError::ExternalArgumentMissing {
                     message: format!(
-                        "Field \"{}\" is missing argument \"{}\" in some subgraphs where it is marked @external: ",
-                        dest, arg_name
+                        "Field \"{dest}\" is missing argument \"{arg_name}\" in some subgraphs where it is marked @external: "
                     ),
                 },
                 &self.argument_sources(sources, arg_name)?,
@@ -630,14 +628,12 @@ impl Merger {
             self.error_reporter.report_mismatch_error::<ObjectFieldArgumentDefinitionPosition, ()>(
                 CompositionError::ExternalArgumentTypeMismatch {
                     message: format!(
-                        "Type of argument \"{}\" is incompatible across subgraphs (where \"{}\" is marked @external): it has ",
-                        argument_pos,
-                        dest,
+                        "Type of argument \"{argument_pos}\" is incompatible across subgraphs (where \"{dest}\" is marked @external): it has ",
                     ),
                 },
                 &argument_pos,
                 &self.argument_sources(sources, arg_name)?,
-                |source, _| Some(format!("type \"{}\"", source)),
+                |source, _| Some(format!("type \"{source}\"")),
             );
         }
 
@@ -650,14 +646,12 @@ impl Merger {
             self.error_reporter.report_mismatch_error::<ObjectFieldArgumentDefinitionPosition, ()>(
                 CompositionError::ExternalArgumentDefaultMismatch {
                     message: format!(
-                        "Argument \"{}\" has incompatible defaults across subgraphs (where \"{}\" is marked @external): it has ",
-                        argument_pos,
-                        dest,
+                        "Argument \"{argument_pos}\" has incompatible defaults across subgraphs (where \"{dest}\" is marked @external): it has ",
                     ),
                 },
                 &argument_pos,
                 &self.argument_sources(sources, arg_name)?,
-                |source, _| Some(format!("default value {:?}", source)), // TODO: Need proper value formatting
+                |source, _| Some(format!("default value {source:?}")), // TODO: Need proper value formatting
             );
         }
 
@@ -1125,7 +1119,7 @@ impl Merger {
                 continue;
             };
 
-            let prefixed_context = format!("{}__{}", subgraph_name, context);
+            let prefixed_context = format!("{subgraph_name}__{context}");
 
             context_args.push(Node::new(Value::Object(vec![
                 (name!("context"), Node::new(Value::String(prefixed_context))),

--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -1017,8 +1017,8 @@ impl Merger {
             let overridden = merge_context.is_unused_overridden(idx);
             match source_opt {
                 Some(source_pos) => {
-                    if !overridden {
-                        if let Some(subgraph) = self.subgraphs.get(idx) {
+                    if !overridden
+                        && let Some(subgraph) = self.subgraphs.get(idx) {
                             // Check if field is external
                             let is_external = match source_pos {
                                 DirectiveTargetPosition::ObjectField(pos) => self
@@ -1040,8 +1040,7 @@ impl Merger {
                             // Check for requires and provides directives using subgraph-specific metadata
                             if let Ok(Some(provides_directive_name)) =
                                 subgraph.provides_directive_name()
-                            {
-                                if !source_pos
+                                && !source_pos
                                     .get_applied_directives(
                                         subgraph.schema(),
                                         &provides_directive_name,
@@ -1050,11 +1049,9 @@ impl Merger {
                                 {
                                     return Ok(true);
                                 }
-                            }
                             if let Ok(Some(requires_directive_name)) =
                                 subgraph.requires_directive_name()
-                            {
-                                if !source_pos
+                                && !source_pos
                                     .get_applied_directives(
                                         subgraph.schema(),
                                         &requires_directive_name,
@@ -1063,21 +1060,18 @@ impl Merger {
                                 {
                                     return Ok(true);
                                 }
-                            }
                         }
-                    }
                 }
                 None => {
                     // This subgraph does not have the field, so if it has the field type, we need a join__field.
-                    if let Some(subgraph) = self.subgraphs.get(idx) {
-                        if subgraph
+                    if let Some(subgraph) = self.subgraphs.get(idx)
+                        && subgraph
                             .schema()
                             .try_get_type(parent_name.clone())
                             .is_some()
                         {
                             return Ok(true);
                         }
-                    }
                 }
             }
         }

--- a/apollo-federation/src/merger/merge_union.rs
+++ b/apollo-federation/src/merger/merge_union.rs
@@ -55,8 +55,8 @@ impl Merger {
     ) -> Result<(), FederationError> {
         // Add @join__unionMember directive for each subgraph that has this member
         for (&idx, source) in sources.iter() {
-            if let Some(union_type) = source {
-                if union_type.members.contains(member_name) {
+            if let Some(union_type) = source
+                && union_type.members.contains(member_name) {
                     // Get the join spec name for this subgraph
                     let name_in_join_spec = self.join_spec_name(idx)?;
 
@@ -69,7 +69,6 @@ impl Merger {
                     // Apply the directive to the destination union
                     dest.insert_directive(&mut self.merged, Component::new(directive))?;
                 }
-            }
         }
 
         Ok(())

--- a/apollo-federation/src/merger/merge_union.rs
+++ b/apollo-federation/src/merger/merge_union.rs
@@ -56,19 +56,20 @@ impl Merger {
         // Add @join__unionMember directive for each subgraph that has this member
         for (&idx, source) in sources.iter() {
             if let Some(union_type) = source
-                && union_type.members.contains(member_name) {
-                    // Get the join spec name for this subgraph
-                    let name_in_join_spec = self.join_spec_name(idx)?;
+                && union_type.members.contains(member_name)
+            {
+                // Get the join spec name for this subgraph
+                let name_in_join_spec = self.join_spec_name(idx)?;
 
-                    let directive = self.join_spec_definition.union_member_directive(
-                        &self.merged,
-                        name_in_join_spec,
-                        member_name.as_ref(),
-                    )?;
+                let directive = self.join_spec_definition.union_member_directive(
+                    &self.merged,
+                    name_in_join_spec,
+                    member_name.as_ref(),
+                )?;
 
-                    // Apply the directive to the destination union
-                    dest.insert_directive(&mut self.merged, Component::new(directive))?;
-                }
+                // Apply the directive to the destination union
+                dest.insert_directive(&mut self.merged, Component::new(directive))?;
+            }
         }
 
         Ok(())

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -271,8 +271,8 @@ impl Merger {
             .iter()
             .max_by_key(|spec| spec.minimum_federation_version());
 
-        if let Some(spec) = spec_with_max_implied_version {
-            if spec
+        if let Some(spec) = spec_with_max_implied_version
+            && spec
                 .minimum_federation_version()
                 .satisfies(linked_federation_version)
                 && spec
@@ -293,7 +293,6 @@ impl Merger {
                 });
                 return spec.minimum_federation_version();
             }
-        }
         linked_federation_version
     }
 
@@ -303,15 +302,14 @@ impl Merger {
         subgraphs
             .iter()
             .fold(Default::default(), |mut acc, subgraph| {
-                if let Ok(Some(directive_name)) = subgraph.from_context_directive_name() {
-                    if let Ok(referencers) = subgraph
+                if let Ok(Some(directive_name)) = subgraph.from_context_directive_name()
+                    && let Ok(referencers) = subgraph
                         .schema()
                         .referencers()
                         .get_directive(&directive_name)
                     {
                         acc.extend(referencers);
                     }
-                }
                 acc
             })
     }
@@ -322,15 +320,14 @@ impl Merger {
         subgraphs
             .iter()
             .fold(Default::default(), |mut acc, subgraph| {
-                if let Ok(Some(directive_name)) = subgraph.override_directive_name() {
-                    if let Ok(referencers) = subgraph
+                if let Ok(Some(directive_name)) = subgraph.override_directive_name()
+                    && let Ok(referencers) = subgraph
                         .schema()
                         .referencers()
                         .get_directive(&directive_name)
                     {
                         acc.extend(referencers);
                     }
-                }
                 acc
             })
     }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -275,24 +275,24 @@ impl Merger {
             && spec
                 .minimum_federation_version()
                 .satisfies(linked_federation_version)
-                && spec
-                    .minimum_federation_version()
-                    .gt(linked_federation_version)
-            {
-                error_reporter.add_hint(CompositionHint {
-                    code: HintCode::ImplicitlyUpgradedFederationVersion
-                        .code()
-                        .to_string(),
-                    message: format!(
-                        "Subgraph {} has been implicitly upgraded from federation {} to {}",
-                        subgraph.name,
-                        linked_federation_version,
-                        spec.minimum_federation_version()
-                    ),
-                    locations: Default::default(), // TODO: need @link directive application AST node
-                });
-                return spec.minimum_federation_version();
-            }
+            && spec
+                .minimum_federation_version()
+                .gt(linked_federation_version)
+        {
+            error_reporter.add_hint(CompositionHint {
+                code: HintCode::ImplicitlyUpgradedFederationVersion
+                    .code()
+                    .to_string(),
+                message: format!(
+                    "Subgraph {} has been implicitly upgraded from federation {} to {}",
+                    subgraph.name,
+                    linked_federation_version,
+                    spec.minimum_federation_version()
+                ),
+                locations: Default::default(), // TODO: need @link directive application AST node
+            });
+            return spec.minimum_federation_version();
+        }
         linked_federation_version
     }
 
@@ -307,9 +307,9 @@ impl Merger {
                         .schema()
                         .referencers()
                         .get_directive(&directive_name)
-                    {
-                        acc.extend(referencers);
-                    }
+                {
+                    acc.extend(referencers);
+                }
                 acc
             })
     }
@@ -325,9 +325,9 @@ impl Merger {
                         .schema()
                         .referencers()
                         .get_directive(&directive_name)
-                    {
-                        acc.extend(referencers);
-                    }
+                {
+                    acc.extend(referencers);
+                }
                 acc
             })
     }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -976,7 +976,7 @@ impl Merger {
                         Some(format!("arguments: [{}]", elt.arguments.iter().map(|arg| format!("{}: {}", arg.name, arg.value)).join(", ")))
                     },
                     |application, subgraphs| format!("The supergraph will use {} (from {}), but found ", application, subgraphs.unwrap_or_else(|| "undefined".to_string())),
-                    |application, subgraphs| format!("{} in {}", application, subgraphs),
+                    |application, subgraphs| format!("{application} in {subgraphs}"),
                     None::<fn(Option<&Directive>) -> bool>,
                     false,
                     false,
@@ -1136,7 +1136,7 @@ impl Merger {
                 error,
                 typ,
                 sources,
-                |typ, _is_supergraph| Some(format!("type \"{}\"", typ)),
+                |typ, _is_supergraph| Some(format!("type \"{typ}\"")),
             );
 
             Ok(false)
@@ -1163,7 +1163,7 @@ impl Merger {
                 ),
                 typ,
                 sources,
-                |typ, _is_supergraph| Some(format!("type \"{}\"", typ)),
+                |typ, _is_supergraph| Some(format!("type \"{typ}\"")),
                 |elt, subgraphs| {
                     format!(
                         "will use type \"{}\" (from {}) in supergraph but \"{}\" has ",
@@ -1172,7 +1172,7 @@ impl Merger {
                         dest.coordinate(parent_type_name)
                     )
                 },
-                |elt, subgraphs| format!("{} \"{}\" in {}", type_class, elt, subgraphs),
+                |elt, subgraphs| format!("{type_class} \"{elt}\" in {subgraphs}"),
                 None::<fn(Option<&Type>) -> bool>,
                 false,
                 false,
@@ -1355,7 +1355,7 @@ impl Merger {
         if !target_schema.types.contains_key(name) {
             self.error_reporter_mut()
                 .add_error(CompositionError::InternalError {
-                    message: format!("Cannot find type '{}' in target schema", name),
+                    message: format!("Cannot find type '{name}' in target schema"),
                 });
         }
 
@@ -2062,7 +2062,7 @@ pub(crate) mod tests {
                 assert_eq!(input_example.coordinate, "Parent.status_filter");
                 assert_eq!(output_example.coordinate, "Parent.user_status");
             }
-            _ => panic!("Expected Both usage, got {:?}", usage),
+            _ => panic!("Expected Both usage, got {usage:?}"),
         }
     }
 
@@ -2147,7 +2147,7 @@ pub(crate) mod tests {
         match result {
             Ok(false) => {} // Expected
             Ok(true) => panic!("Expected Ok(false), got Ok(true)"),
-            Err(e) => panic!("Expected Ok(false), got Err: {:?}", e),
+            Err(e) => panic!("Expected Ok(false), got Err: {e:?}"),
         }
         assert!(
             merger.has_errors(),
@@ -2180,7 +2180,7 @@ pub(crate) mod tests {
         match result {
             Ok(false) => {} // Expected
             Ok(true) => panic!("Expected Ok(false), got Ok(true)"),
-            Err(e) => panic!("Expected Ok(false), got Err: {:?}", e),
+            Err(e) => panic!("Expected Ok(false), got Err: {e:?}"),
         }
         assert!(
             merger.has_errors(),

--- a/apollo-federation/src/operation/merging.rs
+++ b/apollo-federation/src/operation/merging.rs
@@ -190,8 +190,7 @@ impl SelectionSet {
                                     .type_condition_position
                                     .clone()
                                     .map_or_else(String::new, |cond| format!(
-                                        "(type condition: {}) ",
-                                        cond
+                                        "(type condition: {cond}) "
                                     ),),
                             );
                         };

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2506,7 +2506,6 @@ impl InlineFragmentSelection {
         };
 
         let mut remove_defer = false;
-        #[expect(clippy::redundant_clone)]
         let mut args_copy = args.clone();
         if let Some(BooleanOrVariable::Boolean(b)) = &args.if_ {
             if *b {

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -727,8 +727,8 @@ mod field_selection {
             self,
             selection_set: Option<SelectionSet>,
         ) -> FieldSelection {
-            if cfg!(debug_assertions) {
-                if let Some(ref selection_set) = selection_set {
+            if cfg!(debug_assertions)
+                && let Some(ref selection_set) = selection_set {
                     if let Ok(field_type) = self.output_base_type() {
                         if let Ok(field_type_position) =
                             CompositeTypeDefinitionPosition::try_from(field_type)
@@ -755,7 +755,6 @@ mod field_selection {
                         );
                     }
                 }
-            }
 
             FieldSelection {
                 field: self,
@@ -2158,11 +2157,10 @@ fn compute_aliases_for_non_merging_fields(
 fn gen_alias_name(base_name: &Name, unavailable_names: &IndexMap<Name, SeenResponseName>) -> Name {
     let mut counter = 0usize;
     loop {
-        if let Ok(name) = Name::try_from(format!("{base_name}__alias_{counter}")) {
-            if !unavailable_names.contains_key(&name) {
+        if let Ok(name) = Name::try_from(format!("{base_name}__alias_{counter}"))
+            && !unavailable_names.contains_key(&name) {
                 return name;
             }
-        }
         counter += 1;
     }
 }
@@ -2245,11 +2243,10 @@ impl FieldSelection {
         if predicate(self.field.clone().into()) {
             return true;
         }
-        if let Some(selection_set) = &self.selection_set {
-            if selection_set.any_element(predicate) {
+        if let Some(selection_set) = &self.selection_set
+            && selection_set.any_element(predicate) {
                 return true;
             }
-        }
         false
     }
 }
@@ -2437,14 +2434,13 @@ impl DeferNormalizer {
         };
         let mut stack = selection_set.into_iter().collect::<Vec<_>>();
         while let Some(selection) = stack.pop() {
-            if let Selection::InlineFragment(inline) = selection {
-                if let Some(args) = inline.inline_fragment.defer_directive_arguments()? {
+            if let Selection::InlineFragment(inline) = selection
+                && let Some(args) = inline.inline_fragment.defer_directive_arguments()? {
                     let DeferDirectiveArguments { label, if_: _ } = args;
                     if let Some(label) = label {
                         digest.used_labels.insert(label);
                     }
                 }
-            }
             stack.extend(selection.selection_set().into_iter().flatten());
         }
         Ok(digest)
@@ -2826,8 +2822,8 @@ impl TryFrom<&SelectionSet> for executable::SelectionSet {
         let mut flattened = vec![];
         for normalized_selection in val.selections.values() {
             let selection: executable::Selection = normalized_selection.try_into()?;
-            if let executable::Selection::Field(field) = &selection {
-                if field.name == *INTROSPECTION_TYPENAME_FIELD_NAME
+            if let executable::Selection::Field(field) = &selection
+                && field.name == *INTROSPECTION_TYPENAME_FIELD_NAME
                     && field.directives.is_empty()
                     && field.alias.is_none()
                 {
@@ -2838,7 +2834,6 @@ impl TryFrom<&SelectionSet> for executable::SelectionSet {
                     flattened.insert(0, selection);
                     continue;
                 }
-            }
             flattened.push(selection);
         }
         if flattened.is_empty() {

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -728,33 +728,34 @@ mod field_selection {
             selection_set: Option<SelectionSet>,
         ) -> FieldSelection {
             if cfg!(debug_assertions)
-                && let Some(ref selection_set) = selection_set {
-                    if let Ok(field_type) = self.output_base_type() {
-                        if let Ok(field_type_position) =
-                            CompositeTypeDefinitionPosition::try_from(field_type)
-                        {
-                            debug_assert_eq!(
-                                field_type_position, selection_set.type_position,
-                                "Field and its selection set should point to the same type position [field position: {}, selection position: {}]",
-                                field_type_position, selection_set.type_position,
-                            );
-                            debug_assert_eq!(
-                                self.schema, selection_set.schema,
-                                "Field and its selection set should point to the same schema",
-                            );
-                        } else {
-                            debug_assert!(
-                                false,
-                                "Field with subselection does not reference CompositeTypePosition"
-                            );
-                        }
+                && let Some(ref selection_set) = selection_set
+            {
+                if let Ok(field_type) = self.output_base_type() {
+                    if let Ok(field_type_position) =
+                        CompositeTypeDefinitionPosition::try_from(field_type)
+                    {
+                        debug_assert_eq!(
+                            field_type_position, selection_set.type_position,
+                            "Field and its selection set should point to the same type position [field position: {}, selection position: {}]",
+                            field_type_position, selection_set.type_position,
+                        );
+                        debug_assert_eq!(
+                            self.schema, selection_set.schema,
+                            "Field and its selection set should point to the same schema",
+                        );
                     } else {
                         debug_assert!(
                             false,
                             "Field with subselection does not reference CompositeTypePosition"
                         );
                     }
+                } else {
+                    debug_assert!(
+                        false,
+                        "Field with subselection does not reference CompositeTypePosition"
+                    );
                 }
+            }
 
             FieldSelection {
                 field: self,
@@ -2158,9 +2159,10 @@ fn gen_alias_name(base_name: &Name, unavailable_names: &IndexMap<Name, SeenRespo
     let mut counter = 0usize;
     loop {
         if let Ok(name) = Name::try_from(format!("{base_name}__alias_{counter}"))
-            && !unavailable_names.contains_key(&name) {
-                return name;
-            }
+            && !unavailable_names.contains_key(&name)
+        {
+            return name;
+        }
         counter += 1;
     }
 }
@@ -2244,9 +2246,10 @@ impl FieldSelection {
             return true;
         }
         if let Some(selection_set) = &self.selection_set
-            && selection_set.any_element(predicate) {
-                return true;
-            }
+            && selection_set.any_element(predicate)
+        {
+            return true;
+        }
         false
     }
 }
@@ -2435,12 +2438,13 @@ impl DeferNormalizer {
         let mut stack = selection_set.into_iter().collect::<Vec<_>>();
         while let Some(selection) = stack.pop() {
             if let Selection::InlineFragment(inline) = selection
-                && let Some(args) = inline.inline_fragment.defer_directive_arguments()? {
-                    let DeferDirectiveArguments { label, if_: _ } = args;
-                    if let Some(label) = label {
-                        digest.used_labels.insert(label);
-                    }
+                && let Some(args) = inline.inline_fragment.defer_directive_arguments()?
+            {
+                let DeferDirectiveArguments { label, if_: _ } = args;
+                if let Some(label) = label {
+                    digest.used_labels.insert(label);
                 }
+            }
             stack.extend(selection.selection_set().into_iter().flatten());
         }
         Ok(digest)
@@ -2824,16 +2828,16 @@ impl TryFrom<&SelectionSet> for executable::SelectionSet {
             let selection: executable::Selection = normalized_selection.try_into()?;
             if let executable::Selection::Field(field) = &selection
                 && field.name == *INTROSPECTION_TYPENAME_FIELD_NAME
-                    && field.directives.is_empty()
-                    && field.alias.is_none()
-                {
-                    // Move the plain __typename to the start of the selection set.
-                    // This looks nicer, and matches existing tests.
-                    // Note: The plain-ness is also defined in `Field::is_plain_typename_field`.
-                    // PORT_NOTE: JS does this in `selectionsInPrintOrder`
-                    flattened.insert(0, selection);
-                    continue;
-                }
+                && field.directives.is_empty()
+                && field.alias.is_none()
+            {
+                // Move the plain __typename to the start of the selection set.
+                // This looks nicer, and matches existing tests.
+                // Note: The plain-ness is also defined in `Field::is_plain_typename_field`.
+                // PORT_NOTE: JS does this in `selectionsInPrintOrder`
+                flattened.insert(0, selection);
+                continue;
+            }
             flattened.push(selection);
         }
         if flattened.is_empty() {

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -261,16 +261,16 @@ impl<'a> FragmentGenerator<'a> {
                     let minified_field_selection = self.minify_field_selection(field)?;
                     if let executable::Selection::Field(field) = &minified_field_selection
                         && field.name == *INTROSPECTION_TYPENAME_FIELD_NAME
-                            && field.directives.is_empty()
-                            && field.alias.is_none()
-                        {
-                            // Move the plain __typename to the start of the selection set.
-                            // This looks nicer, and matches existing tests.
-                            // Note: The plain-ness is also defined in `Field::is_plain_typename_field`.
-                            // PORT_NOTE: JS does this in `selectionsInPrintOrder`
-                            new_selections.insert(0, minified_field_selection);
-                            continue;
-                        }
+                        && field.directives.is_empty()
+                        && field.alias.is_none()
+                    {
+                        // Move the plain __typename to the start of the selection set.
+                        // This looks nicer, and matches existing tests.
+                        // Note: The plain-ness is also defined in `Field::is_plain_typename_field`.
+                        // PORT_NOTE: JS does this in `selectionsInPrintOrder`
+                        new_selections.insert(0, minified_field_selection);
+                        continue;
+                    }
                     new_selections.push(minified_field_selection);
                 }
                 Selection::InlineFragment(inline_fragment) => {

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -259,8 +259,8 @@ impl<'a> FragmentGenerator<'a> {
             match selection {
                 Selection::Field(field) => {
                     let minified_field_selection = self.minify_field_selection(field)?;
-                    if let executable::Selection::Field(field) = &minified_field_selection {
-                        if field.name == *INTROSPECTION_TYPENAME_FIELD_NAME
+                    if let executable::Selection::Field(field) = &minified_field_selection
+                        && field.name == *INTROSPECTION_TYPENAME_FIELD_NAME
                             && field.directives.is_empty()
                             && field.alias.is_none()
                         {
@@ -271,7 +271,6 @@ impl<'a> FragmentGenerator<'a> {
                             new_selections.insert(0, minified_field_selection);
                             continue;
                         }
-                    }
                     new_selections.push(minified_field_selection);
                 }
                 Selection::InlineFragment(inline_fragment) => {

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -113,14 +113,13 @@ impl InlineFragmentSelection {
         // but `parent_type` runtimes may be a subset. So first check if the selection should not be discarded on that account (that
         // is, we should not keep the selection if its condition runtimes don't intersect at all with those of
         // `parent_type` as that would ultimately make an invalid selection set).
-        if let Some(type_condition) = this_condition {
-            if (self.inline_fragment.schema != *schema
+        if let Some(type_condition) = this_condition
+            && (self.inline_fragment.schema != *schema
                 || self.inline_fragment.parent_type_position != *parent_type)
                 && !runtime_types_intersect(type_condition, parent_type, schema)
             {
                 return Ok(None);
             }
-        }
 
         // We know the condition is "valid", but it may not be useful. That said, if the condition has directives,
         // we preserve the fragment no matter what.
@@ -217,13 +216,11 @@ impl InlineFragmentSelection {
                         if let Some(type_condition) = &inline_fragment_selection
                             .inline_fragment
                             .type_condition_position
-                        {
-                            if type_condition.is_object_type()
+                            && type_condition.is_object_type()
                                 && runtime_types_intersect(parent_type, type_condition, schema)
                             {
                                 liftable_selections.insert(selection.clone());
-                            }
-                        };
+                            };
                     }
                     _ => continue,
                 }

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -116,10 +116,10 @@ impl InlineFragmentSelection {
         if let Some(type_condition) = this_condition
             && (self.inline_fragment.schema != *schema
                 || self.inline_fragment.parent_type_position != *parent_type)
-                && !runtime_types_intersect(type_condition, parent_type, schema)
-            {
-                return Ok(None);
-            }
+            && !runtime_types_intersect(type_condition, parent_type, schema)
+        {
+            return Ok(None);
+        }
 
         // We know the condition is "valid", but it may not be useful. That said, if the condition has directives,
         // we preserve the fragment no matter what.
@@ -217,10 +217,10 @@ impl InlineFragmentSelection {
                             .inline_fragment
                             .type_condition_position
                             && type_condition.is_object_type()
-                                && runtime_types_intersect(parent_type, type_condition, schema)
-                            {
-                                liftable_selections.insert(selection.clone());
-                            };
+                            && runtime_types_intersect(parent_type, type_condition, schema)
+                        {
+                            liftable_selections.insert(selection.clone());
+                        };
                     }
                     _ => continue,
                 }

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -483,8 +483,8 @@ impl SchemaQueryGraphBuilder {
         output_type_definition_position: OutputTypeDefinitionPosition,
     ) -> Result<NodeIndex, FederationError> {
         let type_name = output_type_definition_position.type_name().clone();
-        if let Some(existing) = self.base.query_graph.types_to_nodes()?.get(&type_name) {
-            if let Some(first_node) = existing.first() {
+        if let Some(existing) = self.base.query_graph.types_to_nodes()?.get(&type_name)
+            && let Some(first_node) = existing.first() {
                 return if existing.len() == 1 {
                     Ok(*first_node)
                 } else {
@@ -498,7 +498,6 @@ impl SchemaQueryGraphBuilder {
                     .into())
                 };
             }
-        }
         let node = self
             .base
             .create_new_node(output_type_definition_position.clone().into())?;

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -484,20 +484,21 @@ impl SchemaQueryGraphBuilder {
     ) -> Result<NodeIndex, FederationError> {
         let type_name = output_type_definition_position.type_name().clone();
         if let Some(existing) = self.base.query_graph.types_to_nodes()?.get(&type_name)
-            && let Some(first_node) = existing.first() {
-                return if existing.len() == 1 {
-                    Ok(*first_node)
-                } else {
-                    Err(SingleFederationError::Internal {
-                        message: format!(
-                            "Only one node should have been created for type \"{}\", got {}",
-                            type_name,
-                            existing.len(),
-                        ),
-                    }
-                    .into())
-                };
-            }
+            && let Some(first_node) = existing.first()
+        {
+            return if existing.len() == 1 {
+                Ok(*first_node)
+            } else {
+                Err(SingleFederationError::Internal {
+                    message: format!(
+                        "Only one node should have been created for type \"{}\", got {}",
+                        type_name,
+                        existing.len(),
+                    ),
+                }
+                .into())
+            };
+        }
         let node = self
             .base
             .create_new_node(output_type_definition_position.clone().into())?;

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -888,8 +888,7 @@ impl SchemaQueryGraphBuilder {
                 _ => {
                     return Err(SingleFederationError::Internal {
                         message: format!(
-                            "Type \"{}\" was abstract in subgraph but not in API schema",
-                            type_name,
+                            "Type \"{type_name}\" was abstract in subgraph but not in API schema",
                         ),
                     }
                     .into());
@@ -1299,8 +1298,7 @@ impl FederatedQueryGraphBuilder {
                 .get(type_pos.type_name())
                 .ok_or_else(|| SingleFederationError::Internal {
                     message: format!(
-                        "Type \"{}\" unexpectedly missing from subgraph \"{}\"",
-                        type_pos, source,
+                        "Type \"{type_pos}\" unexpectedly missing from subgraph \"{source}\"",
                     ),
                 })?
                 .directives();
@@ -1329,9 +1327,7 @@ impl FederatedQueryGraphBuilder {
                 else {
                     return Err(SingleFederationError::Internal {
                             message: format!(
-                                "Invalid \"@key\" application on non-object/interface type \"{}\" in subgraph \"{}\"",
-                                type_pos,
-                                source,
+                                "Invalid \"@key\" application on non-object/interface type \"{type_pos}\" in subgraph \"{source}\"",
                             )
                         }.into());
                 };
@@ -1358,9 +1354,7 @@ impl FederatedQueryGraphBuilder {
                         let head = other_nodes.first().ok_or_else(|| {
                             SingleFederationError::Internal {
                                 message: format!(
-                                    "Types-to-nodes set unexpectedly empty for type \"{}\" in subgraph \"{}\"",
-                                    type_pos,
-                                    other_source,
+                                    "Types-to-nodes set unexpectedly empty for type \"{type_pos}\" in subgraph \"{other_source}\"",
                                 ),
                             }
                         })?;
@@ -1371,9 +1365,7 @@ impl FederatedQueryGraphBuilder {
                             return Err(
                                 SingleFederationError::Internal {
                                     message: format!(
-                                        "Types-to-nodes set unexpectedly had more than one element for type \"{}\" in subgraph \"{}\"",
-                                        type_pos,
-                                        other_source,
+                                        "Types-to-nodes set unexpectedly had more than one element for type \"{type_pos}\" in subgraph \"{other_source}\"",
                                     ),
                                 }
                                     .into()
@@ -1402,9 +1394,7 @@ impl FederatedQueryGraphBuilder {
                         else {
                             return Err(SingleFederationError::Internal {
                                     message: format!(
-                                        "Type \"{}\" was marked with \"@interfaceObject\" in subgraph \"{}\", but was non-interface in supergraph",
-                                        type_pos,
-                                        other_source,
+                                        "Type \"{type_pos}\" was marked with \"@interfaceObject\" in subgraph \"{other_source}\", but was non-interface in supergraph",
                                     )
                                 }.into());
                         };
@@ -1429,9 +1419,7 @@ impl FederatedQueryGraphBuilder {
                             let head = implementation_nodes.first().ok_or_else(|| {
                                 SingleFederationError::Internal {
                                     message: format!(
-                                        "Types-to-nodes set unexpectedly empty for type \"{}\" in subgraph \"{}\"",
-                                        implementation_type_in_supergraph_pos,
-                                        other_source,
+                                        "Types-to-nodes set unexpectedly empty for type \"{implementation_type_in_supergraph_pos}\" in subgraph \"{other_source}\"",
                                     ),
                                 }
                             })?;
@@ -1439,9 +1427,7 @@ impl FederatedQueryGraphBuilder {
                                 return Err(
                                     SingleFederationError::Internal {
                                         message: format!(
-                                            "Types-to-nodes set unexpectedly had more than one element for type \"{}\" in subgraph \"{}\"",
-                                            implementation_type_in_supergraph_pos,
-                                            other_source,
+                                            "Types-to-nodes set unexpectedly had more than one element for type \"{implementation_type_in_supergraph_pos}\" in subgraph \"{other_source}\"",
                                         ),
                                     }.into()
                                 );
@@ -1510,8 +1496,7 @@ impl FederatedQueryGraphBuilder {
             if edge_weight.conditions.is_some() {
                 return Err(SingleFederationError::Internal {
                     message: format!(
-                        "Field-collection edge for field \"{}\" unexpectedly had conditions",
-                        field_definition_position,
+                        "Field-collection edge for field \"{field_definition_position}\" unexpectedly had conditions",
                     ),
                 }
                 .into());
@@ -2007,8 +1992,7 @@ impl FederatedQueryGraphBuilder {
                                 .get(tail_type)
                                 .ok_or_else(|| SingleFederationError::Internal {
                                     message: format!(
-                                        "Types-to-nodes map missing type \"{}\" in subgraph \"{}\"",
-                                        tail_type, source,
+                                        "Types-to-nodes map missing type \"{tail_type}\" in subgraph \"{source}\"",
                                     ),
                                 })?;
                             // Note because this is an IndexSet, the non-provides should be first
@@ -2027,9 +2011,7 @@ impl FederatedQueryGraphBuilder {
                                 return Err(
                                     SingleFederationError::Internal {
                                         message: format!(
-                                            "Missing non-provides node for type \"{}\" in subgraph \"{}\"",
-                                            tail_type,
-                                            source,
+                                            "Missing non-provides node for type \"{tail_type}\" in subgraph \"{source}\"",
                                         )
                                     }.into()
                                 );
@@ -2097,8 +2079,7 @@ impl FederatedQueryGraphBuilder {
                                 .ok_or_else(|| {
                                     SingleFederationError::Internal {
                                         message: format!(
-                                            "Shouldn't have selection \"{}\" in an @provides, as its type condition has no query graph edge",
-                                            inline_fragment_selection,
+                                            "Shouldn't have selection \"{inline_fragment_selection}\" in an @provides, as its type condition has no query graph edge",
                                         )
                                     }
                                 })?;
@@ -2156,8 +2137,7 @@ impl FederatedQueryGraphBuilder {
             .get_mut(type_pos.type_name())
             .ok_or_else(|| SingleFederationError::Internal {
                 message: format!(
-                    "Unexpectedly missing @provides type \"{}\" in types-to-nodes map",
-                    type_pos,
+                    "Unexpectedly missing @provides type \"{type_pos}\" in types-to-nodes map",
                 ),
             })?
             .insert(new_node);
@@ -2266,8 +2246,7 @@ impl FederatedQueryGraphBuilder {
                     .get(&type_pos.type_name)
                     .ok_or_else(|| SingleFederationError::Internal {
                         message: format!(
-                            "Types-to-nodes map missing type \"{}\" in subgraph \"{}\"",
-                            type_pos, source,
+                            "Types-to-nodes map missing type \"{type_pos}\" in subgraph \"{source}\"",
                         ),
                     })?;
                 // Note because this is an IndexSet, the non-provides should be first since it was
@@ -2284,8 +2263,7 @@ impl FederatedQueryGraphBuilder {
                 let Some(node) = node else {
                     return Err(SingleFederationError::Internal {
                         message: format!(
-                            "Missing non-provides node for type \"{}\" in subgraph \"{}\"",
-                            type_pos, source,
+                            "Missing non-provides node for type \"{type_pos}\" in subgraph \"{source}\"",
                         ),
                     }
                     .into());
@@ -2298,9 +2276,7 @@ impl FederatedQueryGraphBuilder {
                 else {
                     return Err(SingleFederationError::Internal {
                             message: format!(
-                                "Type \"{}\" was marked with \"@interfaceObject\" in subgraph \"{}\", but was non-interface in supergraph",
-                                type_pos,
-                                source,
+                                "Type \"{type_pos}\" was marked with \"@interfaceObject\" in subgraph \"{source}\", but was non-interface in supergraph",
                             )
                         }.into());
                 };
@@ -2374,8 +2350,7 @@ impl FederatedQueryGraphBuilderSubgraphs {
                     // means they should include an @interfaceObject definition.
                     SingleFederationError::Internal {
                         message: format!(
-                            "Subgraph \"{}\" unexpectedly missing @interfaceObject definition",
-                            source,
+                            "Subgraph \"{source}\" unexpectedly missing @interfaceObject definition",
                         ),
                     }
                 })?;

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -72,7 +72,7 @@ impl std::fmt::Display for ConditionResolution {
                 Ok(())
             }
             ConditionResolution::Unsatisfied { reason } => {
-                writeln!(f, "Unsatisfied: reason={:?}", reason)
+                writeln!(f, "Unsatisfied: reason={reason:?}")
             }
         }
     }

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -647,133 +647,132 @@ where
             )));
         }
         if let Some(path_tree) = &condition_path_tree
-            && edge_weight.conditions.is_none() {
-                return Err(FederationError::internal(format!(
-                    "Unexpectedly got conditions paths {path_tree} for edge {edge_weight} without conditions",
-                )));
-            }
+            && edge_weight.conditions.is_none()
+        {
+            return Err(FederationError::internal(format!(
+                "Unexpectedly got conditions paths {path_tree} for edge {edge_weight} without conditions",
+            )));
+        }
 
         if matches!(
             edge_weight.transition,
             QueryGraphEdgeTransition::Downcast { .. }
-        )
-            && let Some(Some(last_edge)) = self.edges.last().map(|e| (*e).into()) {
-                let Some(last_edge_trigger) = self.edge_triggers.last() else {
+        ) && let Some(Some(last_edge)) = self.edges.last().map(|e| (*e).into())
+        {
+            let Some(last_edge_trigger) = self.edge_triggers.last() else {
+                return Err(FederationError::internal(
+                    "Could not find corresponding trigger for edge",
+                ));
+            };
+            if let Some(OpPathElement::InlineFragment(last_operation_element)) =
+                last_edge_trigger.get_op_path_element()
+                && last_operation_element.directives.is_empty()
+            {
+                // This mean we have 2 typecasts back-to-back, and that means the
+                // previous operation element might not be useful on this path. More
+                // precisely, the previous typecast was only useful if it restricted the
+                // possible runtime types of the type on which it applied more than the
+                // current typecast does (but note that if the previous typecast had
+                // directives, we keep it no matter what in case those directives are
+                // important).
+                //
+                // That is, we're in the case where we have (somewhere potentially deep
+                // in a query):
+                //   f {  # field 'f' of type A
+                //     ... on B {
+                //       ... on C {
+                //          # more stuff
+                //       }
+                //     }
+                //   }
+                // If the intersection of A and C is non empty and included (or equal)
+                // to the intersection of A and B, then there is no reason to have
+                // `... on B` at all because:
+                //  1. you can do `... on C` on `f` directly since the intersection of A
+                //     and C is non-empty.
+                //  2. `... on C` restricts strictly more than `... on B` and so the
+                //     latter can't impact the result.
+                // So if we detect that we're in that situation, we remove the
+                // `... on B` (but note that this is an optimization, keeping `... on B`
+                // wouldn't be incorrect, just useless).
+                let Some(runtime_types_before_tail) =
+                    &self.runtime_types_before_tail_if_last_is_cast
+                else {
                     return Err(FederationError::internal(
-                        "Could not find corresponding trigger for edge",
+                        "Could not find runtime types of path prior to inline fragment",
                     ));
                 };
-                if let Some(OpPathElement::InlineFragment(last_operation_element)) =
-                    last_edge_trigger.get_op_path_element()
-                    && last_operation_element.directives.is_empty() {
-                        // This mean we have 2 typecasts back-to-back, and that means the
-                        // previous operation element might not be useful on this path. More
-                        // precisely, the previous typecast was only useful if it restricted the
-                        // possible runtime types of the type on which it applied more than the
-                        // current typecast does (but note that if the previous typecast had
-                        // directives, we keep it no matter what in case those directives are
-                        // important).
-                        //
-                        // That is, we're in the case where we have (somewhere potentially deep
-                        // in a query):
-                        //   f {  # field 'f' of type A
-                        //     ... on B {
-                        //       ... on C {
-                        //          # more stuff
-                        //       }
-                        //     }
-                        //   }
-                        // If the intersection of A and C is non empty and included (or equal)
-                        // to the intersection of A and B, then there is no reason to have
-                        // `... on B` at all because:
-                        //  1. you can do `... on C` on `f` directly since the intersection of A
-                        //     and C is non-empty.
-                        //  2. `... on C` restricts strictly more than `... on B` and so the
-                        //     latter can't impact the result.
-                        // So if we detect that we're in that situation, we remove the
-                        // `... on B` (but note that this is an optimization, keeping `... on B`
-                        // wouldn't be incorrect, just useless).
-                        let Some(runtime_types_before_tail) =
-                            &self.runtime_types_before_tail_if_last_is_cast
-                        else {
-                            return Err(FederationError::internal(
-                                "Could not find runtime types of path prior to inline fragment",
-                            ));
-                        };
-                        let new_runtime_types_of_tail = self.graph.advance_possible_runtime_types(
-                            runtime_types_before_tail,
-                            Some(new_edge),
-                        )?;
-                        if !new_runtime_types_of_tail.is_empty()
-                            && new_runtime_types_of_tail.is_subset(&self.runtime_types_of_tail)
+                let new_runtime_types_of_tail = self
+                    .graph
+                    .advance_possible_runtime_types(runtime_types_before_tail, Some(new_edge))?;
+                if !new_runtime_types_of_tail.is_empty()
+                    && new_runtime_types_of_tail.is_subset(&self.runtime_types_of_tail)
+                {
+                    debug!(
+                        "Previous cast {last_operation_element:?} is made obsolete by new cast {trigger:?}, removing from path."
+                    );
+                    // Note that `edge` starts at the node we wish to eliminate from the
+                    // path. So we need to replace it with the edge going directly from
+                    // the previous node to the new tail for this path.
+                    //
+                    // PORT_NOTE: The JS codebase has a bug where it doesn't check that
+                    // the searched edges are downcast edges. We fix that here.
+                    let (last_edge_head, _) = self.graph.edge_endpoints(last_edge)?;
+                    let edge_tail_weight = self.graph.node_weight(edge_tail)?;
+                    let mut new_edge = None;
+                    for new_edge_ref in self.graph.out_edges(last_edge_head) {
+                        if !matches!(
+                            new_edge_ref.weight().transition,
+                            QueryGraphEdgeTransition::Downcast { .. }
+                        ) {
+                            continue;
+                        }
+                        if self.graph.node_weight(new_edge_ref.target())?.type_
+                            == edge_tail_weight.type_
                         {
-                            debug!(
-                                "Previous cast {last_operation_element:?} is made obsolete by new cast {trigger:?}, removing from path."
-                            );
-                            // Note that `edge` starts at the node we wish to eliminate from the
-                            // path. So we need to replace it with the edge going directly from
-                            // the previous node to the new tail for this path.
-                            //
-                            // PORT_NOTE: The JS codebase has a bug where it doesn't check that
-                            // the searched edges are downcast edges. We fix that here.
-                            let (last_edge_head, _) = self.graph.edge_endpoints(last_edge)?;
-                            let edge_tail_weight = self.graph.node_weight(edge_tail)?;
-                            let mut new_edge = None;
-                            for new_edge_ref in self.graph.out_edges(last_edge_head) {
-                                if !matches!(
-                                    new_edge_ref.weight().transition,
-                                    QueryGraphEdgeTransition::Downcast { .. }
-                                ) {
-                                    continue;
-                                }
-                                if self.graph.node_weight(new_edge_ref.target())?.type_
-                                    == edge_tail_weight.type_
-                                {
-                                    new_edge = Some(new_edge_ref.id());
-                                    break;
-                                }
-                            }
-                            if let Some(new_edge) = new_edge {
-                                // We replace the previous operation element with this one.
-                                edges.pop();
-                                edge_triggers.pop();
-                                edge_conditions.pop();
-                                edges.push(new_edge.into());
-                                edge_triggers.push(Arc::new(trigger));
-                                edge_conditions.push(condition_path_tree);
-                                return Ok(GraphPath {
-                                    graph: self.graph.clone(),
-                                    head: self.head,
-                                    tail: edge_tail,
-                                    edges,
-                                    edge_triggers,
-                                    edge_conditions,
-                                    last_subgraph_entering_edge_info: self
-                                        .last_subgraph_entering_edge_info
-                                        .clone(),
-                                    own_path_ids: self.own_path_ids.clone(),
-                                    overriding_path_ids: self.overriding_path_ids.clone(),
-                                    runtime_types_of_tail: Arc::new(new_runtime_types_of_tail),
-                                    runtime_types_before_tail_if_last_is_cast: self
-                                        .runtime_types_before_tail_if_last_is_cast
-                                        .clone(),
-                                    // We know the edge is a `DownCast`, so if there is no new
-                                    // `@defer` taking precedence, we just inherit the prior
-                                    // version.
-                                    defer_on_tail: if defer.is_some() {
-                                        defer
-                                    } else {
-                                        self.defer_on_tail.clone()
-                                    },
-                                    matching_context_ids: self.matching_context_ids.clone(),
-                                    arguments_to_context_usages: self
-                                        .arguments_to_context_usages
-                                        .clone(),
-                                });
-                            }
+                            new_edge = Some(new_edge_ref.id());
+                            break;
                         }
                     }
+                    if let Some(new_edge) = new_edge {
+                        // We replace the previous operation element with this one.
+                        edges.pop();
+                        edge_triggers.pop();
+                        edge_conditions.pop();
+                        edges.push(new_edge.into());
+                        edge_triggers.push(Arc::new(trigger));
+                        edge_conditions.push(condition_path_tree);
+                        return Ok(GraphPath {
+                            graph: self.graph.clone(),
+                            head: self.head,
+                            tail: edge_tail,
+                            edges,
+                            edge_triggers,
+                            edge_conditions,
+                            last_subgraph_entering_edge_info: self
+                                .last_subgraph_entering_edge_info
+                                .clone(),
+                            own_path_ids: self.own_path_ids.clone(),
+                            overriding_path_ids: self.overriding_path_ids.clone(),
+                            runtime_types_of_tail: Arc::new(new_runtime_types_of_tail),
+                            runtime_types_before_tail_if_last_is_cast: self
+                                .runtime_types_before_tail_if_last_is_cast
+                                .clone(),
+                            // We know the edge is a `DownCast`, so if there is no new
+                            // `@defer` taking precedence, we just inherit the prior
+                            // version.
+                            defer_on_tail: if defer.is_some() {
+                                defer
+                            } else {
+                                self.defer_on_tail.clone()
+                            },
+                            matching_context_ids: self.matching_context_ids.clone(),
+                            arguments_to_context_usages: self.arguments_to_context_usages.clone(),
+                        });
+                    }
+                }
             }
+        }
 
         if matches!(
             edge_weight.transition,
@@ -1043,17 +1042,18 @@ where
         // to be inefficient after the last edge. Note that is purely an optimization (see
         // https://github.com/apollographql/federation/pull/1653 for more details).
         if let Some(last_edge) = self.edges.last()
-            && let Some(last_edge) = (*last_edge).into() {
-                let Some(non_trivial_followup_edges) =
-                    self.graph.non_trivial_followup_edges.get(&last_edge)
-                else {
-                    return Err(FederationError::internal(format!(
-                        "Unexpectedly missing entry for {last_edge} in non-trivial followup edges map",
-                        last_edge = EdgeIndexDisplay::new(last_edge, &self.graph)
-                    )));
-                };
-                return Ok(Either::Right(non_trivial_followup_edges.iter().copied()));
-            }
+            && let Some(last_edge) = (*last_edge).into()
+        {
+            let Some(non_trivial_followup_edges) =
+                self.graph.non_trivial_followup_edges.get(&last_edge)
+            else {
+                return Err(FederationError::internal(format!(
+                    "Unexpectedly missing entry for {last_edge} in non-trivial followup edges map",
+                    last_edge = EdgeIndexDisplay::new(last_edge, &self.graph)
+                )));
+            };
+            return Ok(Either::Right(non_trivial_followup_edges.iter().copied()));
+        }
 
         Ok(Either::Left(
             self.graph.out_edges(self.tail).into_iter().map(get_id),
@@ -1094,17 +1094,20 @@ where
             let tail_schema = self.graph.schema_by_source(&tail_weight.source)?;
             let tail_schema_definition = &tail_schema.schema().schema_definition;
             if let Some(query_type_name) = &tail_schema_definition.query
-                && tail_type_pos.type_name() == &query_type_name.name {
-                    continue;
-                }
+                && tail_type_pos.type_name() == &query_type_name.name
+            {
+                continue;
+            }
             if let Some(mutation_type_name) = &tail_schema_definition.mutation
-                && tail_type_pos.type_name() == &mutation_type_name.name {
-                    continue;
-                }
+                && tail_type_pos.type_name() == &mutation_type_name.name
+            {
+                continue;
+            }
             if let Some(subscription_type_name) = &tail_schema_definition.subscription
-                && tail_type_pos.type_name() == &subscription_type_name.name {
-                    continue;
-                }
+                && tail_type_pos.type_name() == &subscription_type_name.name
+            {
+                continue;
+            }
             return Ok(false);
         }
         Ok(true)
@@ -1256,9 +1259,9 @@ where
                                 .members
                                 .iter()
                                 .any(|item| &item.name == parent_type_in_supergraph.type_name())
-                            {
-                                return Ok(true);
-                            }
+                        {
+                            return Ok(true);
+                        }
                         Ok(false)
                     })? {
                         continue;
@@ -1393,51 +1396,50 @@ where
             && matches!(
                 edge_weight.transition,
                 QueryGraphEdgeTransition::FieldCollection { .. }
+            )
+        {
+            let last_edge_weight = self.graph.edge_weight(last_edge)?;
+            if !matches!(
+                last_edge_weight.transition,
+                QueryGraphEdgeTransition::KeyResolution
             ) {
-                let last_edge_weight = self.graph.edge_weight(last_edge)?;
-                if !matches!(
-                    last_edge_weight.transition,
-                    QueryGraphEdgeTransition::KeyResolution
-                ) {
-                    let in_same_subgraph = if let ConditionResolution::Satisfied {
-                        path_tree: Some(path_tree),
-                        ..
-                    } = &resolution
-                    {
-                        path_tree.is_all_in_same_subgraph()?
-                    } else {
-                        true
+                let in_same_subgraph = if let ConditionResolution::Satisfied {
+                    path_tree: Some(path_tree),
+                    ..
+                } = &resolution
+                {
+                    path_tree.is_all_in_same_subgraph()?
+                } else {
+                    true
+                };
+                if in_same_subgraph {
+                    debug!("@requires conditions are satisfied, but validating post-require key.");
+                    let (edge_head, _) = self.graph.edge_endpoints(edge)?;
+                    if self.graph.get_locally_satisfiable_key(edge_head)?.is_none() {
+                        debug!("Post-require conditions cannot be satisfied");
+                        return Ok(ConditionResolution::Unsatisfied {
+                            reason: Some(UnsatisfiedConditionReason::NoPostRequireKey),
+                        });
                     };
-                    if in_same_subgraph {
-                        debug!(
-                            "@requires conditions are satisfied, but validating post-require key."
-                        );
-                        let (edge_head, _) = self.graph.edge_endpoints(edge)?;
-                        if self.graph.get_locally_satisfiable_key(edge_head)?.is_none() {
-                            debug!("Post-require conditions cannot be satisfied");
-                            return Ok(ConditionResolution::Unsatisfied {
-                                reason: Some(UnsatisfiedConditionReason::NoPostRequireKey),
-                            });
-                        };
-                        // We're in a case where we have an `@requires` application (we have
-                        // conditions and the new edge has a `FieldCollection` transition) and we
-                        // have to jump to another subgraph to satisfy the `@requires`, which means
-                        // we need to use a key on "the current subgraph" to resume collecting the
-                        // field with the `@requires`. `get_locally_satisfiable_key()` essentially
-                        // tells us that we have such key, and that's good enough here. Note that
-                        // the way the code is organised, we don't use an actual edge of the query
-                        // graph, so we cannot use `condition_resolver` and so it's not easy to get
-                        // a proper cost or tree. That's ok in the sense that the cost of the key is
-                        // negligible because we know it's a "local" one (there is no subgraph jump)
-                        // and the code to build plan will deal with adding that key anyway (so not
-                        // having the tree is ok).
-                        // TODO(Sylvain): the whole handling of `@requires` is a bit too complex and
-                        // hopefully we might be able to clean that up, but it's unclear to me how
-                        // at the moment and it may not be a small change so this will have to do
-                        // for now.
-                    }
+                    // We're in a case where we have an `@requires` application (we have
+                    // conditions and the new edge has a `FieldCollection` transition) and we
+                    // have to jump to another subgraph to satisfy the `@requires`, which means
+                    // we need to use a key on "the current subgraph" to resume collecting the
+                    // field with the `@requires`. `get_locally_satisfiable_key()` essentially
+                    // tells us that we have such key, and that's good enough here. Note that
+                    // the way the code is organised, we don't use an actual edge of the query
+                    // graph, so we cannot use `condition_resolver` and so it's not easy to get
+                    // a proper cost or tree. That's ok in the sense that the cost of the key is
+                    // negligible because we know it's a "local" one (there is no subgraph jump)
+                    // and the code to build plan will deal with adding that key anyway (so not
+                    // having the tree is ok).
+                    // TODO(Sylvain): the whole handling of `@requires` is a bit too complex and
+                    // hopefully we might be able to clean that up, but it's unclear to me how
+                    // at the moment and it may not be a small change so this will have to do
+                    // for now.
                 }
             }
+        }
         if let ConditionResolution::Satisfied {
             cost,
             context_map: ctx_map,
@@ -1629,24 +1631,22 @@ where
                     && ((prev_for_source.0.edges.len() < to_advance.edges.len() + 1)
                         || (prev_for_source.0.edges.len() == to_advance.edges.len() + 1
                             && prev_for_source.1 <= 1.0))
-                    {
-                        debug!(
-                            "Ignored: a better (shorter) path to the same subgraph already added"
-                        );
-                        // We've already found another path that gets us to the same subgraph rather
-                        // than the edge we're about to check. If that previous path is strictly
-                        // shorter than the path we'd obtain with the new edge, then we don't
-                        // consider this edge (it's a longer way to get to the same place). And if
-                        // the previous path is the same size (as the one obtained with that edge),
-                        // but that previous path's cost for getting the condition was 0 or 1, then
-                        // the new edge cannot really improve on this and we don't bother with it.
-                        //
-                        // Note that a cost of 0 can only happen during composition validation where
-                        // all costs are 0 to mean "we don't care about costs". This effectively
-                        // means that for validation, as soon as we have a path to a subgraph, we
-                        // ignore other options even if they may be "faster".
-                        continue;
-                    }
+                {
+                    debug!("Ignored: a better (shorter) path to the same subgraph already added");
+                    // We've already found another path that gets us to the same subgraph rather
+                    // than the edge we're about to check. If that previous path is strictly
+                    // shorter than the path we'd obtain with the new edge, then we don't
+                    // consider this edge (it's a longer way to get to the same place). And if
+                    // the previous path is the same size (as the one obtained with that edge),
+                    // but that previous path's cost for getting the condition was 0 or 1, then
+                    // the new edge cannot really improve on this and we don't bother with it.
+                    //
+                    // Note that a cost of 0 can only happen during composition validation where
+                    // all costs are 0 to mean "we don't care about costs". This effectively
+                    // means that for validation, as soon as we have a path to a subgraph, we
+                    // ignore other options even if they may be "faster".
+                    continue;
+                }
 
                 if excluded_conditions.is_excluded(edge_weight.conditions.as_ref()) {
                     debug!("Ignored: edge condition is excluded");
@@ -1726,13 +1726,13 @@ where
                 // cost is lower than the previous one.
                 if let Some(prev_for_source) = prev_for_source
                     && prev_for_source.0.edges.len() == to_advance.edges.len() + 1
-                        && prev_for_source.1 <= cost
-                    {
-                        debug!(
-                            "Ignored: a better (less costly) path to the same subgraph already added"
-                        );
-                        continue;
-                    }
+                    && prev_for_source.1 <= cost
+                {
+                    debug!(
+                        "Ignored: a better (less costly) path to the same subgraph already added"
+                    );
+                    continue;
+                }
 
                 // It's important we minimize the number of options this method returns, because
                 // during query planning with many fields, options here translate to state

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -643,15 +643,13 @@ where
         let tail_weight = self.graph.node_weight(self.tail)?;
         if self.tail != edge_head {
             return Err(FederationError::internal(format!(
-                "Cannot add edge {} to path ending at {}",
-                edge_weight, tail_weight
+                "Cannot add edge {edge_weight} to path ending at {tail_weight}"
             )));
         }
         if let Some(path_tree) = &condition_path_tree {
             if edge_weight.conditions.is_none() {
                 return Err(FederationError::internal(format!(
-                    "Unexpectedly got conditions paths {} for edge {} without conditions",
-                    path_tree, edge_weight,
+                    "Unexpectedly got conditions paths {path_tree} for edge {edge_weight} without conditions",
                 )));
             }
         }
@@ -1710,8 +1708,7 @@ where
                         )?;
                         let extra_message = if has_overridden_field {
                             format!(
-                                " (note that some of those key fields are overridden in \"{}\")",
-                                from_subgraph,
+                                " (note that some of those key fields are overridden in \"{from_subgraph}\")",
                             )
                         } else {
                             "".to_owned()

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -515,11 +515,11 @@ impl OpIndirectPaths {
                 if matches!(
                     last_edge_weight.transition,
                     QueryGraphEdgeTransition::KeyResolution
-                )
-                    && let Some(conditions) = &last_edge_weight.conditions
-                        && conditions.contains_top_level_field(field)? {
-                            continue;
-                        }
+                ) && let Some(conditions) = &last_edge_weight.conditions
+                    && conditions.contains_top_level_field(field)?
+                {
+                    continue;
+                }
             }
             filtered.push(path.clone())
         }
@@ -1681,38 +1681,35 @@ impl OpGraphPath {
                             && supergraph_schema
                                 .possible_runtime_types(type_condition_pos.into())?
                                 .contains(tail_type_pos)
-                            {
-                                debug!("Type is a super-type of the current type. No edge to take");
-                                // Type condition is applicable on the tail type, so the types are
-                                // already exploded but the condition can reference types from the
-                                // supergraph that are not present in the local subgraph.
-                                //
-                                // If the operation element has applied directives we need to
-                                // convert it to an inline fragment without type condition,
-                                // otherwise we ignore the fragment altogether.
-                                if operation_inline_fragment.directives.is_empty() {
-                                    return Ok((Some(vec![self.clone().into()]), None));
-                                }
-                                let operation_inline_fragment = InlineFragment {
-                                    schema: self
-                                        .graph
-                                        .schema_by_source(&tail_weight.source)?
-                                        .clone(),
-                                    parent_type_position: tail_type_pos.clone().into(),
-                                    type_condition_position: None,
-                                    directives: operation_inline_fragment.directives.clone(),
-                                    selection_id: SelectionId::new(),
-                                };
-                                let defer_directive_arguments =
-                                    operation_inline_fragment.defer_directive_arguments()?;
-                                let fragment_path = self.add(
-                                    operation_inline_fragment.into(),
-                                    None,
-                                    ConditionResolution::no_conditions(),
-                                    defer_directive_arguments,
-                                )?;
-                                return Ok((Some(vec![fragment_path.into()]), None));
+                        {
+                            debug!("Type is a super-type of the current type. No edge to take");
+                            // Type condition is applicable on the tail type, so the types are
+                            // already exploded but the condition can reference types from the
+                            // supergraph that are not present in the local subgraph.
+                            //
+                            // If the operation element has applied directives we need to
+                            // convert it to an inline fragment without type condition,
+                            // otherwise we ignore the fragment altogether.
+                            if operation_inline_fragment.directives.is_empty() {
+                                return Ok((Some(vec![self.clone().into()]), None));
                             }
+                            let operation_inline_fragment = InlineFragment {
+                                schema: self.graph.schema_by_source(&tail_weight.source)?.clone(),
+                                parent_type_position: tail_type_pos.clone().into(),
+                                type_condition_position: None,
+                                directives: operation_inline_fragment.directives.clone(),
+                                selection_id: SelectionId::new(),
+                            };
+                            let defer_directive_arguments =
+                                operation_inline_fragment.defer_directive_arguments()?;
+                            let fragment_path = self.add(
+                                operation_inline_fragment.into(),
+                                None,
+                                ConditionResolution::no_conditions(),
+                                defer_directive_arguments,
+                            )?;
+                            return Ok((Some(vec![fragment_path.into()]), None));
+                        }
 
                         if self.tail_is_interface_object()? {
                             let mut fake_downcast_edge = None;

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -162,7 +162,7 @@ pub(crate) enum OpPathElement {
 }
 
 impl HasSelectionKey for OpPathElement {
-    fn key(&self) -> SelectionKey {
+    fn key(&self) -> SelectionKey<'_> {
         match self {
             OpPathElement::Field(field) => field.key(),
             OpPathElement::InlineFragment(fragment) => fragment.key(),
@@ -515,13 +515,11 @@ impl OpIndirectPaths {
                 if matches!(
                     last_edge_weight.transition,
                     QueryGraphEdgeTransition::KeyResolution
-                ) {
-                    if let Some(conditions) = &last_edge_weight.conditions {
-                        if conditions.contains_top_level_field(field)? {
+                )
+                    && let Some(conditions) = &last_edge_weight.conditions
+                        && conditions.contains_top_level_field(field)? {
                             continue;
                         }
-                    }
-                }
             }
             filtered.push(path.clone())
         }
@@ -1679,8 +1677,8 @@ impl OpGraphPath {
                         let type_condition_pos = supergraph_schema.get_type(type_condition_name)?;
                         let abstract_type_condition_pos: Option<AbstractTypeDefinitionPosition> =
                             type_condition_pos.clone().try_into().ok();
-                        if let Some(type_condition_pos) = abstract_type_condition_pos {
-                            if supergraph_schema
+                        if let Some(type_condition_pos) = abstract_type_condition_pos
+                            && supergraph_schema
                                 .possible_runtime_types(type_condition_pos.into())?
                                 .contains(tail_type_pos)
                             {
@@ -1715,7 +1713,6 @@ impl OpGraphPath {
                                 )?;
                                 return Ok((Some(vec![fragment_path.into()]), None));
                             }
-                        }
 
                         if self.tail_is_interface_object()? {
                             let mut fake_downcast_edge = None;

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -229,8 +229,7 @@ impl OpPathElement {
             if let Some(application) = self.directives().get(directive_name) {
                 let Some(arg) = application.specified_argument_by_name("if") else {
                     return Err(FederationError::internal(format!(
-                        "@{} missing required argument \"if\"",
-                        directive_name
+                        "@{directive_name} missing required argument \"if\""
                     )));
                 };
                 let value = match arg.deref() {
@@ -1182,8 +1181,7 @@ impl OpGraphPath {
                             {
                                 let edge_weight = self.graph.edge_weight(edge)?;
                                 return Err(FederationError::internal(format!(
-                                    "Unexpectedly missing {} for {} from path {}",
-                                    operation_field, edge_weight, self,
+                                    "Unexpectedly missing {operation_field} for {edge_weight} from path {self}",
                                 )));
                             }
                             operation_field = Field {
@@ -1252,8 +1250,7 @@ impl OpGraphPath {
                                 let interface_edge_weight =
                                     self.graph.edge_weight(*interface_edge)?;
                                 return Err(FederationError::internal(format!(
-                                    "Interface edge {} unexpectedly had conditions",
-                                    interface_edge_weight
+                                    "Interface edge {interface_edge_weight} unexpectedly had conditions"
                                 )));
                             }
                             field_path
@@ -1456,8 +1453,7 @@ impl OpGraphPath {
                                 // condition (only fragments can).
                                 if field_options_for_implementation.is_empty() {
                                     return Err(FederationError::internal(format!(
-                                        "Unexpected unsatisfiable path after {}",
-                                        operation_field
+                                        "Unexpected unsatisfiable path after {operation_field}"
                                     )));
                                 }
                                 debug!(
@@ -1529,8 +1525,7 @@ impl OpGraphPath {
                         // the query should have been flagged invalid if a field was selected on
                         // something else.
                         Err(FederationError::internal(format!(
-                            "Unexpectedly found field {} on non-composite type {}",
-                            operation_field, tail_type_pos,
+                            "Unexpectedly found field {operation_field} on non-composite type {tail_type_pos}",
                         )))
                     }
                 }
@@ -1772,8 +1767,7 @@ impl OpGraphPath {
                     _ => {
                         // We shouldn't have a fragment on a non-composite type.
                         Err(FederationError::internal(format!(
-                            "Unexpectedly found inline fragment {} on non-composite type {}",
-                            operation_inline_fragment, tail_type_pos,
+                            "Unexpectedly found inline fragment {operation_inline_fragment} on non-composite type {tail_type_pos}",
                         )))
                     }
                 }
@@ -2194,8 +2188,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
                         // exited the method early).
                         if advance_options.is_empty() {
                             return Err(FederationError::internal(format!(
-                                "Unexpected empty options after non-collecting path {} for {}",
-                                path_with_non_collecting_edges, operation_element,
+                                "Unexpected empty options after non-collecting path {path_with_non_collecting_edges} for {operation_element}",
                             )));
                         }
                         // There is a special case we can deal with now. Namely, suppose we have a

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -182,8 +182,7 @@ impl TransitionGraphPath {
             },
         );
         Ok(format!(
-            " (please ensure that this is not due to key {} being accidentally marked @external)",
-            fields_list
+            " (please ensure that this is not due to key {fields_list} being accidentally marked @external)"
         ))
     }
 
@@ -412,8 +411,7 @@ impl TransitionGraphPath {
                                     }
                                     Some(UnsatisfiedConditionReason::NoSetContext) => {
                                         format!(
-                                            "could not find a match for required context for field \"{}\"",
-                                            field_definition_position,
+                                            "could not find a match for required context for field \"{field_definition_position}\"",
                                         )
                                     }
                                     None => {
@@ -523,32 +521,28 @@ impl TransitionGraphPath {
                             // subgraph not having that implementation because it uses
                             // @interfaceObject on an interface of that implementation.
                             break 'details format!(
-                                "cannot find implementation type \"{}\" (supergraph interface \"{}\" is declared with @interfaceObject in \"{}\")",
-                                parent_type_pos, tail_type_pos, subgraph,
+                                "cannot find implementation type \"{parent_type_pos}\" (supergraph interface \"{tail_type_pos}\" is declared with @interfaceObject in \"{subgraph}\")",
                             );
                         }
                         let Some(Ok(parent_type_pos_in_subgraph)) = parent_type_pos_in_subgraph
                             .map(CompositeTypeDefinitionPosition::try_from)
                         else {
                             break 'details format!(
-                                "cannot find field \"{}\"",
-                                field_definition_position,
+                                "cannot find field \"{field_definition_position}\"",
                             );
                         };
                         let Ok(field_pos_in_subgraph) = parent_type_pos_in_subgraph
                             .field(field_definition_position.field_name().clone())
                         else {
                             break 'details format!(
-                                "cannot find field \"{}\"",
-                                field_definition_position,
+                                "cannot find field \"{field_definition_position}\"",
                             );
                         };
                         let Ok(field_in_subgraph) =
                             field_pos_in_subgraph.get(subgraph_schema.schema())
                         else {
                             break 'details format!(
-                                "cannot find field \"{}\"",
-                                field_definition_position,
+                                "cannot find field \"{field_definition_position}\"",
                             );
                         };
                         // The subgraph has the field but no corresponding edge. This should only
@@ -583,8 +577,7 @@ impl TransitionGraphPath {
                         };
                         if overriding_subgraphs.is_empty() {
                             format!(
-                                "field \"{}\" is not resolvable because marked @external",
-                                field_definition_position,
+                                "field \"{field_definition_position}\" is not resolvable because marked @external",
                             )
                         } else {
                             format!(
@@ -597,7 +590,7 @@ impl TransitionGraphPath {
                     QueryGraphEdgeTransition::Downcast {
                         to_type_position, ..
                     } => {
-                        format!("cannot find type \"{}\"", to_type_position)
+                        format!("cannot find type \"{to_type_position}\"")
                     }
                     _ => {
                         bail!("Unhandled direct transition {}", transition);
@@ -978,13 +971,11 @@ impl TransitionPathWithLazyIndirectPaths {
                                 };
                             let explanation = if key_resolvables.is_empty() {
                                 format!(
-                                    "{} \"{}\" has no @key defined in subgraph \"{}\"",
-                                    kind_of_type, tail_type_pos, subgraph,
+                                    "{kind_of_type} \"{tail_type_pos}\" has no @key defined in subgraph \"{subgraph}\"",
                                 )
                             } else {
                                 format!(
-                                    "none of the @key defined on {} \"{}\" in subgraph \"{}\" are resolvable (they are all declared with their \"resolvable\" argument set to false)",
-                                    kind_of_type, tail_type_pos, subgraph,
+                                    "none of the @key defined on {kind_of_type} \"{tail_type_pos}\" in subgraph \"{subgraph}\" are resolvable (they are all declared with their \"resolvable\" argument set to false)",
                                 )
                             };
                             all_dead_ends.push(Arc::new(Unadvanceable {
@@ -992,10 +983,7 @@ impl TransitionPathWithLazyIndirectPaths {
                                 from_subgraph: tail_weight.source.clone(),
                                 to_subgraph: subgraph.clone(),
                                 details: format!(
-                                    "cannot move to subgraph \"{}\", which has field \"{}\", because {}",
-                                    subgraph,
-                                    field_definition_position,
-                                    explanation,
+                                    "cannot move to subgraph \"{subgraph}\", which has field \"{field_definition_position}\", because {explanation}",
                                 ),
                             }))
                         } else {
@@ -1011,12 +999,7 @@ impl TransitionPathWithLazyIndirectPaths {
                                 from_subgraph: tail_weight.source.clone(),
                                 to_subgraph: subgraph.clone(),
                                 details: format!(
-                                    "cannot move to subgraph \"{}\", which has field \"{}\", because interface \"{}\" is not defined in this subgraph (to jump to \"{}\", it would need to both define interface \"{}\" and have a @key on it)",
-                                    subgraph,
-                                    field_definition_position,
-                                    tail_type_pos,
-                                    subgraph,
-                                    tail_type_pos,
+                                    "cannot move to subgraph \"{subgraph}\", which has field \"{field_definition_position}\", because interface \"{tail_type_pos}\" is not defined in this subgraph (to jump to \"{subgraph}\", it would need to both define interface \"{tail_type_pos}\" and have a @key on it)",
                                 ),
                             }))
                         }

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -275,47 +275,47 @@ impl TransitionGraphPath {
             if let Ok(tail_type) =
                 CompositeTypeDefinitionPosition::try_from(tail_weight.type_.clone())
                 && field_definition_position.parent().type_name() != tail_type.type_name()
-                    && !self.tail_is_interface_object()?
-                {
-                    // Usually, when we collect a field, the path should already be on the type of
-                    // that field. But one exception is due to the fact that a type condition may be
-                    // "absorbed" by an @interfaceObject, and once we've taken a key on the
-                    // interface to another subgraph (the tail is not the interface object anymore),
-                    // we need to "restore" the type condition first.
-                    let updated_path = self.advance_with_transition(
-                        &QueryGraphEdgeTransition::Downcast {
-                            source: source.clone(),
-                            from_type_position: tail_type.clone(),
-                            to_type_position: field_definition_position.parent().clone(),
-                        },
-                        condition_resolver,
-                        override_conditions,
-                    )?;
-                    // The case we described above should be the only case we capture here, and so
-                    // the current subgraph must have the implementation type (it may not have the
-                    // field we want, but it must have the type) and so we should be able to advance
-                    // to it.
-                    let Either::Left(updated_path) = updated_path else {
-                        bail!(
-                            "Advancing {} for {} unexpectedly gave unadvanceables",
-                            self,
-                            transition,
-                        );
-                    };
-                    // Also note that there is currently no case where we should have more than one
-                    // option.
-                    let num_options = updated_path.len();
-                    let Some(updated_path) = iter_into_single_item(updated_path.into_iter()) else {
-                        bail!(
-                            "Advancing {} for {} unexpectedly gave {} options",
-                            self,
-                            transition,
-                            num_options,
-                        );
-                    };
-                    to_advance = Either::Right(updated_path);
-                    // We can now continue on dealing with the actual field.
-                }
+                && !self.tail_is_interface_object()?
+            {
+                // Usually, when we collect a field, the path should already be on the type of
+                // that field. But one exception is due to the fact that a type condition may be
+                // "absorbed" by an @interfaceObject, and once we've taken a key on the
+                // interface to another subgraph (the tail is not the interface object anymore),
+                // we need to "restore" the type condition first.
+                let updated_path = self.advance_with_transition(
+                    &QueryGraphEdgeTransition::Downcast {
+                        source: source.clone(),
+                        from_type_position: tail_type.clone(),
+                        to_type_position: field_definition_position.parent().clone(),
+                    },
+                    condition_resolver,
+                    override_conditions,
+                )?;
+                // The case we described above should be the only case we capture here, and so
+                // the current subgraph must have the implementation type (it may not have the
+                // field we want, but it must have the type) and so we should be able to advance
+                // to it.
+                let Either::Left(updated_path) = updated_path else {
+                    bail!(
+                        "Advancing {} for {} unexpectedly gave unadvanceables",
+                        self,
+                        transition,
+                    );
+                };
+                // Also note that there is currently no case where we should have more than one
+                // option.
+                let num_options = updated_path.len();
+                let Some(updated_path) = iter_into_single_item(updated_path.into_iter()) else {
+                    bail!(
+                        "Advancing {} for {} unexpectedly gave {} options",
+                        self,
+                        transition,
+                        num_options,
+                    );
+                };
+                to_advance = Either::Right(updated_path);
+                // We can now continue on dealing with the actual field.
+            }
         }
 
         let mut options: Vec<Arc<TransitionGraphPath>> = vec![];

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -274,8 +274,7 @@ impl TransitionGraphPath {
             let tail_weight = self.graph.node_weight(self.tail)?;
             if let Ok(tail_type) =
                 CompositeTypeDefinitionPosition::try_from(tail_weight.type_.clone())
-            {
-                if field_definition_position.parent().type_name() != tail_type.type_name()
+                && field_definition_position.parent().type_name() != tail_type.type_name()
                     && !self.tail_is_interface_object()?
                 {
                     // Usually, when we collect a field, the path should already be on the type of
@@ -317,7 +316,6 @@ impl TransitionGraphPath {
                     to_advance = Either::Right(updated_path);
                     // We can now continue on dealing with the actual field.
                 }
-            }
         }
 
         let mut options: Vec<Arc<TransitionGraphPath>> = vec![];

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -695,13 +695,13 @@ impl QueryGraph {
     pub(crate) fn out_edges_with_federation_self_edges(
         &self,
         node: NodeIndex,
-    ) -> Vec<EdgeReference<QueryGraphEdge>> {
+    ) -> Vec<EdgeReference<'_, QueryGraphEdge>> {
         Self::sorted_edges(self.graph.edges_directed(node, Direction::Outgoing))
     }
 
     /// The outward edges from the given node, minus self-key and self-root-type-resolution edges,
     /// as they're rarely useful (currently only used by `@defer`).
-    pub(crate) fn out_edges(&self, node: NodeIndex) -> Vec<EdgeReference<QueryGraphEdge>> {
+    pub(crate) fn out_edges(&self, node: NodeIndex) -> Vec<EdgeReference<'_, QueryGraphEdge>> {
         Self::sorted_edges(self.graph.edges_directed(node, Direction::Outgoing).filter(
             |edge_ref| {
                 !(edge_ref.source() == edge_ref.target()

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -86,7 +86,7 @@ impl Display for QueryGraphNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}({})", self.type_, self.source)?;
         if let Some(provide_id) = self.provide_id {
-            write!(f, "-{}", provide_id)?;
+            write!(f, "-{provide_id}")?;
         }
         if self.is_root_node() {
             write!(f, "*")?;
@@ -428,13 +428,13 @@ impl Display for QueryGraphEdgeTransition {
                 write!(f, "key()")
             }
             QueryGraphEdgeTransition::RootTypeResolution { root_kind } => {
-                write!(f, "{}()", root_kind)
+                write!(f, "{root_kind}()")
             }
             QueryGraphEdgeTransition::SubgraphEnteringTransition => {
                 write!(f, "∅")
             }
             QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { to_type_name, .. } => {
-                write!(f, "... on {}", to_type_name)
+                write!(f, "... on {to_type_name}")
             }
         }
     }
@@ -1127,8 +1127,7 @@ impl QueryGraph {
         let schema = self.schema_by_source(source)?;
         let Some(metadata) = schema.subgraph_metadata() else {
             return Err(FederationError::internal(format!(
-                "Interface should have come from a federation subgraph {}",
-                source
+                "Interface should have come from a federation subgraph {source}"
             )));
         };
 

--- a/apollo-federation/src/query_graph/output.rs
+++ b/apollo-federation/src/query_graph/output.rs
@@ -23,7 +23,7 @@ fn label_edge(edge: &QueryGraphEdge) -> String {
     if label.is_empty() {
         String::new()
     } else {
-        format!("label=\"{}\"", edge)
+        format!("label=\"{edge}\"")
     }
 }
 
@@ -67,7 +67,7 @@ fn to_dot_federated(graph: &QueryGraph) -> Result<String, std::fmt::Error> {
 
     fn label_cluster_node(node: &QueryGraphNode) -> String {
         let provide_id = match node.provide_id {
-            Some(id) => format!("#{}", id),
+            Some(id) => format!("#{id}"),
             None => String::new(),
         };
         format!(r#"label="{}{}@{}""#, node.type_, provide_id, node.source)

--- a/apollo-federation/src/query_graph/output.rs
+++ b/apollo-federation/src/query_graph/output.rs
@@ -132,8 +132,8 @@ fn to_dot_federated(graph: &QueryGraph) -> Result<String, std::fmt::Error> {
 
     // Supergraph edges
     for i in stable_graph.edge_indices() {
-        if edge_across_clusters(&stable_graph, i) {
-            if let Some((n1, n2)) = stable_graph.edge_endpoints(i) {
+        if edge_across_clusters(&stable_graph, i)
+            && let Some((n1, n2)) = stable_graph.edge_endpoints(i) {
                 let edge = &stable_graph[i];
                 writeln!(
                     dot_str,
@@ -143,7 +143,6 @@ fn to_dot_federated(graph: &QueryGraph) -> Result<String, std::fmt::Error> {
                     label_edge(edge)
                 )?;
             }
-        }
     }
 
     writeln!(dot_str, "}}")?;

--- a/apollo-federation/src/query_graph/output.rs
+++ b/apollo-federation/src/query_graph/output.rs
@@ -133,16 +133,17 @@ fn to_dot_federated(graph: &QueryGraph) -> Result<String, std::fmt::Error> {
     // Supergraph edges
     for i in stable_graph.edge_indices() {
         if edge_across_clusters(&stable_graph, i)
-            && let Some((n1, n2)) = stable_graph.edge_endpoints(i) {
-                let edge = &stable_graph[i];
-                writeln!(
-                    dot_str,
-                    "  {} -> {} [{}]",
-                    n1.index(),
-                    n2.index(),
-                    label_edge(edge)
-                )?;
-            }
+            && let Some((n1, n2)) = stable_graph.edge_endpoints(i)
+        {
+            let edge = &stable_graph[i];
+            writeln!(
+                dot_str,
+                "  {} -> {} [{}]",
+                n1.index(),
+                n2.index(),
+                label_edge(edge)
+            )?;
+        }
     }
 
     writeln!(dot_str, "}}")?;

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -183,12 +183,11 @@ impl OpPathTree {
         for child in self.childs.iter() {
             let index = child.edge.unwrap_or_else(EdgeIndex::end);
             write!(f, "\n{indent} -> [{}] ", index.index())?;
-            if include_conditions
-                && let Some(ref child_cond) = child.conditions {
-                    write!(f, "!! {{\n{indent} ")?;
-                    child_cond.fmt_internal(f, &child_indent, /*include_conditions*/ true)?;
-                    write!(f, "\n{indent} }}")?;
-                }
+            if include_conditions && let Some(ref child_cond) = child.conditions {
+                write!(f, "!! {{\n{indent} ")?;
+                child_cond.fmt_internal(f, &child_indent, /*include_conditions*/ true)?;
+                write!(f, "\n{indent} }}")?;
+            }
             write!(f, "{} = ", child.trigger)?;
             child
                 .tree

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -183,13 +183,12 @@ impl OpPathTree {
         for child in self.childs.iter() {
             let index = child.edge.unwrap_or_else(EdgeIndex::end);
             write!(f, "\n{indent} -> [{}] ", index.index())?;
-            if include_conditions {
-                if let Some(ref child_cond) = child.conditions {
+            if include_conditions
+                && let Some(ref child_cond) = child.conditions {
                     write!(f, "!! {{\n{indent} ")?;
                     child_cond.fmt_internal(f, &child_indent, /*include_conditions*/ true)?;
                     write!(f, "\n{indent} }}")?;
                 }
-            }
             write!(f, "{} = ", child.trigger)?;
             child
                 .tree

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -339,9 +339,10 @@ fn write_selections(
     mut selections: &[executable::Selection],
 ) -> fmt::Result {
     if let Some(executable::Selection::Field(field)) = selections.first()
-        && field.name == "_entities" {
-            selections = &field.selection_set.selections
-        }
+        && field.name == "_entities"
+    {
+        selections = &field.selection_set.selections
+    }
     state.write("{")?;
 
     // Manually indent and write the newline

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -338,11 +338,10 @@ fn write_selections(
     state: &mut State<'_, '_>,
     mut selections: &[executable::Selection],
 ) -> fmt::Result {
-    if let Some(executable::Selection::Field(field)) = selections.first() {
-        if field.name == "_entities" {
+    if let Some(executable::Selection::Field(field)) = selections.first()
+        && field.name == "_entities" {
             selections = &field.selection_set.selections
         }
-    }
     state.write("{")?;
 
     // Manually indent and write the newline

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2359,8 +2359,7 @@ impl FetchDependencyGraph {
                         .map_or_else(
                             |_| {
                                 Err(FederationError::internal(format!(
-                                    "Invalid call from {} starting at {}: {} is not composite",
-                                    path, parent_type, field_position
+                                    "Invalid call from {path} starting at {parent_type}: {field_position} is not composite"
                                 )))
                             },
                             Ok,
@@ -2374,8 +2373,7 @@ impl FetchDependencyGraph {
                             .map_or_else(
                                 |_| {
                                     Err(FederationError::internal(format!(
-                                        "Invalid call from {} starting at {}: {} is not composite",
-                                        path, parent_type, type_condition_position
+                                        "Invalid call from {path} starting at {parent_type}: {type_condition_position} is not composite"
                                     )))
                                 },
                                 Ok,
@@ -3313,7 +3311,7 @@ impl std::fmt::Display for FetchInputs {
                 // We can safely unwrap because we know the len >= 1.
                 write!(f, "{}", iter.next().unwrap())?;
                 for x in iter {
-                    write!(f, ",{}", x)?;
+                    write!(f, ",{x}")?;
                 }
                 write!(f, "]")
             }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3649,11 +3649,10 @@ fn compute_nodes_for_key_resolution<'a>(
         let mut iter = dependency_graph.parents_relations_of(condition_node);
         if let (Some(condition_node_parent), None) = (iter.next(), iter.next()) {
             // There is exactly one parent
-            if condition_node_parent.parent_node_id == stack_item.node_id {
-                if let Some(condition_path) = condition_node_parent.path_in_parent {
+            if condition_node_parent.parent_node_id == stack_item.node_id
+                && let Some(condition_path) = condition_node_parent.path_in_parent {
                     path = condition_path.strip_prefix(path_in_parent).map(Arc::new)
                 }
-            }
         }
         drop(iter);
         dependency_graph.add_parent(
@@ -4144,8 +4143,8 @@ fn compute_nodes_for_op_path_element<'a>(
         }
     }
 
-    if let OpPathElement::Field(field) = &updated_operation {
-        if *field.name() == TYPENAME_FIELD {
+    if let OpPathElement::Field(field) = &updated_operation
+        && *field.name() == TYPENAME_FIELD {
             // Because of the optimization done in `QueryPlanner.optimizeSiblingTypenames`,
             // we will rarely get an explicit `__typename` edge here.
             // But one case where it can happen is where an @interfaceObject was involved,
@@ -4185,7 +4184,6 @@ fn compute_nodes_for_op_path_element<'a>(
             )?;
             updated_node.must_preserve_selection_set = true
         }
-    }
     if let QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { .. } = &edge.transition {
         // We shouldn't add the operation "as is" as it's a down-cast but we're "faking it".
         // However, if the operation has directives, we should preserve that.

--- a/apollo-federation/src/query_plan/generate.rs
+++ b/apollo-federation/src/query_plan/generate.rs
@@ -148,9 +148,10 @@ where
         // and the partial we have is already more costly than that,
         // then no point continuing with it.
         if let (Some((_, min_cost)), Some(partial_cost)) = (&min, &partial_cost)
-            && partial_cost >= min_cost {
-                continue;
-            }
+            && partial_cost >= min_cost
+        {
+            continue;
+        }
 
         // Does not panic as we only ever insert in the stack with non-empty `remaining`
         let next_choices = &mut remaining.as_mut_slice()[0];
@@ -221,10 +222,11 @@ fn insert_in_stack<Plan, Element>(
 
 fn pick_next<Element>(opt_index: Option<usize>, remaining: &Choices<Element>) -> usize {
     if let Some(index) = opt_index
-        && let Some(choice) = remaining.get(index) {
-            assert!(choice.is_some(), "Invalid index {index}");
-            return index;
-        }
+        && let Some(choice) = remaining.get(index)
+    {
+        assert!(choice.is_some(), "Invalid index {index}");
+        return index;
+    }
     remaining
         .iter()
         .position(|choice| choice.is_some())

--- a/apollo-federation/src/query_plan/generate.rs
+++ b/apollo-federation/src/query_plan/generate.rs
@@ -147,11 +147,10 @@ where
         // If we've found some plan already,
         // and the partial we have is already more costly than that,
         // then no point continuing with it.
-        if let (Some((_, min_cost)), Some(partial_cost)) = (&min, &partial_cost) {
-            if partial_cost >= min_cost {
+        if let (Some((_, min_cost)), Some(partial_cost)) = (&min, &partial_cost)
+            && partial_cost >= min_cost {
                 continue;
             }
-        }
 
         // Does not panic as we only ever insert in the stack with non-empty `remaining`
         let next_choices = &mut remaining.as_mut_slice()[0];
@@ -221,12 +220,11 @@ fn insert_in_stack<Plan, Element>(
 }
 
 fn pick_next<Element>(opt_index: Option<usize>, remaining: &Choices<Element>) -> usize {
-    if let Some(index) = opt_index {
-        if let Some(choice) = remaining.get(index) {
+    if let Some(index) = opt_index
+        && let Some(choice) = remaining.get(index) {
             assert!(choice.is_some(), "Invalid index {index}");
             return index;
         }
-    }
     remaining
         .iter()
         .position(|choice| choice.is_some())

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -309,8 +309,8 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
 
         traversal.open_branches = map_options_to_selections(selection_set, initial_options);
 
-        if let Some(non_local_selection_state) = non_local_selection_state {
-            if traversal
+        if let Some(non_local_selection_state) = non_local_selection_state
+            && traversal
                 .check_non_local_selections_limit_exceeded_at_root(non_local_selection_state)?
             {
                 return Err(SingleFederationError::QueryPlanComplexityExceeded {
@@ -321,7 +321,6 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 }
                 .into());
             }
-        }
 
         Ok(traversal)
     }
@@ -442,8 +441,8 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 .set(evaluated_paths_count.get() + simultaneous_indirect_path_count);
 
             new_options.extend(followups_for_option);
-            if let Some(options_limit) = self.parameters.config.debug.paths_limit {
-                if new_options.len() > options_limit as usize {
+            if let Some(options_limit) = self.parameters.config.debug.paths_limit
+                && new_options.len() > options_limit as usize {
                     return Err(SingleFederationError::QueryPlanComplexityExceeded {
                         message: format!(
                             "Too many options generated for {selection}, reached the limit of {options_limit}.",
@@ -451,7 +450,6 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                     }
                     .into());
                 }
-            }
         }
 
         snapshot!(

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -446,8 +446,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 if new_options.len() > options_limit as usize {
                     return Err(SingleFederationError::QueryPlanComplexityExceeded {
                         message: format!(
-                            "Too many options generated for {}, reached the limit of {}.",
-                            selection, options_limit,
+                            "Too many options generated for {selection}, reached the limit of {options_limit}.",
                         ),
                     }
                     .into());
@@ -525,8 +524,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             return if self.is_top_level {
                 if self.parameters.disabled_subgraphs.is_empty() {
                     Err(FederationError::internal(format!(
-                        "Was not able to find any options for {}: This shouldn't have happened.",
-                        selection,
+                        "Was not able to find any options for {selection}: This shouldn't have happened.",
                     )))
                 } else {
                     // If subgraphs were disabled, this could be expected, and we indicate this in

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -312,15 +312,15 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         if let Some(non_local_selection_state) = non_local_selection_state
             && traversal
                 .check_non_local_selections_limit_exceeded_at_root(non_local_selection_state)?
-            {
-                return Err(SingleFederationError::QueryPlanComplexityExceeded {
-                    message: format!(
-                        "Number of non-local selections exceeds limit of {}",
-                        Self::MAX_NON_LOCAL_SELECTIONS,
-                    ),
-                }
-                .into());
+        {
+            return Err(SingleFederationError::QueryPlanComplexityExceeded {
+                message: format!(
+                    "Number of non-local selections exceeds limit of {}",
+                    Self::MAX_NON_LOCAL_SELECTIONS,
+                ),
             }
+            .into());
+        }
 
         Ok(traversal)
     }
@@ -442,14 +442,15 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
 
             new_options.extend(followups_for_option);
             if let Some(options_limit) = self.parameters.config.debug.paths_limit
-                && new_options.len() > options_limit as usize {
-                    return Err(SingleFederationError::QueryPlanComplexityExceeded {
+                && new_options.len() > options_limit as usize
+            {
+                return Err(SingleFederationError::QueryPlanComplexityExceeded {
                         message: format!(
                             "Too many options generated for {selection}, reached the limit of {options_limit}.",
                         ),
                     }
                     .into());
-                }
+            }
         }
 
         snapshot!(

--- a/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
@@ -494,8 +494,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 .next_nodes_with_indirect_options
                 .remaining_nodes
                 .insert(*next_node)
-            {
-                if let Some(options) = self
+                && let Some(options) = self
                     .parameters
                     .federated_query_graph
                     .non_local_selection_metadata()
@@ -507,7 +506,6 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                         .types
                         .extend(options.iter().cloned());
                 }
-            }
         }
 
         Ok(next_nodes_info)
@@ -635,14 +633,12 @@ pub(crate) fn precompute_non_local_selection_metadata(
         if let Some(options_metadata) = metadata
             .types_to_indirect_options
             .get_mut(node_type_pos.type_name())
-        {
-            if options_metadata.same_type_options.contains(&node) {
+            && options_metadata.same_type_options.contains(&node) {
                 options_metadata
                     .interface_object_options
                     .extend(options.into_iter());
                 continue;
             }
-        }
         metadata
             .remaining_nodes_to_interface_object_options
             .insert(node, options);

--- a/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
@@ -500,12 +500,12 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                     .non_local_selection_metadata()
                     .remaining_nodes_to_interface_object_options
                     .get(next_node)
-                {
-                    next_nodes_info
-                        .next_nodes_with_indirect_options
-                        .types
-                        .extend(options.iter().cloned());
-                }
+            {
+                next_nodes_info
+                    .next_nodes_with_indirect_options
+                    .types
+                    .extend(options.iter().cloned());
+            }
         }
 
         Ok(next_nodes_info)
@@ -633,12 +633,13 @@ pub(crate) fn precompute_non_local_selection_metadata(
         if let Some(options_metadata) = metadata
             .types_to_indirect_options
             .get_mut(node_type_pos.type_name())
-            && options_metadata.same_type_options.contains(&node) {
-                options_metadata
-                    .interface_object_options
-                    .extend(options.into_iter());
-                continue;
-            }
+            && options_metadata.same_type_options.contains(&node)
+        {
+            options_metadata
+                .interface_object_options
+                .extend(options.into_iter());
+            continue;
+        }
         metadata
             .remaining_nodes_to_interface_object_options
             .insert(node, options);

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -184,7 +184,7 @@ impl FederationBlueprint {
             return Self::on_unknown_directive_validation_error(schema, directive_name, &message);
         }
 
-        let did_you_mean = did_you_mean(suggestions.iter().map(|s| format!("@{}", s)));
+        let did_you_mean = did_you_mean(suggestions.iter().map(|s| format!("@{s}")));
         SingleFederationError::InvalidGraphQL {
             message: format!("{message}{did_you_mean}\n"),
         }
@@ -254,7 +254,7 @@ impl FederationBlueprint {
                 all_directive_names.iter().map(|name| name.to_string()),
             );
             if !suggestions.is_empty() {
-                let did_you_mean = did_you_mean(suggestions.iter().map(|s| format!("@{}", s)));
+                let did_you_mean = did_you_mean(suggestions.iter().map(|s| format!("@{s}")));
                 let note = if suggestions.len() == 1 {
                     "it is a federation 2 directive"
                 } else {

--- a/apollo-federation/src/schema/definitions.rs
+++ b/apollo-federation/src/schema/definitions.rs
@@ -11,7 +11,7 @@ fn is_composite_type(ty: &NamedType, schema: &Schema) -> Result<bool, Federation
             .types
             .get(ty)
             .ok_or_else(|| SingleFederationError::Internal {
-                message: format!("Cannot find type `'{}\'", ty),
+                message: format!("Cannot find type `'{ty}\'"),
             })?,
         apollo_compiler::schema::ExtendedType::Object(_)
             | apollo_compiler::schema::ExtendedType::Interface(_)

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -380,7 +380,7 @@ impl FederationSchema {
     /// For subgraph schemas where the `@context` directive is a federation spec directive.
     pub(crate) fn context_directive_applications(
         &self,
-    ) -> FallibleDirectiveIterator<ContextDirective> {
+    ) -> FallibleDirectiveIterator<ContextDirective<'_>> {
         let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
         let context_directive_definition = federation_spec.context_directive_definition(self)?;
         let context_directive_referencers = self
@@ -440,7 +440,7 @@ impl FederationSchema {
     pub(crate) fn context_directive_applications_in_supergraph(
         &self,
         context_spec: &ContextSpecDefinition,
-    ) -> FallibleDirectiveIterator<ContextDirective> {
+    ) -> FallibleDirectiveIterator<ContextDirective<'_>> {
         let context_directive_definition = context_spec.context_directive_definition(self)?;
         let context_directive_referencers = self
             .referencers()
@@ -465,7 +465,7 @@ impl FederationSchema {
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn from_context_directive_applications(
         &self,
-    ) -> FallibleDirectiveIterator<FromContextDirective> {
+    ) -> FallibleDirectiveIterator<FromContextDirective<'_>> {
         let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
         let from_context_directive_definition =
             federation_spec.from_context_directive_definition(self)?;
@@ -511,7 +511,7 @@ impl FederationSchema {
         Ok(applications)
     }
 
-    pub(crate) fn key_directive_applications(&self) -> FallibleDirectiveIterator<KeyDirective> {
+    pub(crate) fn key_directive_applications(&self) -> FallibleDirectiveIterator<KeyDirective<'_>> {
         let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
         let key_directive_definition = federation_spec.key_directive_definition(self)?;
         let key_directive_referencers = self
@@ -573,7 +573,7 @@ impl FederationSchema {
 
     pub(crate) fn provides_directive_applications(
         &self,
-    ) -> FallibleDirectiveIterator<ProvidesDirective> {
+    ) -> FallibleDirectiveIterator<ProvidesDirective<'_>> {
         let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
         let provides_directive_definition = federation_spec.provides_directive_definition(self)?;
         let provides_directive_referencers = self
@@ -624,7 +624,7 @@ impl FederationSchema {
 
     pub(crate) fn requires_directive_applications(
         &self,
-    ) -> FallibleDirectiveIterator<RequiresDirective> {
+    ) -> FallibleDirectiveIterator<RequiresDirective<'_>> {
         let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
         let requires_directive_definition = federation_spec.requires_directive_definition(self)?;
         let requires_directive_referencers = self
@@ -672,7 +672,7 @@ impl FederationSchema {
         Ok(applications)
     }
 
-    pub(crate) fn tag_directive_applications(&self) -> FallibleDirectiveIterator<TagDirective> {
+    pub(crate) fn tag_directive_applications(&self) -> FallibleDirectiveIterator<TagDirective<'_>> {
         let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
         let tag_directive_definition = federation_spec.tag_directive_definition(self)?;
         let tag_directive_referencers = self
@@ -982,7 +982,7 @@ impl FederationSchema {
 
     pub(crate) fn list_size_directive_applications(
         &self,
-    ) -> FallibleDirectiveIterator<ListSizeDirective> {
+    ) -> FallibleDirectiveIterator<ListSizeDirective<'_>> {
         let Some(list_size_directive_name) = CostSpecDefinition::list_size_directive_name(self)?
         else {
             return Ok(Vec::new());
@@ -1024,7 +1024,7 @@ impl FederationSchema {
 
     pub(crate) fn cache_tag_directive_applications(
         &self,
-    ) -> FallibleDirectiveIterator<CacheTagDirective> {
+    ) -> FallibleDirectiveIterator<CacheTagDirective<'_>> {
         let federation_spec = get_federation_spec_definition_from_subgraph(self)?;
         let Ok(cache_tag_directive_definition) =
             federation_spec.cache_tag_directive_definition(self)

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -161,7 +161,7 @@ impl FederationSchema {
                 .types
                 .get(&type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema has no type \"{}\"", type_name),
+                    message: format!("Schema has no type \"{type_name}\""),
                 })?;
         Ok(match type_ {
             ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition { type_name }.into(),
@@ -283,8 +283,7 @@ impl FederationSchema {
                 type_name: FEDERATION_ENTITY_TYPE_NAME_IN_SPEC,
             })),
             Some(_) => Err(FederationError::internal(format!(
-                "Unexpectedly found non-union for federation spec's `{}` type definition",
-                FEDERATION_ENTITY_TYPE_NAME_IN_SPEC
+                "Unexpectedly found non-union for federation spec's `{FEDERATION_ENTITY_TYPE_NAME_IN_SPEC}` type definition"
             ))),
             None => Ok(None),
         }

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -1346,8 +1346,7 @@ impl SchemaDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Schema definition's directive application \"@{}\" does not refer to an existing directive.",
-                    name,
+                    "Schema definition's directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -1504,14 +1503,14 @@ impl SchemaRootDefinitionPosition {
         match self.root_kind {
             SchemaRootDefinitionKind::Query => schema_definition.query.as_ref().ok_or_else(|| {
                 SingleFederationError::Internal {
-                    message: format!("Schema definition has no root {} type", self),
+                    message: format!("Schema definition has no root {self} type"),
                 }
                 .into()
             }),
             SchemaRootDefinitionKind::Mutation => {
                 schema_definition.mutation.as_ref().ok_or_else(|| {
                     SingleFederationError::Internal {
-                        message: format!("Schema definition has no root {} type", self),
+                        message: format!("Schema definition has no root {self} type"),
                     }
                     .into()
                 })
@@ -1519,7 +1518,7 @@ impl SchemaRootDefinitionPosition {
             SchemaRootDefinitionKind::Subscription => {
                 schema_definition.subscription.as_ref().ok_or_else(|| {
                     SingleFederationError::Internal {
-                        message: format!("Schema definition has no root {} type", self),
+                        message: format!("Schema definition has no root {self} type"),
                     }
                     .into()
                 })
@@ -1541,7 +1540,7 @@ impl SchemaRootDefinitionPosition {
     ) -> Result<(), FederationError> {
         if self.try_get(&schema.schema).is_some() {
             return Err(SingleFederationError::Internal {
-                message: format!("Root {} already exists on schema definition", self),
+                message: format!("Root {self} already exists on schema definition"),
             }
             .into());
         }
@@ -1816,7 +1815,7 @@ impl ScalarTypeDefinitionPosition {
                 .scalar_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -1883,9 +1882,7 @@ impl ScalarTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Scalar type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Scalar type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -2215,7 +2212,7 @@ impl ObjectTypeDefinitionPosition {
                 .object_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -2372,9 +2369,7 @@ impl ObjectTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Object type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Object type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -2397,9 +2392,7 @@ impl ObjectTypeDefinitionPosition {
         let interface_type_referencers = referencers.interface_types.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Object type \"{}\"'s implements \"{}\" does not refer to an existing interface.",
-                    self,
-                    name,
+                    "Object type \"{self}\"'s implements \"{name}\" does not refer to an existing interface.",
                 ),
             }
         })?;
@@ -2864,9 +2857,7 @@ impl ObjectFieldDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Object field \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Object field \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -3152,9 +3143,7 @@ impl ObjectFieldArgumentDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Object field argument \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Object field argument \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -3531,7 +3520,7 @@ impl InterfaceTypeDefinitionPosition {
                 .interface_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -3658,9 +3647,7 @@ impl InterfaceTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Interface type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Interface type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -3683,9 +3670,7 @@ impl InterfaceTypeDefinitionPosition {
         let interface_type_referencers = referencers.interface_types.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Interface type \"{}\"'s implements \"{}\" does not refer to an existing interface.",
-                    self,
-                    name,
+                    "Interface type \"{self}\"'s implements \"{name}\" does not refer to an existing interface.",
                 ),
             }
         })?;
@@ -4097,9 +4082,7 @@ impl InterfaceFieldDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Interface field \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Interface field \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -4393,9 +4376,7 @@ impl InterfaceFieldArgumentDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Interface field argument \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Interface field argument \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -4665,7 +4646,7 @@ impl UnionTypeDefinitionPosition {
                 .union_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -4777,9 +4758,7 @@ impl UnionTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Union type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Union type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -4802,8 +4781,7 @@ impl UnionTypeDefinitionPosition {
         let object_type_referencers = referencers.object_types.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Union type \"{}\"'s member \"{}\" does not refer to an existing object.",
-                    self, name,
+                    "Union type \"{self}\"'s member \"{name}\" does not refer to an existing object.",
                 ),
             }
         })?;
@@ -4976,8 +4954,7 @@ impl UnionTypenameFieldDefinitionPosition {
             scalar_type_referencers.union_fields.insert(self.clone());
         } else {
             return Err(FederationError::internal(format!(
-                "Schema missing referencers for type \"{}\"",
-                output_type_reference
+                "Schema missing referencers for type \"{output_type_reference}\""
             )));
         }
         Ok(())
@@ -5154,7 +5131,7 @@ impl EnumTypeDefinitionPosition {
                 .enum_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -5234,9 +5211,7 @@ impl EnumTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Enum type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Enum type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -5547,9 +5522,7 @@ impl EnumValueDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Enum value \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Enum value \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -5751,7 +5724,7 @@ impl InputObjectTypeDefinitionPosition {
                 .input_object_types
                 .shift_remove(&self.type_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for type \"{}\"", self),
+                    message: format!("Schema missing referencers for type \"{self}\""),
                 })?,
         ))
     }
@@ -5831,9 +5804,7 @@ impl InputObjectTypeDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Input object type \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Input object type \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -6159,9 +6130,7 @@ impl InputObjectFieldDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Input object field \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Input object field \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;
@@ -6405,7 +6374,7 @@ impl DirectiveDefinitionPosition {
                 .directives
                 .shift_remove(&self.directive_name)
                 .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema missing referencers for directive \"{}\"", self),
+                    message: format!("Schema missing referencers for directive \"{self}\""),
                 })?,
         ))
     }
@@ -6612,9 +6581,7 @@ impl DirectiveArgumentDefinitionPosition {
         let directive_referencers = referencers.directives.get_mut(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Directive argument \"{}\"'s directive application \"@{}\" does not refer to an existing directive.",
-                    self,
-                    name,
+                    "Directive argument \"{self}\"'s directive application \"@{name}\" does not refer to an existing directive.",
                 ),
             }
         })?;

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -251,9 +251,10 @@ impl SchemaUpgrader {
                     if let Some(arg) = directive
                         .make_mut()
                         .specified_argument_by_name_mut("fields")
-                        && let Some(new_fields_string) = Self::make_fields_string_if_not(arg)? {
-                            *arg.make_mut() = Value::String(new_fields_string);
-                        }
+                        && let Some(new_fields_string) = Self::make_fields_string_if_not(arg)?
+                    {
+                        *arg.make_mut() = Value::String(new_fields_string);
+                    }
                 }
             }
         }
@@ -268,9 +269,10 @@ impl SchemaUpgrader {
                 if let Some(arg) = directive
                     .make_mut()
                     .specified_argument_by_name_mut("fields")
-                    && let Some(new_fields_string) = Self::make_fields_string_if_not(arg)? {
-                        *arg.make_mut() = Value::String(new_fields_string);
-                    }
+                    && let Some(new_fields_string) = Self::make_fields_string_if_not(arg)?
+                {
+                    *arg.make_mut() = Value::String(new_fields_string);
+                }
             }
         }
         Ok(())
@@ -812,55 +814,45 @@ impl SchemaUpgrader {
                 .iter()
                 .try_for_each(|application| -> Result<(), FederationError> {
                     if let Ok(application) = application
-                        && let Ok(target) = FieldDefinitionPosition::try_from(application.target.clone())
-                            && metadata
-                                .external_metadata()
-                                .is_external(&target)
-                            {
-                                let used_in_other_definitions =
-                                    self.subgraphs.iter().fallible_any(
-                                        |(name, subgraph)| -> Result<bool, FederationError> {
-                                            if &upgrade_metadata.subgraph_name != name {
-                                                // check to see if the field is external in the other subgraphs
-                                                if let Some(other_metadata) =
-                                                    &subgraph.schema().subgraph_metadata
-                                                    && !other_metadata
-                                                        .external_metadata()
-                                                        .is_external(&target)
-                                                    {
-                                                        // at this point, we need to check to see if there is a @tag directive on the other subgraph that matches the current application
-                                                        let other_applications = subgraph
-                                                            .schema()
-                                                            .tag_directive_applications()?;
-                                                        return other_applications.iter().fallible_any(
-                                                            |other_app_result| -> Result<bool, FederationError> {
-                                                                if let Ok(other_tag_directive) =
-                                                                    (*other_app_result).as_ref()
-                                                                    && application.target
-                                                                        == other_tag_directive.target
-                                                                        && application.arguments.name
-                                                                            == other_tag_directive
-                                                                                .arguments
-                                                                                .name
-                                                                    {
-                                                                        return Ok(true);
-                                                                    }
-                                                                Ok(false)
-                                                            },
-                                                        );
-                                                    }
-                                            }
-                                            Ok(false)
-                                        },
-                                    );
-                                if used_in_other_definitions? {
-                                    // remove @tag
-                                    to_delete.push((
-                                        target,
-                                        application.directive.clone(),
-                                    ));
+                        && let Ok(target) =
+                            FieldDefinitionPosition::try_from(application.target.clone())
+                        && metadata.external_metadata().is_external(&target)
+                    {
+                        let used_in_other_definitions = self.subgraphs.iter().fallible_any(
+                            |(name, subgraph)| -> Result<bool, FederationError> {
+                                if &upgrade_metadata.subgraph_name != name {
+                                    // check to see if the field is external in the other subgraphs
+                                    if let Some(other_metadata) =
+                                        &subgraph.schema().subgraph_metadata
+                                        && !other_metadata.external_metadata().is_external(&target)
+                                    {
+                                        // at this point, we need to check to see if there is a @tag directive on the other subgraph that matches the current application
+                                        let other_applications =
+                                            subgraph.schema().tag_directive_applications()?;
+                                        return other_applications.iter().fallible_any(
+                                            |other_app_result| -> Result<bool, FederationError> {
+                                                if let Ok(other_tag_directive) =
+                                                    (*other_app_result).as_ref()
+                                                    && application.target
+                                                        == other_tag_directive.target
+                                                    && application.arguments.name
+                                                        == other_tag_directive.arguments.name
+                                                {
+                                                    return Ok(true);
+                                                }
+                                                Ok(false)
+                                            },
+                                        );
+                                    }
                                 }
-                            }
+                                Ok(false)
+                            },
+                        );
+                        if used_in_other_definitions? {
+                            // remove @tag
+                            to_delete.push((target, application.directive.clone()));
+                        }
+                    }
                     Ok(())
                 })?;
         }

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -251,11 +251,9 @@ impl SchemaUpgrader {
                     if let Some(arg) = directive
                         .make_mut()
                         .specified_argument_by_name_mut("fields")
-                    {
-                        if let Some(new_fields_string) = Self::make_fields_string_if_not(arg)? {
+                        && let Some(new_fields_string) = Self::make_fields_string_if_not(arg)? {
                             *arg.make_mut() = Value::String(new_fields_string);
                         }
-                    }
                 }
             }
         }
@@ -270,11 +268,9 @@ impl SchemaUpgrader {
                 if let Some(arg) = directive
                     .make_mut()
                     .specified_argument_by_name_mut("fields")
-                {
-                    if let Some(new_fields_string) = Self::make_fields_string_if_not(arg)? {
+                    && let Some(new_fields_string) = Self::make_fields_string_if_not(arg)? {
                         *arg.make_mut() = Value::String(new_fields_string);
                     }
-                }
             }
         }
         Ok(())
@@ -815,9 +811,9 @@ impl SchemaUpgrader {
             applications
                 .iter()
                 .try_for_each(|application| -> Result<(), FederationError> {
-                    if let Ok(application) = application {
-                        if let Ok(target) = FieldDefinitionPosition::try_from(application.target.clone()) {
-                            if metadata
+                    if let Ok(application) = application
+                        && let Ok(target) = FieldDefinitionPosition::try_from(application.target.clone())
+                            && metadata
                                 .external_metadata()
                                 .is_external(&target)
                             {
@@ -828,8 +824,7 @@ impl SchemaUpgrader {
                                                 // check to see if the field is external in the other subgraphs
                                                 if let Some(other_metadata) =
                                                     &subgraph.schema().subgraph_metadata
-                                                {
-                                                    if !other_metadata
+                                                    && !other_metadata
                                                         .external_metadata()
                                                         .is_external(&target)
                                                     {
@@ -841,8 +836,7 @@ impl SchemaUpgrader {
                                                             |other_app_result| -> Result<bool, FederationError> {
                                                                 if let Ok(other_tag_directive) =
                                                                     (*other_app_result).as_ref()
-                                                                {
-                                                                    if application.target
+                                                                    && application.target
                                                                         == other_tag_directive.target
                                                                         && application.arguments.name
                                                                             == other_tag_directive
@@ -851,12 +845,10 @@ impl SchemaUpgrader {
                                                                     {
                                                                         return Ok(true);
                                                                     }
-                                                                }
                                                                 Ok(false)
                                                             },
                                                         );
                                                     }
-                                                }
                                             }
                                             Ok(false)
                                         },
@@ -869,8 +861,6 @@ impl SchemaUpgrader {
                                     ));
                                 }
                             }
-                        }
-                    }
                     Ok(())
                 })?;
         }

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -497,16 +497,14 @@ impl ExternalMetadata {
 
     pub(crate) fn selects_any_external_field(&self, selection_set: &SelectionSet) -> bool {
         for selection in selection_set.selections.values() {
-            if let Selection::Field(field_selection) = selection {
-                if self.is_external(&field_selection.field.field_position) {
+            if let Selection::Field(field_selection) = selection
+                && self.is_external(&field_selection.field.field_position) {
                     return true;
                 }
-            }
-            if let Some(selection_set) = selection.selection_set() {
-                if self.selects_any_external_field(selection_set) {
+            if let Some(selection_set) = selection.selection_set()
+                && self.selects_any_external_field(selection_set) {
                     return true;
                 }
-            }
         }
         false
     }

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -498,13 +498,15 @@ impl ExternalMetadata {
     pub(crate) fn selects_any_external_field(&self, selection_set: &SelectionSet) -> bool {
         for selection in selection_set.selections.values() {
             if let Selection::Field(field_selection) = selection
-                && self.is_external(&field_selection.field.field_position) {
-                    return true;
-                }
+                && self.is_external(&field_selection.field.field_position)
+            {
+                return true;
+            }
             if let Some(selection_set) = selection.selection_set()
-                && self.selects_any_external_field(selection_set) {
-                    return true;
-                }
+                && self.selects_any_external_field(selection_set)
+            {
+                return true;
+            }
         }
         false
     }

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -473,7 +473,7 @@ impl TypeAndDirectiveSpecification for InputObjectTypeSpecification {
                 new_definition_fields.as_slice(),
                 existing_definition_fields.as_slice(),
                 schema,
-                format!("input object type {}", actual_name).as_str(),
+                format!("input object type {actual_name}").as_str(),
                 |s| SingleFederationError::TypeDefinitionInvalid {
                     message: s.to_string(),
                 },
@@ -821,7 +821,7 @@ fn is_valid_input_type_redefinition(
 fn default_value_message(value: Option<&Value>) -> String {
     match value {
         None => "no default value".to_string(),
-        Some(value) => format!("default value {}", value),
+        Some(value) => format!("default value {value}"),
     }
 }
 
@@ -913,8 +913,7 @@ fn ensure_same_fields(
         let Some(existing_field) = existing_field else {
             errors.push(SingleFederationError::TypeDefinitionInvalid {
                 message: format!(
-                    "Invalid definition of type {}: missing field {}",
-                    obj_type_name, field_name
+                    "Invalid definition of type {obj_type_name}: missing field {field_name}"
                 ),
             });
             continue;

--- a/apollo-federation/src/schema/validators/from_context.rs
+++ b/apollo-federation/src/schema/validators/from_context.rs
@@ -77,8 +77,8 @@ pub(crate) fn validate_from_context_directives(
                 };
 
                 // We need the context locations from the context map for this target
-                if let Some(set_context_locations) = context_map.get(context) {
-                    if let Err(validation_error) = validate_field_value(
+                if let Some(set_context_locations) = context_map.get(context)
+                    && let Err(validation_error) = validate_field_value(
                         context,
                         selection,
                         &from_context,
@@ -88,7 +88,6 @@ pub(crate) fn validate_from_context_directives(
                     ) {
                         errors.push(validation_error);
                     }
-                }
             }
             Err(e) => errors.push(e),
         }
@@ -398,8 +397,8 @@ fn validate_field_value(
             SelectionType::InlineFragment { type_conditions } => {
                 // For inline fragment selections, validate each fragment
                 for selection in selection_set.selections.iter() {
-                    if let Selection::InlineFragment(frag) = selection {
-                        if let Some(type_condition) = &frag.type_condition {
+                    if let Selection::InlineFragment(frag) = selection
+                        && let Some(type_condition) = &frag.type_condition {
                             let Some(extended_type) =
                                 schema.schema().types.get(type_condition.as_str())
                             else {
@@ -460,7 +459,6 @@ fn validate_field_value(
                                 return Ok(());
                             }
                         }
-                    }
                 }
                 let context_location_names: std::collections::HashSet<String> =
                     set_context_locations
@@ -866,8 +864,8 @@ fn validate_field_value_type_inner(
     }
 
     for selection in selection_set.selections.iter() {
-        if let Selection::Field(field) = selection {
-            if let Some(nested_type) = validate_field_value_type_inner(
+        if let Selection::Field(field) = selection
+            && let Some(nested_type) = validate_field_value_type_inner(
                 &field.selection_set,
                 schema,
                 from_context_parent,
@@ -881,7 +879,6 @@ fn validate_field_value_type_inner(
             //         types_array.push(base_type);
             //     }
             // }
-        }
     }
 
     if types_array.is_empty() {
@@ -916,12 +913,11 @@ fn validate_field_value_type(
     from_context_parent: &FieldArgumentDefinitionPosition,
     errors: &mut MultipleFederationErrors,
 ) -> Result<Option<Type>, FederationError> {
-    if let Some(metadata) = &schema.subgraph_metadata {
-        if let Some(interface_object_directive) = metadata
+    if let Some(metadata) = &schema.subgraph_metadata
+        && let Some(interface_object_directive) = metadata
             .federation_spec_definition()
             .interface_object_directive_definition(schema)?
-        {
-            if current_type.has_applied_directive(schema, &interface_object_directive.name) {
+            && current_type.has_applied_directive(schema, &interface_object_directive.name) {
                 errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!("Context \"{}\" is used in \"{}\" but the selection is invalid: One of the types in the selection is an interfaceObject: \"{}\".", context, from_context_parent, current_type.type_name())
@@ -929,8 +925,6 @@ fn validate_field_value_type(
                     .into(),
                 );
             }
-        }
-    }
     Ok(validate_field_value_type_inner(
         selection_set,
         schema,

--- a/apollo-federation/src/schema/validators/from_context.rs
+++ b/apollo-federation/src/schema/validators/from_context.rs
@@ -219,8 +219,7 @@ fn validate_selection_format(
                     errors.push(
                         SingleFederationError::ContextSelectionInvalid {
                             message: format!(
-                                "Context \"{}\" is used in \"{}\" but the selection is invalid: inline fragments must have type conditions",
-                                context, from_context_parent
+                                "Context \"{context}\" is used in \"{from_context_parent}\" but the selection is invalid: inline fragments must have type conditions"
                             ),
                         }
                         .into(),
@@ -232,8 +231,7 @@ fn validate_selection_format(
                 errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: fragment spreads are not allowed",
-                            context, from_context_parent
+                            "Context \"{context}\" is used in \"{from_context_parent}\" but the selection is invalid: fragment spreads are not allowed"
                         ),
                     }
                     .into(),
@@ -246,7 +244,7 @@ fn validate_selection_format(
     if has_field && has_inline_fragment {
         errors.push(
             SingleFederationError::ContextSelectionInvalid {
-                message: format!("Context \"{}\" is used in \"{}\" but the selection is invalid: multiple fields could be selected", context, from_context_parent),
+                message: format!("Context \"{context}\" is used in \"{from_context_parent}\" but the selection is invalid: multiple fields could be selected"),
             }
             .into(),
         );
@@ -259,8 +257,7 @@ fn validate_selection_format(
         errors.push(
             SingleFederationError::ContextSelectionInvalid {
                 message: format!(
-                    "Context \"{}\" is used in \"{}\" but the selection is invalid: type conditions have the same name",
-                    context, from_context_parent
+                    "Context \"{context}\" is used in \"{from_context_parent}\" but the selection is invalid: type conditions have the same name"
                 ),
             }
             .into(),
@@ -353,8 +350,7 @@ fn validate_field_value(
             errors.push(
             SingleFederationError::ContextSelectionInvalid {
                 message: format!(
-                    "Context \"{}\" is used in \"{}\" but the selection is invalid: multiple selections are made",
-                    context, target
+                    "Context \"{context}\" is used in \"{target}\" but the selection is invalid: multiple selections are made"
                 ),
             }
             .into(),
@@ -380,8 +376,7 @@ fn validate_field_value(
                     errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: the type of the selection does not match the expected type \"{}\"",
-                            context, target, expected_type
+                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection does not match the expected type \"{expected_type}\""
                         ),
                     }
                     .into(),
@@ -392,8 +387,7 @@ fn validate_field_value(
                     errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: the type of the selection \"{}\" does not match the expected type \"{}\"",
-                            context, target, resolved_type, expected_type
+                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection \"{resolved_type}\" does not match the expected type \"{expected_type}\""
                         ),
                     }
                     .into(),
@@ -446,8 +440,7 @@ fn validate_field_value(
                                     errors.push(
                                     SingleFederationError::ContextSelectionInvalid {
                                         message: format!(
-                                            "Context \"{}\" is used in \"{}\" but the selection is invalid: the type of the selection \"{}\" does not match the expected type \"{}\"",
-                                            context, target, resolved_type, expected_type
+                                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection \"{resolved_type}\" does not match the expected type \"{expected_type}\""
                                         ),
                                     }
                                     .into(),
@@ -459,8 +452,7 @@ fn validate_field_value(
                                 errors.push(
                                 SingleFederationError::ContextSelectionInvalid {
                                     message: format!(
-                                        "Context \"{}\" is used in \"{}\" but the selection is invalid: the type of the selection does not match the expected type \"{}\"",
-                                        context, target, expected_type
+                                        "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection does not match the expected type \"{expected_type}\""
                                     ),
                                 }
                                 .into(),
@@ -521,8 +513,7 @@ fn validate_field_value(
                     errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: no type condition matches the location \"{}\"",
-                            context, target, context_locations_str
+                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: no type condition matches the location \"{context_locations_str}\""
                         ),
                     }
                     .into(),
@@ -540,8 +531,7 @@ fn validate_field_value(
                 errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!(
-                            "Context \"{}\" is used in \"{}\" but the selection is invalid: type condition \"{}\" is never used",
-                            context, target, type_condition
+                            "Context \"{context}\" is used in \"{target}\" but the selection is invalid: type condition \"{type_condition}\" is never used"
                         ),
                     }
                     .into(),
@@ -627,8 +617,7 @@ impl FromContextValidator for DenyOnAbstractType {
             errors.push(
             SingleFederationError::ContextNotSet {
                 message: format!(
-                    "@fromContext argument cannot be used on a field that exists on an abstract type \"{}\".",
-                    target
+                    "@fromContext argument cannot be used on a field that exists on an abstract type \"{target}\"."
                 ),
                 }
                 .into(),
@@ -669,8 +658,7 @@ impl FromContextValidator for DenyOnInterfaceImplementation {
                     errors.push(
                         SingleFederationError::ContextNotSet {
                             message: format!(
-                                "@fromContext argument cannot be used on a field implementing an interface field \"{}\".",
-                                target
+                                "@fromContext argument cannot be used on a field implementing an interface field \"{target}\"."
                             ),
                         }
                         .into(),
@@ -709,8 +697,7 @@ impl<'a> FromContextValidator for RequireContextExists<'a> {
             errors.push(
                 SingleFederationError::NoContextReferenced {
                     message: format!(
-                        "@fromContext argument does not reference a context \"${} {}\".",
-                        context, selection
+                        "@fromContext argument does not reference a context \"${context} {selection}\"."
                     ),
                 }
                 .into(),
@@ -719,8 +706,7 @@ impl<'a> FromContextValidator for RequireContextExists<'a> {
             errors.push(
                 SingleFederationError::ContextNotSet {
                     message: format!(
-                        "Context \"{}\" is used at location \"{}\" but is never set.",
-                        context, target
+                        "Context \"{context}\" is used at location \"{target}\" but is never set."
                     ),
                 }
                 .into(),
@@ -729,8 +715,7 @@ impl<'a> FromContextValidator for RequireContextExists<'a> {
             errors.push(
                 SingleFederationError::NoSelectionForContext {
                     message: format!(
-                        "@fromContext directive in field \"{}\" has no selection",
-                        target
+                        "@fromContext directive in field \"{target}\" has no selection"
                     ),
                 }
                 .into(),
@@ -779,8 +764,7 @@ impl FromContextValidator for RequireResolvableKey {
                 errors.push(
                     SingleFederationError::ContextNoResolvableKey {
                         message: format!(
-                            "Object \"{}\" has no resolvable key but has a field with a contextual argument.",
-                            parent
+                            "Object \"{parent}\" has no resolvable key but has a field with a contextual argument."
                         ),
                     }
                     .into(),
@@ -832,8 +816,7 @@ impl FromContextValidator for DenyDefaultValues {
             errors.push(
                 SingleFederationError::ContextSelectionInvalid {
                     message: format!(
-                        "@fromContext arguments may not have a default value: \"{}\".",
-                        target
+                        "@fromContext arguments may not have a default value: \"{target}\"."
                     ),
                 }
                 .into(),

--- a/apollo-federation/src/schema/validators/from_context.rs
+++ b/apollo-federation/src/schema/validators/from_context.rs
@@ -85,9 +85,10 @@ pub(crate) fn validate_from_context_directives(
                         set_context_locations,
                         schema,
                         errors,
-                    ) {
-                        errors.push(validation_error);
-                    }
+                    )
+                {
+                    errors.push(validation_error);
+                }
             }
             Err(e) => errors.push(e),
         }
@@ -398,45 +399,43 @@ fn validate_field_value(
                 // For inline fragment selections, validate each fragment
                 for selection in selection_set.selections.iter() {
                     if let Selection::InlineFragment(frag) = selection
-                        && let Some(type_condition) = &frag.type_condition {
-                            let Some(extended_type) =
-                                schema.schema().types.get(type_condition.as_str())
-                            else {
-                                errors.push(
+                        && let Some(type_condition) = &frag.type_condition
+                    {
+                        let Some(extended_type) =
+                            schema.schema().types.get(type_condition.as_str())
+                        else {
+                            errors.push(
                                 SingleFederationError::ContextSelectionInvalid { message: format!(
                                     "Inline fragment type condition invalid. Type '{}' does not exist in schema.", type_condition.as_str()
                                 ) }
                                 .into(),
                             );
-                                continue;
-                            };
-                            let frag_type_position = TypeDefinitionPosition::from(extended_type);
-                            if ObjectTypeDefinitionPosition::try_from(frag_type_position.clone())
-                                .is_err()
-                            {
-                                errors.push(
+                            continue;
+                        };
+                        let frag_type_position = TypeDefinitionPosition::from(extended_type);
+                        if ObjectTypeDefinitionPosition::try_from(frag_type_position.clone())
+                            .is_err()
+                        {
+                            errors.push(
                                 SingleFederationError::ContextSelectionInvalid { message:
                                     "Inline fragment type condition invalid: type conditions must be an object type".to_string()
                                  }.into(),
                             );
-                                continue;
-                            }
+                            continue;
+                        }
 
-                            if let Ok(Some(resolved_type)) = validate_field_value_type(
-                                context,
-                                &frag_type_position,
-                                &frag.selection_set,
-                                schema,
-                                target,
-                                errors,
-                            ) {
-                                // For inline fragments, remove NonNull wrapper as other subgraphs may not define this
-                                // This matches the TypeScript behavior
-                                if !is_valid_implementation_field_type(
-                                    expected_type,
-                                    &resolved_type,
-                                ) {
-                                    errors.push(
+                        if let Ok(Some(resolved_type)) = validate_field_value_type(
+                            context,
+                            &frag_type_position,
+                            &frag.selection_set,
+                            schema,
+                            target,
+                            errors,
+                        ) {
+                            // For inline fragments, remove NonNull wrapper as other subgraphs may not define this
+                            // This matches the TypeScript behavior
+                            if !is_valid_implementation_field_type(expected_type, &resolved_type) {
+                                errors.push(
                                     SingleFederationError::ContextSelectionInvalid {
                                         message: format!(
                                             "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection \"{resolved_type}\" does not match the expected type \"{expected_type}\""
@@ -444,11 +443,11 @@ fn validate_field_value(
                                     }
                                     .into(),
                                     );
-                                    return Ok(());
-                                }
-                                used_type_conditions.insert(type_condition.as_str().to_string());
-                            } else {
-                                errors.push(
+                                return Ok(());
+                            }
+                            used_type_conditions.insert(type_condition.as_str().to_string());
+                        } else {
+                            errors.push(
                                 SingleFederationError::ContextSelectionInvalid {
                                     message: format!(
                                         "Context \"{context}\" is used in \"{target}\" but the selection is invalid: the type of the selection does not match the expected type \"{expected_type}\""
@@ -456,9 +455,9 @@ fn validate_field_value(
                                 }
                                 .into(),
                                 );
-                                return Ok(());
-                            }
+                            return Ok(());
                         }
+                    }
                 }
                 let context_location_names: std::collections::HashSet<String> =
                     set_context_locations
@@ -870,15 +869,16 @@ fn validate_field_value_type_inner(
                 schema,
                 from_context_parent,
                 errors,
-            ) {
-                types_array.push(nested_type);
-            }
-            // } else {
-            //     if let Ok(field_def) = field.field.field_position.get(schema.schema()) {
-            //         let base_type = &field_def.ty;
-            //         types_array.push(base_type);
-            //     }
-            // }
+            )
+        {
+            types_array.push(nested_type);
+        }
+        // } else {
+        //     if let Ok(field_def) = field.field.field_position.get(schema.schema()) {
+        //         let base_type = &field_def.ty;
+        //         types_array.push(base_type);
+        //     }
+        // }
     }
 
     if types_array.is_empty() {
@@ -917,14 +917,15 @@ fn validate_field_value_type(
         && let Some(interface_object_directive) = metadata
             .federation_spec_definition()
             .interface_object_directive_definition(schema)?
-            && current_type.has_applied_directive(schema, &interface_object_directive.name) {
-                errors.push(
+        && current_type.has_applied_directive(schema, &interface_object_directive.name)
+    {
+        errors.push(
                     SingleFederationError::ContextSelectionInvalid {
                         message: format!("Context \"{}\" is used in \"{}\" but the selection is invalid: One of the types in the selection is an interfaceObject: \"{}\".", context, from_context_parent, current_type.type_name())
                     }
                     .into(),
                 );
-            }
+    }
     Ok(validate_field_value_type_inner(
         selection_set,
         schema,

--- a/apollo-federation/src/schema/validators/interface_object.rs
+++ b/apollo-federation/src/schema/validators/interface_object.rs
@@ -80,7 +80,7 @@ fn validate_keys_on_interfaces_are_also_on_all_implementations(
                 let types_list = human_readable_list(
                     implementations_with_missing_keys
                         .iter()
-                        .map(|pos| format!("\"{}\"", pos)),
+                        .map(|pos| format!("\"{pos}\"")),
                     HumanReadableListOptions {
                         prefix: Some(HumanReadableListPrefix {
                             singular: "type",
@@ -103,7 +103,7 @@ fn validate_keys_on_interfaces_are_also_on_all_implementations(
                 let types_list = human_readable_list(
                     implementations_with_non_resolvable_keys
                         .iter()
-                        .map(|pos| format!("\"{}\"", pos)),
+                        .map(|pos| format!("\"{pos}\"")),
                     HumanReadableListOptions {
                         prefix: Some(HumanReadableListPrefix {
                             singular: "type",
@@ -156,8 +156,7 @@ fn validate_interface_objects_are_on_entities(
             error_collector.errors.push(
                 SingleFederationError::InterfaceObjectUsageError {
                     message: format!(
-                        "The @interfaceObject directive can only be applied to entity types but type \"{}\" has no @key in this subgraph.",
-                        type_pos
+                        "The @interfaceObject directive can only be applied to entity types but type \"{type_pos}\" has no @key in this subgraph."
                     )
                 }
             )

--- a/apollo-federation/src/schema/validators/key.rs
+++ b/apollo-federation/src/schema/validators/key.rs
@@ -70,12 +70,12 @@ pub(crate) fn validate_key_directives(
                         if did_not_find_errors
                             && let Err(validation_error) =
                                 fields.validate(Valid::assume_valid_ref(schema.schema()))
-                            {
-                                errors.push(invalid_fields_error_from_diagnostics(
-                                    &key,
-                                    validation_error,
-                                ));
-                            }
+                        {
+                            errors.push(invalid_fields_error_from_diagnostics(
+                                &key,
+                                validation_error,
+                            ));
+                        }
                     }
                     Err(e) => errors.push(invalid_fields_error_from_diagnostics(&key, e.errors)),
                 }

--- a/apollo-federation/src/schema/validators/key.rs
+++ b/apollo-federation/src/schema/validators/key.rs
@@ -67,8 +67,8 @@ pub(crate) fn validate_key_directives(
                         // We apply federation-specific validation rules without validating first to maintain compatibility with existing messaging,
                         // but if we get to this point without errors, we want to make sure it's still a valid selection.
                         let did_not_find_errors = existing_error_count == errors.errors.len();
-                        if did_not_find_errors {
-                            if let Err(validation_error) =
+                        if did_not_find_errors
+                            && let Err(validation_error) =
                                 fields.validate(Valid::assume_valid_ref(schema.schema()))
                             {
                                 errors.push(invalid_fields_error_from_diagnostics(
@@ -76,7 +76,6 @@ pub(crate) fn validate_key_directives(
                                     validation_error,
                                 ));
                             }
-                        }
                     }
                     Err(e) => errors.push(invalid_fields_error_from_diagnostics(&key, e.errors)),
                 }

--- a/apollo-federation/src/schema/validators/list_size.rs
+++ b/apollo-federation/src/schema/validators/list_size.rs
@@ -57,8 +57,8 @@ fn validate_assumed_size_not_negative(
     list_size: &ListSizeDirective,
     errors: &mut MultipleFederationErrors,
 ) {
-    if let Some(size) = list_size.directive.assumed_size {
-        if size < 0 {
+    if let Some(size) = list_size.directive.assumed_size
+        && size < 0 {
             errors
                 .errors
                 .push(SingleFederationError::ListSizeInvalidAssumedSize {
@@ -68,7 +68,6 @@ fn validate_assumed_size_not_negative(
                     ),
                 });
         }
-    }
 }
 
 /// Validate `slicingArguments` select valid integer arguments on the target type per

--- a/apollo-federation/src/schema/validators/list_size.rs
+++ b/apollo-federation/src/schema/validators/list_size.rs
@@ -58,16 +58,17 @@ fn validate_assumed_size_not_negative(
     errors: &mut MultipleFederationErrors,
 ) {
     if let Some(size) = list_size.directive.assumed_size
-        && size < 0 {
-            errors
-                .errors
-                .push(SingleFederationError::ListSizeInvalidAssumedSize {
-                    message: format!(
-                        "Assumed size of \"{}.{}\" cannot be negative",
-                        list_size.parent_type, list_size.target.name
-                    ),
-                });
-        }
+        && size < 0
+    {
+        errors
+            .errors
+            .push(SingleFederationError::ListSizeInvalidAssumedSize {
+                message: format!(
+                    "Assumed size of \"{}.{}\" cannot be negative",
+                    list_size.parent_type, list_size.target.name
+                ),
+            });
+    }
 }
 
 /// Validate `slicingArguments` select valid integer arguments on the target type per

--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -231,8 +231,7 @@ pub(crate) fn validate_merged_schema(
                         },
                         |incompatible_subgraphs| {
                             Ok(format!(
-                                "cannot provide a value for argument \"{}\" of field \"{}\" as argument \"{}\" is not defined in {}",
-                                argument_name, field_name, argument_name, incompatible_subgraphs,
+                                "cannot provide a value for argument \"{argument_name}\" of field \"{field_name}\" as argument \"{argument_name}\" is not defined in {incompatible_subgraphs}",
                             ))
                         },
                         subgraphs,
@@ -266,8 +265,7 @@ pub(crate) fn validate_merged_schema(
                         },
                         |incompatible_subgraphs| {
                             Ok(format!(
-                                "no value provided for argument \"{}\" of field \"{}\" but a value is mandatory as \"{}\" is required in {}",
-                                argument_name, field_name, argument_name, incompatible_subgraphs,
+                                "no value provided for argument \"{argument_name}\" of field \"{field_name}\" but a value is mandatory as \"{argument_name}\" is required in {incompatible_subgraphs}",
                             ))
                         },
                         subgraphs,

--- a/apollo-federation/src/schema/validators/provides.rs
+++ b/apollo-federation/src/schema/validators/provides.rs
@@ -90,12 +90,12 @@ pub(crate) fn validate_provides_directives(
                         if did_not_find_errors
                             && let Err(validation_error) =
                                 fields.validate(Valid::assume_valid_ref(schema.schema()))
-                            {
-                                errors.push(invalid_fields_error_from_diagnostics(
-                                    &provides,
-                                    validation_error,
-                                ));
-                            }
+                        {
+                            errors.push(invalid_fields_error_from_diagnostics(
+                                &provides,
+                                validation_error,
+                            ));
+                        }
                     }
                     Err(e) => {
                         errors.push(invalid_fields_error_from_diagnostics(&provides, e.errors))

--- a/apollo-federation/src/schema/validators/provides.rs
+++ b/apollo-federation/src/schema/validators/provides.rs
@@ -87,8 +87,8 @@ pub(crate) fn validate_provides_directives(
                         // We apply federation-specific validation rules without validating first to maintain compatibility with existing messaging,
                         // but if we get to this point without errors, we want to make sure it's still a valid selection.
                         let did_not_find_errors = existing_error_count == errors.errors.len();
-                        if did_not_find_errors {
-                            if let Err(validation_error) =
+                        if did_not_find_errors
+                            && let Err(validation_error) =
                                 fields.validate(Valid::assume_valid_ref(schema.schema()))
                             {
                                 errors.push(invalid_fields_error_from_diagnostics(
@@ -96,7 +96,6 @@ pub(crate) fn validate_provides_directives(
                                     validation_error,
                                 ));
                             }
-                        }
                     }
                     Err(e) => {
                         errors.push(invalid_fields_error_from_diagnostics(&provides, e.errors))

--- a/apollo-federation/src/schema/validators/requires.rs
+++ b/apollo-federation/src/schema/validators/requires.rs
@@ -62,12 +62,12 @@ pub(crate) fn validate_requires_directives(
                         if did_not_find_errors
                             && let Err(validation_error) =
                                 fields.validate(Valid::assume_valid_ref(schema.schema()))
-                            {
-                                errors.push(invalid_fields_error_from_diagnostics(
-                                    &requires,
-                                    validation_error,
-                                ));
-                            }
+                        {
+                            errors.push(invalid_fields_error_from_diagnostics(
+                                &requires,
+                                validation_error,
+                            ));
+                        }
                     }
                     Err(e) => {
                         errors.push(invalid_fields_error_from_diagnostics(&requires, e.errors))

--- a/apollo-federation/src/schema/validators/requires.rs
+++ b/apollo-federation/src/schema/validators/requires.rs
@@ -59,8 +59,8 @@ pub(crate) fn validate_requires_directives(
                         // We apply federation-specific validation rules without validating first to maintain compatibility with existing messaging,
                         // but if we get to this point without errors, we want to make sure it's still a valid selection.
                         let did_not_find_errors = existing_error_count == errors.errors.len();
-                        if did_not_find_errors {
-                            if let Err(validation_error) =
+                        if did_not_find_errors
+                            && let Err(validation_error) =
                                 fields.validate(Valid::assume_valid_ref(schema.schema()))
                             {
                                 errors.push(invalid_fields_error_from_diagnostics(
@@ -68,7 +68,6 @@ pub(crate) fn validate_requires_directives(
                                     validation_error,
                                 ));
                             }
-                        }
                     }
                     Err(e) => {
                         errors.push(invalid_fields_error_from_diagnostics(&requires, e.errors))

--- a/apollo-federation/src/schema/validators/tag.rs
+++ b/apollo-federation/src/schema/validators/tag.rs
@@ -36,8 +36,7 @@ pub(crate) fn validate_tag_directives(
         if tag_name.len() > MAX_TAG_LENGTH || !TAG_NAME_PATTERN.is_match(tag_name) {
             let message = if matches!(tag_directive.target, TagDirectiveTargetPosition::Schema(_)) {
                 format!(
-                    "Schema root has invalid @tag directive value '{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                    tag_name
+                    "Schema root has invalid @tag directive value '{tag_name}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                 )
             } else {
                 format!(

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -558,11 +558,11 @@ pub mod test_utils {
                 b.len(),
                 a.len(),
                 b.iter()
-                    .map(|(code, msg)| { format!("- {}: {}", code, msg) })
+                    .map(|(code, msg)| { format!("- {code}: {msg}") })
                     .collect::<Vec<_>>()
                     .join("\n"),
                 a.iter()
-                    .map(|(code, msg)| { format!("+ {}: {}", code, msg) })
+                    .map(|(code, msg)| { format!("+ {code}: {msg}") })
                     .collect::<Vec<_>>()
                     .join("\n"),
             ));

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -621,7 +621,7 @@ fn find_unused_name_for_directive(
     // The schema already defines a directive named `@link` so we need to use an alias. To keep it
     // simple, we add a number in the end (so we try `@link1`, and if that's taken `@link2`, ...)
     for i in 1..=1000 {
-        let candidate = Name::try_from(format!("{}{}", directive_name, i))?;
+        let candidate = Name::try_from(format!("{directive_name}{i}"))?;
         if schema.get_directive_definition(&candidate).is_none() {
             return Ok(Some(candidate));
         }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -367,8 +367,7 @@ fn collect_empty_subgraphs(
             .get(&graph_directive_definition.name)
             .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
                 message: format!(
-                    "Value \"{}\" of join__Graph enum has no @join__graph directive",
-                    enum_value_name
+                    "Value \"{enum_value_name}\" of join__Graph enum has no @join__graph directive"
                 ),
             })?;
         let graph_arguments = join_spec_definition.graph_directive_arguments(graph_application)?;
@@ -648,7 +647,7 @@ fn add_empty_type(
     // In fed2, we always mark all types with `@join__type` but making sure.
     if type_directive_applications.is_empty() {
         return Err(SingleFederationError::InvalidFederationSupergraph {
-            message: format!("Missing @join__type on \"{}\"", type_definition_position),
+            message: format!("Missing @join__type on \"{type_definition_position}\""),
         }
         .into());
     }
@@ -1009,10 +1008,7 @@ fn extract_object_type_content(
                         return Err(
                             SingleFederationError::InvalidFederationSupergraph {
                                 message: format!(
-                                    "@join__field cannot exist on {}.{} for subgraph {} without type-level @join__type",
-                                    type_name,
-                                    field_name,
-                                    graph_enum_value,
+                                    "@join__field cannot exist on {type_name}.{field_name} for subgraph {graph_enum_value} without type-level @join__type",
                                 ),
                             }.into()
                         );
@@ -1070,9 +1066,7 @@ fn extract_interface_type_content(
             let is_interface_object = *subgraph_info.get(graph_enum_value).ok_or_else(|| {
                 SingleFederationError::InvalidFederationSupergraph {
                     message: format!(
-                        "@join__implements cannot exist on {} for subgraph {} without type-level @join__type",
-                        type_name,
-                        graph_enum_value,
+                        "@join__implements cannot exist on {type_name} for subgraph {graph_enum_value} without type-level @join__type",
                     ),
                 }
             })?;
@@ -1198,10 +1192,7 @@ fn extract_interface_type_content(
                         return Err(
                             SingleFederationError::InvalidFederationSupergraph {
                                 message: format!(
-                                    "@join__field cannot exist on {}.{} for subgraph {} without type-level @join__type",
-                                    type_name,
-                                    field_name,
-                                    graph_enum_value,
+                                    "@join__field cannot exist on {type_name}.{field_name} for subgraph {graph_enum_value} without type-level @join__type",
                                 ),
                             }.into()
                         );
@@ -1475,10 +1466,7 @@ fn extract_input_object_type_content(
                         return Err(
                             SingleFederationError::InvalidFederationSupergraph {
                                 message: format!(
-                                    "@join__field cannot exist on {}.{} for subgraph {} without type-level @join__type",
-                                    type_name,
-                                    input_field_name,
-                                    graph_enum_value,
+                                    "@join__field cannot exist on {type_name}.{input_field_name} for subgraph {graph_enum_value} without type-level @join__type",
                                 ),
                             }.into()
                         );
@@ -1611,11 +1599,11 @@ fn add_subgraph_field(
             } = args;
             let (_, context_name_in_subgraph) = context.rsplit_once("__").ok_or_else(|| {
                 SingleFederationError::InvalidFederationSupergraph {
-                    message: format!(r#"Invalid context "{}" in supergraph schema"#, context),
+                    message: format!(r#"Invalid context "{context}" in supergraph schema"#),
                 }
             })?;
 
-            let arg = format!("${} {}", context_name_in_subgraph, selection);
+            let arg = format!("${context_name_in_subgraph} {selection}");
             let from_context_directive =
                 federation_spec_definition.from_context_directive(&subgraph.schema, arg)?;
             let directives = std::iter::once(from_context_directive).collect();
@@ -1702,8 +1690,7 @@ fn get_subgraph<'subgraph>(
         .ok_or_else(|| {
             SingleFederationError::Internal {
                 message: format!(
-                    "Invalid graph enum_value \"{}\": does not match an enum value defined in the @join__Graph enum",
-                    graph_enum_value,
+                    "Invalid graph enum_value \"{graph_enum_value}\": does not match an enum value defined in the @join__Graph enum",
                 ),
             }
         })?;
@@ -2278,8 +2265,7 @@ fn maybe_dump_subgraph_schema(subgraph: FederationSubgraph, message: &mut String
         }
         _ => write!(
             message,
-            "Re-run with environment variable '{}' set to 'true' to extract the invalid subgraph",
-            DEBUG_SUBGRAPHS_ENV_VARIABLE_NAME
+            "Re-run with environment variable '{DEBUG_SUBGRAPHS_ENV_VARIABLE_NAME}' set to 'true' to extract the invalid subgraph"
         ),
     };
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -116,7 +116,7 @@ pub(crate) fn compose(
         .map(|(name, schema)| {
             (
                 *name,
-                format!("extend schema {DEFAULT_LINK_DIRECTIVE}\n\n{}", schema,),
+                format!("extend schema {DEFAULT_LINK_DIRECTIVE}\n\n{schema}",),
             )
         })
         .collect();

--- a/apollo-federation/tests/subgraph/parse_expand_tests.rs
+++ b/apollo-federation/tests/subgraph/parse_expand_tests.rs
@@ -17,7 +17,7 @@ fn can_parse_and_expand() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("T"));
@@ -48,7 +48,7 @@ fn can_parse_and_expand_with_renames() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.directive_definitions.contains_key("myKey"));
@@ -78,7 +78,7 @@ fn can_parse_and_expand_with_namespace() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.directive_definitions.contains_key("key"));
@@ -118,7 +118,7 @@ fn can_parse_and_expand_preserves_user_definitions() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("Purpose"));
@@ -139,7 +139,7 @@ fn can_parse_and_expand_works_with_fed_v1() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e);
+        println!("{e}");
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("T"));

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -101,7 +101,7 @@ mod fieldset_based_directives {
             let schema_str = format!(
                 r#"
                 extend schema
-                @link(url: "https://specs.apollo.dev/federation/v{}", import: ["@key"])
+                @link(url: "https://specs.apollo.dev/federation/v{version}", import: ["@key"])
 
                 type Query {{
                 t: T
@@ -110,8 +110,7 @@ mod fieldset_based_directives {
                 interface T @key(fields: "f") {{
                 f: Int
                 }}
-            "#,
-                version
+            "#
             );
             let err = build_for_errors_with_option(&schema_str, BuildOption::AsIs);
 
@@ -2119,127 +2118,109 @@ mod tag_tests {
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema root has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema root has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Foo has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Foo has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Foo.foo1 has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Foo.foo1 has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Foo.foo2(arg:) has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Foo.foo2(arg:) has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Bar has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Bar has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Query.foo has invalid @tag directive value '{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Query.foo has invalid @tag directive value '{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Query.bar has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Query.bar has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Query.baz has invalid @tag directive value 'test{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Query.baz has invalid @tag directive value 'test{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Bar.bar1 has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Bar.bar1 has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Bar.bar2(arg:) has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Bar.bar2(arg:) has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Baz has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Baz has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element CustomScalar has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element CustomScalar has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestEnum has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestEnum has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestEnum.VALUE1 has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestEnum.VALUE1 has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestInput has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestInput has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestInput.inputField1 has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestInput.inputField1 has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestInput.inputField3 has invalid @tag directive value '{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestInput.inputField3 has invalid @tag directive value '{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element @custom(arg:) has invalid @tag directive value 'test{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element @custom(arg:) has invalid @tag directive value 'test{symbol}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                 ]
@@ -2261,15 +2242,13 @@ mod tag_tests {
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element Query.foo has invalid @tag directive value '{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element Query.foo has invalid @tag directive value '{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                     (
                         "INVALID_TAG_NAME",
                         &format!(
-                            "[S] Schema element TestInput.inputField3 has invalid @tag directive value '{}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                            symbol
+                            "[S] Schema element TestInput.inputField3 has invalid @tag directive value '{symbol}test' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                         )
                     ),
                 ]
@@ -2320,8 +2299,7 @@ mod tag_tests {
             [(
                 "INVALID_TAG_NAME",
                 &format!(
-                    "[S] Schema element T has invalid @tag directive value '{}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores.",
-                    invalid
+                    "[S] Schema element T has invalid @tag directive value '{invalid}' for argument \"name\". Values must start with an alphanumeric character or underscore and contain only slashes, hyphens, or underscores."
                 )
             )]
         );

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -8,7 +8,7 @@ description = "A configurable, high-performance routing runtime for Apollo Feder
 license = "Elastic-2.0"
 
 # renovate-automation: rustc version
-rust-version = "1.87.0"
+rust-version = "1.89.0"
 edition = "2024"
 build = "build/main.rs"
 default-run = "router"

--- a/apollo-router/README.md
+++ b/apollo-router/README.md
@@ -27,4 +27,4 @@ Most Apollo Router Core features can be defined using our [YAML configuration](h
 If you prefer to write customizations in Rust or need more advanced customizations, see our section on [native customizations](https://www.apollographql.com/docs/router/customizations/native) for information on how to use `apollo-router` as a Rust library.  We also publish Rust-specific documentation on our [`apollo-router` crate docs](https://docs.rs/crate/apollo-router).
 
 <!-- renovate-automation: rustc version -->
-The minimum supported Rust version (MSRV) for this version of `apollo-router` is **1.87.0**.
+The minimum supported Rust version (MSRV) for this version of `apollo-router` is **1.89.0**.

--- a/apollo-router/benches/deeply_nested.rs
+++ b/apollo-router/benches/deeply_nested.rs
@@ -123,7 +123,7 @@ async fn spawn_router(graphql_recursion_limit: usize) -> tokio::process::Child {
                 }
             }
             if VERBOSE {
-                println!("{}", line);
+                println!("{line}");
             }
         }
     });
@@ -183,9 +183,9 @@ async fn spawn_subgraph() -> ShutdownOnDrop {
 
                     tokio::spawn(async move {
                         if let Err(err) = conn.await {
-                            eprintln!("connection error: {}", err);
+                            eprintln!("connection error: {err}");
                         }
-                        eprintln!("connection dropped: {}", peer_addr);
+                        eprintln!("connection dropped: {peer_addr}");
                     });
                 }
                 _ = rx.recv() => {

--- a/apollo-router/benches/deeply_nested.rs
+++ b/apollo-router/benches/deeply_nested.rs
@@ -117,10 +117,11 @@ async fn spawn_router(graphql_recursion_limit: usize) -> tokio::process::Child {
         let mut tx = Some(tx);
         while let Some(line) = router_stdout.next_line().await.unwrap() {
             if line.contains("GraphQL endpoint exposed")
-                && let Some(tx) = tx.take() {
-                    let _ = tx.send(());
-                    // Don’t stop here, keep consuming output so the pipe doesn’t block on a full buffer
-                }
+                && let Some(tx) = tx.take()
+            {
+                let _ = tx.send(());
+                // Don’t stop here, keep consuming output so the pipe doesn’t block on a full buffer
+            }
             if VERBOSE {
                 println!("{line}");
             }
@@ -153,9 +154,10 @@ async fn graphql_client(nesting_level: usize) -> Result<Value, String> {
         .map_err(|e| e.to_string())?;
     let json = serde_json::from_slice::<Value>(&body.to_bytes()).map_err(|e| e.to_string())?;
     if let Some(errors) = json.get("errors")
-        && !errors.is_null() {
-            return Err(errors.to_string());
-        }
+        && !errors.is_null()
+    {
+        return Err(errors.to_string());
+    }
     Ok(json.get("data").cloned().unwrap_or(Value::Null))
 }
 

--- a/apollo-router/benches/deeply_nested.rs
+++ b/apollo-router/benches/deeply_nested.rs
@@ -116,12 +116,11 @@ async fn spawn_router(graphql_recursion_limit: usize) -> tokio::process::Child {
     tokio::spawn(async move {
         let mut tx = Some(tx);
         while let Some(line) = router_stdout.next_line().await.unwrap() {
-            if line.contains("GraphQL endpoint exposed") {
-                if let Some(tx) = tx.take() {
+            if line.contains("GraphQL endpoint exposed")
+                && let Some(tx) = tx.take() {
                     let _ = tx.send(());
                     // Don’t stop here, keep consuming output so the pipe doesn’t block on a full buffer
                 }
-            }
             if VERBOSE {
                 println!("{line}");
             }
@@ -153,11 +152,10 @@ async fn graphql_client(nesting_level: usize) -> Result<Value, String> {
         .await
         .map_err(|e| e.to_string())?;
     let json = serde_json::from_slice::<Value>(&body.to_bytes()).map_err(|e| e.to_string())?;
-    if let Some(errors) = json.get("errors") {
-        if !errors.is_null() {
+    if let Some(errors) = json.get("errors")
+        && !errors.is_null() {
             return Err(errors.to_string());
         }
-    }
     Ok(json.get("data").cloned().unwrap_or(Value::Null))
 }
 

--- a/apollo-router/benches/huge_requests.rs
+++ b/apollo-router/benches/huge_requests.rs
@@ -76,7 +76,7 @@ async fn one_request(string_variable_bytes: usize) {
                 }
             }
             if VERBOSE {
-                println!("{}", line);
+                println!("{line}");
             }
         }
     });
@@ -166,9 +166,9 @@ async fn spawn_subgraph() -> ShutdownOnDrop {
 
                     tokio::spawn(async move {
                         if let Err(err) = conn.await {
-                            eprintln!("connection error: {}", err);
+                            eprintln!("connection error: {err}");
                         }
-                        eprintln!("connection dropped: {}", peer_addr);
+                        eprintln!("connection dropped: {peer_addr}");
                     });
                 }
                 _ = rx.recv() => {

--- a/apollo-router/benches/huge_requests.rs
+++ b/apollo-router/benches/huge_requests.rs
@@ -70,10 +70,11 @@ async fn one_request(string_variable_bytes: usize) {
         let mut tx = Some(tx);
         while let Some(line) = router_stdout.next_line().await.unwrap() {
             if line.contains("GraphQL endpoint exposed")
-                && let Some(tx) = tx.take() {
-                    let _ = tx.send(());
-                    // Don’t stop here, keep consuming output so the pipe doesn’t block on a full buffer
-                }
+                && let Some(tx) = tx.take()
+            {
+                let _ = tx.send(());
+                // Don’t stop here, keep consuming output so the pipe doesn’t block on a full buffer
+            }
             if VERBOSE {
                 println!("{line}");
             }

--- a/apollo-router/benches/huge_requests.rs
+++ b/apollo-router/benches/huge_requests.rs
@@ -69,12 +69,11 @@ async fn one_request(string_variable_bytes: usize) {
     tokio::spawn(async move {
         let mut tx = Some(tx);
         while let Some(line) = router_stdout.next_line().await.unwrap() {
-            if line.contains("GraphQL endpoint exposed") {
-                if let Some(tx) = tx.take() {
+            if line.contains("GraphQL endpoint exposed")
+                && let Some(tx) = tx.take() {
                     let _ = tx.send(());
                     // Don’t stop here, keep consuming output so the pipe doesn’t block on a full buffer
                 }
-            }
             if VERBOSE {
                 println!("{line}");
             }

--- a/apollo-router/build/studio.rs
+++ b/apollo-router/build/studio.rs
@@ -48,6 +48,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "#[serde(serialize_with = \"crate::plugins::telemetry::apollo_exporter::serialize_timestamp\")]",
         )
         .type_attribute(".", "#[derive(serde::Serialize)]")
+        .type_attribute(".", "#[allow(dead_code)]")
         .type_attribute("StatsContext", "#[derive(Eq, Hash)]")
         .emit_rerun_if_changed(false)
         .compile_protos(&[reports_out],  &[&out_dir])?;

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -452,15 +452,16 @@ fn extract_enums_from_selection_set(
                     }
                     // Otherwise if the response value is an object, add any enums from the field's selection set
                     else if let JsonValue::Object(value_object) = field_value
-                        && let Some(selection_set) = selection_set {
-                            extract_enums_from_selection_set(
-                                selection_set,
-                                fragments,
-                                schema,
-                                value_object,
-                                result_set,
-                            );
-                        }
+                        && let Some(selection_set) = selection_set
+                    {
+                        extract_enums_from_selection_set(
+                            selection_set,
+                            fragments,
+                            schema,
+                            value_object,
+                            result_set,
+                        );
+                    }
                 }
             }
             SpecSelection::InlineFragment { selection_set, .. } => {
@@ -552,10 +553,10 @@ impl UsageGenerator<'_> {
                             .signature_doc
                             .fragments
                             .get(&fragment_node.fragment_name)
-                        {
-                            e.insert(fragment.clone());
-                            self.extract_signature_fragments(&fragment.selection_set);
-                        }
+                    {
+                        e.insert(fragment.clone());
+                        self.extract_signature_fragments(&fragment.selection_set);
+                    }
                 }
             }
         }
@@ -1089,9 +1090,10 @@ fn format_field(
     f: &mut fmt::Formatter,
 ) -> fmt::Result {
     if is_enhanced(normalization_algorithm)
-        && let Some(alias) = &field.alias {
-            write!(f, "{alias}:")?;
-        }
+        && let Some(alias) = &field.alias
+    {
+        write!(f, "{alias}:")?;
+    }
 
     f.write_str(&field.name)?;
 

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -194,7 +194,7 @@ impl UsageReportingOperationDetails {
             .as_deref()
             .unwrap_or("")
             .to_string();
-        format!("# {}\n{}", op_name, op_sig)
+        format!("# {op_name}\n{op_sig}")
     }
 }
 
@@ -242,7 +242,7 @@ impl UsageReporting {
                 operation_details.get_signature_and_operation()
             }
             UsageReporting::Error(error_key) => {
-                format!("## {}\n", error_key)
+                format!("## {error_key}\n")
             }
             UsageReporting::PersistedQuery {
                 operation_details,
@@ -267,7 +267,7 @@ impl UsageReporting {
                 operation_details, ..
             } => operation_details.get_signature_and_operation(),
             UsageReporting::Error(error_key) => {
-                format!("# # {}\n", error_key)
+                format!("# # {error_key}\n")
             }
         };
         Self::hash_string(&string_to_hash)
@@ -279,7 +279,7 @@ impl UsageReporting {
             | UsageReporting::PersistedQuery {
                 operation_details, ..
             } => operation_details.operation_name_or_default(),
-            UsageReporting::Error(error_key) => format!("# {}", error_key),
+            UsageReporting::Error(error_key) => format!("# {error_key}"),
         }
     }
 
@@ -951,7 +951,7 @@ fn format_operation(
     if !shorthand {
         f.write_str(operation.operation_type.name())?;
         if let Some(name) = &operation.name {
-            write!(f, " {}", name)?;
+            write!(f, " {name}")?;
         }
 
         // print variables sorted by name
@@ -1034,7 +1034,7 @@ fn format_selection_set(
                 formatter: &ApolloReportingSignatureFormatter::Field(field),
                 normalization_algorithm,
             };
-            let field_str = format!("{}", formatter);
+            let field_str = format!("{formatter}");
             f.write_str(&field_str)?;
 
             // We need to insert a space if this is not the last field and it ends in an alphanumeric character.
@@ -1111,7 +1111,7 @@ fn format_field(
                     formatter: &ApolloReportingSignatureFormatter::Argument(a),
                     normalization_algorithm,
                 };
-                format!("{}", formatter)
+                format!("{formatter}")
             })
             .collect();
 
@@ -1129,7 +1129,7 @@ fn format_field(
                         .last()
                         .is_none_or(|c| c.is_alphanumeric() || c == '_'))
             {
-                write!(f, "{}", separator)?;
+                write!(f, "{separator}")?;
             }
         }
         f.write_str(")")?;
@@ -1146,7 +1146,7 @@ fn format_inline_fragment(
     f: &mut fmt::Formatter,
 ) -> fmt::Result {
     if let Some(type_name) = &inline_fragment.type_condition {
-        write!(f, "...on {}", type_name)?;
+        write!(f, "...on {type_name}")?;
     } else {
         f.write_str("...")?;
     }
@@ -1205,7 +1205,7 @@ fn format_directives(
                     formatter: &ApolloReportingSignatureFormatter::Argument(argument),
                     normalization_algorithm,
                 };
-                write!(f, "{}", formatter)?;
+                write!(f, "{formatter}")?;
             }
 
             f.write_str(")")?;
@@ -1230,7 +1230,7 @@ fn format_value(
                     if index != 0 {
                         f.write_str(",")?;
                     }
-                    write!(f, "{}:", name)?;
+                    write!(f, "{name}:")?;
                     format_value(val, normalization_algorithm, f)?;
                 }
                 f.write_str("}")

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -451,8 +451,8 @@ fn extract_enums_from_selection_set(
                         add_enum_value_to_map(&enum_type.name, field_value, result_set);
                     }
                     // Otherwise if the response value is an object, add any enums from the field's selection set
-                    else if let JsonValue::Object(value_object) = field_value {
-                        if let Some(selection_set) = selection_set {
+                    else if let JsonValue::Object(value_object) = field_value
+                        && let Some(selection_set) = selection_set {
                             extract_enums_from_selection_set(
                                 selection_set,
                                 fragments,
@@ -461,7 +461,6 @@ fn extract_enums_from_selection_set(
                                 result_set,
                             );
                         }
-                    }
                 }
             }
             SpecSelection::InlineFragment { selection_set, .. } => {
@@ -548,8 +547,8 @@ impl UsageGenerator<'_> {
                 }
                 Selection::FragmentSpread(fragment_node) => {
                     let fragment_name = fragment_node.fragment_name.to_string();
-                    if let Entry::Vacant(e) = self.fragments_map.entry(fragment_name) {
-                        if let Some(fragment) = self
+                    if let Entry::Vacant(e) = self.fragments_map.entry(fragment_name)
+                        && let Some(fragment) = self
                             .signature_doc
                             .fragments
                             .get(&fragment_node.fragment_name)
@@ -557,7 +556,6 @@ impl UsageGenerator<'_> {
                             e.insert(fragment.clone());
                             self.extract_signature_fragments(&fragment.selection_set);
                         }
-                    }
                 }
             }
         }
@@ -1090,11 +1088,10 @@ fn format_field(
     normalization_algorithm: &ApolloSignatureNormalizationAlgorithm,
     f: &mut fmt::Formatter,
 ) -> fmt::Result {
-    if is_enhanced(normalization_algorithm) {
-        if let Some(alias) = &field.alias {
+    if is_enhanced(normalization_algorithm)
+        && let Some(alias) = &field.alias {
             write!(f, "{alias}:")?;
         }
-    }
 
     f.write_str(&field.name)?;
 

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -60,26 +60,28 @@ pub(super) fn ensure_endpoints_consistency(
         && supergraph_listen_endpoint
             .iter()
             .any(|e| e.path == configuration.supergraph.path)
-            && let Some((ip, port)) = configuration.supergraph.listen.ip_and_port() {
-                return Err(ApolloRouterError::SameRouteUsedTwice(
-                    ip,
-                    port,
-                    configuration.supergraph.path.clone(),
-                ));
-            }
+        && let Some((ip, port)) = configuration.supergraph.listen.ip_and_port()
+    {
+        return Err(ApolloRouterError::SameRouteUsedTwice(
+            ip,
+            port,
+            configuration.supergraph.path.clone(),
+        ));
+    }
 
     // check the extra endpoints
     let mut listen_addrs_and_paths = HashSet::new();
     for (listen, endpoints) in endpoints.iter_all() {
         for endpoint in endpoints {
             if let Some((ip, port)) = listen.ip_and_port()
-                && !listen_addrs_and_paths.insert((ip, port, endpoint.path.clone())) {
-                    return Err(ApolloRouterError::SameRouteUsedTwice(
-                        ip,
-                        port,
-                        endpoint.path.clone(),
-                    ));
-                }
+                && !listen_addrs_and_paths.insert((ip, port, endpoint.path.clone()))
+            {
+                return Err(ApolloRouterError::SameRouteUsedTwice(
+                    ip,
+                    port,
+                    endpoint.path.clone(),
+                ));
+            }
         }
     }
     Ok(())
@@ -128,25 +130,27 @@ pub(super) fn ensure_listenaddrs_consistency(
 
     if configuration.health_check.enabled
         && let Some((ip, port)) = configuration.health_check.listen.ip_and_port()
-            && let Some(previous_ip) = all_ports.insert(port, ip)
-                && ip != previous_ip {
-                    return Err(ApolloRouterError::DifferentListenAddrsOnSamePort(
-                        previous_ip,
-                        ip,
-                        port,
-                    ));
-                }
+        && let Some(previous_ip) = all_ports.insert(port, ip)
+        && ip != previous_ip
+    {
+        return Err(ApolloRouterError::DifferentListenAddrsOnSamePort(
+            previous_ip,
+            ip,
+            port,
+        ));
+    }
 
     for addr in endpoints.keys() {
         if let Some((ip, port)) = addr.ip_and_port()
             && let Some(previous_ip) = all_ports.insert(port, ip)
-                && ip != previous_ip {
-                    return Err(ApolloRouterError::DifferentListenAddrsOnSamePort(
-                        previous_ip,
-                        ip,
-                        port,
-                    ));
-                }
+            && ip != previous_ip
+        {
+            return Err(ApolloRouterError::DifferentListenAddrsOnSamePort(
+                previous_ip,
+                ip,
+                port,
+            ));
+        }
     }
 
     Ok(())

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -56,34 +56,30 @@ pub(super) fn ensure_endpoints_consistency(
     endpoints: &MultiMap<ListenAddr, Endpoint>,
 ) -> Result<(), ApolloRouterError> {
     // check the main endpoint
-    if let Some(supergraph_listen_endpoint) = endpoints.get_vec(&configuration.supergraph.listen) {
-        if supergraph_listen_endpoint
+    if let Some(supergraph_listen_endpoint) = endpoints.get_vec(&configuration.supergraph.listen)
+        && supergraph_listen_endpoint
             .iter()
             .any(|e| e.path == configuration.supergraph.path)
-        {
-            if let Some((ip, port)) = configuration.supergraph.listen.ip_and_port() {
+            && let Some((ip, port)) = configuration.supergraph.listen.ip_and_port() {
                 return Err(ApolloRouterError::SameRouteUsedTwice(
                     ip,
                     port,
                     configuration.supergraph.path.clone(),
                 ));
             }
-        }
-    }
 
     // check the extra endpoints
     let mut listen_addrs_and_paths = HashSet::new();
     for (listen, endpoints) in endpoints.iter_all() {
         for endpoint in endpoints {
-            if let Some((ip, port)) = listen.ip_and_port() {
-                if !listen_addrs_and_paths.insert((ip, port, endpoint.path.clone())) {
+            if let Some((ip, port)) = listen.ip_and_port()
+                && !listen_addrs_and_paths.insert((ip, port, endpoint.path.clone())) {
                     return Err(ApolloRouterError::SameRouteUsedTwice(
                         ip,
                         port,
                         endpoint.path.clone(),
                     ));
                 }
-            }
         }
     }
     Ok(())
@@ -130,32 +126,27 @@ pub(super) fn ensure_listenaddrs_consistency(
         all_ports.insert(main_port, main_ip);
     }
 
-    if configuration.health_check.enabled {
-        if let Some((ip, port)) = configuration.health_check.listen.ip_and_port() {
-            if let Some(previous_ip) = all_ports.insert(port, ip) {
-                if ip != previous_ip {
+    if configuration.health_check.enabled
+        && let Some((ip, port)) = configuration.health_check.listen.ip_and_port()
+            && let Some(previous_ip) = all_ports.insert(port, ip)
+                && ip != previous_ip {
                     return Err(ApolloRouterError::DifferentListenAddrsOnSamePort(
                         previous_ip,
                         ip,
                         port,
                     ));
                 }
-            }
-        }
-    }
 
     for addr in endpoints.keys() {
-        if let Some((ip, port)) = addr.ip_and_port() {
-            if let Some(previous_ip) = all_ports.insert(port, ip) {
-                if ip != previous_ip {
+        if let Some((ip, port)) = addr.ip_and_port()
+            && let Some(previous_ip) = all_ports.insert(port, ip)
+                && ip != previous_ip {
                     return Err(ApolloRouterError::DifferentListenAddrsOnSamePort(
                         previous_ip,
                         ip,
                         port,
                     ));
                 }
-            }
-        }
     }
 
     Ok(())

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1638,10 +1638,10 @@ async fn assert_cors_origin(response: reqwest::Response, origin: &str) {
             .text()
             .await
             .unwrap_or_else(|_| "Failed to get response body".to_string());
-        println!("Response status: {}", status);
-        println!("Response headers: {:?}", headers);
-        println!("Response body: {}", body);
-        panic!("Response status is not success: {}", status);
+        println!("Response status: {status}");
+        println!("Response headers: {headers:?}");
+        println!("Response body: {body}");
+        panic!("Response status is not success: {status}");
     }
     let headers = response.headers();
     assert_headers_valid(&response);
@@ -2286,7 +2286,7 @@ async fn send_to_unix_socket(addr: &ListenAddr, method: Method, body: &str) -> S
     let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await.unwrap();
     tokio::task::spawn(async move {
         if let Err(err) = conn.await {
-            println!("Connection failed: {:?}", err);
+            println!("Connection failed: {err:?}");
         }
     });
 

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -227,7 +227,7 @@ where
             tracing::error!("couldn't serialize value to redis {}. This is a bug in the router, please file an issue: https://github.com/apollographql/router/issues/new", e);
             RedisError::new(
                 RedisErrorKind::Parse,
-                format!("couldn't serialize value to redis {}", e),
+                format!("couldn't serialize value to redis {e}"),
             )
         })?;
 
@@ -448,8 +448,7 @@ impl RedisCacheStorage {
                     return Err(RedisError::new(
                         RedisErrorKind::Config,
                         format!(
-                            "invalid Redis URL scheme, expected a scheme from {SUPPORTED_REDIS_SCHEMES:?}, got: {}",
-                            scheme
+                            "invalid Redis URL scheme, expected a scheme from {SUPPORTED_REDIS_SCHEMES:?}, got: {scheme}"
                         ),
                     ));
                 }
@@ -759,7 +758,7 @@ mod test {
     fn it_preprocesses_redis_schemas_correctly() {
         // Base Format
         for scheme in ["redis", "rediss"] {
-            let url_s = format!("{}://username:password@host:6666/database", scheme);
+            let url_s = format!("{scheme}://username:password@host:6666/database");
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
             assert!(super::RedisCacheStorage::preprocess_urls(urls).is_ok());
@@ -767,8 +766,7 @@ mod test {
         // Cluster Format
         for scheme in ["redis-cluster", "rediss-cluster"] {
             let url_s = format!(
-                "{}://username:password@host:6666?node=host1:6667&node=host2:6668",
-                scheme
+                "{scheme}://username:password@host:6666?node=host1:6667&node=host2:6668"
             );
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
@@ -777,8 +775,7 @@ mod test {
         // Sentinel Format
         for scheme in ["redis-sentinel", "rediss-sentinel"] {
             let url_s = format!(
-                "{}://username:password@host:6666?node=host1:6667&node=host2:6668&sentinelServiceName=myservice&sentinelUserName=username2&sentinelPassword=password2",
-                scheme
+                "{scheme}://username:password@host:6666?node=host1:6667&node=host2:6668&sentinelServiceName=myservice&sentinelUserName=username2&sentinelPassword=password2"
             );
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
@@ -786,7 +783,7 @@ mod test {
         }
         // Make sure it fails on sample invalid schemes
         for scheme in ["wrong", "something"] {
-            let url_s = format!("{}://username:password@host:6666/database", scheme);
+            let url_s = format!("{scheme}://username:password@host:6666/database");
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
             assert!(super::RedisCacheStorage::preprocess_urls(urls).is_err());

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -765,9 +765,8 @@ mod test {
         }
         // Cluster Format
         for scheme in ["redis-cluster", "rediss-cluster"] {
-            let url_s = format!(
-                "{scheme}://username:password@host:6666?node=host1:6667&node=host2:6668"
-            );
+            let url_s =
+                format!("{scheme}://username:password@host:6666?node=host1:6667&node=host2:6668");
             let url = Url::parse(&url_s).expect("it's a valid url");
             let urls = vec![url.clone(), url];
             assert!(super::RedisCacheStorage::preprocess_urls(urls).is_ok());

--- a/apollo-router/src/configuration/cors.rs
+++ b/apollo-router/src/configuration/cors.rs
@@ -298,14 +298,13 @@ impl Cors {
                 );
             }
 
-            if let Some(headers) = &self.expose_headers {
-                if headers.iter().any(|x| x == "*") {
+            if let Some(headers) = &self.expose_headers
+                && headers.iter().any(|x| x == "*") {
                     return Err(
                         "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
                         with `Access-Control-Expose-Headers: *`",
                     );
                 }
-            }
         }
 
         // Check per-policy fields for wildcards when policy-level credentials are enabled
@@ -322,14 +321,13 @@ impl Cors {
                         );
                     }
 
-                    if let Some(methods) = &policy.methods {
-                        if methods.iter().any(|x| x == "*") {
+                    if let Some(methods) = &policy.methods
+                        && methods.iter().any(|x| x == "*") {
                             return Err(
                                 "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
                                 with `Access-Control-Allow-Methods: *` in policy",
                             );
                         }
-                    }
 
                     if policy.expose_headers.iter().any(|x| x == "*") {
                         return Err(

--- a/apollo-router/src/configuration/cors.rs
+++ b/apollo-router/src/configuration/cors.rs
@@ -299,12 +299,13 @@ impl Cors {
             }
 
             if let Some(headers) = &self.expose_headers
-                && headers.iter().any(|x| x == "*") {
-                    return Err(
-                        "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
+                && headers.iter().any(|x| x == "*")
+            {
+                return Err(
+                    "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
                         with `Access-Control-Expose-Headers: *`",
-                    );
-                }
+                );
+            }
         }
 
         // Check per-policy fields for wildcards when policy-level credentials are enabled
@@ -322,12 +323,13 @@ impl Cors {
                     }
 
                     if let Some(methods) = &policy.methods
-                        && methods.iter().any(|x| x == "*") {
-                            return Err(
-                                "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
+                        && methods.iter().any(|x| x == "*")
+                    {
+                        return Err(
+                            "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
                                 with `Access-Control-Allow-Methods: *` in policy",
-                            );
-                        }
+                        );
+                    }
 
                     if policy.expose_headers.iter().any(|x| x == "*") {
                         return Err(

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -64,9 +64,10 @@ impl InstrumentData {
         if let Ok(json_path) = JsonPathInst::from_str(path) {
             let value_at_path = json_path.find_slice(value).into_iter().next();
             if let Some(Value::Object(children)) = value_at_path.as_deref()
-                && let Some(first_key) = children.keys().next() {
-                    attributes.insert(attr_name.to_string(), first_key.clone().into());
-                }
+                && let Some(first_key) = children.keys().next()
+            {
+                attributes.insert(attr_name.to_string(), first_key.clone().into());
+            }
         }
     }
 

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -63,11 +63,10 @@ impl InstrumentData {
     ) {
         if let Ok(json_path) = JsonPathInst::from_str(path) {
             let value_at_path = json_path.find_slice(value).into_iter().next();
-            if let Some(Value::Object(children)) = value_at_path.as_deref() {
-                if let Some(first_key) = children.keys().next() {
+            if let Some(Value::Object(children)) = value_at_path.as_deref()
+                && let Some(first_key) = children.keys().next() {
                     attributes.insert(attr_name.to_string(), first_key.clone().into());
                 }
-            }
         }
     }
 

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -594,7 +594,7 @@ fn gen_schema(
                 .unwrap_or_default()
                 .into_iter()
                 // Wrap plugin name with regex start/end to enforce exact match
-                .map(|(k, v)| (format!("^{}$", k), v))
+                .map(|(k, v)| (format!("^{k}$"), v))
                 .collect(),
             ..Default::default()
         })),

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -126,7 +126,7 @@ pub(crate) fn validate_yaml_configuration(
         match result {
             Ok(schema) => schema,
             Err(e) => {
-                panic!("failed to compile configuration schema: {}", e)
+                panic!("failed to compile configuration schema: {e}")
             }
         }
     });

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -960,7 +960,7 @@ fn test_deserialize_derive_default() {
             if deserialize_regex.is_match(line) {
                 // Get the struct name
                 if let Some(struct_name) = find_struct_name(&lines, line_number) {
-                    let manual_implementation = format!("impl Default for {} ", struct_name);
+                    let manual_implementation = format!("impl Default for {struct_name} ");
 
                     let has_field_level_defaults =
                         has_field_level_serde_defaults(&lines, line_number);

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -84,7 +84,7 @@ pub(crate) fn upgrade_configuration(
         if let Some(migration) = Asset::get(&filename) {
             let parsed_migration = serde_yaml::from_slice(&migration.data).map_err(|error| {
                 ConfigurationError::MigrationFailure {
-                    error: format!("Failed to parse migration {}: {}", filename, error),
+                    error: format!("Failed to parse migration {filename}: {error}"),
                 }
             })?;
             migrations.push(parsed_migration);
@@ -207,12 +207,12 @@ fn apply_migration(config: &Value, migration: &Migration) -> Result<Value, Confi
 pub(crate) fn generate_upgrade(config: &str, diff: bool) -> Result<String, ConfigurationError> {
     let parsed_config =
         serde_yaml::from_str(config).map_err(|error| ConfigurationError::MigrationFailure {
-            error: format!("Failed to parse config: {}", error),
+            error: format!("Failed to parse config: {error}"),
         })?;
     let upgraded_config = upgrade_configuration(&parsed_config, true, UpgradeMode::Major)?;
     let upgraded_config = serde_yaml::to_string(&upgraded_config).map_err(|error| {
         ConfigurationError::MigrationFailure {
-            error: format!("Failed to serialize upgraded config: {}", error),
+            error: format!("Failed to serialize upgraded config: {error}"),
         }
     })?;
     generate_upgrade_output(config, &upgraded_config, diff)

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -523,7 +523,7 @@ impl std::fmt::Display for ParseErrors {
             if i > 0 {
                 f.write_str("\n")?;
             }
-            write!(f, "{}", error)?;
+            write!(f, "{error}")?;
         }
         let remaining = errors.count();
         if remaining > 0 {

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -447,7 +447,7 @@ impl Executable {
                 )?
                 .validate()?;
 
-                println!("Configuration at path {:?} is valid!", config_path);
+                println!("Configuration at path {config_path:?} is valid!");
 
                 Ok(())
             }

--- a/apollo-router/src/graphql/mod.rs
+++ b/apollo-router/src/graphql/mod.rs
@@ -160,13 +160,13 @@ impl Error {
 
     pub(crate) fn from_value(value: Value) -> Result<Error, MalformedResponseError> {
         let mut object = ensure_object!(value).map_err(|error| MalformedResponseError {
-            reason: format!("invalid error within `errors`: {}", error),
+            reason: format!("invalid error within `errors`: {error}"),
         })?;
 
         let extensions =
             extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
                 .map_err(|err| MalformedResponseError {
-                    reason: format!("invalid `extensions` within error: {}", err),
+                    reason: format!("invalid `extensions` within error: {err}"),
                 })?
                 .unwrap_or_default();
         let message = match extract_key_value_from_object!(object, "message", Value::String(s) => s)
@@ -176,7 +176,7 @@ impl Error {
                 reason: "missing required `message` property within error".to_owned(),
             }),
             Err(err) => Err(MalformedResponseError {
-                reason: format!("invalid `message` within error: {}", err),
+                reason: format!("invalid `message` within error: {err}"),
             }),
         }?;
         let locations = extract_key_value_from_object!(object, "locations")
@@ -184,14 +184,14 @@ impl Error {
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| MalformedResponseError {
-                reason: format!("invalid `locations` within error: {}", err),
+                reason: format!("invalid `locations` within error: {err}"),
             })?
             .unwrap_or_default();
         let path = extract_key_value_from_object!(object, "path")
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| MalformedResponseError {
-                reason: format!("invalid `path` within error: {}", err),
+                reason: format!("invalid `path` within error: {err}"),
             })?;
         let apollo_id: Option<Uuid> = extract_key_value_from_object!(
             object,
@@ -199,11 +199,11 @@ impl Error {
             Value::String(s) => s
         )
         .map_err(|err| MalformedResponseError {
-            reason: format!("invalid `apolloId` within error: {}", err),
+            reason: format!("invalid `apolloId` within error: {err}"),
         })?
         .map(|s| {
             Uuid::from_str(s.as_str()).map_err(|err| MalformedResponseError {
-                reason: format!("invalid `apolloId` within error: {}", err),
+                reason: format!("invalid `apolloId` within error: {err}"),
             })
         })
         .transpose()?;

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -101,9 +101,9 @@ impl IntrospectionCache {
         schema: &Arc<spec::Schema>,
         doc: &ParsedDocument,
     ) -> ControlFlow<Result<graphql::Response, ComputeBackPressureError>, ()> {
-        if doc.operation.selection_set.selections.len() == 1 {
-            if let Selection::Field(field) = &doc.operation.selection_set.selections[0] {
-                if field.name == "__typename" && field.directives.is_empty() {
+        if doc.operation.selection_set.selections.len() == 1
+            && let Selection::Field(field) = &doc.operation.selection_set.selections[0]
+                && field.name == "__typename" && field.directives.is_empty() {
                     // `{ alias: __typename }` is much less common so handling it here is not essential
                     // but easier than a conditional to reject it
                     let key = field.response_key().as_str();
@@ -115,8 +115,6 @@ impl IntrospectionCache {
                     let data = json!({key: object_type_name});
                     ControlFlow::Break(Ok(graphql::Response::builder().data(data).build()))?
                 }
-            }
-        }
         ControlFlow::Continue(())
     }
 

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -103,18 +103,20 @@ impl IntrospectionCache {
     ) -> ControlFlow<Result<graphql::Response, ComputeBackPressureError>, ()> {
         if doc.operation.selection_set.selections.len() == 1
             && let Selection::Field(field) = &doc.operation.selection_set.selections[0]
-                && field.name == "__typename" && field.directives.is_empty() {
-                    // `{ alias: __typename }` is much less common so handling it here is not essential
-                    // but easier than a conditional to reject it
-                    let key = field.response_key().as_str();
-                    let object_type_name = schema
-                        .api_schema()
-                        .root_operation(doc.operation.operation_type)
-                        .expect("validation should have caught undefined root operation")
-                        .as_str();
-                    let data = json!({key: object_type_name});
-                    ControlFlow::Break(Ok(graphql::Response::builder().data(data).build()))?
-                }
+            && field.name == "__typename"
+            && field.directives.is_empty()
+        {
+            // `{ alias: __typename }` is much less common so handling it here is not essential
+            // but easier than a conditional to reject it
+            let key = field.response_key().as_str();
+            let object_type_name = schema
+                .api_schema()
+                .root_operation(doc.operation.operation_type)
+                .expect("validation should have caught undefined root operation")
+                .as_str();
+            let data = json!({key: object_type_name});
+            ControlFlow::Break(Ok(graphql::Response::builder().data(data).build()))?
+        }
         ControlFlow::Continue(())
     }
 

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -876,7 +876,7 @@ where
     } else {
         "".to_string()
     };
-    let res = format!("@{}", tc_string);
+    let res = format!("@{tc_string}");
     serializer.serialize_str(res.as_str())
 }
 
@@ -920,7 +920,7 @@ where
     } else {
         "".to_string()
     };
-    let res = format!("{}{}", key, tc_string);
+    let res = format!("{key}{tc_string}");
     serializer.serialize_str(res.as_str())
 }
 
@@ -1060,7 +1060,7 @@ impl Path {
                 if let Some(c) = type_conditions {
                     tc = format!("|[{}]", c.join(","));
                 };
-                Some(format!("{}{}", key, tc))
+                Some(format!("{key}{tc}"))
             }
             _ => None,
         })

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -550,11 +550,10 @@ fn filter_type_conditions(value: Value, type_conditions: &Option<TypeConditions>
     if let Some(tc) = type_conditions {
         match value {
             Value::Object(ref o) => {
-                if let Some(Value::String(type_name)) = &o.get("__typename") {
-                    if !tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
+                if let Some(Value::String(type_name)) = &o.get("__typename")
+                    && !tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
                         return Value::Null;
                     }
-                }
             }
             Value::Array(v) => {
                 return Value::Array(
@@ -585,29 +584,24 @@ fn iterate_path<'a, F>(
                 for (i, value) in array.iter().enumerate() {
                     if let Some(tc) = type_conditions {
                         if !tc.is_empty() {
-                            if let Value::Object(o) = value {
-                                if let Some(Value::String(type_name)) = o.get("__typename") {
-                                    if tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
+                            if let Value::Object(o) = value
+                                && let Some(Value::String(type_name)) = o.get("__typename")
+                                    && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
                                         parent.push(PathElement::Index(i));
                                         iterate_path(schema, parent, &path[1..], value, f);
                                         parent.pop();
                                     }
-                                }
-                            }
 
                             if let Value::Array(array) = value {
                                 for (i, value) in array.iter().enumerate() {
-                                    if let Value::Object(o) = value {
-                                        if let Some(Value::String(type_name)) = o.get("__typename")
-                                        {
-                                            if tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                                    if let Value::Object(o) = value
+                                        && let Some(Value::String(type_name)) = o.get("__typename")
+                                            && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
                                             {
                                                 parent.push(PathElement::Index(i));
                                                 iterate_path(schema, parent, &path[1..], value, f);
                                                 parent.pop();
                                             }
-                                        }
-                                    }
                                 }
                             }
                         }
@@ -620,38 +614,33 @@ fn iterate_path<'a, F>(
             }
         }
         Some(PathElement::Index(i)) => {
-            if let Value::Array(a) = data {
-                if let Some(value) = a.get(*i) {
+            if let Value::Array(a) = data
+                && let Some(value) = a.get(*i) {
                     parent.push(PathElement::Index(*i));
                     iterate_path(schema, parent, &path[1..], value, f);
                     parent.pop();
                 }
-            }
         }
         Some(PathElement::Key(k, type_conditions)) => {
             if let Some(tc) = type_conditions {
                 if !tc.is_empty() {
                     if let Value::Object(o) = data {
-                        if let Some(value) = o.get(k.as_str()) {
-                            if let Some(Value::String(type_name)) = value.get("__typename") {
-                                if tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
+                        if let Some(value) = o.get(k.as_str())
+                            && let Some(Value::String(type_name)) = value.get("__typename")
+                                && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
                                     parent.push(PathElement::Key(k.to_string(), None));
                                     iterate_path(schema, parent, &path[1..], value, f);
                                     parent.pop();
                                 }
-                            }
-                        }
                     } else if let Value::Array(array) = data {
                         for (i, value) in array.iter().enumerate() {
-                            if let Value::Object(o) = value {
-                                if let Some(Value::String(type_name)) = o.get("__typename") {
-                                    if tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
+                            if let Value::Object(o) = value
+                                && let Some(Value::String(type_name)) = o.get("__typename")
+                                    && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
                                         parent.push(PathElement::Index(i));
                                         iterate_path(schema, parent, path, value, f);
                                         parent.pop();
                                     }
-                                }
-                            }
                         }
                     }
                 }
@@ -703,17 +692,14 @@ fn iterate_path_mut<'a, F>(
             if let Some(array) = data.as_array_mut() {
                 for (i, value) in array.iter_mut().enumerate() {
                     if let Some(tc) = type_conditions {
-                        if !tc.is_empty() {
-                            if let Value::Object(o) = value {
-                                if let Some(Value::String(type_name)) = o.get("__typename") {
-                                    if tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
+                        if !tc.is_empty()
+                            && let Value::Object(o) = value
+                                && let Some(Value::String(type_name)) = o.get("__typename")
+                                    && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
                                         parent.push(PathElement::Index(i));
                                         iterate_path_mut(schema, parent, &path[1..], value, f);
                                         parent.pop();
                                     }
-                                }
-                            }
-                        }
                     } else {
                         parent.push(PathElement::Index(i));
                         iterate_path_mut(schema, parent, &path[1..], value, f);
@@ -723,38 +709,33 @@ fn iterate_path_mut<'a, F>(
             }
         }
         Some(PathElement::Index(i)) => {
-            if let Value::Array(a) = data {
-                if let Some(value) = a.get_mut(*i) {
+            if let Value::Array(a) = data
+                && let Some(value) = a.get_mut(*i) {
                     parent.push(PathElement::Index(*i));
                     iterate_path_mut(schema, parent, &path[1..], value, f);
                     parent.pop();
                 }
-            }
         }
         Some(PathElement::Key(k, type_conditions)) => {
             if let Some(tc) = type_conditions {
                 if !tc.is_empty() {
                     if let Value::Object(o) = data {
-                        if let Some(value) = o.get_mut(k.as_str()) {
-                            if let Some(Value::String(type_name)) = value.get("__typename") {
-                                if tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
+                        if let Some(value) = o.get_mut(k.as_str())
+                            && let Some(Value::String(type_name)) = value.get("__typename")
+                                && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
                                     parent.push(PathElement::Key(k.to_string(), None));
                                     iterate_path_mut(schema, parent, &path[1..], value, f);
                                     parent.pop();
                                 }
-                            }
-                        }
                     } else if let Value::Array(array) = data {
                         for (i, value) in array.iter_mut().enumerate() {
-                            if let Value::Object(o) = value {
-                                if let Some(Value::String(type_name)) = o.get("__typename") {
-                                    if tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
+                            if let Value::Object(o) = value
+                                && let Some(Value::String(type_name)) = o.get("__typename")
+                                    && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
                                         parent.push(PathElement::Index(i));
                                         iterate_path_mut(schema, parent, path, value, f);
                                         parent.pop();
                                     }
-                                }
-                            }
                         }
                     }
                 }
@@ -1072,11 +1053,10 @@ impl Path {
 
     // Removes the empty key if at root (used for TypedConditions)
     pub fn remove_empty_key_root(&self) -> Self {
-        if let Some(PathElement::Key(k, type_conditions)) = self.0.first() {
-            if k.is_empty() && type_conditions.is_none() {
+        if let Some(PathElement::Key(k, type_conditions)) = self.0.first()
+            && k.is_empty() && type_conditions.is_none() {
                 return Path(self.iter().skip(1).cloned().collect());
             }
-        }
 
         self.clone()
     }

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -551,9 +551,10 @@ fn filter_type_conditions(value: Value, type_conditions: &Option<TypeConditions>
         match value {
             Value::Object(ref o) => {
                 if let Some(Value::String(type_name)) = &o.get("__typename")
-                    && !tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
-                        return Value::Null;
-                    }
+                    && !tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                {
+                    return Value::Null;
+                }
             }
             Value::Array(v) => {
                 return Value::Array(
@@ -586,22 +587,23 @@ fn iterate_path<'a, F>(
                         if !tc.is_empty() {
                             if let Value::Object(o) = value
                                 && let Some(Value::String(type_name)) = o.get("__typename")
-                                    && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
-                                        parent.push(PathElement::Index(i));
-                                        iterate_path(schema, parent, &path[1..], value, f);
-                                        parent.pop();
-                                    }
+                                && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                            {
+                                parent.push(PathElement::Index(i));
+                                iterate_path(schema, parent, &path[1..], value, f);
+                                parent.pop();
+                            }
 
                             if let Value::Array(array) = value {
                                 for (i, value) in array.iter().enumerate() {
                                     if let Value::Object(o) = value
                                         && let Some(Value::String(type_name)) = o.get("__typename")
-                                            && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
-                                            {
-                                                parent.push(PathElement::Index(i));
-                                                iterate_path(schema, parent, &path[1..], value, f);
-                                                parent.pop();
-                                            }
+                                        && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                                    {
+                                        parent.push(PathElement::Index(i));
+                                        iterate_path(schema, parent, &path[1..], value, f);
+                                        parent.pop();
+                                    }
                                 }
                             }
                         }
@@ -615,11 +617,12 @@ fn iterate_path<'a, F>(
         }
         Some(PathElement::Index(i)) => {
             if let Value::Array(a) = data
-                && let Some(value) = a.get(*i) {
-                    parent.push(PathElement::Index(*i));
-                    iterate_path(schema, parent, &path[1..], value, f);
-                    parent.pop();
-                }
+                && let Some(value) = a.get(*i)
+            {
+                parent.push(PathElement::Index(*i));
+                iterate_path(schema, parent, &path[1..], value, f);
+                parent.pop();
+            }
         }
         Some(PathElement::Key(k, type_conditions)) => {
             if let Some(tc) = type_conditions {
@@ -627,20 +630,22 @@ fn iterate_path<'a, F>(
                     if let Value::Object(o) = data {
                         if let Some(value) = o.get(k.as_str())
                             && let Some(Value::String(type_name)) = value.get("__typename")
-                                && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
-                                    parent.push(PathElement::Key(k.to_string(), None));
-                                    iterate_path(schema, parent, &path[1..], value, f);
-                                    parent.pop();
-                                }
+                            && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                        {
+                            parent.push(PathElement::Key(k.to_string(), None));
+                            iterate_path(schema, parent, &path[1..], value, f);
+                            parent.pop();
+                        }
                     } else if let Value::Array(array) = data {
                         for (i, value) in array.iter().enumerate() {
                             if let Value::Object(o) = value
                                 && let Some(Value::String(type_name)) = o.get("__typename")
-                                    && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
-                                        parent.push(PathElement::Index(i));
-                                        iterate_path(schema, parent, path, value, f);
-                                        parent.pop();
-                                    }
+                                && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                            {
+                                parent.push(PathElement::Index(i));
+                                iterate_path(schema, parent, path, value, f);
+                                parent.pop();
+                            }
                         }
                     }
                 }
@@ -694,12 +699,13 @@ fn iterate_path_mut<'a, F>(
                     if let Some(tc) = type_conditions {
                         if !tc.is_empty()
                             && let Value::Object(o) = value
-                                && let Some(Value::String(type_name)) = o.get("__typename")
-                                    && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
-                                        parent.push(PathElement::Index(i));
-                                        iterate_path_mut(schema, parent, &path[1..], value, f);
-                                        parent.pop();
-                                    }
+                            && let Some(Value::String(type_name)) = o.get("__typename")
+                            && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                        {
+                            parent.push(PathElement::Index(i));
+                            iterate_path_mut(schema, parent, &path[1..], value, f);
+                            parent.pop();
+                        }
                     } else {
                         parent.push(PathElement::Index(i));
                         iterate_path_mut(schema, parent, &path[1..], value, f);
@@ -710,11 +716,12 @@ fn iterate_path_mut<'a, F>(
         }
         Some(PathElement::Index(i)) => {
             if let Value::Array(a) = data
-                && let Some(value) = a.get_mut(*i) {
-                    parent.push(PathElement::Index(*i));
-                    iterate_path_mut(schema, parent, &path[1..], value, f);
-                    parent.pop();
-                }
+                && let Some(value) = a.get_mut(*i)
+            {
+                parent.push(PathElement::Index(*i));
+                iterate_path_mut(schema, parent, &path[1..], value, f);
+                parent.pop();
+            }
         }
         Some(PathElement::Key(k, type_conditions)) => {
             if let Some(tc) = type_conditions {
@@ -722,20 +729,22 @@ fn iterate_path_mut<'a, F>(
                     if let Value::Object(o) = data {
                         if let Some(value) = o.get_mut(k.as_str())
                             && let Some(Value::String(type_name)) = value.get("__typename")
-                                && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
-                                    parent.push(PathElement::Key(k.to_string(), None));
-                                    iterate_path_mut(schema, parent, &path[1..], value, f);
-                                    parent.pop();
-                                }
+                            && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                        {
+                            parent.push(PathElement::Key(k.to_string(), None));
+                            iterate_path_mut(schema, parent, &path[1..], value, f);
+                            parent.pop();
+                        }
                     } else if let Value::Array(array) = data {
                         for (i, value) in array.iter_mut().enumerate() {
                             if let Value::Object(o) = value
                                 && let Some(Value::String(type_name)) = o.get("__typename")
-                                    && tc.iter().any(|tc| tc.as_str() == type_name.as_str()) {
-                                        parent.push(PathElement::Index(i));
-                                        iterate_path_mut(schema, parent, path, value, f);
-                                        parent.pop();
-                                    }
+                                && tc.iter().any(|tc| tc.as_str() == type_name.as_str())
+                            {
+                                parent.push(PathElement::Index(i));
+                                iterate_path_mut(schema, parent, path, value, f);
+                                parent.pop();
+                            }
                         }
                     }
                 }
@@ -1054,9 +1063,11 @@ impl Path {
     // Removes the empty key if at root (used for TypedConditions)
     pub fn remove_empty_key_root(&self) -> Self {
         if let Some(PathElement::Key(k, type_conditions)) = self.0.first()
-            && k.is_empty() && type_conditions.is_none() {
-                return Path(self.iter().skip(1).cloned().collect());
-            }
+            && k.is_empty()
+            && type_conditions.is_none()
+        {
+            return Path(self.iter().skip(1).cloned().collect());
+        }
 
         self.clone()
     }

--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -240,23 +240,20 @@ pub(crate) mod test_utils {
             attributes: &[KeyValue],
         ) -> bool {
             let attributes = AttributeSet::from(attributes);
-            if let Some(value) = value.to_u64() {
-                if self.metric_matches(name, &ty, value, count, &attributes) {
+            if let Some(value) = value.to_u64()
+                && self.metric_matches(name, &ty, value, count, &attributes) {
                     return true;
                 }
-            }
 
-            if let Some(value) = value.to_i64() {
-                if self.metric_matches(name, &ty, value, count, &attributes) {
+            if let Some(value) = value.to_i64()
+                && self.metric_matches(name, &ty, value, count, &attributes) {
                     return true;
                 }
-            }
 
-            if let Some(value) = value.to_f64() {
-                if self.metric_matches(name, &ty, value, count, &attributes) {
+            if let Some(value) = value.to_f64()
+                && self.metric_matches(name, &ty, value, count, &attributes) {
                     return true;
                 }
-            }
 
             false
         }
@@ -288,8 +285,7 @@ pub(crate) mod test_utils {
                         });
                     }
                 } else if let Some(histogram) = metric.data.as_any().downcast_ref::<Histogram<T>>()
-                {
-                    if matches!(ty, MetricType::Histogram) {
+                    && matches!(ty, MetricType::Histogram) {
                         if count {
                             return histogram.data_points.iter().any(|datapoint| {
                                 datapoint.count == value.to_u64().unwrap()
@@ -302,7 +298,6 @@ pub(crate) mod test_utils {
                             });
                         }
                     }
-                }
             }
             false
         }
@@ -331,13 +326,11 @@ pub(crate) mod test_utils {
                         });
                     }
                 } else if let Some(histogram) = metric.data.as_any().downcast_ref::<Histogram<T>>()
-                {
-                    if matches!(ty, MetricType::Histogram) {
+                    && matches!(ty, MetricType::Histogram) {
                         return histogram.data_points.iter().any(|datapoint| {
                             Self::equal_attributes(&attributes, &datapoint.attributes)
                         });
                     }
-                }
             }
             false
         }
@@ -485,11 +478,10 @@ pub(crate) mod test_utils {
                     .datapoints
                     .iter_mut()
                     .for_each(|datapoint| {
-                        if let Some(sum) = &datapoint.sum {
-                            if sum.as_f64().unwrap_or_default() > 0.0 {
+                        if let Some(sum) = &datapoint.sum
+                            && sum.as_f64().unwrap_or_default() > 0.0 {
                                 datapoint.sum = Some(0.1.into());
                             }
-                        }
                     });
             }
             serde_metric

--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -241,19 +241,22 @@ pub(crate) mod test_utils {
         ) -> bool {
             let attributes = AttributeSet::from(attributes);
             if let Some(value) = value.to_u64()
-                && self.metric_matches(name, &ty, value, count, &attributes) {
-                    return true;
-                }
+                && self.metric_matches(name, &ty, value, count, &attributes)
+            {
+                return true;
+            }
 
             if let Some(value) = value.to_i64()
-                && self.metric_matches(name, &ty, value, count, &attributes) {
-                    return true;
-                }
+                && self.metric_matches(name, &ty, value, count, &attributes)
+            {
+                return true;
+            }
 
             if let Some(value) = value.to_f64()
-                && self.metric_matches(name, &ty, value, count, &attributes) {
-                    return true;
-                }
+                && self.metric_matches(name, &ty, value, count, &attributes)
+            {
+                return true;
+            }
 
             false
         }
@@ -285,19 +288,20 @@ pub(crate) mod test_utils {
                         });
                     }
                 } else if let Some(histogram) = metric.data.as_any().downcast_ref::<Histogram<T>>()
-                    && matches!(ty, MetricType::Histogram) {
-                        if count {
-                            return histogram.data_points.iter().any(|datapoint| {
-                                datapoint.count == value.to_u64().unwrap()
-                                    && Self::equal_attributes(attributes, &datapoint.attributes)
-                            });
-                        } else {
-                            return histogram.data_points.iter().any(|datapoint| {
-                                datapoint.sum == value
-                                    && Self::equal_attributes(attributes, &datapoint.attributes)
-                            });
-                        }
+                    && matches!(ty, MetricType::Histogram)
+                {
+                    if count {
+                        return histogram.data_points.iter().any(|datapoint| {
+                            datapoint.count == value.to_u64().unwrap()
+                                && Self::equal_attributes(attributes, &datapoint.attributes)
+                        });
+                    } else {
+                        return histogram.data_points.iter().any(|datapoint| {
+                            datapoint.sum == value
+                                && Self::equal_attributes(attributes, &datapoint.attributes)
+                        });
                     }
+                }
             }
             false
         }
@@ -326,11 +330,12 @@ pub(crate) mod test_utils {
                         });
                     }
                 } else if let Some(histogram) = metric.data.as_any().downcast_ref::<Histogram<T>>()
-                    && matches!(ty, MetricType::Histogram) {
-                        return histogram.data_points.iter().any(|datapoint| {
-                            Self::equal_attributes(&attributes, &datapoint.attributes)
-                        });
-                    }
+                    && matches!(ty, MetricType::Histogram)
+                {
+                    return histogram.data_points.iter().any(|datapoint| {
+                        Self::equal_attributes(&attributes, &datapoint.attributes)
+                    });
+                }
             }
             false
         }
@@ -479,9 +484,10 @@ pub(crate) mod test_utils {
                     .iter_mut()
                     .for_each(|datapoint| {
                         if let Some(sum) = &datapoint.sum
-                            && sum.as_f64().unwrap_or_default() > 0.0 {
-                                datapoint.sum = Some(0.1.into());
-                            }
+                            && sum.as_f64().unwrap_or_default() > 0.0
+                        {
+                            datapoint.sum = Some(0.1.into());
+                        }
                     });
             }
             serde_metric

--- a/apollo-router/src/notification.rs
+++ b/apollo-router/src/notification.rs
@@ -925,11 +925,10 @@ where
 
     #[cfg(test)]
     fn try_delete(&mut self, topic: K) {
-        if let Some(sub) = self.subscriptions.get(&topic) {
-            if sub.msg_sender.receiver_count() > 1 {
+        if let Some(sub) = self.subscriptions.get(&topic)
+            && sub.msg_sender.receiver_count() > 1 {
                 return;
             }
-        }
 
         self.force_delete(topic);
     }

--- a/apollo-router/src/notification.rs
+++ b/apollo-router/src/notification.rs
@@ -926,9 +926,10 @@ where
     #[cfg(test)]
     fn try_delete(&mut self, topic: K) {
         if let Some(sub) = self.subscriptions.get(&topic)
-            && sub.msg_sender.receiver_count() > 1 {
-                return;
-            }
+            && sub.msg_sender.receiver_count() > 1
+        {
+            return;
+        }
 
         self.force_delete(topic);
     }

--- a/apollo-router/src/otel_compat.rs
+++ b/apollo-router/src/otel_compat.rs
@@ -29,10 +29,9 @@ pub struct HeaderInjector<'a>(pub &'a mut http::HeaderMap);
 impl opentelemetry::propagation::Injector for HeaderInjector<'_> {
     /// Set a key and value in the HeaderMap.  Does nothing if the key or value are not valid inputs.
     fn set(&mut self, key: &str, value: String) {
-        if let Ok(name) = http::header::HeaderName::from_bytes(key.as_bytes()) {
-            if let Ok(val) = http::header::HeaderValue::from_str(&value) {
+        if let Ok(name) = http::header::HeaderName::from_bytes(key.as_bytes())
+            && let Ok(val) = http::header::HeaderValue::from_str(&value) {
                 self.0.insert(name, val);
             }
-        }
     }
 }

--- a/apollo-router/src/otel_compat.rs
+++ b/apollo-router/src/otel_compat.rs
@@ -30,8 +30,9 @@ impl opentelemetry::propagation::Injector for HeaderInjector<'_> {
     /// Set a key and value in the HeaderMap.  Does nothing if the key or value are not valid inputs.
     fn set(&mut self, key: &str, value: String) {
         if let Ok(name) = http::header::HeaderName::from_bytes(key.as_bytes())
-            && let Ok(val) = http::header::HeaderValue::from_str(&value) {
-                self.0.insert(name, val);
-            }
+            && let Ok(val) = http::header::HeaderValue::from_str(&value)
+        {
+            self.0.insert(name, val);
+        }
     }
 }

--- a/apollo-router/src/plugins/authentication/connector.rs
+++ b/apollo-router/src/plugins/authentication/connector.rs
@@ -23,8 +23,8 @@ impl ConnectorAuth {
         let signing_params = self.signing_params.clone();
         ServiceBuilder::new()
             .map_request(move |req: connector::request_service::Request| {
-                if let Some(ref source_name) = req.connector.id.source_name {
-                    if let Some(signing_params) = signing_params
+                if let Some(ref source_name) = req.connector.id.source_name
+                    && let Some(signing_params) = signing_params
                         .get(&ConnectorSourceRef::new(
                             req.connector.id.subgraph_name.clone(),
                             source_name.clone(),
@@ -35,7 +35,6 @@ impl ConnectorAuth {
                             .extensions()
                             .with_lock(|lock| lock.insert(signing_params));
                     }
-                }
                 req
             })
             .service(service)

--- a/apollo-router/src/plugins/authentication/connector.rs
+++ b/apollo-router/src/plugins/authentication/connector.rs
@@ -30,11 +30,11 @@ impl ConnectorAuth {
                             source_name.clone(),
                         ))
                         .cloned()
-                    {
-                        req.context
-                            .extensions()
-                            .with_lock(|lock| lock.insert(signing_params));
-                    }
+                {
+                    req.context
+                        .extensions()
+                        .with_lock(|lock| lock.insert(signing_params));
+                }
                 req
             })
             .service(service)

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -111,7 +111,7 @@ impl JwksManager {
         }
     }
 
-    pub(super) fn iter_jwks(&self) -> Iter {
+    pub(super) fn iter_jwks(&self) -> Iter<'_> {
         Iter {
             list: self.list.clone(),
             manager: self,

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -308,9 +308,10 @@ pub(super) fn search_jwks(
     {
         // filter accepted algorithms
         if let Some(algs) = algorithms
-            && !algs.contains(&criteria.alg) {
-                continue;
-            }
+            && !algs.contains(&criteria.alg)
+        {
+            continue;
+        }
 
         // Try to figure out if our jwks contains a candidate key (i.e.: a key which matches our
         // criteria)
@@ -540,9 +541,10 @@ pub(super) fn extract_jwt<'a, 'b: 'a>(
                         Err(_) => continue,
                         Ok(cookie) => {
                             if cookie.name() == name
-                                && let Some(value) = cookie.value_raw() {
-                                    return Some(Ok(value));
-                                }
+                                && let Some(value) = cookie.value_raw()
+                            {
+                                return Some(Ok(value));
+                            }
                         }
                     }
                 }

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -307,11 +307,10 @@ pub(super) fn search_jwks(
     } in jwks_manager.iter_jwks()
     {
         // filter accepted algorithms
-        if let Some(algs) = algorithms {
-            if !algs.contains(&criteria.alg) {
+        if let Some(algs) = algorithms
+            && !algs.contains(&criteria.alg) {
                 continue;
             }
-        }
 
         // Try to figure out if our jwks contains a candidate key (i.e.: a key which matches our
         // criteria)
@@ -540,11 +539,10 @@ pub(super) fn extract_jwt<'a, 'b: 'a>(
                     match cookie {
                         Err(_) => continue,
                         Ok(cookie) => {
-                            if cookie.name() == name {
-                                if let Some(value) = cookie.value_raw() {
+                            if cookie.name() == name
+                                && let Some(value) = cookie.value_raw() {
                                     return Some(Ok(value));
                                 }
-                            }
                         }
                     }
                 }

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -322,9 +322,10 @@ impl AuthenticationPlugin {
 
         for source in &router_conf.jwt.sources {
             if let Source::Header { value_prefix, .. } = source
-                && value_prefix.as_bytes().iter().any(u8::is_ascii_whitespace) {
-                    return Err(Error::BadHeaderValuePrefix.into());
-                }
+                && value_prefix.as_bytes().iter().any(u8::is_ascii_whitespace)
+            {
+                return Err(Error::BadHeaderValuePrefix.into());
+            }
         }
 
         router_conf.jwt.sources.insert(
@@ -572,25 +573,25 @@ fn authenticate(
                 .as_object()
                 .and_then(|o| o.get("iss"))
                 .and_then(|value| value.as_str())
-                && !configured_issuers.contains(token_issuer) {
-                    let mut issuers_for_error: Vec<String> =
-                        configured_issuers.into_iter().collect();
-                    issuers_for_error.sort(); // done to maintain consistent ordering in error message
-                    return failure_message(
-                        request,
-                        config,
-                        AuthenticationError::InvalidIssuer {
-                            expected: issuers_for_error
-                                .iter()
-                                .map(|issuer| issuer.to_string())
-                                .collect::<Vec<_>>()
-                                .join(", "),
-                            token: token_issuer.to_string(),
-                        },
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        source_of_extracted_jwt,
-                    );
-                }
+            && !configured_issuers.contains(token_issuer)
+        {
+            let mut issuers_for_error: Vec<String> = configured_issuers.into_iter().collect();
+            issuers_for_error.sort(); // done to maintain consistent ordering in error message
+            return failure_message(
+                request,
+                config,
+                AuthenticationError::InvalidIssuer {
+                    expected: issuers_for_error
+                        .iter()
+                        .map(|issuer| issuer.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    token: token_issuer.to_string(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+                source_of_extracted_jwt,
+            );
+        }
 
         if let Some(configured_audiences) = audiences {
             let maybe_token_audiences = token_data.claims.as_object().and_then(|o| o.get("aud"));

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -321,11 +321,10 @@ impl AuthenticationPlugin {
         }
 
         for source in &router_conf.jwt.sources {
-            if let Source::Header { value_prefix, .. } = source {
-                if value_prefix.as_bytes().iter().any(u8::is_ascii_whitespace) {
+            if let Source::Header { value_prefix, .. } = source
+                && value_prefix.as_bytes().iter().any(u8::is_ascii_whitespace) {
                     return Err(Error::BadHeaderValuePrefix.into());
                 }
-            }
         }
 
         router_conf.jwt.sources.insert(
@@ -567,14 +566,13 @@ fn authenticate(
             }
         };
 
-        if let Some(configured_issuers) = issuers {
-            if let Some(token_issuer) = token_data
+        if let Some(configured_issuers) = issuers
+            && let Some(token_issuer) = token_data
                 .claims
                 .as_object()
                 .and_then(|o| o.get("iss"))
                 .and_then(|value| value.as_str())
-            {
-                if !configured_issuers.contains(token_issuer) {
+                && !configured_issuers.contains(token_issuer) {
                     let mut issuers_for_error: Vec<String> =
                         configured_issuers.into_iter().collect();
                     issuers_for_error.sort(); // done to maintain consistent ordering in error message
@@ -593,8 +591,6 @@ fn authenticate(
                         source_of_extracted_jwt,
                     );
                 }
-            }
-        }
 
         if let Some(configured_audiences) = audiences {
             let maybe_token_audiences = token_data.claims.as_object().and_then(|o| o.get("aud"));

--- a/apollo-router/src/plugins/authentication/subgraph.rs
+++ b/apollo-router/src/plugins/authentication/subgraph.rs
@@ -355,7 +355,7 @@ impl SigningParamsConfig {
         let (signing_instructions, _signature) = sign(signable_request, &signing_params.into())
             .map_err(|err| {
                 increment_failure_counter(subgraph_name);
-                let error = format!("failed to sign GraphQL body for AWS SigV4: {}", err);
+                let error = format!("failed to sign GraphQL body for AWS SigV4: {err}");
                 tracing::error!("{}", error);
                 error
             })?
@@ -394,7 +394,7 @@ impl SigningParamsConfig {
         let (signing_instructions, _signature) = sign(signable_request, &signing_params.into())
             .map_err(|err| {
                 increment_failure_counter(subgraph_name);
-                let error = format!("failed to sign GraphQL body for AWS SigV4: {}", err);
+                let error = format!("failed to sign GraphQL body for AWS SigV4: {err}");
                 tracing::error!("{}", error);
                 error
             })?
@@ -425,7 +425,7 @@ impl SigningParamsConfig {
             .await
             .map_err(|err| {
                 increment_failure_counter(self.subgraph_name.as_str());
-                let error = format!("failed to get credentials for AWS SigV4 signing: {}", err);
+                let error = format!("failed to get credentials for AWS SigV4 signing: {err}");
                 tracing::error!("{}", error);
                 error.into()
             })

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -168,7 +168,7 @@ async fn build_a_test_harness(
         .await
     {
         Ok(test_harness) => test_harness,
-        Err(e) => panic!("Failed to build test harness: {}", e),
+        Err(e) => panic!("Failed to build test harness: {e}"),
     }
 }
 
@@ -692,7 +692,7 @@ async fn it_inserts_success_jwt_status_into_context() {
             assert_eq!(r#type, "header");
             assert!(name.eq_ignore_ascii_case("Authorization"));
         }
-        JwtStatus::Failure { .. } => panic!("expected a success but got {:?}", jwt_context),
+        JwtStatus::Failure { .. } => panic!("expected a success but got {jwt_context:?}"),
     }
 
     let response: graphql::Response = serde_json::from_slice(
@@ -1742,7 +1742,7 @@ async fn jwks_send_headers() {
     let got_header = Arc::new(AtomicBool::new(false));
     let gh = got_header.clone();
     let service = move |headers: HeaderMap| {
-        println!("got re: {:?}", headers);
+        println!("got re: {headers:?}");
         let gh: Arc<AtomicBool> = gh.clone();
         async move {
             if headers.get("jwks-authz").and_then(|v| v.to_str().ok()) == Some("user1") {

--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -160,10 +160,10 @@ impl traverse::Visitor for AuthenticatedCheckVisitor<'_> {
                 .types
                 .get(name)
                 .is_some_and(|type_definition| self.is_type_authenticated(type_definition))
-            {
-                self.found = true;
-                return Ok(());
-            }
+        {
+            self.found = true;
+            return Ok(());
+        }
 
         traverse::inline_fragment(self, parent_type, node)
     }
@@ -253,9 +253,10 @@ impl<'a> AuthenticatedVisitor<'a> {
 
         let type_name = field_def.ty.inner_named_type();
         if let Some(type_definition) = self.schema.types.get(type_name)
-            && self.implementors_with_different_type_requirements(type_name, type_definition) {
-                return true;
-            }
+            && self.implementors_with_different_type_requirements(type_name, type_definition)
+        {
+            return true;
+        }
         false
     }
 
@@ -292,26 +293,27 @@ impl<'a> AuthenticatedVisitor<'a> {
         field: &ast::Field,
     ) -> bool {
         if let Some(t) = self.schema.types.get(parent_type)
-            && t.is_interface() {
-                let mut is_authenticated: Option<bool> = None;
+            && t.is_interface()
+        {
+            let mut is_authenticated: Option<bool> = None;
 
-                for ty in self.implementors(parent_type) {
-                    if let Ok(f) = self.schema.type_field(ty, &field.name) {
-                        let field_is_authenticated =
-                            f.directives.has(&self.authenticated_directive_name);
-                        match is_authenticated {
-                            Some(other) => {
-                                if field_is_authenticated != other {
-                                    return true;
-                                }
+            for ty in self.implementors(parent_type) {
+                if let Ok(f) = self.schema.type_field(ty, &field.name) {
+                    let field_is_authenticated =
+                        f.directives.has(&self.authenticated_directive_name);
+                    match is_authenticated {
+                        Some(other) => {
+                            if field_is_authenticated != other {
+                                return true;
                             }
-                            _ => {
-                                is_authenticated = Some(field_is_authenticated);
-                            }
+                        }
+                        _ => {
+                            is_authenticated = Some(field_is_authenticated);
                         }
                     }
                 }
             }
+        }
         false
     }
 }

--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -154,8 +154,8 @@ impl traverse::Visitor for AuthenticatedCheckVisitor<'_> {
         parent_type: &str,
         node: &executable::InlineFragment,
     ) -> Result<(), BoxError> {
-        if let Some(name) = &node.type_condition {
-            if self
+        if let Some(name) = &node.type_condition
+            && self
                 .schema
                 .types
                 .get(name)
@@ -164,7 +164,6 @@ impl traverse::Visitor for AuthenticatedCheckVisitor<'_> {
                 self.found = true;
                 return Ok(());
             }
-        }
 
         traverse::inline_fragment(self, parent_type, node)
     }
@@ -253,11 +252,10 @@ impl<'a> AuthenticatedVisitor<'a> {
         }
 
         let type_name = field_def.ty.inner_named_type();
-        if let Some(type_definition) = self.schema.types.get(type_name) {
-            if self.implementors_with_different_type_requirements(type_name, type_definition) {
+        if let Some(type_definition) = self.schema.types.get(type_name)
+            && self.implementors_with_different_type_requirements(type_name, type_definition) {
                 return true;
             }
-        }
         false
     }
 
@@ -293,8 +291,8 @@ impl<'a> AuthenticatedVisitor<'a> {
         parent_type: &str,
         field: &ast::Field,
     ) -> bool {
-        if let Some(t) = self.schema.types.get(parent_type) {
-            if t.is_interface() {
+        if let Some(t) = self.schema.types.get(parent_type)
+            && t.is_interface() {
                 let mut is_authenticated: Option<bool> = None;
 
                 for ty in self.implementors(parent_type) {
@@ -314,7 +312,6 @@ impl<'a> AuthenticatedVisitor<'a> {
                     }
                 }
             }
-        }
         false
     }
 }

--- a/apollo-router/src/plugins/authorization/policy.rs
+++ b/apollo-router/src/plugins/authorization/policy.rs
@@ -174,9 +174,10 @@ impl traverse::Visitor for PolicyExtractionVisitor<'_> {
         node: &executable::InlineFragment,
     ) -> Result<(), BoxError> {
         if let Some(type_condition) = &node.type_condition
-            && let Some(ty) = self.schema.types.get(type_condition) {
-                self.get_policies_from_type(ty);
-            }
+            && let Some(ty) = self.schema.types.get(type_condition)
+        {
+            self.get_policies_from_type(ty);
+        }
         traverse::inline_fragment(self, parent_type, node)
     }
 
@@ -318,9 +319,10 @@ impl<'a> PolicyFilteringVisitor<'a> {
 
         let type_name = field_def.ty.inner_named_type();
         if let Some(type_definition) = self.schema.types.get(type_name)
-            && self.implementors_with_different_type_requirements(type_name, type_definition) {
-                return true;
-            }
+            && self.implementors_with_different_type_requirements(type_name, type_definition)
+        {
+            return true;
+        }
         false
     }
 
@@ -375,41 +377,42 @@ impl<'a> PolicyFilteringVisitor<'a> {
         field: &ast::Field,
     ) -> bool {
         if let Some(t) = self.schema.types.get(parent_type)
-            && t.is_interface() {
-                let mut policies_sets: Option<Vec<Vec<String>>> = None;
+            && t.is_interface()
+        {
+            let mut policies_sets: Option<Vec<Vec<String>>> = None;
 
-                for ty in self.implementors(parent_type) {
-                    if let Ok(f) = self.schema.type_field(ty, &field.name) {
-                        // aggregate the list of policies sets
-                        // we transform to a common representation of sorted vectors because the element order
-                        // of hashsets is not stable
-                        let field_policies = f
-                            .directives
-                            .get(&self.policy_directive_name)
-                            .map(|directive| {
-                                let mut v = policies_sets_argument(directive)
-                                    .map(|h| {
-                                        let mut v = h.into_iter().collect::<Vec<_>>();
-                                        v.sort();
-                                        v
-                                    })
-                                    .collect::<Vec<_>>();
-                                v.sort();
-                                v
-                            })
-                            .unwrap_or_default();
+            for ty in self.implementors(parent_type) {
+                if let Ok(f) = self.schema.type_field(ty, &field.name) {
+                    // aggregate the list of policies sets
+                    // we transform to a common representation of sorted vectors because the element order
+                    // of hashsets is not stable
+                    let field_policies = f
+                        .directives
+                        .get(&self.policy_directive_name)
+                        .map(|directive| {
+                            let mut v = policies_sets_argument(directive)
+                                .map(|h| {
+                                    let mut v = h.into_iter().collect::<Vec<_>>();
+                                    v.sort();
+                                    v
+                                })
+                                .collect::<Vec<_>>();
+                            v.sort();
+                            v
+                        })
+                        .unwrap_or_default();
 
-                        match &policies_sets {
-                            None => policies_sets = Some(field_policies),
-                            Some(other_policies) => {
-                                if field_policies != *other_policies {
-                                    return true;
-                                }
+                    match &policies_sets {
+                        None => policies_sets = Some(field_policies),
+                        Some(other_policies) => {
+                            if field_policies != *other_policies {
+                                return true;
                             }
                         }
                     }
                 }
             }
+        }
         false
     }
 }

--- a/apollo-router/src/plugins/authorization/policy.rs
+++ b/apollo-router/src/plugins/authorization/policy.rs
@@ -173,11 +173,10 @@ impl traverse::Visitor for PolicyExtractionVisitor<'_> {
         parent_type: &str,
         node: &executable::InlineFragment,
     ) -> Result<(), BoxError> {
-        if let Some(type_condition) = &node.type_condition {
-            if let Some(ty) = self.schema.types.get(type_condition) {
+        if let Some(type_condition) = &node.type_condition
+            && let Some(ty) = self.schema.types.get(type_condition) {
                 self.get_policies_from_type(ty);
             }
-        }
         traverse::inline_fragment(self, parent_type, node)
     }
 
@@ -318,11 +317,10 @@ impl<'a> PolicyFilteringVisitor<'a> {
         }
 
         let type_name = field_def.ty.inner_named_type();
-        if let Some(type_definition) = self.schema.types.get(type_name) {
-            if self.implementors_with_different_type_requirements(type_name, type_definition) {
+        if let Some(type_definition) = self.schema.types.get(type_name)
+            && self.implementors_with_different_type_requirements(type_name, type_definition) {
                 return true;
             }
-        }
         false
     }
 
@@ -376,8 +374,8 @@ impl<'a> PolicyFilteringVisitor<'a> {
         parent_type: &str,
         field: &ast::Field,
     ) -> bool {
-        if let Some(t) = self.schema.types.get(parent_type) {
-            if t.is_interface() {
+        if let Some(t) = self.schema.types.get(parent_type)
+            && t.is_interface() {
                 let mut policies_sets: Option<Vec<Vec<String>>> = None;
 
                 for ty in self.implementors(parent_type) {
@@ -412,7 +410,6 @@ impl<'a> PolicyFilteringVisitor<'a> {
                     }
                 }
             }
-        }
         false
     }
 }

--- a/apollo-router/src/plugins/authorization/scopes.rs
+++ b/apollo-router/src/plugins/authorization/scopes.rs
@@ -174,9 +174,10 @@ impl traverse::Visitor for ScopeExtractionVisitor<'_> {
         node: &executable::InlineFragment,
     ) -> Result<(), BoxError> {
         if let Some(type_condition) = &node.type_condition
-            && let Some(ty) = self.schema.types.get(type_condition) {
-                self.scopes_from_type(ty);
-            }
+            && let Some(ty) = self.schema.types.get(type_condition)
+        {
+            self.scopes_from_type(ty);
+        }
         traverse::inline_fragment(self, parent_type, node)
     }
 
@@ -317,9 +318,10 @@ impl<'a> ScopeFilteringVisitor<'a> {
 
         let field_type = field_def.ty.inner_named_type();
         if let Some(type_definition) = self.schema.types.get(field_type)
-            && self.implementors_with_different_type_requirements(field_def, type_definition) {
-                return true;
-            }
+            && self.implementors_with_different_type_requirements(field_def, type_definition)
+        {
+            return true;
+        }
         false
     }
 
@@ -375,41 +377,42 @@ impl<'a> ScopeFilteringVisitor<'a> {
         field: &ast::Field,
     ) -> bool {
         if let Some(t) = self.schema.types.get(parent_type)
-            && t.is_interface() {
-                let mut scope_sets = None;
+            && t.is_interface()
+        {
+            let mut scope_sets = None;
 
-                for ty in self.implementors(parent_type) {
-                    if let Ok(f) = self.schema.type_field(ty, &field.name) {
-                        // aggregate the list of scope sets
-                        // we transform to a common representation of sorted vectors because the element order
-                        // of hashsets is not stable
-                        let field_scope_sets = f
-                            .directives
-                            .get(&self.requires_scopes_directive_name)
-                            .map(|directive| {
-                                let mut v = scopes_sets_argument(directive)
-                                    .map(|h| {
-                                        let mut v = h.into_iter().collect::<Vec<_>>();
-                                        v.sort();
-                                        v
-                                    })
-                                    .collect::<Vec<_>>();
-                                v.sort();
-                                v
-                            })
-                            .unwrap_or_default();
+            for ty in self.implementors(parent_type) {
+                if let Ok(f) = self.schema.type_field(ty, &field.name) {
+                    // aggregate the list of scope sets
+                    // we transform to a common representation of sorted vectors because the element order
+                    // of hashsets is not stable
+                    let field_scope_sets = f
+                        .directives
+                        .get(&self.requires_scopes_directive_name)
+                        .map(|directive| {
+                            let mut v = scopes_sets_argument(directive)
+                                .map(|h| {
+                                    let mut v = h.into_iter().collect::<Vec<_>>();
+                                    v.sort();
+                                    v
+                                })
+                                .collect::<Vec<_>>();
+                            v.sort();
+                            v
+                        })
+                        .unwrap_or_default();
 
-                        match &scope_sets {
-                            None => scope_sets = Some(field_scope_sets),
-                            Some(other_scope_sets) => {
-                                if field_scope_sets != *other_scope_sets {
-                                    return true;
-                                }
+                    match &scope_sets {
+                        None => scope_sets = Some(field_scope_sets),
+                        Some(other_scope_sets) => {
+                            if field_scope_sets != *other_scope_sets {
+                                return true;
                             }
                         }
                     }
                 }
             }
+        }
 
         false
     }

--- a/apollo-router/src/plugins/authorization/scopes.rs
+++ b/apollo-router/src/plugins/authorization/scopes.rs
@@ -173,11 +173,10 @@ impl traverse::Visitor for ScopeExtractionVisitor<'_> {
         parent_type: &str,
         node: &executable::InlineFragment,
     ) -> Result<(), BoxError> {
-        if let Some(type_condition) = &node.type_condition {
-            if let Some(ty) = self.schema.types.get(type_condition) {
+        if let Some(type_condition) = &node.type_condition
+            && let Some(ty) = self.schema.types.get(type_condition) {
                 self.scopes_from_type(ty);
             }
-        }
         traverse::inline_fragment(self, parent_type, node)
     }
 
@@ -317,11 +316,10 @@ impl<'a> ScopeFilteringVisitor<'a> {
         }
 
         let field_type = field_def.ty.inner_named_type();
-        if let Some(type_definition) = self.schema.types.get(field_type) {
-            if self.implementors_with_different_type_requirements(field_def, type_definition) {
+        if let Some(type_definition) = self.schema.types.get(field_type)
+            && self.implementors_with_different_type_requirements(field_def, type_definition) {
                 return true;
             }
-        }
         false
     }
 
@@ -376,8 +374,8 @@ impl<'a> ScopeFilteringVisitor<'a> {
         parent_type: &str,
         field: &ast::Field,
     ) -> bool {
-        if let Some(t) = self.schema.types.get(parent_type) {
-            if t.is_interface() {
+        if let Some(t) = self.schema.types.get(parent_type)
+            && t.is_interface() {
                 let mut scope_sets = None;
 
                 for ty in self.implementors(parent_type) {
@@ -412,7 +410,6 @@ impl<'a> ScopeFilteringVisitor<'a> {
                     }
                 }
             }
-        }
 
         false
     }

--- a/apollo-router/src/plugins/cache/cache_control.rs
+++ b/apollo-router/src/plugins/cache/cache_control.rs
@@ -165,9 +165,10 @@ impl CacheControl {
         );
 
         if let Some(age) = self.age
-            && age != 0 {
-                headers.insert(AGE, age.into());
-            }
+            && age != 0
+        {
+            headers.insert(AGE, age.into());
+        }
 
         Ok(())
     }

--- a/apollo-router/src/plugins/cache/cache_control.rs
+++ b/apollo-router/src/plugins/cache/cache_control.rs
@@ -164,11 +164,10 @@ impl CacheControl {
             HeaderValue::from_str(&self.to_cache_control_header()?)?,
         );
 
-        if let Some(age) = self.age {
-            if age != 0 {
+        if let Some(age) = self.age
+            && age != 0 {
                 headers.insert(AGE, age.into());
             }
-        }
 
         Ok(())
     }

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -900,11 +900,12 @@ impl CacheService {
         invalidation_extensions: Value,
     ) {
         if let Ok(requests) = from_value(invalidation_extensions)
-            && let Err(e) = self.invalidation.invalidate(origin, requests).await {
-                tracing::error!(error = %e,
-                   message = "could not invalidate entity cache entries",
-                );
-            }
+            && let Err(e) = self.invalidation.invalidate(origin, requests).await
+        {
+            tracing::error!(error = %e,
+               message = "could not invalidate entity cache entries",
+            );
+        }
     }
 }
 
@@ -1367,10 +1368,9 @@ fn extract_cache_key_root(
         "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph_name}:type:{entity_type}:hash:{query_hash}:data:{additional_data_hash}"
     );
 
-    if is_known_private
-        && let Some(id) = private_id {
-            let _ = write!(&mut key, ":{id}");
-        }
+    if is_known_private && let Some(id) = private_id {
+        let _ = write!(&mut key, ":{id}");
+    }
     key
 }
 
@@ -1447,10 +1447,9 @@ fn extract_cache_keys(
         let mut key = format!(
             "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph_name}:type:{typename}:entity:{hashed_entity_key}:representation:{hashed_representation}:hash:{query_hash}:data:{additional_data_hash}"
         );
-        if is_known_private
-            && let Some(id) = private_id {
-                let _ = write!(&mut key, ":{id}");
-            }
+        if is_known_private && let Some(id) = private_id {
+            let _ = write!(&mut key, ":{id}");
+        }
 
         // Restore the `representation` back whole again
         representation.insert(TYPENAME, typename_value);

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -899,13 +899,12 @@ impl CacheService {
         origin: InvalidationOrigin,
         invalidation_extensions: Value,
     ) {
-        if let Ok(requests) = from_value(invalidation_extensions) {
-            if let Err(e) = self.invalidation.invalidate(origin, requests).await {
+        if let Ok(requests) = from_value(invalidation_extensions)
+            && let Err(e) = self.invalidation.invalidate(origin, requests).await {
                 tracing::error!(error = %e,
                    message = "could not invalidate entity cache entries",
                 );
             }
-        }
     }
 }
 
@@ -1368,11 +1367,10 @@ fn extract_cache_key_root(
         "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph_name}:type:{entity_type}:hash:{query_hash}:data:{additional_data_hash}"
     );
 
-    if is_known_private {
-        if let Some(id) = private_id {
+    if is_known_private
+        && let Some(id) = private_id {
             let _ = write!(&mut key, ":{id}");
         }
-    }
     key
 }
 
@@ -1449,11 +1447,10 @@ fn extract_cache_keys(
         let mut key = format!(
             "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph_name}:type:{typename}:entity:{hashed_entity_key}:representation:{hashed_representation}:hash:{query_hash}:data:{additional_data_hash}"
         );
-        if is_known_private {
-            if let Some(id) = private_id {
+        if is_known_private
+            && let Some(id) = private_id {
                 let _ = write!(&mut key, ":{id}");
             }
-        }
 
         // Restore the `representation` back whole again
         representation.insert(TYPENAME, typename_value);

--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -125,13 +125,14 @@ impl Invalidation {
                 }
                 Ok(mut scan_res) => {
                     if let Some(keys) = scan_res.take_results()
-                        && !keys.is_empty() {
-                            let deleted = redis_storage
-                                .delete_from_scan_result(keys)
-                                .await
-                                .unwrap_or(0) as u64;
-                            count += deleted;
-                        }
+                        && !keys.is_empty()
+                    {
+                        let deleted = redis_storage
+                            .delete_from_scan_result(keys)
+                            .await
+                            .unwrap_or(0) as u64;
+                        count += deleted;
+                    }
                     scan_res.next();
                 }
             }

--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -124,15 +124,14 @@ impl Invalidation {
                     break;
                 }
                 Ok(mut scan_res) => {
-                    if let Some(keys) = scan_res.take_results() {
-                        if !keys.is_empty() {
+                    if let Some(keys) = scan_res.take_results()
+                        && !keys.is_empty() {
                             let deleted = redis_storage
                                 .delete_from_scan_result(keys)
                                 .await
                                 .unwrap_or(0) as u64;
                             count += deleted;
                         }
-                    }
                     scan_res.next();
                 }
             }

--- a/apollo-router/src/plugins/cache/metrics.rs
+++ b/apollo-router/src/plugins/cache/metrics.rs
@@ -81,11 +81,10 @@ impl CacheMetricsService {
 
         let response = self.service.ready().await?.call(request).await?;
 
-        if let Some(cache_attributes) = cache_attributes {
-            if let Some(counter) = &self.counter {
+        if let Some(cache_attributes) = cache_attributes
+            && let Some(counter) = &self.counter {
                 Self::update_cache_metrics(&self.name, counter, &response, cache_attributes)
             }
-        }
 
         Ok(response)
     }

--- a/apollo-router/src/plugins/cache/metrics.rs
+++ b/apollo-router/src/plugins/cache/metrics.rs
@@ -82,9 +82,10 @@ impl CacheMetricsService {
         let response = self.service.ready().await?.call(request).await?;
 
         if let Some(cache_attributes) = cache_attributes
-            && let Some(counter) = &self.counter {
-                Self::update_cache_metrics(&self.name, counter, &response, cache_attributes)
-            }
+            && let Some(counter) = &self.counter
+        {
+            Self::update_cache_metrics(&self.name, counter, &response, cache_attributes)
+        }
 
         Ok(response)
     }

--- a/apollo-router/src/plugins/cache/tests.rs
+++ b/apollo-router/src/plugins/cache/tests.rs
@@ -52,12 +52,11 @@ impl Mocks for MockStore {
 
         match &*command.cmd {
             "GET" => {
-                if let Some(RedisValue::Bytes(b)) = command.args.first() {
-                    if let Some(bytes) = self.map.lock().get(b) {
+                if let Some(RedisValue::Bytes(b)) = command.args.first()
+                    && let Some(bytes) = self.map.lock().get(b) {
                         println!("-> returning {:?}", std::str::from_utf8(bytes));
                         return Ok(RedisValue::Bytes(bytes.clone()));
                     }
-                }
             }
             "MGET" => {
                 let mut result: Vec<RedisValue> = Vec::new();

--- a/apollo-router/src/plugins/cache/tests.rs
+++ b/apollo-router/src/plugins/cache/tests.rs
@@ -53,10 +53,11 @@ impl Mocks for MockStore {
         match &*command.cmd {
             "GET" => {
                 if let Some(RedisValue::Bytes(b)) = command.args.first()
-                    && let Some(bytes) = self.map.lock().get(b) {
-                        println!("-> returning {:?}", std::str::from_utf8(bytes));
-                        return Ok(RedisValue::Bytes(bytes.clone()));
-                    }
+                    && let Some(bytes) = self.map.lock().get(b)
+                {
+                    println!("-> returning {:?}", std::str::from_utf8(bytes));
+                    return Ok(RedisValue::Bytes(bytes.clone()));
+                }
             }
             "MGET" => {
                 let mut result: Vec<RedisValue> = Vec::new();

--- a/apollo-router/src/plugins/chaos/reload.rs
+++ b/apollo-router/src/plugins/chaos/reload.rs
@@ -352,7 +352,7 @@ mod tests {
                 assert!(reloaded_schema.sdl.contains(&schema.sdl));
                 assert_eq!(reloaded_schema.launch_id, schema.launch_id);
             }
-            _ => panic!("Expected UpdateSchema event, got {:?}", event),
+            _ => panic!("Expected UpdateSchema event, got {event:?}"),
         }
     }
 
@@ -378,7 +378,7 @@ mod tests {
                 // Should be a clone of the original config (different Arc but same contents)
                 assert!(!Arc::ptr_eq(&reloaded_config, &config));
             }
-            _ => panic!("Expected UpdateConfiguration event, got {:?}", event),
+            _ => panic!("Expected UpdateConfiguration event, got {event:?}"),
         }
     }
 

--- a/apollo-router/src/plugins/connectors/configuration.rs
+++ b/apollo-router/src/plugins/connectors/configuration.rs
@@ -124,17 +124,18 @@ pub(crate) fn apply_config(
 
     for connector in Arc::make_mut(&mut connectors.by_service_name).values_mut() {
         if let Ok(source_ref) = ConnectorSourceRef::try_from(&mut *connector)
-            && let Some(source_config) = config.sources.get(&source_ref.to_string()) {
-                if let Some(uri) = source_config.override_url.as_ref() {
-                    // Discards potential StringTemplate parsing error as URI should
-                    // always be a valid template string.
-                    connector.transport.source_template = uri.to_string().parse().ok();
-                }
-                if let Some(max_requests) = source_config.max_requests_per_operation {
-                    connector.max_requests = Some(max_requests);
-                }
-                connector.config = Some(source_config.custom.clone());
+            && let Some(source_config) = config.sources.get(&source_ref.to_string())
+        {
+            if let Some(uri) = source_config.override_url.as_ref() {
+                // Discards potential StringTemplate parsing error as URI should
+                // always be a valid template string.
+                connector.transport.source_template = uri.to_string().parse().ok();
             }
+            if let Some(max_requests) = source_config.max_requests_per_operation {
+                connector.max_requests = Some(max_requests);
+            }
+            connector.config = Some(source_config.custom.clone());
+        }
 
         // TODO: remove this after deprecation period
         #[allow(deprecated)]

--- a/apollo-router/src/plugins/connectors/configuration.rs
+++ b/apollo-router/src/plugins/connectors/configuration.rs
@@ -123,8 +123,8 @@ pub(crate) fn apply_config(
     };
 
     for connector in Arc::make_mut(&mut connectors.by_service_name).values_mut() {
-        if let Ok(source_ref) = ConnectorSourceRef::try_from(&mut *connector) {
-            if let Some(source_config) = config.sources.get(&source_ref.to_string()) {
+        if let Ok(source_ref) = ConnectorSourceRef::try_from(&mut *connector)
+            && let Some(source_config) = config.sources.get(&source_ref.to_string()) {
                 if let Some(uri) = source_config.override_url.as_ref() {
                     // Discards potential StringTemplate parsing error as URI should
                     // always be a valid template string.
@@ -135,7 +135,6 @@ pub(crate) fn apply_config(
                 }
                 connector.config = Some(source_config.custom.clone());
             }
-        }
 
         // TODO: remove this after deprecation period
         #[allow(deprecated)]

--- a/apollo-router/src/plugins/connectors/make_requests/graphql_utils.rs
+++ b/apollo-router/src/plugins/connectors/make_requests/graphql_utils.rs
@@ -28,17 +28,18 @@ pub(super) fn field_arguments_map(
 
     for argument_def in field.definition.arguments.iter() {
         if let Some(value) = argument_def.default_value.as_ref()
-            && !arguments.contains_key(argument_def.name.as_str()) {
-                arguments.insert(
-                    argument_def.name.as_str(),
-                    argument_value_to_json(value, variables).map_err(|err| {
-                        format!(
-                            "failed to convert default value on {}({}:) to json: {}",
-                            field.definition.name, argument_def.name, err
-                        )
-                    })?,
-                );
-            }
+            && !arguments.contains_key(argument_def.name.as_str())
+        {
+            arguments.insert(
+                argument_def.name.as_str(),
+                argument_value_to_json(value, variables).map_err(|err| {
+                    format!(
+                        "failed to convert default value on {}({}:) to json: {}",
+                        field.definition.name, argument_def.name, err
+                    )
+                })?,
+            );
+        }
     }
 
     Ok(arguments)

--- a/apollo-router/src/plugins/connectors/make_requests/graphql_utils.rs
+++ b/apollo-router/src/plugins/connectors/make_requests/graphql_utils.rs
@@ -27,8 +27,8 @@ pub(super) fn field_arguments_map(
     }
 
     for argument_def in field.definition.arguments.iter() {
-        if let Some(value) = argument_def.default_value.as_ref() {
-            if !arguments.contains_key(argument_def.name.as_str()) {
+        if let Some(value) = argument_def.default_value.as_ref()
+            && !arguments.contains_key(argument_def.name.as_str()) {
                 arguments.insert(
                     argument_def.name.as_str(),
                     argument_value_to_json(value, variables).map_err(|err| {
@@ -39,7 +39,6 @@ pub(super) fn field_arguments_map(
                     })?,
                 );
             }
-        }
     }
 
     Ok(arguments)

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -113,21 +113,21 @@ impl Plugin for Connectors {
                             if is_debug_enabled
                                 && let Some(debug) = res.context.extensions().with_lock(|lock| {
                                     lock.get::<Arc<Mutex<ConnectorContext>>>().cloned()
-                                }) {
-                                    let (parts, stream) = res.response.into_parts();
+                                })
+                            {
+                                let (parts, stream) = res.response.into_parts();
 
-                                    let stream = stream.map(move |mut chunk| {
-                                        let serialized = { &debug.lock().clone().serialize() };
-                                        chunk.extensions.insert(
-                                            CONNECTORS_DEBUG_KEY,
-                                            json!({"version": "2", "data": serialized }),
-                                        );
-                                        chunk
-                                    });
+                                let stream = stream.map(move |mut chunk| {
+                                    let serialized = { &debug.lock().clone().serialize() };
+                                    chunk.extensions.insert(
+                                        CONNECTORS_DEBUG_KEY,
+                                        json!({"version": "2", "data": serialized }),
+                                    );
+                                    chunk
+                                });
 
-                                    res.response =
-                                        http::Response::from_parts(parts, Box::pin(stream));
-                                }
+                                res.response = http::Response::from_parts(parts, Box::pin(stream));
+                            }
 
                             Ok(res)
                         }

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -110,8 +110,8 @@ impl Plugin for Connectors {
                                     limits.log();
                                 }
                             });
-                            if is_debug_enabled {
-                                if let Some(debug) = res.context.extensions().with_lock(|lock| {
+                            if is_debug_enabled
+                                && let Some(debug) = res.context.extensions().with_lock(|lock| {
                                     lock.get::<Arc<Mutex<ConnectorContext>>>().cloned()
                                 }) {
                                     let (parts, stream) = res.response.into_parts();
@@ -128,7 +128,6 @@ impl Plugin for Connectors {
                                     res.response =
                                         http::Response::from_parts(parts, Box::pin(stream));
                                 }
-                            }
 
                             Ok(res)
                         }

--- a/apollo-router/src/plugins/connectors/request_limit.rs
+++ b/apollo-router/src/plugins/connectors/request_limit.rs
@@ -25,10 +25,10 @@ impl Display for RequestLimitKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             RequestLimitKey::SourceName(source_name) => {
-                write!(f, "connector source {}", source_name)
+                write!(f, "connector source {source_name}")
             }
             RequestLimitKey::ConnectorLabel(connector_label) => {
-                write!(f, "connector {}", connector_label)
+                write!(f, "connector {connector_label}")
             }
         }
     }

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -565,8 +565,7 @@ async fn basic_connection_errors() {
         msg.starts_with(
             "Connector error: HTTP fetch failed from 'connectors.json': tcp connect error:" // *nix: Connection refused, Windows: No connection could be made
         ),
-        "got message: {}",
-        msg
+        "got message: {msg}"
     );
     assert_eq!(err.get("path").unwrap(), &serde_json::json!(["users"]));
     assert_eq!(
@@ -2289,8 +2288,8 @@ async fn execute(
     mut request_mutator: impl FnMut(&mut Request),
     license: Option<LicenseState>,
 ) -> serde_json::Value {
-    let connector_uri = format!("{}/", uri);
-    let subgraph_uri = format!("{}/graphql", uri);
+    let connector_uri = format!("{uri}/");
+    let subgraph_uri = format!("{uri}/graphql");
 
     // we cannot use Testharness because the subgraph connectors are actually extracted in YamlRouterFactory
     let mut factory = YamlRouterFactory;

--- a/apollo-router/src/plugins/connectors/tests/req_asserts.rs
+++ b/apollo-router/src/plugins/connectors/tests/req_asserts.rs
@@ -52,38 +52,34 @@ impl Matcher {
     }
 
     fn matches(&self, request: &wiremock::Request, index: usize) -> Result<(), String> {
-        if let Some(method) = self.method.as_ref() {
-            if method != &request.method.to_string() {
+        if let Some(method) = self.method.as_ref()
+            && method != &request.method.to_string() {
                 return Err(format!(
                     "[Request {index}]: Expected method {method}, got {}",
                     request.method
                 ));
             }
-        }
 
-        if let Some(path) = self.path.as_ref() {
-            if path != request.url.path() {
+        if let Some(path) = self.path.as_ref()
+            && path != request.url.path() {
                 return Err(format!(
                     "[Request {index}]: Expected path {path}, got {}",
                     request.url.path()
                 ));
             }
-        }
 
-        if let Some(query) = self.query.as_ref() {
-            if query != request.url.query().unwrap_or_default() {
+        if let Some(query) = self.query.as_ref()
+            && query != request.url.query().unwrap_or_default() {
                 return Err(format!(
                     "[Request {index}]: Expected query {query}, got {}",
                     request.url.query().unwrap_or_default()
                 ));
             }
-        }
 
-        if let Some(body) = self.body.as_ref() {
-            if body != &request.body_json::<serde_json::Value>().unwrap() {
+        if let Some(body) = self.body.as_ref()
+            && body != &request.body_json::<serde_json::Value>().unwrap() {
                 return Err(format!("[Request {index}]: incorrect body"));
             }
-        }
 
         for (name, expected) in self.headers.iter() {
             let actual: HashSet<String> = request

--- a/apollo-router/src/plugins/connectors/tests/req_asserts.rs
+++ b/apollo-router/src/plugins/connectors/tests/req_asserts.rs
@@ -53,33 +53,37 @@ impl Matcher {
 
     fn matches(&self, request: &wiremock::Request, index: usize) -> Result<(), String> {
         if let Some(method) = self.method.as_ref()
-            && method != &request.method.to_string() {
-                return Err(format!(
-                    "[Request {index}]: Expected method {method}, got {}",
-                    request.method
-                ));
-            }
+            && method != &request.method.to_string()
+        {
+            return Err(format!(
+                "[Request {index}]: Expected method {method}, got {}",
+                request.method
+            ));
+        }
 
         if let Some(path) = self.path.as_ref()
-            && path != request.url.path() {
-                return Err(format!(
-                    "[Request {index}]: Expected path {path}, got {}",
-                    request.url.path()
-                ));
-            }
+            && path != request.url.path()
+        {
+            return Err(format!(
+                "[Request {index}]: Expected path {path}, got {}",
+                request.url.path()
+            ));
+        }
 
         if let Some(query) = self.query.as_ref()
-            && query != request.url.query().unwrap_or_default() {
-                return Err(format!(
-                    "[Request {index}]: Expected query {query}, got {}",
-                    request.url.query().unwrap_or_default()
-                ));
-            }
+            && query != request.url.query().unwrap_or_default()
+        {
+            return Err(format!(
+                "[Request {index}]: Expected query {query}, got {}",
+                request.url.query().unwrap_or_default()
+            ));
+        }
 
         if let Some(body) = self.body.as_ref()
-            && body != &request.body_json::<serde_json::Value>().unwrap() {
-                return Err(format!("[Request {index}]: incorrect body"));
-            }
+            && body != &request.body_json::<serde_json::Value>().unwrap()
+        {
+            return Err(format!("[Request {index}]: incorrect body"));
+        }
 
         for (name, expected) in self.headers.iter() {
             let actual: HashSet<String> = request

--- a/apollo-router/src/plugins/connectors/tests/req_asserts.rs
+++ b/apollo-router/src/plugins/connectors/tests/req_asserts.rs
@@ -190,7 +190,7 @@ impl Plan {
                             continue 'requests;
                         }
                     }
-                    panic!("No plan matched request {:?}", request);
+                    panic!("No plan matched request {request:?}");
                 }
             }
         }

--- a/apollo-router/src/plugins/cors.rs
+++ b/apollo-router/src/plugins/cors.rs
@@ -53,8 +53,7 @@ impl CorsLayer {
                 for origin in &policy.origins {
                     http::HeaderValue::from_str(origin).map_err(|_| {
                         format!(
-                            "origin '{}' is not valid: failed to parse header value",
-                            origin
+                            "origin '{origin}' is not valid: failed to parse header value"
                         )
                     })?;
                 }
@@ -349,7 +348,7 @@ impl<S> CorsService<S> {
                 let mut existing_values = existing_str.split(',').map(|v| v.trim());
 
                 if !existing_values.any(|existing| existing.eq_ignore_ascii_case(value.as_str())) {
-                    let new_vary = format!("{}, {}", existing_str, value);
+                    let new_vary = format!("{existing_str}, {value}");
                     let new_header_value = http::HeaderValue::from_str(&new_vary)
                         .expect("combining pre-existing header + hardcoded valid value can not produce an invalid result");
                     headers.insert(VARY, new_header_value);

--- a/apollo-router/src/plugins/cors.rs
+++ b/apollo-router/src/plugins/cors.rs
@@ -63,9 +63,10 @@ impl CorsLayer {
 
                 // Validate origin-specific methods
                 if let Some(methods) = &policy.methods
-                    && !methods.is_empty() {
-                        parse_values::<http::Method>(methods, "method")?;
-                    }
+                    && !methods.is_empty()
+                {
+                    parse_values::<http::Method>(methods, "method")?;
+                }
 
                 // Validate origin-specific expose headers
                 if !policy.expose_headers.is_empty() {
@@ -274,27 +275,27 @@ impl<S> CorsService<S> {
             } else {
                 // If no headers are configured, mirror the client's Access-Control-Request-Headers
                 if let Some(request_headers) = request_headers
-                    && let Ok(headers_str) = request_headers.to_str() {
-                        response.headers_mut().insert(
-                            ACCESS_CONTROL_ALLOW_HEADERS,
-                            http::HeaderValue::from_str(headers_str)
-                                .unwrap_or_else(|_| http::HeaderValue::from_static("")),
-                        );
-                    }
+                    && let Ok(headers_str) = request_headers.to_str()
+                {
+                    response.headers_mut().insert(
+                        ACCESS_CONTROL_ALLOW_HEADERS,
+                        http::HeaderValue::from_str(headers_str)
+                            .unwrap_or_else(|_| http::HeaderValue::from_static("")),
+                    );
+                }
             }
         }
 
         // Set Access-Control-Expose-Headers (only for non-preflight requests)
-        if !is_preflight
-            && let Some(headers) = expose_headers {
-                // Join the headers with commas for a single header value
-                let header_value = headers.join(", ");
-                response.headers_mut().insert(
-                    ACCESS_CONTROL_EXPOSE_HEADERS,
-                    http::HeaderValue::from_str(&header_value)
-                        .unwrap_or_else(|_| http::HeaderValue::from_static("")),
-                );
-            }
+        if !is_preflight && let Some(headers) = expose_headers {
+            // Join the headers with commas for a single header value
+            let header_value = headers.join(", ");
+            response.headers_mut().insert(
+                ACCESS_CONTROL_EXPOSE_HEADERS,
+                http::HeaderValue::from_str(&header_value)
+                    .unwrap_or_else(|_| http::HeaderValue::from_static("")),
+            );
+        }
 
         // Set Access-Control-Allow-Methods (for preflight requests)
         // The CORS protocol specifies an Access-Control-Request-Method header on requests,
@@ -311,15 +312,14 @@ impl<S> CorsService<S> {
         }
 
         // Set Access-Control-Max-Age (only for preflight requests)
-        if is_preflight
-            && let Some(max_age) = max_age {
-                let max_age_secs = max_age.as_secs();
-                response.headers_mut().insert(
-                    ACCESS_CONTROL_MAX_AGE,
-                    http::HeaderValue::from_str(&max_age_secs.to_string())
-                        .unwrap_or_else(|_| http::HeaderValue::from_static("")),
-                );
-            }
+        if is_preflight && let Some(max_age) = max_age {
+            let max_age_secs = max_age.as_secs();
+            response.headers_mut().insert(
+                ACCESS_CONTROL_MAX_AGE,
+                http::HeaderValue::from_str(&max_age_secs.to_string())
+                    .unwrap_or_else(|_| http::HeaderValue::from_static("")),
+            );
+        }
 
         // Set Vary header - append to existing values instead of overwriting
         Self::append_vary_header(response, ORIGIN);

--- a/apollo-router/src/plugins/cors.rs
+++ b/apollo-router/src/plugins/cors.rs
@@ -52,9 +52,7 @@ impl CorsLayer {
                 // Validate origin URLs
                 for origin in &policy.origins {
                     http::HeaderValue::from_str(origin).map_err(|_| {
-                        format!(
-                            "origin '{origin}' is not valid: failed to parse header value"
-                        )
+                        format!("origin '{origin}' is not valid: failed to parse header value")
                     })?;
                 }
 

--- a/apollo-router/src/plugins/cors.rs
+++ b/apollo-router/src/plugins/cors.rs
@@ -62,11 +62,10 @@ impl CorsLayer {
                 }
 
                 // Validate origin-specific methods
-                if let Some(methods) = &policy.methods {
-                    if !methods.is_empty() {
+                if let Some(methods) = &policy.methods
+                    && !methods.is_empty() {
                         parse_values::<http::Method>(methods, "method")?;
                     }
-                }
 
                 // Validate origin-specific expose headers
                 if !policy.expose_headers.is_empty() {
@@ -274,21 +273,20 @@ impl<S> CorsService<S> {
                 );
             } else {
                 // If no headers are configured, mirror the client's Access-Control-Request-Headers
-                if let Some(request_headers) = request_headers {
-                    if let Ok(headers_str) = request_headers.to_str() {
+                if let Some(request_headers) = request_headers
+                    && let Ok(headers_str) = request_headers.to_str() {
                         response.headers_mut().insert(
                             ACCESS_CONTROL_ALLOW_HEADERS,
                             http::HeaderValue::from_str(headers_str)
                                 .unwrap_or_else(|_| http::HeaderValue::from_static("")),
                         );
                     }
-                }
             }
         }
 
         // Set Access-Control-Expose-Headers (only for non-preflight requests)
-        if !is_preflight {
-            if let Some(headers) = expose_headers {
+        if !is_preflight
+            && let Some(headers) = expose_headers {
                 // Join the headers with commas for a single header value
                 let header_value = headers.join(", ");
                 response.headers_mut().insert(
@@ -297,7 +295,6 @@ impl<S> CorsService<S> {
                         .unwrap_or_else(|_| http::HeaderValue::from_static("")),
                 );
             }
-        }
 
         // Set Access-Control-Allow-Methods (for preflight requests)
         // The CORS protocol specifies an Access-Control-Request-Method header on requests,
@@ -314,8 +311,8 @@ impl<S> CorsService<S> {
         }
 
         // Set Access-Control-Max-Age (only for preflight requests)
-        if is_preflight {
-            if let Some(max_age) = max_age {
+        if is_preflight
+            && let Some(max_age) = max_age {
                 let max_age_secs = max_age.as_secs();
                 response.headers_mut().insert(
                     ACCESS_CONTROL_MAX_AGE,
@@ -323,7 +320,6 @@ impl<S> CorsService<S> {
                         .unwrap_or_else(|_| http::HeaderValue::from_static("")),
                 );
             }
-        }
 
         // Set Vary header - append to existing values instead of overwriting
         Self::append_vary_header(response, ORIGIN);

--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -49,13 +49,12 @@ impl<'schema> ListSizeDirective<'schema> {
         if let Some(slicing_argument_names) = parsed.slicing_argument_names.as_ref() {
             // First, collect the default values for each argument
             for argument in &field.definition.arguments {
-                if slicing_argument_names.contains(argument.name.as_str()) {
-                    if let Some(numeric_value) =
+                if slicing_argument_names.contains(argument.name.as_str())
+                    && let Some(numeric_value) =
                         argument.default_value.as_ref().and_then(|v| v.to_i32())
                     {
                         slicing_arguments.insert(&argument.name, numeric_value);
                     }
-                }
             }
             // Then, overwrite any default values with the actual values passed in the query
             for argument in &field.arguments {

--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -52,9 +52,9 @@ impl<'schema> ListSizeDirective<'schema> {
                 if slicing_argument_names.contains(argument.name.as_str())
                     && let Some(numeric_value) =
                         argument.default_value.as_ref().and_then(|v| v.to_i32())
-                    {
-                        slicing_arguments.insert(&argument.name, numeric_value);
-                    }
+                {
+                    slicing_arguments.insert(&argument.name, numeric_value);
+                }
             }
             // Then, overwrite any default values with the actual values passed in the query
             for argument in &field.arguments {

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -429,8 +429,7 @@ impl StaticCostCalculator {
 
         let schema = self.subgraph_schemas.get(subgraph).ok_or_else(|| {
             DemandControlError::QueryParseFailure(format!(
-                "Query planner did not provide a schema for service {}",
-                subgraph
+                "Query planner did not provide a schema for service {subgraph}"
             ))
         })?;
 

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -208,7 +208,7 @@ impl DemandControlError {
 
 impl<T> From<WithErrors<T>> for DemandControlError {
     fn from(value: WithErrors<T>) -> Self {
-        DemandControlError::QueryParseFailure(format!("{}", value))
+        DemandControlError::QueryParseFailure(format!("{value}"))
     }
 }
 
@@ -220,8 +220,7 @@ impl From<FieldLookupError<'_>> for DemandControlError {
             ),
             FieldLookupError::NoSuchField(type_name, _) => {
                 DemandControlError::QueryParseFailure(format!(
-                    "Attempted to look up a field on type {}, but the field does not exist",
-                    type_name
+                    "Attempted to look up a field on type {type_name}, but the field does not exist"
                 ))
             }
         }

--- a/apollo-router/src/plugins/expose_query_plan.rs
+++ b/apollo-router/src/plugins/expose_query_plan.rs
@@ -129,15 +129,14 @@ impl Plugin for ExposeQueryPlan {
                             let (parts, stream) = res.response.into_parts();
                             let (mut first, rest) = StreamExt::into_future(stream).await;
 
-                            if let Some(first) = &mut first {
-                                if let Some(plan) =
+                            if let Some(first) = &mut first
+                                && let Some(plan) =
                                     res.context.get_json_value(QUERY_PLAN_CONTEXT_KEY)
                                 {
                                     first
                                         .extensions
                                         .insert("apolloQueryPlan", json!({ "object": { "kind": "QueryPlan", "node": plan }, "text": res.context.get_json_value(FORMATTED_QUERY_PLAN_CONTEXT_KEY) }));
                                 }
-                            }
                             res.response = http::Response::from_parts(
                                 parts,
                                 once(ready(first.unwrap_or_default())).chain(rest).boxed(),

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -233,7 +233,7 @@ async fn supergraph_layer(mut req: supergraph::Request) -> Result<supergraph::Re
                         variables,
                         variable_path,
                         serde_json_bytes::Value::String(
-                            format!("<Placeholder for file '{}'>", filename).into(),
+                            format!("<Placeholder for file '{filename}'>").into(),
                         ),
                     )
                     .map_err(|path| FileUploadError::InputValueNotFound(path.join(".")))?;

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -153,7 +153,7 @@ impl PluginPrivate for FileUploadsPlugin {
     }
 }
 
-fn get_multipart_mime(req: &router::Request) -> Option<MediaType> {
+fn get_multipart_mime(req: &router::Request) -> Option<MediaType<'_>> {
     req.router_request
         .headers()
         .get(CONTENT_TYPE)

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -240,11 +240,12 @@ where
                         self.state.read_files_counter += 1;
 
                         if let Some(name) = field.name()
-                            && self.file_names.remove(name) {
-                                let prefix = (self.file_prefix_fn)(field.headers());
-                                self.current_field = Some(field);
-                                return Poll::Ready(Some(Ok(prefix)));
-                            }
+                            && self.file_names.remove(name)
+                        {
+                            let prefix = (self.file_prefix_fn)(field.headers());
+                            self.current_field = Some(field);
+                            return Poll::Ready(Some(Ok(prefix)));
+                        }
 
                         // The file is extraneous, but the rest can still be processed.
                         // Just ignore it and don’t exit with an error.

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -174,7 +174,7 @@ where
             let filename = field
                 .file_name()
                 .or_else(|| field.name())
-                .map(|name| format!("'{}'", name))
+                .map(|name| format!("'{name}'"))
                 .unwrap_or_else(|| "unknown".to_owned());
 
             let field = Pin::new(field);
@@ -228,7 +228,7 @@ where
                     return Poll::Ready(Some(Err(FileUploadError::MissingFiles(
                         files
                             .into_iter()
-                            .map(|file| format!("'{}'", file))
+                            .map(|file| format!("'{file}'"))
                             .join(", "),
                     ))));
                 }

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -226,10 +226,7 @@ where
 
                     let files = mem::take(&mut self.file_names);
                     return Poll::Ready(Some(Err(FileUploadError::MissingFiles(
-                        files
-                            .into_iter()
-                            .map(|file| format!("'{file}'"))
-                            .join(", "),
+                        files.into_iter().map(|file| format!("'{file}'")).join(", "),
                     ))));
                 }
                 Poll::Ready(Ok(Some(field))) => {

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -239,13 +239,12 @@ where
                     } else {
                         self.state.read_files_counter += 1;
 
-                        if let Some(name) = field.name() {
-                            if self.file_names.remove(name) {
+                        if let Some(name) = field.name()
+                            && self.file_names.remove(name) {
                                 let prefix = (self.file_prefix_fn)(field.headers());
                                 self.current_field = Some(field);
                                 return Poll::Ready(Some(Ok(prefix)));
                             }
-                        }
 
                         // The file is extraneous, but the rest can still be processed.
                         // Just ignore it and don’t exit with an error.

--- a/apollo-router/src/plugins/file_uploads/rearrange_query_plan.rs
+++ b/apollo-router/src/plugins/file_uploads/rearrange_query_plan.rs
@@ -109,7 +109,7 @@ fn rearrange_plan_node<'a>(
                     return Err(FileUploadError::VariablesForbiddenInsideSubscription(
                         rest_variables
                             .into_keys()
-                            .map(|name| format!("${}", name))
+                            .map(|name| format!("${name}"))
                             .join(", "),
                     ));
                 }
@@ -146,7 +146,7 @@ fn rearrange_plan_node<'a>(
                 return Err(FileUploadError::VariablesForbiddenInsideDefer(
                     deferred_variables
                         .into_keys()
-                        .map(|name| format!("${}", name))
+                        .map(|name| format!("${name}"))
                         .join(", "),
                 ));
             }
@@ -193,7 +193,7 @@ fn rearrange_plan_node<'a>(
                 return Err(FileUploadError::DuplicateVariableUsages(
                     duplicate_variables
                         .iter()
-                        .map(|name| format!("${}", name))
+                        .map(|name| format!("${name}"))
                         .join(", "),
                 ));
             }
@@ -241,7 +241,7 @@ fn rearrange_plan_node<'a>(
                 return Err(FileUploadError::DuplicateVariableUsages(
                     duplicate_variables
                         .iter()
-                        .map(|name| format!("${}", name))
+                        .map(|name| format!("${name}"))
                         .join(", "),
                 ));
             }

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -522,11 +522,10 @@ fn get_deployment_type(official_helm_chart: Option<&str>, deployment_type: Optio
     }
 
     // Check for a custom deployment type via APOLLO_ROUTER_DEPLOYMENT_TYPE
-    if let Some(val) = deployment_type {
-        if !val.is_empty() {
+    if let Some(val) = deployment_type
+        && !val.is_empty() {
             return val.to_string();
         }
-    }
 
     "unknown".to_string()
 }

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -523,9 +523,10 @@ fn get_deployment_type(official_helm_chart: Option<&str>, deployment_type: Optio
 
     // Check for a custom deployment type via APOLLO_ROUTER_DEPLOYMENT_TYPE
     if let Some(val) = deployment_type
-        && !val.is_empty() {
-            return val.to_string();
-        }
+        && !val.is_empty()
+    {
+        return val.to_string();
+    }
 
     "unknown".to_string()
 }

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -1776,7 +1776,7 @@ mod test {
                     if let Some(header) = headers.get(*name) {
                         assert_eq!(header.to_str().unwrap(), *value);
                     } else {
-                        panic!("missing header {}", name);
+                        panic!("missing header {name}");
                     }
                 }
                 Ok(subgraph::Response::fake_builder().build())

--- a/apollo-router/src/plugins/healthcheck/mod.rs
+++ b/apollo-router/src/plugins/healthcheck/mod.rs
@@ -404,7 +404,7 @@ mod test {
             get_axum_router(listen_addr, config, response_status_code).await;
 
         let request = http::Request::builder()
-            .uri(format!("http://{}/health?ready=", router_addr))
+            .uri(format!("http://{router_addr}/health?ready="))
             .body(http_body_util::Empty::new())
             .expect("valid request");
 

--- a/apollo-router/src/plugins/include_subgraph_errors/tests.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/tests.rs
@@ -71,7 +71,7 @@ async fn run_test_case(
         .collect::<Vec<Value>>();
     let request = serde_json::to_string_pretty(&parsed_responses).expect("request to json");
 
-    let description = format!("CONFIG:\n{}\n\nREQUEST:\n{}", config, request);
+    let description = format!("CONFIG:\n{config}\n\nREQUEST:\n{request}");
     with_settings!({
         description => description,
     }, {

--- a/apollo-router/src/plugins/mock_subgraphs/execution/engine.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/execution/engine.rs
@@ -167,11 +167,10 @@ fn collect_fields<'a>(
                 )
             }
             Selection::InlineFragment(inline) => {
-                if let Some(condition) = &inline.type_condition {
-                    if !does_fragment_type_apply(schema, object_type, condition) {
+                if let Some(condition) = &inline.type_condition
+                    && !does_fragment_type_apply(schema, object_type, condition) {
                         continue;
                     }
-                }
                 collect_fields(
                     schema,
                     document,

--- a/apollo-router/src/plugins/mock_subgraphs/execution/engine.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/execution/engine.rs
@@ -168,9 +168,10 @@ fn collect_fields<'a>(
             }
             Selection::InlineFragment(inline) => {
                 if let Some(condition) = &inline.type_condition
-                    && !does_fragment_type_apply(schema, object_type, condition) {
-                        continue;
-                    }
+                    && !does_fragment_type_apply(schema, object_type, condition)
+                {
+                    continue;
+                }
                 collect_fields(
                     schema,
                     document,

--- a/apollo-router/src/plugins/mock_subgraphs/mod.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/mod.rs
@@ -336,8 +336,8 @@ fn resolve_value<'a>(
 ) -> Result<ResolvedValue<'a>, String> {
     match mock {
         JsonValue::Object(map) => {
-            if !in_entity {
-                if let Some(keys) = map.get("__cacheTags") {
+            if !in_entity
+                && let Some(keys) = map.get("__cacheTags") {
                     response_extensions
                         .borrow_mut()
                         .entry(GRAPHQL_RESPONSE_EXTENSION_ROOT_FIELDS_CACHE_TAGS)
@@ -346,7 +346,6 @@ fn resolve_value<'a>(
                         .unwrap()
                         .extend_from_slice(keys.as_array().unwrap());
                 };
-            }
             Ok(ResolvedValue::object(MockResolver {
                 in_entity,
                 mocks: map,

--- a/apollo-router/src/plugins/mock_subgraphs/mod.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/mod.rs
@@ -336,16 +336,15 @@ fn resolve_value<'a>(
 ) -> Result<ResolvedValue<'a>, String> {
     match mock {
         JsonValue::Object(map) => {
-            if !in_entity
-                && let Some(keys) = map.get("__cacheTags") {
-                    response_extensions
-                        .borrow_mut()
-                        .entry(GRAPHQL_RESPONSE_EXTENSION_ROOT_FIELDS_CACHE_TAGS)
-                        .or_insert_with(|| JsonValue::Array(Vec::new()))
-                        .as_array_mut()
-                        .unwrap()
-                        .extend_from_slice(keys.as_array().unwrap());
-                };
+            if !in_entity && let Some(keys) = map.get("__cacheTags") {
+                response_extensions
+                    .borrow_mut()
+                    .entry(GRAPHQL_RESPONSE_EXTENSION_ROOT_FIELDS_CACHE_TAGS)
+                    .or_insert_with(|| JsonValue::Array(Vec::new()))
+                    .as_array_mut()
+                    .unwrap()
+                    .extend_from_slice(keys.as_array().unwrap());
+            };
             Ok(ResolvedValue::object(MockResolver {
                 in_entity,
                 mocks: map,

--- a/apollo-router/src/plugins/progressive_override/tests.rs
+++ b/apollo-router/src/plugins/progressive_override/tests.rs
@@ -32,11 +32,10 @@ fn test_progressive_overrides_are_recognised_vor_join_v0_4_and_above() {
         format!(
             r#"schema
                 @link(url: "https://specs.apollo.dev/link/v1.0")
-                @link(url: "https://specs.apollo.dev/join/{}", for: EXECUTION)
+                @link(url: "https://specs.apollo.dev/join/{version}", for: EXECUTION)
                 @link(url: "https://specs.apollo.dev/context/v0.1", for: SECURITY)
 
-                directive @join__field repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION"#,
-            version
+                directive @join__field repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION"#
         )
     };
 

--- a/apollo-router/src/plugins/record_replay/recording.rs
+++ b/apollo-router/src/plugins/record_replay/recording.rs
@@ -34,7 +34,7 @@ impl Recording {
         digest.update(req);
         let hash = hex::encode(digest.finalize().as_slice());
 
-        PathBuf::from(format!("{}-{}.json", operation_name, hash))
+        PathBuf::from(format!("{operation_name}-{hash}.json"))
     }
 }
 

--- a/apollo-router/src/plugins/record_replay/replay.rs
+++ b/apollo-router/src/plugins/record_replay/replay.rs
@@ -347,9 +347,9 @@ impl ReplayReport {
         print_line(width);
 
         if !old.is_empty() {
-            println!("{}", style(format_args!("-{}", old_hint)).red());
+            println!("{}", style(format_args!("-{old_hint}")).red());
         }
-        println!("{}", style(format_args!("+{}", new_hint)).green());
+        println!("{}", style(format_args!("+{new_hint}")).green());
 
         println!("────────────┬{:─^1$}", "", width.saturating_sub(13));
         let mut has_changes = false;

--- a/apollo-router/src/plugins/response_cache/cache_control.rs
+++ b/apollo-router/src/plugins/response_cache/cache_control.rs
@@ -166,9 +166,10 @@ impl CacheControl {
         );
 
         if let Some(age) = self.age
-            && age != 0 {
-                headers.insert(AGE, age.into());
-            }
+            && age != 0
+        {
+            headers.insert(AGE, age.into());
+        }
 
         Ok(())
     }

--- a/apollo-router/src/plugins/response_cache/cache_control.rs
+++ b/apollo-router/src/plugins/response_cache/cache_control.rs
@@ -165,11 +165,10 @@ impl CacheControl {
             HeaderValue::from_str(&self.to_cache_control_header()?)?,
         );
 
-        if let Some(age) = self.age {
-            if age != 0 {
+        if let Some(age) = self.age
+            && age != 0 {
                 headers.insert(AGE, age.into());
             }
-        }
 
         Ok(())
     }

--- a/apollo-router/src/plugins/response_cache/metrics.rs
+++ b/apollo-router/src/plugins/response_cache/metrics.rs
@@ -91,9 +91,10 @@ impl CacheMetricsService {
         let response = self.service.ready().await?.call(request).await?;
 
         if let Some(cache_attributes) = cache_attributes
-            && let Some(counter) = &self.counter {
-                Self::update_cache_metrics(&self.name, counter, &response, cache_attributes)
-            }
+            && let Some(counter) = &self.counter
+        {
+            Self::update_cache_metrics(&self.name, counter, &response, cache_attributes)
+        }
 
         Ok(response)
     }

--- a/apollo-router/src/plugins/response_cache/metrics.rs
+++ b/apollo-router/src/plugins/response_cache/metrics.rs
@@ -90,11 +90,10 @@ impl CacheMetricsService {
 
         let response = self.service.ready().await?.call(request).await?;
 
-        if let Some(cache_attributes) = cache_attributes {
-            if let Some(counter) = &self.counter {
+        if let Some(cache_attributes) = cache_attributes
+            && let Some(counter) = &self.counter {
                 Self::update_cache_metrics(&self.name, counter, &response, cache_attributes)
             }
-        }
 
         Ok(response)
     }

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -451,18 +451,18 @@ impl PluginPrivate for ResponseCache {
                 if debug
                     && let Some(debug_data) =
                         response.context.get_json_value(CONTEXT_DEBUG_CACHE_KEYS)
-                    {
-                        return response.map_stream(move |mut body| {
-                            body.extensions.insert(
-                                CACHE_DEBUG_EXTENSIONS_KEY,
-                                serde_json_bytes::json!({
-                                    "version": CACHE_DEBUGGER_VERSION,
-                                    "data": debug_data.clone()
-                                }),
-                            );
-                            body
-                        });
-                    }
+                {
+                    return response.map_stream(move |mut body| {
+                        body.extensions.insert(
+                            CACHE_DEBUG_EXTENSIONS_KEY,
+                            serde_json_bytes::json!({
+                                "version": CACHE_DEBUGGER_VERSION,
+                                "data": debug_data.clone()
+                            }),
+                        );
+                        body
+                    });
+                }
 
                 response
             })
@@ -1961,10 +1961,9 @@ fn extract_cache_key_root(
         "{INTERNAL_CACHE_TAG_PREFIX}version:{RESPONSE_CACHE_VERSION}:subgraph:{subgraph_name}:type:{entity_type}"
     )];
 
-    if is_known_private
-        && let Some(id) = private_id {
-            let _ = write!(&mut key, ":{id}");
-        }
+    if is_known_private && let Some(id) = private_id {
+        let _ = write!(&mut key, ":{id}");
+    }
     (key, invalidation_keys)
 }
 
@@ -2071,10 +2070,9 @@ fn extract_cache_keys(
             &representation_entity_key,
         )?;
 
-        if is_known_private
-            && let Some(id) = private_id {
-                let _ = write!(&mut key, ":{id}");
-            }
+        if is_known_private && let Some(id) = private_id {
+            let _ = write!(&mut key, ":{id}");
+        }
 
         // Restore the `representation` back whole again
         representation.insert(TYPENAME, typename_value);

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -448,8 +448,8 @@ impl PluginPrivate for ResponseCache {
                     let _ = cache_control.to_headers(response.response.headers_mut());
                 }
 
-                if debug {
-                    if let Some(debug_data) =
+                if debug
+                    && let Some(debug_data) =
                         response.context.get_json_value(CONTEXT_DEBUG_CACHE_KEYS)
                     {
                         return response.map_stream(move |mut body| {
@@ -463,7 +463,6 @@ impl PluginPrivate for ResponseCache {
                             body
                         });
                     }
-                }
 
                 response
             })
@@ -1962,11 +1961,10 @@ fn extract_cache_key_root(
         "{INTERNAL_CACHE_TAG_PREFIX}version:{RESPONSE_CACHE_VERSION}:subgraph:{subgraph_name}:type:{entity_type}"
     )];
 
-    if is_known_private {
-        if let Some(id) = private_id {
+    if is_known_private
+        && let Some(id) = private_id {
             let _ = write!(&mut key, ":{id}");
         }
-    }
     (key, invalidation_keys)
 }
 
@@ -2073,11 +2071,10 @@ fn extract_cache_keys(
             &representation_entity_key,
         )?;
 
-        if is_known_private {
-            if let Some(id) = private_id {
+        if is_known_private
+            && let Some(id) = private_id {
                 let _ = write!(&mut key, ":{id}");
             }
-        }
 
         // Restore the `representation` back whole again
         representation.insert(TYPENAME, typename_value);

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -633,7 +633,7 @@ struct Position {
 impl fmt::Display for Position {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some((line, pos)) = self.line.zip(self.pos) {
-            write!(f, "line {}, position {}", line, pos)
+            write!(f, "line {line}, position {pos}")
         } else {
             write!(f, "none")
         }

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -900,7 +900,7 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
             .iter()
             .find(|e| e.message.contains("rhai execution error"))
             .expect("unexpected non-rhai error");
-        panic!("Got an unexpected rhai error: {:?}", rhai_error);
+        panic!("Got an unexpected rhai error: {rhai_error:?}");
     }
 
     // Check that the header was actually removed

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -130,8 +130,8 @@ impl SubscriptionModeConfig {
             }
         }
 
-        if let Some(callback_cfg) = &self.callback {
-            if callback_cfg.subgraphs.contains(service_name) || callback_cfg.subgraphs.is_empty() {
+        if let Some(callback_cfg) = &self.callback
+            && (callback_cfg.subgraphs.contains(service_name) || callback_cfg.subgraphs.is_empty()) {
                 let callback_cfg = CallbackMode {
                     public_url: callback_cfg.public_url.clone(),
                     heartbeat_interval: callback_cfg.heartbeat_interval,
@@ -141,7 +141,6 @@ impl SubscriptionModeConfig {
                 };
                 return SubscriptionMode::Callback(callback_cfg).into();
             }
-        }
 
         None
     }

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -131,16 +131,17 @@ impl SubscriptionModeConfig {
         }
 
         if let Some(callback_cfg) = &self.callback
-            && (callback_cfg.subgraphs.contains(service_name) || callback_cfg.subgraphs.is_empty()) {
-                let callback_cfg = CallbackMode {
-                    public_url: callback_cfg.public_url.clone(),
-                    heartbeat_interval: callback_cfg.heartbeat_interval,
-                    listen: callback_cfg.listen.clone(),
-                    path: callback_cfg.path.clone(),
-                    subgraphs: HashSet::new(), // We don't need it
-                };
-                return SubscriptionMode::Callback(callback_cfg).into();
-            }
+            && (callback_cfg.subgraphs.contains(service_name) || callback_cfg.subgraphs.is_empty())
+        {
+            let callback_cfg = CallbackMode {
+                public_url: callback_cfg.public_url.clone(),
+                heartbeat_interval: callback_cfg.heartbeat_interval,
+                listen: callback_cfg.listen.clone(),
+                path: callback_cfg.path.clone(),
+                subgraphs: HashSet::new(), // We don't need it
+            };
+            return SubscriptionMode::Callback(callback_cfg).into();
+        }
 
         None
     }

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -322,12 +322,13 @@ impl ApolloExporter {
                         if has_traces && !self.strip_traces.load(Ordering::SeqCst) {
                             // If we had traces then maybe disable sending traces from this exporter based on the response.
                             if let Ok(response) = serde_json::Value::from_str(&data)
-                                && let Some(Value::Bool(true)) = response.get("tracesIgnored") {
-                                    tracing::warn!(
-                                        "traces will not be sent to Apollo as this account is on a free plan"
-                                    );
-                                    self.strip_traces.store(true, Ordering::SeqCst);
-                                }
+                                && let Some(Value::Bool(true)) = response.get("tracesIgnored")
+                            {
+                                tracing::warn!(
+                                    "traces will not be sent to Apollo as this account is on a free plan"
+                                );
+                                self.strip_traces.store(true, Ordering::SeqCst);
+                            }
                         }
                         return Ok(());
                     }

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -321,14 +321,13 @@ impl ApolloExporter {
                         );
                         if has_traces && !self.strip_traces.load(Ordering::SeqCst) {
                             // If we had traces then maybe disable sending traces from this exporter based on the response.
-                            if let Ok(response) = serde_json::Value::from_str(&data) {
-                                if let Some(Value::Bool(true)) = response.get("tracesIgnored") {
+                            if let Ok(response) = serde_json::Value::from_str(&data)
+                                && let Some(Value::Bool(true)) = response.get("tracesIgnored") {
                                     tracing::warn!(
                                         "traces will not be sent to Apollo as this account is on a free plan"
                                     );
                                     self.strip_traces.store(true, Ordering::SeqCst);
                                 }
-                            }
                         }
                         return Ok(());
                     }

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -257,7 +257,7 @@ impl TraceIdFormat {
     pub(crate) fn format(&self, trace_id: TraceId) -> String {
         match self {
             TraceIdFormat::Hexadecimal | TraceIdFormat::OpenTelemetry => {
-                format!("{:032x}", trace_id)
+                format!("{trace_id:032x}")
             }
             TraceIdFormat::Decimal => format!("{}", u128::from_be_bytes(trace_id.to_bytes())),
             TraceIdFormat::Datadog => trace_id.to_datadog(),

--- a/apollo-router/src/plugins/telemetry/config_new/cache/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/cache/attributes.rs
@@ -25,12 +25,11 @@ impl DefaultForLevel for CacheAttributes {
         requirement_level: DefaultAttributeRequirementLevel,
         kind: TelemetryDataKind,
     ) {
-        if let TelemetryDataKind::Metrics = kind {
-            if let DefaultAttributeRequirementLevel::Required = requirement_level {
+        if let TelemetryDataKind::Metrics = kind
+            && let DefaultAttributeRequirementLevel::Required = requirement_level {
                 self.entity_type
                     .get_or_insert(StandardAttribute::Bool(false));
             }
-        }
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/config_new/cache/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/cache/attributes.rs
@@ -26,10 +26,11 @@ impl DefaultForLevel for CacheAttributes {
         kind: TelemetryDataKind,
     ) {
         if let TelemetryDataKind::Metrics = kind
-            && let DefaultAttributeRequirementLevel::Required = requirement_level {
-                self.entity_type
-                    .get_or_insert(StandardAttribute::Bool(false));
-            }
+            && let DefaultAttributeRequirementLevel::Required = requirement_level
+        {
+            self.entity_type
+                .get_or_insert(StandardAttribute::Bool(false));
+        }
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/config_new/conditions.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditions.rs
@@ -100,8 +100,7 @@ where
                         Ok(())
                     } else {
                         Err(format!(
-                            "the 'exists' condition use a selector applied at the wrong stage, this condition will be executed at the {} stage",
-                            stage
+                            "the 'exists' condition use a selector applied at the wrong stage, this condition will be executed at the {stage} stage"
                         ))
                     }
                 }

--- a/apollo-router/src/plugins/telemetry/config_new/conditions.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditions.rs
@@ -67,13 +67,12 @@ where
                     (SelectorOrValue::Value(_), SelectorOrValue::Selector(sel))
                     | (SelectorOrValue::Selector(sel), SelectorOrValue::Value(_)) => {
                         // Special condition for events
-                        if let Some(Stage::Request) = &restricted_stage {
-                            if !sel.is_active(Stage::Request) {
+                        if let Some(Stage::Request) = &restricted_stage
+                            && !sel.is_active(Stage::Request) {
                                 return Err(format!(
                                     "selector {sel:?} is only valid for request stage, this log event will never trigger"
                                 ));
                             }
-                        }
                         Ok(())
                     }
                     (SelectorOrValue::Selector(sel1), SelectorOrValue::Selector(sel2)) => {

--- a/apollo-router/src/plugins/telemetry/config_new/conditions.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditions.rs
@@ -68,11 +68,12 @@ where
                     | (SelectorOrValue::Selector(sel), SelectorOrValue::Value(_)) => {
                         // Special condition for events
                         if let Some(Stage::Request) = &restricted_stage
-                            && !sel.is_active(Stage::Request) {
-                                return Err(format!(
-                                    "selector {sel:?} is only valid for request stage, this log event will never trigger"
-                                ));
-                            }
+                            && !sel.is_active(Stage::Request)
+                        {
+                            return Err(format!(
+                                "selector {sel:?} is only valid for request stage, this log event will never trigger"
+                            ));
+                        }
                         Ok(())
                     }
                     (SelectorOrValue::Selector(sel1), SelectorOrValue::Selector(sel2)) => {

--- a/apollo-router/src/plugins/telemetry/config_new/connector/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/attributes.rs
@@ -108,11 +108,9 @@ impl Selectors<ConnectorRequest, ConnectorResponse, ()> for ConnectorAttributes 
             .connector_source_name
             .as_ref()
             .and_then(|a| a.key(CONNECTOR_SOURCE_NAME))
-        {
-            if let Some(ref source_name) = request.connector.id.source_name {
+            && let Some(ref source_name) = request.connector.id.source_name {
                 attrs.push(KeyValue::new(key, source_name.value.clone()));
             }
-        }
         if let Some(key) = self
             .connector_http_method
             .as_ref()

--- a/apollo-router/src/plugins/telemetry/config_new/connector/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/attributes.rs
@@ -108,9 +108,10 @@ impl Selectors<ConnectorRequest, ConnectorResponse, ()> for ConnectorAttributes 
             .connector_source_name
             .as_ref()
             .and_then(|a| a.key(CONNECTOR_SOURCE_NAME))
-            && let Some(ref source_name) = request.connector.id.source_name {
-                attrs.push(KeyValue::new(key, source_name.value.clone()));
-            }
+            && let Some(ref source_name) = request.connector.id.source_name
+        {
+            attrs.push(KeyValue::new(key, source_name.value.clone()));
+        }
         if let Some(key) = self
             .connector_http_method
             .as_ref()

--- a/apollo-router/src/plugins/telemetry/config_new/connector/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/events.rs
@@ -105,8 +105,8 @@ impl CustomEvents<ConnectorRequest, ConnectorResponse, (), ConnectorAttributes, 
     }
 
     pub(crate) fn on_error(&mut self, error: &BoxError, ctx: &Context) {
-        if let Some(error_event) = &mut self.error {
-            if error_event.condition.evaluate_error(error, ctx) {
+        if let Some(error_event) = &mut self.error
+            && error_event.condition.evaluate_error(error, ctx) {
                 log_event(
                     error_event.level,
                     "connector.http.error",
@@ -117,7 +117,6 @@ impl CustomEvents<ConnectorRequest, ConnectorResponse, (), ConnectorAttributes, 
                     "",
                 );
             }
-        }
         for custom_event in &mut self.custom {
             custom_event.on_error(error, ctx);
         }

--- a/apollo-router/src/plugins/telemetry/config_new/connector/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/connector/events.rs
@@ -106,17 +106,18 @@ impl CustomEvents<ConnectorRequest, ConnectorResponse, (), ConnectorAttributes, 
 
     pub(crate) fn on_error(&mut self, error: &BoxError, ctx: &Context) {
         if let Some(error_event) = &mut self.error
-            && error_event.condition.evaluate_error(error, ctx) {
-                log_event(
-                    error_event.level,
-                    "connector.http.error",
-                    vec![KeyValue::new(
-                        Key::from_static_str("error"),
-                        opentelemetry::Value::String(error.to_string().into()),
-                    )],
-                    "",
-                );
-            }
+            && error_event.condition.evaluate_error(error, ctx)
+        {
+            log_event(
+                error_event.level,
+                "connector.http.error",
+                vec![KeyValue::new(
+                    Key::from_static_str("error"),
+                    opentelemetry::Value::String(error.to_string().into()),
+                )],
+                "",
+            );
+        }
         for custom_event in &mut self.custom {
             custom_event.on_error(error, ctx);
         }

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -146,20 +146,22 @@ where
             .expect("failed to dereference attributes");
         let mut properties = BTreeMap::new();
         if let Schema::Object(schema_object) = attribute_schema
-            && let Some(object_validation) = &schema_object.object {
-                for key in object_validation.properties.keys() {
-                    properties.insert(key.clone(), Schema::Bool(true));
-                }
+            && let Some(object_validation) = &schema_object.object
+        {
+            for key in object_validation.properties.keys() {
+                properties.insert(key.clone(), Schema::Bool(true));
             }
+        }
         let mut schema = attribute_schema.clone();
         if let Schema::Object(schema_object) = &mut schema
-            && let Some(object_validation) = &mut schema_object.object {
-                object_validation.additional_properties = custom
-                    .into_object()
-                    .object
-                    .expect("could not get obejct validation")
-                    .additional_properties;
-            }
+            && let Some(object_validation) = &mut schema_object.object
+        {
+            object_validation.additional_properties = custom
+                .into_object()
+                .object
+                .expect("could not get obejct validation")
+                .additional_properties;
+        }
         schema
     }
 }

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -145,23 +145,21 @@ where
             .dereference(&attributes)
             .expect("failed to dereference attributes");
         let mut properties = BTreeMap::new();
-        if let Schema::Object(schema_object) = attribute_schema {
-            if let Some(object_validation) = &schema_object.object {
+        if let Schema::Object(schema_object) = attribute_schema
+            && let Some(object_validation) = &schema_object.object {
                 for key in object_validation.properties.keys() {
                     properties.insert(key.clone(), Schema::Bool(true));
                 }
             }
-        }
         let mut schema = attribute_schema.clone();
-        if let Schema::Object(schema_object) = &mut schema {
-            if let Some(object_validation) = &mut schema_object.object {
+        if let Schema::Object(schema_object) = &mut schema
+            && let Some(object_validation) = &mut schema_object.object {
                 object_validation.additional_properties = custom
                     .into_object()
                     .object
                     .expect("could not get obejct validation")
                     .additional_properties;
             }
-        }
         schema
     }
 }

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -98,9 +98,7 @@ where
                             let mut temp_attributes: Map<String, Value> = Map::new();
                             temp_attributes.insert(key.clone(), value.clone());
                             Att::deserialize(Value::Object(temp_attributes)).map_err(|e| {
-                                A::Error::custom(format!(
-                                    "failed to parse attribute '{key}': {e}"
-                                ))
+                                A::Error::custom(format!("failed to parse attribute '{key}': {e}"))
                             })?;
                             attributes.insert(key, value);
                         }

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -99,8 +99,7 @@ where
                             temp_attributes.insert(key.clone(), value.clone());
                             Att::deserialize(Value::Object(temp_attributes)).map_err(|e| {
                                 A::Error::custom(format!(
-                                    "failed to parse attribute '{}': {}",
-                                    key, e
+                                    "failed to parse attribute '{key}': {e}"
                                 ))
                             })?;
                             attributes.insert(key, value);

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
@@ -48,13 +48,12 @@ impl DefaultForLevel for GraphQLAttributes {
         requirement_level: DefaultAttributeRequirementLevel,
         kind: TelemetryDataKind,
     ) {
-        if let TelemetryDataKind::Metrics = kind {
-            if let DefaultAttributeRequirementLevel::Required = requirement_level {
+        if let TelemetryDataKind::Metrics = kind
+            && let DefaultAttributeRequirementLevel::Required = requirement_level {
                 self.field_name.get_or_insert(StandardAttribute::Bool(true));
                 self.field_type.get_or_insert(StandardAttribute::Bool(true));
                 self.type_name.get_or_insert(StandardAttribute::Bool(true));
             }
-        }
     }
 }
 
@@ -85,60 +84,51 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
             .field_name
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("graphql.field.name")))
-        {
-            if let Some(name) = (GraphQLSelector::FieldName {
+            && let Some(name) = (GraphQLSelector::FieldName {
                 field_name: FieldName::String,
             })
             .on_response_field(ty, field, value, ctx)
             {
                 attrs.push(KeyValue::new(key, name));
             }
-        }
         if let Some(key) = self
             .field_type
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("graphql.field.type")))
-        {
-            if let Some(ty) = (GraphQLSelector::FieldType {
+            && let Some(ty) = (GraphQLSelector::FieldType {
                 field_type: FieldType::Name,
             })
             .on_response_field(ty, field, value, ctx)
             {
                 attrs.push(KeyValue::new(key, ty));
             }
-        }
         if let Some(key) = self
             .type_name
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("graphql.type.name")))
-        {
-            if let Some(ty) = (GraphQLSelector::TypeName {
+            && let Some(ty) = (GraphQLSelector::TypeName {
                 type_name: TypeName::String,
             })
             .on_response_field(ty, field, value, ctx)
             {
                 attrs.push(KeyValue::new(key, ty));
             }
-        }
         if let Some(key) = self
             .list_length
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("graphql.list.length")))
-        {
-            if let Some(length) = (GraphQLSelector::ListLength {
+            && let Some(length) = (GraphQLSelector::ListLength {
                 list_length: ListLength::Value,
             })
             .on_response_field(ty, field, value, ctx)
             {
                 attrs.push(KeyValue::new(key, length));
             }
-        }
         if let Some(key) = self
             .operation_name
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("graphql.operation.name")))
-        {
-            if let Some(length) = (GraphQLSelector::OperationName {
+            && let Some(length) = (GraphQLSelector::OperationName {
                 operation_name: OperationName::String,
                 default: None,
             })
@@ -146,7 +136,6 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
             {
                 attrs.push(KeyValue::new(key, length));
             }
-        }
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
@@ -49,11 +49,12 @@ impl DefaultForLevel for GraphQLAttributes {
         kind: TelemetryDataKind,
     ) {
         if let TelemetryDataKind::Metrics = kind
-            && let DefaultAttributeRequirementLevel::Required = requirement_level {
-                self.field_name.get_or_insert(StandardAttribute::Bool(true));
-                self.field_type.get_or_insert(StandardAttribute::Bool(true));
-                self.type_name.get_or_insert(StandardAttribute::Bool(true));
-            }
+            && let DefaultAttributeRequirementLevel::Required = requirement_level
+        {
+            self.field_name.get_or_insert(StandardAttribute::Bool(true));
+            self.field_type.get_or_insert(StandardAttribute::Bool(true));
+            self.type_name.get_or_insert(StandardAttribute::Bool(true));
+        }
     }
 }
 
@@ -88,9 +89,9 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
                 field_name: FieldName::String,
             })
             .on_response_field(ty, field, value, ctx)
-            {
-                attrs.push(KeyValue::new(key, name));
-            }
+        {
+            attrs.push(KeyValue::new(key, name));
+        }
         if let Some(key) = self
             .field_type
             .as_ref()
@@ -99,9 +100,9 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
                 field_type: FieldType::Name,
             })
             .on_response_field(ty, field, value, ctx)
-            {
-                attrs.push(KeyValue::new(key, ty));
-            }
+        {
+            attrs.push(KeyValue::new(key, ty));
+        }
         if let Some(key) = self
             .type_name
             .as_ref()
@@ -110,9 +111,9 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
                 type_name: TypeName::String,
             })
             .on_response_field(ty, field, value, ctx)
-            {
-                attrs.push(KeyValue::new(key, ty));
-            }
+        {
+            attrs.push(KeyValue::new(key, ty));
+        }
         if let Some(key) = self
             .list_length
             .as_ref()
@@ -121,9 +122,9 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
                 list_length: ListLength::Value,
             })
             .on_response_field(ty, field, value, ctx)
-            {
-                attrs.push(KeyValue::new(key, length));
-            }
+        {
+            attrs.push(KeyValue::new(key, length));
+        }
         if let Some(key) = self
             .operation_name
             .as_ref()
@@ -133,9 +134,9 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
                 default: None,
             })
             .on_response_field(ty, field, value, ctx)
-            {
-                attrs.push(KeyValue::new(key, length));
-            }
+        {
+            attrs.push(KeyValue::new(key, length));
+        }
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
@@ -134,8 +134,8 @@ impl Instrumented for GraphQLInstruments {
         }
         self.custom.on_response_event(response, ctx);
 
-        if !self.custom.is_empty() || self.list_length.is_some() || self.field_execution.is_some() {
-            if let Some(executable_document) = ctx.executable_document() {
+        if (!self.custom.is_empty() || self.list_length.is_some() || self.field_execution.is_some())
+            && let Some(executable_document) = ctx.executable_document() {
                 GraphQLInstrumentsVisitor {
                     ctx,
                     instruments: self,
@@ -148,7 +148,6 @@ impl Instrumented for GraphQLInstruments {
                         .unwrap_or_default(),
                 );
             }
-        }
     }
 
     fn on_response_field(&self, ty: &NamedType, field: &Field, value: &Value, ctx: &Context) {

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
@@ -135,19 +135,20 @@ impl Instrumented for GraphQLInstruments {
         self.custom.on_response_event(response, ctx);
 
         if (!self.custom.is_empty() || self.list_length.is_some() || self.field_execution.is_some())
-            && let Some(executable_document) = ctx.executable_document() {
-                GraphQLInstrumentsVisitor {
-                    ctx,
-                    instruments: self,
-                }
-                .visit(
-                    &executable_document,
-                    response,
-                    &ctx.get_demand_control_context()
-                        .map(|c| c.variables)
-                        .unwrap_or_default(),
-                );
+            && let Some(executable_document) = ctx.executable_document()
+        {
+            GraphQLInstrumentsVisitor {
+                ctx,
+                instruments: self,
             }
+            .visit(
+                &executable_document,
+                response,
+                &ctx.get_demand_control_context()
+                    .map(|c| c.variables)
+                    .unwrap_or_default(),
+            );
+        }
     }
 
     fn on_response_field(&self, ty: &NamedType, field: &Field, value: &Value, ctx: &Context) {

--- a/apollo-router/src/plugins/telemetry/config_new/http_common/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/http_common/attributes.rs
@@ -204,19 +204,21 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
                 .headers()
                 .get(&CONTENT_LENGTH)
                 .and_then(|h| h.to_str().ok())
-                && let Ok(content_length) = content_length.parse::<i64>() {
-                    attrs.push(KeyValue::new(
-                        key,
-                        opentelemetry::Value::I64(content_length),
-                    ));
-                }
+            && let Ok(content_length) = content_length.parse::<i64>()
+        {
+            attrs.push(KeyValue::new(
+                key,
+                opentelemetry::Value::I64(content_length),
+            ));
+        }
         if let Some(key) = self
             .network_protocol_name
             .as_ref()
             .and_then(|a| a.key(NETWORK_PROTOCOL_NAME.into()))
-            && let Some(scheme) = request.router_request.uri().scheme() {
-                attrs.push(KeyValue::new(key, scheme.to_string()));
-            }
+            && let Some(scheme) = request.router_request.uri().scheme()
+        {
+            attrs.push(KeyValue::new(key, scheme.to_string()));
+        }
         if let Some(key) = self
             .network_protocol_version
             .as_ref()
@@ -240,13 +242,14 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
             .and_then(|a| a.key(NETWORK_TYPE.into()))
             && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.server_address {
-                    if socket.is_ipv4() {
-                        attrs.push(KeyValue::new(key, "ipv4".to_string()));
-                    } else if socket.is_ipv6() {
-                        attrs.push(KeyValue::new(key, "ipv6".to_string()));
-                    }
-                }
+            && let Some(socket) = connection_info.server_address
+        {
+            if socket.is_ipv4() {
+                attrs.push(KeyValue::new(key, "ipv4".to_string()));
+            } else if socket.is_ipv6() {
+                attrs.push(KeyValue::new(key, "ipv6".to_string()));
+            }
+        }
 
         attrs
     }
@@ -262,12 +265,13 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
                 .headers()
                 .get(&CONTENT_LENGTH)
                 .and_then(|h| h.to_str().ok())
-                && let Ok(content_length) = content_length.parse::<i64>() {
-                    attrs.push(KeyValue::new(
-                        key,
-                        opentelemetry::Value::I64(content_length),
-                    ));
-                }
+            && let Ok(content_length) = content_length.parse::<i64>()
+        {
+            attrs.push(KeyValue::new(
+                key,
+                opentelemetry::Value::I64(content_length),
+            ));
+        }
 
         if let Some(key) = self
             .http_response_status_code
@@ -281,16 +285,17 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
         }
 
         if let Some(key) = self.error_type.as_ref().and_then(|a| a.key(ERROR_TYPE))
-            && !response.response.status().is_success() {
-                attrs.push(KeyValue::new(
-                    key,
-                    response
-                        .response
-                        .status()
-                        .canonical_reason()
-                        .unwrap_or("unknown"),
-                ));
-            }
+            && !response.response.status().is_success()
+        {
+            attrs.push(KeyValue::new(
+                key,
+                response
+                    .response
+                    .status()
+                    .canonical_reason()
+                    .unwrap_or("unknown"),
+            ));
+        }
 
         attrs
     }

--- a/apollo-router/src/plugins/telemetry/config_new/http_common/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/http_common/attributes.rs
@@ -199,30 +199,24 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
             .http_request_body_size
             .as_ref()
             .and_then(|a| a.key(HTTP_REQUEST_BODY_SIZE.into()))
-        {
-            if let Some(content_length) = request
+            && let Some(content_length) = request
                 .router_request
                 .headers()
                 .get(&CONTENT_LENGTH)
                 .and_then(|h| h.to_str().ok())
-            {
-                if let Ok(content_length) = content_length.parse::<i64>() {
+                && let Ok(content_length) = content_length.parse::<i64>() {
                     attrs.push(KeyValue::new(
                         key,
                         opentelemetry::Value::I64(content_length),
                     ));
                 }
-            }
-        }
         if let Some(key) = self
             .network_protocol_name
             .as_ref()
             .and_then(|a| a.key(NETWORK_PROTOCOL_NAME.into()))
-        {
-            if let Some(scheme) = request.router_request.uri().scheme() {
+            && let Some(scheme) = request.router_request.uri().scheme() {
                 attrs.push(KeyValue::new(key, scheme.to_string()));
             }
-        }
         if let Some(key) = self
             .network_protocol_version
             .as_ref()
@@ -244,19 +238,15 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
             .network_type
             .as_ref()
             .and_then(|a| a.key(NETWORK_TYPE.into()))
-        {
-            if let Some(connection_info) =
+            && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.server_address {
+                && let Some(socket) = connection_info.server_address {
                     if socket.is_ipv4() {
                         attrs.push(KeyValue::new(key, "ipv4".to_string()));
                     } else if socket.is_ipv6() {
                         attrs.push(KeyValue::new(key, "ipv6".to_string()));
                     }
                 }
-            }
-        }
 
         attrs
     }
@@ -267,21 +257,17 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
             .http_response_body_size
             .as_ref()
             .and_then(|a| a.key(HTTP_RESPONSE_BODY_SIZE.into()))
-        {
-            if let Some(content_length) = response
+            && let Some(content_length) = response
                 .response
                 .headers()
                 .get(&CONTENT_LENGTH)
                 .and_then(|h| h.to_str().ok())
-            {
-                if let Ok(content_length) = content_length.parse::<i64>() {
+                && let Ok(content_length) = content_length.parse::<i64>() {
                     attrs.push(KeyValue::new(
                         key,
                         opentelemetry::Value::I64(content_length),
                     ));
                 }
-            }
-        }
 
         if let Some(key) = self
             .http_response_status_code
@@ -294,8 +280,8 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
             ));
         }
 
-        if let Some(key) = self.error_type.as_ref().and_then(|a| a.key(ERROR_TYPE)) {
-            if !response.response.status().is_success() {
+        if let Some(key) = self.error_type.as_ref().and_then(|a| a.key(ERROR_TYPE))
+            && !response.response.status().is_success() {
                 attrs.push(KeyValue::new(
                     key,
                     response
@@ -305,7 +291,6 @@ impl Selectors<router::Request, router::Response, ()> for HttpCommonAttributes {
                         .unwrap_or("unknown"),
                 ));
             }
-        }
 
         attrs
     }

--- a/apollo-router/src/plugins/telemetry/config_new/http_server/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/http_server/attributes.rs
@@ -230,11 +230,9 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 attrs.push(KeyValue::new(key, forwarded.ip().to_string()));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.peer_address {
+                && let Some(socket) = connection_info.peer_address {
                     attrs.push(KeyValue::new(key, socket.ip().to_string()));
                 }
-            }
         }
         if let Some(key) = self
             .client_port
@@ -245,11 +243,9 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 attrs.push(KeyValue::new(key, forwarded.port() as i64));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.peer_address {
+                && let Some(socket) = connection_info.peer_address {
                     attrs.push(KeyValue::new(key, socket.port() as i64));
                 }
-            }
         }
 
         if let Some(key) = self
@@ -263,11 +259,9 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 attrs.push(KeyValue::new(key, forwarded));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.server_address {
+                && let Some(socket) = connection_info.server_address {
                     attrs.push(KeyValue::new(key, socket.ip().to_string()));
                 }
-            }
         }
         if let Some(key) = self
             .server_port
@@ -278,66 +272,48 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 attrs.push(KeyValue::new(key, forwarded as i64));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.server_address {
+                && let Some(socket) = connection_info.server_address {
                     attrs.push(KeyValue::new(key, socket.port() as i64));
                 }
-            }
         }
 
         if let Some(key) = self
             .network_local_address
             .as_ref()
             .and_then(|a| a.key(NETWORK_LOCAL_ADDRESS))
-        {
-            if let Some(connection_info) =
+            && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.server_address {
+                && let Some(socket) = connection_info.server_address {
                     attrs.push(KeyValue::new(key, socket.ip().to_string()));
                 }
-            }
-        }
         if let Some(key) = self
             .network_local_port
             .as_ref()
             .and_then(|a| a.key(NETWORK_LOCAL_PORT))
-        {
-            if let Some(connection_info) =
+            && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.server_address {
+                && let Some(socket) = connection_info.server_address {
                     attrs.push(KeyValue::new(key, socket.port() as i64));
                 }
-            }
-        }
 
         if let Some(key) = self
             .network_peer_address
             .as_ref()
             .and_then(|a| a.key(NETWORK_PEER_ADDRESS))
-        {
-            if let Some(connection_info) =
+            && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.peer_address {
+                && let Some(socket) = connection_info.peer_address {
                     attrs.push(KeyValue::new(key, socket.ip().to_string()));
                 }
-            }
-        }
         if let Some(key) = self
             .network_peer_port
             .as_ref()
             .and_then(|a| a.key(NETWORK_PEER_PORT))
-        {
-            if let Some(connection_info) =
+            && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-            {
-                if let Some(socket) = connection_info.peer_address {
+                && let Some(socket) = connection_info.peer_address {
                     attrs.push(KeyValue::new(key, socket.port() as i64));
                 }
-            }
-        }
 
         let router_uri = request.router_request.uri();
         if let Some(key) = self.url_path.as_ref().and_then(|a| a.key(URL_PATH.into())) {
@@ -347,26 +323,21 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
             .url_query
             .as_ref()
             .and_then(|a| a.key(URL_QUERY.into()))
-        {
-            if let Some(query) = router_uri.query() {
+            && let Some(query) = router_uri.query() {
                 attrs.push(KeyValue::new(key, query.to_string()));
             }
-        }
         if let Some(key) = self
             .url_scheme
             .as_ref()
             .and_then(|a| a.key(URL_SCHEME.into()))
-        {
-            if let Some(scheme) = router_uri.scheme_str() {
+            && let Some(scheme) = router_uri.scheme_str() {
                 attrs.push(KeyValue::new(key, scheme.to_string()));
             }
-        }
         if let Some(key) = self
             .user_agent_original
             .as_ref()
             .and_then(|a| a.key(USER_AGENT_ORIGINAL.into()))
-        {
-            if let Some(user_agent) = request
+            && let Some(user_agent) = request
                 .router_request
                 .headers()
                 .get(&USER_AGENT)
@@ -374,7 +345,6 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
             {
                 attrs.push(KeyValue::new(key, user_agent.to_string()));
             }
-        }
 
         attrs
     }

--- a/apollo-router/src/plugins/telemetry/config_new/http_server/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/http_server/attributes.rs
@@ -230,9 +230,10 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 attrs.push(KeyValue::new(key, forwarded.ip().to_string()));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.peer_address {
-                    attrs.push(KeyValue::new(key, socket.ip().to_string()));
-                }
+                && let Some(socket) = connection_info.peer_address
+            {
+                attrs.push(KeyValue::new(key, socket.ip().to_string()));
+            }
         }
         if let Some(key) = self
             .client_port
@@ -243,9 +244,10 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 attrs.push(KeyValue::new(key, forwarded.port() as i64));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.peer_address {
-                    attrs.push(KeyValue::new(key, socket.port() as i64));
-                }
+                && let Some(socket) = connection_info.peer_address
+            {
+                attrs.push(KeyValue::new(key, socket.port() as i64));
+            }
         }
 
         if let Some(key) = self
@@ -259,9 +261,10 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 attrs.push(KeyValue::new(key, forwarded));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.server_address {
-                    attrs.push(KeyValue::new(key, socket.ip().to_string()));
-                }
+                && let Some(socket) = connection_info.server_address
+            {
+                attrs.push(KeyValue::new(key, socket.ip().to_string()));
+            }
         }
         if let Some(key) = self
             .server_port
@@ -272,9 +275,10 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 attrs.push(KeyValue::new(key, forwarded as i64));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.server_address {
-                    attrs.push(KeyValue::new(key, socket.port() as i64));
-                }
+                && let Some(socket) = connection_info.server_address
+            {
+                attrs.push(KeyValue::new(key, socket.port() as i64));
+            }
         }
 
         if let Some(key) = self
@@ -283,18 +287,20 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
             .and_then(|a| a.key(NETWORK_LOCAL_ADDRESS))
             && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.server_address {
-                    attrs.push(KeyValue::new(key, socket.ip().to_string()));
-                }
+            && let Some(socket) = connection_info.server_address
+        {
+            attrs.push(KeyValue::new(key, socket.ip().to_string()));
+        }
         if let Some(key) = self
             .network_local_port
             .as_ref()
             .and_then(|a| a.key(NETWORK_LOCAL_PORT))
             && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.server_address {
-                    attrs.push(KeyValue::new(key, socket.port() as i64));
-                }
+            && let Some(socket) = connection_info.server_address
+        {
+            attrs.push(KeyValue::new(key, socket.port() as i64));
+        }
 
         if let Some(key) = self
             .network_peer_address
@@ -302,18 +308,20 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
             .and_then(|a| a.key(NETWORK_PEER_ADDRESS))
             && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.peer_address {
-                    attrs.push(KeyValue::new(key, socket.ip().to_string()));
-                }
+            && let Some(socket) = connection_info.peer_address
+        {
+            attrs.push(KeyValue::new(key, socket.ip().to_string()));
+        }
         if let Some(key) = self
             .network_peer_port
             .as_ref()
             .and_then(|a| a.key(NETWORK_PEER_PORT))
             && let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
-                && let Some(socket) = connection_info.peer_address {
-                    attrs.push(KeyValue::new(key, socket.port() as i64));
-                }
+            && let Some(socket) = connection_info.peer_address
+        {
+            attrs.push(KeyValue::new(key, socket.port() as i64));
+        }
 
         let router_uri = request.router_request.uri();
         if let Some(key) = self.url_path.as_ref().and_then(|a| a.key(URL_PATH.into())) {
@@ -323,16 +331,18 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
             .url_query
             .as_ref()
             .and_then(|a| a.key(URL_QUERY.into()))
-            && let Some(query) = router_uri.query() {
-                attrs.push(KeyValue::new(key, query.to_string()));
-            }
+            && let Some(query) = router_uri.query()
+        {
+            attrs.push(KeyValue::new(key, query.to_string()));
+        }
         if let Some(key) = self
             .url_scheme
             .as_ref()
             .and_then(|a| a.key(URL_SCHEME.into()))
-            && let Some(scheme) = router_uri.scheme_str() {
-                attrs.push(KeyValue::new(key, scheme.to_string()));
-            }
+            && let Some(scheme) = router_uri.scheme_str()
+        {
+            attrs.push(KeyValue::new(key, scheme.to_string()));
+        }
         if let Some(key) = self
             .user_agent_original
             .as_ref()
@@ -342,9 +352,9 @@ impl Selectors<router::Request, router::Response, ()> for HttpServerAttributes {
                 .headers()
                 .get(&USER_AGENT)
                 .and_then(|h| h.to_str().ok())
-            {
-                attrs.push(KeyValue::new(key, user_agent.to_string()));
-            }
+        {
+            attrs.push(KeyValue::new(key, user_agent.to_string()));
+        }
 
         attrs
     }

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -2080,8 +2080,8 @@ impl Instrumented for ActiveRequestsCounter {
 
     fn on_request(&self, request: &Self::Request) {
         let mut inner = self.inner.lock();
-        if inner.attrs_config.http_request_method {
-            if let Some(attr) = (RouterSelector::RequestMethod {
+        if inner.attrs_config.http_request_method
+            && let Some(attr) = (RouterSelector::RequestMethod {
                 request_method: true,
             })
             .on_request(request)
@@ -2090,30 +2090,26 @@ impl Instrumented for ActiveRequestsCounter {
                     .attributes
                     .push(KeyValue::new(HTTP_REQUEST_METHOD, attr));
             }
-        }
-        if inner.attrs_config.server_address {
-            if let Some(attr) = HttpServerAttributes::forwarded_host(request)
+        if inner.attrs_config.server_address
+            && let Some(attr) = HttpServerAttributes::forwarded_host(request)
                 .and_then(|h| h.host().map(|h| h.to_string()))
             {
                 inner.attributes.push(KeyValue::new(SERVER_ADDRESS, attr));
             }
-        }
-        if inner.attrs_config.server_port {
-            if let Some(attr) =
+        if inner.attrs_config.server_port
+            && let Some(attr) =
                 HttpServerAttributes::forwarded_host(request).and_then(|h| h.port_u16())
             {
                 inner
                     .attributes
                     .push(KeyValue::new(SERVER_PORT, attr as i64));
             }
-        }
-        if inner.attrs_config.url_scheme {
-            if let Some(attr) = request.router_request.uri().scheme_str() {
+        if inner.attrs_config.url_scheme
+            && let Some(attr) = request.router_request.uri().scheme_str() {
                 inner
                     .attributes
                     .push(KeyValue::new(URL_SCHEME, attr.to_string()));
             }
-        }
         if let Some(counter) = &inner.counter {
             counter.add(1, &inner.attributes);
         }
@@ -2137,11 +2133,10 @@ impl Instrumented for ActiveRequestsCounter {
 impl Drop for ActiveRequestsCounter {
     fn drop(&mut self) {
         let inner = self.inner.try_lock();
-        if let Some(mut inner) = inner {
-            if let Some(counter) = &inner.counter.take() {
+        if let Some(mut inner) = inner
+            && let Some(counter) = &inner.counter.take() {
                 counter.add(-1, &inner.attributes);
             }
-        }
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -2848,7 +2848,7 @@ mod tests {
             // There's no async in this test, but introducing an async block allows us to separate metrics for each fixture.
             async move {
                 if fixture.ends_with("test.yaml") {
-                    println!("Running test for fixture: {}", fixture);
+                    println!("Running test for fixture: {fixture}");
                     let path = PathBuf::from_str(&fixture).unwrap();
                     let fixture_name = path
                         .parent()

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -2085,31 +2085,32 @@ impl Instrumented for ActiveRequestsCounter {
                 request_method: true,
             })
             .on_request(request)
-            {
-                inner
-                    .attributes
-                    .push(KeyValue::new(HTTP_REQUEST_METHOD, attr));
-            }
+        {
+            inner
+                .attributes
+                .push(KeyValue::new(HTTP_REQUEST_METHOD, attr));
+        }
         if inner.attrs_config.server_address
             && let Some(attr) = HttpServerAttributes::forwarded_host(request)
                 .and_then(|h| h.host().map(|h| h.to_string()))
-            {
-                inner.attributes.push(KeyValue::new(SERVER_ADDRESS, attr));
-            }
+        {
+            inner.attributes.push(KeyValue::new(SERVER_ADDRESS, attr));
+        }
         if inner.attrs_config.server_port
             && let Some(attr) =
                 HttpServerAttributes::forwarded_host(request).and_then(|h| h.port_u16())
-            {
-                inner
-                    .attributes
-                    .push(KeyValue::new(SERVER_PORT, attr as i64));
-            }
+        {
+            inner
+                .attributes
+                .push(KeyValue::new(SERVER_PORT, attr as i64));
+        }
         if inner.attrs_config.url_scheme
-            && let Some(attr) = request.router_request.uri().scheme_str() {
-                inner
-                    .attributes
-                    .push(KeyValue::new(URL_SCHEME, attr.to_string()));
-            }
+            && let Some(attr) = request.router_request.uri().scheme_str()
+        {
+            inner
+                .attributes
+                .push(KeyValue::new(URL_SCHEME, attr.to_string()));
+        }
         if let Some(counter) = &inner.counter {
             counter.add(1, &inner.attributes);
         }
@@ -2134,9 +2135,10 @@ impl Drop for ActiveRequestsCounter {
     fn drop(&mut self) {
         let inner = self.inner.try_lock();
         if let Some(mut inner) = inner
-            && let Some(counter) = &inner.counter.take() {
-                counter.add(-1, &inner.attributes);
-            }
+            && let Some(counter) = &inner.counter.take()
+        {
+            counter.add(-1, &inner.attributes);
+        }
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/config_new/logging.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/logging.rs
@@ -244,7 +244,7 @@ impl<'de> Deserialize<'de> for Format {
                 match value {
                     "json" => Ok(Format::Json(JsonFormat::default())),
                     "text" => Ok(Format::Text(TextFormat::default())),
-                    _ => Err(E::custom(format!("unknown log format: {}", value))),
+                    _ => Err(E::custom(format!("unknown log format: {value}"))),
                 }
             }
 
@@ -258,8 +258,7 @@ impl<'de> Deserialize<'de> for Format {
                     Some("json") => Ok(Format::Json(map.next_value::<JsonFormat>()?)),
                     Some("text") => Ok(Format::Text(map.next_value::<TextFormat>()?)),
                     Some(value) => Err(serde::de::Error::custom(format!(
-                        "unknown log format: {}",
-                        value
+                        "unknown log format: {value}"
                     ))),
                     _ => Err(serde::de::Error::custom("unknown log format")),
                 }

--- a/apollo-router/src/plugins/telemetry/config_new/router/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/attributes.rs
@@ -64,21 +64,17 @@ impl Selectors<router::Request, router::Response, ()> for RouterAttributes {
             .trace_id
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("trace_id")))
-        {
-            if let Some(trace_id) = trace_id() {
+            && let Some(trace_id) = trace_id() {
                 attrs.push(KeyValue::new(key, trace_id.to_string()));
             }
-        }
 
         if let Some(key) = self
             .datadog_trace_id
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("dd.trace_id")))
-        {
-            if let Some(trace_id) = trace_id() {
+            && let Some(trace_id) = trace_id() {
                 attrs.push(KeyValue::new(key, trace_id.to_datadog()));
             }
-        }
         if let Some(true) = &self.baggage {
             let context = Span::current().context();
             let baggage = context.baggage();

--- a/apollo-router/src/plugins/telemetry/config_new/router/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/attributes.rs
@@ -64,17 +64,19 @@ impl Selectors<router::Request, router::Response, ()> for RouterAttributes {
             .trace_id
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("trace_id")))
-            && let Some(trace_id) = trace_id() {
-                attrs.push(KeyValue::new(key, trace_id.to_string()));
-            }
+            && let Some(trace_id) = trace_id()
+        {
+            attrs.push(KeyValue::new(key, trace_id.to_string()));
+        }
 
         if let Some(key) = self
             .datadog_trace_id
             .as_ref()
             .and_then(|a| a.key(Key::from_static_str("dd.trace_id")))
-            && let Some(trace_id) = trace_id() {
-                attrs.push(KeyValue::new(key, trace_id.to_datadog()));
-            }
+            && let Some(trace_id) = trace_id()
+        {
+            attrs.push(KeyValue::new(key, trace_id.to_datadog()));
+        }
         if let Some(true) = &self.baggage {
             let context = Span::current().context();
             let baggage = context.baggage();

--- a/apollo-router/src/plugins/telemetry/config_new/router/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/events.rs
@@ -71,7 +71,7 @@ impl CustomEvents<router::Request, router::Response, (), RouterAttributes, Route
                 let headers = response.response.headers();
                 attrs.push(KeyValue::new(
                     HTTP_RESPONSE_HEADERS,
-                    opentelemetry::Value::String(format!("{:?}", headers).into()),
+                    opentelemetry::Value::String(format!("{headers:?}").into()),
                 ));
                 attrs.push(KeyValue::new(
                     HTTP_RESPONSE_STATUS,

--- a/apollo-router/src/plugins/telemetry/config_new/router/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/events.rs
@@ -32,19 +32,21 @@ pub(crate) type RouterEvents =
 impl CustomEvents<router::Request, router::Response, (), RouterAttributes, RouterSelector> {
     pub(crate) fn on_request(&mut self, request: &router::Request) {
         if let Some(request_event) = &mut self.request
-            && request_event.condition.evaluate_request(request) == Some(true) {
-                request
-                    .context
-                    .extensions()
-                    .with_lock(|ext| ext.insert(DisplayRouterRequest(request_event.level)));
-            }
+            && request_event.condition.evaluate_request(request) == Some(true)
+        {
+            request
+                .context
+                .extensions()
+                .with_lock(|ext| ext.insert(DisplayRouterRequest(request_event.level)));
+        }
         if let Some(response_event) = &mut self.response
-            && response_event.condition.evaluate_request(request) != Some(false) {
-                request
-                    .context
-                    .extensions()
-                    .with_lock(|ext| ext.insert(DisplayRouterResponse));
-            }
+            && response_event.condition.evaluate_request(request) != Some(false)
+        {
+            request
+                .context
+                .extensions()
+                .with_lock(|ext| ext.insert(DisplayRouterResponse));
+        }
         for custom_event in &mut self.custom {
             custom_event.on_request(request);
         }
@@ -52,50 +54,49 @@ impl CustomEvents<router::Request, router::Response, (), RouterAttributes, Route
 
     pub(crate) fn on_response(&mut self, response: &router::Response) {
         if let Some(response_event) = &self.response
-            && response_event.condition.evaluate_response(response) {
-                let mut attrs = Vec::with_capacity(4);
+            && response_event.condition.evaluate_response(response)
+        {
+            let mut attrs = Vec::with_capacity(4);
 
-                #[cfg(test)]
-                let mut headers: indexmap::IndexMap<String, http::HeaderValue> = response
-                    .response
-                    .headers()
-                    .clone()
-                    .into_iter()
-                    .filter_map(|(name, val)| Some((name?.to_string(), val)))
-                    .collect();
-                #[cfg(test)]
-                headers.sort_keys();
-                #[cfg(not(test))]
-                let headers = response.response.headers();
-                attrs.push(KeyValue::new(
-                    HTTP_RESPONSE_HEADERS,
-                    opentelemetry::Value::String(format!("{headers:?}").into()),
-                ));
-                attrs.push(KeyValue::new(
-                    HTTP_RESPONSE_STATUS,
-                    opentelemetry::Value::String(format!("{}", response.response.status()).into()),
-                ));
-                attrs.push(KeyValue::new(
-                    HTTP_RESPONSE_VERSION,
-                    opentelemetry::Value::String(
-                        format!("{:?}", response.response.version()).into(),
-                    ),
-                ));
+            #[cfg(test)]
+            let mut headers: indexmap::IndexMap<String, http::HeaderValue> = response
+                .response
+                .headers()
+                .clone()
+                .into_iter()
+                .filter_map(|(name, val)| Some((name?.to_string(), val)))
+                .collect();
+            #[cfg(test)]
+            headers.sort_keys();
+            #[cfg(not(test))]
+            let headers = response.response.headers();
+            attrs.push(KeyValue::new(
+                HTTP_RESPONSE_HEADERS,
+                opentelemetry::Value::String(format!("{headers:?}").into()),
+            ));
+            attrs.push(KeyValue::new(
+                HTTP_RESPONSE_STATUS,
+                opentelemetry::Value::String(format!("{}", response.response.status()).into()),
+            ));
+            attrs.push(KeyValue::new(
+                HTTP_RESPONSE_VERSION,
+                opentelemetry::Value::String(format!("{:?}", response.response.version()).into()),
+            ));
 
-                if let Some(body) = response
-                    .context
-                    .extensions()
-                    // Clone here in case anything else also needs access to the body
-                    .with_lock(|ext| ext.get::<RouterResponseBodyExtensionType>().cloned())
-                {
-                    attrs.push(KeyValue::new(
-                        HTTP_RESPONSE_BODY,
-                        opentelemetry::Value::String(body.0.into()),
-                    ));
-                }
-
-                log_event(response_event.level, "router.response", attrs, "");
+            if let Some(body) = response
+                .context
+                .extensions()
+                // Clone here in case anything else also needs access to the body
+                .with_lock(|ext| ext.get::<RouterResponseBodyExtensionType>().cloned())
+            {
+                attrs.push(KeyValue::new(
+                    HTTP_RESPONSE_BODY,
+                    opentelemetry::Value::String(body.0.into()),
+                ));
             }
+
+            log_event(response_event.level, "router.response", attrs, "");
+        }
         for custom_event in &mut self.custom {
             custom_event.on_response(response);
         }
@@ -103,17 +104,18 @@ impl CustomEvents<router::Request, router::Response, (), RouterAttributes, Route
 
     pub(crate) fn on_error(&mut self, error: &BoxError, ctx: &Context) {
         if let Some(error_event) = &self.error
-            && error_event.condition.evaluate_error(error, ctx) {
-                log_event(
-                    error_event.level,
-                    "router.error",
-                    vec![KeyValue::new(
-                        Key::from_static_str("error"),
-                        opentelemetry::Value::String(error.to_string().into()),
-                    )],
-                    "",
-                );
-            }
+            && error_event.condition.evaluate_error(error, ctx)
+        {
+            log_event(
+                error_event.level,
+                "router.error",
+                vec![KeyValue::new(
+                    Key::from_static_str("error"),
+                    opentelemetry::Value::String(error.to_string().into()),
+                )],
+                "",
+            );
+        }
         for custom_event in &mut self.custom {
             custom_event.on_error(error, ctx);
         }

--- a/apollo-router/src/plugins/telemetry/config_new/router/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/events.rs
@@ -31,30 +31,28 @@ pub(crate) type RouterEvents =
 
 impl CustomEvents<router::Request, router::Response, (), RouterAttributes, RouterSelector> {
     pub(crate) fn on_request(&mut self, request: &router::Request) {
-        if let Some(request_event) = &mut self.request {
-            if request_event.condition.evaluate_request(request) == Some(true) {
+        if let Some(request_event) = &mut self.request
+            && request_event.condition.evaluate_request(request) == Some(true) {
                 request
                     .context
                     .extensions()
                     .with_lock(|ext| ext.insert(DisplayRouterRequest(request_event.level)));
             }
-        }
-        if let Some(response_event) = &mut self.response {
-            if response_event.condition.evaluate_request(request) != Some(false) {
+        if let Some(response_event) = &mut self.response
+            && response_event.condition.evaluate_request(request) != Some(false) {
                 request
                     .context
                     .extensions()
                     .with_lock(|ext| ext.insert(DisplayRouterResponse));
             }
-        }
         for custom_event in &mut self.custom {
             custom_event.on_request(request);
         }
     }
 
     pub(crate) fn on_response(&mut self, response: &router::Response) {
-        if let Some(response_event) = &self.response {
-            if response_event.condition.evaluate_response(response) {
+        if let Some(response_event) = &self.response
+            && response_event.condition.evaluate_response(response) {
                 let mut attrs = Vec::with_capacity(4);
 
                 #[cfg(test)]
@@ -98,15 +96,14 @@ impl CustomEvents<router::Request, router::Response, (), RouterAttributes, Route
 
                 log_event(response_event.level, "router.response", attrs, "");
             }
-        }
         for custom_event in &mut self.custom {
             custom_event.on_response(response);
         }
     }
 
     pub(crate) fn on_error(&mut self, error: &BoxError, ctx: &Context) {
-        if let Some(error_event) = &self.error {
-            if error_event.condition.evaluate_error(error, ctx) {
+        if let Some(error_event) = &self.error
+            && error_event.condition.evaluate_error(error, ctx) {
                 log_event(
                     error_event.level,
                     "router.error",
@@ -117,7 +114,6 @@ impl CustomEvents<router::Request, router::Response, (), RouterAttributes, Route
                     "",
                 );
             }
-        }
         for custom_event in &mut self.custom {
             custom_event.on_error(error, ctx);
         }

--- a/apollo-router/src/plugins/telemetry/config_new/subgraph/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/subgraph/attributes.rs
@@ -77,16 +77,18 @@ impl Selectors<subgraph::Request, subgraph::Response, ()> for SubgraphAttributes
             .graphql_document
             .as_ref()
             .and_then(|a| a.key(SUBGRAPH_GRAPHQL_DOCUMENT))
-            && let Some(query) = &request.subgraph_request.body().query {
-                attrs.push(KeyValue::new(key, query.clone()));
-            }
+            && let Some(query) = &request.subgraph_request.body().query
+        {
+            attrs.push(KeyValue::new(key, query.clone()));
+        }
         if let Some(key) = self
             .graphql_operation_name
             .as_ref()
             .and_then(|a| a.key(SUBGRAPH_GRAPHQL_OPERATION_NAME))
-            && let Some(op_name) = &request.subgraph_request.body().operation_name {
-                attrs.push(KeyValue::new(key, op_name.clone()));
-            }
+            && let Some(op_name) = &request.subgraph_request.body().operation_name
+        {
+            attrs.push(KeyValue::new(key, op_name.clone()));
+        }
         if let Some(key) = self
             .graphql_operation_type
             .as_ref()
@@ -123,9 +125,9 @@ impl Selectors<subgraph::Request, subgraph::Response, ()> for SubgraphAttributes
                 .get::<_, usize>(SubgraphRequestResendCountKey::new(&response.id))
                 .ok()
                 .flatten()
-            {
-                attrs.push(KeyValue::new(key, resend_count as i64));
-            }
+        {
+            attrs.push(KeyValue::new(key, resend_count as i64));
+        }
 
         attrs
     }

--- a/apollo-router/src/plugins/telemetry/config_new/subgraph/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/subgraph/attributes.rs
@@ -77,20 +77,16 @@ impl Selectors<subgraph::Request, subgraph::Response, ()> for SubgraphAttributes
             .graphql_document
             .as_ref()
             .and_then(|a| a.key(SUBGRAPH_GRAPHQL_DOCUMENT))
-        {
-            if let Some(query) = &request.subgraph_request.body().query {
+            && let Some(query) = &request.subgraph_request.body().query {
                 attrs.push(KeyValue::new(key, query.clone()));
             }
-        }
         if let Some(key) = self
             .graphql_operation_name
             .as_ref()
             .and_then(|a| a.key(SUBGRAPH_GRAPHQL_OPERATION_NAME))
-        {
-            if let Some(op_name) = &request.subgraph_request.body().operation_name {
+            && let Some(op_name) = &request.subgraph_request.body().operation_name {
                 attrs.push(KeyValue::new(key, op_name.clone()));
             }
-        }
         if let Some(key) = self
             .graphql_operation_type
             .as_ref()
@@ -122,8 +118,7 @@ impl Selectors<subgraph::Request, subgraph::Response, ()> for SubgraphAttributes
             .http_request_resend_count
             .as_ref()
             .and_then(|a| a.key(HTTP_REQUEST_RESEND_COUNT))
-        {
-            if let Some(resend_count) = response
+            && let Some(resend_count) = response
                 .context
                 .get::<_, usize>(SubgraphRequestResendCountKey::new(&response.id))
                 .ok()
@@ -131,7 +126,6 @@ impl Selectors<subgraph::Request, subgraph::Response, ()> for SubgraphAttributes
             {
                 attrs.push(KeyValue::new(key, resend_count as i64));
             }
-        }
 
         attrs
     }

--- a/apollo-router/src/plugins/telemetry/config_new/subgraph/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/subgraph/events.rs
@@ -22,8 +22,8 @@ pub(crate) type SubgraphEvents =
     CustomEvents<subgraph::Request, subgraph::Response, (), SubgraphAttributes, SubgraphSelector>;
 impl CustomEvents<subgraph::Request, subgraph::Response, (), SubgraphAttributes, SubgraphSelector> {
     pub(crate) fn on_request(&mut self, request: &subgraph::Request) {
-        if let Some(mut request_event) = self.request.take() {
-            if request_event.condition.evaluate_request(request) == Some(true) {
+        if let Some(mut request_event) = self.request.take()
+            && request_event.condition.evaluate_request(request) == Some(true) {
                 request.context.extensions().with_lock(|lock| {
                     lock.insert(SubgraphEventRequest {
                         level: request_event.level,
@@ -31,9 +31,8 @@ impl CustomEvents<subgraph::Request, subgraph::Response, (), SubgraphAttributes,
                     })
                 });
             }
-        }
-        if let Some(mut response_event) = self.response.take() {
-            if response_event.condition.evaluate_request(request) != Some(false) {
+        if let Some(mut response_event) = self.response.take()
+            && response_event.condition.evaluate_request(request) != Some(false) {
                 request.context.extensions().with_lock(|lock| {
                     lock.insert(SubgraphEventResponse {
                         level: response_event.level,
@@ -41,7 +40,6 @@ impl CustomEvents<subgraph::Request, subgraph::Response, (), SubgraphAttributes,
                     })
                 });
             }
-        }
         for custom_event in &mut self.custom {
             custom_event.on_request(request);
         }
@@ -54,8 +52,8 @@ impl CustomEvents<subgraph::Request, subgraph::Response, (), SubgraphAttributes,
     }
 
     pub(crate) fn on_error(&mut self, error: &BoxError, ctx: &Context) {
-        if let Some(error_event) = &self.error {
-            if error_event.condition.evaluate_error(error, ctx) {
+        if let Some(error_event) = &self.error
+            && error_event.condition.evaluate_error(error, ctx) {
                 log_event(
                     error_event.level,
                     "subgraph.error",
@@ -66,7 +64,6 @@ impl CustomEvents<subgraph::Request, subgraph::Response, (), SubgraphAttributes,
                     "",
                 );
             }
-        }
         for custom_event in &mut self.custom {
             custom_event.on_error(error, ctx);
         }

--- a/apollo-router/src/plugins/telemetry/config_new/subgraph/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/subgraph/events.rs
@@ -23,23 +23,25 @@ pub(crate) type SubgraphEvents =
 impl CustomEvents<subgraph::Request, subgraph::Response, (), SubgraphAttributes, SubgraphSelector> {
     pub(crate) fn on_request(&mut self, request: &subgraph::Request) {
         if let Some(mut request_event) = self.request.take()
-            && request_event.condition.evaluate_request(request) == Some(true) {
-                request.context.extensions().with_lock(|lock| {
-                    lock.insert(SubgraphEventRequest {
-                        level: request_event.level,
-                        condition: Arc::new(Mutex::new(request_event.condition)),
-                    })
-                });
-            }
+            && request_event.condition.evaluate_request(request) == Some(true)
+        {
+            request.context.extensions().with_lock(|lock| {
+                lock.insert(SubgraphEventRequest {
+                    level: request_event.level,
+                    condition: Arc::new(Mutex::new(request_event.condition)),
+                })
+            });
+        }
         if let Some(mut response_event) = self.response.take()
-            && response_event.condition.evaluate_request(request) != Some(false) {
-                request.context.extensions().with_lock(|lock| {
-                    lock.insert(SubgraphEventResponse {
-                        level: response_event.level,
-                        condition: Arc::new(response_event.condition),
-                    })
-                });
-            }
+            && response_event.condition.evaluate_request(request) != Some(false)
+        {
+            request.context.extensions().with_lock(|lock| {
+                lock.insert(SubgraphEventResponse {
+                    level: response_event.level,
+                    condition: Arc::new(response_event.condition),
+                })
+            });
+        }
         for custom_event in &mut self.custom {
             custom_event.on_request(request);
         }
@@ -53,17 +55,18 @@ impl CustomEvents<subgraph::Request, subgraph::Response, (), SubgraphAttributes,
 
     pub(crate) fn on_error(&mut self, error: &BoxError, ctx: &Context) {
         if let Some(error_event) = &self.error
-            && error_event.condition.evaluate_error(error, ctx) {
-                log_event(
-                    error_event.level,
-                    "subgraph.error",
-                    vec![KeyValue::new(
-                        Key::from_static_str("error"),
-                        opentelemetry::Value::String(error.to_string().into()),
-                    )],
-                    "",
-                );
-            }
+            && error_event.condition.evaluate_error(error, ctx)
+        {
+            log_event(
+                error_event.level,
+                "subgraph.error",
+                vec![KeyValue::new(
+                    Key::from_static_str("error"),
+                    opentelemetry::Value::String(error.to_string().into()),
+                )],
+                "",
+            );
+        }
         for custom_event in &mut self.custom {
             custom_event.on_error(error, ctx);
         }

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/attributes.rs
@@ -90,37 +90,31 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
             .graphql_document
             .as_ref()
             .and_then(|a| a.key(GRAPHQL_DOCUMENT.into()))
-        {
-            if let Some(query) = &request.supergraph_request.body().query {
+            && let Some(query) = &request.supergraph_request.body().query {
                 attrs.push(KeyValue::new(key, query.clone()));
             }
-        }
         if let Some(key) = self
             .graphql_operation_name
             .as_ref()
             .and_then(|a| a.key(GRAPHQL_OPERATION_NAME.into()))
-        {
-            if let Some(operation_name) = &request
+            && let Some(operation_name) = &request
                 .context
                 .get::<_, String>(OPERATION_NAME)
                 .unwrap_or_default()
             {
                 attrs.push(KeyValue::new(key, operation_name.clone()));
             }
-        }
         if let Some(key) = self
             .graphql_operation_type
             .as_ref()
             .and_then(|a| a.key(GRAPHQL_OPERATION_TYPE.into()))
-        {
-            if let Some(operation_type) = &request
+            && let Some(operation_type) = &request
                 .context
                 .get::<_, String>(OPERATION_KIND)
                 .unwrap_or_default()
             {
                 attrs.push(KeyValue::new(key, operation_type.clone()));
             }
-        }
 
         attrs
     }

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/attributes.rs
@@ -90,9 +90,10 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
             .graphql_document
             .as_ref()
             .and_then(|a| a.key(GRAPHQL_DOCUMENT.into()))
-            && let Some(query) = &request.supergraph_request.body().query {
-                attrs.push(KeyValue::new(key, query.clone()));
-            }
+            && let Some(query) = &request.supergraph_request.body().query
+        {
+            attrs.push(KeyValue::new(key, query.clone()));
+        }
         if let Some(key) = self
             .graphql_operation_name
             .as_ref()
@@ -101,9 +102,9 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
                 .context
                 .get::<_, String>(OPERATION_NAME)
                 .unwrap_or_default()
-            {
-                attrs.push(KeyValue::new(key, operation_name.clone()));
-            }
+        {
+            attrs.push(KeyValue::new(key, operation_name.clone()));
+        }
         if let Some(key) = self
             .graphql_operation_type
             .as_ref()
@@ -112,9 +113,9 @@ impl Selectors<supergraph::Request, supergraph::Response, crate::graphql::Respon
                 .context
                 .get::<_, String>(OPERATION_KIND)
                 .unwrap_or_default()
-            {
-                attrs.push(KeyValue::new(key, operation_type.clone()));
-            }
+        {
+            attrs.push(KeyValue::new(key, operation_type.clone()));
+        }
 
         attrs
     }

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
@@ -42,61 +42,63 @@ impl
 {
     pub(crate) fn on_request(&mut self, request: &supergraph::Request) {
         if let Some(request_event) = &mut self.request
-            && request_event.condition.evaluate_request(request) == Some(true) {
-                let mut attrs = Vec::with_capacity(5);
-                #[cfg(test)]
-                let mut headers: indexmap::IndexMap<String, http::HeaderValue> = request
-                    .supergraph_request
-                    .headers()
-                    .clone()
-                    .into_iter()
-                    .filter_map(|(name, val)| Some((name?.to_string(), val)))
-                    .collect();
-                #[cfg(test)]
-                headers.sort_keys();
-                #[cfg(not(test))]
-                let headers = request.supergraph_request.headers();
-                attrs.push(KeyValue::new(
-                    HTTP_REQUEST_HEADERS,
-                    opentelemetry::Value::String(format!("{headers:?}").into()),
-                ));
-                attrs.push(KeyValue::new(
-                    HTTP_REQUEST_METHOD,
-                    opentelemetry::Value::String(
-                        format!("{}", request.supergraph_request.method()).into(),
-                    ),
-                ));
-                attrs.push(KeyValue::new(
-                    HTTP_REQUEST_URI,
-                    opentelemetry::Value::String(
-                        format!("{}", request.supergraph_request.uri()).into(),
-                    ),
-                ));
-                attrs.push(KeyValue::new(
-                    HTTP_REQUEST_VERSION,
-                    opentelemetry::Value::String(
-                        format!("{:?}", request.supergraph_request.version()).into(),
-                    ),
-                ));
-                attrs.push(KeyValue::new(
-                    HTTP_REQUEST_BODY,
-                    opentelemetry::Value::String(
-                        serde_json::to_string(request.supergraph_request.body())
-                            .unwrap_or_default()
-                            .into(),
-                    ),
-                ));
-                log_event(request_event.level, "supergraph.request", attrs, "");
-            }
+            && request_event.condition.evaluate_request(request) == Some(true)
+        {
+            let mut attrs = Vec::with_capacity(5);
+            #[cfg(test)]
+            let mut headers: indexmap::IndexMap<String, http::HeaderValue> = request
+                .supergraph_request
+                .headers()
+                .clone()
+                .into_iter()
+                .filter_map(|(name, val)| Some((name?.to_string(), val)))
+                .collect();
+            #[cfg(test)]
+            headers.sort_keys();
+            #[cfg(not(test))]
+            let headers = request.supergraph_request.headers();
+            attrs.push(KeyValue::new(
+                HTTP_REQUEST_HEADERS,
+                opentelemetry::Value::String(format!("{headers:?}").into()),
+            ));
+            attrs.push(KeyValue::new(
+                HTTP_REQUEST_METHOD,
+                opentelemetry::Value::String(
+                    format!("{}", request.supergraph_request.method()).into(),
+                ),
+            ));
+            attrs.push(KeyValue::new(
+                HTTP_REQUEST_URI,
+                opentelemetry::Value::String(
+                    format!("{}", request.supergraph_request.uri()).into(),
+                ),
+            ));
+            attrs.push(KeyValue::new(
+                HTTP_REQUEST_VERSION,
+                opentelemetry::Value::String(
+                    format!("{:?}", request.supergraph_request.version()).into(),
+                ),
+            ));
+            attrs.push(KeyValue::new(
+                HTTP_REQUEST_BODY,
+                opentelemetry::Value::String(
+                    serde_json::to_string(request.supergraph_request.body())
+                        .unwrap_or_default()
+                        .into(),
+                ),
+            ));
+            log_event(request_event.level, "supergraph.request", attrs, "");
+        }
         if let Some(mut response_event) = self.response.take()
-            && response_event.condition.evaluate_request(request) != Some(false) {
-                request.context.extensions().with_lock(|lock| {
-                    lock.insert(SupergraphEventResponse {
-                        level: response_event.level,
-                        condition: Arc::new(response_event.condition),
-                    })
-                });
-            }
+            && response_event.condition.evaluate_request(request) != Some(false)
+        {
+            request.context.extensions().with_lock(|lock| {
+                lock.insert(SupergraphEventResponse {
+                    level: response_event.level,
+                    condition: Arc::new(response_event.condition),
+                })
+            });
+        }
         for custom_event in &mut self.custom {
             custom_event.on_request(request);
         }
@@ -116,17 +118,18 @@ impl
 
     pub(crate) fn on_error(&mut self, error: &BoxError, ctx: &Context) {
         if let Some(error_event) = &self.error
-            && error_event.condition.evaluate_error(error, ctx) {
-                log_event(
-                    error_event.level,
-                    "supergraph.error",
-                    vec![KeyValue::new(
-                        Key::from_static_str("error"),
-                        opentelemetry::Value::String(error.to_string().into()),
-                    )],
-                    "",
-                );
-            }
+            && error_event.condition.evaluate_error(error, ctx)
+        {
+            log_event(
+                error_event.level,
+                "supergraph.error",
+                vec![KeyValue::new(
+                    Key::from_static_str("error"),
+                    opentelemetry::Value::String(error.to_string().into()),
+                )],
+                "",
+            );
+        }
         for custom_event in &mut self.custom {
             custom_event.on_error(error, ctx);
         }

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
@@ -58,7 +58,7 @@ impl
                 let headers = request.supergraph_request.headers();
                 attrs.push(KeyValue::new(
                     HTTP_REQUEST_HEADERS,
-                    opentelemetry::Value::String(format!("{:?}", headers).into()),
+                    opentelemetry::Value::String(format!("{headers:?}").into()),
                 ));
                 attrs.push(KeyValue::new(
                     HTTP_REQUEST_METHOD,

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
@@ -41,8 +41,8 @@ impl
     >
 {
     pub(crate) fn on_request(&mut self, request: &supergraph::Request) {
-        if let Some(request_event) = &mut self.request {
-            if request_event.condition.evaluate_request(request) == Some(true) {
+        if let Some(request_event) = &mut self.request
+            && request_event.condition.evaluate_request(request) == Some(true) {
                 let mut attrs = Vec::with_capacity(5);
                 #[cfg(test)]
                 let mut headers: indexmap::IndexMap<String, http::HeaderValue> = request
@@ -88,9 +88,8 @@ impl
                 ));
                 log_event(request_event.level, "supergraph.request", attrs, "");
             }
-        }
-        if let Some(mut response_event) = self.response.take() {
-            if response_event.condition.evaluate_request(request) != Some(false) {
+        if let Some(mut response_event) = self.response.take()
+            && response_event.condition.evaluate_request(request) != Some(false) {
                 request.context.extensions().with_lock(|lock| {
                     lock.insert(SupergraphEventResponse {
                         level: response_event.level,
@@ -98,7 +97,6 @@ impl
                     })
                 });
             }
-        }
         for custom_event in &mut self.custom {
             custom_event.on_request(request);
         }
@@ -117,8 +115,8 @@ impl
     }
 
     pub(crate) fn on_error(&mut self, error: &BoxError, ctx: &Context) {
-        if let Some(error_event) = &self.error {
-            if error_event.condition.evaluate_error(error, ctx) {
+        if let Some(error_event) = &self.error
+            && error_event.condition.evaluate_error(error, ctx) {
                 log_event(
                     error_event.level,
                     "supergraph.error",
@@ -129,7 +127,6 @@ impl
                     "",
                 );
             }
-        }
         for custom_event in &mut self.custom {
             custom_event.on_error(error, ctx);
         }

--- a/apollo-router/src/plugins/telemetry/endpoint.rs
+++ b/apollo-router/src/plugins/telemetry/endpoint.rs
@@ -45,7 +45,7 @@ impl UriEndpoint {
 
                     if let Some(port) = port {
                         parts.authority = Some(
-                            Authority::from_str(format!("{}:{}", host, port).as_str())
+                            Authority::from_str(format!("{host}:{port}").as_str())
                                 .expect("host and port must have come from a valid uri, qed"),
                         )
                     } else {
@@ -93,8 +93,7 @@ impl<'de> Deserialize<'de> for UriEndpoint {
                 match Uri::from_str(v) {
                     Ok(uri) => Ok(UriEndpoint { uri: Some(uri) }),
                     Err(_) => Err(Error::custom(format!(
-                        "invalid endpoint: {}. Expected a valid uri or 'default'",
-                        v
+                        "invalid endpoint: {v}. Expected a valid uri or 'default'"
                     ))),
                 }
             }
@@ -151,8 +150,7 @@ impl<'de> Deserialize<'de> for SocketEndpoint {
                         socket: Some(socket),
                     }),
                     Err(_) => Err(Error::custom(format!(
-                        "invalid endpoint: {}. Expected a valid socket or 'default'",
-                        v
+                        "invalid endpoint: {v}. Expected a valid socket or 'default'"
                     ))),
                 }
             }

--- a/apollo-router/src/plugins/telemetry/error_counter/mod.rs
+++ b/apollo-router/src/plugins/telemetry/error_counter/mod.rs
@@ -67,8 +67,7 @@ pub(crate) async fn count_supergraph_errors(
         if let Some(value_completion) = response_body
             .extensions
             .get(EXTENSIONS_VALUE_COMPLETION_KEY)
-        {
-            if let Some(vc_array) = value_completion.as_array() {
+            && let Some(vc_array) = value_completion.as_array() {
                 // We only count these in the supergraph layer to avoid double counting
                 let errors: Vec<graphql::Error> = vc_array
                     .iter()
@@ -76,7 +75,6 @@ pub(crate) async fn count_supergraph_errors(
                     .collect();
                 count_operation_errors(&errors, &context, &errors_config);
             }
-        }
 
         // Refresh context with the most up-to-date list of errors
         let _ = context.insert(COUNTED_ERRORS, to_set(&response_body.errors));

--- a/apollo-router/src/plugins/telemetry/error_counter/mod.rs
+++ b/apollo-router/src/plugins/telemetry/error_counter/mod.rs
@@ -67,14 +67,15 @@ pub(crate) async fn count_supergraph_errors(
         if let Some(value_completion) = response_body
             .extensions
             .get(EXTENSIONS_VALUE_COMPLETION_KEY)
-            && let Some(vc_array) = value_completion.as_array() {
-                // We only count these in the supergraph layer to avoid double counting
-                let errors: Vec<graphql::Error> = vc_array
-                    .iter()
-                    .filter_map(graphql::Error::from_value_completion_value)
-                    .collect();
-                count_operation_errors(&errors, &context, &errors_config);
-            }
+            && let Some(vc_array) = value_completion.as_array()
+        {
+            // We only count these in the supergraph layer to avoid double counting
+            let errors: Vec<graphql::Error> = vc_array
+                .iter()
+                .filter_map(graphql::Error::from_value_completion_value)
+                .collect();
+            count_operation_errors(&errors, &context, &errors_config);
+        }
 
         // Refresh context with the most up-to-date list of errors
         let _ = context.insert(COUNTED_ERRORS, to_set(&response_body.errors));

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -247,11 +247,11 @@ impl field::Visit for FieldsVisitor<'_, '_> {
         match field_name {
             name if name.starts_with("r#") => {
                 self.values
-                    .insert(&name[2..], serde_json::Value::from(format!("{:?}", value)));
+                    .insert(&name[2..], serde_json::Value::from(format!("{value:?}")));
             }
             name => {
                 self.values
-                    .insert(name, serde_json::Value::from(format!("{:?}", value)));
+                    .insert(name, serde_json::Value::from(format!("{value:?}")));
             }
         };
     }

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -306,32 +306,28 @@ where
                 serializer.serialize_entry("target", meta.target())?;
             }
 
-            if self.config.display_filename {
-                if let Some(filename) = meta.file() {
+            if self.config.display_filename
+                && let Some(filename) = meta.file() {
                     serializer.serialize_entry("filename", filename)?;
                 }
-            }
 
-            if self.config.display_line_number {
-                if let Some(line_number) = meta.line() {
+            if self.config.display_line_number
+                && let Some(line_number) = meta.line() {
                     serializer.serialize_entry("line_number", &line_number)?;
                 }
-            }
-            if self.config.display_current_span {
-                if let Some(ref span) = current_span {
+            if self.config.display_current_span
+                && let Some(ref span) = current_span {
                     serializer
                         .serialize_entry("span", &SerializableSpan(span, &self.excluded_attributes))
                         .unwrap_or(());
                 }
-            }
 
             // dd.trace_id is special. It must appear as a root attribute on log lines, so we need to extract it from the root span.
             // We're just going to assume if it's there then we should output it, as the user will have to have configured it to be there.
-            if let Some(span) = &current_span {
-                if let Some(dd_trace_id) = extract_dd_trace_id(span) {
+            if let Some(span) = &current_span
+                && let Some(dd_trace_id) = extract_dd_trace_id(span) {
                     serializer.serialize_entry("dd.trace_id", &dd_trace_id)?;
                 }
-            }
             if self.config.display_span_list && current_span.is_some() {
                 serializer.serialize_entry(
                     "spans",
@@ -357,28 +353,24 @@ fn extract_dd_trace_id<'a, 'b, T: LookupSpan<'a>>(span: &SpanRef<'a, T>) -> Opti
     if let Some(root_span) = root.next() {
         let ext = root_span.extensions();
         // Extract dd_trace_id, this could be in otel data or log attributes
-        if let Some(otel_data) = ext.get::<OtelData>() {
-            if let Some(attributes) = otel_data.builder.attributes.as_ref() {
-                if let Some(kv) = attributes
+        if let Some(otel_data) = ext.get::<OtelData>()
+            && let Some(attributes) = otel_data.builder.attributes.as_ref()
+                && let Some(kv) = attributes
                     .iter()
                     .find(|kv| kv.key.as_str() == "dd.trace_id")
                 {
                     dd_trace_id = Some(kv.value.to_string());
-                }
-            }
-        };
+                };
 
-        if dd_trace_id.is_none() {
-            if let Some(log_attr) = ext.get::<LogAttributes>() {
-                if let Some(kv) = log_attr
+        if dd_trace_id.is_none()
+            && let Some(log_attr) = ext.get::<LogAttributes>()
+                && let Some(kv) = log_attr
                     .attributes()
                     .iter()
                     .find(|kv| kv.key.as_str() == "dd.trace_id")
                 {
                     dd_trace_id = Some(kv.value.to_string());
                 }
-            }
-        }
     }
     dd_trace_id
 }

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -307,27 +307,31 @@ where
             }
 
             if self.config.display_filename
-                && let Some(filename) = meta.file() {
-                    serializer.serialize_entry("filename", filename)?;
-                }
+                && let Some(filename) = meta.file()
+            {
+                serializer.serialize_entry("filename", filename)?;
+            }
 
             if self.config.display_line_number
-                && let Some(line_number) = meta.line() {
-                    serializer.serialize_entry("line_number", &line_number)?;
-                }
+                && let Some(line_number) = meta.line()
+            {
+                serializer.serialize_entry("line_number", &line_number)?;
+            }
             if self.config.display_current_span
-                && let Some(ref span) = current_span {
-                    serializer
-                        .serialize_entry("span", &SerializableSpan(span, &self.excluded_attributes))
-                        .unwrap_or(());
-                }
+                && let Some(ref span) = current_span
+            {
+                serializer
+                    .serialize_entry("span", &SerializableSpan(span, &self.excluded_attributes))
+                    .unwrap_or(());
+            }
 
             // dd.trace_id is special. It must appear as a root attribute on log lines, so we need to extract it from the root span.
             // We're just going to assume if it's there then we should output it, as the user will have to have configured it to be there.
             if let Some(span) = &current_span
-                && let Some(dd_trace_id) = extract_dd_trace_id(span) {
-                    serializer.serialize_entry("dd.trace_id", &dd_trace_id)?;
-                }
+                && let Some(dd_trace_id) = extract_dd_trace_id(span)
+            {
+                serializer.serialize_entry("dd.trace_id", &dd_trace_id)?;
+            }
             if self.config.display_span_list && current_span.is_some() {
                 serializer.serialize_entry(
                     "spans",
@@ -355,22 +359,22 @@ fn extract_dd_trace_id<'a, 'b, T: LookupSpan<'a>>(span: &SpanRef<'a, T>) -> Opti
         // Extract dd_trace_id, this could be in otel data or log attributes
         if let Some(otel_data) = ext.get::<OtelData>()
             && let Some(attributes) = otel_data.builder.attributes.as_ref()
-                && let Some(kv) = attributes
-                    .iter()
-                    .find(|kv| kv.key.as_str() == "dd.trace_id")
-                {
-                    dd_trace_id = Some(kv.value.to_string());
-                };
+            && let Some(kv) = attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == "dd.trace_id")
+        {
+            dd_trace_id = Some(kv.value.to_string());
+        };
 
         if dd_trace_id.is_none()
             && let Some(log_attr) = ext.get::<LogAttributes>()
-                && let Some(kv) = log_attr
-                    .attributes()
-                    .iter()
-                    .find(|kv| kv.key.as_str() == "dd.trace_id")
-                {
-                    dd_trace_id = Some(kv.value.to_string());
-                }
+            && let Some(kv) = log_attr
+                .attributes()
+                .iter()
+                .find(|kv| kv.key.as_str() == "dd.trace_id")
+        {
+            dd_trace_id = Some(kv.value.to_string());
+        }
     }
     dd_trace_id
 }

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -344,10 +344,10 @@ where
                     DisplayTraceIdFormat::Bool(false) => None,
                 };
                 if let Some(trace_id) = trace_id {
-                    write!(writer, "trace_id: {} ", trace_id)?;
+                    write!(writer, "trace_id: {trace_id} ")?;
                 }
                 if self.config.display_span_id {
-                    write!(writer, "span_id: {} ", span_id)?;
+                    write!(writer, "span_id: {span_id} ")?;
                 }
             }
         }
@@ -552,7 +552,7 @@ impl<'a> DefaultVisitor<'a> {
 
         self.maybe_pad();
         self.result = match field_name {
-            "message" => write!(self.writer, "{:?}", value),
+            "message" => write!(self.writer, "{value:?}"),
             name if name.starts_with("r#") => write!(
                 self.writer,
                 "{}{}{:?}",
@@ -578,7 +578,7 @@ impl field::Visit for DefaultVisitor<'_> {
         }
 
         if field.name() == "message" {
-            self.record_debug(field, &format_args!("{}", value))
+            self.record_debug(field, &format_args!("{value}"))
         } else {
             self.record_debug(field, &value)
         }
@@ -599,7 +599,7 @@ impl field::Visit for DefaultVisitor<'_> {
                 ),
             )
         } else {
-            self.record_debug(field, &format_args!("{}", value))
+            self.record_debug(field, &format_args!("{value}"))
         }
     }
 
@@ -628,7 +628,7 @@ impl std::fmt::Display for ErrorSourceList<'_> {
         let mut list = f.debug_list();
         let mut curr = Some(self.0);
         while let Some(curr_err) = curr {
-            list.entry(&format_args!("{}", curr_err));
+            list.entry(&format_args!("{curr_err}"));
             curr = curr_err.source();
         }
         list.finish()

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -325,31 +325,32 @@ where
             .or_else(|| ctx.lookup_current());
 
         if let Some(ref span) = current_span
-            && let Some((trace_id, span_id)) = get_trace_and_span_id(span) {
-                let trace_id = match self.config.display_trace_id {
-                    DisplayTraceIdFormat::Bool(true)
-                    | DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Hexadecimal)
-                    | DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::OpenTelemetry) => {
-                        Some(TraceIdFormat::Hexadecimal.format(trace_id))
-                    }
-                    DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Decimal) => {
-                        Some(TraceIdFormat::Decimal.format(trace_id))
-                    }
-                    DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Datadog) => {
-                        Some(TraceIdFormat::Datadog.format(trace_id))
-                    }
-                    DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Uuid) => {
-                        Some(TraceIdFormat::Uuid.format(trace_id))
-                    }
-                    DisplayTraceIdFormat::Bool(false) => None,
-                };
-                if let Some(trace_id) = trace_id {
-                    write!(writer, "trace_id: {trace_id} ")?;
+            && let Some((trace_id, span_id)) = get_trace_and_span_id(span)
+        {
+            let trace_id = match self.config.display_trace_id {
+                DisplayTraceIdFormat::Bool(true)
+                | DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Hexadecimal)
+                | DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::OpenTelemetry) => {
+                    Some(TraceIdFormat::Hexadecimal.format(trace_id))
                 }
-                if self.config.display_span_id {
-                    write!(writer, "span_id: {span_id} ")?;
+                DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Decimal) => {
+                    Some(TraceIdFormat::Decimal.format(trace_id))
                 }
+                DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Datadog) => {
+                    Some(TraceIdFormat::Datadog.format(trace_id))
+                }
+                DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Uuid) => {
+                    Some(TraceIdFormat::Uuid.format(trace_id))
+                }
+                DisplayTraceIdFormat::Bool(false) => None,
+            };
+            if let Some(trace_id) = trace_id {
+                write!(writer, "trace_id: {trace_id} ")?;
             }
+            if self.config.display_span_id {
+                write!(writer, "span_id: {span_id} ")?;
+            }
+        }
 
         if self.config.display_resource {
             self.format_resource(&mut writer, &self.resource)?;

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -324,8 +324,8 @@ where
             .and_then(|id| ctx.span(id))
             .or_else(|| ctx.lookup_current());
 
-        if let Some(ref span) = current_span {
-            if let Some((trace_id, span_id)) = get_trace_and_span_id(span) {
+        if let Some(ref span) = current_span
+            && let Some((trace_id, span_id)) = get_trace_and_span_id(span) {
                 let trace_id = match self.config.display_trace_id {
                     DisplayTraceIdFormat::Bool(true)
                     | DisplayTraceIdFormat::TraceIdFormat(TraceIdFormat::Hexadecimal)
@@ -350,7 +350,6 @@ where
                     write!(writer, "span_id: {span_id} ")?;
                 }
             }
-        }
 
         if self.config.display_resource {
             self.format_resource(&mut writer, &self.resource)?;

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/histogram/list_length.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/histogram/list_length.rs
@@ -58,16 +58,16 @@ mod test {
         assert_eq!(v.len(), MAXIMUM_SIZE);
 
         for (i, item) in v.iter().enumerate().take(100) {
-            assert_eq!(*item, 1, "testing contents of bucket {}", i);
+            assert_eq!(*item, 1, "testing contents of bucket {i}");
         }
         for (i, item) in v.iter().enumerate().take(190).skip(100) {
-            assert_eq!(*item, 10, "testing contents of bucket {}", i);
+            assert_eq!(*item, 10, "testing contents of bucket {i}");
         }
         for (i, item) in v.iter().enumerate().take(280).skip(190) {
-            assert_eq!(*item, 100, "testing contents of bucket {}", i);
+            assert_eq!(*item, 100, "testing contents of bucket {i}");
         }
         for (i, item) in v.iter().enumerate().take(382).skip(280) {
-            assert_eq!(*item, 1000, "testing contents of bucket {}", i);
+            assert_eq!(*item, 1000, "testing contents of bucket {i}");
         }
         assert_eq!(v[MAXIMUM_SIZE - 1], 7000, "testing contents of last bucket");
     }

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -580,15 +580,14 @@ mod test {
             r#"
             telemetry:
               apollo:
-                endpoint: "{endpoint}"
+                endpoint: "{ENDPOINT_DEFAULT}"
                 apollo_key: "key"
                 apollo_graph_ref: "ref"
                 client_name_header: "name_header"
                 client_version_header: "version_header"
                 buffer_size: 10000
                 schema_id: "schema_sha"
-            "#,
-            endpoint = ENDPOINT_DEFAULT
+            "#
         );
 
         async move { create_telemetry_plugin(&config).await }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -449,9 +449,9 @@ impl PluginPrivate for Telemetry {
             .map_response(move |response: router::Response| {
                 // The current span *should* be the request span as we are outside the instrument block.
                 let span = Span::current();
-                if let Some(span_name) = span.metadata().map(|metadata| metadata.name()) {
-                    if (use_legacy_request_span && span_name == REQUEST_SPAN_NAME)
-                        || (!use_legacy_request_span && span_name == ROUTER_SPAN_NAME)
+                if let Some(span_name) = span.metadata().map(|metadata| metadata.name())
+                    && ((use_legacy_request_span && span_name == REQUEST_SPAN_NAME)
+                        || (!use_legacy_request_span && span_name == ROUTER_SPAN_NAME))
                     {
                         //https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/instrumentation/graphql/
                         let operation_kind = response.context.get::<_, String>(OPERATION_KIND);
@@ -477,7 +477,6 @@ impl PluginPrivate for Telemetry {
                             ),
                         };
                     }
-                }
 
                 response
             })
@@ -2001,8 +2000,7 @@ fn store_ftv1(subgraph_name: &ByteString, resp: SubgraphResponse) -> SubgraphRes
         .context
         .extensions()
         .with_lock(|lock| lock.contains_key::<EnableSubgraphFtv1>())
-    {
-        if let Some(serde_json_bytes::Value::String(ftv1)) =
+        && let Some(serde_json_bytes::Value::String(ftv1)) =
             resp.response.body().extensions.get("ftv1")
         {
             // Record the ftv1 trace for processing later
@@ -2019,7 +2017,6 @@ fn store_ftv1(subgraph_name: &ByteString, resp: SubgraphResponse) -> SubgraphRes
                     Value::Array(vec)
                 })
         }
-    }
     resp
 }
 

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -738,7 +738,7 @@ impl PluginPrivate for Telemetry {
                 let format_id = |trace_id: TraceId| {
                     let id = match config.exporters.tracing.response_trace_id.format {
                         TraceIdFormat::Hexadecimal | TraceIdFormat::OpenTelemetry => {
-                            format!("{:032x}", trace_id)
+                            format!("{trace_id:032x}")
                         }
                         TraceIdFormat::Decimal => {
                             format!("{}", u128::from_be_bytes(trace_id.to_bytes()))

--- a/apollo-router/src/plugins/telemetry/otel/layer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/layer.rs
@@ -216,14 +216,14 @@ impl field::Visit for SpanEventVisitor<'_, '_> {
     /// [`Span`]: opentelemetry::trace::Span
     fn record_debug(&mut self, field: &field::Field, value: &dyn fmt::Debug) {
         match field.name() {
-            "message" => self.event_builder.name = format!("{:?}", value).into(),
+            "message" => self.event_builder.name = format!("{value:?}").into(),
             name => {
                 if name == "kind" {
                     self.custom_event = true;
                 }
                 self.event_builder
                     .attributes
-                    .push(KeyValue::new(name, format!("{:?}", value)));
+                    .push(KeyValue::new(name, format!("{value:?}")));
             }
         }
     }
@@ -362,13 +362,13 @@ impl field::Visit for SpanAttributeVisitor<'_> {
     /// [`Span`]: opentelemetry::trace::Span
     fn record_debug(&mut self, field: &field::Field, value: &dyn fmt::Debug) {
         match field.name() {
-            OTEL_NAME => self.span_builder.name = format!("{:?}", value).into(),
-            OTEL_KIND => self.span_builder.span_kind = str_to_span_kind(&format!("{:?}", value)),
-            OTEL_STATUS_CODE => self.span_builder.status = str_to_status(&format!("{:?}", value)),
+            OTEL_NAME => self.span_builder.name = format!("{value:?}").into(),
+            OTEL_KIND => self.span_builder.span_kind = str_to_span_kind(&format!("{value:?}")),
+            OTEL_STATUS_CODE => self.span_builder.status = str_to_status(&format!("{value:?}")),
             OTEL_STATUS_MESSAGE => {
-                self.span_builder.status = otel::Status::error(format!("{:?}", value))
+                self.span_builder.status = otel::Status::error(format!("{value:?}"))
             }
-            _ => self.record(Key::new(field.name()).string(format!("{:?}", value))),
+            _ => self.record(Key::new(field.name()).string(format!("{value:?}"))),
         }
     }
 
@@ -1096,7 +1096,7 @@ impl Timings {
 }
 
 fn thread_id_integer(id: thread::ThreadId) -> u64 {
-    let thread_id = format!("{:?}", id);
+    let thread_id = format!("{id:?}");
     thread_id
         .trim_start_matches("ThreadId(")
         .trim_end_matches(')')

--- a/apollo-router/src/plugins/telemetry/otel/layer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/layer.rs
@@ -265,20 +265,21 @@ impl field::Visit for SpanEventVisitor<'_, '_> {
 
         if self.exception_config.propagate
             && let Some(span) = &mut self.span_builder
-                && let Some(attrs) = span.attributes.as_mut() {
-                    attrs.push(KeyValue::new(FIELD_EXCEPTION_MESSAGE, error_msg.clone()));
+            && let Some(attrs) = span.attributes.as_mut()
+        {
+            attrs.push(KeyValue::new(FIELD_EXCEPTION_MESSAGE, error_msg.clone()));
 
-                    // NOTE: This is actually not the stacktrace of the exception. This is
-                    // the "source chain". It represents the hierarchy of errors from the
-                    // app level to the lowest level such as IO. It does not represent all
-                    // of the callsites in the code that led to the error happening.
-                    // `std::error::Error::backtrace` is a nightly-only API and cannot be
-                    // used here until the feature is stabilized.
-                    attrs.push(KeyValue::new(
-                        FIELD_EXCEPTION_STACKTRACE,
-                        Value::Array(chain.clone().into()),
-                    ));
-                }
+            // NOTE: This is actually not the stacktrace of the exception. This is
+            // the "source chain". It represents the hierarchy of errors from the
+            // app level to the lowest level such as IO. It does not represent all
+            // of the callsites in the code that led to the error happening.
+            // `std::error::Error::backtrace` is a nightly-only API and cannot be
+            // used here until the feature is stabilized.
+            attrs.push(KeyValue::new(
+                FIELD_EXCEPTION_STACKTRACE,
+                Value::Array(chain.clone().into()),
+            ));
+        }
 
         self.event_builder
             .attributes

--- a/apollo-router/src/plugins/telemetry/otel/layer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/layer.rs
@@ -263,9 +263,9 @@ impl field::Visit for SpanEventVisitor<'_, '_> {
                 .push(Key::new(FIELD_EXCEPTION_STACKTRACE).array(chain.clone()));
         }
 
-        if self.exception_config.propagate {
-            if let Some(span) = &mut self.span_builder {
-                if let Some(attrs) = span.attributes.as_mut() {
+        if self.exception_config.propagate
+            && let Some(span) = &mut self.span_builder
+                && let Some(attrs) = span.attributes.as_mut() {
                     attrs.push(KeyValue::new(FIELD_EXCEPTION_MESSAGE, error_msg.clone()));
 
                     // NOTE: This is actually not the stacktrace of the exception. This is
@@ -279,8 +279,6 @@ impl field::Visit for SpanEventVisitor<'_, '_> {
                         Value::Array(chain.clone().into()),
                     ));
                 }
-            }
-        }
 
         self.event_builder
             .attributes

--- a/apollo-router/src/plugins/telemetry/otel/named_runtime_channel.rs
+++ b/apollo-router/src/plugins/telemetry/otel/named_runtime_channel.rs
@@ -70,12 +70,10 @@ impl<T: Send> NamedSender<T> {
         NamedSender {
             name,
             channel_full_message: format!(
-                "cannot send message to batch processor '{}' as the channel is full",
-                name
+                "cannot send message to batch processor '{name}' as the channel is full"
             ),
             channel_closed_message: format!(
-                "cannot send message to batch processor '{}' as the channel is closed",
-                name
+                "cannot send message to batch processor '{name}' as the channel is closed"
             ),
             sender,
         }

--- a/apollo-router/src/plugins/telemetry/otel/tracer.rs
+++ b/apollo-router/src/plugins/telemetry/otel/tracer.rs
@@ -227,8 +227,7 @@ mod tests {
             assert_eq!(
                 sampled.span().span_context().is_sampled(),
                 is_sampled,
-                "{}",
-                name
+                "{name}"
             )
         }
     }

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -237,7 +237,7 @@ impl GrpcExporter {
         let endpoint = endpoint
             .to_string()
             .parse::<Url>()
-            .map_err(|e| BoxError::from(format!("invalid GRPC endpoint {}, {}", endpoint, e)))?;
+            .map_err(|e| BoxError::from(format!("invalid GRPC endpoint {endpoint}, {e}")))?;
         let domain_name = self.default_tls_domain(&endpoint);
 
         if let (Some(ca), Some(key), Some(cert), Some(domain_name)) =

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -105,8 +105,8 @@ pub(crate) fn apollo_opentelemetry_initialized() -> bool {
 // To that end, we update the context just for that request to create valid span et trace ids, with the
 // sampling bit set to false
 pub(crate) fn prepare_context(context: Context) -> Context {
-    if !context.span().span_context().is_valid() {
-        if let Some(tracer) = OPENTELEMETRY_TRACER_HANDLE.get() {
+    if !context.span().span_context().is_valid()
+        && let Some(tracer) = OPENTELEMETRY_TRACER_HANDLE.get() {
             let span_context = SpanContext::new(
                 tracer.new_trace_id(),
                 tracer.new_span_id(),
@@ -116,7 +116,6 @@ pub(crate) fn prepare_context(context: Context) -> Context {
             );
             return context.with_remote_span_context(span_context);
         }
-    }
     context
 }
 

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -106,16 +106,17 @@ pub(crate) fn apollo_opentelemetry_initialized() -> bool {
 // sampling bit set to false
 pub(crate) fn prepare_context(context: Context) -> Context {
     if !context.span().span_context().is_valid()
-        && let Some(tracer) = OPENTELEMETRY_TRACER_HANDLE.get() {
-            let span_context = SpanContext::new(
-                tracer.new_trace_id(),
-                tracer.new_span_id(),
-                TraceFlags::default(),
-                false,
-                TraceState::default(),
-            );
-            return context.with_remote_span_context(span_context);
-        }
+        && let Some(tracer) = OPENTELEMETRY_TRACER_HANDLE.get()
+    {
+        let span_context = SpanContext::new(
+            tracer.new_trace_id(),
+            tracer.new_span_id(),
+            TraceFlags::default(),
+            false,
+            TraceState::default(),
+        );
+        return context.with_remote_span_context(span_context);
+    }
     context
 }
 

--- a/apollo-router/src/plugins/telemetry/resource.rs
+++ b/apollo-router/src/plugins/telemetry/resource.rs
@@ -81,7 +81,7 @@ pub trait ConfigResource {
             resource.merge(&Resource::new(vec![KeyValue::new(
                 opentelemetry_semantic_conventions::resource::SERVICE_NAME,
                 executable_name
-                    .map(|executable_name| format!("{}:{}", UNKNOWN_SERVICE, executable_name))
+                    .map(|executable_name| format!("{UNKNOWN_SERVICE}:{executable_name}"))
                     .unwrap_or_else(|| UNKNOWN_SERVICE.to_string()),
             )]))
         } else {

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -1279,9 +1279,10 @@ impl ChildNodes for Vec<TreeData> {
         if let Some((idx, _)) = self
             .iter()
             .find_position(|child| matches!(child, TreeData::QueryPlanNode(_)))
-            && let TreeData::QueryPlanNode(node) = self.remove(idx) {
-                return Some(node);
-            }
+            && let TreeData::QueryPlanNode(node) = self.remove(idx)
+        {
+            return Some(node);
+        }
         None
     }
 
@@ -1303,9 +1304,10 @@ impl ChildNodes for Vec<TreeData> {
         if let Some((idx, _)) = self
             .iter()
             .find_position(|child| matches!(child, TreeData::DeferPrimary(_)))
-            && let TreeData::DeferPrimary(node) = self.remove(idx) {
-                return Some(node);
-            }
+            && let TreeData::DeferPrimary(node) = self.remove(idx)
+        {
+            return Some(node);
+        }
         None
     }
 
@@ -1327,9 +1329,10 @@ impl ChildNodes for Vec<TreeData> {
         if let Some((idx, _)) = self
             .iter()
             .find_position(|child| matches!(child, TreeData::ConditionIf(_)))
-            && let TreeData::ConditionIf(node) = self.remove(idx) {
-                return node;
-            }
+            && let TreeData::ConditionIf(node) = self.remove(idx)
+        {
+            return node;
+        }
         None
     }
 
@@ -1337,9 +1340,10 @@ impl ChildNodes for Vec<TreeData> {
         if let Some((idx, _)) = self
             .iter()
             .find_position(|child| matches!(child, TreeData::ConditionElse(_)))
-            && let TreeData::ConditionElse(node) = self.remove(idx) {
-                return node;
-            }
+            && let TreeData::ConditionElse(node) = self.remove(idx)
+        {
+            return node;
+        }
         None
     }
 }

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -1279,11 +1279,9 @@ impl ChildNodes for Vec<TreeData> {
         if let Some((idx, _)) = self
             .iter()
             .find_position(|child| matches!(child, TreeData::QueryPlanNode(_)))
-        {
-            if let TreeData::QueryPlanNode(node) = self.remove(idx) {
+            && let TreeData::QueryPlanNode(node) = self.remove(idx) {
                 return Some(node);
             }
-        }
         None
     }
 
@@ -1305,11 +1303,9 @@ impl ChildNodes for Vec<TreeData> {
         if let Some((idx, _)) = self
             .iter()
             .find_position(|child| matches!(child, TreeData::DeferPrimary(_)))
-        {
-            if let TreeData::DeferPrimary(node) = self.remove(idx) {
+            && let TreeData::DeferPrimary(node) = self.remove(idx) {
                 return Some(node);
             }
-        }
         None
     }
 
@@ -1331,11 +1327,9 @@ impl ChildNodes for Vec<TreeData> {
         if let Some((idx, _)) = self
             .iter()
             .find_position(|child| matches!(child, TreeData::ConditionIf(_)))
-        {
-            if let TreeData::ConditionIf(node) = self.remove(idx) {
+            && let TreeData::ConditionIf(node) = self.remove(idx) {
                 return node;
             }
-        }
         None
     }
 
@@ -1343,11 +1337,9 @@ impl ChildNodes for Vec<TreeData> {
         if let Some((idx, _)) = self
             .iter()
             .find_position(|child| matches!(child, TreeData::ConditionElse(_)))
-        {
-            if let TreeData::ConditionElse(node) = self.remove(idx) {
+            && let TreeData::ConditionElse(node) = self.remove(idx) {
                 return node;
             }
-        }
         None
     }
 }

--- a/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
@@ -159,21 +159,20 @@ impl TracingConfigurator for Config {
                     } else {
                         span.name.clone()
                     };
-                    if let Some(mapping) = resource_mappings.get(span_name.as_ref()) {
-                        if let Some(KeyValue {
+                    if let Some(mapping) = resource_mappings.get(span_name.as_ref())
+                        && let Some(KeyValue {
                             key: _,
                             value: Value::String(v),
                         }) = span.attributes.iter().find(|kv| kv.key == *mapping)
                         {
                             return v.as_str();
                         }
-                    }
                     span.name.as_ref()
                 })
             })
             .with_name_mapping(move |span, _model_config| {
-                if fixed_span_names {
-                    if let Some(original) = span
+                if fixed_span_names
+                    && let Some(original) = span
                         .attributes
                         .iter()
                         .find(|kv| kv.key.as_str() == OTEL_ORIGINAL_NAME)
@@ -186,7 +185,6 @@ impl TracingConfigurator for Config {
                             }
                         }
                     }
-                }
                 &span.name
             })
             .with(
@@ -272,8 +270,8 @@ impl SpanExporter for ExporterWrapper {
             };
 
             // Unfortunately trace state is immutable, so we have to create a new one
-            if let Some(setting) = self.span_metrics.get(final_span_name) {
-                if *setting != span.span_context.trace_state().measuring_enabled() {
+            if let Some(setting) = self.span_metrics.get(final_span_name)
+                && *setting != span.span_context.trace_state().measuring_enabled() {
                     let new_trace_state = span.span_context.trace_state().with_measuring(*setting);
                     span.span_context = SpanContext::new(
                         span.span_context.trace_id(),
@@ -283,7 +281,6 @@ impl SpanExporter for ExporterWrapper {
                         new_trace_state,
                     )
                 }
-            }
 
             // Set the span kind https://github.com/DataDog/dd-trace-go/blob/main/ddtrace/ext/span_kind.go
             let span_kind = match &span.span_kind {

--- a/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
@@ -164,9 +164,9 @@ impl TracingConfigurator for Config {
                             key: _,
                             value: Value::String(v),
                         }) = span.attributes.iter().find(|kv| kv.key == *mapping)
-                        {
-                            return v.as_str();
-                        }
+                    {
+                        return v.as_str();
+                    }
                     span.name.as_ref()
                 })
             })
@@ -176,15 +176,15 @@ impl TracingConfigurator for Config {
                         .attributes
                         .iter()
                         .find(|kv| kv.key.as_str() == OTEL_ORIGINAL_NAME)
-                    {
-                        // Datadog expects static span names, not the ones in the otel spec.
-                        // Remap the span name to the original name if it was remapped.
-                        for name in BUILT_IN_SPAN_NAMES {
-                            if name == original.value.as_str() {
-                                return name;
-                            }
+                {
+                    // Datadog expects static span names, not the ones in the otel spec.
+                    // Remap the span name to the original name if it was remapped.
+                    for name in BUILT_IN_SPAN_NAMES {
+                        if name == original.value.as_str() {
+                            return name;
                         }
                     }
+                }
                 &span.name
             })
             .with(
@@ -271,16 +271,17 @@ impl SpanExporter for ExporterWrapper {
 
             // Unfortunately trace state is immutable, so we have to create a new one
             if let Some(setting) = self.span_metrics.get(final_span_name)
-                && *setting != span.span_context.trace_state().measuring_enabled() {
-                    let new_trace_state = span.span_context.trace_state().with_measuring(*setting);
-                    span.span_context = SpanContext::new(
-                        span.span_context.trace_id(),
-                        span.span_context.span_id(),
-                        span.span_context.trace_flags(),
-                        span.span_context.is_remote(),
-                        new_trace_state,
-                    )
-                }
+                && *setting != span.span_context.trace_state().measuring_enabled()
+            {
+                let new_trace_state = span.span_context.trace_state().with_measuring(*setting);
+                span.span_context = SpanContext::new(
+                    span.span_context.trace_id(),
+                    span.span_context.span_id(),
+                    span.span_context.trace_flags(),
+                    span.span_context.is_remote(),
+                    new_trace_state,
+                )
+            }
 
             // Set the span kind https://github.com/DataDog/dd-trace-go/blob/main/ddtrace/ext/span_kind.go
             let span_kind = match &span.span_kind {

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/intern.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/intern.rs
@@ -452,13 +452,13 @@ mod tests {
 
         f1.write_to(&mut buffer);
 
-        assert_eq!(&buffer[..], format!("{}", f1).as_bytes());
+        assert_eq!(&buffer[..], format!("{f1}").as_bytes());
 
         buffer.clear();
 
         f2.write_to(&mut buffer);
 
-        assert_eq!(&buffer[..], format!("{}", f2).as_bytes());
+        assert_eq!(&buffer[..], format!("{f2}").as_bytes());
     }
 
     #[test]
@@ -470,13 +470,13 @@ mod tests {
 
         s1.write_to(&mut buffer);
 
-        assert_eq!(&buffer[..], format!("\"{}\"", s1).as_bytes());
+        assert_eq!(&buffer[..], format!("\"{s1}\"").as_bytes());
 
         buffer.clear();
 
         s2.write_to(&mut buffer);
 
-        assert_eq!(&buffer[..], format!("\"{}\"", s2).as_bytes());
+        assert_eq!(&buffer[..], format!("\"{s2}\"").as_bytes());
     }
 
     fn test_encoding_intern_value(value: InternValue<'_>) {

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/mod.rs
@@ -309,7 +309,7 @@ pub(crate) mod propagator {
                 SamplingPriority::AutoKeep => 1,
                 SamplingPriority::UserKeep => 2,
             };
-            write!(f, "{}", value)
+            write!(f, "{value}")
         }
     }
 

--- a/apollo-router/src/plugins/test/router_ext.rs
+++ b/apollo-router/src/plugins/test/router_ext.rs
@@ -56,13 +56,13 @@ impl RequestTestExt<router::Request, router::Response> for RouterRequest {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -71,7 +71,7 @@ impl RequestTestExt<router::Request, router::Response> for RouterRequest {
             .router_request
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 
@@ -118,13 +118,13 @@ impl ResponseTestExt for RouterResponse {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -133,7 +133,7 @@ impl ResponseTestExt for RouterResponse {
             .response
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 

--- a/apollo-router/src/plugins/test/subgraph_ext.rs
+++ b/apollo-router/src/plugins/test/subgraph_ext.rs
@@ -69,13 +69,13 @@ impl RequestTestExt<subgraph::Request, subgraph::Response> for SubgraphRequest {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -84,7 +84,7 @@ impl RequestTestExt<subgraph::Request, subgraph::Response> for SubgraphRequest {
             .subgraph_request
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 
@@ -118,13 +118,13 @@ impl ResponseTestExt for SubgraphResponse {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -133,7 +133,7 @@ impl ResponseTestExt for SubgraphResponse {
             .response
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 

--- a/apollo-router/src/plugins/test/supergraph_ext.rs
+++ b/apollo-router/src/plugins/test/supergraph_ext.rs
@@ -67,13 +67,13 @@ impl RequestTestExt<supergraph::Request, supergraph::Response> for SupergraphReq
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -82,7 +82,7 @@ impl RequestTestExt<supergraph::Request, supergraph::Response> for SupergraphReq
             .supergraph_request
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 
@@ -117,13 +117,13 @@ impl ResponseTestExt for SupergraphResponse {
 
     fn assert_context_contains(&self, key: &str) {
         if !self.context.contains_key(key) {
-            panic!("context '{}' value not found", key)
+            panic!("context '{key}' value not found")
         }
     }
 
     fn assert_context_not_contains(&self, key: &str) {
         if self.context.contains_key(key) {
-            panic!("context '{}' value was present", key)
+            panic!("context '{key}' value was present")
         }
     }
 
@@ -132,7 +132,7 @@ impl ResponseTestExt for SupergraphResponse {
             .response
             .headers()
             .get(key)
-            .unwrap_or_else(|| panic!("header '{}' not found", key));
+            .unwrap_or_else(|| panic!("header '{key}' not found"));
         pretty_assertions::assert_eq!(header_value, value, "header '{}' value mismatch", key);
     }
 

--- a/apollo-router/src/protocols/websocket.rs
+++ b/apollo-router/src/protocols/websocket.rs
@@ -282,7 +282,7 @@ where
             })?;
         if !matches!(resp, Some(Ok(ServerMessage::ConnectionAck))) {
             return Err(graphql::Error::builder()
-                .message(format!("didn't receive the connection ack from websocket connection but instead got: {:?}", resp))
+                .message(format!("didn't receive the connection ack from websocket connection but instead got: {resp:?}"))
                 .extension_code("WEBSOCKET_ACK_ERROR")
                 .build());
         }
@@ -953,7 +953,7 @@ mod tests {
         let socket_addr =
             emulate_correct_websocket_server_new_protocol(send_ping, heartbeat_interval, port)
                 .await;
-        let url = format!("ws://{}/ws", socket_addr);
+        let url = format!("ws://{socket_addr}/ws");
         let mut request = url.into_client_request().unwrap();
         request.headers_mut().insert(
             http::header::SEC_WEBSOCKET_PROTOCOL,
@@ -1020,7 +1020,7 @@ mod tests {
 
     async fn test_ws_connection_old_proto(send_ping: bool, port: Option<u16>) {
         let socket_addr = emulate_correct_websocket_server_old_protocol(send_ping, port).await;
-        let url = format!("ws://{}/ws", socket_addr);
+        let url = format!("ws://{socket_addr}/ws");
         let mut request = url.into_client_request().unwrap();
         request.headers_mut().insert(
             http::header::SEC_WEBSOCKET_PROTOCOL,

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -279,19 +279,18 @@ where
         // persisted queries are added first because they should get a lower priority in the LRU cache,
         // since a lot of them may be there to support old clients
         let mut all_cache_keys: Vec<WarmUpCachingQueryKey> = Vec::with_capacity(capacity);
-        if should_warm_with_pqs
-            && let Some(queries) = persisted_queries_operations {
-                for query in queries {
-                    all_cache_keys.push(WarmUpCachingQueryKey {
-                        query,
-                        operation_name: None,
-                        hash: None,
-                        metadata: CacheKeyMetadata::default(),
-                        plan_options: PlanOptions::default(),
-                        config_mode_hash: self.config_mode_hash.clone(),
-                    });
-                }
+        if should_warm_with_pqs && let Some(queries) = persisted_queries_operations {
+            for query in queries {
+                all_cache_keys.push(WarmUpCachingQueryKey {
+                    query,
+                    operation_name: None,
+                    hash: None,
+                    metadata: CacheKeyMetadata::default(),
+                    plan_options: PlanOptions::default(),
+                    config_mode_hash: self.config_mode_hash.clone(),
+                });
             }
+        }
 
         all_cache_keys.shuffle(&mut rand::rng());
 
@@ -345,13 +344,13 @@ where
                     // if the query hash did not change with the schema update, we can reuse the previously cached entry
                     if let Some(hash) = hash
                         && hash == doc.hash
-                            && let Some(entry) =
-                                { previous_cache.lock().await.get(&caching_key).cloned() }
-                            {
-                                self.cache.insert_in_memory(caching_key, entry).await;
-                                reused += 1;
-                                continue;
-                            }
+                        && let Some(entry) =
+                            { previous_cache.lock().await.get(&caching_key).cloned() }
+                    {
+                        self.cache.insert_in_memory(caching_key, entry).await;
+                        reused += 1;
+                        continue;
+                    }
                 }
             };
 

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -279,8 +279,8 @@ where
         // persisted queries are added first because they should get a lower priority in the LRU cache,
         // since a lot of them may be there to support old clients
         let mut all_cache_keys: Vec<WarmUpCachingQueryKey> = Vec::with_capacity(capacity);
-        if should_warm_with_pqs {
-            if let Some(queries) = persisted_queries_operations {
+        if should_warm_with_pqs
+            && let Some(queries) = persisted_queries_operations {
                 for query in queries {
                     all_cache_keys.push(WarmUpCachingQueryKey {
                         query,
@@ -292,7 +292,6 @@ where
                     });
                 }
             }
-        }
 
         all_cache_keys.shuffle(&mut rand::rng());
 
@@ -344,17 +343,15 @@ where
                 // check if prewarming via seeing if the previous cache exists (aka a reloaded router); if reloading, try to reuse the
                 if let Some(ref previous_cache) = previous_cache {
                     // if the query hash did not change with the schema update, we can reuse the previously cached entry
-                    if let Some(hash) = hash {
-                        if hash == doc.hash {
-                            if let Some(entry) =
+                    if let Some(hash) = hash
+                        && hash == doc.hash
+                            && let Some(entry) =
                                 { previous_cache.lock().await.get(&caching_key).cloned() }
                             {
                                 self.cache.insert_in_memory(caching_key, entry).await;
                                 reused += 1;
                                 continue;
                             }
-                        }
-                    }
                 }
             };
 

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -917,7 +917,7 @@ mod tests {
 
                 fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
                     self.map
-                        .insert(field.name().to_string(), format!("{:?}", value));
+                        .insert(field.name().to_string(), format!("{value:?}"));
                 }
             }
 
@@ -1255,7 +1255,7 @@ mod tests {
             Ok(_) => panic!(
                 "Expected the task to be aborted due to client drop, but it completed successfully"
             ),
-            Err(e) => assert!(e.is_cancelled(), "Task should be cancelled, got: {:?}", e),
+            Err(e) => assert!(e.is_cancelled(), "Task should be cancelled, got: {e:?}"),
         }
 
         // Give a small delay to ensure the span is recorded

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -325,17 +325,17 @@ impl PlanNode {
                                         && err_path
                                             .iter()
                                             .any(|elem| matches!(elem, PathElement::Flatten(_)))
-                                        {
-                                            for path in paths.iter().flatten() {
-                                                if err_path.equal_if_flattened(path) {
-                                                    let mut err = err.clone();
-                                                    err.path = Some(path.clone());
-                                                    errors.push(err);
-                                                }
+                                    {
+                                        for path in paths.iter().flatten() {
+                                            if err_path.equal_if_flattened(path) {
+                                                let mut err = err.clone();
+                                                err.path = Some(path.clone());
+                                                errors.push(err);
                                             }
-
-                                            continue;
                                         }
+
+                                        continue;
+                                    }
 
                                     errors.push(err);
                                 }

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -321,8 +321,8 @@ impl PlanNode {
                                 // to all elements in the array.
                                 errors = Vec::default();
                                 for err in raw_errors {
-                                    if let Some(err_path) = err.path.as_ref() {
-                                        if err_path
+                                    if let Some(err_path) = err.path.as_ref()
+                                        && err_path
                                             .iter()
                                             .any(|elem| matches!(elem, PathElement::Flatten(_)))
                                         {
@@ -336,7 +336,6 @@ impl PlanNode {
 
                                             continue;
                                         }
-                                    }
 
                                     errors.push(err);
                                 }

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -313,8 +313,8 @@ impl FetchNode {
         value: &Value,
         errors: &[Error],
     ) {
-        if let Some(id) = id {
-            if let Some(sender) = deferred_fetches.get(id.as_str()) {
+        if let Some(id) = id
+            && let Some(sender) = deferred_fetches.get(id.as_str()) {
                 u64_counter!(
                     "apollo.router.operations.defer.fetch",
                     "Number of deferred responses fetched from subgraphs",
@@ -329,7 +329,6 @@ impl FetchNode {
                     );
                 }
             }
-        }
     }
 
     #[instrument(skip_all, level = "debug", name = "response_insert")]
@@ -396,8 +395,8 @@ impl FetchNode {
 
             // we have to nest conditions and do early returns here
             // because we need to take ownership of the inner value
-            if let Some(Value::Object(mut map)) = response.data {
-                if let Some(entities) = map.remove("_entities") {
+            if let Some(Value::Object(mut map)) = response.data
+                && let Some(entities) = map.remove("_entities") {
                     tracing::trace!("received entities: {:?}", &entities);
 
                     if let Value::Array(array) = entities {
@@ -421,7 +420,6 @@ impl FetchNode {
                         return (value, errors);
                     }
                 }
-            }
 
             // if we get here, it means that the response was missing the `_entities` key
             // This can happen if the subgraph failed during query execution e.g. for permissions checks.

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -314,21 +314,22 @@ impl FetchNode {
         errors: &[Error],
     ) {
         if let Some(id) = id
-            && let Some(sender) = deferred_fetches.get(id.as_str()) {
-                u64_counter!(
-                    "apollo.router.operations.defer.fetch",
-                    "Number of deferred responses fetched from subgraphs",
-                    1
+            && let Some(sender) = deferred_fetches.get(id.as_str())
+        {
+            u64_counter!(
+                "apollo.router.operations.defer.fetch",
+                "Number of deferred responses fetched from subgraphs",
+                1
+            );
+            if let Err(e) = sender.clone().send((value.clone(), Vec::from(errors))) {
+                tracing::error!(
+                    "error sending fetch result at path {} and id {:?} for deferred response building: {}",
+                    current_dir,
+                    id,
+                    e
                 );
-                if let Err(e) = sender.clone().send((value.clone(), Vec::from(errors))) {
-                    tracing::error!(
-                        "error sending fetch result at path {} and id {:?} for deferred response building: {}",
-                        current_dir,
-                        id,
-                        e
-                    );
-                }
             }
+        }
     }
 
     #[instrument(skip_all, level = "debug", name = "response_insert")]
@@ -396,30 +397,31 @@ impl FetchNode {
             // we have to nest conditions and do early returns here
             // because we need to take ownership of the inner value
             if let Some(Value::Object(mut map)) = response.data
-                && let Some(entities) = map.remove("_entities") {
-                    tracing::trace!("received entities: {:?}", &entities);
+                && let Some(entities) = map.remove("_entities")
+            {
+                tracing::trace!("received entities: {:?}", &entities);
 
-                    if let Value::Array(array) = entities {
-                        let mut value = Value::default();
+                if let Value::Array(array) = entities {
+                    let mut value = Value::default();
 
-                        for (index, mut entity) in array.into_iter().enumerate() {
-                            rewrites::apply_rewrites(schema, &mut entity, &self.output_rewrites);
+                    for (index, mut entity) in array.into_iter().enumerate() {
+                        rewrites::apply_rewrites(schema, &mut entity, &self.output_rewrites);
 
-                            if let Some(paths) = inverted_paths.get(index) {
-                                if paths.len() > 1 {
-                                    for path in &paths[1..] {
-                                        let _ = value.insert(path, entity.clone());
-                                    }
-                                }
-
-                                if let Some(path) = paths.first() {
-                                    let _ = value.insert(path, entity);
+                        if let Some(paths) = inverted_paths.get(index) {
+                            if paths.len() > 1 {
+                                for path in &paths[1..] {
+                                    let _ = value.insert(path, entity.clone());
                                 }
                             }
+
+                            if let Some(path) = paths.first() {
+                                let _ = value.insert(path, entity);
+                            }
                         }
-                        return (value, errors);
                     }
+                    return (value, errors);
                 }
+            }
 
             // if we get here, it means that the response was missing the `_entities` key
             // This can happen if the subgraph failed during query execution e.g. for permissions checks.

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -159,16 +159,14 @@ impl PlanNode {
                 else_clause,
                 ..
             } => {
-                if let Some(node) = if_clause {
-                    if node.contains_mutations() {
+                if let Some(node) = if_clause
+                    && node.contains_mutations() {
                         return true;
                     }
-                }
-                if let Some(node) = else_clause {
-                    if node.contains_mutations() {
+                if let Some(node) = else_clause
+                    && node.contains_mutations() {
                         return true;
                     }
-                }
                 false
             }
         }
@@ -194,16 +192,14 @@ impl PlanNode {
                 {
                     // right now ConditionNode is only used with defer, but it might be used
                     // in the future to implement @skip and @include execution
-                    if let Some(node) = if_clause {
-                        if node.is_deferred(variables, query) {
+                    if let Some(node) = if_clause
+                        && node.is_deferred(variables, query) {
                             return true;
                         }
-                    }
-                } else if let Some(node) = else_clause {
-                    if node.is_deferred(variables, query) {
+                } else if let Some(node) = else_clause
+                    && node.is_deferred(variables, query) {
                         return true;
                     }
-                }
 
                 false
             }

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -160,13 +160,15 @@ impl PlanNode {
                 ..
             } => {
                 if let Some(node) = if_clause
-                    && node.contains_mutations() {
-                        return true;
-                    }
+                    && node.contains_mutations()
+                {
+                    return true;
+                }
                 if let Some(node) = else_clause
-                    && node.contains_mutations() {
-                        return true;
-                    }
+                    && node.contains_mutations()
+                {
+                    return true;
+                }
                 false
             }
         }
@@ -193,13 +195,15 @@ impl PlanNode {
                     // right now ConditionNode is only used with defer, but it might be used
                     // in the future to implement @skip and @include execution
                     if let Some(node) = if_clause
-                        && node.is_deferred(variables, query) {
-                            return true;
-                        }
-                } else if let Some(node) = else_clause
-                    && node.is_deferred(variables, query) {
+                        && node.is_deferred(variables, query)
+                    {
                         return true;
                     }
+                } else if let Some(node) = else_clause
+                    && node.is_deferred(variables, query)
+                {
+                    return true;
+                }
 
                 false
             }

--- a/apollo-router/src/query_planner/rewrites.rs
+++ b/apollo-router/src/query_planner/rewrites.rs
@@ -73,16 +73,18 @@ impl DataRewrite {
                 {
                     data.select_values_and_paths_mut(schema, &parent, |_path, selected| {
                         if let Some(obj) = selected.as_object_mut()
-                            && let Some(value) = obj.remove(k.as_str()) {
-                                obj.insert(renamer.rename_key_to.as_str(), value);
-                            }
+                            && let Some(value) = obj.remove(k.as_str())
+                        {
+                            obj.insert(renamer.rename_key_to.as_str(), value);
+                        }
 
                         if let Some(arr) = selected.as_array_mut() {
                             for item in arr {
                                 if let Some(obj) = item.as_object_mut()
-                                    && let Some(value) = obj.remove(k.as_str()) {
-                                        obj.insert(renamer.rename_key_to.as_str(), value);
-                                    }
+                                    && let Some(value) = obj.remove(k.as_str())
+                                {
+                                    obj.insert(renamer.rename_key_to.as_str(), value);
+                                }
                             }
                         }
                     });

--- a/apollo-router/src/query_planner/rewrites.rs
+++ b/apollo-router/src/query_planner/rewrites.rs
@@ -72,19 +72,17 @@ impl DataRewrite {
                     split_path_last_element(&renamer.path)
                 {
                     data.select_values_and_paths_mut(schema, &parent, |_path, selected| {
-                        if let Some(obj) = selected.as_object_mut() {
-                            if let Some(value) = obj.remove(k.as_str()) {
+                        if let Some(obj) = selected.as_object_mut()
+                            && let Some(value) = obj.remove(k.as_str()) {
                                 obj.insert(renamer.rename_key_to.as_str(), value);
                             }
-                        }
 
                         if let Some(arr) = selected.as_array_mut() {
                             for item in arr {
-                                if let Some(obj) = item.as_object_mut() {
-                                    if let Some(value) = obj.remove(k.as_str()) {
+                                if let Some(obj) = item.as_object_mut()
+                                    && let Some(value) = obj.remove(k.as_str()) {
                                         obj.insert(renamer.rename_key_to.as_str(), value);
                                     }
-                                }
                             }
                         }
                     });

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -121,8 +121,8 @@ pub(crate) fn execute_selection_set<'a>(
             }) => match type_condition {
                 None => continue,
                 Some(condition) => {
-                    if type_condition_matches(schema, current_type, condition) {
-                        if let Value::Object(selected) =
+                    if type_condition_matches(schema, current_type, condition)
+                        && let Value::Object(selected) =
                             execute_selection_set(input_content, selections, schema, current_type)
                         {
                             for (key, value) in selected.into_iter() {
@@ -136,7 +136,6 @@ pub(crate) fn execute_selection_set<'a>(
                                 }
                             }
                         }
-                    }
                 }
             },
         }

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -124,18 +124,18 @@ pub(crate) fn execute_selection_set<'a>(
                     if type_condition_matches(schema, current_type, condition)
                         && let Value::Object(selected) =
                             execute_selection_set(input_content, selections, schema, current_type)
-                        {
-                            for (key, value) in selected.into_iter() {
-                                match output.entry(key) {
-                                    Entry::Vacant(e) => {
-                                        e.insert(value);
-                                    }
-                                    Entry::Occupied(e) => {
-                                        e.into_mut().type_aware_deep_merge(value, schema);
-                                    }
+                    {
+                        for (key, value) in selected.into_iter() {
+                            match output.entry(key) {
+                                Entry::Vacant(e) => {
+                                    e.insert(value);
+                                }
+                                Entry::Occupied(e) => {
+                                    e.into_mut().type_aware_deep_merge(value, schema);
                                 }
                             }
                         }
+                    }
                 }
             },
         }

--- a/apollo-router/src/query_planner/subgraph_context.rs
+++ b/apollo-router/src/query_planner/subgraph_context.rs
@@ -175,7 +175,7 @@ impl<'a> SubgraphContext<'a> {
                     // append _<index> to each of the arguments and push all the values into hash_map
                     hash_map.extend(item.iter().map(|(k, v)| {
                         let mut new_named_param = k.clone();
-                        new_named_param.push_str(&format!("_{}", index));
+                        new_named_param.push_str(&format!("_{index}"));
                         (new_named_param, v.clone())
                     }));
                 }
@@ -284,7 +284,7 @@ fn transform_operation(
         // it is a field selection for _entities, so it's ok to reach in and give it an alias
         let mut cloned = field_selection.clone();
         let cfs = cloned.make_mut();
-        cfs.alias = Some(Name::new_unchecked(&format!("_{}", i)));
+        cfs.alias = Some(Name::new_unchecked(&format!("_{i}")));
 
         transform_field_arguments(&mut cfs.arguments, arguments, i);
         transform_selection_set(&mut cfs.selection_set, arguments, i);

--- a/apollo-router/src/query_planner/subgraph_context.rs
+++ b/apollo-router/src/query_planner/subgraph_context.rs
@@ -86,8 +86,8 @@ impl<'a> SubgraphContext<'a> {
         schema: &'a Schema,
         context_rewrites: &'a Option<Vec<DataRewrite>>,
     ) -> Option<SubgraphContext<'a>> {
-        if let Some(rewrites) = context_rewrites {
-            if !rewrites.is_empty() {
+        if let Some(rewrites) = context_rewrites
+            && !rewrites.is_empty() {
                 return Some(SubgraphContext {
                     data,
                     schema,
@@ -95,7 +95,6 @@ impl<'a> SubgraphContext<'a> {
                     named_args: Vec::new(),
                 });
             }
-        }
         None
     }
 
@@ -332,15 +331,14 @@ fn transform_field_arguments(
 ) {
     arguments_in_selection.iter_mut().for_each(|arg| {
         let arg = arg.make_mut();
-        if let Some(v) = arg.value.as_variable() {
-            if arguments.contains(v.as_str()) {
+        if let Some(v) = arg.value.as_variable()
+            && arguments.contains(v.as_str()) {
                 arg.value = Node::new(ast::Value::Variable(Name::new_unchecked(&format!(
                     "{}_{}",
                     v.as_str(),
                     index
                 ))));
             }
-        }
     });
 }
 

--- a/apollo-router/src/query_planner/subgraph_context.rs
+++ b/apollo-router/src/query_planner/subgraph_context.rs
@@ -87,14 +87,15 @@ impl<'a> SubgraphContext<'a> {
         context_rewrites: &'a Option<Vec<DataRewrite>>,
     ) -> Option<SubgraphContext<'a>> {
         if let Some(rewrites) = context_rewrites
-            && !rewrites.is_empty() {
-                return Some(SubgraphContext {
-                    data,
-                    schema,
-                    context_rewrites: rewrites,
-                    named_args: Vec::new(),
-                });
-            }
+            && !rewrites.is_empty()
+        {
+            return Some(SubgraphContext {
+                data,
+                schema,
+                context_rewrites: rewrites,
+                named_args: Vec::new(),
+            });
+        }
         None
     }
 
@@ -332,13 +333,14 @@ fn transform_field_arguments(
     arguments_in_selection.iter_mut().for_each(|arg| {
         let arg = arg.make_mut();
         if let Some(v) = arg.value.as_variable()
-            && arguments.contains(v.as_str()) {
-                arg.value = Node::new(ast::Value::Variable(Name::new_unchecked(&format!(
-                    "{}_{}",
-                    v.as_str(),
-                    index
-                ))));
-            }
+            && arguments.contains(v.as_str())
+        {
+            arg.value = Node::new(ast::Value::Variable(Name::new_unchecked(&format!(
+                "{}_{}",
+                v.as_str(),
+                index
+            ))));
+        }
     });
 }
 

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -308,7 +308,7 @@ mod tests {
         if let LayerMissingTitle = result {
             // Expected error
         } else {
-            panic!("Expected OCILayerMissingTitle error, got {:?}", result);
+            panic!("Expected OCILayerMissingTitle error, got {result:?}");
         }
     }
 }

--- a/apollo-router/src/router/event/schema.rs
+++ b/apollo-router/src/router/event/schema.rs
@@ -183,12 +183,6 @@ impl SchemaSource {
     }
 }
 
-#[derive(thiserror::Error, Debug)]
-enum FetcherError {
-    #[error("failed to build http client")]
-    InitializationError(#[from] reqwest::Error),
-}
-
 // Encapsulates fetching the schema from the first viable url.
 // It will try each url in order until it finds one that works.
 async fn fetch_supergraph_from_first_viable_url(urls: &[Url]) -> Option<SchemaState> {

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -155,8 +155,8 @@ impl RouterSuperServiceFactory for YamlRouterFactory {
         let plugin_registry = &*crate::plugin::PLUGINS;
         let mut initial_telemetry_plugin = None;
 
-        if previous_router.is_none() && apollo_opentelemetry_initialized() {
-            if let Some(factory) = plugin_registry
+        if previous_router.is_none() && apollo_opentelemetry_initialized()
+            && let Some(factory) = plugin_registry
                 .iter()
                 .find(|factory| factory.name == "apollo.telemetry")
             {
@@ -194,7 +194,6 @@ impl RouterSuperServiceFactory for YamlRouterFactory {
                     }
                 }
             }
-        }
 
         let router_span = tracing::info_span!(STARTING_SPAN_NAME);
         Self.inner_create(
@@ -863,14 +862,13 @@ fn inject_schema_id(
             return;
         }
     }
-    if let Some(apollo) = configuration.get_mut("apollo") {
-        if let Some(apollo) = apollo.as_object_mut() {
+    if let Some(apollo) = configuration.get_mut("apollo")
+        && let Some(apollo) = apollo.as_object_mut() {
             apollo.insert(
                 "schema_id".to_string(),
                 Value::String(schema_id.to_string()),
             );
         }
-    }
 }
 
 #[cfg(test)]

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -315,7 +315,7 @@ fn log_request(
 
         attrs.push(KeyValue::new(
             HTTP_REQUEST_HEADERS,
-            opentelemetry::Value::String(format!("{:?}", headers).into()),
+            opentelemetry::Value::String(format!("{headers:?}").into()),
         ));
         attrs.push(KeyValue::new(
             HTTP_REQUEST_METHOD,

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -81,11 +81,11 @@ impl FromStr for ConnectorSourceRef {
         let mut parts = s.split('.');
         let subgraph_name = parts
             .next()
-            .ok_or(format!("Invalid connector source reference '{}'", s))?
+            .ok_or(format!("Invalid connector source reference '{s}'"))?
             .to_string();
         let source_name = parts
             .next()
-            .ok_or(format!("Invalid connector source reference '{}'", s))?;
+            .ok_or(format!("Invalid connector source reference '{s}'"))?;
         Ok(Self::new(subgraph_name, SourceName::cast(source_name)))
     }
 }

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -84,9 +84,10 @@ impl Stream for StreamWrapper {
 impl Drop for StreamWrapper {
     fn drop(&mut self) {
         if let Some(closed_signal) = self.1.take()
-            && let Err(err) = closed_signal.send(()) {
-                tracing::trace!("cannot close the subscription: {err:?}");
-            }
+            && let Err(err) = closed_signal.send(())
+        {
+            tracing::trace!("cannot close the subscription: {err:?}");
+        }
 
         self.0.close();
     }

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -83,11 +83,10 @@ impl Stream for StreamWrapper {
 
 impl Drop for StreamWrapper {
     fn drop(&mut self) {
-        if let Some(closed_signal) = self.1.take() {
-            if let Err(err) = closed_signal.send(()) {
+        if let Some(closed_signal) = self.1.take()
+            && let Err(err) = closed_signal.send(()) {
                 tracing::trace!("cannot close the subscription: {err:?}");
             }
-        }
 
         self.0.close();
     }

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -305,7 +305,7 @@ where
                 0
             }
         });
-        let otel_name = format!("POST {}", schema_uri);
+        let otel_name = format!("POST {schema_uri}");
 
         let http_req_span = tracing::info_span!(HTTP_REQUEST_SPAN_NAME,
             "otel.kind" = "CLIENT",

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -328,19 +328,20 @@ impl FetchService {
         if let Some(max_opened_subscriptions) = subscription_config
             .as_ref()
             .and_then(|s| s.max_opened_subscriptions)
-            && OPENED_SUBSCRIPTIONS.load(Ordering::Relaxed) >= max_opened_subscriptions {
-                return Box::pin(async {
-                    Ok((
-                        Value::default(),
-                        vec![
-                            Error::builder()
-                                .message("can't open new subscription, limit reached")
-                                .extension_code("SUBSCRIPTION_MAX_LIMIT")
-                                .build(),
-                        ],
-                    ))
-                });
-            }
+            && OPENED_SUBSCRIPTIONS.load(Ordering::Relaxed) >= max_opened_subscriptions
+        {
+            return Box::pin(async {
+                Ok((
+                    Value::default(),
+                    vec![
+                        Error::builder()
+                            .message("can't open new subscription, limit reached")
+                            .extension_code("SUBSCRIPTION_MAX_LIMIT")
+                            .build(),
+                    ],
+                ))
+            });
+        }
         let mode = match subscription_config.as_ref() {
             Some(config) => config
                 .mode

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -328,8 +328,7 @@ impl FetchService {
         if let Some(max_opened_subscriptions) = subscription_config
             .as_ref()
             .and_then(|s| s.max_opened_subscriptions)
-        {
-            if OPENED_SUBSCRIPTIONS.load(Ordering::Relaxed) >= max_opened_subscriptions {
+            && OPENED_SUBSCRIPTIONS.load(Ordering::Relaxed) >= max_opened_subscriptions {
                 return Box::pin(async {
                     Ok((
                         Value::default(),
@@ -342,7 +341,6 @@ impl FetchService {
                     ))
                 });
             }
-        }
         let mode = match subscription_config.as_ref() {
             Some(config) => config
                 .mode

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -457,8 +457,7 @@ impl FetchService {
                     vec![
                         Error::builder()
                             .message(format!(
-                                "subscription mode is not configured for subgraph {:?}",
-                                service_name
+                                "subscription mode is not configured for subgraph {service_name:?}"
                             ))
                             .extension_code("INVALID_SUBSCRIPTION_MODE")
                             .build(),

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -111,7 +111,7 @@ where
                 .serve_connection_with_upgrades(io, svc)
                 .await
             {
-                eprintln!("server error: {}", err);
+                eprintln!("server error: {err}");
             }
         });
     }
@@ -136,7 +136,7 @@ where
                 .serve_connection_with_upgrades(io, svc)
                 .await
             {
-                eprintln!("server error: {}", err);
+                eprintln!("server error: {err}");
             }
         });
     }
@@ -852,7 +852,7 @@ async fn test_unix_socket() {
     async fn handle(mut req: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
         let data = router::body::into_bytes(req.body_mut()).await.unwrap();
         let body = std::str::from_utf8(&data).unwrap();
-        println!("{:?}", body);
+        println!("{body:?}");
         let response = http::Response::builder()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, "application/json")

--- a/apollo-router/src/services/layers/persisted_queries/manifest.rs
+++ b/apollo-router/src/services/layers/persisted_queries/manifest.rs
@@ -52,7 +52,7 @@ impl SignedUrlChunk {
     pub(crate) fn parse_and_validate(raw_chunk: &str) -> Result<Self, BoxError> {
         let parsed_chunk =
             serde_json::from_str::<SignedUrlChunk>(raw_chunk).map_err(|e| -> BoxError {
-                format!("Could not parse persisted query manifest chunk: {}", e).into()
+                format!("Could not parse persisted query manifest chunk: {e}").into()
             })?;
 
         parsed_chunk.validate()

--- a/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
+++ b/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
@@ -214,18 +214,13 @@ async fn fetch_chunk(http_client: Client, chunk_url: &String) -> Result<SignedUr
         .await
         .and_then(|r| r.error_for_status())
         .map_err(|e| -> BoxError {
-            format!(
-                "error fetching persisted queries manifest chunk from {chunk_url}: {e}"
-            )
-            .into()
+            format!("error fetching persisted queries manifest chunk from {chunk_url}: {e}").into()
         })?
         .json::<SignedUrlChunk>()
         .await
         .map_err(|e| -> BoxError {
-            format!(
-                "error reading body of persisted queries manifest chunk from {chunk_url}: {e}"
-            )
-            .into()
+            format!("error reading body of persisted queries manifest chunk from {chunk_url}: {e}")
+                .into()
         })?;
 
     chunk.validate()
@@ -336,10 +331,7 @@ async fn load_local_manifests(paths: Vec<String>) -> Result<PersistedQueryManife
 
     for path in paths.iter() {
         let raw_file_contents = read_to_string(path).await.map_err(|e| -> BoxError {
-            format!(
-                "Failed to read persisted query list file at path: {path}, {e}"
-            )
-            .into()
+            format!("Failed to read persisted query list file at path: {path}, {e}").into()
         })?;
 
         let chunk = SignedUrlChunk::parse_and_validate(&raw_file_contents)?;

--- a/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
+++ b/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
@@ -215,8 +215,7 @@ async fn fetch_chunk(http_client: Client, chunk_url: &String) -> Result<SignedUr
         .and_then(|r| r.error_for_status())
         .map_err(|e| -> BoxError {
             format!(
-                "error fetching persisted queries manifest chunk from {}: {}",
-                chunk_url, e
+                "error fetching persisted queries manifest chunk from {chunk_url}: {e}"
             )
             .into()
         })?
@@ -224,8 +223,7 @@ async fn fetch_chunk(http_client: Client, chunk_url: &String) -> Result<SignedUr
         .await
         .map_err(|e| -> BoxError {
             format!(
-                "error reading body of persisted queries manifest chunk from {}: {}",
-                chunk_url, e
+                "error reading body of persisted queries manifest chunk from {chunk_url}: {e}"
             )
             .into()
         })?;
@@ -339,8 +337,7 @@ async fn load_local_manifests(paths: Vec<String>) -> Result<PersistedQueryManife
     for path in paths.iter() {
         let raw_file_contents = read_to_string(path).await.map_err(|e| -> BoxError {
             format!(
-                "Failed to read persisted query list file at path: {}, {}",
-                path, e
+                "Failed to read persisted query list file at path: {path}, {e}"
             )
             .into()
         })?;

--- a/apollo-router/src/services/layers/persisted_queries/mod.rs
+++ b/apollo-router/src/services/layers/persisted_queries/mod.rs
@@ -110,8 +110,8 @@ impl PersistedQueryLayer {
                 Ok(request)
             } else if let Some(log_unknown) = manifest_poller.never_allows_freeform_graphql() {
                 // If we don't have an ID and we require an ID, return an error immediately,
-                if log_unknown {
-                    if let Some(operation_body) = request.supergraph_request.body().query.as_ref() {
+                if log_unknown
+                    && let Some(operation_body) = request.supergraph_request.body().query.as_ref() {
                         // Note: it's kind of inconsistent that if we require
                         // IDs and skip_enforcement is set, we don't call
                         // log_unknown_operation on freeform GraphQL, but if we
@@ -120,7 +120,6 @@ impl PersistedQueryLayer {
                         // operations.
                         log_unknown_operation(operation_body, false);
                     }
-                }
                 Err(supergraph_err_pq_id_required(request))
             } else {
                 // Let the freeform document (or complete lack of a document) be

--- a/apollo-router/src/services/layers/persisted_queries/mod.rs
+++ b/apollo-router/src/services/layers/persisted_queries/mod.rs
@@ -111,15 +111,16 @@ impl PersistedQueryLayer {
             } else if let Some(log_unknown) = manifest_poller.never_allows_freeform_graphql() {
                 // If we don't have an ID and we require an ID, return an error immediately,
                 if log_unknown
-                    && let Some(operation_body) = request.supergraph_request.body().query.as_ref() {
-                        // Note: it's kind of inconsistent that if we require
-                        // IDs and skip_enforcement is set, we don't call
-                        // log_unknown_operation on freeform GraphQL, but if we
-                        // *don't* require IDs and skip_enforcement is set, we
-                        // *do* call log_unknown_operation on unknown
-                        // operations.
-                        log_unknown_operation(operation_body, false);
-                    }
+                    && let Some(operation_body) = request.supergraph_request.body().query.as_ref()
+                {
+                    // Note: it's kind of inconsistent that if we require
+                    // IDs and skip_enforcement is set, we don't call
+                    // log_unknown_operation on freeform GraphQL, but if we
+                    // *don't* require IDs and skip_enforcement is set, we
+                    // *do* call log_unknown_operation on unknown
+                    // operations.
+                    log_unknown_operation(operation_body, false);
+                }
                 Err(supergraph_err_pq_id_required(request))
             } else {
                 // Let the freeform document (or complete lack of a document) be

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -465,7 +465,7 @@ pub(crate) fn get_operation(
 
 impl Display for ParsedDocumentInner {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -284,11 +284,10 @@ impl Response {
         // There are instances where we have errors that need to be counted for telemetry in this
         // layer, but we don't want to deserialize the body. In these cases we can pass in the
         // list of errors to add to context for counting later in the telemetry plugin.
-        if let Some(errors) = errors_for_context {
-            if !errors.is_empty() {
+        if let Some(errors) = errors_for_context
+            && !errors.is_empty() {
                 Self::add_errors_to_context(&errors, &context);
             }
-        }
         let mut res = Self { response, context };
         if let Some(body_to_stash) = body_to_stash {
             res.stash_the_body_in_extensions(body_to_stash)
@@ -406,11 +405,10 @@ impl Response {
                 );
 
                 Either::Left(futures::stream::unfold(multipart, |mut m| async {
-                    if let Ok(Some(response)) = m.next_field().await {
-                        if let Ok(bytes) = response.bytes().await {
+                    if let Ok(Some(response)) = m.next_field().await
+                        && let Ok(bytes) = response.bytes().await {
                             return Some((serde_json::from_slice::<graphql::Response>(&bytes), m));
                         }
-                    }
                     None
                 }))
             } else {

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -285,9 +285,10 @@ impl Response {
         // layer, but we don't want to deserialize the body. In these cases we can pass in the
         // list of errors to add to context for counting later in the telemetry plugin.
         if let Some(errors) = errors_for_context
-            && !errors.is_empty() {
-                Self::add_errors_to_context(&errors, &context);
-            }
+            && !errors.is_empty()
+        {
+            Self::add_errors_to_context(&errors, &context);
+        }
         let mut res = Self { response, context };
         if let Some(body_to_stash) = body_to_stash {
             res.stash_the_body_in_extensions(body_to_stash)
@@ -406,9 +407,10 @@ impl Response {
 
                 Either::Left(futures::stream::unfold(multipart, |mut m| async {
                     if let Ok(Some(response)) = m.next_field().await
-                        && let Ok(bytes) = response.bytes().await {
-                            return Some((serde_json::from_slice::<graphql::Response>(&bytes), m));
-                        }
+                        && let Ok(bytes) = response.bytes().await
+                    {
+                        return Some((serde_json::from_slice::<graphql::Response>(&bytes), m));
+                    }
                     None
                 }))
             } else {

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -772,7 +772,7 @@ impl RouterService {
 
                     attrs.push(KeyValue::new(
                         HTTP_REQUEST_HEADERS,
-                        opentelemetry::Value::String(format!("{:?}", headers).into()),
+                        opentelemetry::Value::String(format!("{headers:?}").into()),
                     ));
                     attrs.push(KeyValue::new(
                         HTTP_REQUEST_METHOD,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1427,12 +1427,10 @@ fn get_graphql_content_type(service_name: &str, parts: &Parts) -> Result<Content
                 Ok(ContentType::ApplicationGraphqlResponseJson)
             }
             Some(mime) => Err(format!(
-                "subgraph response contains unsupported content-type: {}",
-                mime,
+                "subgraph response contains unsupported content-type: {mime}",
             )),
             None => Err(format!(
-                "subgraph response contains invalid 'content-type' header value {:?}",
-                raw_content_type,
+                "subgraph response contains invalid 'content-type' header value {raw_content_type:?}",
             )),
         }
     } else {
@@ -1710,7 +1708,7 @@ mod tests {
                     .serve_connection_with_upgrades(io, svc)
                     .await
                 {
-                    eprintln!("server error: {}", err);
+                    eprintln!("server error: {err}");
                 }
             });
         }

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -2851,9 +2851,7 @@ async fn no_typename_on_interface() {
             .unwrap()
             .get("name")
             .unwrap(),
-        "{:?}\n{:?}",
-        with_typename,
-        no_typename
+        "{with_typename:?}\n{no_typename:?}"
     );
     insta::assert_json_snapshot!(with_typename);
 
@@ -2894,9 +2892,7 @@ async fn no_typename_on_interface() {
             .unwrap()
             .get("name")
             .unwrap(),
-        "{:?}\n{:?}",
-        with_reversed_fragments,
-        no_typename
+        "{with_reversed_fragments:?}\n{no_typename:?}"
     );
     insta::assert_json_snapshot!(with_reversed_fragments);
 }

--- a/apollo-router/src/spec/operation_limits.rs
+++ b/apollo-router/src/spec/operation_limits.rs
@@ -100,9 +100,10 @@ pub(crate) fn check(
         let mut messages = Vec::new();
         max.combine(measured, |ident, max, measured| {
             if let Some(max) = max
-                && measured > max {
-                    messages.push(format!("{ident}: {measured}, max_{ident}: {max}"))
-                }
+                && measured > max
+            {
+                messages.push(format!("{ident}: {measured}, max_{ident}: {max}"))
+            }
         });
         let message = messages.join(", ");
         tracing::warn!(

--- a/apollo-router/src/spec/operation_limits.rs
+++ b/apollo-router/src/spec/operation_limits.rs
@@ -99,11 +99,10 @@ pub(crate) fn check(
     if exceeded.any() {
         let mut messages = Vec::new();
         max.combine(measured, |ident, max, measured| {
-            if let Some(max) = max {
-                if measured > max {
+            if let Some(max) = max
+                && measured > max {
                     messages.push(format!("{ident}: {measured}, max_{ident}: {max}"))
                 }
-            }
         });
         let message = messages.join(", ");
         tracing::warn!(

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -800,8 +800,7 @@ impl Query {
                         parameters.errors.push(
                             Error::builder()
                                 .message(format!(
-                                    "Cannot return null for non-nullable field {}.{field_name_str}",
-                                    root_type_name
+                                    "Cannot return null for non-nullable field {root_type_name}.{field_name_str}"
                                 ))
                                 .path(Path::from_response_slice(path))
                                 .build(),

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -162,13 +162,12 @@ impl Query {
                                 },
                             );
 
-                            if !parameters.errors.is_empty() {
-                                if let Ok(value) = serde_json_bytes::to_value(&parameters.errors) {
+                            if !parameters.errors.is_empty()
+                                && let Ok(value) = serde_json_bytes::to_value(&parameters.errors) {
                                     response
                                         .extensions
                                         .insert(EXTENSIONS_VALUE_COMPLETION_KEY, value);
                                 }
-                            }
 
                             return parameters.nullified;
                         }
@@ -218,13 +217,12 @@ impl Query {
                             Err(InvalidValue) => Value::Null,
                         },
                     );
-                    if !parameters.errors.is_empty() {
-                        if let Ok(value) = serde_json_bytes::to_value(&parameters.errors) {
+                    if !parameters.errors.is_empty()
+                        && let Ok(value) = serde_json_bytes::to_value(&parameters.errors) {
                             response
                                 .extensions
                                 .insert(EXTENSIONS_VALUE_COMPLETION_KEY, value);
                         }
-                    }
 
                     return parameters.nullified;
                 }
@@ -674,11 +672,10 @@ impl Query {
 
                     if is_apply {
                         // if this is the filtered query, we must keep the __typename field because the original query must know the type
-                        if !self.is_original {
-                            if let Some(input_type) = input.get(TYPENAME) {
+                        if !self.is_original
+                            && let Some(input_type) = input.get(TYPENAME) {
                                 output.insert(TYPENAME, input_type.clone());
                             }
-                        }
 
                         self.apply_selection_set(
                             selection_set,
@@ -715,11 +712,10 @@ impl Query {
 
                         if is_apply {
                             // if this is the filtered query, we must keep the __typename field because the original query must know the type
-                            if !self.is_original {
-                                if let Some(input_type) = input.get(TYPENAME) {
+                            if !self.is_original
+                                && let Some(input_type) = input.get(TYPENAME) {
                                     output.insert(TYPENAME, input_type.clone());
                                 }
-                            }
 
                             self.apply_selection_set(
                                 selection_set,

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -163,11 +163,12 @@ impl Query {
                             );
 
                             if !parameters.errors.is_empty()
-                                && let Ok(value) = serde_json_bytes::to_value(&parameters.errors) {
-                                    response
-                                        .extensions
-                                        .insert(EXTENSIONS_VALUE_COMPLETION_KEY, value);
-                                }
+                                && let Ok(value) = serde_json_bytes::to_value(&parameters.errors)
+                            {
+                                response
+                                    .extensions
+                                    .insert(EXTENSIONS_VALUE_COMPLETION_KEY, value);
+                            }
 
                             return parameters.nullified;
                         }
@@ -218,11 +219,12 @@ impl Query {
                         },
                     );
                     if !parameters.errors.is_empty()
-                        && let Ok(value) = serde_json_bytes::to_value(&parameters.errors) {
-                            response
-                                .extensions
-                                .insert(EXTENSIONS_VALUE_COMPLETION_KEY, value);
-                        }
+                        && let Ok(value) = serde_json_bytes::to_value(&parameters.errors)
+                    {
+                        response
+                            .extensions
+                            .insert(EXTENSIONS_VALUE_COMPLETION_KEY, value);
+                    }
 
                     return parameters.nullified;
                 }
@@ -673,9 +675,10 @@ impl Query {
                     if is_apply {
                         // if this is the filtered query, we must keep the __typename field because the original query must know the type
                         if !self.is_original
-                            && let Some(input_type) = input.get(TYPENAME) {
-                                output.insert(TYPENAME, input_type.clone());
-                            }
+                            && let Some(input_type) = input.get(TYPENAME)
+                        {
+                            output.insert(TYPENAME, input_type.clone());
+                        }
 
                         self.apply_selection_set(
                             selection_set,
@@ -713,9 +716,10 @@ impl Query {
                         if is_apply {
                             // if this is the filtered query, we must keep the __typename field because the original query must know the type
                             if !self.is_original
-                                && let Some(input_type) = input.get(TYPENAME) {
-                                    output.insert(TYPENAME, input_type.clone());
-                                }
+                                && let Some(input_type) = input.get(TYPENAME)
+                            {
+                                output.insert(TYPENAME, input_type.clone());
+                            }
 
                             self.apply_selection_set(
                                 selection_set,

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -1829,7 +1829,7 @@ fn variable_validation() {
         }}",
         json!({"input":{}})
     );
-    assert!(res.is_ok(), "validation should have succeeded: {:?}", res);
+    assert!(res.is_ok(), "validation should have succeeded: {res:?}");
 }
 
 #[test]

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -317,7 +317,7 @@ impl Schema {
                     };
 
                     let Some(version_in_url) =
-                        Version::parse(format!("{}.0", version_in_link).as_str()).ok()
+                        Version::parse(format!("{version_in_link}.0").as_str()).ok()
                     else {
                         return false;
                     };
@@ -355,7 +355,7 @@ impl Schema {
                     };
 
                     let Some(version_in_url) =
-                        Version::parse(format!("{}.0", version_in_link).as_str()).ok()
+                        Version::parse(format!("{version_in_link}.0").as_str()).ok()
                     else {
                         return false;
                     };

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -192,15 +192,17 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     configuration_reload = true;
                 }
                 if let Some(new_schema) = new_schema
-                    && schema.as_ref() != new_schema.as_ref() {
-                        *schema = new_schema;
-                        schema_reload = true;
-                    }
+                    && schema.as_ref() != new_schema.as_ref()
+                {
+                    *schema = new_schema;
+                    schema_reload = true;
+                }
                 if let Some(new_license) = new_license
-                    && *license != new_license {
-                        *license = new_license;
-                        license_reload = true;
-                    }
+                    && *license != new_license
+                {
+                    *license = new_license;
+                    license_reload = true;
+                }
 
                 // Let users know we are about to process a state reload event
                 tracing::info!(

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -191,18 +191,16 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     *configuration = new_configuration;
                     configuration_reload = true;
                 }
-                if let Some(new_schema) = new_schema {
-                    if schema.as_ref() != new_schema.as_ref() {
+                if let Some(new_schema) = new_schema
+                    && schema.as_ref() != new_schema.as_ref() {
                         *schema = new_schema;
                         schema_reload = true;
                     }
-                }
-                if let Some(new_license) = new_license {
-                    if *license != new_license {
+                if let Some(new_license) = new_license
+                    && *license != new_license {
                         *license = new_license;
                         license_reload = true;
                     }
-                }
 
                 // Let users know we are about to process a state reload event
                 tracing::info!(

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -575,14 +575,12 @@ pub fn make_fake_batch(
         // name from -> to.
         // If our request doesn't have an operation name or we weren't given an op_from_to,
         // just duplicate the request as is.
-        if let Some((from, to)) = op_from_to {
-            if let Some(operation_name) = &req.operation_name {
-                if operation_name == from {
+        if let Some((from, to)) = op_from_to
+            && let Some(operation_name) = &req.operation_name
+                && operation_name == from {
                     new_req.query = req.query.clone().map(|q| q.replace(from, to));
                     new_req.operation_name = Some(to.to_string());
                 }
-            }
-        }
 
         let mut json_bytes_req = serde_json::to_vec(&req).unwrap();
         let mut json_bytes_new_req = serde_json::to_vec(&new_req).unwrap();

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -577,10 +577,11 @@ pub fn make_fake_batch(
         // just duplicate the request as is.
         if let Some((from, to)) = op_from_to
             && let Some(operation_name) = &req.operation_name
-                && operation_name == from {
-                    new_req.query = req.query.clone().map(|q| q.replace(from, to));
-                    new_req.operation_name = Some(to.to_string());
-                }
+            && operation_name == from
+        {
+            new_req.query = req.query.clone().map(|q| q.replace(from, to));
+            new_req.operation_name = Some(to.to_string());
+        }
 
         let mut json_bytes_req = serde_json::to_vec(&req).unwrap();
         let mut json_bytes_new_req = serde_json::to_vec(&new_req).unwrap();

--- a/apollo-router/src/test_harness/http_snapshot.rs
+++ b/apollo-router/src/test_harness/http_snapshot.rs
@@ -302,15 +302,16 @@ fn response_from_snapshot(
                 // Look up snapshot using regex
                 for snapshot in snapshots_by_regex.iter() {
                     if let Some(regex) = &snapshot.request.regex
-                        && regex.is_match(uri) {
-                            debug!(
-                                url = %uri,
-                                method = %method,
-                                regex = %regex.to_string(),
-                                "Found existing snapshot"
-                            );
-                            return Some(snapshot);
-                        }
+                        && regex.is_match(uri)
+                    {
+                        debug!(
+                            url = %uri,
+                            method = %method,
+                            regex = %regex.to_string(),
+                            "Found existing snapshot"
+                        );
+                        return Some(snapshot);
+                    }
                 }
                 None
             })

--- a/apollo-router/src/test_harness/http_snapshot.rs
+++ b/apollo-router/src/test_harness/http_snapshot.rs
@@ -301,8 +301,8 @@ fn response_from_snapshot(
             .or_else(|| {
                 // Look up snapshot using regex
                 for snapshot in snapshots_by_regex.iter() {
-                    if let Some(regex) = &snapshot.request.regex {
-                        if regex.is_match(uri) {
+                    if let Some(regex) = &snapshot.request.regex
+                        && regex.is_match(uri) {
                             debug!(
                                 url = %uri,
                                 method = %method,
@@ -311,7 +311,6 @@ fn response_from_snapshot(
                             );
                             return Some(snapshot);
                         }
-                    }
                 }
                 None
             })

--- a/apollo-router/src/uplink/feature_gate_enforcement.rs
+++ b/apollo-router/src/uplink/feature_gate_enforcement.rs
@@ -177,8 +177,7 @@ impl Display for FeatureGateViolation {
             } => {
                 write!(
                     f,
-                    "* {} @link(url: \"{}\")\n  To enable:\n\n{}",
-                    name, url, to_enable
+                    "* {name} @link(url: \"{url}\")\n  To enable:\n\n{to_enable}"
                 )
             }
         }

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -224,14 +224,13 @@ impl LicenseEnforcementReport {
                     name,
                     version_req,
                 } => {
-                    if let Some(link_spec) = link_specs.get(spec_url) {
-                        if version_req.matches(&link_spec.version) {
+                    if let Some(link_spec) = link_specs.get(spec_url)
+                        && version_req.matches(&link_spec.version) {
                             schema_violations.push(SchemaViolation::Spec {
                                 url: link_spec.url.to_string(),
                                 name: name.to_string(),
                             });
                         }
-                    }
                 }
                 SchemaRestriction::DirectiveArgument {
                     spec_url,
@@ -240,8 +239,8 @@ impl LicenseEnforcementReport {
                     argument,
                     explanation,
                 } => {
-                    if let Some(link_spec) = link_specs.get(spec_url) {
-                        if version_req.matches(&link_spec.version) {
+                    if let Some(link_spec) = link_specs.get(spec_url)
+                        && version_req.matches(&link_spec.version) {
                             let directive_name = link_spec.directive_name(name);
                             if schema
                                 .supergraph_schema()
@@ -277,21 +276,19 @@ impl LicenseEnforcementReport {
                                 });
                             }
                         }
-                    }
                 }
                 SchemaRestriction::SpecInJoinDirective {
                     spec_url,
                     name,
                     version_req,
                 } => {
-                    if let Some(link_spec) = link_specs_in_join_directive.get(spec_url) {
-                        if version_req.matches(&link_spec.version) {
+                    if let Some(link_spec) = link_specs_in_join_directive.get(spec_url)
+                        && version_req.matches(&link_spec.version) {
                             schema_violations.push(SchemaViolation::Spec {
                                 url: link_spec.url.to_string(),
                                 name: name.to_string(),
                             });
                         }
-                    }
                 }
             }
         }

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -808,7 +808,7 @@ impl Display for SchemaViolation {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             SchemaViolation::Spec { name, url } => {
-                write!(f, "* @{}\n  {}", name, url)
+                write!(f, "* @{name}\n  {url}")
             }
             SchemaViolation::DirectiveArgument {
                 name,
@@ -816,7 +816,7 @@ impl Display for SchemaViolation {
                 argument,
                 explanation,
             } => {
-                write!(f, "* @{}.{}\n  {}\n\n{}", name, argument, url, explanation)
+                write!(f, "* @{name}.{argument}\n  {url}\n\n{explanation}")
             }
         }
     }

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -225,12 +225,13 @@ impl LicenseEnforcementReport {
                     version_req,
                 } => {
                     if let Some(link_spec) = link_specs.get(spec_url)
-                        && version_req.matches(&link_spec.version) {
-                            schema_violations.push(SchemaViolation::Spec {
-                                url: link_spec.url.to_string(),
-                                name: name.to_string(),
-                            });
-                        }
+                        && version_req.matches(&link_spec.version)
+                    {
+                        schema_violations.push(SchemaViolation::Spec {
+                            url: link_spec.url.to_string(),
+                            name: name.to_string(),
+                        });
+                    }
                 }
                 SchemaRestriction::DirectiveArgument {
                     spec_url,
@@ -240,42 +241,43 @@ impl LicenseEnforcementReport {
                     explanation,
                 } => {
                     if let Some(link_spec) = link_specs.get(spec_url)
-                        && version_req.matches(&link_spec.version) {
-                            let directive_name = link_spec.directive_name(name);
-                            if schema
-                                .supergraph_schema()
-                                .types
-                                .values()
-                                .flat_map(|def| match def {
-                                    // To traverse additional directive locations, add match arms for the respective definition types required.
-                                    ExtendedType::Object(object_type_def) => {
-                                        let directives_on_object = object_type_def
-                                            .directives
-                                            .get_all(&directive_name)
-                                            .map(|component| &component.node);
-                                        let directives_on_fields =
-                                            object_type_def.fields.values().flat_map(|field| {
-                                                field.directives.get_all(&directive_name)
-                                            });
+                        && version_req.matches(&link_spec.version)
+                    {
+                        let directive_name = link_spec.directive_name(name);
+                        if schema
+                            .supergraph_schema()
+                            .types
+                            .values()
+                            .flat_map(|def| match def {
+                                // To traverse additional directive locations, add match arms for the respective definition types required.
+                                ExtendedType::Object(object_type_def) => {
+                                    let directives_on_object = object_type_def
+                                        .directives
+                                        .get_all(&directive_name)
+                                        .map(|component| &component.node);
+                                    let directives_on_fields =
+                                        object_type_def.fields.values().flat_map(|field| {
+                                            field.directives.get_all(&directive_name)
+                                        });
 
-                                        directives_on_object
-                                            .chain(directives_on_fields)
-                                            .collect::<Vec<_>>()
-                                    }
-                                    _ => vec![],
-                                })
-                                .any(|directive| {
-                                    directive.specified_argument_by_name(argument).is_some()
-                                })
-                            {
-                                schema_violations.push(SchemaViolation::DirectiveArgument {
-                                    url: link_spec.url.to_string(),
-                                    name: directive_name.to_string(),
-                                    argument: argument.to_string(),
-                                    explanation: explanation.to_string(),
-                                });
-                            }
+                                    directives_on_object
+                                        .chain(directives_on_fields)
+                                        .collect::<Vec<_>>()
+                                }
+                                _ => vec![],
+                            })
+                            .any(|directive| {
+                                directive.specified_argument_by_name(argument).is_some()
+                            })
+                        {
+                            schema_violations.push(SchemaViolation::DirectiveArgument {
+                                url: link_spec.url.to_string(),
+                                name: directive_name.to_string(),
+                                argument: argument.to_string(),
+                                explanation: explanation.to_string(),
+                            });
                         }
+                    }
                 }
                 SchemaRestriction::SpecInJoinDirective {
                     spec_url,
@@ -283,12 +285,13 @@ impl LicenseEnforcementReport {
                     version_req,
                 } => {
                     if let Some(link_spec) = link_specs_in_join_directive.get(spec_url)
-                        && version_req.matches(&link_spec.version) {
-                            schema_violations.push(SchemaViolation::Spec {
-                                url: link_spec.url.to_string(),
-                                name: name.to_string(),
-                            });
-                        }
+                        && version_req.matches(&link_spec.version)
+                    {
+                        schema_violations.push(SchemaViolation::Spec {
+                            url: link_spec.url.to_string(),
+                            name: name.to_string(),
+                        });
+                    }
                 }
             }
         }

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -966,7 +966,7 @@ mod test {
 
     fn to_friendly<R: std::fmt::Debug>(r: Result<R, Error>) -> Result<String, String> {
         match r {
-            Ok(e) => Ok(format!("result {:?}", e)),
+            Ok(e) => Ok(format!("result {e:?}")),
             Err(e) => Err(e.to_string()),
         }
     }

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -484,13 +484,11 @@ where
         .send()
         .await
         .inspect_err(|e| {
-            if let Some(hyper_err) = e.source() {
-                if let Some(os_err) = hyper_err.source() {
-                    if os_err.to_string().contains("tcp connect error: Cannot assign requested address (os error 99)") {
+            if let Some(hyper_err) = e.source()
+                && let Some(os_err) = hyper_err.source()
+                    && os_err.to_string().contains("tcp connect error: Cannot assign requested address (os error 99)") {
                         tracing::warn!("If your router is executing within a kubernetes pod, this failure may be caused by istio-proxy injection. See https://github.com/apollographql/router/issues/3533 for more details about how to solve this");
                     }
-                }
-            }
         })?;
     tracing::debug!("uplink response {:?}", res);
     let response_body: graphql_client::Response<Query::ResponseData> = res.json().await?;

--- a/apollo-router/src/uplink/parsed_link_spec.rs
+++ b/apollo-router/src/uplink/parsed_link_spec.rs
@@ -96,7 +96,7 @@ impl ParsedLinkSpec {
     // 3. Otherwise, use the spec name as the prefix.
     pub(super) fn directive_name(&self, default_name: &str) -> String {
         if let Some(imported_as) = &self.imported_as {
-            format!("{}__{}", imported_as, default_name)
+            format!("{imported_as}__{default_name}")
         } else if self.spec_name == default_name {
             default_name.to_string()
         } else {

--- a/apollo-router/src/uplink/persisted_queries_manifest_stream.rs
+++ b/apollo-router/src/uplink/persisted_queries_manifest_stream.rs
@@ -147,9 +147,9 @@ mod test {
 
                 let persisted_query_manifest = results
                     .first()
-                    .unwrap_or_else(|| panic!("expected one result from {}", url))
+                    .unwrap_or_else(|| panic!("expected one result from {url}"))
                     .as_ref()
-                    .unwrap_or_else(|_| panic!("schema should be OK from {}", url))
+                    .unwrap_or_else(|_| panic!("schema should be OK from {url}"))
                     .as_ref()
                     .unwrap();
                 assert!(!persisted_query_manifest.is_empty())

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -135,9 +135,9 @@ mod test {
 
                 let schema = results
                     .first()
-                    .unwrap_or_else(|| panic!("expected one result from {}", url))
+                    .unwrap_or_else(|| panic!("expected one result from {url}"))
                     .as_ref()
-                    .unwrap_or_else(|_| panic!("schema should be OK from {}", url));
+                    .unwrap_or_else(|_| panic!("schema should be OK from {url}"));
                 assert!(schema.contains("type Product"))
             }
         }

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -251,17 +251,16 @@ impl IntegrationTest {
             .expect("Failed to read config file");
 
         // Check if placeholder exists in config
-        let placeholder_pattern = format!("{{{{{}}}}}", placeholder_name);
-        let port_pattern = format!(":{{{{{}}}}}", placeholder_name);
-        let addr_pattern = format!("127.0.0.1:{{{{{}}}}}", placeholder_name);
+        let placeholder_pattern = format!("{{{{{placeholder_name}}}}}");
+        let port_pattern = format!(":{{{{{placeholder_name}}}}}");
+        let addr_pattern = format!("127.0.0.1:{{{{{placeholder_name}}}}}");
 
         if !current_config.contains(&placeholder_pattern)
             && !current_config.contains(&port_pattern)
             && !current_config.contains(&addr_pattern)
         {
             panic!(
-                "Placeholder '{}' not found in config file. Expected one of: '{}', '{}', or '{}'",
-                placeholder_name, placeholder_pattern, port_pattern, addr_pattern
+                "Placeholder '{placeholder_name}' not found in config file. Expected one of: '{placeholder_pattern}', '{port_pattern}', or '{addr_pattern}'"
             );
         }
 
@@ -1132,7 +1131,7 @@ impl IntegrationTest {
     #[allow(dead_code)]
     pub fn print_logs(&self) {
         for line in &self.logs {
-            println!("{}", line);
+            println!("{line}");
         }
     }
 
@@ -1277,7 +1276,7 @@ impl IntegrationTest {
         let now = Instant::now();
         let mut last_metrics = String::new();
         let text = regex::escape(text).replace("<any>", ".+");
-        let re = Regex::new(&format!("(?m)^{}", text)).expect("Invalid regex");
+        let re = Regex::new(&format!("(?m)^{text}")).expect("Invalid regex");
         while now.elapsed() < duration.unwrap_or_else(|| Duration::from_secs(15)) {
             if let Ok(metrics) = self
                 .get_metrics_response()
@@ -1520,17 +1519,17 @@ fn merge_overrides(
     if let Some(port_replacements) = port_replacements {
         for (placeholder, port) in port_replacements {
             // Replace placeholder patterns like {{PLACEHOLDER_NAME}} with the actual port
-            let placeholder_pattern = format!("{{{{{}}}}}", placeholder);
+            let placeholder_pattern = format!("{{{{{placeholder}}}}}");
             yaml_with_ports = yaml_with_ports.replace(&placeholder_pattern, &port.to_string());
 
             // Also replace patterns like :{{PLACEHOLDER_NAME}} with :port
-            let port_pattern = format!(":{{{{{}}}}}", placeholder);
-            yaml_with_ports = yaml_with_ports.replace(&port_pattern, &format!(":{}", port));
+            let port_pattern = format!(":{{{{{placeholder}}}}}");
+            yaml_with_ports = yaml_with_ports.replace(&port_pattern, &format!(":{port}"));
 
             // Replace full address patterns like 127.0.0.1:{{PLACEHOLDER_NAME}}
-            let addr_pattern = format!("127.0.0.1:{{{{{}}}}}", placeholder);
+            let addr_pattern = format!("127.0.0.1:{{{{{placeholder}}}}}");
             yaml_with_ports =
-                yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{}", port));
+                yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{port}"));
         }
     }
 
@@ -1566,7 +1565,7 @@ fn merge_overrides(
         for (name, url) in overrides2 {
             let mut obj = serde_json::Map::new();
             obj.insert("override_url".to_string(), url.clone());
-            sources.insert(format!("connectors.{}", name), Value::Object(obj));
+            sources.insert(format!("connectors.{name}"), Value::Object(obj));
         }
     }
 

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1172,13 +1172,14 @@ impl IntegrationTest {
         let now = Instant::now();
         while now.elapsed() < Duration::from_secs(5) {
             if let Ok(line) = self.stdio_rx.try_recv()
-                && line.contains(msg) {
-                    self.dump_stack_traces();
-                    panic!(
-                        "'{msg}' detected in logs. Log dump below:\n\n{logs}",
-                        logs = self.logs.join("\n")
-                    );
-                }
+                && line.contains(msg)
+            {
+                self.dump_stack_traces();
+                panic!(
+                    "'{msg}' detected in logs. Log dump below:\n\n{logs}",
+                    logs = self.logs.join("\n")
+                );
+            }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
@@ -1336,9 +1337,10 @@ impl IntegrationTest {
             .expect("failed to fetch metrics")
             .text()
             .await
-            && metrics.contains(text) {
-                panic!("'{text}' detected in metrics\n{metrics}");
-            }
+            && metrics.contains(text)
+        {
+            panic!("'{text}' detected in metrics\n{metrics}");
+        }
     }
 
     #[allow(dead_code)]

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1171,15 +1171,14 @@ impl IntegrationTest {
     pub async fn assert_log_not_contains(&mut self, msg: &str) {
         let now = Instant::now();
         while now.elapsed() < Duration::from_secs(5) {
-            if let Ok(line) = self.stdio_rx.try_recv() {
-                if line.contains(msg) {
+            if let Ok(line) = self.stdio_rx.try_recv()
+                && line.contains(msg) {
                     self.dump_stack_traces();
                     panic!(
                         "'{msg}' detected in logs. Log dump below:\n\n{logs}",
                         logs = self.logs.join("\n")
                     );
                 }
-            }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
@@ -1337,11 +1336,9 @@ impl IntegrationTest {
             .expect("failed to fetch metrics")
             .text()
             .await
-        {
-            if metrics.contains(text) {
+            && metrics.contains(text) {
                 panic!("'{text}' detected in metrics\n{metrics}");
             }
-        }
     }
 
     #[allow(dead_code)]

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1528,8 +1528,7 @@ fn merge_overrides(
 
             // Replace full address patterns like 127.0.0.1:{{PLACEHOLDER_NAME}}
             let addr_pattern = format!("127.0.0.1:{{{{{placeholder}}}}}");
-            yaml_with_ports =
-                yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{port}"));
+            yaml_with_ports = yaml_with_ports.replace(&addr_pattern, &format!("127.0.0.1:{port}"));
         }
     }
 

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -192,8 +192,7 @@ async fn test_full_pipeline(
     assert_eq!(
         response.status(),
         response_status,
-        "Failed at stage {}",
-        stage
+        "Failed at stage {stage}"
     );
 
     router.graceful_shutdown().await;

--- a/apollo-router/tests/integration/docs.rs
+++ b/apollo-router/tests/integration/docs.rs
@@ -12,8 +12,8 @@ fn check_config_json() {
     let result = jsonpath_lib::select(&config, "$.sidebar.*.*").expect("values must be selectable");
     let re = Regex::new(r"^[a-z/-]+$").expect("regex must be valid");
     for value in result {
-        if let Value::String(path) = value {
-            if !path.starts_with("https://") {
+        if let Value::String(path) = value
+            && !path.starts_with("https://") {
                 assert!(
                     re.is_match(path),
                     "{path} in config.json was not kebab case"
@@ -27,6 +27,5 @@ fn check_config_json() {
                     );
                 }
             }
-        }
     }
 }

--- a/apollo-router/tests/integration/docs.rs
+++ b/apollo-router/tests/integration/docs.rs
@@ -13,19 +13,20 @@ fn check_config_json() {
     let re = Regex::new(r"^[a-z/-]+$").expect("regex must be valid");
     for value in result {
         if let Value::String(path) = value
-            && !path.starts_with("https://") {
+            && !path.starts_with("https://")
+        {
+            assert!(
+                re.is_match(path),
+                "{path} in config.json was not kebab case"
+            );
+            if path != "/" {
+                let path_in_docs = format!("../docs/source{path}.mdx");
+                let path_in_docs = Path::new(&path_in_docs);
                 assert!(
-                    re.is_match(path),
-                    "{path} in config.json was not kebab case"
+                    path_in_docs.exists(),
+                    "{path} in docs/source/config.json did not exist"
                 );
-                if path != "/" {
-                    let path_in_docs = format!("../docs/source{path}.mdx");
-                    let path_in_docs = Path::new(&path_in_docs);
-                    assert!(
-                        path_in_docs.exists(),
-                        "{path} in docs/source/config.json did not exist"
-                    );
-                }
             }
+        }
     }
 }

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -298,7 +298,7 @@ async fn test_plugin_ordering() {
         });
         tokio::spawn(async move {
             if let Err(e) = server.await {
-                eprintln!("coprocessor server error: {}", e);
+                eprintln!("coprocessor server error: {e}");
             }
         });
         (coprocessor_url, shutdown_on_drop)

--- a/apollo-router/tests/integration/rhai.rs
+++ b/apollo-router/tests/integration/rhai.rs
@@ -111,7 +111,7 @@ async fn test_rhai_hot_reload_works() {
     ] {
         // We should see 1. and 2. versions of the expected logs
         for i in 1..3 {
-            let expected = format!("{}. {}", i, expected_log);
+            let expected = format!("{i}. {expected_log}");
             assert!(logs.contains(&expected));
         }
     }

--- a/apollo-router/tests/integration/subscriptions/callback.rs
+++ b/apollo-router/tests/integration/subscriptions/callback.rs
@@ -19,7 +19,7 @@ async fn test_subscription_callback() -> Result<(), BoxError> {
 
     // Start callback server to receive router callbacks
     let (callback_addr, callback_state) = start_callback_server().await;
-    let callback_url = format!("http://{}/callback", callback_addr);
+    let callback_url = format!("http://{callback_addr}/callback");
 
     // Start mock subgraph server that will send callbacks
     let subgraph_server =
@@ -161,7 +161,7 @@ async fn test_subscription_callback_error_scenarios() -> Result<(), BoxError> {
     let (callback_addr, callback_state) = start_callback_server().await;
 
     let client = reqwest::Client::new();
-    let callback_url = format!("http://{}/callback/test-id", callback_addr);
+    let callback_url = format!("http://{callback_addr}/callback/test-id");
 
     // Test invalid payload - missing required fields
     let invalid_payload = serde_json::json!({
@@ -320,7 +320,7 @@ async fn test_subscription_callback_error_payload() -> Result<(), BoxError> {
 
     // Start callback server to receive router callbacks
     let (callback_addr, callback_state) = start_callback_server().await;
-    let callback_url = format!("http://{}/callback", callback_addr);
+    let callback_url = format!("http://{callback_addr}/callback");
 
     // Start mock subgraph server with custom payloads
     let subgraph_server = start_callback_subgraph_server_with_payloads(
@@ -426,7 +426,7 @@ async fn test_subscription_callback_pure_error_payload() -> Result<(), BoxError>
 
     // Start callback server to receive router callbacks
     let (callback_addr, callback_state) = start_callback_server().await;
-    let callback_url = format!("http://{}/callback", callback_addr);
+    let callback_url = format!("http://{callback_addr}/callback");
 
     // Start mock subgraph server with custom payloads
     let subgraph_server = start_callback_subgraph_server_with_payloads(

--- a/apollo-router/tests/integration/subscriptions/callback.rs
+++ b/apollo-router/tests/integration/subscriptions/callback.rs
@@ -133,11 +133,12 @@ async fn verify_callback_events(
     for callback in &next_callbacks {
         if let Some(payload) = &callback.payload
             && let Some(data) = payload.get("data")
-                && let Some(user_created) = data.get("userWasCreated") {
-                    actual_user_events.push(user_created.clone());
-                }
-                // If there's a data field but no userWasCreated, it's an empty/error case
-            // If there's no data field (pure error payload), we don't extract anything
+            && let Some(user_created) = data.get("userWasCreated")
+        {
+            actual_user_events.push(user_created.clone());
+        }
+        // If there's a data field but no userWasCreated, it's an empty/error case
+        // If there's no data field (pure error payload), we don't extract anything
     }
 
     // Simple equality comparison using pretty_assertions

--- a/apollo-router/tests/integration/subscriptions/callback.rs
+++ b/apollo-router/tests/integration/subscriptions/callback.rs
@@ -131,15 +131,13 @@ async fn verify_callback_events(
     // Extract userWasCreated events for validation
     let mut actual_user_events = Vec::new();
     for callback in &next_callbacks {
-        if let Some(payload) = &callback.payload {
-            if let Some(data) = payload.get("data") {
-                if let Some(user_created) = data.get("userWasCreated") {
+        if let Some(payload) = &callback.payload
+            && let Some(data) = payload.get("data")
+                && let Some(user_created) = data.get("userWasCreated") {
                     actual_user_events.push(user_created.clone());
                 }
                 // If there's a data field but no userWasCreated, it's an empty/error case
-            }
             // If there's no data field (pure error payload), we don't extract anything
-        }
     }
 
     // Simple equality comparison using pretty_assertions

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -68,8 +68,7 @@ pub const SUBSCRIPTION_COPROCESSOR_CONFIG: &str =
 pub const CALLBACK_CONFIG: &str = include_str!("fixtures/callback.router.yaml");
 pub fn create_sub_query(interval_ms: u64, nb_events: usize) -> String {
     format!(
-        r#"subscription {{  userWasCreated(intervalMs: {}, nbEvents: {}) {{    name reviews {{ body }} }}}}"#,
-        interval_ms, nb_events
+        r#"subscription {{  userWasCreated(intervalMs: {interval_ms}, nbEvents: {nb_events}) {{    name reviews {{ body }} }}}}"#
     )
 }
 

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -312,85 +312,82 @@ async fn handle_websocket(
                                 if let Some(payload) = parsed.get("payload")
                                     && let Some(query) =
                                         payload.get("query").and_then(|q| q.as_str())
-                                        && query.contains("userWasCreated") {
-                                            let interval_ms = config.interval_ms;
-                                            let payloads = &config.payloads;
+                                    && query.contains("userWasCreated")
+                                {
+                                    let interval_ms = config.interval_ms;
+                                    let payloads = &config.payloads;
 
-                                            info!(
-                                                "Starting subscription with {} events, interval {}ms (configured)",
-                                                payloads.len(),
-                                                interval_ms
-                                            );
+                                    info!(
+                                        "Starting subscription with {} events, interval {}ms (configured)",
+                                        payloads.len(),
+                                        interval_ms
+                                    );
 
-                                            // Give the router time to fully establish the subscription stream
+                                    // Give the router time to fully establish the subscription stream
+                                    tokio::time::sleep(tokio::time::Duration::from_millis(100))
+                                        .await;
+
+                                    // Send multiple subscription events
+                                    for (i, custom_payload) in payloads.iter().enumerate() {
+                                        // Always send exactly what we're given - no transformation
+                                        let event_data = json!({
+                                            "id": id,
+                                            "type": "data",
+                                            "payload": custom_payload
+                                        });
+
+                                        if socket
+                                            .send(axum::extract::ws::Message::text(
+                                                serde_json::to_string(&event_data).unwrap(),
+                                            ))
+                                            .await
+                                            .is_err()
+                                        {
+                                            break 'global;
+                                        }
+
+                                        debug!(
+                                            "Sent subscription event {}/{}",
+                                            i + 1,
+                                            payloads.len()
+                                        );
+
+                                        // Wait between events
+                                        if i < payloads.len() - 1 {
                                             tokio::time::sleep(tokio::time::Duration::from_millis(
-                                                100,
+                                                interval_ms,
                                             ))
                                             .await;
-
-                                            // Send multiple subscription events
-                                            for (i, custom_payload) in payloads.iter().enumerate() {
-                                                // Always send exactly what we're given - no transformation
-                                                let event_data = json!({
-                                                    "id": id,
-                                                    "type": "data",
-                                                    "payload": custom_payload
-                                                });
-
-                                                if socket
-                                                    .send(axum::extract::ws::Message::text(
-                                                        serde_json::to_string(&event_data).unwrap(),
-                                                    ))
-                                                    .await
-                                                    .is_err()
-                                                {
-                                                    break 'global;
-                                                }
-
-                                                debug!(
-                                                    "Sent subscription event {}/{}",
-                                                    i + 1,
-                                                    payloads.len()
-                                                );
-
-                                                // Wait between events
-                                                if i < payloads.len() - 1 {
-                                                    tokio::time::sleep(
-                                                        tokio::time::Duration::from_millis(
-                                                            interval_ms,
-                                                        ),
-                                                    )
-                                                    .await;
-                                                }
-                                            }
-
-                                            if config.terminate_subscription {
-                                                // Send completion
-                                                let complete = json!({
-                                                    "id": id,
-                                                    "type": "complete"
-                                                });
-                                                if socket
-                                                    .send(axum::extract::ws::Message::text(
-                                                        serde_json::to_string(&complete).unwrap(),
-                                                    ))
-                                                    .await
-                                                    .is_err()
-                                                {
-                                                    break 'global;
-                                                }
-
-                                                info!(
-                                                    "Completed subscription with {} events",
-                                                    payloads.len()
-                                                );
-                                            } else {
-                                                info!(
-                                                    "Sent {} subscription events but did not send `complete` message",
-                                                    payloads.len()
-                                                );
-                                            }
                                         }
+                                    }
+
+                                    if config.terminate_subscription {
+                                        // Send completion
+                                        let complete = json!({
+                                            "id": id,
+                                            "type": "complete"
+                                        });
+                                        if socket
+                                            .send(axum::extract::ws::Message::text(
+                                                serde_json::to_string(&complete).unwrap(),
+                                            ))
+                                            .await
+                                            .is_err()
+                                        {
+                                            break 'global;
+                                        }
+
+                                        info!(
+                                            "Completed subscription with {} events",
+                                            payloads.len()
+                                        );
+                                    } else {
+                                        info!(
+                                            "Sent {} subscription events but did not send `complete` message",
+                                            payloads.len()
+                                        );
+                                    }
+                                }
                             }
                             Some("stop") => {
                                 // Handle stop message

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -309,11 +309,10 @@ async fn handle_websocket(
                                 let id = parsed.get("id").and_then(|i| i.as_str()).unwrap_or("1");
 
                                 // Handle subscription
-                                if let Some(payload) = parsed.get("payload") {
-                                    if let Some(query) =
+                                if let Some(payload) = parsed.get("payload")
+                                    && let Some(query) =
                                         payload.get("query").and_then(|q| q.as_str())
-                                    {
-                                        if query.contains("userWasCreated") {
+                                        && query.contains("userWasCreated") {
                                             let interval_ms = config.interval_ms;
                                             let payloads = &config.payloads;
 
@@ -392,8 +391,6 @@ async fn handle_websocket(
                                                 );
                                             }
                                         }
-                                    }
-                                }
                             }
                             Some("stop") => {
                                 // Handle stop message

--- a/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
+++ b/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
@@ -225,7 +225,7 @@ async fn test_subscription_ws_passthrough() -> Result<(), BoxError> {
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -291,7 +291,7 @@ async fn test_subscription_ws_passthrough_with_coprocessor() -> Result<(), BoxEr
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string(
@@ -369,7 +369,7 @@ async fn test_subscription_ws_passthrough_error_payload() -> Result<(), BoxError
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -452,7 +452,7 @@ async fn test_subscription_ws_passthrough_pure_error_payload() -> Result<(), Box
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -540,7 +540,7 @@ async fn test_subscription_ws_passthrough_pure_error_payload_with_coprocessor()
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string(
@@ -633,7 +633,7 @@ async fn test_subscription_ws_passthrough_on_config_reload() -> Result<(), BoxEr
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -734,7 +734,7 @@ async fn test_subscription_ws_passthrough_on_schema_reload() -> Result<(), BoxEr
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");
@@ -834,7 +834,7 @@ async fn test_subscription_ws_passthrough_dedup() -> Result<(), BoxError> {
         .await;
 
     // Configure URLs using the string replacement method
-    let ws_url = format!("ws://{}/ws", ws_addr);
+    let ws_url = format!("ws://{ws_addr}/ws");
     router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
     router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
     router.replace_config_string("rng:", "accounts:");

--- a/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
+++ b/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
@@ -771,7 +771,7 @@ async fn test_failed_connector_request_emits_histogram() {
 fn assert_metrics_contain(actual_metrics: &[ExportMetricsServiceRequest], expected_metric: Metric) {
     let expected_name = &expected_metric.name.clone();
     let actual_metric = find_metric(expected_name, actual_metrics)
-        .unwrap_or_else(|| panic!("Metric '{}' not found", expected_name));
+        .unwrap_or_else(|| panic!("Metric '{expected_name}' not found"));
 
     let actual_metrics: Vec<Metric> = match &actual_metric.data {
         Some(metric::Data::Sum(sum)) => sum
@@ -784,7 +784,7 @@ fn assert_metrics_contain(actual_metrics: &[ExportMetricsServiceRequest], expect
             .iter()
             .map(|dp| Metric::from_histogram_datapoint(expected_name, dp))
             .collect(),
-        _ => panic!("Metric type for '{}' is not yet implemented", expected_name),
+        _ => panic!("Metric type for '{expected_name}' is not yet implemented"),
     };
 
     let metric_found = actual_metrics.iter().any(|m| {
@@ -903,10 +903,10 @@ impl Display for Metric {
                     BoolValue(b) => b.to_string(),
                     IntValue(n) => n.to_string(),
                     DoubleValue(d) => d.to_string(),
-                    other => format!("{:?}", other),
+                    other => format!("{other:?}"),
                 })
                 .unwrap_or_else(|| "nil".into());
-            write!(f, "\n\t{}={}", key, value)?;
+            write!(f, "\n\t{key}={value}")?;
         }
         write!(f, "\n]")
     }

--- a/apollo-router/tests/integration/telemetry/datadog.rs
+++ b/apollo-router/tests/integration/telemetry/datadog.rs
@@ -1218,7 +1218,7 @@ impl Verifier for DatadogTraceSpec {
                 for resource in span.select_path("$.meta")? {
                     for (key, value) in &self.trace_spec.resources {
                         let mut found = false;
-                        if let Some(resource) =
+                        if let Some(resource_value) =
                             resource.as_object().and_then(|resource| resource.get(*key))
                         {
                             let resource_value =

--- a/apollo-router/tests/integration/telemetry/datadog.rs
+++ b/apollo-router/tests/integration/telemetry/datadog.rs
@@ -1218,19 +1218,18 @@ impl Verifier for DatadogTraceSpec {
                 for resource in span.select_path("$.meta")? {
                     for (key, value) in &self.trace_spec.resources {
                         let mut found = false;
-                        if let Some(resource) = resource.as_object() {
-                            if let Some(resource_value) = resource.get(*key) {
-                                let resource_value =
-                                    resource_value.as_string().expect("resources are strings");
-                                if resource_value == *value {
-                                    found = true;
-                                }
+                        if let Some(resource) =
+                            resource.as_object().and_then(|resource| resource.get(*key))
+                        {
+                            let resource_value =
+                                resource_value.as_string().expect("resources are strings");
+                            if resource_value == *value {
+                                found = true;
                             }
                         }
                         if !found {
                             return Err(BoxError::from(format!(
-                                "resource not found: {}={}",
-                                key, value
+                                "resource not found: {key}={value}",
                             )));
                         }
                     }

--- a/apollo-router/tests/integration/telemetry/propagation.rs
+++ b/apollo-router/tests/integration/telemetry/propagation.rs
@@ -27,12 +27,12 @@ async fn test_trace_id_via_header() -> Result<(), BoxError> {
     router.assert_started().await;
     make_call(&mut router, trace_id).await;
     router
-        .wait_for_log_message(&format!("trace_id: {}", trace_id))
+        .wait_for_log_message(&format!("trace_id: {trace_id}"))
         .await;
 
     make_call(&mut router, trace_id).await;
     router
-        .wait_for_log_message(&format!("\"id_from_header\": \"{}\"", trace_id))
+        .wait_for_log_message(&format!("\"id_from_header\": \"{trace_id}\""))
         .await;
 
     router.graceful_shutdown().await;

--- a/apollo-router/tests/integration/telemetry/verifier.rs
+++ b/apollo-router/tests/integration/telemetry/verifier.rs
@@ -86,7 +86,7 @@ pub trait Verifier {
 
         // For now just validate service name.
         let trace: Value = self.get_trace(trace_id).await?;
-        println!("trace: {}", trace_id);
+        println!("trace: {trace_id}");
         self.verify_services(&trace)?;
         println!("services verified");
         self.verify_spans_present(&trace)?;

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -1441,8 +1441,8 @@ async fn all_stock_router_example_yamls_are_valid() {
             if !cfg!(target_family = "unix") && entry_parent.join(".unixonly").exists() {
                 break;
             }
-            if let Some(name) = example_directory_entry.file_name().to_str() {
-                if name.ends_with("yaml") || name.ends_with("yml") {
+            if let Some(name) = example_directory_entry.file_name().to_str()
+                && (name.ends_with("yaml") || name.ends_with("yml")) {
                     let raw_yaml = std::fs::read_to_string(entry_path)
                         .unwrap_or_else(|e| panic!("unable to read {display_path}: {e}"));
                     {
@@ -1463,7 +1463,6 @@ async fn all_stock_router_example_yamls_are_valid() {
                             });
                     }
                 }
-            }
         }
     }
 }

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -1442,27 +1442,27 @@ async fn all_stock_router_example_yamls_are_valid() {
                 break;
             }
             if let Some(name) = example_directory_entry.file_name().to_str()
-                && (name.ends_with("yaml") || name.ends_with("yml")) {
-                    let raw_yaml = std::fs::read_to_string(entry_path)
-                        .unwrap_or_else(|e| panic!("unable to read {display_path}: {e}"));
-                    {
-                        let mut configuration: Configuration = serde_yaml::from_str(&raw_yaml)
-                            .unwrap_or_else(|e| panic!("unable to parse YAML {display_path}: {e}"));
-                        let (_mock_guard, configuration) =
-                            if configuration.persisted_queries.enabled {
-                                let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-                                configuration.uplink = Some(uplink_config);
-                                (Some(_mock_guard), configuration)
-                            } else {
-                                (None, configuration)
-                            };
-                        setup_router_and_registry_with_config(configuration)
-                            .await
-                            .unwrap_or_else(|e| {
-                                panic!("unable to start up router for {display_path}: {e}");
-                            });
-                    }
+                && (name.ends_with("yaml") || name.ends_with("yml"))
+            {
+                let raw_yaml = std::fs::read_to_string(entry_path)
+                    .unwrap_or_else(|e| panic!("unable to read {display_path}: {e}"));
+                {
+                    let mut configuration: Configuration = serde_yaml::from_str(&raw_yaml)
+                        .unwrap_or_else(|e| panic!("unable to parse YAML {display_path}: {e}"));
+                    let (_mock_guard, configuration) = if configuration.persisted_queries.enabled {
+                        let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
+                        configuration.uplink = Some(uplink_config);
+                        (Some(_mock_guard), configuration)
+                    } else {
+                        (None, configuration)
+                    };
+                    setup_router_and_registry_with_config(configuration)
+                        .await
+                        .unwrap_or_else(|e| {
+                            panic!("unable to start up router for {display_path}: {e}");
+                        });
                 }
+            }
         }
     }
 }

--- a/apollo-router/tests/samples_tests.rs
+++ b/apollo-router/tests/samples_tests.rs
@@ -555,7 +555,7 @@ impl TestExecution {
         }
 
         writeln!(out, "query: {}\n", serde_json::to_string(&request).unwrap()).unwrap();
-        writeln!(out, "header: {:?}\n", headers).unwrap();
+        writeln!(out, "header: {headers:?}\n").unwrap();
 
         let (_, response) = router
             .execute_query(
@@ -571,7 +571,7 @@ impl TestExecution {
         for (key, value) in expected_headers {
             if !response.headers().contains_key(key) {
                 failed = true;
-                writeln!(out, "expected header {} to be present", key).unwrap();
+                writeln!(out, "expected header {key} to be present").unwrap();
             } else if response.headers().get(key).unwrap() != value {
                 failed = true;
                 writeln!(

--- a/apollo-router/tests/type_conditions.rs
+++ b/apollo-router/tests/type_conditions.rs
@@ -482,14 +482,15 @@ fn normalize_response_extensions(mut response: Response) -> Response {
     for (key, value) in extensions.iter_mut() {
         visit_object(key, value, &mut |key, value| {
             if key.as_str() == "operation"
-                && let Value::String(s) = value {
-                    let new_value = Document::parse(s.as_str(), key.as_str())
-                        .unwrap()
-                        .serialize()
-                        .no_indent()
-                        .to_string();
-                    *value = Value::String(new_value.into());
-                }
+                && let Value::String(s) = value
+            {
+                let new_value = Document::parse(s.as_str(), key.as_str())
+                    .unwrap()
+                    .serialize()
+                    .no_indent()
+                    .to_string();
+                *value = Value::String(new_value.into());
+            }
         });
     }
     response

--- a/apollo-router/tests/type_conditions.rs
+++ b/apollo-router/tests/type_conditions.rs
@@ -481,8 +481,8 @@ fn normalize_response_extensions(mut response: Response) -> Response {
 
     for (key, value) in extensions.iter_mut() {
         visit_object(key, value, &mut |key, value| {
-            if key.as_str() == "operation" {
-                if let Value::String(s) = value {
+            if key.as_str() == "operation"
+                && let Value::String(s) = value {
                     let new_value = Document::parse(s.as_str(), key.as_str())
                         .unwrap()
                         .serialize()
@@ -490,7 +490,6 @@ fn normalize_response_extensions(mut response: Response) -> Response {
                         .to_string();
                     *value = Value::String(new_value.into());
                 }
-            }
         });
     }
     response

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.87.0 as build
+FROM rust:1.89.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router

--- a/docs/source/routing/customization/custom-binary.mdx
+++ b/docs/source/routing/customization/custom-binary.mdx
@@ -16,7 +16,7 @@ Learn how to compile a custom binary from Apollo Router Core source, which is re
 ## Prerequisites
 
 <!-- renovate-automation: rustc version -->
-To compile the router, you need to have [Rust 1.87.0 or later](https://www.rust-lang.org/tools/install) installed.
+To compile the router, you need to have [Rust 1.89.0 or later](https://www.rust-lang.org/tools/install) installed.
 
 ## 1. Create a new project
 
@@ -102,7 +102,7 @@ Nice work! You now have a custom router binary with an associated plugin. Next, 
 
 ## Memory allocator
 
-On Linux the `apollo-router` crate sets [jemalloc](http://jemalloc.net/) 
+On Linux the `apollo-router` crate sets [jemalloc](http://jemalloc.net/)
 as [the global memory allocator for Rust](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute)
 to reduce memory fragmentation.
 Future versions may do so on more platforms, or switch to yet a different allocator.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # renovate-automation: rustc version
-channel = "1.87.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # renovate-automation: rustc version
-channel = "1.88.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR bumps the rust toolchain version to 1.88 and fixes the lints.

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
