### PR TITLE
Fix: non-connect directives throwing off index count

### DIFF
--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@simple.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@simple.graphql.snap
@@ -340,7 +340,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
             "connectors.example http: GET /{$args.id}",
         ),
     },
-    "connectors_User_d_1": Connector {
+    "connectors_User_d_0": Connector {
         id: ConnectId {
             subgraph_name: "connectors",
             source_name: Some(
@@ -351,7 +351,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.
                 ObjectOrInterfaceFieldDirectivePosition {
                     field: Object(User.d),
                     directive_name: "connect",
-                    directive_index: 1,
+                    directive_index: 0,
                 },
             ),
         },

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@steelthread.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@steelthread.graphql.snap
@@ -340,7 +340,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
             "connectors.json http: GET /users/{$args.id}",
         ),
     },
-    "connectors_User_d_1": Connector {
+    "connectors_User_d_0": Connector {
         id: ConnectId {
             subgraph_name: "connectors",
             source_name: Some(
@@ -351,7 +351,7 @@ input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelth
                 ObjectOrInterfaceFieldDirectivePosition {
                     field: Object(User.d),
                     directive_name: "connect",
-                    directive_index: 1,
+                    directive_index: 0,
                 },
             ),
         },

--- a/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@simple.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@simple.graphql.snap
@@ -3,7 +3,7 @@ source: apollo-federation/src/connectors/expand/tests/mod.rs
 expression: raw_sdl
 input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/simple.graphql
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @join__directive(graphs: [], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1"}) @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_USERS_0, CONNECTORS_QUERY_USER_0, CONNECTORS_USER_D_1], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @join__directive(graphs: [], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1"}) @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_USERS_0, CONNECTORS_QUERY_USER_0, CONNECTORS_USER_D_0], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) {
   query: Query
 }
 
@@ -52,20 +52,20 @@ scalar join__DirectiveArguments
 enum join__Graph {
   CONNECTORS_QUERY_USER_0 @join__graph(name: "connectors_Query_user_0", url: "none")
   CONNECTORS_QUERY_USERS_0 @join__graph(name: "connectors_Query_users_0", url: "none")
-  CONNECTORS_USER_D_1 @join__graph(name: "connectors_User_d_1", url: "none")
+  CONNECTORS_USER_D_0 @join__graph(name: "connectors_User_d_0", url: "none")
   GRAPHQL @join__graph(name: "graphql", url: "https://graphql")
 }
 
-type User @join__type(graph: CONNECTORS_QUERY_USER_0, key: "id") @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_1, key: "c b") @join__type(graph: GRAPHQL, key: "id") {
+type User @join__type(graph: CONNECTORS_QUERY_USER_0, key: "id") @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_0, key: "c b") @join__type(graph: GRAPHQL, key: "id") {
   a: String @join__field(graph: CONNECTORS_QUERY_USER_0, type: "String") @join__field(graph: CONNECTORS_QUERY_USERS_0, type: "String")
-  b: String @join__field(graph: CONNECTORS_QUERY_USER_0, type: "String") @join__field(graph: CONNECTORS_USER_D_1, type: "String")
+  b: String @join__field(graph: CONNECTORS_QUERY_USER_0, type: "String") @join__field(graph: CONNECTORS_USER_D_0, type: "String")
   id: ID! @join__field(graph: CONNECTORS_QUERY_USER_0, type: "ID!") @join__field(graph: CONNECTORS_QUERY_USERS_0, type: "ID!") @join__field(graph: GRAPHQL, type: "ID!")
-  d: String @join__field(graph: CONNECTORS_USER_D_1, type: "String")
-  c: String @join__field(graph: CONNECTORS_USER_D_1, type: "String") @join__field(graph: GRAPHQL, type: "String")
+  d: String @join__field(graph: CONNECTORS_USER_D_0, type: "String")
+  c: String @join__field(graph: CONNECTORS_USER_D_0, type: "String") @join__field(graph: GRAPHQL, type: "String")
 }
 
-type Query @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_1) @join__type(graph: GRAPHQL) {
+type Query @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_0) @join__type(graph: GRAPHQL) {
   user(id: ID!): User @join__field(graph: CONNECTORS_QUERY_USER_0, type: "User")
   users: [User] @join__field(graph: CONNECTORS_QUERY_USERS_0, type: "[User]")
-  _: ID @inaccessible @join__field(graph: CONNECTORS_USER_D_1, type: "ID")
+  _: ID @inaccessible @join__field(graph: CONNECTORS_USER_D_0, type: "ID")
 }

--- a/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@steelthread.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@steelthread.graphql.snap
@@ -3,7 +3,7 @@ source: apollo-federation/src/connectors/expand/tests/mod.rs
 expression: raw_sdl
 input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/steelthread.graphql
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @join__directive(graphs: [], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1"}) @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_USERS_0, CONNECTORS_QUERY_USER_0, CONNECTORS_USER_D_1], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @join__directive(graphs: [], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1"}) @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_USERS_0, CONNECTORS_QUERY_USER_0, CONNECTORS_USER_D_0], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) {
   query: Query
 }
 
@@ -52,20 +52,20 @@ scalar join__DirectiveArguments
 enum join__Graph {
   CONNECTORS_QUERY_USER_0 @join__graph(name: "connectors_Query_user_0", url: "none")
   CONNECTORS_QUERY_USERS_0 @join__graph(name: "connectors_Query_users_0", url: "none")
-  CONNECTORS_USER_D_1 @join__graph(name: "connectors_User_d_1", url: "none")
+  CONNECTORS_USER_D_0 @join__graph(name: "connectors_User_d_0", url: "none")
   GRAPHQL @join__graph(name: "graphql", url: "https://localhost:4001")
 }
 
-type User @join__type(graph: CONNECTORS_QUERY_USER_0, key: "id") @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_1, key: "c") @join__type(graph: GRAPHQL, key: "id") {
+type User @join__type(graph: CONNECTORS_QUERY_USER_0, key: "id") @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_0, key: "c") @join__type(graph: GRAPHQL, key: "id") {
   id: ID! @join__field(graph: CONNECTORS_QUERY_USER_0, type: "ID!") @join__field(graph: CONNECTORS_QUERY_USERS_0, type: "ID!") @join__field(graph: GRAPHQL, type: "ID!")
   name: String @join__field(graph: CONNECTORS_QUERY_USER_0, type: "String") @join__field(graph: CONNECTORS_QUERY_USERS_0, type: "String")
   username: String @join__field(graph: CONNECTORS_QUERY_USER_0, type: "String")
-  d: String @join__field(graph: CONNECTORS_USER_D_1, type: "String")
-  c: String @join__field(graph: CONNECTORS_USER_D_1, type: "String") @join__field(graph: GRAPHQL, type: "String")
+  d: String @join__field(graph: CONNECTORS_USER_D_0, type: "String")
+  c: String @join__field(graph: CONNECTORS_USER_D_0, type: "String") @join__field(graph: GRAPHQL, type: "String")
 }
 
-type Query @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_1) @join__type(graph: GRAPHQL) {
+type Query @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_0) @join__type(graph: GRAPHQL) {
   user(id: ID!): User @join__field(graph: CONNECTORS_QUERY_USER_0, type: "User")
   users: [User] @join__field(graph: CONNECTORS_QUERY_USERS_0, type: "[User]")
-  _: ID @inaccessible @join__field(graph: CONNECTORS_USER_D_1, type: "ID")
+  _: ID @inaccessible @join__field(graph: CONNECTORS_USER_D_0, type: "ID")
 }

--- a/apollo-federation/src/connectors/spec/connect.rs
+++ b/apollo-federation/src/connectors/spec/connect.rs
@@ -60,8 +60,8 @@ pub(crate) fn extract_connect_directive_arguments(
                 field_def
                     .directives
                     .iter()
+                    .filter(|directive| directive.name == *name)
                     .enumerate()
-                    .filter(|(_, directive)| directive.name == *name)
                     .map(move |(i, directive)| {
                         let field_pos = if is_interface {
                             ObjectOrInterfaceFieldDefinitionPosition::Interface(
@@ -106,8 +106,8 @@ pub(crate) fn extract_connect_directive_arguments(
                 .flat_map(|ty| {
                     ty.directives
                         .iter()
+                        .filter(|directive| directive.name == *name)
                         .enumerate()
-                        .filter(|(_, directive)| directive.name == *name)
                         .map(move |(i, directive)| {
                             let position =
                                 ConnectorPosition::Type(ObjectTypeDefinitionDirectivePosition {


### PR DESCRIPTION
Fixes a problem with `run` and `test` connector tools where if you had another directive (E.g. `@key`) on a field/type, the connector index would be off by 1 because we were using `enumerate` to get the index numbers _before_ applying the filter.

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
