### PR TITLE
Add tests for response validation

### DIFF
--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure.snap
@@ -164,7 +164,7 @@ snapshot_kind: text
         ]
       },
       {
-        "message": "Cannot return null for non-nullable field T!.t",
+        "message": "Cannot return null for non-nullable field Query.t",
         "path": [
           "t"
         ]

--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
@@ -161,7 +161,7 @@ expression: response
         ]
       },
       {
-        "message": "Cannot return null for non-nullable field T!.t",
+        "message": "Cannot return null for non-nullable field Query.t",
         "path": [
           "t"
         ]


### PR DESCRIPTION
Reintroduces tests from #5787. That PR adds error reporting when we nullify a field (due to it being invalid, or a required property of an object not having a value). Unfortunately, adding this reporting broke several customers in production, hence why it was reverted.

Without that error reporting, though, we are doing something clearly wrong. There is no way for a client to differentiate between a `null` value due to an _error_, or a `null` value that is intended. Testing the existing behaviour is step 0 towards resolving this long-standing defect.

This is a very early draft that just revives the testing from the old PR. Strategy here should be...:

- [ ] Update these tests to expect the _current behaviour_ (right now they expect _improved_ behaviour)
- [ ] Cover a lot more permutations of data types expected by the schema and data types returned by the subgraph

Then later, in separate PRs:

- Add a (probably _opt-in_) configuration that reports errors correctly when we nullify a field. This would resolve the defect. It would be enabled by default in a future major version.
- Add further validation/coercion of responses, for example for values with type `ID`, also opt-in behind a config flag.

<!-- [ROUTER-887] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-887]: https://apollographql.atlassian.net/browse/ROUTER-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ