### PR TITLE
fix: respect Redis cluster slots when inserting multiple items

### DIFF
--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -649,7 +649,9 @@ impl RedisCacheStorage {
             .set::<(), _, _>(key, value, expiration, None, false)
             .await;
         tracing::trace!("insert result {:?}", r);
-        r.inspect_err(|e| self.record_error(e)).ok()
+        if let Err(err) = r {
+            self.record_error(&err);
+        }
     }
 
     pub(crate) async fn insert_multiple<K: KeyType, V: ValueType>(

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -348,12 +348,12 @@ impl RedisCacheStorage {
                 loop {
                     match error_rx.recv().await {
                         Ok((error, Some(server))) => {
-                            tracing::error!(
-                                "Redis client disconnected from {server:?} with error: {error:?}",
-                            )
+                            tracing::error!("Redis client ({server:?}) error: {error:?}",);
+                            record_redis_error(&error, caller);
                         }
                         Ok((error, None)) => {
-                            tracing::error!("Redis client disconnected with error: {error:?}",)
+                            tracing::error!("Redis client error: {error:?}",);
+                            record_redis_error(&error, caller);
                         }
                         Err(RecvError::Lagged(_)) => continue,
                         Err(RecvError::Closed) => break,

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -363,7 +363,17 @@ impl RedisCacheStorage {
             tokio::spawn(async move {
                 loop {
                     match reconnect_rx.recv().await {
-                        Ok(server) => tracing::info!("Redis client connected to {server:?}"),
+                        Ok(server) => {
+                            u64_counter_with_unit!(
+                                "apollo.router.cache.redis.reconnections",
+                                "Number of Redis reconnections",
+                                "{reconnection}",
+                                1,
+                                kind = caller,
+                                server = server.to_string()
+                            );
+                            tracing::info!("Redis client connected to {server:?}")
+                        }
                         Err(RecvError::Lagged(_)) => continue,
                         Err(RecvError::Closed) => break,
                     }

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -649,6 +649,7 @@ impl RedisCacheStorage {
             .set::<(), _, _>(key, value, expiration, None, false)
             .await;
         tracing::trace!("insert result {:?}", r);
+        r.inspect_err(|e| self.record_error(e)).ok()
     }
 
     pub(crate) async fn insert_multiple<K: KeyType, V: ValueType>(
@@ -699,8 +700,9 @@ impl RedisCacheStorage {
             pipeline.last().await
         };
 
-        if let Some(Err(err)) = result {
+        if let Err(err) = result {
             tracing::trace!("caught error during insert: {err:?}");
+            self.record_error(&err);
         }
     }
 

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -371,7 +371,7 @@ impl RedisCacheStorage {
                             tracing::debug!("Redis client ({server:?}) unresponsive");
                             u64_counter_with_unit!(
                                 "apollo.router.cache.redis.unresponsive",
-                                "Number of Redis unresponsive events",
+                                "Counter for Redis client unresponsive events",
                                 "{event}",
                                 1,
                                 kind = caller,
@@ -389,8 +389,8 @@ impl RedisCacheStorage {
                     match reconnect_rx.recv().await {
                         Ok(server) => {
                             u64_counter_with_unit!(
-                                "apollo.router.cache.redis.reconnections",
-                                "Number of Redis reconnections",
+                                "apollo.router.cache.redis.reconnection",
+                                "Counter for Redis client reconnection events",
                                 "{reconnection}",
                                 1,
                                 kind = caller,

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -657,29 +657,51 @@ impl RedisCacheStorage {
         ttl: Option<Duration>,
     ) {
         tracing::trace!("inserting into redis: {:#?}", data);
+        let expiration = ttl
+            .or(self.ttl)
+            .map(|ttl| Expiration::EX(ttl.as_secs() as i64));
 
-        let r = match ttl.as_ref().or(self.ttl.as_ref()) {
-            None => self.inner.mset(data.to_owned()).await,
-            Some(ttl) => {
-                let expiration = Some(Expiration::EX(ttl.as_secs() as i64));
-                let pipeline = self.inner.next().pipeline();
-
-                for (key, value) in data {
-                    let _ = pipeline
-                        .set::<(), _, _>(
-                            self.make_key(key.clone()),
-                            value.clone(),
-                            expiration.clone(),
-                            None,
-                            false,
-                        )
-                        .await;
-                }
-
-                pipeline.last().await
+        let result = if self.is_cluster {
+            // when using a cluster of redis nodes, the keys are hashed, and the hash number indicates which
+            // node will store it. So first we have to group the keys by hash, because we cannot do a SET
+            // across multiple nodes (error: "ERR CROSSSLOT Keys in request don't hash to the same slot")
+            let mut pipelines = HashMap::new();
+            for (key, value) in data {
+                let key = self.make_key(key.clone());
+                let hash = ClusterRouting::hash_key(key.as_bytes());
+                let pipeline_entry = pipelines
+                    .entry(hash)
+                    .or_insert_with(|| self.inner.next().pipeline());
+                let _ = pipeline_entry
+                    .set::<(), _, _>(key, value.clone(), expiration.clone(), None, false)
+                    .await;
             }
+
+            let mut tasks = Vec::new();
+            for pipeline in pipelines.into_values() {
+                tasks.push(async move { pipeline.last().await });
+            }
+
+            let results: Vec<Result<(), _>> = futures::future::join_all(tasks).await;
+            results
+                .into_iter()
+                .find(|res| res.is_err())
+                .unwrap_or(Ok(()))
+        } else {
+            let pipeline = self.inner.next().pipeline();
+            for (key, value) in data {
+                let key = self.make_key(key.clone());
+                let _ = pipeline
+                    .set::<(), _, _>(key, value.clone(), expiration.clone(), None, false)
+                    .await;
+            }
+
+            pipeline.last().await
         };
-        tracing::trace!("insert result {:?}", r);
+
+        if let Some(Err(err)) = result {
+            tracing::trace!("caught error during insert: {err:?}");
+        }
     }
 
     /// Delete keys *without* adding the `namespace` prefix because `keys` is from


### PR DESCRIPTION
The existing `insert` code will silently fail when we try to insert multiple values which correspond to different [Redis cluster hash slots](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#key-distribution-model). This PR corrects that behavior, raises errors when inserts fail, and adds new metrics to track Redis client health.

New metrics:
* `apollo.router.cache.redis.unresponsive`: counter for 'unresponsive' events raised by the Redis library
  * `kind`: Redis cache purpose (`APQ`, `query planner`, `entity`)
  * `server`: Redis server that became unresponsive
* `apollo.router.cache.redis.reconnection`: counter for 'reconnect' events raised by the Redis library
  * `kind`: Redis cache purpose (`APQ`, `query planner`, `entity`)
  * `server`: Redis server that required client reconnection

<!-- start metadata -->

<!-- [ROUTER-1431] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
