### PR TITLE
Tninesling/add fields shallow

### DIFF
--- a/apollo-federation/src/merger/merge_input.rs
+++ b/apollo-federation/src/merger/merge_input.rs
@@ -1,6 +1,11 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
 use apollo_compiler::Node;
+use apollo_compiler::ast::InputValueDefinition;
 use apollo_compiler::ast::Type;
 use apollo_compiler::collections::IndexMap;
+use apollo_compiler::schema::Component;
 use apollo_compiler::schema::InputObjectType;
 
 use crate::error::CompositionError;
@@ -10,6 +15,7 @@ use crate::merger::hints::HintCode;
 use crate::merger::merge::Merger;
 use crate::merger::merge::Sources;
 use crate::merger::merge_field::FieldMergeContext;
+use crate::merger::merge_field::PLACEHOLDER_TYPE_NAME;
 use crate::schema::position::DirectiveTargetPosition;
 use crate::schema::position::InputObjectFieldDefinitionPosition;
 use crate::schema::position::InputObjectTypeDefinitionPosition;
@@ -24,7 +30,7 @@ impl Merger {
     ) -> Result<(), FederationError> {
         // Like for other inputs, we add all the fields found in any subgraphs initially as a simple mean to have a complete list of
         // field to iterate over, but we will remove those that are not in all subgraphs.
-        let added = self.add_input_fields_shallow(sources, dest);
+        let added = self.add_input_fields_shallow(sources, dest)?;
 
         for (dest_field, subgraph_fields) in added {
             // We merge the details of the field first, even if we may remove it afterwards because 1) this ensure we always checks type
@@ -163,16 +169,79 @@ impl Merger {
         Ok(())
     }
 
-    // TODO: FED-549
+    /// Adds a shallow copy of each field in an InputObject type to the supergraph schema. This is
+    /// an implementation of `addFieldsShallow` from the JS implementation, but specialized to
+    /// InputObject fields. As such, any logic specific to Object and Interface types is removed in
+    /// this implementation. See [Merger::add_fields_shallow] for the equivalent implementation for
+    /// those types.
     fn add_input_fields_shallow(
         &mut self,
-        _sources: &Sources<Node<InputObjectType>>,
-        _dest: &InputObjectTypeDefinitionPosition,
-    ) -> IndexMap<InputObjectFieldDefinitionPosition, Sources<InputObjectFieldDefinitionPosition>>
-    {
-        // TODO: Implement proper field merging logic
-        // For now, return empty to allow compilation
-        IndexMap::default()
+        sources: &Sources<Node<InputObjectType>>,
+        dest: &InputObjectTypeDefinitionPosition,
+    ) -> Result<
+        IndexMap<InputObjectFieldDefinitionPosition, Sources<InputObjectFieldDefinitionPosition>>,
+        FederationError,
+    > {
+        let mut added: IndexMap<
+            InputObjectFieldDefinitionPosition,
+            Sources<InputObjectFieldDefinitionPosition>,
+        > = Default::default();
+        let mut fields_to_add: HashMap<usize, HashSet<InputObjectFieldDefinitionPosition>> =
+            Default::default();
+        let mut extra_sources: Sources<InputObjectFieldDefinitionPosition> = Default::default();
+
+        for (idx, source) in sources {
+            if let Some(source) = source {
+                for field_name in source.fields.keys() {
+                    fields_to_add.entry(*idx).or_default().insert(
+                        InputObjectFieldDefinitionPosition {
+                            type_name: dest.type_name.clone(),
+                            field_name: field_name.clone(),
+                        },
+                    );
+                }
+            }
+
+            if self.subgraphs[*idx]
+                .schema()
+                .try_get_type(dest.type_name.clone())
+                .is_some()
+            {
+                // Our needsJoinField logic adds @join__field if any subgraphs define
+                // the parent type containing the field but not the field itself. In
+                // those cases, for each field we add, we need to add undefined entries
+                // for each subgraph that defines the parent object/interface/input
+                // type. We do this by populating extraSources with undefined entries
+                // here, then create each new Sources map from that starting set (see
+                // `new Map(extraSources)` below).
+                extra_sources.insert(*idx, None);
+            }
+        }
+
+        for (idx, field_set) in fields_to_add {
+            for field in field_set {
+                // While the JS implementation checked `isMergedField` here, that would always
+                // return true for input fields, so we omit that check.
+                if !added.contains_key(&field) {
+                    field.insert(
+                        &mut self.merged,
+                        Component::new(InputValueDefinition {
+                            description: None,
+                            name: field.field_name.clone(),
+                            default_value: None,
+                            ty: Node::new(Type::Named(PLACEHOLDER_TYPE_NAME)),
+                            directives: Default::default(),
+                        }),
+                    )?;
+                }
+                added
+                    .entry(field.clone())
+                    .or_insert_with(|| extra_sources.clone())
+                    .insert(idx, Some(field));
+            }
+        }
+
+        Ok(added)
     }
 
     fn merge_input_field(

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -838,11 +838,12 @@ impl Merger {
         let is_value_type = !is_entity && self.merged.is_root_type(&obj.type_name);
         let is_subscription = self.merged.is_subscription_root_type(&obj.type_name);
 
-        let added = self.add_fields_shallow(&obj)?;
+        let added = self.add_fields_shallow(obj.clone())?;
         if added.is_empty() {
             obj.remove(&mut self.merged)?;
         } else {
             for (field, subgraph_fields) in added {
+                let field: FieldDefinitionPosition = field.into();
                 if is_value_type {
                     self.hint_on_inconsistent_value_type_field(
                         &subgraph_fields,
@@ -866,13 +867,6 @@ impl Merger {
             }
         }
         Ok(())
-    }
-
-    fn add_fields_shallow(
-        &mut self,
-        obj: &ObjectTypeDefinitionPosition,
-    ) -> Result<HashMap<FieldDefinitionPosition, Sources<()>>, FederationError> {
-        todo!("Implement add_fields_shallow")
     }
 
     fn validate_override(

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -1018,6 +1018,21 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
         }
     }
 
+    pub(crate) fn implemented_interfaces<'schema>(
+        &self,
+        schema: &'schema FederationSchema,
+    ) -> Result<&'schema apollo_compiler::collections::IndexSet<ComponentName>, PositionLookupError>
+    {
+        match self {
+            Self::Object(type_) => type_
+                .get(schema.schema())
+                .map(|obj| &obj.implements_interfaces),
+            Self::Interface(type_) => type_
+                .get(schema.schema())
+                .map(|itf| &itf.implements_interfaces),
+        }
+    }
+
     pub(crate) fn insert_implements_interface(
         &self,
         schema: &mut FederationSchema,
@@ -1257,6 +1272,17 @@ impl ObjectOrInterfaceFieldDefinitionPosition {
 
     pub(crate) fn coordinate(&self) -> String {
         format!("{}.{}", self.type_name(), self.field_name())
+    }
+
+    pub(crate) fn insert(
+        &self,
+        schema: &mut FederationSchema,
+        field_def: Component<FieldDefinition>,
+    ) -> Result<(), FederationError> {
+        match self {
+            Self::Object(field) => field.insert(schema, field_def),
+            Self::Interface(field) => field.insert(schema, field_def),
+        }
     }
 }
 


### PR DESCRIPTION
# Shallow Field Additions

During merge, we determine the fields which should be merged and create a shallow (name-only) placeholder in the supergraph schema. In JS, this was implemented as [Merger.addFieldsShallow](https://github.com/apollographql/federation/blob/92ad46254f7c7927521186e120ab2dfab5139fbc/composition-js/src/merging/merge.ts#L1247), and it handled fields for Object, Interface, and InputObject types. However, it used some slightly more advanced TypeScript features to change the return type based on which type kind it was acting on. It also had extra logic for output types, so I have implemented two versions of the original function: one for output types and one for input types.

## Placeholder fields

In both the input and output type implementations, we need to create a placeholder field in the supergraph schema. The JS implementation calls [destField.add(field.name)](https://github.com/apollographql/federation/blob/92ad46254f7c7927521186e120ab2dfab5139fbc/composition-js/src/merging/merge.ts#L1305) with no type information, and I cannot tell if/how it infers the return type at this point. The Rust implementation creates a dummy placeholder return type called `PLACEHOLDER`, which should be ignored during the deep merge phase.

## Tweaks to the Object and Interface type implementation

1. I have updated the signature for `Merger::add_fields_shallow` to operate on `ObjectOrInterfaceTypeDefinitionPosition` instead of `FieldDefinitionPosition` because the latter would require extra pattern matching for the `__typename` field on `Union` types, which is not applicable in this logic.

1. Additionally, I inlined the check to `isMergedField` because it needs access to the subgraph to check if we're looking at a root operation type, and that subgraph is already in scope.

## Omissions from the InputObject type implementation

1. The JS version of `addFieldsShallow` starts with an `@interfaceObject` check, which only applies to the output types. That is omitted from `Merger::add_input_fields_shallow`.

1. The `isMergedField` check would always return true for input types because they are not instances of `FieldDefinition`, so we skip that check and always shallow merge input fields.

<!-- [FED-549] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
