### PR TITLE
[Subgraph Insights] Bump Subgraph Metrics config to Preview

### DIFF
--- a/apollo-router/src/configuration/migrations/2040-preview_subgraph_metrics.yaml
+++ b/apollo-router/src/configuration/migrations/2040-preview_subgraph_metrics.yaml
@@ -1,0 +1,5 @@
+description: Subgraph metrics are now in preview
+actions:
+  - type: move
+    from: telemetry.apollo.experimental_subgraph_metrics
+    to: telemetry.apollo.preview_subgraph_metrics

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,7 @@
 ---
 source: apollo-router/src/configuration/tests.rs
 expression: "&schema"
+snapshot_kind: text
 ---
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1511,11 +1512,6 @@ expression: "&schema"
           "$ref": "#/definitions/Protocol",
           "description": "#/definitions/Protocol"
         },
-        "experimental_subgraph_metrics": {
-          "default": false,
-          "description": "Enable sending additional subgraph metrics to Apollo Studio via OTLP",
-          "type": "boolean"
-        },
         "field_level_instrumentation_sampler": {
           "$ref": "#/definitions/SamplerOption",
           "description": "#/definitions/SamplerOption"
@@ -1527,6 +1523,11 @@ expression: "&schema"
         "otlp_tracing_sampler": {
           "$ref": "#/definitions/SamplerOption",
           "description": "#/definitions/SamplerOption"
+        },
+        "preview_subgraph_metrics": {
+          "default": false,
+          "description": "Enable sending additional subgraph metrics to Apollo Studio via OTLP",
+          "type": "boolean"
         },
         "send_headers": {
           "$ref": "#/definitions/ForwardHeaders",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@apollo_subgraph_metrics.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@apollo_subgraph_metrics.yaml.snap
@@ -1,0 +1,9 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+snapshot_kind: text
+---
+---
+telemetry:
+  apollo:
+    preview_subgraph_metrics: true

--- a/apollo-router/src/configuration/testdata/migrations/apollo_subgraph_metrics.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/apollo_subgraph_metrics.yaml
@@ -1,0 +1,3 @@
+telemetry:
+  apollo:
+    experimental_subgraph_metrics: enabled

--- a/apollo-router/src/configuration/testdata/migrations/apollo_subgraph_metrics.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/apollo_subgraph_metrics.yaml
@@ -1,3 +1,3 @@
 telemetry:
   apollo:
-    experimental_subgraph_metrics: enabled
+    experimental_subgraph_metrics: true

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -121,7 +121,7 @@ pub(crate) struct Config {
     pub(crate) experimental_local_field_metrics: bool,
 
     /// Enable sending additional subgraph metrics to Apollo Studio via OTLP
-    pub(crate) experimental_subgraph_metrics: bool,
+    pub(crate) preview_subgraph_metrics: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
@@ -256,7 +256,7 @@ impl Default for Config {
             signature_normalization_algorithm: ApolloSignatureNormalizationAlgorithm::default(),
             experimental_local_field_metrics: false,
             metrics_reference_mode: ApolloMetricsReferenceMode::default(),
-            experimental_subgraph_metrics: false,
+            preview_subgraph_metrics: false,
         }
     }
 }

--- a/apollo-router/src/plugins/telemetry/config_new/apollo/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/apollo/instruments.rs
@@ -118,7 +118,7 @@ impl ApolloSubgraphInstruments {
         let attribute_count = selectors.custom.len() + 1; // 1 for subgraph_name on attributes
 
         let apollo_router_operations_fetch_duration =
-            apollo_config.experimental_subgraph_metrics.then(|| {
+            apollo_config.preview_subgraph_metrics.then(|| {
                 CustomHistogram::builder()
                     .increment(Increment::Duration(Instant::now()))
                     .attributes(Vec::with_capacity(attribute_count))
@@ -236,7 +236,7 @@ impl ApolloConnectorInstruments {
         let attribute_count = selectors.custom.len() + 1; // 1 for subgraph_name on attributes
 
         let apollo_router_operations_fetch_duration =
-            apollo_config.experimental_subgraph_metrics.then(|| {
+            apollo_config.preview_subgraph_metrics.then(|| {
                 CustomHistogram::builder()
                     .increment(Increment::Duration(Instant::now()))
                     .attributes(Vec::with_capacity(attribute_count))

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/apollo/connector_fetch_duration/router.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/apollo/connector_fetch_duration/router.yaml
@@ -1,6 +1,6 @@
 telemetry:
   apollo:
-    experimental_subgraph_metrics: true
+    preview_subgraph_metrics: true
   instrumentation:
     instruments:
       connector:

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/apollo/subgraph_fetch_duration/router.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/apollo/subgraph_fetch_duration/router.yaml
@@ -1,6 +1,6 @@
 telemetry:
   apollo:
-    experimental_subgraph_metrics: true
+    preview_subgraph_metrics: true
   instrumentation:
     instruments:
       subgraph:

--- a/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
+++ b/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
@@ -592,7 +592,7 @@ async fn test_subgraph_request_emits_histogram() {
                 experimental_otlp_metrics_protocol: http
                 batch_processor:
                   scheduled_delay: 10ms
-                experimental_subgraph_metrics: true
+                preview_subgraph_metrics: true
             include_subgraph_errors:
               all: true
         "#,
@@ -652,7 +652,7 @@ async fn test_failed_subgraph_request_emits_histogram() {
                 experimental_otlp_metrics_protocol: http
                 batch_processor:
                   scheduled_delay: 10ms
-                experimental_subgraph_metrics: true
+                preview_subgraph_metrics: true
             include_subgraph_errors:
               all: true
         "#,
@@ -713,7 +713,7 @@ async fn test_connector_request_emits_histogram() {
                 experimental_otlp_metrics_protocol: http
                 batch_processor:
                   scheduled_delay: 10ms
-                experimental_subgraph_metrics: true
+                preview_subgraph_metrics: true
             include_subgraph_errors:
               all: true
         "#,
@@ -787,7 +787,7 @@ async fn test_failed_connector_request_emits_histogram() {
                 experimental_otlp_metrics_protocol: http
                 batch_processor:
                   scheduled_delay: 10ms
-                experimental_subgraph_metrics: true
+                preview_subgraph_metrics: true
             traffic_shaping:
                 connector:
                     sources:


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-1406] -->
---
Bring the subgraph metrics config backing the Subgraph Insights feature from `experimental` to `preview`.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
