### PR TITLE
refactor: add connector_service hook to headers plugin

### DIFF
--- a/apollo-router/src/plugin/test/mod.rs
+++ b/apollo-router/src/plugin/test/mod.rs
@@ -9,7 +9,7 @@ mod restricted;
 #[cfg(test)]
 pub use mock::connector::MockConnector;
 pub use mock::subgraph::MockSubgraph;
-pub use service::MockConnectService;
+pub use service::MockConnectorRequestService;
 pub use service::MockConnectorService;
 pub use service::MockExecutionService;
 pub use service::MockHttpClientService;

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -111,13 +111,13 @@ mock_service!(Execution, ExecutionRequest, ExecutionResponse);
 mock_service!(Subgraph, SubgraphRequest, SubgraphResponse);
 mock_service!(
     Connector,
-    connector::request_service::Request,
-    connector::request_service::Response
-);
-mock_service!(
-    Connect,
     crate::services::connect::Request,
     crate::services::connect::Response
+);
+mock_service!(
+    ConnectorRequest,
+    connector::request_service::Request,
+    connector::request_service::Response
 );
 mock_async_service!(HttpClient, HyperRequest<Body>, HyperResponse<Body>);
 

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -42,7 +42,6 @@ use crate::plugin::serde::deserialize_option_header_name;
 use crate::plugin::serde::deserialize_option_header_value;
 use crate::plugin::serde::deserialize_regex;
 use crate::services::SubgraphRequest;
-use crate::services::connector;
 use crate::services::subgraph;
 
 register_private_plugin!("apollo", "headers", Headers);
@@ -274,15 +273,17 @@ impl PluginPrivate for Headers {
             .boxed()
     }
 
-    fn connector_request_service(
+    fn connector_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
-        source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
+        _subgraph_name: &str,
+        source_name: &str,
+        _service_name: &str,
+        service: crate::services::connect::BoxService,
+    ) -> crate::services::connect::BoxService {
         ServiceBuilder::new()
             .layer(HeadersLayer::new(
                 self.connector_source_operations
-                    .get(&source_name)
+                    .get(source_name)
                     .cloned()
                     .unwrap_or_else(|| self.all_connector_operations.clone()),
             ))
@@ -356,9 +357,9 @@ where
     }
 }
 
-impl<S> Service<connector::request_service::Request> for HeadersService<S>
+impl<S> Service<crate::services::connect::Request> for HeadersService<S>
 where
-    S: Service<connector::request_service::Request>,
+    S: Service<crate::services::connect::Request>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -368,7 +369,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: connector::request_service::Request) -> Self::Future {
+    fn call(&mut self, mut req: crate::services::connect::Request) -> Self::Future {
         self.modify_connector_request(&mut req);
         self.inner.call(req)
     }
@@ -395,26 +396,28 @@ impl<S> HeadersService<S> {
         }
     }
 
-    fn modify_connector_request(&self, req: &mut connector::request_service::Request) {
-        let mut already_propagated: HashSet<String> = HashSet::new();
+    fn modify_connector_request(&self, req: &mut crate::services::connect::Request) {
+        for prepared_request in &mut req.prepared_requests {
+            let mut already_propagated: HashSet<String> = HashSet::new();
 
-        let TransportRequest::Http(ref mut http_request) = req.transport_request;
-        let body_to_value = serde_json::from_str(http_request.inner.body()).ok();
-        let supergraph_headers = req.supergraph_request.headers();
-        let context = &req.context;
-        // We need to know what headers were added prior to this processing to that we can properly override as needed
-        let existing_headers = http_request.inner.headers().clone();
-        let headers_mut = http_request.inner.headers_mut();
+            let TransportRequest::Http(ref mut http_request) = prepared_request.transport_request;
+            let body_to_value = serde_json::from_str(http_request.inner.body()).ok();
+            let supergraph_headers = prepared_request.supergraph_request.headers();
+            let context = &prepared_request.context;
+            // We need to know what headers were added prior to this processing to that we can properly override as needed
+            let existing_headers = http_request.inner.headers().clone();
+            let headers_mut = http_request.inner.headers_mut();
 
-        for operation in &*self.operations {
-            operation.process_header_rules(
-                &mut already_propagated,
-                supergraph_headers,
-                &body_to_value,
-                context,
-                headers_mut,
-                Some(&existing_headers),
-            );
+            for operation in &*self.operations {
+                operation.process_header_rules(
+                    &mut already_propagated,
+                    supergraph_headers,
+                    &body_to_value,
+                    context,
+                    headers_mut,
+                    Some(&existing_headers),
+                );
+            }
         }
     }
 }
@@ -633,6 +636,7 @@ mod test {
     use crate::query_planner::fetch::OperationKind;
     use crate::services::SubgraphRequest;
     use crate::services::SubgraphResponse;
+    use crate::services::connector;
 
     #[test]
     fn test_subgraph_config() {
@@ -1579,19 +1583,15 @@ mod test {
     }
 
     fn example_connector_response(
-        _req: connector::request_service::Request,
-    ) -> Result<connector::request_service::Response, BoxError> {
-        let key = ResponseKey::RootField {
-            name: "hello".to_string(),
-            inputs: Default::default(),
-            selection: Arc::new(JSONSelection::parse("$.data").unwrap()),
-        };
-        Ok(connector::request_service::Response::test_new(
-            key,
-            Vec::new(),
-            json!(""),
-            None,
-        ))
+        _req: crate::services::connect::Request,
+    ) -> Result<crate::services::connect::Response, BoxError> {
+        use crate::graphql;
+
+        Ok(crate::services::connect::Response {
+            response: http::Response::builder()
+                .body(graphql::Response::default())
+                .unwrap(),
+        })
     }
 
     fn example_request() -> SubgraphRequest {
@@ -1637,7 +1637,7 @@ mod test {
         }
     }
 
-    fn example_connector_request() -> connector::request_service::Request {
+    fn example_connector_request() -> crate::services::connect::Request {
         let ctx = Context::new();
         ctx.insert("my_key", "my_value_from_context".to_string())
             .unwrap();
@@ -1694,8 +1694,8 @@ mod test {
             debug: Default::default(),
         };
 
-        connector::request_service::Request {
-            context: ctx,
+        let prepared_request = connector::request_service::Request {
+            context: ctx.clone(),
             connector: Arc::new(connector),
             transport_request: http_request.into(),
             key,
@@ -1717,6 +1717,13 @@ mod test {
                     )
                     .expect("expecting valid request"),
             ),
+        };
+
+        crate::services::connect::Request {
+            service_name: "test_service".into(),
+            context: ctx,
+            prepared_requests: vec![prepared_request],
+            subgraph_name: "test_subgraph".to_string(),
         }
     }
 
@@ -1738,20 +1745,25 @@ mod test {
         }
     }
 
-    impl connector::request_service::Request {
+    impl crate::services::connect::Request {
         fn assert_headers(&self, headers: Vec<(&'static str, &'static str)>) -> bool {
             let mut headers = headers.clone();
             headers.push((HOST.as_str(), "rhost"));
             headers.push((CONTENT_LENGTH.as_str(), "22"));
             headers.push((CONTENT_TYPE.as_str(), "graphql"));
-            let TransportRequest::Http(ref http_request) = self.transport_request;
-            let actual_headers = http_request
-                .inner
-                .headers()
-                .iter()
-                .map(|(name, value)| (name.as_str(), value.to_str().unwrap()))
-                .collect::<HashSet<_>>();
-            assert_eq!(actual_headers, headers.into_iter().collect::<HashSet<_>>());
+            let expected_headers: HashSet<_> = headers.into_iter().collect();
+
+            // Check headers on all prepared requests
+            for prepared_request in &self.prepared_requests {
+                let TransportRequest::Http(ref http_request) = prepared_request.transport_request;
+                let actual_headers = http_request
+                    .inner
+                    .headers()
+                    .iter()
+                    .map(|(name, value)| (name.as_str(), value.to_str().unwrap()))
+                    .collect::<HashSet<_>>();
+                assert_eq!(actual_headers, expected_headers);
+            }
 
             true
         }


### PR DESCRIPTION
Add the connector_service hook implementation to the Headers plugin to support the new connector service architecture introduced in PR1. This ensures the headers plugin is properly integrated with the connector service chain.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
