### PR TITLE
fix(federation/composition): suppress `TYPE_DEFINITION_INVALID` error - "Invalid definition of type _Entity"

### DIFF
--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -777,9 +777,13 @@ fn is_fed_spec_link_directive(schema: &Schema, directive: &Directive) -> bool {
 impl FederationSchema {
     fn add_federation_operations(&mut self) -> Result<(), FederationError> {
         // Add federation operation types
-        ANY_TYPE_SPEC.check_or_add(self, None)?;
-        SERVICE_TYPE_SPEC.check_or_add(self, None)?;
-        self.entity_type_spec()?.check_or_add(self, None)?;
+        // PORT_NOTE: The JS version ignores errors from these check-or-add calls.
+        //            (https://github.com/apollographql/federation/blob/e17173bf9e7b3fdee42a9ee0ac4bd269de67e374/internals-js/src/federation.ts#L2505)
+        //            Many corpus subgraphs have `_Entity` definitions that do not exactly match
+        //            the one computed by composition. Reporting error here will break them.
+        _ = ANY_TYPE_SPEC.check_or_add(self, None);
+        _ = SERVICE_TYPE_SPEC.check_or_add(self, None);
+        _ = self.entity_type_spec()?.check_or_add(self, None);
 
         // Add the root `Query` Type (if not already present) and get the actual name in the schema.
         let query_root_pos = SchemaRootDefinitionPosition {

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -1510,4 +1510,42 @@ mod tests {
             .expand_links()
             .expect("expands links");
     }
+
+    #[test]
+    fn ignores_unexpected_custom_entity_type_spec() {
+        // This test used to panic.
+        // The `_Entity` type is not expected to be defined, but defined.
+        let schema_doc = r#"
+            union _Entity = Int
+        "#;
+        Subgraph::parse("subgraph", "subgraph.graphql", schema_doc)
+            .expect("parses schema")
+            .expand_links()
+            .expect("expands links");
+    }
+
+    #[test]
+    fn ignores_custom_entity_type_spec_even_when_incorrectly_defined() {
+        // This test used to panic.
+        // When `_Entity` type is expected to be defined, but defined incorrectly.
+        let schema_doc = r#"
+            type X {
+                data: Int!
+            }
+
+            type Y @key(fields: "id") {
+                id: ID!
+            }
+
+            union _Entity = X
+
+            type Query {
+                test: X
+            }
+        "#;
+        Subgraph::parse("subgraph", "subgraph.graphql", schema_doc)
+            .expect("parses schema")
+            .expand_links()
+            .expect("expands links");
+    }
 }


### PR DESCRIPTION
The JS composition ignores unexpected/incorrect `_Entity` type definitions in subgraphs ([github](https://github.com/apollographql/federation/blob/e17173bf9e7b3fdee42a9ee0ac4bd269de67e374/internals-js/src/federation.ts#L2505)).
This PR follows the suite in Rust composition to avoid spurious composition errors.

<!-- [FED-765] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary