### PR TITLE
Port compose.external.test.ts

### DIFF
--- a/apollo-federation/tests/composition/external.rs
+++ b/apollo-federation/tests/composition/external.rs
@@ -1,0 +1,206 @@
+use apollo_federation::error::CompositionError;
+use apollo_federation::supergraph::Supergraph;
+
+use super::ServiceDefinition;
+use super::compose_as_fed2_subgraphs;
+
+fn error_messages<S>(result: &Result<Supergraph<S>, Vec<CompositionError>>) -> Vec<String> {
+    match result {
+        Ok(_) => panic!("Expected an error, but got a successful composition"),
+        Err(err) => err.iter().map(|e| e.to_string()).collect(),
+    }
+}
+
+fn assert_composition_success<S>(result: &Result<Supergraph<S>, Vec<CompositionError>>) {
+    match result {
+        Ok(_) => {}
+        Err(err) => panic!("Expected successful composition, but got errors: {:?}", err),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "Compose directive manager validation not yet implemented."]
+    fn errors_on_incompatible_types_with_external() {
+        let subgraph_a = ServiceDefinition {
+            name: "subgraphA",
+            type_defs: r#"
+                type Query {
+                    T: T! @provides(fields: "f")
+                }
+
+                type T @key(fields: "id") {
+                    id: ID!
+                    f: String @external
+                }
+            "#,
+        };
+
+        let subgraph_b = ServiceDefinition {
+            name: "subgraphB",
+            type_defs: r#"
+                type T @key(fields: "id") {
+                    id: ID!
+                    f: Int @shareable
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+        let messages = error_messages(&result);
+        assert_eq!(
+            messages,
+            [
+                r#"Type of field "T.f" is incompatible across subgraphs (where marked @external): it has type "Int" in subgraph "subgraphB" but type "String" in subgraph "subgraphA""#
+            ]
+        );
+    }
+
+    #[test]
+    #[ignore = "Compose directive manager validation not yet implemented."]
+    fn errors_on_missing_arguments_to_external_declaration() {
+        let subgraph_a = ServiceDefinition {
+            name: "subgraphA",
+            type_defs: r#"
+                type Query {
+                    T: T! @provides(fields: "f")
+                }
+
+                type T @key(fields: "id") {
+                    id: ID!
+                    f: String @external
+                }
+            "#,
+        };
+
+        let subgraph_b = ServiceDefinition {
+            name: "subgraphB",
+            type_defs: r#"
+                type T @key(fields: "id") {
+                    id: ID!
+                    f(x: Int): String @shareable
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+        let messages = error_messages(&result);
+        assert_eq!(
+            messages,
+            [
+                r#"Field "T.f" is missing argument "T.f(x:)" in some subgraphs where it is marked @external: argument "T.f(x:)" is declared in subgraph "subgraphB" but not in subgraph "subgraphA" (where "T.f" is @external)."#
+            ]
+        );
+    }
+
+    #[test]
+    #[ignore = "Compose directive manager validation not yet implemented."]
+    fn errors_on_incompatible_argument_types_in_external_declaration() {
+        let subgraph_a = ServiceDefinition {
+            name: "subgraphA",
+            type_defs: r#"
+                type Query {
+                    T: T!
+                }
+
+                interface I {
+                    f(x: String): String
+                }
+
+                type T implements I @key(fields: "id") {
+                    id: ID!
+                    f(x: String): String @external
+                }
+            "#,
+        };
+
+        let subgraph_b = ServiceDefinition {
+            name: "subgraphB",
+            type_defs: r#"
+                type T @key(fields: "id") {
+                    id: ID!
+                    f(x: Int): String
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+        let messages = error_messages(&result);
+        assert_eq!(
+            messages,
+            [
+                r#"Type of argument "T.f(x:)" is incompatible across subgraphs (where "T.f" is marked @external): it has type "Int" in subgraph "subgraphB" but type "String" in subgraph "subgraphA""#
+            ]
+        );
+    }
+
+    #[test]
+    #[ignore = "Compose directive manager validation not yet implemented."]
+    fn external_marked_on_type() {
+        let subgraph_a = ServiceDefinition {
+            name: "subgraphA",
+            type_defs: r#"
+                type Query {
+                    T: T!
+                }
+
+                type T @key(fields: "id") {
+                    id: ID!
+                    x: X @external
+                    y: Int @requires(fields: "x { a b c d }")
+                }
+
+                type X @external {
+                    a: Int
+                    b: Int
+                    c: Int
+                    d: Int
+                }
+            "#,
+        };
+
+        let subgraph_b = ServiceDefinition {
+            name: "subgraphB",
+            type_defs: r#"
+                type T @key(fields: "id") {
+                    id: ID!
+                    x: X
+                }
+
+                type X {
+                    a: Int
+                    b: Int
+                    c: Int
+                    d: Int
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+        assert_composition_success(&result);
+
+        // Confirm the output schema is correct
+        let supergraph_schema = r#"
+            type Query {
+                T: T!
+            }
+
+            type T {
+                id: ID!
+                x: X
+                y: Int
+            }
+
+            type X {
+                a: Int
+                b: Int
+                c: Int
+                d: Int
+            }
+        "#;
+        assert_eq!(&result.unwrap().schema().schema().to_string(), supergraph_schema);
+    }
+}

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -1,6 +1,8 @@
 // TODO: Enable this test module when @composeDirective logic is implemented in FED-645
 // mod compose_directive;
 mod demand_control;
+// TODO: remove #[ignore] from tests once compose directive manager validation is implemented
+mod external;
 mod subscription;
 mod validation_errors;
 


### PR DESCRIPTION
Ports tests from [compose.external.test.ts](https://github.com/apollographql/federation/blob/main/composition-js/src/__tests__/compose.external.test.ts). However, tests are marked as `#[ignore]`, as the `@composeDirective` manager validation has not yet been implemented.


<!-- [FED-687] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [X] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
