### PR TITLE
fix: release builds of docker images should utilize correct target platform (backport #8187)

### DIFF
--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -3,6 +3,10 @@ ARG ROUTER_RELEASE=latest
 ARG ARTIFACT_URL=
 ARG CIRCLE_TOKEN=
 ARG ARTIFACT_URL_SHA256SUM=
+# We will use TARGETPLATFORM inside the download_and_validate_router.sh script
+# It is set automatically by Docker when doing a buildx build, see:
+#  https://docs.docker.com/build/building/multi-platform/
+ARG TARGETPLATFORM
 
 RUN \
   apt-get update -y \


### PR DESCRIPTION
## Motivation

When making #8056, I missed an important detail in my analysis of the CircleCI script responsible for building the router releases.  In particular, I failed to observe that the `--platform` argument was variable and could be both arm64 and amd64 varieties and actually requests [BOTH], which packages two within one container [multi-build style].

This change updates the `download_and_validate.sh` script to make use of a Docker provided `TARGETPLATFORM` variable in deciding which release tarball to place within the built image, depending on the platform.

## Manual Testing

Overall the thing to run to reproduce the regression on an Arm Mac is: `docker run -ti --platform=linux/arm64 ghcr.io/apollographql/router:v2.6.0`.  You can replace this tag with any version you'd like, but v2.6.0 is broken and others work.

### Reproduction on 2.6.0 (ARM 🦾)

:x:

```
$ docker run -ti --platform=linux/arm64 ghcr.io/apollographql/router:v2.6.0
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
```

### Reproduction on `2.6.1-alpha.0` (ARM 🦾)

> [!NOTE]
> `2.6.1-alpha.0` was done as a test build on this PR.  See [this link](https://app.circleci.com/pipelines/github/apollographql/router/38992/workflows/7b18ea9c-882d-477e-94ba-e395456bd798)

✅  Works

```
$ docker run -ti --platform=linux/arm64 ghcr.io/apollographql/router:v2.6.1-alpha.0
Apollo Router v2.6.1-alpha.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)

... [snipped for brevity, but works!]
```

### Additional verification

#### AMD 🦵 

##### Reproduction on 2.6.0 (AMD 🦵)

✅  Works

```
$ docker run -ti --platform=linux/amd64 ghcr.io/apollographql/router:v2.6.0
<jemalloc>: MADV_DONTNEED does not work (memset will be used instead)
<jemalloc>: (This is the expected behaviour if you are running under QEMU)
Apollo Router v2.6.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)

... [snipped for brevity, but works!]
```

##### Reproduction on 2.6.1-alpha.0 (AMD 🦵)

✅ Works

```
$ docker run -ti --platform=linux/amd64 ghcr.io/apollographql/router:v2.6.1-alpha.0
<jemalloc>: MADV_DONTNEED does not work (memset will be used instead)
<jemalloc>: (This is the expected behaviour if you are running under QEMU)
Apollo Router v2.6.1-alpha.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)

... [snipped for brevity, but works!]
```

[BOTH]: https://github.com/apollographql/router/blob/0f801b8703bdc4abe7f56b4c4b3a94bfad518fec/.circleci/config.yml#L924-L927
[multi-build style]: https://docs.docker.com/build/building/multi-platform/




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

See details above on Manual testing

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1428]: https://apollographql.atlassian.net/browse/ROUTER-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #8187 done by [Mergify](https://mergify.com).