### PR TITLE
Connection cancellation race (backport #8169)

### DIFF
--- a/.changesets/fix_bryn_connection_cancellation_race.md
+++ b/.changesets/fix_bryn_connection_cancellation_race.md
@@ -1,0 +1,9 @@
+### Connection shutdown sometimes fails over hot reload ([PR #8169](https://github.com/apollographql/router/pull/8169))
+
+A race in the way that connections were shutdown when a hot-reload is triggered meant that occasionally some connections 
+were left in active state and never entered terminating state. This could cause OOMs over time as multiple pipelines are 
+left active.
+
+This is now fixed and connections that are opening at the same time as shutdown will immediately terminate.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/8169


### PR DESCRIPTION
Previously we were using Notify to indicate to connections that they should shut down when a reload happens. However, this creates a race condition where if a connection is being established at the moment that shutdown is called the new connection will never receive the shutdown notification. Notify only notifies current waiters and will not immediately resolve if new waiters are added.

This PR switches to CancellationToken which once cancelled will always yield cancelled immediately.

This would manifest for users as ever growing memory use over hot reloads as a connection could potentially hold onto a pipeline forever.

**Note: there is no unit test**
The reason for this is that to trgger this it requires an enormous number of iterations, it's not possible to trigger it as part of a standard CI run.
I have reproduced by introducing sleeps at critical points which allows reproducing of a connection being created after the point where the the connection has shut down. 





---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1427]: https://apollographql.atlassian.net/browse/ROUTER-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #8169 done by [Mergify](https://mergify.com).