### PR TITLE
fix(federation/composition): fixed link alias handling in schema upgrading

### DIFF
--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -163,10 +163,13 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
             } else {
                 &mut types_by_imported_name
             };
+            // Conflicting imports are not allowed, except for duplicate imports within the same
+            // @link application. Although it's odd, JS composition allows it.
             if let Some((other_link, _)) = element_map.insert(
                 imported_name.clone(),
                 (Arc::clone(link), Arc::clone(import)),
-            ) {
+            ) && !Arc::ptr_eq(&other_link, link)
+            {
                 return Err(LinkError::BootstrapError(format!(
                     "name conflict: both {} and {} import {}",
                     link.url,

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -263,8 +263,11 @@ impl LinkSpecDefinition {
             purpose: None,
         });
         Ok(())
-            .and_try(create_link_purpose_type_spec().check_or_add(schema, Some(&mock_link)))
-            .and_try(create_link_import_type_spec().check_or_add(schema, Some(&mock_link)))
+            .and_try(
+                self.type_specs()
+                    .into_iter()
+                    .try_for_all(|spec| spec.check_or_add(schema, Some(&mock_link))),
+            )
             .and_try(
                 self.directive_specs()
                     .into_iter()

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -589,6 +589,52 @@ impl TypeDefinitionPosition {
             ),
         }
     }
+
+    pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<bool, FederationError> {
+        let is_some = match self {
+            TypeDefinitionPosition::Scalar(scalar_pos) => scalar_pos.remove(schema)?.is_some(),
+            TypeDefinitionPosition::Enum(enum_pos) => enum_pos.remove(schema)?.is_some(),
+            TypeDefinitionPosition::Object(object_pos) => object_pos.remove(schema)?.is_some(),
+            TypeDefinitionPosition::Interface(interface_pos) => {
+                interface_pos.remove(schema)?.is_some()
+            }
+            TypeDefinitionPosition::Union(union_pos) => union_pos.remove(schema)?.is_some(),
+            TypeDefinitionPosition::InputObject(input_object_pos) => {
+                input_object_pos.remove(schema)?.is_some()
+            }
+        };
+        Ok(is_some)
+    }
+
+    #[allow(unused)]
+    pub(crate) fn remove_recursive(
+        &self,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
+        match self {
+            TypeDefinitionPosition::Scalar(scalar_pos) => {
+                // Note: No `remove_recursive` for scalars
+                _ = scalar_pos.remove(schema)?;
+            }
+            TypeDefinitionPosition::Enum(enum_pos) => {
+                // Note: No `remove_recursive` for enums
+                _ = enum_pos.remove(schema)?;
+            }
+            TypeDefinitionPosition::Object(object_pos) => {
+                object_pos.remove_recursive(schema)?;
+            }
+            TypeDefinitionPosition::Interface(interface_pos) => {
+                interface_pos.remove_recursive(schema)?;
+            }
+            TypeDefinitionPosition::Union(union_pos) => {
+                union_pos.remove_recursive(schema)?;
+            }
+            TypeDefinitionPosition::InputObject(input_object_pos) => {
+                input_object_pos.remove_recursive(schema)?;
+            }
+        };
+        Ok(())
+    }
 }
 
 impl From<&ExtendedType> for TypeDefinitionPosition {

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -31,7 +31,7 @@ use crate::subgraph::SubgraphError;
 use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Upgraded;
-use crate::subgraph::typestate::add_federation_link_to_schema;
+use crate::subgraph::typestate::add_federation_link_to_test_schema;
 use crate::subgraph::typestate::expand_schema;
 use crate::supergraph::GRAPHQL_SUBSCRIPTION_TYPE_NAME;
 use crate::supergraph::remove_inactive_requires_and_provides_from_subgraph;
@@ -132,7 +132,7 @@ impl SchemaUpgrader {
 
         // re-expand all federation directive definitions
         let federation_spec = FederationSpecDefinition::auto_expanded_federation_spec();
-        add_federation_link_to_schema(&mut schema.schema, federation_spec.version())?;
+        add_federation_link_to_test_schema(&mut schema.schema, federation_spec.version())?;
         let mut schema = expand_schema(schema.into_inner())?;
 
         self.remove_external_on_interface(&mut schema);

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -19,11 +19,11 @@ use super::position::InterfaceFieldDefinitionPosition;
 use super::position::InterfaceTypeDefinitionPosition;
 use super::position::ObjectFieldDefinitionPosition;
 use super::position::ObjectTypeDefinitionPosition;
+use crate::bail;
 use crate::error::CompositionError;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
-use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::SchemaElement;
 use crate::schema::SubgraphMetadata;
@@ -31,8 +31,8 @@ use crate::subgraph::SubgraphError;
 use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Upgraded;
-use crate::subgraph::typestate::add_federation_link_to_test_schema;
 use crate::subgraph::typestate::expand_schema;
+use crate::subgraph::typestate::schema_as_fed2_subgraph;
 use crate::supergraph::GRAPHQL_SUBSCRIPTION_TYPE_NAME;
 use crate::supergraph::remove_inactive_requires_and_provides_from_subgraph;
 use crate::utils::FallibleIterator;
@@ -121,19 +121,12 @@ impl SchemaUpgrader {
         };
         self.pre_upgrade_validations(&upgrade_metadata, &subgraph)?;
 
-        // TODO avoid cloning here
-        let mut schema = subgraph.schema().clone();
+        // TODO avoid cloning the schema here
+        let mut schema = self.upgrade_spec_links(subgraph.schema().clone())?;
 
         // Fix federation directive arguments (fields) to ensure they're proper strings
         // Note: Implementation simplified for compilation purposes
         self.fix_federation_directives_arguments(&mut schema)?;
-
-        self.remove_links(&mut schema)?;
-
-        // re-expand all federation directive definitions
-        let federation_spec = FederationSpecDefinition::auto_expanded_federation_spec();
-        add_federation_link_to_test_schema(&mut schema.schema, federation_spec.version())?;
-        let mut schema = expand_schema(schema.into_inner())?;
 
         self.remove_external_on_interface(&mut schema);
 
@@ -166,6 +159,25 @@ impl SchemaUpgrader {
                 .map_err(|err| err.into_federation_error())?
                 .assume_upgraded();
         Ok(upgraded_subgraph)
+    }
+
+    fn upgrade_spec_links(
+        &self,
+        mut schema: FederationSchema,
+    ) -> Result<FederationSchema, FederationError> {
+        // PORT_NOTE: This is a new step in Rust composition. Since JS implementation does not
+        //            validate using undefined directives, fed2 directives can be used without
+        //            matching definitions. In Rust, all directive applications must be defined in
+        //            the schema and valid.
+
+        // Fed1 links and definitions are removed here, so we can add fed2 links below.
+        self.remove_fed1_links_and_definitions(&mut schema)?;
+
+        // Add link spec & federation 2 spec.
+        let inner_schema = schema_as_fed2_subgraph(schema, false)?;
+
+        // re-expand all federation directive definitions
+        expand_schema(inner_schema)
     }
 
     // integrates checkForExtensionWithNoBase from the JS code
@@ -278,7 +290,19 @@ impl SchemaUpgrader {
         Ok(())
     }
 
-    fn remove_links(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+    fn remove_fed1_links_and_definitions(
+        &self,
+        schema: &mut FederationSchema,
+    ) -> Result<(), FederationError> {
+        let Some(metadata) = schema.metadata() else {
+            bail!("Schema must have metadata to upgrade");
+        };
+        let link_spec = metadata.link_spec_definition()?;
+        let Some(link_link) = link_spec.link_in_schema(schema)? else {
+            bail!("Schema must have a link spec link to upgrade");
+        };
+        let link_name_in_schema = link_link.spec_name_in_schema().clone();
+
         // for @core, we want to remove both the definition and all references, but for other
         // federation directives, just remove the definitions
         let directives_to_remove = [
@@ -308,21 +332,31 @@ impl SchemaUpgrader {
                             &definition.directive_name
                         ),
                     })?;
-            } else if definition.directive_name == name!("core") {
+            } else if definition.directive_name == *link_name_in_schema {
                 definition.remove(schema)?;
             }
         }
 
         // now remove other federation types
-        if let Some(TypeDefinitionPosition::Enum(enum_obj)) =
-            schema.try_get_type(name!("core__Purpose"))
-        {
-            enum_obj.remove(schema)?;
-        }
-        if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) =
-            schema.try_get_type(name!("core__Import"))
-        {
-            scalar_obj.remove(schema)?;
+        for type_spec in link_spec.type_specs() {
+            let type_name_in_schema = link_link.type_name_in_schema(type_spec.name());
+            if let Some(type_pos) = schema.try_get_type(type_name_in_schema.clone()) {
+                match type_pos {
+                    TypeDefinitionPosition::Enum(enum_pos) => {
+                        enum_pos.remove(schema)?;
+                    }
+                    TypeDefinitionPosition::Scalar(scalar_pos) => {
+                        scalar_pos.remove(schema)?;
+                    }
+                    _ => {
+                        bail!(
+                            "unexpected type kind `{type_kind}` for `{type_name_in_schema}` (spec name: {spec_name})",
+                            type_kind = type_pos.kind(),
+                            spec_name = type_spec.name(),
+                        )
+                    }
+                }
+            }
         }
         if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) =
             schema.try_get_type(name!("_FieldSet"))

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -341,21 +341,7 @@ impl SchemaUpgrader {
         for type_spec in link_spec.type_specs() {
             let type_name_in_schema = link_link.type_name_in_schema(type_spec.name());
             if let Some(type_pos) = schema.try_get_type(type_name_in_schema.clone()) {
-                match type_pos {
-                    TypeDefinitionPosition::Enum(enum_pos) => {
-                        enum_pos.remove(schema)?;
-                    }
-                    TypeDefinitionPosition::Scalar(scalar_pos) => {
-                        scalar_pos.remove(schema)?;
-                    }
-                    _ => {
-                        bail!(
-                            "unexpected type kind `{type_kind}` for `{type_name_in_schema}` (spec name: {spec_name})",
-                            type_kind = type_pos.kind(),
-                            spec_name = type_spec.name(),
-                        )
-                    }
-                }
+                type_pos.remove(schema)?;
             }
         }
         if let Some(TypeDefinitionPosition::Scalar(scalar_obj)) =

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -1496,4 +1496,17 @@ mod tests {
             Some(name!("MySubscription")).as_ref()
         );
     }
+
+    #[test]
+    fn allows_duplicate_imports_within_same_link() {
+        // This test used to panic.
+        let schema_doc = r#"
+          extend schema @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key" "@key"])
+          type Query { test: Int! }
+        "#;
+        Subgraph::parse("subgraph", "subgraph.graphql", schema_doc)
+            .expect("parses schema")
+            .expand_links()
+            .expect("expands links");
+    }
 }

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -963,6 +963,34 @@ mod tests {
     }
 
     #[test]
+    fn implilcit_fed1_link_does_not_add_import_type() {
+        let subgraph = Subgraph::parse(
+            "S",
+            "",
+            r#"
+                type Query {
+                    s: String
+                }"#,
+        )
+        .expect("valid schema")
+        .expand_links()
+        .expect("expands subgraph");
+
+        let mut defined_type_names = subgraph
+            .state
+            .schema
+            .schema()
+            .types
+            .keys()
+            .filter(|k| k.starts_with("core__"))
+            .cloned()
+            .collect::<Vec<_>>();
+        defined_type_names.sort();
+
+        assert_eq!(defined_type_names, vec![name!("core__Purpose")]);
+    }
+
+    #[test]
     fn injects_missing_directive_definitions_fed_2_0() {
         let subgraph = Subgraph::parse(
             "S",

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -444,7 +444,7 @@ impl<S: HasMetadata> Subgraph<S> {
 /// - Similar to `add_fed1_link_to_schema` & `schema_as_fed2_subgraph`, but the link can be added
 ///   before collecting metadata.
 /// - This is mainly for testing.
-pub(crate) fn add_federation_link_to_test_schema(
+fn add_federation_link_to_test_schema(
     schema: &mut Schema,
     federation_version: &Version,
 ) -> Result<(), FederationError> {
@@ -502,13 +502,12 @@ fn add_fed1_link_to_schema(
         })],
     };
     let origin = schema.schema().schema_definition.origin_to_use();
-    crate::schema::position::SchemaDefinitionPosition.insert_directive_at(
+    crate::schema::position::SchemaDefinitionPosition.insert_directive(
         schema,
         Component {
             origin,
             node: directive.into(),
         },
-        0, // @link to link spec should be first
     )
 }
 

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -962,7 +962,7 @@ mod tests {
     }
 
     #[test]
-    fn implilcit_fed1_link_does_not_add_import_type() {
+    fn implicit_fed1_link_does_not_add_import_type() {
         let subgraph = Subgraph::parse(
             "S",
             "",

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -181,19 +181,9 @@ impl Subgraph<Initial> {
         } else {
             FederationSpecDefinition::auto_expanded_federation_spec()
         };
-        add_federation_link_to_schema(&mut schema, federation_spec.version())
+        add_federation_link_to_test_schema(&mut schema, federation_spec.version())
             .map_err(|e| SubgraphError::new_without_locations(self.name.clone(), e))?;
         Ok(Self::new(&self.name, &self.url, schema))
-    }
-
-    /// Converts the schema to a fed2 schema.
-    /// - It is assumed to have no federation spec link.
-    /// - Returns an equivalent subgraph with a `@link` to the auto expanded federation spec.
-    /// - Similar to `into_fed2_test_subgraph`, but more robust.
-    pub fn into_fed2_subgraph(self) -> Result<Self, FederationError> {
-        let schema = new_federation_subgraph_schema(self.state.schema)?;
-        let inner_schema = schema_as_fed2_subgraph(schema, false)?;
-        Ok(Self::new(&self.name, &self.url, inner_schema))
     }
 
     pub fn assume_expanded(self) -> Result<Subgraph<Expanded>, SubgraphError> {
@@ -454,7 +444,7 @@ impl<S: HasMetadata> Subgraph<S> {
 /// - Similar to `add_fed1_link_to_schema` & `schema_as_fed2_subgraph`, but the link can be added
 ///   before collecting metadata.
 /// - This is mainly for testing.
-pub(crate) fn add_federation_link_to_schema(
+pub(crate) fn add_federation_link_to_test_schema(
     schema: &mut Schema,
     federation_version: &Version,
 ) -> Result<(), FederationError> {
@@ -495,7 +485,7 @@ pub(crate) fn add_federation_link_to_schema(
 
 /// Turns a schema without a federation spec link into a federation 1 subgraph schema.
 /// - Adds a fed 1 spec link directive to the schema.
-pub(crate) fn add_fed1_link_to_schema(
+fn add_fed1_link_to_schema(
     schema: &mut FederationSchema,
     link_spec: &LinkSpecDefinition,
     link_name_in_schema: Name,
@@ -523,40 +513,40 @@ pub(crate) fn add_fed1_link_to_schema(
 }
 
 /// Turns a schema without a federation spec link into a federation 2 subgraph schema.
-/// - It may have a link spec, but it must not have a federation spec.
-/// - This is related to `add_federation_link_to_schema` but for real subgraphs.
+/// - The schema must not have a federation spec. But, it may have a link spec.
+/// - This is used for fed1-to-fed2 schema upgrading.
+/// - Also, it is used by `new_empty_federation_2_subgraph_schema`.
 // PORT_NOTE: This corresponds to the `setSchemaAsFed2Subgraph` function in JS.
 //            The inner Schema is not exposed as mutable at the moment. So, this function consumes
 //            the input and returns the updated inner Schema.
-fn schema_as_fed2_subgraph(
+pub(crate) fn schema_as_fed2_subgraph(
     mut schema: FederationSchema,
     use_latest: bool,
 ) -> Result<Schema, FederationError> {
-    let (link_spec, metadata) = if let Some(metadata) = schema.metadata() {
-        let spec = metadata.link_spec_definition()?;
+    let (link_name_in_schema, metadata) = if let Some(metadata) = schema.metadata() {
+        let link_spec = metadata.link_spec_definition()?;
         // We don't accept pre-1.0 @core: this avoid having to care about what the name
         // of the argument below is, and why would be bother?
         ensure!(
-            spec.url()
+            link_spec
+                .url()
                 .version
                 .satisfies(LinkSpecDefinition::latest().version()),
             "Fed2 schema must use @link with version >= 1.0, but schema uses {spec_url}",
-            spec_url = spec.url()
+            spec_url = link_spec.url()
         );
-        (spec, metadata)
+        let Some(link) = link_spec.link_in_schema(&schema)? else {
+            bail!("Core schema is missing the link spec link directive");
+        };
+        (link.spec_name_in_schema().clone(), metadata)
     } else {
-        let default_link_name = &LinkSpecDefinition::latest().identity().name;
-        let alias = find_unused_name_for_directive(&schema, default_link_name)?;
-        LinkSpecDefinition::latest().add_to_schema(&mut schema, alias)?;
+        let link_spec = LinkSpecDefinition::latest();
+        let link_name_in_schema = add_link_spec_to_schema(&mut schema, link_spec)?;
         schema.collect_links_metadata()?;
         let Some(metadata) = schema.metadata() else {
             bail!("Schema should now be a core schema")
         };
-        (LinkSpecDefinition::latest(), metadata)
-    };
-
-    let Some(link) = link_spec.link_in_schema(&schema)? else {
-        bail!("Core schema is missing @link directive");
+        (link_name_in_schema, metadata)
     };
 
     let fed_spec = if use_latest {
@@ -591,7 +581,7 @@ fn schema_as_fed2_subgraph(
         .make_mut()
         .directives
         .push(Component::new(Directive {
-            name: link.spec_name_in_schema().clone(),
+            name: link_name_in_schema,
             arguments: vec![
                 Node::new(ast::Argument {
                     name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
@@ -743,14 +733,25 @@ fn bootstrap_spec_links(schema: &mut FederationSchema) -> Result<(), FederationE
             let link_spec = LinkSpecDefinition::fed1_latest();
             // PORT_NOTE: JS version doesn't add link specs here, (maybe) due to a potential name
             //            conflict. We generate an alias to avoid conflicts, if necessary.
-            let link_spec_name = &link_spec.identity().name;
-            let alias = find_unused_name_for_directive(schema, link_spec_name)?;
-            let link_name_in_schema = alias.clone().unwrap_or_else(|| link_spec_name.clone());
-            link_spec.add_to_schema(schema, alias)?;
+            let link_name_in_schema = add_link_spec_to_schema(schema, link_spec)?;
             add_fed1_link_to_schema(schema, link_spec, link_name_in_schema)?;
         }
     }
     Ok(())
+}
+
+/// Add `@link` (or `@core` if fed1) to the `schema` definition.
+/// - Potentially, alias the directive name to avoid conflicts.
+/// - Returns the determined link directive name in schema.
+fn add_link_spec_to_schema(
+    schema: &mut FederationSchema,
+    link_spec: &'static LinkSpecDefinition,
+) -> Result<Name, FederationError> {
+    let link_spec_name = &link_spec.identity().name;
+    let alias = find_unused_name_for_directive(schema, link_spec_name)?;
+    let link_name_in_schema = alias.clone().unwrap_or_else(|| link_spec_name.clone());
+    link_spec.add_to_schema(schema, alias)?;
+    Ok(link_name_in_schema)
 }
 
 fn has_federation_spec_link(schema: &Schema) -> bool {

--- a/apollo-federation/tests/composition/demand_control.rs
+++ b/apollo-federation/tests/composition/demand_control.rs
@@ -86,7 +86,7 @@ fn subgraph_with_renamed_cost() -> Subgraph<Initial> {
       scalarWithCost: ExpensiveInt
       objectWithCost: ExpensiveObject
     }
-    "#).unwrap().into_fed2_subgraph().unwrap()
+    "#).unwrap().into_fed2_test_subgraph(false).unwrap()
 }
 
 fn subgraph_with_renamed_listsize() -> Subgraph<Initial> {
@@ -103,7 +103,7 @@ fn subgraph_with_renamed_listsize() -> Subgraph<Initial> {
       fieldWithListSize: [String!] @renamedListSize(assumedSize: 2000, requireOneSlicingArgument: false)
       fieldWithDynamicListSize(first: Int!): HasInts @renamedListSize(slicingArguments: ["first"], sizedFields: ["ints"], requireOneSlicingArgument: true)
     }
-    "#).unwrap().into_fed2_subgraph().unwrap()
+    "#).unwrap().into_fed2_test_subgraph(false).unwrap()
 }
 
 fn subgraph_with_cost_from_federation_spec() -> Subgraph<Initial> {


### PR DESCRIPTION
### Problem

The schema upgrader didn't recognize renamed link directives previously.
Also, the upgrader used to call`add_federation_link_to_schema`, which was meant for testing and didn't handle link directive name conflicts.

### Fix Summary

#### Main fix

- fixed schema upgrader to correctly remove renamed link specs from the original schema
- fixed schema upgrader to avoid link directive name conflicts in the upgraded schemas (using `schema_as_fed2_subgraph`)

#### Cosmetic improvements in the expanded subgraph schema
- fixed `add_definitions_to_schema` not to add an unnecessary `Import` type spec for `@core`
- fixed `add_fed1_link_to_schema` not to add fed1 spec ahead of the link spec itself.

### Reviewer Note

This PR has 3 commits and it will be easier to review commit by commit:

- The first is a pure refactoring intended for making it easier to implement the fix.
- The second commit is for tests. This commit can be used to reproduce the errors.
- The last commit is actual fix.

<!-- [FED-752] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This PR is for unreleased composition feature.

[FED-752]: https://apollographql.atlassian.net/browse/FED-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ