### PR TITLE
fix(helm): deploymentAnnotations value (backport #8164)

### DIFF
--- a/.changesets/fix_glasser_helm_deployment_annotations.md
+++ b/.changesets/fix_glasser_helm_deployment_annotations.md
@@ -1,0 +1,5 @@
+### Enable annotations on deployments via Helm Chart ([PR #8164](https://github.com/apollographql/router/pull/8164))
+
+The Helm chart previously did not allow customization of annotations on the deployment itself (as opposed to the pods within it, which is done with `podAnnotations`); this can now be done with the `deploymentAnnotations` value.
+
+By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/8164

--- a/docs/shared/helm-show-router-output.mdx
+++ b/docs/shared/helm-show-router-output.mdx
@@ -121,6 +121,7 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+deploymentAnnotations: {}
 
 podSecurityContext:
   {}

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -44,6 +44,7 @@ helm show values oci://ghcr.io/apollographql/helm-charts/router
 | containerPorts.health | int | `8088` | For exposing the health check endpoint |
 | containerPorts.http | int | `4000` | If you override the port in `router.configuration.server.listen` then make sure to match the listen port here |
 | containerPorts.metrics | int | `9090` | For exposing the metrics port when running a serviceMonitor for example |
+| deploymentAnnotations | object | `{}` | Sets annotations for the deployment resource itself (not its pods) |
 | extraContainers | list | `[]` | An array of extra containers to include in the router pod Example: extraContainers:   - name: coprocessor     image: acme/coprocessor:1.0     ports:       - containerPort: 4001 |
 | extraEnvVars | list | `[]` |  |
 | extraEnvVarsCM | string | `""` |  |
@@ -71,7 +72,7 @@ helm show values oci://ghcr.io/apollographql/helm-charts/router
 | managedFederation.graphRef | string | `""` | If using managed federation, the variant of which graph to use |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
+| podAnnotations | object | `{}` | Sets annotations for individual pods in the deployment |
 | podDisruptionBudget | object | `{}` | Sets the [pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) for Deployment pods |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` | Set to existing PriorityClass name to control pod preemption by the scheduler |

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -7,19 +7,21 @@ metadata:
     {{- if .Values.extraLabels }}
     {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
+  annotations:
   {{/* There may not be much configuration so check that there is something */}}
   {{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
   {{- if ((((((.Values.router).configuration).telemetry).exporters).metrics).prometheus).enabled }}
-  annotations:
     prometheus.io/path: {{ .Values.router.configuration.telemetry.exporters.metrics.prometheus.path | default "/metrics" }}
     prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.exporters.metrics.prometheus.listen | last) | default "9090" | quote }}
     prometheus.io/scrape: "true"
   {{- else if (((((.Values.router).configuration).telemetry).metrics).prometheus).enabled }}
-  annotations:
     prometheus.io/path: {{ .Values.router.configuration.telemetry.metrics.prometheus.path | default "/metrics" }}
     prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" | quote }}
     prometheus.io/scrape: "true"
   {{- end }}
+    {{- if .Values.deploymentAnnotations }}
+    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -120,6 +120,7 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+deploymentAnnotations: {}
 
 podSecurityContext:
   {}


### PR DESCRIPTION
This lets you put annotations on the deployment itself (as opposed to the pods within it, which is done with podAnnotations).

For example, you could use this to have
https://github.com/stakater/Reloader reload router when config maps or secrets change.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #8164 done by [Mergify](https://mergify.com).