### PR TITLE
docs: fix missing end of code block

### DIFF
--- a/docs/source/routing/observability/client-id-enforcement.mdx
+++ b/docs/source/routing/observability/client-id-enforcement.mdx
@@ -74,6 +74,7 @@ fn process_request(request) {
     request.context["apollo::telemetry::client_name"] = "custom name";
     request.context["apollo::telemetry::client_version"] = "custom version";
 }
+```
 
 ### Enforcing via Rhai script
 


### PR DESCRIPTION
Accidentally introduced in #7516. Doc-only non-semantic change.
See https://www.apollographql.com/docs/graphos/routing/observability/client-id-enforcement#via-router-customization for what it looks like now.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
