### PR TITLE
deps: raise minimum `linkme` version

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -132,7 +132,7 @@ jsonpath-rust = "0.3.5"
 jsonschema = { version = "0.17.1", default-features = false }
 jsonwebtoken = "9.3.0"
 libc = "0.2.155"
-linkme = "0.3.27"
+linkme = "0.3.30"
 lru = "0.16.0"
 mediatype = "0.20.0"
 mockall = "0.13.0"


### PR DESCRIPTION
Users depending on the `apollo-router` crate may see errors when
compiling with the 2024 edition if they have `linkme` < `0.3.30` in
their dependency tree.

This PR raises the minimum required version so this does not happen.

Note anyone running into this issue can fix it by simply running
`cargo update`, which will use the latest `linkme` version.

<!-- start metadata -->

<!-- [ROUTER-1422] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- <strike>Changeset is included for user-facing changes</strike>
- [x] Changes are compatible[^1]
- <strike>Documentation[^2] completed</strike>
- <strike>Performance impact assessed and acceptable</strike>
- <strike>Metrics and logs are added[^3] and documented</strike>
- <strike>Tests added and passing[^4]</strike>

**Exceptions**

Arguably, a changeset could be justified, but it's very niche and would be noise to 99.9% of users.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
