### PR TITLE
fix(subscription): fix deduplication and websocket stream termination (backport #8104)

### DIFF
--- a/.changesets/fix_bnjjj_fix_subs_closing.md
+++ b/.changesets/fix_bnjjj_fix_subs_closing.md
@@ -1,0 +1,7 @@
+### Fix deduplication and websocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))
+
+Fixes an issue where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.
+
+Previously, when clients disconnected from subscription streams, the router would correctly close client connections but would leave the underlying WebSocket connection to the subgraph open indefinitely in some cases.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/8104

--- a/apollo-router/src/notification.rs
+++ b/apollo-router/src/notification.rs
@@ -53,11 +53,14 @@ pub(crate) enum NotifyError<K, V> {
 type ResponseSender<V> =
     oneshot::Sender<Option<(broadcast::Sender<Option<V>>, broadcast::Receiver<Option<V>>)>>;
 
-type ResponseSenderWithCreated<V> = oneshot::Sender<(
-    broadcast::Sender<Option<V>>,
-    broadcast::Receiver<Option<V>>,
-    bool,
-)>;
+pub(crate) struct CreatedTopicPayload<V> {
+    msg_sender: broadcast::Sender<Option<V>>,
+    msg_receiver: broadcast::Receiver<Option<V>>,
+    closing_signal: broadcast::Receiver<()>,
+    created: bool,
+}
+
+type ResponseSenderWithCreated<V> = oneshot::Sender<CreatedTopicPayload<V>>;
 
 pub(crate) enum Notification<K, V> {
     CreateOrSubscribe {
@@ -212,13 +215,63 @@ where
         Ok(())
     }
 
-    // boolean in the tuple means `created`
+    /// Creates or subscribes to a topic, returning a handle and subscription state.
+    ///
+    /// The `Ok()` branch of the `Result` is a tuple, where:
+    ///     - .0: a `Handle` on the subscription event listener,
+    ///     - .1: a boolean, where
+    ///              - `true`: call to this fn `created` this subscription, and
+    ///              - `false`: call to this fn was for a deduplicated subscription
+    ///                         i.e. subscription already exists,
+    ///     - .2: a closing signal in a form of `broadcast::Receiver` that gets
+    ///            triggered once the subscription is closed.
+    ///
+    /// # Closing Signal Usage
+    ///
+    /// The closing signal's usage depends on how subscriptions are managed:
+    ///
+    /// ## Callback Mode (HTTP-based subscriptions)
+    /// - The closing signal is typically **unused** as there are no long-running
+    ///   forwarding tasks to clean up
+    /// - Subscriptions are managed via HTTP callbacks to a public URL
+    /// - Subscription lifecycle is controlled through HTTP responses (404 closes the subscription)
+    /// - Always called with `heartbeat_enabled = true` to enable TTL-based timeout checking
+    ///
+    /// ## Passthrough Mode (WebSocket-based subscriptions)  
+    /// - The closing signal **must be monitored** by the forwarding task using `tokio::select!`
+    /// - Maintains persistent WebSocket connections to subgraphs
+    /// - Needed for proper cleanup when subscriptions are terminated, especially important
+    ///   for deduplication (multiple clients may share one subgraph connection)
+    /// - Always called with `heartbeat_enabled = false` as WebSockets have their own
+    ///   connection management
+    ///
+    /// # Parameters
+    /// - `topic`: The subscription topic identifier
+    /// - `heartbeat_enabled`: Controls TTL-based timeout checking at the notification layer:
+    ///   - `true`: Enables TTL checking. For callback mode, subscriptions will timeout if
+    ///     no heartbeat is received within the TTL period. The actual heartbeat interval
+    ///     is configured separately and sent to subgraphs in the subscription extension.
+    ///     When subgraphs send heartbeat messages, they're processed via `invalid_ids()`
+    ///     which calls `touch()` to update the subscription's `updated_at` timestamp.
+    ///   - `false`: Disables TTL checking (used by passthrough/WebSocket mode)
+    /// - `operation_name`: Optional GraphQL operation name for metrics
+    ///
+    /// # Heartbeat Processing for Callback Mode
+    ///
+    /// When callback mode is configured with a heartbeat interval:
+    /// 1. The interval is converted to milliseconds and sent to the subgraph as
+    ///    `heartbeat_interval_ms` in the subscription extension
+    /// 2. Subgraphs send periodic heartbeat callbacks with subscription IDs
+    /// 3. The heartbeat handler validates IDs and calls `notify.invalid_ids()`
+    /// 4. This updates each valid subscription's timestamp via `touch()`
+    /// 5. The TTL checker uses these timestamps to determine if subscriptions are alive
+    ///    and closes those that haven't been touched within the TTL period
     pub(crate) async fn create_or_subscribe(
         &mut self,
         topic: K,
         heartbeat_enabled: bool,
         operation_name: Option<String>,
-    ) -> Result<(Handle<K, V>, bool), NotifyError<K, V>> {
+    ) -> Result<(Handle<K, V>, bool, broadcast::Receiver<()>), NotifyError<K, V>> {
         let (sender, _receiver) =
             broadcast::channel(self.queue_size.unwrap_or(DEFAULT_MSG_CHANNEL_SIZE));
 
@@ -233,7 +286,12 @@ where
             })
             .await?;
 
-        let (msg_sender, msg_receiver, created) = rx.await?;
+        let CreatedTopicPayload {
+            msg_sender,
+            msg_receiver,
+            closing_signal,
+            created,
+        } = rx.await?;
         let handle = Handle::new(
             topic,
             self.sender.clone(),
@@ -241,7 +299,7 @@ where
             BroadcastStream::from(msg_receiver),
         );
 
-        Ok((handle, created))
+        Ok((handle, created, closing_signal))
     }
 
     pub(crate) async fn subscribe(&mut self, topic: K) -> Result<Handle<K, V>, NotifyError<K, V>> {
@@ -702,6 +760,7 @@ async fn task<K, V>(
 #[derive(Debug)]
 struct Subscription<V> {
     msg_sender: broadcast::Sender<Option<V>>,
+    closing_signal: broadcast::Sender<()>,
     heartbeat_enabled: bool,
     updated_at: Instant,
     operation_name: Option<String>,
@@ -710,11 +769,13 @@ struct Subscription<V> {
 impl<V> Subscription<V> {
     fn new(
         msg_sender: broadcast::Sender<Option<V>>,
+        closing_signal: broadcast::Sender<()>,
         heartbeat_enabled: bool,
         operation_name: Option<String>,
     ) -> Self {
         Self {
             msg_sender,
+            closing_signal,
             heartbeat_enabled,
             updated_at: Instant::now(),
             operation_name,
@@ -723,6 +784,10 @@ impl<V> Subscription<V> {
     // Update the updated_at value
     fn touch(&mut self) {
         self.updated_at = Instant::now();
+    }
+
+    fn closing_signal(&self) -> broadcast::Receiver<()> {
+        self.closing_signal.subscribe()
     }
 }
 
@@ -765,12 +830,18 @@ where
         sender: broadcast::Sender<Option<V>>,
         heartbeat_enabled: bool,
         operation_name: Option<String>,
-    ) {
+    ) -> broadcast::Receiver<()> {
+        let (closing_signal_tx, closing_signal_rx) = broadcast::channel(1);
         let existed = self
             .subscriptions
             .insert(
                 topic,
-                Subscription::new(sender, heartbeat_enabled, operation_name.clone()),
+                Subscription::new(
+                    sender,
+                    closing_signal_tx,
+                    heartbeat_enabled,
+                    operation_name.clone(),
+                ),
             )
             .is_some();
         if !existed {
@@ -781,6 +852,8 @@ where
                 graphql.operation.name = operation_name.unwrap_or_default()
             );
         }
+
+        closing_signal_rx
     }
 
     fn subscribe(&mut self, topic: K, sender: ResponseSender<V>) {
@@ -807,16 +880,23 @@ where
     ) {
         match self.subscriptions.get(&topic) {
             Some(subscription) => {
-                let _ = sender.send((
-                    subscription.msg_sender.clone(),
-                    subscription.msg_sender.subscribe(),
-                    false,
-                ));
+                let _ = sender.send(CreatedTopicPayload {
+                    msg_sender: subscription.msg_sender.clone(),
+                    msg_receiver: subscription.msg_sender.subscribe(),
+                    closing_signal: subscription.closing_signal(),
+                    created: false,
+                });
             }
             None => {
-                self.create_topic(topic, msg_sender.clone(), heartbeat_enabled, operation_name);
+                let closing_signal =
+                    self.create_topic(topic, msg_sender.clone(), heartbeat_enabled, operation_name);
 
-                let _ = sender.send((msg_sender.clone(), msg_sender.subscribe(), true));
+                let _ = sender.send(CreatedTopicPayload {
+                    msg_sender: msg_sender.clone(),
+                    msg_receiver: msg_sender.subscribe(),
+                    closing_signal,
+                    created: true,
+                });
             }
         }
     }
@@ -829,17 +909,9 @@ where
             }
             None => tracing::trace!("Cannot find the subscription to unsubscribe"),
         }
-        #[allow(clippy::collapsible_if)]
         if topic_to_delete {
             tracing::trace!("deleting subscription from unsubscribe");
-            if let Some(sub) = self.subscriptions.remove(&topic) {
-                i64_up_down_counter!(
-                    "apollo.router.opened.subscriptions",
-                    "Number of opened subscriptions",
-                    -1,
-                    graphql.operation.name = sub.operation_name.unwrap_or_default()
-                );
-            }
+            self.force_delete(topic);
         };
     }
 
@@ -905,20 +977,9 @@ where
             self.subscriptions = remaining_subs;
 
             // Send error message to all killed connections
-            for (_subscriber_id, subscription) in closed_subs {
+            for (_, subscription) in closed_subs {
                 tracing::trace!("deleting subscription from kill_dead_topics");
-                i64_up_down_counter!(
-                    "apollo.router.opened.subscriptions",
-                    "Number of opened subscriptions",
-                    -1,
-                    graphql.operation.name = subscription.operation_name.unwrap_or_default()
-                );
-                if let Some(heartbeat_error_message) = &heartbeat_error_message {
-                    let _ = subscription
-                        .msg_sender
-                        .send(heartbeat_error_message.clone().into());
-                    let _ = subscription.msg_sender.send(None);
-                }
+                self._force_delete(subscription, heartbeat_error_message.as_ref());
             }
         }
     }
@@ -938,14 +999,23 @@ where
         tracing::trace!("deleting subscription from force_delete");
         let sub = self.subscriptions.remove(&topic);
         if let Some(sub) = sub {
-            i64_up_down_counter!(
-                "apollo.router.opened.subscriptions",
-                "Number of opened subscriptions",
-                -1,
-                graphql.operation.name = sub.operation_name.unwrap_or_default()
-            );
-            let _ = sub.msg_sender.send(None);
+            self._force_delete(sub, None);
         }
+    }
+
+    fn _force_delete(&mut self, sub: Subscription<V>, error_message: Option<&V>) {
+        tracing::trace!("deleting subscription from _force_delete");
+        i64_up_down_counter!(
+            "apollo.router.opened.subscriptions",
+            "Number of opened subscriptions",
+            -1,
+            graphql.operation.name = sub.operation_name.unwrap_or_default()
+        );
+        if let Some(error_message) = error_message {
+            let _ = sub.msg_sender.send(error_message.clone().into());
+        }
+        let _ = sub.msg_sender.send(None);
+        let _ = sub.closing_signal.send(());
     }
 
     #[cfg(test)]
@@ -1022,12 +1092,12 @@ mod tests {
         let topic_1 = Uuid::new_v4();
         let topic_2 = Uuid::new_v4();
 
-        let (handle1, created) = notify
+        let (handle1, created, mut subscription_closing_signal_1) = notify
             .create_or_subscribe(topic_1, false, None)
             .await
             .unwrap();
         assert!(created);
-        let (_handle2, created) = notify
+        let (_handle2, created, mut subscription_closing_signal_2) = notify
             .create_or_subscribe(topic_2, false, None)
             .await
             .unwrap();
@@ -1059,6 +1129,9 @@ mod tests {
 
         let subscriptions_nb = notify.debug().await.unwrap();
         assert_eq!(subscriptions_nb, 0);
+
+        subscription_closing_signal_1.try_recv().unwrap();
+        subscription_closing_signal_2.try_recv().unwrap();
     }
 
     #[tokio::test]
@@ -1067,12 +1140,12 @@ mod tests {
         let topic_1 = Uuid::new_v4();
         let topic_2 = Uuid::new_v4();
 
-        let (handle1, created) = notify
+        let (handle1, created, mut subscription_closing_signal_1) = notify
             .create_or_subscribe(topic_1, true, None)
             .await
             .unwrap();
         assert!(created);
-        let (_handle2, created) = notify
+        let (_handle2, created, mut subscription_closing_signal_2) = notify
             .create_or_subscribe(topic_2, true, None)
             .await
             .unwrap();
@@ -1108,6 +1181,9 @@ mod tests {
 
         let subscriptions_nb = notify.debug().await.unwrap();
         assert_eq!(subscriptions_nb, 0);
+        drop(handle1);
+        subscription_closing_signal_1.try_recv().unwrap();
+        subscription_closing_signal_2.try_recv().unwrap();
     }
 
     #[tokio::test]
@@ -1117,12 +1193,12 @@ mod tests {
             let topic_1 = Uuid::new_v4();
             let topic_2 = Uuid::new_v4();
 
-            let (handle1, created) = notify
+            let (handle1, created, mut subscription_closing_signal_1) = notify
                 .create_or_subscribe(topic_1, true, Some("TestSubscription".to_string()))
                 .await
                 .unwrap();
             assert!(created);
-            let (_handle2, created) = notify
+            let (_handle2, created, mut subscription_closing_signal_2) = notify
                 .create_or_subscribe(topic_2, true, Some("TestSubscriptionBis".to_string()))
                 .await
                 .unwrap();
@@ -1198,6 +1274,8 @@ mod tests {
                 0i64,
                 "graphql.operation.name" = "TestSubscriptionBis"
             );
+            subscription_closing_signal_1.try_recv().unwrap();
+            subscription_closing_signal_2.try_recv().unwrap();
         }
         .with_metrics()
         .await;
@@ -1212,12 +1290,12 @@ mod tests {
         let topic_1 = Uuid::new_v4();
         let topic_2 = Uuid::new_v4();
 
-        let (handle1, created) = notify
+        let (handle1, created, mut subscription_closing_signal_1) = notify
             .create_or_subscribe(topic_1, true, None)
             .await
             .unwrap();
         assert!(created);
-        let (_handle2, created) = notify
+        let (_handle2, created, mut subscription_closing_signal_2) = notify
             .create_or_subscribe(topic_2, true, None)
             .await
             .unwrap();
@@ -1268,6 +1346,8 @@ mod tests {
 
         assert!(!notify.exist(topic_1).await.unwrap());
         assert!(!notify.exist(topic_2).await.unwrap());
+        subscription_closing_signal_1.try_recv().unwrap();
+        subscription_closing_signal_2.try_recv().unwrap();
 
         let subscriptions_nb = notify.debug().await.unwrap();
         assert_eq!(subscriptions_nb, 0);

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -836,7 +836,7 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
         let new_sub_id = uuid::Uuid::new_v4().to_string();
-        let (handler, _created) = notify
+        let (handler, _created, _) = notify
             .create_or_subscribe(new_sub_id.clone(), true, None)
             .await
             .unwrap();
@@ -979,7 +979,7 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
         let new_sub_id = uuid::Uuid::new_v4().to_string();
-        let (_handler, _created) = notify
+        let (_handler, _created, _) = notify
             .create_or_subscribe(new_sub_id.clone(), true, None)
             .await
             .unwrap();
@@ -1069,7 +1069,7 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
         let new_sub_id = uuid::Uuid::new_v4().to_string();
-        let (handler, _created) = notify
+        let (handler, _created, _) = notify
             .create_or_subscribe(new_sub_id.clone(), true, None)
             .await
             .unwrap();

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -27,12 +27,7 @@ use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use rustls::RootCertStore;
 use serde::Serialize;
-<<<<<<< HEAD
-=======
-use serde_json_bytes::Entry;
-use serde_json_bytes::json;
 use tokio::select;
->>>>>>> a894b6cf (fix(subscription): fix deduplication and websocket stream termination (#8104))
 use tokio::sync::oneshot;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::connect_async_tls_with_config;

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -27,6 +27,12 @@ use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use rustls::RootCertStore;
 use serde::Serialize;
+<<<<<<< HEAD
+=======
+use serde_json_bytes::Entry;
+use serde_json_bytes::json;
+use tokio::select;
+>>>>>>> a894b6cf (fix(subscription): fix deduplication and websocket stream termination (#8104))
 use tokio::sync::oneshot;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::connect_async_tls_with_config;
@@ -292,7 +298,14 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                         let operation_name =
                             context.get::<_, String>(OPERATION_NAME).ok().flatten();
                         // Call create_or_subscribe on notify
-                        let (handle, created) = notify
+                        // Note: _subscription_closing_signal is intentionally unused in callback mode.
+                        // In callback mode, subscriptions are managed via HTTP callbacks rather than
+                        // persistent connections, so there's no long-running task that needs to be
+                        // notified when the subscription closes (unlike passthrough mode which uses
+                        // the signal to clean up WebSocket forwarding tasks).
+                        //
+                        // Callback subscriptions are closed when the subgraph returns 404
+                        let (handle, created, _subscription_closing_signal) = notify
                             .create_or_subscribe(subscription_id.clone(), true, operation_name)
                             .await?;
 
@@ -503,7 +516,20 @@ async fn call_websocket(
             reason: "cannot get the websocket stream".to_string(),
         })?;
     let supergraph_operation_name = context.get::<_, String>(OPERATION_NAME).ok().flatten();
-    let (handle, created) = notify
+    // In passthrough mode, we maintain persistent WebSocket connections and need the
+    // subscription_closing_signal to properly clean up long-running forwarding tasks
+    // when subscriptions are terminated (see tokio::select! usage below).
+    //
+    // Websocket subscriptions are closed when:
+    // * The closing signal is received from the subgraph.
+    // * The connection to the subgraph is severed.
+    //
+    // The reason that we need the subscription closing signal is that deduplication will
+    // cause multiple client subscriptions to listen to the same source subscription. Therefore we
+    // must not close the subscription if a single connection is dropped. Only when ALL connections are dropped.
+    // Conversely, if the connection between router and subgraph is closed, ALL client subscription connections
+    // are dropped immediately.
+    let (handle, created, mut subscription_closing_signal) = notify
         .create_or_subscribe(subscription_hash.clone(), false, supergraph_operation_name)
         .await?;
     u64_counter!(
@@ -685,17 +711,27 @@ async fn call_websocket(
         })?;
 
     let (handle_sink, handle_stream) = handle.split();
-
     // Forward GraphQL subscription stream to WebSocket handle
     // Connection lifecycle is managed by the WebSocket infrastructure,
     // so we don't need to handle connection_closed_signal here
     tokio::task::spawn(async move {
-        if let Err(e) = gql_stream
-            .map(Ok::<_, graphql::Error>)
-            .forward(handle_sink)
-            .await
-        {
-            tracing::debug!("WebSocket subscription stream ended: {}", e);
+        select! {
+            // We prefer to specify the order of checks within the select
+            biased;
+            // gql_stream is the stream opened from router to subgraph to receive events
+            // handle_sink is just a broadcast sender to send the events received from subgraphs to the router's client
+            // if all router's clients are closed the sink will be closed too and then the .forward future will end
+            // It will then also trigger poll_close on the gql_stream which will initiate the termination process (like properly closing ws connection cf protocols/websocket.rs)
+            _ = gql_stream
+                .map(Ok::<_, graphql::Error>)
+                .forward(handle_sink) => {
+                tracing::debug!("gql_stream empty");
+            },
+            // This branch handles subscription termination signals. Unlike callback mode,
+            // passthrough mode maintains persistent connections that require explicit cleanup.
+            _ = subscription_closing_signal.recv() => {
+                tracing::debug!("subscription_closing_signal triggered");
+            }
         }
     });
 

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -973,7 +973,7 @@ async fn root_typename_with_defer() {
 #[tokio::test]
 async fn subscription_with_callback() {
     let mut notify = Notify::builder().build();
-    let (handle, _) = notify
+    let (handle, _, _) = notify
         .create_or_subscribe("TEST_TOPIC".to_string(), false, None)
         .await
         .unwrap();
@@ -1054,7 +1054,7 @@ async fn subscription_with_callback() {
 #[tokio::test]
 async fn subscription_callback_schema_reload() {
     let mut notify = Notify::builder().build();
-    let (handle, _) = notify
+    let (handle, _, _) = notify
         .create_or_subscribe("TEST_TOPIC".to_string(), false, None)
         .await
         .unwrap();
@@ -1143,7 +1143,7 @@ async fn subscription_callback_schema_reload() {
 #[tokio::test]
 async fn subscription_with_callback_with_limit() {
     let mut notify = Notify::builder().build();
-    let (handle, _) = notify
+    let (handle, _, _) = notify
         .create_or_subscribe("TEST_TOPIC".to_string(), false, None)
         .await
         .unwrap();

--- a/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
+++ b/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::time::Duration;
 
 use regex::Regex;
 use tower::BoxError;
@@ -907,6 +908,169 @@ async fn test_subscription_ws_passthrough_dedup() -> Result<(), BoxError> {
     router.graceful_shutdown().await;
 
     assert!(is_closed.load(std::sync::atomic::Ordering::Relaxed));
+    // Check for errors in router logs
+    router.assert_log_not_contained("connection shutdown exceeded, forcing close");
+
+    info!(
+        "✅ Passthrough subscription mode test completed successfully with {} events",
+        custom_payloads.len()
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscription_ws_passthrough_dedup_close_early() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return Ok(());
+    }
+
+    // Create fixed payloads for consistent testing
+    let custom_payloads = vec![create_user_data_payload(1), create_user_data_payload(2)];
+    let interval_ms = 50;
+    let is_subscription_closed = Arc::new(AtomicBool::new(false));
+
+    // Start subscription server with fixed payloads, but do not terminate the connection
+    let (ws_addr, http_server) = start_subscription_server_with_payloads(
+        custom_payloads.clone(),
+        interval_ms,
+        true,
+        is_subscription_closed.clone(),
+    )
+    .await;
+
+    // Create router with port reservations
+    let mut router = IntegrationTest::builder()
+        .supergraph("tests/integration/subscriptions/fixtures/supergraph.graphql")
+        .config(include_str!(
+            "fixtures/subscription_schema_reload.router.yaml"
+        ))
+        .build()
+        .await;
+
+    // Configure URLs using the string replacement method
+    let ws_url = format!("ws://{}/ws", ws_addr);
+    router.replace_config_string("http://localhost:{{PRODUCTS_PORT}}", &http_server.uri());
+    router.replace_config_string("http://localhost:{{ACCOUNTS_PORT}}", &ws_url);
+    router.replace_config_string("rng:", "accounts:");
+
+    info!("WebSocket server started at: {}", ws_url);
+
+    router.start().await;
+    router.assert_started().await;
+
+    // Use the configured query that matches our server configuration
+    let query = create_sub_query(interval_ms, custom_payloads.len());
+    let ((_, response), (_, response_bis)) = futures::join!(
+        router.run_subscription(&query),
+        router.run_subscription(&query)
+    );
+
+    // Expect the router to handle both subscriptions successfully
+    assert!(
+        response.status().is_success(),
+        "Subscription request failed with status: {}",
+        response.status()
+    );
+    assert!(
+        response_bis.status().is_success(),
+        "Subscription request failed with status: {}",
+        response_bis.status()
+    );
+
+    let metrics = router.get_metrics_response().await?.text().await?;
+    let sum_metric_counts = |regex: &Regex| {
+        regex
+            .captures_iter(&metrics)
+            .flat_map(|cap| cap.get(1).unwrap().as_str().parse::<usize>())
+            .sum()
+    };
+
+    let stream = response.bytes_stream();
+    let stream_bis = response_bis.bytes_stream();
+
+    // Check that both the original (deduplicated) and the duplicate subscription
+    // are reflected in metrics.
+    let deduplicated_sub =
+        Regex::new(r#"(?m)^apollo_router_operations_subscriptions_total[{].+subscriptions_deduplicated="true".+[}] ([0-9]+)"#)
+            .expect("regex");
+    let total_deduplicated_sub: usize = sum_metric_counts(&deduplicated_sub);
+    assert_eq!(total_deduplicated_sub, 1);
+    let duplicated_sub =
+        Regex::new(r#"(?m)^apollo_router_operations_subscriptions_total[{].+subscriptions_deduplicated="false".+[}] ([0-9]+)"#)
+            .expect("regex");
+    let total_duplicated_sub: usize = sum_metric_counts(&duplicated_sub);
+    assert_eq!(total_duplicated_sub, 1);
+
+    // We'll start consuming both subscriptions, but cancel the first one as soon as a message is
+    // received. the `bis` subscription should continue to receive messages after that.
+    let mut multipart = multer::Multipart::new(stream, "graphql");
+    let mut multipart_bis = multer::Multipart::new(stream_bis, "graphql");
+
+    // Task for the first (deduplicated) subscription.
+    let task = tokio::task::spawn(tokio::time::timeout(Duration::from_secs(30), async move {
+        let expected_event = create_expected_user_payload(1);
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .expect("could not read next chunk")
+        {
+            let parsed: serde_json::Value = field.json().await.expect("invalid JSON chunk");
+            // Heartbeat
+            if parsed == serde_json::json!({}) {
+                continue;
+            }
+            assert_eq!(parsed, expected_event);
+            // Close the connection early. The other connection from the duplicate
+            // subscription should continue to receive events...
+            break;
+        }
+    }));
+    // This the the other connection with the duplicate subscription to the one above.
+    // After the subscription above is closed, it should continue to receive events.
+    let task_bis = tokio::task::spawn(tokio::time::timeout(Duration::from_secs(30), async move {
+        let mut expected_events = vec![
+            create_expected_user_payload(1),
+            create_expected_user_payload(2),
+        ];
+        while let Some(field) = multipart_bis
+            .next_field()
+            .await
+            .expect("could not read next chunk")
+        {
+            let parsed: serde_json::Value = field.json().await.expect("invalid JSON chunk");
+            // Heartbeat
+            if parsed == serde_json::json!({}) {
+                continue;
+            }
+            assert_eq!(parsed, expected_events.remove(0));
+        }
+
+        // Make sure that we're actually testing what we think we're testing, i.e. the first task
+        // closed its connection successfully
+        assert!(task.is_finished(), "primary connection should be closed");
+        task.await
+            .expect("asserted that it completes")
+            .expect("should not have timed out");
+        assert!(
+            expected_events.is_empty(),
+            "should have consumed all events"
+        );
+    }));
+
+    // If _this_ times out, then chances are that the connection is essentially inert, and the
+    // router stopped serving us events on the deduped subscription.
+    // See https://github.com/apollographql/router/pull/7879
+    task_bis
+        .await
+        .expect("task should complete")
+        .expect("should not have timed out");
+
+    router.graceful_shutdown().await;
+
+    // Check the subscription event listener is closed.
+    assert!(is_subscription_closed.load(std::sync::atomic::Ordering::Relaxed));
     // Check for errors in router logs
     router.assert_log_not_contained("connection shutdown exceeded, forcing close");
 


### PR DESCRIPTION
A regression was introduced in https://github.com/apollographql/router/pull/7879 while attempting to fix an earlier regression. In this PR, we removed the client connection closing signal, which had been unnecessary and was causing deduplicated subscriptions to stop receiving events when the original (first) matching subscription was closed from the client to the router. However, eliminating this channel led to a new issue: subscriptions between the router and subgraph were not closed correctly. Although all client-to-router connections closed as expected, the connection from the router to the subgraph remained open until an event was received for that subscription.

This PR resolves the problem by introducing a closing signal channel in `Notify`, which automatically sends a notification when a subscription is fully closed. A subscription is now considered closed when there are no remaining receivers (client-to-router connections).


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1407]: https://apollographql.atlassian.net/browse/ROUTER-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #8104 done by [Mergify](https://mergify.com).