### PR TITLE
feat(response_cache): add new selector to get cache status

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,7 +1,6 @@
 ---
 source: apollo-router/src/configuration/tests.rs
 expression: "&schema"
-snapshot_kind: text
 ---
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -417,6 +416,15 @@ snapshot_kind: text
       "enum": [
         "hit",
         "miss"
+      ],
+      "type": "string"
+    },
+    "CacheStatus": {
+      "enum": [
+        "hit",
+        "miss",
+        "partial_hit",
+        "status"
       ],
       "type": "string"
     },
@@ -7646,6 +7654,24 @@ snapshot_kind: text
           },
           "required": [
             "response_cache"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "entity_type": {
+              "$ref": "#/definitions/EntityType",
+              "description": "#/definitions/EntityType",
+              "nullable": true
+            },
+            "response_cache_status": {
+              "$ref": "#/definitions/CacheStatus",
+              "description": "#/definitions/CacheStatus"
+            }
+          },
+          "required": [
+            "response_cache_status"
           ],
           "type": "object"
         }

--- a/apollo-router/src/plugins/telemetry/config_new/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/selectors.rs
@@ -77,3 +77,12 @@ pub(crate) enum CacheKind {
     Hit,
     Miss,
 }
+
+#[derive(Deserialize, JsonSchema, Clone, PartialEq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CacheStatus {
+    Hit,
+    Miss,
+    PartialHit,
+    Status,
+}

--- a/apollo-router/src/plugins/telemetry/config_new/subgraph/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/subgraph/selectors.rs
@@ -23,6 +23,7 @@ use crate::plugins::telemetry::config_new::instruments::InstrumentValue;
 use crate::plugins::telemetry::config_new::instruments::Standard;
 use crate::plugins::telemetry::config_new::selectors::All;
 use crate::plugins::telemetry::config_new::selectors::CacheKind;
+use crate::plugins::telemetry::config_new::selectors::CacheStatus;
 use crate::plugins::telemetry::config_new::selectors::EntityType;
 use crate::plugins::telemetry::config_new::selectors::ErrorRepr;
 use crate::plugins::telemetry::config_new::selectors::OperationKind;
@@ -269,6 +270,12 @@ pub(crate) enum SubgraphSelector {
         /// Select if you want to get response cache hit or response cache miss
         response_cache: CacheKind,
         /// Specify the entity type on which you want the cache data. (default: all)
+        entity_type: Option<EntityType>,
+    },
+    ResponseCacheStatus {
+        /// Select if you want to know if it's a cache hit (all data coming from cache), miss (all data coming from subgraph) or partial_hit (not all entities are coming from cache for example)
+        response_cache_status: CacheStatus,
+        /// Specify the entity type on which you want the cache data status. (default: all)
         entity_type: Option<EntityType>,
     },
 }
@@ -644,6 +651,56 @@ impl Selector for SubgraphSelector {
                     }
                 }
             }
+            SubgraphSelector::ResponseCacheStatus {
+                response_cache_status,
+                entity_type,
+            } => {
+                let cache_info: response_cache::plugin::CacheSubgraph = response
+                    .context
+                    .get(response_cache::metrics::CacheMetricContextKey::new(
+                        response.subgraph_name.clone(),
+                    ))
+                    .ok()
+                    .flatten()?;
+
+                let (cache_hit, cache_miss, entity_type_exist) = cache_info.0.iter().fold(
+                    (0, 0, false),
+                    |(mut cache_hit, mut cache_miss, mut entity_type_exist),
+                     (current_entity_type, cache_hit_miss)| {
+                        let compute = match entity_type {
+                            Some(EntityType::All(All::All)) | None => true,
+                            Some(EntityType::Named(entity_type_name)) => {
+                                current_entity_type == entity_type_name
+                            }
+                        };
+                        if compute {
+                            cache_hit += cache_hit_miss.hit;
+                            cache_miss += cache_hit_miss.miss;
+                            entity_type_exist = true;
+                        }
+
+                        (cache_hit, cache_miss, entity_type_exist)
+                    },
+                );
+                entity_type_exist.then(|| match response_cache_status {
+                    CacheStatus::Hit => (cache_hit > 0 && cache_miss == 0).into(),
+                    CacheStatus::Miss => (cache_hit == 0).into(),
+                    CacheStatus::PartialHit => (cache_hit > 0 && cache_miss > 0).into(),
+                    CacheStatus::Status => {
+                        if cache_miss == 0 {
+                            if cache_hit > 0 {
+                                opentelemetry::Value::String("hit".into())
+                            } else {
+                                opentelemetry::Value::String("miss".into())
+                            }
+                        } else if cache_hit > 0 {
+                            opentelemetry::Value::String("partial_hit".into())
+                        } else {
+                            opentelemetry::Value::String("miss".into())
+                        }
+                    }
+                })
+            }
             // For request
             _ => None,
         }
@@ -793,6 +850,7 @@ mod test {
     use crate::plugins::telemetry::config_new::Selector;
     use crate::plugins::telemetry::config_new::selectors::All;
     use crate::plugins::telemetry::config_new::selectors::CacheKind;
+    use crate::plugins::telemetry::config_new::selectors::CacheStatus;
     use crate::plugins::telemetry::config_new::selectors::EntityType;
     use crate::plugins::telemetry::config_new::selectors::OperationKind;
     use crate::plugins::telemetry::config_new::selectors::OperationName;
@@ -1243,6 +1301,264 @@ mod test {
                     .build(),
             ),
             Some(opentelemetry::Value::I64(5))
+        );
+    }
+
+    #[test]
+    fn response_cache_status_all() {
+        let selector = SubgraphSelector::ResponseCacheStatus {
+            response_cache_status: CacheStatus::Status,
+            entity_type: Some(EntityType::All(All::All)),
+        };
+        let selector_hit = SubgraphSelector::ResponseCacheStatus {
+            response_cache_status: CacheStatus::Hit,
+            entity_type: Some(EntityType::All(All::All)),
+        };
+        let context = crate::context::Context::new();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            None
+        );
+        let cache_info = response_cache::plugin::CacheSubgraph(
+            [
+                (
+                    "Products".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 3, miss: 1 },
+                ),
+                (
+                    "Reviews".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 2, miss: 0 },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let _ = context
+            .insert(
+                response_cache::metrics::CacheMetricContextKey::new("test".to_string()),
+                cache_info,
+            )
+            .unwrap();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::String("partial_hit".into()))
+        );
+
+        let context = crate::context::Context::new();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            None
+        );
+        let cache_info = response_cache::plugin::CacheSubgraph(
+            [
+                (
+                    "Products".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 3, miss: 0 },
+                ),
+                (
+                    "Reviews".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 2, miss: 0 },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let _ = context
+            .insert(
+                response_cache::metrics::CacheMetricContextKey::new("test".to_string()),
+                cache_info,
+            )
+            .unwrap();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::String("hit".into()))
+        );
+        assert_eq!(
+            selector_hit.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::Bool(true))
+        );
+        let cache_info = response_cache::plugin::CacheSubgraph(
+            [
+                (
+                    "Products".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 0, miss: 1 },
+                ),
+                (
+                    "Reviews".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 0, miss: 4 },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let _ = context
+            .insert(
+                response_cache::metrics::CacheMetricContextKey::new("test".to_string()),
+                cache_info,
+            )
+            .unwrap();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::String("miss".into()))
+        );
+    }
+
+    #[test]
+    fn response_cache_status_type() {
+        let selector = SubgraphSelector::ResponseCacheStatus {
+            response_cache_status: CacheStatus::Status,
+            entity_type: Some(EntityType::Named("Products".to_string())),
+        };
+        let selector_hit = SubgraphSelector::ResponseCacheStatus {
+            response_cache_status: CacheStatus::Hit,
+            entity_type: Some(EntityType::Named("Products".to_string())),
+        };
+        let context = crate::context::Context::new();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            None
+        );
+        let cache_info = response_cache::plugin::CacheSubgraph(
+            [
+                (
+                    "Products".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 3, miss: 1 },
+                ),
+                (
+                    "Reviews".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 0, miss: 3 },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let _ = context
+            .insert(
+                response_cache::metrics::CacheMetricContextKey::new("test".to_string()),
+                cache_info,
+            )
+            .unwrap();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::String("partial_hit".into()))
+        );
+
+        let context = crate::context::Context::new();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            None
+        );
+        let cache_info = response_cache::plugin::CacheSubgraph(
+            [
+                (
+                    "Products".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 3, miss: 0 },
+                ),
+                (
+                    "Reviews".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 2, miss: 1 },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let _ = context
+            .insert(
+                response_cache::metrics::CacheMetricContextKey::new("test".to_string()),
+                cache_info,
+            )
+            .unwrap();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::String("hit".into()))
+        );
+        assert_eq!(
+            selector_hit.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::Bool(true))
+        );
+        let cache_info = response_cache::plugin::CacheSubgraph(
+            [
+                (
+                    "Products".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 0, miss: 1 },
+                ),
+                (
+                    "Reviews".to_string(),
+                    response_cache::plugin::CacheHitMiss { hit: 4, miss: 4 },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let _ = context
+            .insert(
+                response_cache::metrics::CacheMetricContextKey::new("test".to_string()),
+                cache_info,
+            )
+            .unwrap();
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::String("miss".into()))
         );
     }
 


### PR DESCRIPTION
This gives us the abililty to configure subgraph instruments like this:

```yaml
telemetry:
  instrumentation:
    events:
      subgraph:
        response:
          level: info
          condition:
            all:
              - eq:
                  - subgraph_name: true
                  - static: posts
              - eq:
                  - response_cache_status: status
                  - miss
    instruments:
      subgraph:
        http.client.request.duration:
          attributes:
            subgraph.name: true
            http.response.status_code:
              subgraph_response_status: code
            response.cache.hit:
              response_cache: hit
            response.cache.status:
              response_cache_status: status
```

and will be easier to filter on a subgraph coming from cache or not or partially.