### PR TITLE
fix(federation/composition): Don't error for `@join__field` on an input object field during API schema query graph creation

### DIFF
--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -121,7 +121,9 @@ pub fn build_supergraph_api_query_graph(
     let mut override_labels_by_field = IndexMap::default();
     for (pos, node) in join_field_applications {
         let Ok(pos) = FieldDefinitionPosition::try_from(pos.clone()) else {
-            bail!("unexpected @join__field directive application position at {pos}");
+            // @join__field can also appear on input object fields, which can't be overridden, so we
+            // just skip those fields here.
+            continue;
         };
         let args = join_spec.field_directive_arguments(node)?;
         if let Some(override_label) = args.override_label {


### PR DESCRIPTION
When creating the API schema query graph during composition, we collect which fields have progressive overrides along with their labels. We extract this from `@join__field` applications in the supergraph schema, but this extraction code was mistakenly bailing when `@join__field` was seen on an input object field (which they're allowed to be on). We now instead ignore such applications during extraction, as input object fields cannot be overridden.

<!-- FED-756 -->
