### PR TITLE
Port subscription merging integration tests

### DIFF
--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -1,6 +1,7 @@
 // TODO: Enable this test module when @composeDirective logic is implemented in FED-645
 // mod compose_directive;
 mod demand_control;
+mod subscription;
 mod validation_errors;
 
 pub(crate) mod test_helpers {

--- a/apollo-federation/tests/composition/subscription.rs
+++ b/apollo-federation/tests/composition/subscription.rs
@@ -1,0 +1,132 @@
+use crate::composition::ServiceDefinition;
+use crate::composition::test_helpers::compose_as_fed2_subgraphs;
+
+#[ignore = "until merge implementation completed"]
+#[test]
+fn type_subscription_appears_in_the_supergraph() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+                type Query {
+                    me: User!
+                }
+
+                type Subscription {
+                    onNewUser: User!
+                }
+
+                type User {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+                type Query {
+                    foo: Int
+                }
+
+                type Subscription {
+                    bar: Int
+                }
+            "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap();
+    let schema = result.schema().schema().to_string();
+    assert!(
+        schema.contains(r#"onNewUser: User! @join__field(graph: SUBGRAPHA)"#),
+        "expected Subscription.onNewUser to be owned by SUBGRAPHA with a join directive; schema was:\n{}",
+        schema
+    );
+}
+
+#[ignore = "until merge implementation completed"]
+#[test]
+fn directives_incompatible_with_subscriptions_wont_compose() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+                type Query {
+                    me: User!
+                }
+
+                type Subscription {
+                    onNewUser: User! @shareable
+                }
+
+                type User {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+                type Query {
+                    foo: Int
+                }
+
+                type Subscription {
+                    bar: Int
+                }
+            "#,
+    };
+
+    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap_err();
+    assert_eq!(errors.len(), 1);
+    let msg = errors.first().unwrap().to_string();
+    assert_eq!(
+        msg,
+        "Fields on root level subscription object cannot be marked as shareable"
+    );
+}
+
+#[ignore = "until merge implementation completed"]
+#[test]
+fn subscription_name_collisions_across_subgraphs_should_not_compose() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+                type Query {
+                    me: User!
+                }
+
+                type Subscription {
+                    onNewUser: User
+                    foo: Int!
+                }
+
+                type User {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+                type Query {
+                    foo: Int
+                }
+
+                type Subscription {
+                    foo: Int!
+                }
+            "#,
+    };
+
+    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap_err();
+    assert_eq!(errors.len(), 1);
+    let msg = errors.first().unwrap().to_string();
+    assert_eq!(
+        msg,
+        "Non-shareable field \"Subscription.foo\" is resolved from multiple subgraphs: it is resolved from subgraphs \"subgraphA\" and \"subgraphB\" and defined as non-shareable in all of them"
+    );
+}


### PR DESCRIPTION
Ports the three tests from [compose.subscription.test.ts](https://github.com/apollographql/federation/blob/main/composition-js/src/__tests__/compose.subscription.test.ts) around merging root subscriptions. These tests are currently set to ignore until the merge implementation can execute without panicking on todos.

<!-- [FED-689] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[FED-689]: https://apollographql.atlassian.net/browse/FED-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ