### PR TITLE
prep release: v2.6.1

### DIFF
--- a/.changesets/fix_bnjjj_fix_subs_closing.md
+++ b/.changesets/fix_bnjjj_fix_subs_closing.md
@@ -1,7 +1,0 @@
-### Fix deduplication and websocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))
-
-Fixes an issue where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.
-
-Previously, when clients disconnected from subscription streams, the router would correctly close client connections but would leave the underlying WebSocket connection to the subgraph open indefinitely in some cases.
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/8104

--- a/.changesets/fix_glasser_helm_deployment_annotations.md
+++ b/.changesets/fix_glasser_helm_deployment_annotations.md
@@ -1,5 +1,0 @@
-### Enable annotations on deployments via Helm Chart ([PR #8164](https://github.com/apollographql/router/pull/8164))
-
-The Helm chart previously did not allow customization of annotations on the deployment itself (as opposed to the pods within it, which is done with `podAnnotations`); this can now be done with the `deploymentAnnotations` value.
-
-By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/8164

--- a/.changesets/fix_princess_cantaloupe.md
+++ b/.changesets/fix_princess_cantaloupe.md
@@ -1,5 +1,0 @@
-### Make the `id` field optional for WebSocket subscription `connection_error` messages ([Issue #6138](https://github.com/apollographql/router/issues/6138))
-
-Fixed a Subscriptions over WebSocket issue where `connection_error` messages from subgraphs would be swallowed by the router because they incorrectly required an `id` field. According to the `graphql-transport-ws` specification (one of two transport specifications we provide support for), `connection_error` messages only require a `payload` field, **not** an `id` field. The `id` field in is now optional which will allow the underlying error message to propagate to clients when underlying connection failures occur.
-
-By [@jeffutter](https://github.com/jeffutter) in https://github.com/apollographql/router/pull/8189

--- a/.changesets/fix_rreg_fix_entities_errors_missing_service.md
+++ b/.changesets/fix_rreg_fix_entities_errors_missing_service.md
@@ -1,7 +1,0 @@
-### Fix _entities Apollo Error Metrics Missing Service Attribute ([PR #8153](https://github.com/apollographql/router/pull/8153))
-
-Error counting https://github.com/apollographql/router/pull/7712 introduced a bug where `_entities` errors from a subgraph fetch no longer reported a service (subgraph or connector) attribute. This erroneously categorized these errors as from the Router rather than their originating service in the Studio UI.
-
-The attribute has been re-added, fixing this issue.
-
-By [@rregitsky](https://github.com/rregitsky) in https://github.com/apollographql/router/pull/8153

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ By [@rregitsky](https://github.com/rregitsky) in https://github.com/apollographq
 
 ### Deduplication and WebSocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))
 
-Fixed an issue where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.
+Fixed a regression introduced in v2.5.0, where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.
 
 Previously, when clients disconnected from subscription streams, the router would correctly close client connections but would leave the underlying WebSocket connection to the subgraph open indefinitely in some cases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,15 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ### Fix _entities Apollo Error Metrics Missing Service Attribute ([PR #8153](https://github.com/apollographql/router/pull/8153))
 
-Error counting https://github.com/apollographql/router/pull/7712 introduced a bug where `_entities` errors from a subgraph fetch no longer reported a service (subgraph or connector) attribute. This erroneously categorized these errors as from the Router rather than their originating service in the Studio UI.
+The error counting feature introduced in [PR #7712](https://github.com/apollographql/router/pull/7712) caused a bug where `_entities` errors from subgraph fetches no longer included a service (subgraph or connector) attribute. This incorrectly categorized these errors as originating from the router instead of their actual service in the Apollo Studio UI.
 
-The attribute has been re-added, fixing this issue.
+This fix restores the missing service attribute.
 
 By [@rregitsky](https://github.com/rregitsky) in https://github.com/apollographql/router/pull/8153
 
-### Fix deduplication and websocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))
+### Fix deduplication and WebSocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))
 
-Fixes an issue where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.
+Fixed an issue where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.
 
 Previously, when clients disconnected from subscription streams, the router would correctly close client connections but would leave the underlying WebSocket connection to the subgraph open indefinitely in some cases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+# [2.6.1] - 2025-09-08
+
+## 🐛 Fixes
+
+### Fix _entities Apollo Error Metrics Missing Service Attribute ([PR #8153](https://github.com/apollographql/router/pull/8153))
+
+Error counting https://github.com/apollographql/router/pull/7712 introduced a bug where `_entities` errors from a subgraph fetch no longer reported a service (subgraph or connector) attribute. This erroneously categorized these errors as from the Router rather than their originating service in the Studio UI.
+
+The attribute has been re-added, fixing this issue.
+
+By [@rregitsky](https://github.com/rregitsky) in https://github.com/apollographql/router/pull/8153
+
+### Fix deduplication and websocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))
+
+Fixes an issue where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.
+
+Previously, when clients disconnected from subscription streams, the router would correctly close client connections but would leave the underlying WebSocket connection to the subgraph open indefinitely in some cases.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/8104
+
+### Make the `id` field optional for WebSocket subscription `connection_error` messages ([Issue #6138](https://github.com/apollographql/router/issues/6138))
+
+Fixed a Subscriptions over WebSocket issue where `connection_error` messages from subgraphs would be swallowed by the router because they incorrectly required an `id` field. According to the `graphql-transport-ws` specification (one of two transport specifications we provide support for), `connection_error` messages only require a `payload` field, **not** an `id` field. The `id` field in is now optional which will allow the underlying error message to propagate to clients when underlying connection failures occur.
+
+By [@jeffutter](https://github.com/jeffutter) in https://github.com/apollographql/router/pull/8189
+
+### Enable annotations on deployments via Helm Chart ([PR #8164](https://github.com/apollographql/router/pull/8164))
+
+The Helm chart previously did not allow customization of annotations on the deployment itself (as opposed to the pods within it, which is done with `podAnnotations`); this can now be done with the `deploymentAnnotations` value.
+
+By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/8164
+
+
+
 # [2.6.0] - 2025-08-25
 
 ## 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ### `_entities` Apollo Error Metrics Missing Service Attribute ([PR #8153](https://github.com/apollographql/router/pull/8153))
 
-The error counting feature introduced in [PR #7712](https://github.com/apollographql/router/pull/7712) caused a bug where `_entities` errors from subgraph fetches no longer included a service (subgraph or connector) attribute. This incorrectly categorized these errors as originating from the router instead of their actual service in the Apollo Studio UI.
+The error counting feature introduced in v2.5.0 ([PR #7712](https://github.com/apollographql/router/pull/7712)) caused a bug where `_entities` errors from subgraph fetches no longer included a service (subgraph or connector) attribute. This incorrectly categorized these errors as originating from the router instead of their actual service in the Apollo Studio UI.
 
 This fix restores the missing service attribute.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ## 🐛 Fixes
 
-### Fix _entities Apollo Error Metrics Missing Service Attribute ([PR #8153](https://github.com/apollographql/router/pull/8153))
+### `_entities` Apollo Error Metrics Missing Service Attribute ([PR #8153](https://github.com/apollographql/router/pull/8153))
 
 The error counting feature introduced in [PR #7712](https://github.com/apollographql/router/pull/7712) caused a bug where `_entities` errors from subgraph fetches no longer included a service (subgraph or connector) attribute. This incorrectly categorized these errors as originating from the router instead of their actual service in the Apollo Studio UI.
 
@@ -14,7 +14,7 @@ This fix restores the missing service attribute.
 
 By [@rregitsky](https://github.com/rregitsky) in https://github.com/apollographql/router/pull/8153
 
-### Fix deduplication and WebSocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))
+### Deduplication and WebSocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))
 
 Fixed an issue where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.6.1-rc.0"
+version = "2.6.1"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "2.6.1-rc.0"
+version = "2.6.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "2.6.1-rc.0"
+version = "2.6.1"
 dependencies = [
  "apollo-parser",
  "apollo-router",

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation"
-version = "2.6.1-rc.0"
+version = "2.6.1"
 authors = ["The Apollo GraphQL Contributors"]
 edition = "2024"
 description = "Apollo Federation"

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "2.6.1-rc.0"
+version = "2.6.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "2.6.1-rc.0"
+version = "2.6.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"
@@ -58,7 +58,7 @@ snapshot = ["axum-server"]
 [dependencies]
 anyhow = "1.0.86"
 apollo-compiler.workspace = true
-apollo-federation = { path = "../apollo-federation", version = "=2.6.1-rc.0" }
+apollo-federation = { path = "../apollo-federation", version = "=2.6.1" }
 async-compression = { version = "0.4.6", features = [
     "tokio",
     "brotli",

--- a/docs/shared/k8s-manual-config.mdx
+++ b/docs/shared/k8s-manual-config.mdx
@@ -6,10 +6,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-2.6.1-rc.0
+    helm.sh/chart: router-2.6.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.6.1-rc.0"
+    app.kubernetes.io/version: "v2.6.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: router/templates/secret.yaml
@@ -18,10 +18,10 @@ kind: Secret
 metadata:
   name: "release-name-router"
   labels:
-    helm.sh/chart: router-2.6.1-rc.0
+    helm.sh/chart: router-2.6.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.6.1-rc.0"
+    app.kubernetes.io/version: "v2.6.1"
     app.kubernetes.io/managed-by: Helm
 data:
   managedFederationApiKey: "UkVEQUNURUQ="
@@ -32,10 +32,10 @@ kind: ConfigMap
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-2.6.1-rc.0
+    helm.sh/chart: router-2.6.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.6.1-rc.0"
+    app.kubernetes.io/version: "v2.6.1"
     app.kubernetes.io/managed-by: Helm
 data:
   configuration.yaml: |
@@ -55,10 +55,10 @@ kind: Service
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-2.6.1-rc.0
+    helm.sh/chart: router-2.6.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.6.1-rc.0"
+    app.kubernetes.io/version: "v2.6.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -81,10 +81,10 @@ kind: Deployment
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-2.6.1-rc.0
+    helm.sh/chart: router-2.6.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.6.1-rc.0"
+    app.kubernetes.io/version: "v2.6.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
   
@@ -103,10 +103,10 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: router
       labels:
-        helm.sh/chart: router-2.6.1-rc.0
+        helm.sh/chart: router-2.6.1
         app.kubernetes.io/name: router
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v2.6.1-rc.0"
+        app.kubernetes.io/version: "v2.6.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: release-name-router
@@ -117,7 +117,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v2.6.1-rc.0"
+          image: "ghcr.io/apollographql/router:v2.6.1"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload
@@ -171,10 +171,10 @@ kind: Pod
 metadata:
   name: "release-name-router-test-connection"
   labels:
-    helm.sh/chart: router-2.6.1-rc.0
+    helm.sh/chart: router-2.6.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.6.1-rc.0"
+    app.kubernetes.io/version: "v2.6.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 2.6.1-rc.0
+version: 2.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.6.1-rc.0"
+appVersion: "v2.6.1"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 2.6.1-rc.0](https://img.shields.io/badge/Version-2.6.1--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.6.1-rc.0](https://img.shields.io/badge/AppVersion-v2.6.1--rc.0-informational?style=flat-square)
+![Version: 2.6.1](https://img.shields.io/badge/Version-2.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.6.1](https://img.shields.io/badge/AppVersion-v2.6.1-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 2.6.1-rc.0
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 2.6.1
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 2.6.1-rc.0
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 2.6.1-rc.0 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 2.6.1 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_ROUTER_BINARY_DOWNLOAD_PREFIX:="https://github.
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v2.6.1-rc.0"
+PACKAGE_VERSION="v2.6.1"
 
 download_binary() {
     downloader --check


### PR DESCRIPTION
> **Note**
>
> When approved, this PR will merge into **the `2.6.1` branch** which will — upon being approved itself — merge into `main`.
>
> **Things to review in this PR**:
>  - Changelog correctness (There is a preview below, but it is not necessarily the most up to date.  See the _Files Changed_ for the true reality.)
>  - Version bumps
>  - That it targets the right release branch (`2.6.1` in this case!).
>
---
## 🐛 Fixes

### `_entities` Apollo Error Metrics Missing Service Attribute ([PR #8153](https://github.com/apollographql/router/pull/8153))

The error counting feature introduced in [PR #7712](https://github.com/apollographql/router/pull/7712) caused a bug where `_entities` errors from subgraph fetches no longer included a service (subgraph or connector) attribute. This incorrectly categorized these errors as originating from the router instead of their actual service in the Apollo Studio UI.

This fix restores the missing service attribute.

By [@rregitsky](https://github.com/rregitsky) in https://github.com/apollographql/router/pull/8153

### Deduplication and WebSocket stream termination ([PR #8104](https://github.com/apollographql/router/pull/8104))

Fixed an issue where WebSocket connections to subgraphs would remain open after all client subscriptions were closed. This could lead to unnecessary resource usage and connections not being properly cleaned up until a new event was received.

Previously, when clients disconnected from subscription streams, the router would correctly close client connections but would leave the underlying WebSocket connection to the subgraph open indefinitely in some cases.

By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/8104

### Make the `id` field optional for WebSocket subscription `connection_error` messages ([Issue #6138](https://github.com/apollographql/router/issues/6138))

Fixed a WebSocket subscriptions issue where `connection_error` messages from subgraphs would be dropped by the router because they incorrectly required an `id` field. According to the `graphql-transport-ws` specification (one of two transport specifications we support), `connection_error` messages only require a `payload` field, **not** an `id` field. The `id` field is now optional, which allows the underlying error message to propagate to clients when underlying connection failures occur.

By [@jeffutter](https://github.com/jeffutter) in https://github.com/apollographql/router/pull/8189

### Enable annotations on deployments via Helm Chart ([PR #8164](https://github.com/apollographql/router/pull/8164))

The Helm chart previously did not allow customization of annotations on the deployment itself (as opposed to the pods within it, which is done with `podAnnotations`); this can now be done with the `deploymentAnnotations` value.

By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/8164
