### PR TITLE
Add TLS support for WebSocket subgraph connections

### DIFF
--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -31,9 +31,9 @@ use serde_json_bytes::Entry;
 use serde_json_bytes::json;
 use tokio::select;
 use tokio::sync::oneshot;
+use tokio_tungstenite::Connector;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::connect_async_tls_with_config;
-use tokio_tungstenite::Connector;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tower::BoxError;
 use tower::Service;
@@ -170,7 +170,8 @@ impl SubgraphService {
                 generate_tls_client_config(
                     tls_cert_store,
                     client_cert_config.map(|arc| arc.as_ref()),
-                ).ok()
+                )
+                .ok()
             })
             .map(Arc::new);
 
@@ -180,7 +181,8 @@ impl SubgraphService {
             subscription_config,
             configuration.notify.clone(),
             client_factory,
-        ).map(|service| service.with_tls_config(tls_config))
+        )
+        .map(|service| service.with_tls_config(tls_config))
     }
 
     pub(crate) fn new(
@@ -668,12 +670,11 @@ async fn call_websocket(
 
     let (ws_stream, resp) = match request.uri().scheme_str() {
         Some("wss") => {
-            let connector = tls_config
-                .map(|config| Connector::Rustls(Arc::new(config.clone())));
+            let connector = tls_config.map(|config| Connector::Rustls(Arc::new(config.clone())));
 
             match connector {
                 Some(conn) => connect_async_tls_with_config(request, None, false, Some(conn)).await,
-                None => connect_async(request).await
+                None => connect_async(request).await,
             }
         }
         _ => connect_async(request).instrument(subgraph_req_span).await,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -33,6 +33,7 @@ use tokio::select;
 use tokio::sync::oneshot;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::connect_async_tls_with_config;
+use tokio_tungstenite::Connector;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tower::BoxError;
 use tower::Service;
@@ -137,6 +138,7 @@ pub(crate) struct SubgraphService {
     /// Subscription config if enabled
     subscription_config: Option<SubscriptionConfig>,
     notify: Notify<String, graphql::Response>,
+    tls_config: Option<Arc<rustls::ClientConfig>>,
 }
 
 impl SubgraphService {
@@ -156,13 +158,29 @@ impl SubgraphService {
             .map(|apq| apq.enabled)
             .unwrap_or(configuration.apq.subgraph.all.enabled);
 
+        let tls_config = configuration
+            .tls
+            .subgraph
+            .subgraphs
+            .get(&name)
+            .or(Some(&configuration.tls.subgraph.all))
+            .and_then(|tls| {
+                let tls_cert_store = tls.create_certificate_store().transpose().ok()?;
+                let client_cert_config = tls.client_authentication.as_ref();
+                generate_tls_client_config(
+                    tls_cert_store,
+                    client_cert_config.map(|arc| arc.as_ref()),
+                ).ok()
+            })
+            .map(Arc::new);
+
         SubgraphService::new(
             name,
             enable_apq,
             subscription_config,
             configuration.notify.clone(),
             client_factory,
-        )
+        ).map(|service| service.with_tls_config(tls_config))
     }
 
     pub(crate) fn new(
@@ -178,7 +196,13 @@ impl SubgraphService {
             apq: Arc::new(<AtomicBool>::new(enable_apq)),
             subscription_config,
             notify,
+            tls_config: None,
         })
+    }
+
+    pub(crate) fn with_tls_config(mut self, config: Option<Arc<rustls::ClientConfig>>) -> Self {
+        self.tls_config = config;
+        self
     }
 }
 
@@ -258,6 +282,8 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
 
         let mut notify = self.notify.clone();
 
+        let tls_config = self.tls_config.clone();
+
         let make_calls = async move {
             // Subscription handling
             if request.operation_kind == OperationKind::Subscription
@@ -281,6 +307,7 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                             service_name,
                             ws_conf,
                             hashed_request,
+                            tls_config.as_deref(),
                         )
                         .await;
                     }
@@ -482,6 +509,7 @@ async fn call_websocket(
     service_name: String,
     subgraph_cfg: &WebSocketConfiguration,
     subscription_hash: String,
+    tls_config: Option<&rustls::ClientConfig>,
 ) -> Result<SubgraphResponse, BoxError> {
     let operation_name = request
         .subgraph_request
@@ -640,9 +668,13 @@ async fn call_websocket(
 
     let (ws_stream, resp) = match request.uri().scheme_str() {
         Some("wss") => {
-            connect_async_tls_with_config(request, None, false, None)
-                .instrument(subgraph_req_span)
-                .await
+            let connector = tls_config
+                .map(|config| Connector::Rustls(Arc::new(config.clone())));
+
+            match connector {
+                Some(conn) => connect_async_tls_with_config(request, None, false, Some(conn)).await,
+                None => connect_async(request).await
+            }
         }
         _ => connect_async(request).instrument(subgraph_req_span).await,
     }


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-####] -->
---

# Add TLS Support for WebSocket Subgraph Connections

## Summary

This PR implements TLS/SSL support for WebSocket connections (graphql-ws) to subgraphs and fixes a configuration loading issue that prevented TLS settings from being used.

## Problem

- WebSocket connections using `wss` endpoints did not utilize configured TLS settings in the YAML
- Subgraphs requiring custom certificates or client authentication through mTLS would fail to connect

## Solution

- Enhanced WebSocket connection logic to use configured TLS settings via `connect_async_tls_with_config` of tungstenite
- Maintains backward compatibility for non-TLS connections

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Manual Testing Details:**
- Verified wss:// connections with mTLS-configured subgraph
- Verified ws:// connections after disabling TLS configuration 

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
