### PR TITLE
Fix: Broken or missing Offline Mode links

### DIFF
--- a/docs/source/routing/cloud/migrate-to-dedicated.mdx
+++ b/docs/source/routing/cloud/migrate-to-dedicated.mdx
@@ -16,7 +16,7 @@ GraphOS offers two tiers of cloud routing: Serverless and Dedicated. This guide 
 
 <Note>
 
-Dedicated cloud routers currently support all [premium router features](/router/enterprise-features) except for [safelisting with persisted queries](/graphos/routing/security/persisted-queries/), [automatic persisted queries](/apollo-server/performance/apq/), and [offline licenses](/router/enterprise-features/#offline-enterprise-license). Support for both persisted queries features is on the roadmap.
+Dedicated cloud routers currently support all [premium router features](/router/enterprise-features) except for [safelisting with persisted queries](/graphos/routing/security/persisted-queries/), [automatic persisted queries](/apollo-server/performance/apq/), and [offline licenses](/graphos/routing/license/#offline-license). Support for both persisted queries features is on the roadmap.
 
 </Note>
 

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -3,14 +3,15 @@ title: Router CLI Configuration Reference
 subtitle: ""
 description: Reference of command-line options for Apollo GraphOS Router and Apollo Router Core.
 ---
-import RouterYaml from '../../../shared/router-yaml-complete.mdx';
-import RouterConfigTable from '../../../shared/router-config-properties-table.mdx';
 
-This reference covers the command-line options for configuring an Apollo Router. 
+import RouterYaml from "../../../shared/router-yaml-complete.mdx";
+import RouterConfigTable from "../../../shared/router-config-properties-table.mdx";
+
+This reference covers the command-line options for configuring an Apollo Router.
 
 ## Command-line options
 
-This reference lists and describes the options supported by the `router` binary via command-line options. Where indicated, some of these options can also be provided via an environment variable. 
+This reference lists and describes the options supported by the `router` binary via command-line options. Where indicated, some of these options can also be provided via an environment variable.
 
 <Tip>
 
@@ -92,7 +93,8 @@ The absolute or relative path to a file containing the Apollo graph API key for 
 <td>
 
 ⚠️ **Do not set this option in production!**
-<br/>
+
+<br />
 If set, a router runs in dev mode to help with local development.
 
 [Learn more about dev mode](#development-mode).
@@ -148,7 +150,7 @@ An offline license is specified either as an absolute or relative path to a lice
 
 When not set, the router retrieves an Enterprise license [from GraphOS via Apollo Uplink](/router/enterprise-features/#the-enterprise-license).<br/>
 
-For information about fetching an offline license and configuring the router, see [Offline Enterprise license](/router/enterprise-features/#offline-enterprise-license).
+For information about fetching an offline license and configuring the router, see [Offline Enterprise license](/graphos/routing/license/#offline-license).
 
 </td>
 </tr>
@@ -279,7 +281,6 @@ plugins:
 **Don't set the `--dev` option in production.** If you want to replicate any specific dev mode functionality in production, set the corresponding option in your [YAML config file](/graphos/routing/configuration/yaml).
 
 </Caution>
-
 
 ## Configuration schema for IDE validation
 

--- a/docs/source/routing/configuration/envvars.mdx
+++ b/docs/source/routing/configuration/envvars.mdx
@@ -35,7 +35,7 @@ These environment variables apply only if your supergraph schema is managed by G
 
 The graph ref for the GraphOS graph and variant that the router fetches its supergraph schema from (e.g., `docs-example-graph@staging`).
 
-**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/router/enterprise-features/#offline-enterprise-license) to run the router.
+**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/graphos/routing/license/#offline-license) to run the router.
 
 </td>
 </tr>
@@ -49,7 +49,7 @@ The graph ref for the GraphOS graph and variant that the router fetches its supe
 
 The [graph API key](/graphos/api-keys/#graph-api-keys) that the router should use to authenticate with GraphOS when fetching its supergraph schema.
 
-**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/router/enterprise-features/#offline-enterprise-license) to run the router or when using `APOLLO_KEY_PATH`.
+**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/graphos/routing/license/#offline-license) to run the router or when using `APOLLO_KEY_PATH`.
 
 </td>
 </tr>
@@ -65,7 +65,7 @@ The [graph API key](/graphos/api-keys/#graph-api-keys) that the router should us
 
 A path to a file containing the [graph API key](/graphos/api-keys/#graph-api-keys) that the router should use to authenticate with GraphOS when fetching its supergraph schema.
 
-**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/router/enterprise-features/#offline-enterprise-license) to run the router or when using `APOLLO_KEY`.
+**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/graphos/routing/license/#offline-license) to run the router or when using `APOLLO_KEY`.
 
 </td>
 </tr>

--- a/docs/source/routing/configuration/envvars.mdx
+++ b/docs/source/routing/configuration/envvars.mdx
@@ -35,7 +35,7 @@ These environment variables apply only if your supergraph schema is managed by G
 
 The graph ref for the GraphOS graph and variant that the router fetches its supergraph schema from (e.g., `docs-example-graph@staging`).
 
-**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](#--license) to run the router.
+**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/router/enterprise-features/#offline-enterprise-license) to run the router.
 
 </td>
 </tr>
@@ -49,7 +49,7 @@ The graph ref for the GraphOS graph and variant that the router fetches its supe
 
 The [graph API key](/graphos/api-keys/#graph-api-keys) that the router should use to authenticate with GraphOS when fetching its supergraph schema.
 
-**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](#--license) to run the router or when using `APOLLO_KEY_PATH`.
+**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/router/enterprise-features/#offline-enterprise-license) to run the router or when using `APOLLO_KEY_PATH`.
 
 </td>
 </tr>
@@ -65,7 +65,7 @@ The [graph API key](/graphos/api-keys/#graph-api-keys) that the router should us
 
 A path to a file containing the [graph API key](/graphos/api-keys/#graph-api-keys) that the router should use to authenticate with GraphOS when fetching its supergraph schema.
 
-**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](#--license) to run the router or when using `APOLLO_KEY`.
+**Required** when using [managed federation](/federation/managed-federation/overview/), except when using an [offline license](/router/enterprise-features/#offline-enterprise-license) to run the router or when using `APOLLO_KEY`.
 
 </td>
 </tr>

--- a/docs/source/routing/graphos-features.mdx
+++ b/docs/source/routing/graphos-features.mdx
@@ -1,6 +1,6 @@
 ---
 title: Licensed GraphOS Router Features
-subtitle: Features that requiring a licensed GraphOS plan
+subtitle: Features that require a licensed GraphOS plan
 description: Unlock Enterprise features for the GraphOS Router by connecting it to Apollo GraphOS.
 redirectFrom:
   - /router/enterprise-features

--- a/docs/source/routing/graphos-features.mdx
+++ b/docs/source/routing/graphos-features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Licensed GraphOS Router Features
-subtitle: Features that requiring a licensed GraphOS plan 
+subtitle: Features that requiring a licensed GraphOS plan
 description: Unlock Enterprise features for the GraphOS Router by connecting it to Apollo GraphOS.
-redirectFrom: 
+redirectFrom:
   - /router/enterprise-features
 ---
 
@@ -22,7 +22,7 @@ This page lists the additional features of GraphOS Router that are enabled via i
 - Custom request handling in any language via [external coprocessing](/graphos/routing/customization/coprocessor)
 - Mitigation of potentially malicious requests via [request limits](/graphos/routing/security/request-limits), [demand control](/graphos/routing/security/request-limits), and [safelisting](/graphos/routing/security/persisted-queries)
 - Custom instrumentation and telemetry, including [custom attributes for spans](/graphos/reference/router/telemetry/instrumentation/spans#attributes).
-- An [offline license](/graphos/reference/router/graphos-features#the-enterprise-license) that enables running the router with GraphOS features when disconnected from the internet.
+- An [offline license](/graphos/routing/license/#offline-license) that enables running the router with GraphOS features when disconnected from the internet.
 - [Using contexts to share data](/graphos/schema-design/federated-schemas/entities/use-contexts) with the `@context` and `@fromContext` directives
 
 ## Enabling licensed plan features
@@ -30,8 +30,8 @@ This page lists the additional features of GraphOS Router that are enabled via i
 To enable licensed plan features in a router:
 
 - You must run GraphOS Router v1.12 or later. [Download the latest version.](/graphos/reference/router/self-hosted-install#1-download-and-extract-the-router-binary)
-    - Certain features might require a later router version. See a particular feature's documentation for details.
+  - Certain features might require a later router version. See a particular feature's documentation for details.
 - Your router instances must connect to GraphOS with a **graph API key** and **graph ref** associated with your organization.
-    - You connect your router to GraphOS by setting [these environment variables](/graphos/reference/router/configuration#environment-variables) when starting the router.
+  - You connect your router to GraphOS by setting [these environment variables](/graphos/reference/router/configuration#environment-variables) when starting the router.
 
 > Learn more about the [GraphOS plan license](/graphos/routing/license).

--- a/docs/source/routing/security/persisted-queries.mdx
+++ b/docs/source/routing/security/persisted-queries.mdx
@@ -101,7 +101,7 @@ From version `1.50.0` to `1.54`, the `local_manifests` configuration option was 
 
 </Note>
 
-Adding `local_manifests` to your `persisted-queries` configuration lets you use local persisted query manifests instead of the hosted Uplink version. This is helpful when you're using an offline Enterprise license and can't use Uplink. With `local_manifests`, the router doesn't reload the manifest from the file system, so you need to restart the router to apply changes.
+Adding `local_manifests` to your `persisted-queries` configuration lets you use local persisted query manifests instead of the hosted Uplink version. This is helpful when you're using an [offline Enterprise license](/router/enterprise-features/#offline-enterprise-license) and can't use Uplink. With `local_manifests`, the router doesn't reload the manifest from the file system, so you need to restart the router to apply changes.
 
 ```yaml title="router.yaml"
 persisted_queries:

--- a/docs/source/routing/security/persisted-queries.mdx
+++ b/docs/source/routing/security/persisted-queries.mdx
@@ -206,4 +206,4 @@ This does not affect the behavior of the [`log_unknown` option](#log_unknown): u
 
 ## Limitations
 
-- **Unsupported with offline license**. An GraphOS Router using an [offline Enterprise license](/router/enterprise-features/#offline-enterprise-license) cannot use safelisting with persisted queries. The feature relies on Apollo Uplink to fetch persisted query manifests, so it doesn't work as designed when the router is disconnected from Uplink.
+- **Unsupported with offline license**. An GraphOS Router using an [offline Enterprise license](/graphos/routing/license/#offline-license) cannot use safelisting with persisted queries. The feature relies on Apollo Uplink to fetch persisted query manifests, so it doesn't work as designed when the router is disconnected from Uplink.

--- a/docs/source/routing/security/persisted-queries.mdx
+++ b/docs/source/routing/security/persisted-queries.mdx
@@ -206,4 +206,4 @@ This does not affect the behavior of the [`log_unknown` option](#log_unknown): u
 
 ## Limitations
 
-- **Unsupported with offline license**. An GraphOS Router using an [offline Enterprise license](/graphos/routing/license/#offline-license) cannot use safelisting with persisted queries. The feature relies on Apollo Uplink to fetch persisted query manifests, so it doesn't work as designed when the router is disconnected from Uplink.
+- **Unsupported with offline license**. A GraphOS Router using an [offline license](/graphos/routing/license/#offline-license) cannot use safelisting with persisted queries. The feature relies on Apollo Uplink to fetch persisted query manifests, so it doesn't work as designed when the router is disconnected from Uplink.

--- a/docs/source/routing/security/persisted-queries.mdx
+++ b/docs/source/routing/security/persisted-queries.mdx
@@ -101,7 +101,7 @@ From version `1.50.0` to `1.54`, the `local_manifests` configuration option was 
 
 </Note>
 
-Adding `local_manifests` to your `persisted-queries` configuration lets you use local persisted query manifests instead of the hosted Uplink version. This is helpful when you're using an [offline Enterprise license](/router/enterprise-features/#offline-enterprise-license) and can't use Uplink. With `local_manifests`, the router doesn't reload the manifest from the file system, so you need to restart the router to apply changes.
+Adding `local_manifests` to your `persisted-queries` configuration lets you use local persisted query manifests instead of the hosted Uplink version. This is helpful when you're using an [offline Enterprise license](/graphos/routing/license/#offline-license) and can't use Uplink. With `local_manifests`, the router doesn't reload the manifest from the file system, so you need to restart the router to apply changes.
 
 ```yaml title="router.yaml"
 persisted_queries:


### PR DESCRIPTION
# Motivation

Found some broken (or missing) links to the Offline Mode docs. Snapped those to what it looks like everything else is using.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
