### PR TITLE
Fix: Avoid baseUrl validation when it contains expressions

### DIFF
--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__invalid_source_url_template.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__invalid_source_url_template.graphql.snap
@@ -6,13 +6,6 @@ input_file: apollo-federation/src/connectors/validation/test_data/uri_templates/
 [
     Message {
         code: InvalidUrl,
-        message: "In `@source(baseURL:)`: Expression is not allowed to evaluate to arrays or objects.",
-        locations: [
-            7:40..7:57,
-        ],
-    },
-    Message {
-        code: InvalidUrl,
         message: "Invalid @source `baseURL` template: $args is not valid here, must be one of $config, $env",
         locations: [
             6:50..6:59,

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__valid_source_url_template.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__valid_source_url_template.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/connectors/validation/mod.rs
+expression: "format!(\"{:#?}\", result.errors)"
+input_file: apollo-federation/src/connectors/validation/test_data/uri_templates/valid_source_url_template.graphql
+---
+[]

--- a/apollo-federation/src/connectors/validation/test_data/uri_templates/valid_source_url_template.graphql
+++ b/apollo-federation/src/connectors/validation/test_data/uri_templates/valid_source_url_template.graphql
@@ -1,0 +1,18 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"])
+  @source(name: "v1", http: { baseURL: "https://{$env.var}:{$config.port}" })
+  @source(name: "v2", http: { baseURL: "https://{$env.ENVIRONMENT}" })
+  @source(name: "v3", http: { baseURL: "{$env.BASE_URL}" })
+  @source(
+    name: "v4"
+    http: {
+      baseURL: "http://{$env.ENVIRONMENT->eq('development')->match([true, 'localhost:20002'], [false, 'api.coolbeans.prod' ])}"
+    }
+  )
+
+type Query {
+  resources: [String!]! @connect(source: "v1", http: { GET: "/resources" }, selection: "$")
+  things: [String!]! @connect(source: "v2", http: { GET: "/things" }, selection: "$")
+  stuff: [String!]! @connect(source: "v3", http: { GET: "/stuff" }, selection: "$")
+  items: [String!]! @connect(source: "v4", http: { GET: "/items" }, selection: "$")
+}


### PR DESCRIPTION
With expressions, we don't know the values at composition time so we can't tell if it is valid. This can result in us saying it is NOT valid when at run time it would be.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
