### PR TITLE
chore(xtask,changesets): Ask the user if they want to git stage the changeset (backport #8207)

### DIFF
--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -484,11 +484,52 @@ impl Create {
                     }
                 }
 
-                println!(
-                    "{}",
-                    style("Be sure to finalize the changeset, commit it and push it to Git.")
-                        .magenta()
-                );
+                if Confirm::new()
+                    .default(false)
+                    .with_prompt(format!(
+                        "Do you want to run `git add {}`?",
+                        &new_changeset_path,
+                    ))
+                    .interact()?
+                {
+                    match std::process::Command::new("git")
+                        .arg("add")
+                        .arg(&new_changeset_path)
+                        .output()
+                    {
+                        Ok(output) => {
+                            if output.status.success() {
+                                println!(
+                                    "{} {} {}",
+                                    style("Successfully added").green(),
+                                    style(&new_changeset_path).cyan(),
+                                    style("to git").green()
+                                );
+                            } else {
+                                eprintln!(
+                                    "{} {} {}",
+                                    style("Failed to add").red(),
+                                    style(&new_changeset_path).cyan(),
+                                    style("to git").red()
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "{} {}: {}",
+                                style("Failed to run git add").red(),
+                                style(&new_changeset_path).cyan(),
+                                e
+                            );
+                        }
+                    }
+                } else {
+                    println!(
+                        "{}",
+                        style("Be sure to finalize the changeset, commit it and push it to Git.")
+                            .magenta()
+                    );
+                }
 
                 Ok(())
             })


### PR DESCRIPTION
This adds a default-"no" prompt to the changesets script that asks if you
want to run `git add new_changeset.md`.  For me personally, I often forget
to stage this file because I don't just 'add all files in my workspace'.

Seems like a quality of life improvement to offer.
<hr>This is an automatic backport of pull request #8207 done by [Mergify](https://mergify.com).