### PR TITLE
refactor: move request preparation to connect::Request constructor

### DIFF
--- a/apollo-federation/src/connectors/runtime.rs
+++ b/apollo-federation/src/connectors/runtime.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod debug;
 pub mod errors;
 pub mod form_encoding;

--- a/apollo-federation/src/connectors/runtime/cache.rs
+++ b/apollo-federation/src/connectors/runtime/cache.rs
@@ -1,0 +1,596 @@
+//! Cache key generation utilities for connectors.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use http::HeaderMap;
+
+use super::http_json_transport::TransportRequest;
+use super::key::ResponseKey;
+
+/// Cache key prefix for connector requests
+const CACHE_KEY_PREFIX: &str = "connector:v1";
+
+/// Cache key for connector requests
+#[derive(Debug, Clone)]
+pub enum CacheKey {
+    /// Individual cache keys for entity fetches - one per entity
+    Entities(Vec<CacheKeyComponents>),
+    /// Individual cache keys for root field requests - one per root field
+    Roots(Vec<CacheKeyComponents>),
+}
+
+/// Cache policy for connector responses
+#[derive(Debug, Clone)]
+pub enum CachePolicy {
+    /// Individual cache policies for entity fetches - one per entity
+    Entities(Vec<HeaderMap>),
+    /// Cache policies for root field requests - consumer can combine as needed
+    Roots(Vec<HeaderMap>),
+}
+
+/// Components of a request that should be included in a cache key
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheKeyComponents {
+    /// The subgraph name for uniqueness across subgraphs
+    pub subgraph_name: String,
+    /// HTTP method (GET, POST, etc.)
+    pub method: String,
+    /// The request URI with interpolated values
+    pub uri: String,
+    /// Relevant headers that affect the response (sorted for determinism)
+    pub headers: BTreeMap<String, String>,
+    /// The request body
+    pub body: String,
+}
+
+/// Extract cache key components from transport request
+pub fn extract_cache_components(
+    subgraph_name: &str,
+    transport_request: &TransportRequest,
+) -> CacheKeyComponents {
+    match transport_request {
+        TransportRequest::Http(http_req) => {
+            extract_http_cache_components(subgraph_name, &http_req.inner)
+        }
+    }
+}
+
+/// Extract cache key components from HTTP request
+fn extract_http_cache_components(
+    subgraph_name: &str,
+    req: &http::Request<String>,
+) -> CacheKeyComponents {
+    // Include all headers (sorted for determinism)
+    let headers: BTreeMap<String, String> = req
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            let name_str = name.as_str().to_lowercase();
+            value.to_str().ok().map(|v| (name_str, v.to_string()))
+        })
+        .collect();
+
+    CacheKeyComponents {
+        subgraph_name: subgraph_name.to_string(),
+        method: req.method().as_str().to_string(),
+        uri: req.uri().to_string(),
+        headers,
+        body: req.body().clone(),
+    }
+}
+
+impl fmt::Display for CacheKeyComponents {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Use a format that's easier to debug: connector:v1:subgraph:method:uri:headers:body
+        // where headers are formatted as name1=value1,name2=value2
+        let headers_str = self
+            .headers
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join(",");
+
+        write!(
+            f,
+            "{}:{}:{}:{}:{}:{}",
+            CACHE_KEY_PREFIX, self.subgraph_name, self.method, self.uri, headers_str, self.body
+        )
+    }
+}
+
+/// Create appropriate CacheKey variant based on request types
+pub fn create_cache_key(
+    requests: &[(&ResponseKey, &TransportRequest)],
+    subgraph_name: &str,
+) -> CacheKey {
+    // Check if all requests are root fields
+    let all_root_fields = requests
+        .iter()
+        .any(|(key, _)| matches!(key, ResponseKey::RootField { .. }));
+
+    if all_root_fields {
+        // For root fields, create individual cache keys for each request
+        if requests.is_empty() {
+            return CacheKey::Roots(Vec::new());
+        }
+
+        let individual_keys: Vec<CacheKeyComponents> = requests
+            .iter()
+            .map(|(_, transport_req)| extract_cache_components(subgraph_name, transport_req))
+            .collect();
+
+        CacheKey::Roots(individual_keys)
+    } else {
+        // For entities, create individual cache keys
+        // For batch entities, we need to duplicate keys based on batch size
+        if requests.is_empty() {
+            return CacheKey::Entities(Vec::new());
+        }
+
+        let mut individual_keys = Vec::new();
+
+        for (key, transport_req) in requests.iter() {
+            let components = extract_cache_components(subgraph_name, transport_req);
+
+            match key {
+                ResponseKey::BatchEntity { inputs, .. } => {
+                    // Duplicate the key for each entity in the batch
+                    let batch_size = inputs.batch.len();
+                    for _ in 0..batch_size {
+                        individual_keys.push(components.clone());
+                    }
+                }
+                _ => {
+                    // For non-batch entities, just add the key once
+                    individual_keys.push(components);
+                }
+            }
+        }
+
+        CacheKey::Entities(individual_keys)
+    }
+}
+
+/// Create appropriate CachePolicy variant based on request types
+pub fn create_cache_policy_from_keys(
+    keys: &[ResponseKey],
+    cache_policies: Vec<HeaderMap>,
+) -> CachePolicy {
+    if keys.is_empty() {
+        return CachePolicy::Entities(Vec::new());
+    }
+
+    // Check if all requests are root fields
+    let root_field = keys
+        .iter()
+        .any(|key| matches!(key, ResponseKey::RootField { .. }));
+
+    if root_field {
+        CachePolicy::Roots(cache_policies)
+    } else {
+        // For batch entities, we need to duplicate policies based on batch size
+        let mut expanded_policies = Vec::new();
+
+        for (key, policy) in keys.iter().zip(cache_policies.into_iter()) {
+            match key {
+                ResponseKey::BatchEntity { inputs, .. } => {
+                    // Duplicate the policy for each entity in the batch
+                    let batch_size = inputs.batch.len();
+                    for _ in 0..batch_size {
+                        expanded_policies.push(policy.clone());
+                    }
+                }
+                _ => {
+                    // For non-batch entities, just add the policy once
+                    expanded_policies.push(policy);
+                }
+            }
+        }
+
+        CachePolicy::Entities(expanded_policies)
+    }
+}
+
+/// Create appropriate CachePolicy variant based on request types
+pub fn create_cache_policy(
+    requests: &[(&ResponseKey, &TransportRequest)],
+    response_policies: Vec<HeaderMap>,
+) -> CachePolicy {
+    let keys: Vec<&ResponseKey> = requests.iter().map(|(key, _)| *key).collect();
+    create_cache_policy_from_keys(
+        &keys.iter().map(|k| (*k).clone()).collect::<Vec<_>>(),
+        response_policies,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json_bytes::ByteString;
+    use serde_json_bytes::Map;
+    use serde_json_bytes::Value;
+
+    use super::*;
+    use crate::connectors::runtime::http_json_transport::HttpRequest;
+    use crate::connectors::runtime::inputs::RequestInputs;
+
+    #[test]
+    fn test_extract_cache_components() {
+        let http_req = http::Request::builder()
+            .method("GET")
+            .uri("https://api.example.com/users/123")
+            .header("content-type", "application/json")
+            .header("x-api-key", "secret")
+            .header("authorization", "Bearer token") // Should be excluded
+            .body("{}".to_string())
+            .unwrap();
+
+        let transport_req = TransportRequest::Http(HttpRequest {
+            inner: http_req,
+            debug: (None, vec![]),
+        });
+
+        let components = extract_cache_components("test-subgraph", &transport_req);
+
+        assert_eq!(components.subgraph_name, "test-subgraph");
+        assert_eq!(components.method, "GET");
+        assert_eq!(components.uri, "https://api.example.com/users/123");
+        assert_eq!(components.body, "{}");
+
+        // Should include all headers now (no filtering)
+        assert_eq!(components.headers.len(), 3);
+        assert!(components.headers.contains_key("content-type"));
+        assert!(components.headers.contains_key("x-api-key"));
+        assert!(components.headers.contains_key("authorization"));
+    }
+
+    #[test]
+    fn test_cache_components_delimited_string() {
+        let components = CacheKeyComponents {
+            subgraph_name: "test".to_string(),
+            method: "GET".to_string(),
+            uri: "https://api.example.com/test".to_string(),
+            headers: [
+                ("content-type".to_string(), "application/json".to_string()),
+                ("x-api-key".to_string(), "secret".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            body: "{}".to_string(),
+        };
+
+        let result = components.to_string();
+
+        // Should be deterministic
+        assert_eq!(result, components.to_string());
+
+        // Should be in the format: connector:v1:subgraph:method:uri:headers:body
+        assert_eq!(
+            result,
+            "connector:v1:test:GET:https://api.example.com/test:content-type=application/json,x-api-key=secret:{}"
+        );
+    }
+
+    #[test]
+    fn test_create_cache_key_empty() {
+        let result = create_cache_key(&[], "test-subgraph");
+        matches!(result, CacheKey::Entities(ref keys) if keys.is_empty());
+    }
+
+    #[test]
+    fn test_create_cache_key_root_fields() {
+        use std::sync::Arc;
+
+        use crate::connectors::JSONSelection;
+        use crate::connectors::runtime::inputs::RequestInputs;
+
+        let selection = Arc::new(JSONSelection::parse("field").unwrap());
+        let root_key1 = ResponseKey::RootField {
+            name: "foo".to_string(),
+            selection: selection.clone(),
+            inputs: RequestInputs::default(),
+        };
+        let root_key2 = ResponseKey::RootField {
+            name: "bar".to_string(),
+            selection,
+            inputs: RequestInputs::default(),
+        };
+
+        let http_req1 = http::Request::builder()
+            .method("GET")
+            .uri("https://api.example.com/foo")
+            .body("{}".to_string())
+            .unwrap();
+        let http_req2 = http::Request::builder()
+            .method("GET")
+            .uri("https://api.example.com/bar")
+            .body("{}".to_string())
+            .unwrap();
+
+        let transport1 = TransportRequest::Http(HttpRequest {
+            inner: http_req1,
+            debug: (None, vec![]),
+        });
+        let transport2 = TransportRequest::Http(HttpRequest {
+            inner: http_req2,
+            debug: (None, vec![]),
+        });
+
+        let requests = vec![(root_key1, transport1), (root_key2, transport2)];
+        let request_refs: Vec<_> = requests.iter().map(|(k, t)| (k, t)).collect();
+        let result = create_cache_key(&request_refs, "test-subgraph");
+
+        // Should be Roots variant with individual keys
+        if let CacheKey::Roots(keys) = result {
+            assert_eq!(keys.len(), 2);
+            assert!(keys[0].to_string().starts_with("connector:v1:"));
+            assert!(keys[1].to_string().starts_with("connector:v1:"));
+            // Keys should be different
+            assert_ne!(keys[0].to_string(), keys[1].to_string());
+        } else {
+            panic!("Expected CacheKey::Roots variant");
+        }
+    }
+
+    #[test]
+    fn test_create_cache_key_entities() {
+        use std::sync::Arc;
+
+        use crate::connectors::JSONSelection;
+        use crate::connectors::runtime::inputs::RequestInputs;
+
+        let selection = Arc::new(JSONSelection::parse("field").unwrap());
+        let entity_key1 = ResponseKey::Entity {
+            index: 0,
+            selection: selection.clone(),
+            inputs: RequestInputs::default(),
+        };
+        let entity_key2 = ResponseKey::Entity {
+            index: 1,
+            selection,
+            inputs: RequestInputs::default(),
+        };
+
+        let http_req1 = http::Request::builder()
+            .method("GET")
+            .uri("https://api.example.com/entity/1")
+            .body("{}".to_string())
+            .unwrap();
+        let http_req2 = http::Request::builder()
+            .method("GET")
+            .uri("https://api.example.com/entity/2")
+            .body("{}".to_string())
+            .unwrap();
+
+        let transport1 = TransportRequest::Http(HttpRequest {
+            inner: http_req1,
+            debug: (None, vec![]),
+        });
+        let transport2 = TransportRequest::Http(HttpRequest {
+            inner: http_req2,
+            debug: (None, vec![]),
+        });
+
+        let requests = vec![(entity_key1, transport1), (entity_key2, transport2)];
+        let request_refs: Vec<_> = requests.iter().map(|(k, t)| (k, t)).collect();
+        let result = create_cache_key(&request_refs, "test-subgraph");
+
+        // Should be Entities variant with individual keys
+        matches!(result, CacheKey::Entities(ref keys) if keys.len() == 2);
+    }
+
+    #[test]
+    fn test_create_cache_policy_root_fields() {
+        use std::sync::Arc;
+
+        use crate::connectors::JSONSelection;
+        use crate::connectors::runtime::inputs::RequestInputs;
+
+        let selection = Arc::new(JSONSelection::parse("field").unwrap());
+        let root_key = ResponseKey::RootField {
+            name: "foo".to_string(),
+            selection,
+            inputs: RequestInputs::default(),
+        };
+
+        let http_req = http::Request::builder()
+            .method("GET")
+            .uri("https://api.example.com/foo")
+            .body("{}".to_string())
+            .unwrap();
+
+        let transport = TransportRequest::Http(HttpRequest {
+            inner: http_req,
+            debug: (None, vec![]),
+        });
+
+        let requests = vec![(root_key, transport)];
+        let request_refs: Vec<_> = requests.iter().map(|(k, t)| (k, t)).collect();
+        let policies = vec![HeaderMap::new()];
+        let result = create_cache_policy(&request_refs, policies);
+
+        matches!(result, CachePolicy::Roots(_));
+    }
+
+    #[test]
+    fn test_create_cache_policy_entities() {
+        use std::sync::Arc;
+
+        use crate::connectors::JSONSelection;
+        use crate::connectors::runtime::inputs::RequestInputs;
+
+        let selection = Arc::new(JSONSelection::parse("field").unwrap());
+        let entity_key = ResponseKey::Entity {
+            index: 0,
+            selection,
+            inputs: RequestInputs::default(),
+        };
+
+        let http_req = http::Request::builder()
+            .method("GET")
+            .uri("https://api.example.com/entity/1")
+            .body("{}".to_string())
+            .unwrap();
+
+        let transport = TransportRequest::Http(HttpRequest {
+            inner: http_req,
+            debug: (None, vec![]),
+        });
+
+        let requests = vec![(entity_key, transport)];
+        let request_refs: Vec<_> = requests.iter().map(|(k, t)| (k, t)).collect();
+        let policies = vec![HeaderMap::new()];
+        let result = create_cache_policy(&request_refs, policies);
+
+        matches!(result, CachePolicy::Entities(_));
+    }
+
+    #[test]
+    fn test_batch_entity_key_duplication() {
+        use std::sync::Arc;
+
+        use apollo_compiler::Name;
+        use apollo_compiler::Schema;
+        use apollo_compiler::executable::FieldSet;
+
+        use crate::connectors::JSONSelection;
+
+        // Create a simple schema for testing
+        let schema_str = r#"
+            type Query {
+                entity: Entity
+            }
+
+            type Entity {
+                id: ID!
+                name: String
+            }
+        "#;
+        let schema = Schema::parse_and_validate(schema_str, "test.graphql").unwrap();
+
+        // Create batch entities with different batch sizes
+        let selection = Arc::new(JSONSelection::parse("field").unwrap());
+
+        // First batch entity with 3 items
+        let mut batch1 = Vec::new();
+        for _ in 0..3 {
+            let mut map = Map::new();
+            map.insert(
+                ByteString::from("id"),
+                Value::String(ByteString::from("123")),
+            );
+            batch1.push(map);
+        }
+
+        // Second batch entity with 2 items
+        let mut batch2 = Vec::new();
+        for _ in 0..2 {
+            let mut map = Map::new();
+            map.insert(
+                ByteString::from("id"),
+                Value::String(ByteString::from("456")),
+            );
+            batch2.push(map);
+        }
+
+        let keys =
+            FieldSet::parse_and_validate(&schema, Name::new("Entity").unwrap(), "id", "test")
+                .unwrap();
+
+        let batch_key1 = ResponseKey::BatchEntity {
+            selection: selection.clone(),
+            keys: keys.clone(),
+            inputs: RequestInputs {
+                batch: batch1,
+                ..Default::default()
+            },
+        };
+
+        let batch_key2 = ResponseKey::BatchEntity {
+            selection,
+            keys,
+            inputs: RequestInputs {
+                batch: batch2,
+                ..Default::default()
+            },
+        };
+
+        // Create transport requests
+        let http_req1 = http::Request::builder()
+            .method("POST")
+            .uri("https://api.example.com/batch1")
+            .body("{}".to_string())
+            .unwrap();
+
+        let http_req2 = http::Request::builder()
+            .method("POST")
+            .uri("https://api.example.com/batch2")
+            .body("{}".to_string())
+            .unwrap();
+
+        let transport1 = TransportRequest::Http(HttpRequest {
+            inner: http_req1,
+            debug: (None, vec![]),
+        });
+
+        let transport2 = TransportRequest::Http(HttpRequest {
+            inner: http_req2,
+            debug: (None, vec![]),
+        });
+
+        // Test cache key duplication
+        let requests = vec![(batch_key1, transport1), (batch_key2, transport2)];
+        let request_refs: Vec<_> = requests.iter().map(|(k, t)| (k, t)).collect();
+        let cache_keys = create_cache_key(&request_refs, "test-subgraph");
+
+        // Should have 5 keys total (3 + 2)
+        if let CacheKey::Entities(keys) = cache_keys {
+            assert_eq!(
+                keys.len(),
+                5,
+                "Expected 5 cache keys (3 + 2 from batch entities)"
+            );
+        } else {
+            panic!("Expected CacheKey::Entities variant");
+        }
+
+        // Test cache policy duplication
+        let response_keys = vec![requests[0].0.clone(), requests[1].0.clone()];
+
+        let mut policy1 = HeaderMap::new();
+        policy1.insert(http::header::CACHE_CONTROL, "max-age=60".parse().unwrap());
+
+        let mut policy2 = HeaderMap::new();
+        policy2.insert(http::header::CACHE_CONTROL, "max-age=120".parse().unwrap());
+
+        let policies = vec![policy1, policy2];
+        let cache_policy = create_cache_policy_from_keys(&response_keys, policies);
+
+        // Should have 5 policies total (3 + 2)
+        if let CachePolicy::Entities(policies) = cache_policy {
+            assert_eq!(
+                policies.len(),
+                5,
+                "Expected 5 cache policies (3 + 2 from batch entities)"
+            );
+            // First 3 should have max-age=60
+            for policy in policies.iter().take(3) {
+                assert_eq!(
+                    policy.get(http::header::CACHE_CONTROL).unwrap(),
+                    "max-age=60",
+                    "First 3 policies should have max-age=60"
+                );
+            }
+            // Last 2 should have max-age=120
+            for policy in policies.iter().take(5).skip(3) {
+                assert_eq!(
+                    policy.get(http::header::CACHE_CONTROL).unwrap(),
+                    "max-age=120",
+                    "Last 2 policies should have max-age=120"
+                );
+            }
+        } else {
+            panic!("Expected CachePolicy::Entities variant");
+        }
+    }
+}

--- a/apollo-federation/src/connectors/runtime/http_json_transport.rs
+++ b/apollo-federation/src/connectors/runtime/http_json_transport.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use apollo_compiler::collections::IndexMap;
 use http::HeaderMap;
 use http::HeaderValue;
+use http::header::CACHE_CONTROL;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use parking_lot::Mutex;
@@ -53,6 +54,21 @@ pub enum TransportRequest {
 pub enum TransportResponse {
     /// A response from an HTTP transport
     Http(HttpResponse),
+}
+
+impl TransportResponse {
+    pub fn cache_policies(&self) -> HeaderMap {
+        match self {
+            TransportResponse::Http(http_response) => HeaderMap::from_iter(
+                http_response
+                    .inner
+                    .headers
+                    .get_all(CACHE_CONTROL)
+                    .iter()
+                    .map(|v| (CACHE_CONTROL, v.clone())),
+            ),
+        }
+    }
 }
 
 impl From<HttpRequest> for TransportRequest {

--- a/apollo-router/src/plugin/test/mod.rs
+++ b/apollo-router/src/plugin/test/mod.rs
@@ -9,7 +9,7 @@ mod restricted;
 #[cfg(test)]
 pub use mock::connector::MockConnector;
 pub use mock::subgraph::MockSubgraph;
-pub use service::MockConnectService;
+pub use service::MockConnectorRequestService;
 pub use service::MockConnectorService;
 pub use service::MockExecutionService;
 pub use service::MockHttpClientService;

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -111,13 +111,13 @@ mock_service!(Execution, ExecutionRequest, ExecutionResponse);
 mock_service!(Subgraph, SubgraphRequest, SubgraphResponse);
 mock_service!(
     Connector,
-    connector::request_service::Request,
-    connector::request_service::Response
-);
-mock_service!(
-    Connect,
     crate::services::connect::Request,
     crate::services::connect::Response
+);
+mock_service!(
+    ConnectorRequest,
+    connector::request_service::Request,
+    connector::request_service::Response
 );
 mock_async_service!(HttpClient, HyperRequest<Body>, HyperResponse<Body>);
 

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -220,8 +220,8 @@ pub(crate) fn aggregate_responses(
         },
     );
 
-    Ok(Response {
-        response: http::Response::builder()
+    Ok(Response::with_default_cache_policy(
+        http::Response::builder()
             .body(
                 graphql::Response::builder()
                     .data(data)
@@ -229,7 +229,7 @@ pub(crate) fn aggregate_responses(
                     .build(),
             )
             .unwrap(),
-    })
+    ))
 }
 
 fn log_connectors_event(
@@ -449,6 +449,9 @@ mod tests {
                     incremental: [],
                 },
             },
+            cache_policy: Roots(
+                [],
+            ),
         }
         "###);
     }
@@ -566,6 +569,9 @@ mod tests {
                     incremental: [],
                 },
             },
+            cache_policy: Roots(
+                [],
+            ),
         }
         "###);
     }
@@ -647,7 +653,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert_debug_snapshot!(res, @r#"
+        assert_debug_snapshot!(res, @r###"
         Response {
             response: Response {
                 status: 200,
@@ -686,8 +692,11 @@ mod tests {
                     incremental: [],
                 },
             },
+            cache_policy: Roots(
+                [],
+            ),
         }
-        "#);
+        "###);
     }
 
     #[tokio::test]
@@ -813,6 +822,9 @@ mod tests {
                     incremental: [],
                 },
             },
+            cache_policy: Roots(
+                [],
+            ),
         }
         "###);
     }
@@ -945,7 +957,7 @@ mod tests {
         let body = res.response.body_mut();
         body.errors = body.errors.iter_mut().map(|e| e.with_null_id()).collect();
 
-        assert_debug_snapshot!(res, @r#"
+        assert_debug_snapshot!(res, @r###"
         Response {
             response: Response {
                 status: 200,
@@ -1088,8 +1100,11 @@ mod tests {
                     incremental: [],
                 },
             },
+            cache_policy: Roots(
+                [],
+            ),
         }
-        "#);
+        "###);
     }
 
     #[tokio::test]
@@ -1176,6 +1191,9 @@ mod tests {
                     incremental: [],
                 },
             },
+            cache_policy: Roots(
+                [],
+            ),
         }
         "###);
     }

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::executable::FieldSet;
 use apollo_compiler::executable::Selection;
+use apollo_compiler::validation::Valid;
 use apollo_federation::connectors::Connector;
 use apollo_federation::connectors::EntityResolver;
 use apollo_federation::connectors::runtime::debug::ConnectorContext;
@@ -11,7 +14,7 @@ use apollo_federation::connectors::runtime::key::ResponseKey;
 use parking_lot::Mutex;
 
 use crate::Context;
-use crate::services::connect;
+use crate::query_planner::fetch::Variables;
 use crate::services::connector::request_service::Request;
 
 const REPRESENTATIONS_VAR: &str = "representations";
@@ -19,30 +22,41 @@ const ENTITIES: &str = "_entities";
 const TYPENAME: &str = "__typename";
 
 pub(crate) fn make_requests(
-    request: connect::Request,
+    operation: &Valid<ExecutableDocument>,
+    variables: &Variables,
+    keys: Option<&Valid<FieldSet>>,
     context: &Context,
+    supergraph_request: Arc<http::Request<crate::graphql::Request>>,
     connector: Arc<Connector>,
     debug: &Option<Arc<Mutex<ConnectorContext>>>,
 ) -> Result<Vec<Request>, MakeRequestError> {
     let request_params = match connector.entity_resolver {
         Some(EntityResolver::Explicit) | Some(EntityResolver::TypeSingle) => {
-            entities_from_request(connector.clone(), &request)
+            entities_from_request(connector.clone(), operation, variables)
         }
         Some(EntityResolver::Implicit) => {
-            entities_with_fields_from_request(connector.clone(), &request)
+            entities_with_fields_from_request(connector.clone(), operation, variables)
         }
-        Some(EntityResolver::TypeBatch) => batch_entities_from_request(connector.clone(), &request),
-        None => root_fields(connector.clone(), &request),
+        Some(EntityResolver::TypeBatch) => {
+            batch_entities_from_request(connector.clone(), operation, variables, keys)
+        }
+        None => root_fields(connector.clone(), operation, variables),
     }?;
 
-    request_params_to_requests(context, connector, request_params, request, debug)
+    request_params_to_requests(
+        context,
+        connector,
+        request_params,
+        supergraph_request,
+        debug,
+    )
 }
 
 fn request_params_to_requests(
     context: &Context,
     connector: Arc<Connector>,
     request_params: Vec<ResponseKey>,
-    original_request: connect::Request,
+    supergraph_request: Arc<http::Request<crate::graphql::Request>>,
     debug: &Option<Arc<Mutex<ConnectorContext>>>,
 ) -> Result<Vec<Request>, MakeRequestError> {
     let mut results = vec![];
@@ -55,13 +69,10 @@ fn request_params_to_requests(
                 .clone()
                 .merger(&connector.request_variable_keys)
                 .config(connector.config.as_ref())
-                .context(&original_request.context)
-                .request(
-                    &connector.request_headers,
-                    original_request.supergraph_request.headers(),
-                )
+                .context(context)
+                .request(&connector.request_headers, supergraph_request.headers())
                 .merge(),
-            original_request.supergraph_request.headers(),
+            supergraph_request.headers(),
             debug,
         )?;
 
@@ -71,7 +82,7 @@ fn request_params_to_requests(
             transport_request,
             key: response_key,
             mapping_problems,
-            supergraph_request: original_request.supergraph_request.clone(),
+            supergraph_request: supergraph_request.clone(),
         });
     }
 
@@ -121,12 +132,12 @@ pub(crate) enum MakeRequestError {
 /// ```
 fn root_fields(
     connector: Arc<Connector>,
-    request: &connect::Request,
+    operation: &Valid<ExecutableDocument>,
+    variables: &Variables,
 ) -> Result<Vec<ResponseKey>, MakeRequestError> {
     use MakeRequestError::*;
 
-    let op = request
-        .operation
+    let op = operation
         .operations
         .get(None)
         .map_err(|_| InvalidOperation("no operation document".into()))?;
@@ -142,7 +153,7 @@ fn root_fields(
                     .unwrap_or_else(|| &field.name)
                     .to_string();
 
-                let args = graphql_utils::field_arguments_map(field, &request.variables.variables)
+                let args = graphql_utils::field_arguments_map(field, &variables.variables)
                     .map_err(|err| {
                         InvalidArguments(format!("cannot get inputs from field arguments: {err}"))
                     })?;
@@ -155,7 +166,7 @@ fn root_fields(
                 let response_key = ResponseKey::RootField {
                     name: response_name,
                     selection: Arc::new(connector.selection.apply_selection_set(
-                        &request.operation,
+                        operation,
                         &field.selection_set,
                         None,
                     )),
@@ -197,24 +208,24 @@ fn root_fields(
 /// Returns a list of request inputs and the response key (index in the array).
 fn entities_from_request(
     connector: Arc<Connector>,
-    request: &connect::Request,
+    operation: &Valid<ExecutableDocument>,
+    variables: &Variables,
 ) -> Result<Vec<ResponseKey>, MakeRequestError> {
     use MakeRequestError::*;
 
-    let Some(representations) = request.variables.variables.get(REPRESENTATIONS_VAR) else {
-        return root_fields(connector, request);
+    let Some(representations) = variables.variables.get(REPRESENTATIONS_VAR) else {
+        return root_fields(connector, operation, variables);
     };
 
-    let op = request
-        .operation
+    let op = operation
         .operations
         .get(None)
         .map_err(|_| InvalidOperation("no operation document".into()))?;
 
-    let (entities_field, _) = graphql_utils::get_entity_fields(&request.operation, op)?;
+    let (entities_field, _) = graphql_utils::get_entity_fields(operation, op)?;
 
     let selection = Arc::new(connector.selection.apply_selection_set(
-        &request.operation,
+        operation,
         &entities_field.selection_set,
         None,
     ));
@@ -280,18 +291,17 @@ fn entities_from_request(
 /// name/alias of field) for each.
 fn entities_with_fields_from_request(
     connector: Arc<Connector>,
-    request: &connect::Request,
+    operation: &Valid<ExecutableDocument>,
+    variables: &Variables,
 ) -> Result<Vec<ResponseKey>, MakeRequestError> {
     use MakeRequestError::*;
 
-    let op = request
-        .operation
+    let op = operation
         .operations
         .get(None)
         .map_err(|_| InvalidOperation("no operation document".into()))?;
 
-    let (entities_field, typename_requested) =
-        graphql_utils::get_entity_fields(&request.operation, op)?;
+    let (entities_field, typename_requested) = graphql_utils::get_entity_fields(operation, op)?;
 
     let types_and_fields = entities_field
         .selection_set
@@ -301,7 +311,7 @@ fn entities_with_fields_from_request(
             Selection::Field(_) => Ok::<_, MakeRequestError>(vec![]),
 
             Selection::FragmentSpread(f) => {
-                let Some(frag) = f.fragment_def(&request.operation) else {
+                let Some(frag) = f.fragment_def(operation) else {
                     return Err(InvalidOperation(format!(
                         "invalid operation: fragment `{}` missing",
                         f.fragment_name
@@ -365,8 +375,7 @@ fn entities_with_fields_from_request(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let representations = request
-        .variables
+    let representations = variables
         .variables
         .get(REPRESENTATIONS_VAR)
         .ok_or_else(|| InvalidRepresentations("missing representations variable".into()))?
@@ -383,13 +392,13 @@ fn entities_with_fields_from_request(
         .flatten()
         .flat_map(|(typename, field)| {
             let selection = Arc::new(connector.selection.apply_selection_set(
-                &request.operation,
+                operation,
                 &field.selection_set,
                 None,
             ));
 
             representations.iter().map(move |(i, representation)| {
-                let args = graphql_utils::field_arguments_map(field, &request.variables.variables)
+                let args = graphql_utils::field_arguments_map(field, &variables.variables)
                     .map_err(|err| {
                         InvalidArguments(format!("cannot get inputs from field arguments: {err}"))
                     })?;
@@ -439,30 +448,31 @@ fn entities_with_fields_from_request(
 /// which allows us to match them up and return them in the correct order.
 fn batch_entities_from_request(
     connector: Arc<Connector>,
-    request: &connect::Request,
+    operation: &Valid<ExecutableDocument>,
+    variables: &Variables,
+    keys: Option<&Valid<FieldSet>>,
 ) -> Result<Vec<ResponseKey>, MakeRequestError> {
     use MakeRequestError::*;
 
-    let Some(keys) = &request.keys else {
+    let Some(keys) = keys else {
         return Err(InvalidOperation("TODO better error type".into()));
     };
 
-    let Some(representations) = request.variables.variables.get(REPRESENTATIONS_VAR) else {
+    let Some(representations) = variables.variables.get(REPRESENTATIONS_VAR) else {
         return Err(InvalidRepresentations(
             "batch_entities_from_request called without representations".into(),
         ));
     };
 
-    let op = request
-        .operation
+    let op = operation
         .operations
         .get(None)
         .map_err(|_| InvalidOperation("no operation document".into()))?;
 
-    let (entities_field, _) = graphql_utils::get_entity_fields(&request.operation, op)?;
+    let (entities_field, _) = graphql_utils::get_entity_fields(operation, op)?;
 
     let selection = Arc::new(connector.selection.apply_selection_set(
-        &request.operation,
+        operation,
         &entities_field.selection_set,
         Some(keys),
     ));
@@ -531,6 +541,15 @@ mod tests {
     use crate::graphql;
     use crate::query_planner::fetch::Variables;
 
+    // Helper function to create test Variables directly from a serde_json Value
+    fn create_test_variables(vars: serde_json_bytes::Value) -> Variables {
+        Variables {
+            variables: vars.as_object().unwrap().clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        }
+    }
+
     const DEFAULT_CONNECT_SPEC: ConnectSpec = ConnectSpec::V0_2;
 
     #[test]
@@ -539,28 +558,16 @@ mod tests {
             Schema::parse_and_validate("type Query { a: A } type A { f: String }", "./").unwrap(),
         );
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Query_a_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &schema,
-                    "query { a { f } a2: a { f2: f } }".to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: Default::default(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
-            })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+        let operation = Arc::new(
+            ExecutableDocument::parse_and_validate(
+                &schema,
+                "query { a { f } a2: a { f2: f } }".to_string(),
+                "./",
+            )
+            .unwrap(),
+        );
+
+        let variables = create_test_variables(serde_json_bytes::json!({}));
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -590,7 +597,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::root_fields(Arc::new(connector), &req), @r#"
+        assert_debug_snapshot!(super::root_fields(Arc::new(connector), &operation, &variables), @r#"
         Ok(
             [
                 RootField {
@@ -622,31 +629,16 @@ mod tests {
             Schema::parse_and_validate("type Query {b(var: String): String}", "./").unwrap(),
         );
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Query_b_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &schema,
-                    "query($var: String) { b(var: \"inline\") b2: b(var: $var) }".to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({ "var": "variable" })
-                    .as_object()
-                    .unwrap()
-                    .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
-            })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+        let operation = Arc::new(
+            ExecutableDocument::parse_and_validate(
+                &schema,
+                "query($var: String) { b(var: \"inline\") b2: b(var: $var) }".to_string(),
+                "./",
+            )
+            .unwrap(),
+        );
+
+        let variables = create_test_variables(serde_json_bytes::json!({ "var": "variable" }));
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -676,7 +668,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::root_fields(Arc::new(connector), &req), @r#"
+        assert_debug_snapshot!(super::root_fields(Arc::new(connector), &operation, &variables), @r#"
         Ok(
             [
                 RootField {
@@ -714,11 +706,7 @@ mod tests {
             "./",
         ).unwrap());
 
-        let req = crate::services::connect::Request::builder()
-        .service_name("subgraph_Query_c_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
+        let operation = ExecutableDocument::parse_and_validate(
                     &schema,
                 r#"
                 query(
@@ -738,27 +726,19 @@ mod tests {
                 "#.to_string(),
                     "./",
                 )
-                .unwrap(),
-            )
-            )
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                        "var1": 1, "var2": true, "var3": 0.9,
-                        "var4": "123", "var5": { "a": 42 }, "var6": ["item"],
-                        "var7": null
-                    })
-                    .as_object()
-                    .unwrap()
-                    .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+                .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "var1": 1, "var2": true, "var3": 0.9,
+                "var4": "123", "var5": { "a": 42 }, "var6": ["item"],
+                "var7": null
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -788,7 +768,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::root_fields(Arc::new(connector), &req), @r#"
+        assert_debug_snapshot!(super::root_fields(Arc::new(connector), &operation, &variables), @r#"
         Ok(
             [
                 RootField {
@@ -842,13 +822,9 @@ mod tests {
             .unwrap(),
         );
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Query_entity_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!) {
                     _entities(representations: $representations) {
                         __typename
@@ -859,30 +835,23 @@ mod tests {
                     }
                 }
                 "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "representations": [
-                        { "__typename": "Entity", "id": "1" },
-                        { "__typename": "Entity", "id": "2" },
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "representations": [
+                    { "__typename": "Entity", "id": "1" },
+                    { "__typename": "Entity", "id": "2" },
+                ]
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -912,7 +881,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::entities_from_request(Arc::new(connector), &req).unwrap(), @r#"
+        assert_debug_snapshot!(super::entities_from_request(Arc::new(connector), &operation, &variables).unwrap(), @r#"
         [
             Entity {
                 index: 0,
@@ -964,13 +933,9 @@ mod tests {
             .unwrap(),
         );
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Query_entity_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!) {
                     _entities(representations: $representations) {
                         ... _generated_Entity
@@ -982,30 +947,23 @@ mod tests {
                     alias: field
                 }
                 "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "representations": [
-                        { "__typename": "Entity", "id": "1" },
-                        { "__typename": "Entity", "id": "2" },
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "representations": [
+                    { "__typename": "Entity", "id": "1" },
+                    { "__typename": "Entity", "id": "2" },
+                ]
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -1035,7 +993,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::entities_from_request(Arc::new(connector), &req).unwrap(), @r#"
+        assert_debug_snapshot!(super::entities_from_request(Arc::new(connector), &operation, &variables).unwrap(), @r#"
         [
             Entity {
                 index: 0,
@@ -1076,40 +1034,29 @@ mod tests {
         "#;
         let schema = Arc::new(Schema::parse_and_validate(partial_sdl, "./").unwrap());
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Query_entity_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &schema,
+            r#"
                 query($a: ID!, $b: ID!) {
                     a: entity(id: $a) { field { field } }
                     b: entity(id: $b) { field { alias: field } }
                 }
             "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "a": "1",
-                    "b": "2"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "a": "1",
+                "b": "2"
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -1139,7 +1086,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::entities_from_request(Arc::new(connector), &req).unwrap(), @r#"
+        assert_debug_snapshot!(super::entities_from_request(Arc::new(connector), &operation, &variables).unwrap(), @r#"
         [
             RootField {
                 name: "a",
@@ -1194,13 +1141,9 @@ mod tests {
             .unwrap(),
         );
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Entity_field_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!, $bye: String) {
                     _entities(representations: $representations) {
                         __typename
@@ -1211,31 +1154,24 @@ mod tests {
                     }
                 }
             "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "representations": [
-                        { "__typename": "Entity", "id": "1" },
-                        { "__typename": "Entity", "id": "2" },
-                    ],
-                    "bye": "bye"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "representations": [
+                    { "__typename": "Entity", "id": "1" },
+                    { "__typename": "Entity", "id": "2" },
+                ],
+                "bye": "bye"
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -1265,7 +1201,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::entities_with_fields_from_request(Arc::new(connector), &req).unwrap(), @r#"
+        assert_debug_snapshot!(super::entities_with_fields_from_request(Arc::new(connector), &operation, &variables).unwrap(), @r#"
         [
             EntityField {
                 index: 0,
@@ -1354,13 +1290,9 @@ mod tests {
             .unwrap(),
         );
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Entity_field_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!, $bye: String) {
                     _entities(representations: $representations) {
                         ... _generated_Entity
@@ -1372,31 +1304,24 @@ mod tests {
                     alias: field(foo: $bye) { selected }
                 }
             "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "representations": [
-                        { "__typename": "Entity", "id": "1" },
-                        { "__typename": "Entity", "id": "2" },
-                    ],
-                    "bye": "bye"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "representations": [
+                    { "__typename": "Entity", "id": "1" },
+                    { "__typename": "Entity", "id": "2" },
+                ],
+                "bye": "bye"
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -1426,7 +1351,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::entities_with_fields_from_request(Arc::new(connector), &req).unwrap(), @r#"
+        assert_debug_snapshot!(super::entities_with_fields_from_request(Arc::new(connector), &operation, &variables).unwrap(), @r#"
         [
             EntityField {
                 index: 0,
@@ -1515,13 +1440,9 @@ mod tests {
             .unwrap(),
         );
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Entity_field_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!, $foo: String) {
                     _entities(representations: $representations) {
                         ... on Entity {
@@ -1530,31 +1451,24 @@ mod tests {
                     }
                 }
             "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                  "representations": [
-                      { "__typename": "Entity", "id": "1" },
-                      { "__typename": "Entity", "id": "2" },
-                  ],
-                  "foo": "bar"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+              "representations": [
+                  { "__typename": "Entity", "id": "1" },
+                  { "__typename": "Entity", "id": "2" },
+              ],
+              "foo": "bar"
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -1584,7 +1498,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::entities_with_fields_from_request(Arc::new(connector), &req).unwrap(), @r#"
+        assert_debug_snapshot!(super::entities_with_fields_from_request(Arc::new(connector), &operation, &variables).unwrap(), @r#"
         [
             EntityField {
                 index: 0,
@@ -1643,13 +1557,9 @@ mod tests {
 
         let keys = FieldSet::parse_and_validate(&subgraph_schema, name!(Entity), "id", "").unwrap();
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Entity_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!) {
                     _entities(representations: $representations) {
                         __typename
@@ -1660,31 +1570,23 @@ mod tests {
                     }
                 }
                 "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "representations": [
-                        { "__typename": "Entity", "id": "1" },
-                        { "__typename": "Entity", "id": "2" },
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "representations": [
+                    { "__typename": "Entity", "id": "1" },
+                    { "__typename": "Entity", "id": "2" },
+                ]
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .and_keys(Some(keys))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -1707,7 +1609,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::batch_entities_from_request(Arc::new(connector), &req).unwrap(), @r###"
+        assert_debug_snapshot!(super::batch_entities_from_request(Arc::new(connector), &operation, &variables, Some(&keys)).unwrap(), @r###"
         [
             BatchEntity {
                 selection: "id\nfield\nalias: field",
@@ -1753,13 +1655,9 @@ mod tests {
 
         let keys = FieldSet::parse_and_validate(&subgraph_schema, name!(Entity), "id", "").unwrap();
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Entity_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!) {
                     _entities(representations: $representations) {
                         __typename
@@ -1770,31 +1668,23 @@ mod tests {
                     }
                 }
                 "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "representations": [
-                        { "__typename": "Entity", "id": "1" },
-                        { "__typename": "Entity", "id": "2" },
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "representations": [
+                    { "__typename": "Entity", "id": "1" },
+                    { "__typename": "Entity", "id": "2" },
+                ]
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .and_keys(Some(keys))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -1817,7 +1707,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::batch_entities_from_request(Arc::new(connector), &req).unwrap(), @r###"
+        assert_debug_snapshot!(super::batch_entities_from_request(Arc::new(connector), &operation, &variables, Some(&keys)).unwrap(), @r###"
         [
             BatchEntity {
                 selection: "id\nfield\nalias: field",
@@ -1863,13 +1753,9 @@ mod tests {
 
         let keys = FieldSet::parse_and_validate(&subgraph_schema, name!(Entity), "id", "").unwrap();
 
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Entity_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!) {
                     _entities(representations: $representations) {
                         __typename
@@ -1880,36 +1766,28 @@ mod tests {
                     }
                 }
                 "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "representations": [
-                        { "__typename": "Entity", "id": "1" },
-                        { "__typename": "Entity", "id": "2" },
-                        { "__typename": "Entity", "id": "3" },
-                        { "__typename": "Entity", "id": "4" },
-                        { "__typename": "Entity", "id": "5" },
-                        { "__typename": "Entity", "id": "6" },
-                        { "__typename": "Entity", "id": "7" },
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "representations": [
+                    { "__typename": "Entity", "id": "1" },
+                    { "__typename": "Entity", "id": "2" },
+                    { "__typename": "Entity", "id": "3" },
+                    { "__typename": "Entity", "id": "4" },
+                    { "__typename": "Entity", "id": "5" },
+                    { "__typename": "Entity", "id": "6" },
+                    { "__typename": "Entity", "id": "7" },
+                ]
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .and_keys(Some(keys))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -1932,7 +1810,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::batch_entities_from_request(Arc::new(connector), &req).unwrap(), @r###"
+        assert_debug_snapshot!(super::batch_entities_from_request(Arc::new(connector), &operation, &variables, Some(&keys)).unwrap(), @r###"
         [
             BatchEntity {
                 selection: "id\nfield\nalias: field",
@@ -1985,15 +1863,9 @@ mod tests {
             .unwrap(),
         );
 
-        let keys = FieldSet::parse_and_validate(&subgraph_schema, name!(Entity), "id", "").unwrap();
-
-        let req = crate::services::connect::Request::builder()
-            .service_name("subgraph_Entity_0".into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &subgraph_schema,
-                    r#"
+        let operation = ExecutableDocument::parse_and_validate(
+            &subgraph_schema,
+            r#"
                 query($representations: [_Any!]!) {
                     _entities(representations: $representations) {
                         __typename
@@ -2004,31 +1876,23 @@ mod tests {
                     }
                 }
                 "#
-                    .to_string(),
-                    "./",
-                )
-                .unwrap(),
-            ))
-            .variables(Variables {
-                variables: serde_json_bytes::json!({
-                    "representations": [
-                        { "__typename": "Entity", "id": "1" },
-                        { "__typename": "Entity", "id": "2" },
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
+            .to_string(),
+            "./",
+        )
+        .unwrap();
+        let variables = Variables {
+            variables: serde_json_bytes::json!({
+                "representations": [
+                    { "__typename": "Entity", "id": "1" },
+                    { "__typename": "Entity", "id": "2" },
+                ]
             })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .and_keys(Some(keys))
-            .build();
+            .as_object()
+            .unwrap()
+            .clone(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
 
         let connector = Connector {
             spec: DEFAULT_CONNECT_SPEC,
@@ -2055,7 +1919,7 @@ mod tests {
             label: "test label".into(),
         };
 
-        assert_debug_snapshot!(super::entities_from_request(Arc::new(connector), &req).unwrap(), @r#"
+        assert_debug_snapshot!(super::entities_from_request(Arc::new(connector), &operation, &variables).unwrap(), @r#"
         [
             Entity {
                 index: 0,
@@ -2082,29 +1946,19 @@ mod tests {
     #[test]
     fn make_requests() {
         let schema = Schema::parse_and_validate("type Query { hello: String }", "./").unwrap();
-        let service_name = String::from("subgraph_Query_a_0");
-        let req = crate::services::connect::Request::builder()
-            .service_name(service_name.clone().into())
-            .context(Context::default())
-            .operation(Arc::new(
-                ExecutableDocument::parse_and_validate(
-                    &schema,
-                    "query { a: hello }".to_string(),
-                    "./",
-                )
+        let operation =
+            ExecutableDocument::parse_and_validate(&schema, "query { a: hello }".to_string(), "./")
+                .unwrap();
+        let variables = Variables {
+            variables: Default::default(),
+            inverted_paths: Default::default(),
+            contextual_arguments: Default::default(),
+        };
+        let supergraph_request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
                 .unwrap(),
-            ))
-            .variables(Variables {
-                variables: Default::default(),
-                inverted_paths: Default::default(),
-                contextual_arguments: Default::default(),
-            })
-            .supergraph_request(Arc::new(
-                http::Request::builder()
-                    .body(graphql::Request::builder().build())
-                    .unwrap(),
-            ))
-            .build();
+        );
 
         let connector = Connector {
             spec: ConnectSpec::V0_1,
@@ -2134,20 +1988,25 @@ mod tests {
             label: "test label".into(),
         };
 
-        let requests: Vec<_> =
-            super::make_requests(req, &Context::default(), Arc::new(connector), &None)
-                .unwrap()
-                .into_iter()
-                .map(|req| {
-                    let TransportRequest::Http(http_request) = req.transport_request;
-                    let (parts, _body) = http_request.inner.into_parts();
-                    let new_req = http::Request::from_parts(
-                        parts,
-                        http_body_util::Empty::<bytes::Bytes>::new(),
-                    );
-                    (new_req, req.key, http_request.debug)
-                })
-                .collect();
+        let requests: Vec<_> = super::make_requests(
+            &operation,
+            &variables,
+            None,
+            &Context::new(),
+            supergraph_request.clone(),
+            Arc::new(connector),
+            &None,
+        )
+        .unwrap()
+        .into_iter()
+        .map(|req| {
+            let TransportRequest::Http(http_request) = req.transport_request;
+            let (parts, _body) = http_request.inner.into_parts();
+            let new_req =
+                http::Request::from_parts(parts, http_body_util::Empty::<bytes::Bytes>::new());
+            (new_req, req.key, http_request.debug)
+        })
+        .collect();
 
         assert_debug_snapshot!(requests, @r#"
         [

--- a/apollo-router/src/plugins/connectors/make_requests/graphql_utils.rs
+++ b/apollo-router/src/plugins/connectors/make_requests/graphql_utils.rs
@@ -52,11 +52,10 @@ pub(super) fn argument_value_to_json(
     match value {
         Value::Null => Ok(JSONValue::Null),
         Value::Enum(e) => Ok(JSONValue::String(e.as_str().into())),
-        Value::Variable(name) => variables.get(name.as_str()).cloned().ok_or_else(|| {
-            BoxError::from(format!(
-                "variable {name} used in operation but not defined in variables"
-            ))
-        }),
+        Value::Variable(name) => Ok(variables
+            .get(name.as_str())
+            .cloned()
+            .unwrap_or(JSONValue::Null)),
         Value::String(s) => Ok(JSONValue::String(s.as_str().into())),
         Value::Float(f) => Ok(JSONValue::Number(
             Number::from_f64(

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -2046,7 +2046,7 @@ async fn should_support_using_variable_in_nested_input_argument() {
 }
 
 #[tokio::test]
-async fn should_error_when_using_arguments_that_has_not_been_defined() {
+async fn doesnt_error_when_using_arguments_that_has_not_been_defined() {
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/complexInputType"))
@@ -2071,22 +2071,13 @@ async fn should_error_when_using_arguments_that_has_not_been_defined() {
     )
     .await;
 
-    insta::assert_json_snapshot!(response, @r#"
+    insta::assert_json_snapshot!(response, @r###"
     {
-      "data": null,
-      "errors": [
-        {
-          "message": "HTTP fetch failed from 'connectors': Invalid request arguments: cannot get inputs from field arguments: variable query used in operation but not defined in variables",
-          "path": [],
-          "extensions": {
-            "code": "SUBREQUEST_HTTP_ERROR",
-            "service": "connectors",
-            "reason": "Invalid request arguments: cannot get inputs from field arguments: variable query used in operation but not defined in variables"
-          }
-        }
-      ]
+      "data": {
+        "complexInputType": "Hello world!"
+      }
     }
-    "#);
+    "###);
 }
 
 mod quickstart_tests {

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -42,7 +42,6 @@ use crate::plugin::serde::deserialize_option_header_name;
 use crate::plugin::serde::deserialize_option_header_value;
 use crate::plugin::serde::deserialize_regex;
 use crate::services::SubgraphRequest;
-use crate::services::connector;
 use crate::services::subgraph;
 
 register_private_plugin!("apollo", "headers", Headers);
@@ -274,15 +273,17 @@ impl PluginPrivate for Headers {
             .boxed()
     }
 
-    fn connector_request_service(
+    fn connector_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
-        source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
+        _subgraph_name: &str,
+        source_name: &str,
+        _service_name: &str,
+        service: crate::services::connect::BoxService,
+    ) -> crate::services::connect::BoxService {
         ServiceBuilder::new()
             .layer(HeadersLayer::new(
                 self.connector_source_operations
-                    .get(&source_name)
+                    .get(source_name)
                     .cloned()
                     .unwrap_or_else(|| self.all_connector_operations.clone()),
             ))
@@ -356,9 +357,9 @@ where
     }
 }
 
-impl<S> Service<connector::request_service::Request> for HeadersService<S>
+impl<S> Service<crate::services::connect::Request> for HeadersService<S>
 where
-    S: Service<connector::request_service::Request>,
+    S: Service<crate::services::connect::Request>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -368,7 +369,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: connector::request_service::Request) -> Self::Future {
+    fn call(&mut self, mut req: crate::services::connect::Request) -> Self::Future {
         self.modify_connector_request(&mut req);
         self.inner.call(req)
     }
@@ -395,26 +396,28 @@ impl<S> HeadersService<S> {
         }
     }
 
-    fn modify_connector_request(&self, req: &mut connector::request_service::Request) {
-        let mut already_propagated: HashSet<String> = HashSet::new();
+    fn modify_connector_request(&self, req: &mut crate::services::connect::Request) {
+        for prepared_request in &mut req.prepared_requests {
+            let mut already_propagated: HashSet<String> = HashSet::new();
 
-        let TransportRequest::Http(ref mut http_request) = req.transport_request;
-        let body_to_value = serde_json::from_str(http_request.inner.body()).ok();
-        let supergraph_headers = req.supergraph_request.headers();
-        let context = &req.context;
-        // We need to know what headers were added prior to this processing to that we can properly override as needed
-        let existing_headers = http_request.inner.headers().clone();
-        let headers_mut = http_request.inner.headers_mut();
+            let TransportRequest::Http(ref mut http_request) = prepared_request.transport_request;
+            let body_to_value = serde_json::from_str(http_request.inner.body()).ok();
+            let supergraph_headers = prepared_request.supergraph_request.headers();
+            let context = &prepared_request.context;
+            // We need to know what headers were added prior to this processing to that we can properly override as needed
+            let existing_headers = http_request.inner.headers().clone();
+            let headers_mut = http_request.inner.headers_mut();
 
-        for operation in &*self.operations {
-            operation.process_header_rules(
-                &mut already_propagated,
-                supergraph_headers,
-                &body_to_value,
-                context,
-                headers_mut,
-                Some(&existing_headers),
-            );
+            for operation in &*self.operations {
+                operation.process_header_rules(
+                    &mut already_propagated,
+                    supergraph_headers,
+                    &body_to_value,
+                    context,
+                    headers_mut,
+                    Some(&existing_headers),
+                );
+            }
         }
     }
 }
@@ -633,6 +636,7 @@ mod test {
     use crate::query_planner::fetch::OperationKind;
     use crate::services::SubgraphRequest;
     use crate::services::SubgraphResponse;
+    use crate::services::connector;
 
     #[test]
     fn test_subgraph_config() {
@@ -1579,19 +1583,9 @@ mod test {
     }
 
     fn example_connector_response(
-        _req: connector::request_service::Request,
-    ) -> Result<connector::request_service::Response, BoxError> {
-        let key = ResponseKey::RootField {
-            name: "hello".to_string(),
-            inputs: Default::default(),
-            selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
-        };
-        Ok(connector::request_service::Response::test_new(
-            key,
-            Vec::new(),
-            json!(""),
-            None,
-        ))
+        _req: crate::services::connect::Request,
+    ) -> Result<crate::services::connect::Response, BoxError> {
+        Ok(crate::services::connect::Response::test_new())
     }
 
     fn example_request() -> SubgraphRequest {
@@ -1637,7 +1631,7 @@ mod test {
         }
     }
 
-    fn example_connector_request() -> connector::request_service::Request {
+    fn example_connector_request() -> crate::services::connect::Request {
         let ctx = Context::new();
         ctx.insert("my_key", "my_value_from_context".to_string())
             .unwrap();
@@ -1694,8 +1688,8 @@ mod test {
             debug: Default::default(),
         };
 
-        connector::request_service::Request {
-            context: ctx,
+        let prepared_request = connector::request_service::Request {
+            context: ctx.clone(),
             connector: Arc::new(connector),
             transport_request: http_request.into(),
             key,
@@ -1717,7 +1711,9 @@ mod test {
                     )
                     .expect("expecting valid request"),
             ),
-        }
+        };
+
+        crate::services::connect::Request::test_new(vec![prepared_request])
     }
 
     impl SubgraphRequest {
@@ -1738,20 +1734,25 @@ mod test {
         }
     }
 
-    impl connector::request_service::Request {
+    impl crate::services::connect::Request {
         fn assert_headers(&self, headers: Vec<(&'static str, &'static str)>) -> bool {
             let mut headers = headers.clone();
             headers.push((HOST.as_str(), "rhost"));
             headers.push((CONTENT_LENGTH.as_str(), "22"));
             headers.push((CONTENT_TYPE.as_str(), "graphql"));
-            let TransportRequest::Http(ref http_request) = self.transport_request;
-            let actual_headers = http_request
-                .inner
-                .headers()
-                .iter()
-                .map(|(name, value)| (name.as_str(), value.to_str().unwrap()))
-                .collect::<HashSet<_>>();
-            assert_eq!(actual_headers, headers.into_iter().collect::<HashSet<_>>());
+            let expected_headers: HashSet<_> = headers.into_iter().collect();
+
+            // Check headers on all prepared requests
+            for prepared_request in &self.prepared_requests {
+                let TransportRequest::Http(ref http_request) = prepared_request.transport_request;
+                let actual_headers = http_request
+                    .inner
+                    .headers()
+                    .iter()
+                    .map(|(name, value)| (name.as_str(), value.to_str().unwrap()))
+                    .collect::<HashSet<_>>();
+                assert_eq!(actual_headers, expected_headers);
+            }
 
             true
         }

--- a/apollo-router/src/services/connect.rs
+++ b/apollo-router/src/services/connect.rs
@@ -6,13 +6,18 @@ use std::sync::Arc;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::validation::Valid;
+use apollo_federation::connectors::Connector;
+use apollo_federation::connectors::runtime::debug::ConnectorContext;
+use parking_lot::Mutex;
 use static_assertions::assert_impl_all;
 use tower::BoxError;
 
 use crate::Context;
 use crate::graphql;
 use crate::graphql::Request as GraphQLRequest;
+use crate::plugins::connectors::make_requests::make_requests;
 use crate::query_planner::fetch::Variables;
+use crate::services::connector::request_service::Request as ConnectorRequest;
 
 pub(crate) type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 
@@ -20,10 +25,9 @@ pub(crate) type BoxService = tower::util::BoxService<Request, Response, BoxError
 pub struct Request {
     pub(crate) service_name: Arc<str>,
     pub(crate) context: Context,
-    pub(crate) operation: Arc<Valid<ExecutableDocument>>,
-    pub(crate) supergraph_request: Arc<http::Request<GraphQLRequest>>,
-    pub(crate) variables: Variables,
-    pub(crate) keys: Option<Valid<FieldSet>>,
+    pub(crate) prepared_requests: Vec<ConnectorRequest>,
+    /// Subgraph name needed for lazy cache key generation
+    pub(crate) subgraph_name: String,
 }
 
 impl Debug for Request {
@@ -31,9 +35,8 @@ impl Debug for Request {
         f.debug_struct("Request")
             .field("service_name", &self.service_name)
             .field("context", &self.context)
-            .field("operation", &self.operation)
-            .field("supergraph_request", &self.supergraph_request)
-            .field("variables", &self.variables.variables)
+            .field("subgraph_name", &self.subgraph_name)
+            .field("prepared_requests_len", &self.prepared_requests.len())
             .finish()
     }
 }
@@ -58,14 +61,33 @@ impl Request {
         supergraph_request: Arc<http::Request<GraphQLRequest>>,
         variables: Variables,
         keys: Option<Valid<FieldSet>>,
-    ) -> Self {
-        Self {
+        connector: Arc<Connector>,
+    ) -> Result<Self, BoxError> {
+        // Get debug context from context extensions
+        let debug = context
+            .extensions()
+            .with_lock(|lock| lock.get::<Arc<Mutex<ConnectorContext>>>().cloned());
+
+        // Call make_requests to prepare HTTP requests
+        let prepared_requests = make_requests(
+            &operation,
+            &variables,
+            keys.as_ref(),
+            &context,
+            supergraph_request.clone(),
+            connector.clone(),
+            &debug,
+        )
+        .map_err(BoxError::from)?;
+
+        // Store subgraph name for lazy cache key generation
+        let subgraph_name = connector.id.subgraph_name.to_string();
+
+        Ok(Self {
             service_name,
-            context,
-            operation,
-            supergraph_request,
-            variables,
-            keys,
-        }
+            context: context.clone(),
+            prepared_requests,
+            subgraph_name,
+        })
     }
 }

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -147,7 +147,8 @@ impl FetchService {
                         .supergraph_request(supergraph_request)
                         .variables(variables)
                         .and_keys(keys)
-                        .build(),
+                        .connector(Arc::new(connector.clone()))
+                        .build()?, // TODO: if this fails, it will be converted to a GraphQL error with the internal connector "subgraph" name in the extensions.service_name.
                 )
                 .await
                 .map_to_graphql_error(connector.id.subgraph_name.clone(), &current_dir.to_owned())


### PR DESCRIPTION
- Refactor make_requests to take explicit parameters instead of connect::Request
- Update connect::Request to contain prepared_requests vector
- Move request preparation to happen before connector service call
- Update connector service execute function to use prepared_requests
- Add backward compatibility layer for tests with deprecated fields
- Keep make_requests tests unchanged via legacy function wrappers

This simplifies the connect::Request structure and moves request preparation earlier in the pipeline, setting up for caching support.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
