### PR TITLE
fix(federation/composition): internal error "Type XX was unexpectedly not a composite type"

### DIFF
--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -2041,9 +2041,13 @@ fn remove_inactive_applications(
                 let fields = federation_spec_definition
                     .provides_directive_arguments(directive)?
                     .fields;
-                let parent_type_pos: CompositeTypeDefinitionPosition = schema
-                    .get_type(field.ty.inner_named_type().clone())?
-                    .try_into()?;
+                let Ok(parent_type_pos) = CompositeTypeDefinitionPosition::try_from(
+                    schema.get_type(field.ty.inner_named_type().clone())?,
+                ) else {
+                    // PORT_NOTE: JS composition ignores this error. A proper field set validation
+                    //            should be done elsewhere.
+                    continue;
+                };
                 (fields, parent_type_pos, schema.schema())
             }
             FieldSetDirectiveKind::Requires => {


### PR DESCRIPTION
During `remove_inactive_applications`, field set could be invalid, but the function is not supposed to fail for that, since actual field set validation should be done elsewhere. The JS version skips any field set errors ([github](https://github.com/apollographql/federation/blob/e17173bf9e7b3fdee42a9ee0ac4bd269de67e374/internals-js/src/federation.ts#L2818)).

This PR skips the `@provides`/`@requires` field-set type check in `remove_inactive_applications`. So, we do not report it as an internal error.

<!-- [FED-751] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary