### PR TITLE
fix(federation): removed `RebaseError::InterfaceObjectTypename` error

### DIFF
--- a/.changesets/fix_duckki_fed_678.md
+++ b/.changesets/fix_duckki_fed_678.md
@@ -1,0 +1,5 @@
+### (Federation) Removed `RebaseError::InterfaceObjectTypename` variant ([PR #8109](https://github.com/apollographql/router/pull/8109))
+
+Fixed an uncommon query planning error, "Cannot add selection of field `X` to selection set of parent type `Y` that is potentially an interface object type at runtime". Although fetching `__typename` selections from interface object types are unnecessary, it is difficult to avoid them in all cases and the effect of having those selections in query plans is benign. Thus, the error variant and the check for the error have been removed.
+
+By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/8109

--- a/apollo-federation/tests/query_plan/supergraphs/allows_post_requires_input_with_typename_on_interface_object_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/allows_post_requires_input_with_typename_on_interface_object_type.graphql
@@ -1,0 +1,83 @@
+# Composed from subgraphs with hash: 6a52228f357eb403fba553216a31a338bab93088
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+interface I
+  @join__type(graph: A, key: "id", isInterfaceObject: true)
+  @join__type(graph: B, key: "id")
+  @join__type(graph: C, key: "id", isInterfaceObject: true)
+{
+  id: ID!
+  required: String @join__field(graph: B) @join__field(graph: C, external: true)
+  data: String! @join__field(graph: C, requires: "required")
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  A @join__graph(name: "A", url: "none")
+  B @join__graph(name: "B", url: "none")
+  C @join__graph(name: "C", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type P implements I
+  @join__implements(graph: B, interface: "I")
+  @join__type(graph: B, key: "id")
+{
+  id: ID!
+  required: String
+  data: String! @join__field
+}
+
+type Query
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__type(graph: C)
+{
+  start: I! @join__field(graph: A)
+}


### PR DESCRIPTION
### Summary

- The `rebase_on` method was prohibiting __typename field from being rebased on an interface object type by raising `InterfaceObjectTypename` error.
- But, it seemed unnecessarily prohibitive, rejecting plannable queries.
- Although it's odd to fetch `__typename` from interface object types, there are already several other cases where such `__typename` selections are added to interface object types.
- Such `__typename` selections are benign and we currently don't plan to remove all of those cases at this time.
- Thus, this PR removes the error variant and the check for the error altogether.
- Also, added a regression test that caused the error previously.

<!-- start metadata -->

<!-- [FED-678] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary


[FED-678]: https://apollographql.atlassian.net/browse/FED-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ