### PR TITLE
response_cache: invalidation_endpoint auth is less permissive

### DIFF
--- a/apollo-router/src/plugins/response_cache/invalidation_endpoint.rs
+++ b/apollo-router/src/plugins/response_cache/invalidation_endpoint.rs
@@ -601,6 +601,6 @@ mod tests {
             res.response.headers().get(&CONTENT_TYPE).unwrap(),
             &HeaderValue::from_static("application/json")
         );
-        assert_eq!(res.response.status(), StatusCode::ACCEPTED);
+        assert!(res.response.status() != StatusCode::UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
With this change you'll have to have either a global shared key if you target different subgraphs or the subgraph shared key if you only target one subgraph in every invalidation requests.

<!-- [ROUTER-1396] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1396]: https://apollographql.atlassian.net/browse/ROUTER-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ