### PR TITLE
Fix _entities Apollo Error Metrics Missing Service Attribute

### DIFF
--- a/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
+++ b/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
@@ -222,6 +222,84 @@ async fn test_subgraph_layer_error_emits_metric() {
     router.graceful_shutdown().await;
 }
 
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subgraph_layer_entities_error_emits_metric() {
+    if !graph_os_enabled() {
+        return;
+    }
+    let expected_service = "products";
+    let expected_error_code = "SUBGRAPH_CODE";
+    let expected_client_name = "CLIENT_NAME";
+    let expected_client_version = "v0.14";
+    let expected_path = "/_entities/0/name";
+
+    let mut router = IntegrationTest::builder()
+        .telemetry(Telemetry::Otlp { endpoint: None })
+        .config(
+            r#"
+            telemetry:
+              apollo:
+                experimental_otlp_metrics_protocol: http
+                batch_processor:
+                  scheduled_delay: 10ms
+                errors:
+                  preview_extended_error_metrics: enabled
+        "#,
+        )
+        .responder(
+            ResponseTemplate::new(200).set_body_json(
+                graphql::Response::builder()
+                    .data(json!({"data": {"_entities": [{"name": null}]}}))
+                    .errors(vec![
+                        graphql::Error::builder()
+                            .message("error in subgraph layer")
+                            // Explicitly exclude setting service as it should get populated by subgraph_service
+                            .extension_code(expected_error_code)
+                            // Path must not have leading slash to match expected
+                            .path("_entities/0/name")
+                            .build(),
+                    ])
+                    .build(),
+            ),
+        )
+        .build()
+        .await;
+
+                                                                                                                                                                                                                                        router.start().await;
+    router.assert_started().await;
+
+    router
+        .execute_query(
+            Query::builder()
+                .header("apollographql-client-name", expected_client_name)
+                .header("apollographql-client-version", expected_client_version)
+                .build(),
+        )
+        .await;
+
+    let metrics = router
+        .wait_for_emitted_otel_metrics(Duration::from_millis(20))
+        .await;
+
+    assert!(!metrics.is_empty());
+    assert_metrics_contain(
+        &metrics,
+        Metric::builder()
+            .name("apollo.router.operations.error".to_string())
+            .attribute("graphql.operation.name", "ExampleQuery")
+            .attribute("graphql.operation.type", "query")
+            .attribute("apollo.client.name", expected_client_name)
+            .attribute("apollo.client.version", expected_client_version)
+            .attribute("graphql.error.extensions.code", expected_error_code)
+            .attribute("apollo.router.error.service", expected_service)
+            .attribute("graphql.error.path", expected_path)
+            .value(1)
+            .build(),
+    );
+    router.graceful_shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_include_subgraph_error_disabled_does_not_redact_error_metrics() {
     if !graph_os_enabled() {


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-####] -->
---
Error counting https://github.com/apollographql/router/pull/7712 introduced a bug where `_entities` errors no longer reported a service (subgraph or connector) attribute. This erroneously categorized these errors as from the Router rather than their originating service.

This fixes the bug by re-adding this attribute.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
