### PR TITLE
fix: don't attempt to carryover directives for missing types

### DIFF
--- a/apollo-federation/src/connectors/expand/tests/schemas/ignore/directives.graphql
+++ b/apollo-federation/src/connectors/expand/tests/schemas/ignore/directives.graphql
@@ -9,11 +9,9 @@ schema
   @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@listSize"])
   @link(url: "https://specs.apollo.dev/cacheTag/v0.1", for: EXECUTION)
   @link(url: "https://specs.apollo.dev/context/v0.1", for: SECURITY)
-  @link(
-    url: "http://specs.example.org/custom/v0.1"
-    import: ["@custom1", "@custom2", { name: "@originalName", as: "@custom3" }]
-  )
-  @link(url: "http://bugfix/weird/v1.0", import: ["@weird"]) {
+  @link(url: "http://specs.example.org/custom/v0.1", import: ["@custom1", "@custom2", {name: "@originalName", as: "@custom3"}])
+  @link(url: "http://bugfix/weird/v1.0", import: ["@weird"])
+{
   query: Query
 }
 
@@ -21,13 +19,9 @@ directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENU
 
 directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 
-directive @context__fromContext(
-  field: context__ContextFieldValue
-) on ARGUMENT_DEFINITION
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
 
-directive @cost(
-  weight: Int!
-) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+directive @cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
 
 directive @custom1 on OBJECT | FIELD_DEFINITION
 
@@ -37,71 +31,29 @@ directive @custom3 on OBJECT | FIELD_DEFINITION
 
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-directive @join__directive(
-  graphs: [join__Graph!]
-  name: String!
-  args: join__DirectiveArguments
-) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(
-  graph: join__Graph
-  requires: join__FieldSet
-  provides: join__FieldSet
-  type: String
-  external: Boolean
-  override: String
-  usedOverridden: Boolean
-  overrideLabel: String
-  contextArguments: [join__ContextArgument!]
-) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
-directive @join__implements(
-  graph: join__Graph!
-  interface: String!
-) repeatable on OBJECT | INTERFACE
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 
-directive @join__type(
-  graph: join__Graph!
-  key: join__FieldSet
-  extension: Boolean! = false
-  resolvable: Boolean! = true
-  isInterfaceObject: Boolean! = false
-) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-directive @join__unionMember(
-  graph: join__Graph!
-  member: String!
-) repeatable on UNION
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
-directive @link(
-  url: String
-  as: String
-  for: link__Purpose
-  import: [link__Import]
-) repeatable on SCHEMA
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-directive @listSize(
-  assumedSize: Int
-  slicingArguments: [String!]
-  sizedFields: [String!]
-  requireOneSlicingArgument: Boolean = true
-) on FIELD_DEFINITION
+directive @listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
 
-directive @policy(
-  policies: [[policy__Policy!]!]!
-) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+directive @policy(policies: [[policy__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 
-directive @requiresScopes(
-  scopes: [[requiresScopes__Scope!]!]!
-) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+directive @requiresScopes(scopes: [[requiresScopes__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
 
-directive @tag(
-  name: String!
-) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
 
 directive @weird on FIELD | FIELD_DEFINITION
 
@@ -141,53 +93,50 @@ enum link__Purpose {
 
 scalar policy__Policy
 
-type Query @join__type(graph: ONE) @join__type(graph: TWO) {
+type Query
+  @join__type(graph: ONE)
+  @join__type(graph: TWO)
+{
   tagged: String @join__field(graph: ONE) @tag(name: "tag")
   hidden: String @inaccessible @join__field(graph: ONE)
   custom: T @join__field(graph: ONE) @custom1
   authenticated: String @join__field(graph: ONE) @authenticated
-  requiresScopes: String
-    @join__field(graph: ONE)
-    @requiresScopes(scopes: ["scope"])
+  requiresScopes: String @join__field(graph: ONE) @requiresScopes(scopes: ["scope"])
   policy: String @join__field(graph: ONE) @policy(policies: [["admin"]])
-  overridden: String
-    @join__field(graph: ONE, override: "two", overrideLabel: "label")
-    @join__field(graph: TWO, overrideLabel: "label")
-    @join__directive(
-      graphs: [ONE]
-      name: "federation__cacheTag"
-      args: { format: "hello" }
-    )
+  overridden: String @join__field(graph: ONE, override: "two", overrideLabel: "label") @join__field(graph: TWO, overrideLabel: "label") @join__directive(graphs: [ONE], name: "federation__cacheTag", args: {format: "hello"})
   weird: [String] @join__field(graph: ONE) @weird @listSize(assumedSize: 99)
-  customAgain: String
-    @join__field(graph: TWO)
-    @join__directive(
-      graphs: [TWO]
-      name: "federation__cacheTag"
-      args: { format: "goodbye" }
-    )
-    @custom1
+  customAgain: String @join__field(graph: TWO) @join__directive(graphs: [TWO], name: "federation__cacheTag", args: {format: "goodbye"}) @custom1
   z: Z @join__field(graph: TWO)
 }
 
 scalar requiresScopes__Scope
 
-type T @join__type(graph: ONE) @custom2 {
+type T
+  @join__type(graph: ONE)
+  @custom2
+{
   field: String @custom3 @cost(weight: 5)
 }
 
-type X @join__type(graph: TWO, key: "id") {
-  id: ID!
-  w: String
-    @join__field(
-      graph: TWO
-      contextArguments: [
-        { context: "two__ctx", name: "z", type: "String", selection: " { y }" }
-      ]
-    )
+enum UnusedEnum
+  @join__type(graph: ONE)
+  @inaccessible
+{
+  A @join__enumValue(graph: ONE)
+  B @join__enumValue(graph: ONE)
 }
 
-type Z @join__type(graph: TWO, key: "id") @context(name: "two__ctx") {
+type X
+  @join__type(graph: TWO, key: "id")
+{
+  id: ID!
+  w: String @join__field(graph: TWO, contextArguments: [{context: "two__ctx", name: "z", type: "String", selection: " { y }"}])
+}
+
+type Z
+  @join__type(graph: TWO, key: "id")
+  @context(name: "two__ctx")
+{
   id: ID!
   y: String
   x: X

--- a/apollo-federation/src/connectors/expand/tests/schemas/ignore/directives.yaml
+++ b/apollo-federation/src/connectors/expand/tests/schemas/ignore/directives.yaml
@@ -53,6 +53,11 @@ subgraphs:
         extend type Query {
           weird: [String] @weird @listSize(assumedSize: 99)
         }
+
+        enum UnusedEnum @inaccessible {
+          A
+          B
+        }
   two:
     routing_url: none
     schema:


### PR DESCRIPTION
if a type is unused (no connector references it) it won't end up in the supergraph. but if it has a directive we usually need to preserve, the code would try to add that directive. this change ignores missing types, which weren't reachable anyway to it has no effect on planning

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
