### PR TITLE
cors: add more tests for `allow_any_origin`

### DIFF
--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1532,6 +1532,32 @@ async fn cors_allow_any_origin() -> Result<(), ApolloRouterError> {
 }
 
 #[tokio::test]
+async fn cors_allow_any_origin_but_no_origin_header() -> Result<(), ApolloRouterError> {
+    let conf = Configuration::fake_builder()
+        .cors(Cors::builder().allow_any_origin(true).build())
+        .build()
+        .unwrap();
+    let (server, client) = init_with_config(
+        router::service::empty().await,
+        Arc::new(conf),
+        MultiMap::new(),
+    )
+    .await?;
+    let url = format!("{}/", server.graphql_listen_address().as_ref().unwrap());
+
+    let response = client
+        .request(Method::OPTIONS, url)
+        .header("Access-Control-Request-Method", "POST")
+        .header("Access-Control-Request-Headers", "content-type")
+        .send()
+        .await
+        .unwrap();
+    assert_not_cors_origin(response, "*");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn cors_origin_list() -> Result<(), ApolloRouterError> {
     let valid_origin = "https://thisoriginisallowed.com";
 


### PR DESCRIPTION
Adds tests demonstrating the behaviour change in router v2.5.0 mentioned in https://github.com/apollographql/router/issues/8222.

Previously, if you configured `cors.allow_any_origin: true` and an incoming request did _not_ have an `Origin` header, the router would return `Access-Control-Allow-Origin: *`.
As of v2.5.0, the router does not return any CORS headers if the request does not have an `Origin`, even if `allow_any_origin` is enabled.

My impression is that this is a benign change as browser CORS requests always include `Origin`, but that's pending confirmation.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- <strike>Changeset is included for user-facing changes</strike>
- [x] Changes are compatible[^1]
- <strike>Documentation[^2] completed</strike>
- <strike>Performance impact assessed and acceptable</strike>
- <strike>Metrics and logs are added[^3] and documented</strike>
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - <strike>Manual tests, as necessary</strike>

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
