### PR TITLE
Update docs for graph artifacts

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -221,7 +221,7 @@ pub struct Opt {
     // Should be a Vec<Url> when https://github.com/clap-rs/clap/discussions/3796 is solved
     apollo_uplink_endpoints: Option<String>,
 
-    /// An OCI reference to an image that contains the supergraph schema for the router.
+    /// An OCI reference to a graph artifact that contains the supergraph schema for the router to run.
     #[clap(long, env = "APOLLO_GRAPH_ARTIFACT_REFERENCE", action = ArgAction::Append)]
     graph_artifact_reference: Option<String>,
 

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -184,11 +184,12 @@ For default behavior and possible values, see [Apollo Uplink](/federation/manage
 </td>
 <td>
 
-An OCI reference to an image that contains the supergraph schema for the router.<br/>
+An OCI reference to a graph artifact that contains the supergraph schema for the router to run.<br/><br/>
 
-When this option is set, the router will fetch the schema from the specified OCI image instead of using Apollo Uplink. Note that Apollo Uplink will still be used for entitlements and persisted queries.<br/>
+When this option is set, the router will fetch the schema from the specified graph artifact instead of Apollo Uplink.
+Entitlements and persisted queries will still be fetched from Uplink.<br/><br/>
 
-⚠️ **This option does not support hot reloading schemas.**
+⚠️ **This option is in preview and does not support hot-reloading schemas.**
 
 </td>
 </tr>

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -186,10 +186,10 @@ For default behavior and possible values, see [Apollo Uplink](/federation/manage
 
 An OCI reference to a graph artifact that contains the supergraph schema for the router to run.<br/><br/>
 
-When this option is set, the router will use the schema from the specified graph artifact instead of Apollo Uplink.
-Entitlements and persisted queries will still be fetched from Uplink.<br/><br/>
+When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink.
+The router still fetches entitlements and persisted queries from Uplink.<br/><br/>
 
-⚠️ **This option is in preview and does not support hot-reloading of schemas.**
+⚠️ **This option is in preview and doesn't support hot-reloading of schemas.**
 
 </td>
 </tr>

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -186,10 +186,10 @@ For default behavior and possible values, see [Apollo Uplink](/federation/manage
 
 An OCI reference to a graph artifact that contains the supergraph schema for the router to run.<br/><br/>
 
-When this option is set, the router will fetch the schema from the specified graph artifact instead of Apollo Uplink.
+When this option is set, the router will use the schema from the specified graph artifact instead of Apollo Uplink.
 Entitlements and persisted queries will still be fetched from Uplink.<br/><br/>
 
-⚠️ **This option is in preview and does not support hot-reloading schemas.**
+⚠️ **This option is in preview and does not support hot-reloading of schemas.**
 
 </td>
 </tr>

--- a/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
@@ -24,7 +24,7 @@ The exact image version to use depends on which release you wish to use. In the 
 
 ## Basic example running router in Docker
 
-To run the router, your Docker container must have the [`APOLLO_GRAPH_REF`](/router/configuration/overview#apollo_graph_ref) and [`APOLLO_KEY`](/router/configuration/overview#apollo_key) environment variables set to your graph ref and API key, respectively.
+To run the router, your Docker container must have the [`APOLLO_GRAPH_REF`](/graphos/routing/configuration/envvars#apollo_graph_ref) and [`APOLLO_KEY`](/graphos/routing/configuration/envvars#apollo_key) environment variables set to your graph ref and API key, respectively.
 
 Below is a basic example of running a router image with Docker, either with `docker run` or `docker compose`. It downloads your supergraph schema from Apollo and uses a default configuration that listens for connections on port `4000`.
 
@@ -150,7 +150,7 @@ In this example, we have to mount the local definition of the supergraph into ou
 
 ### Using a graph artifact reference
 
-You can set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to fetch the supergraph schema from a graph artifact:
+You can set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to use the supergraph schema from a graph artifact:
 
 ```bash
 docker run -p 4000:4000 \
@@ -160,11 +160,11 @@ docker run -p 4000:4000 \
   ghcr.io/apollographql/router:<router-image-version>
 ```
 
-When using this option, the router will fetch the schema from the specified graph artifact instead of Apollo Uplink.
+When using this option, the router will use the schema from the specified graph artifact instead of Apollo Uplink.
 Entitlements and persisted queries will still be fetched from Uplink.
-Additional information on graph artifacts is available in the [router CLI options documentation](/docs/graphos/routing/configuration/cli#command-line-options).
+Additional information on graph artifacts is available in the [router CLI options documentation](/graphos/routing/configuration/cli#command-line-options).
 
-⚠️ **This option is in preview and does not support hot-reloading schemas.**
+⚠️ **This option is in preview and does not support hot-reloading of schemas.**
 
 ## Building your own container
 

--- a/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
@@ -150,6 +150,8 @@ In this example, we have to mount the local definition of the supergraph into ou
 
 ### Using a graph artifact reference
 
+⚠️ This option is in preview and doesn't support hot-reloading of schemas.
+
 Set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to use the supergraph schema from a graph artifact:
 
 ```bash
@@ -164,8 +166,6 @@ When you set this option, the router uses the schema from the specified graph ar
 The router still fetches entitlements and persisted queries from Uplink.
 
 For more information on graph artifacts, see the [Router CLI Configuration Reference](/graphos/routing/configuration/cli#--graph-artifact-reference).
-
-⚠️ **This option is in preview and doesn't support hot-reloading of schemas.**
 
 ## Building your own container
 

--- a/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
@@ -24,7 +24,7 @@ The exact image version to use depends on which release you wish to use. In the 
 
 ## Basic example running router in Docker
 
-To run the router, your Docker container must have the [`APOLLO_GRAPH_REF`](/graphos/routing/configuration/envvars#apollo_graph_ref) and [`APOLLO_KEY`](/graphos/routing/configuration/envvars#apollo_key) environment variables set to your graph ref and API key, respectively.
+To run the router, set the [`APOLLO_GRAPH_REF`](/graphos/routing/configuration/envvars#apollo_graph_ref) and [`APOLLO_KEY`](/graphos/routing/configuration/envvars#apollo_key) environment variables in your Docker container to your graph ref and API key.
 
 Below is a basic example of running a router image with Docker, either with `docker run` or `docker compose`. It downloads your supergraph schema from Apollo and uses a default configuration that listens for connections on port `4000`.
 
@@ -53,7 +53,7 @@ services:
 
 Whether you use `docker run` or `docker compose`, make sure to replace `<router-image-version>` with whichever version you want to use, and `<your-graph-ref>` and `<your-graph-api-key>` with your graph reference and API key, respectively.
 
-For more complex configurations, such as overriding subgraph URLs or propagating headers, see [Router Configuration](/router/configuration/overview/).
+For more complex configurations, such as overriding subgraph URLs or propagating headers, see [Router Configuration](/graphos/routing/configuration/overview/).
 
 ## Override the configuration
 
@@ -150,7 +150,7 @@ In this example, we have to mount the local definition of the supergraph into ou
 
 ### Using a graph artifact reference
 
-You can set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to use the supergraph schema from a graph artifact:
+Set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to use the supergraph schema from a graph artifact:
 
 ```bash
 docker run -p 4000:4000 \
@@ -160,11 +160,12 @@ docker run -p 4000:4000 \
   ghcr.io/apollographql/router:<router-image-version>
 ```
 
-When using this option, the router will use the schema from the specified graph artifact instead of Apollo Uplink.
-Entitlements and persisted queries will still be fetched from Uplink.
-Additional information on graph artifacts is available in the [router CLI options documentation](/graphos/routing/configuration/cli#command-line-options).
+When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink.
+The router still fetches entitlements and persisted queries from Uplink.
 
-⚠️ **This option is in preview and does not support hot-reloading of schemas.**
+For more information on graph artifacts, see the [Router CLI Configuration Reference](/graphos/routing/configuration/cli#--graph-artifact-reference).
+
+⚠️ **This option is in preview and doesn't support hot-reloading of schemas.**
 
 ## Building your own container
 

--- a/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
@@ -148,19 +148,23 @@ docker run -p 4000:4000 \
 
 In this example, we have to mount the local definition of the supergraph into our image, _and_ specify the location of the file. It doesn't have to be mounted in the `/dist/schema` directory, but it's a reasonable location to use. We must specify the configuration file location as well, since overriding the default params will override our default config file location. In this case, since we don't want to change our router configuration but want to make sure it's used, we just specify the default location of the default configuration.
 
-### Using an OCI image reference
+### Using a graph artifact reference
 
-You can use the `--graph-artifact-reference` option to fetch the supergraph schema from an OCI image:
+You can set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to fetch the supergraph schema from a graph artifact:
 
 ```bash
 docker run -p 4000:4000 \
   --env APOLLO_KEY="<your-graph-api-key>" \
-  --env APOLLO_GRAPH_ARTIFACT_REFERENCE="<your-oci-reference>" \
+  --env APOLLO_GRAPH_ARTIFACT_REFERENCE="<your-graph-artifact-reference>" \
   --rm \
   ghcr.io/apollographql/router:<router-image-version>
 ```
 
-When using this option, the router will fetch the schema from the specified OCI image instead of using Apollo Uplink.
+When using this option, the router will fetch the schema from the specified graph artifact instead of Apollo Uplink.
+Entitlements and persisted queries will still be fetched from Uplink.
+Additional information on graph artifacts is available in the [router CLI options documentation](/docs/graphos/routing/configuration/cli#command-line-options).
+
+⚠️ **This option is in preview and does not support hot-reloading schemas.**
 
 ## Building your own container
 

--- a/docs/source/routing/self-hosted/containerization/docker.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker.mdx
@@ -98,7 +98,7 @@ If you don't want to automatically update your supergraph via [Apollo Uplink](/f
 
 ### Using an OCI graph artifact reference
 
-You can use the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to fetch the supergraph schema from a graph artifact:
+You can set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to use the supergraph schema from a graph artifact:
 
 ```bash
 docker run -p 4000:4000 \
@@ -108,11 +108,11 @@ docker run -p 4000:4000 \
   ghcr.io/apollographql/apollo-runtime:<runtime-image-version>
 ```
 
-When using this option, the router will fetch the schema from the specified graph artifact instead of Apollo Uplink.
+When using this option, the router will use the schema from the specified graph artifact instead of Apollo Uplink.
 Entitlements and persisted queries will still be fetched from Uplink.
-Additional information on graph artifacts is available in the [router CLI options documentation](/docs/graphos/routing/configuration/cli#command-line-options).
+Additional information on graph artifacts is available in the [router CLI options documentation](/graphos/routing/configuration/cli#command-line-options).
 
-⚠️ **This option is in preview and does not support hot-reloading schemas.**
+⚠️ **This option is in preview and does not support hot-reloading of schemas.**
 
 ## Running a specific Router and MCP version
 

--- a/docs/source/routing/self-hosted/containerization/docker.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker.mdx
@@ -98,6 +98,8 @@ If you don't want to automatically update your supergraph via [Apollo Uplink](/f
 
 ### Using a graph artifact reference
 
+⚠️ This option is in preview and doesn't support hot-reloading of schemas.
+
 Set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to use the supergraph schema from a graph artifact:
 
 ```bash
@@ -111,8 +113,6 @@ docker run -p 4000:4000 \
 When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink.
 The router still fetches entitlements and persisted queries from Uplink.
 For more information on graph artifacts, see the [Router CLI Configuration Reference](/graphos/routing/configuration/cli#--graph-artifact-reference).
-
-⚠️ **This option is in preview and doesn't support hot-reloading of schemas.**
 
 ## Running a specific Router and MCP version
 

--- a/docs/source/routing/self-hosted/containerization/docker.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker.mdx
@@ -94,21 +94,25 @@ Both local and container paths must be specified as absolute paths.
 If you don't want to automatically update your supergraph via [Apollo Uplink](/federation/managed-federation/uplink/), or you don't have connectivity to access Apollo Uplink from your environment, you have two options:
 
 1. Using a local supergraph file, as documented in the [Configuring using local files](#configuring-using-local-files) section.
-1. Using an [OCI image reference](#using-an-oci-image-reference)
+1. Using an [OCI graph artifact reference](#using-an-oci-graph-artifact-reference)
 
-### Using an OCI image reference
+### Using an OCI graph artifact reference
 
-You can use the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to fetch the supergraph schema from an OCI image:
+You can use the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to fetch the supergraph schema from a graph artifact:
 
 ```bash
 docker run -p 4000:4000 \
   --env APOLLO_KEY="<your-graph-api-key>" \
-  --env APOLLO_GRAPH_ARTIFACT_REFERENCE="<your-oci-reference>" \
+  --env APOLLO_GRAPH_ARTIFACT_REFERENCE="<your-graph-artifact-reference>" \
   --rm \
   ghcr.io/apollographql/apollo-runtime:<runtime-image-version>
 ```
 
-When using this option, the router will fetch the schema from the specified OCI image instead of using Apollo Uplink. Additional information on graph artifacts is available in the [router CLI options documentation](/docs/graphos/routing/configuration/cli#command-line-options).
+When using this option, the router will fetch the schema from the specified graph artifact instead of Apollo Uplink.
+Entitlements and persisted queries will still be fetched from Uplink.
+Additional information on graph artifacts is available in the [router CLI options documentation](/docs/graphos/routing/configuration/cli#command-line-options).
+
+⚠️ **This option is in preview and does not support hot-reloading schemas.**
 
 ## Running a specific Router and MCP version
 

--- a/docs/source/routing/self-hosted/containerization/docker.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker.mdx
@@ -20,7 +20,7 @@ The exact image version to use depends on which release you wish to use. In the 
 
 ## Quick start
 
-To run the router, your Docker container must have the [`APOLLO_GRAPH_REF`](/router/configuration/overview#apollo_graph_ref) and [`APOLLO_KEY`](/router/configuration/overview#apollo_key) environment variables set to your graph ref and API key, respectively.
+To run the router, set the [`APOLLO_GRAPH_REF`](/graphos/routing/configuration/envvars#apollo_graph_ref) and [`APOLLO_KEY`](/graphos/routing/configuration/envvars#apollo_key) environment variables in your Docker container to your graph ref and API key.
 
 Below is a basic example of running an Apollo Runtime image with Docker. It downloads your supergraph schema from Apollo and uses a default configuration that listens for connections on port `4000`.
 
@@ -94,11 +94,11 @@ Both local and container paths must be specified as absolute paths.
 If you don't want to automatically update your supergraph via [Apollo Uplink](/federation/managed-federation/uplink/), or you don't have connectivity to access Apollo Uplink from your environment, you have two options:
 
 1. Using a local supergraph file, as documented in the [Configuring using local files](#configuring-using-local-files) section.
-1. Using an [OCI graph artifact reference](#using-an-oci-graph-artifact-reference)
+1. Using a [graph artifact reference](#using-a-graph-artifact-reference)
 
-### Using an OCI graph artifact reference
+### Using a graph artifact reference
 
-You can set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to use the supergraph schema from a graph artifact:
+Set the `APOLLO_GRAPH_ARTIFACT_REFERENCE` environment variable to use the supergraph schema from a graph artifact:
 
 ```bash
 docker run -p 4000:4000 \
@@ -108,11 +108,11 @@ docker run -p 4000:4000 \
   ghcr.io/apollographql/apollo-runtime:<runtime-image-version>
 ```
 
-When using this option, the router will use the schema from the specified graph artifact instead of Apollo Uplink.
-Entitlements and persisted queries will still be fetched from Uplink.
-Additional information on graph artifacts is available in the [router CLI options documentation](/graphos/routing/configuration/cli#command-line-options).
+When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink.
+The router still fetches entitlements and persisted queries from Uplink.
+For more information on graph artifacts, see the [Router CLI Configuration Reference](/graphos/routing/configuration/cli#--graph-artifact-reference).
 
-⚠️ **This option is in preview and does not support hot-reloading of schemas.**
+⚠️ **This option is in preview and doesn't support hot-reloading of schemas.**
 
 ## Running a specific Router and MCP version
 
@@ -122,7 +122,7 @@ To learn more, see the [tagging documentation](https://github.com/apollographql/
 
 ## Additional router configuration information
 
-For more complex configurations, such as overriding subgraph URLs or propagating headers, see [Router Configuration](/router/configuration/overview/).
+For more complex configurations, such as overriding subgraph URLs or propagating headers, see [Router Configuration](/graphos/routing/configuration/overview/).
 
 ## Router-only Docker container
 


### PR DESCRIPTION
This PR updates router documentation for the graph artifacts preview. It also fixes some broken documentation links.

Jira story: [[VUL-1427] [GrAr] Add documentation to router for Graph Artifacts](https://apollographql.atlassian.net/browse/VUL-1427)

Pages to review the changes:

* CLI: https://www.apollographql.com/docs/deploy-preview/b5a223e694f2c188a7ccac1f/graphos/routing/configuration/cli#--graph-artifact-reference
* Docker: https://www.apollographql.com/docs/deploy-preview/b5a223e694f2c188a7ccac1f/graphos/routing/self-hosted/containerization/docker#using-a-graph-artifact-reference
* Docker-Router-Only: https://www.apollographql.com/docs/deploy-preview/b5a223e694f2c188a7ccac1f/graphos/routing/self-hosted/containerization/docker-router-only#using-a-graph-artifact-reference


<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

Completed checklist items above that apply to these documentation updates.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[VUL-1427]: https://apollographql.atlassian.net/browse/VUL-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ