### PR TITLE
Ensure all arrow methods produce `None` if any argument evaluates to `None`

### DIFF
--- a/apollo-federation/src/connectors/json_selection/methods/public/arithmetic.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/arithmetic.rs
@@ -265,6 +265,8 @@ infix_math_method!(ModMethod, mod_method, rem_op);
 mod tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -684,6 +686,146 @@ mod tests {
             result.1[0]
                 .message()
                 .contains("Method ->mod requires at least one argument")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn add_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->add($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![
+                    ApplyToError::from_json(&json!({
+                        "message": "Property .missing not found in object",
+                        "path": ["missing"],
+                        "range": [11, 18],
+                        "spec": spec.to_string(),
+                    })),
+                    ApplyToError::from_json(&json!({
+                        "message": "Method ->add requires numeric arguments",
+                        "path": ["a", "->add"],
+                        "range": [9, 18],
+                        "spec": spec.to_string(),
+                    })),
+                ]
+            ),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn sub_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->sub($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![
+                    ApplyToError::from_json(&json!({
+                        "message": "Property .missing not found in object",
+                        "path": ["missing"],
+                        "range": [11, 18],
+                        "spec": spec.to_string(),
+                    })),
+                    ApplyToError::from_json(&json!({
+                        "message": "Method ->sub requires numeric arguments",
+                        "path": ["a", "->sub"],
+                        "range": [9, 18],
+                        "spec": spec.to_string(),
+                    })),
+                ]
+            ),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn mul_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->mul($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![
+                    ApplyToError::from_json(&json!({
+                        "message": "Property .missing not found in object",
+                        "path": ["missing"],
+                        "range": [11, 18],
+                        "spec": spec.to_string(),
+                    })),
+                    ApplyToError::from_json(&json!({
+                        "message": "Method ->mul requires numeric arguments",
+                        "path": ["a", "->mul"],
+                        "range": [9, 18],
+                        "spec": spec.to_string(),
+                    })),
+                ]
+            ),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn div_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->div($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![
+                    ApplyToError::from_json(&json!({
+                        "message": "Property .missing not found in object",
+                        "path": ["missing"],
+                        "range": [11, 18],
+                        "spec": spec.to_string(),
+                    })),
+                    ApplyToError::from_json(&json!({
+                        "message": "Method ->div requires numeric arguments",
+                        "path": ["a", "->div"],
+                        "range": [9, 18],
+                        "spec": spec.to_string(),
+                    })),
+                ]
+            ),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn mod_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->mod($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![
+                    ApplyToError::from_json(&json!({
+                        "message": "Property .missing not found in object",
+                        "path": ["missing"],
+                        "range": [11, 18],
+                        "spec": spec.to_string(),
+                    })),
+                    ApplyToError::from_json(&json!({
+                        "message": "Method ->mod requires numeric arguments",
+                        "path": ["a", "->mod"],
+                        "range": [9, 18],
+                        "spec": spec.to_string(),
+                    })),
+                ]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
@@ -174,6 +174,8 @@ fn contains_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -427,6 +429,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->contains requires an array input, but got: 123")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn contains_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("arr->contains($.missing)", spec).apply_to(&json!({
+                "arr": [1, 2, 3],
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [16, 23],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/echo.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/echo.rs
@@ -70,6 +70,8 @@ fn echo_shape(
 mod tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -208,6 +210,24 @@ mod tests {
                     "hobbies": ["reading", "fishing", "painting"],
                 })),
                 vec![],
+            ),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn echo_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$->echo($.missing)", spec).apply_to(&json!({})),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [10, 17],
+                    "spec": spec.to_string(),
+                }))]
             ),
         );
     }

--- a/apollo-federation/src/connectors/json_selection/methods/public/entries.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/entries.rs
@@ -152,6 +152,15 @@ fn entries_shape(
                 method_name.shape_location(context.source_id()),
             )
         }
+        ShapeCase::Unknown => {
+            let mut entries = Shape::empty_map();
+            entries.insert("key".to_string(), Shape::string([]));
+            entries.insert("value".to_string(), Shape::unknown([]));
+            Shape::list(
+                Shape::record(entries, method_name.shape_location(context.source_id())),
+                method_name.shape_location(context.source_id()),
+            )
+        }
         _ => Shape::error(
             format!("Method ->{} requires an object input", method_name.as_ref()),
             {

--- a/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
@@ -117,6 +117,8 @@ fn eq_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -350,6 +352,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->eq requires exactly one argument")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn eq_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->eq($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [10, 17],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/get.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/get.rs
@@ -544,6 +544,7 @@ mod tests {
 
     use super::*;
     use crate::assert_debug_snapshot;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -763,6 +764,26 @@ mod tests {
                 "c": 3,
             })),
             (Some(json!(11)), vec![]),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn get_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.arr->get($.missing)", spec).apply_to(&json!({
+                "arr": [1, 2, 3],
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [13, 20],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/gt.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/gt.rs
@@ -138,6 +138,8 @@ fn gt_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -351,6 +353,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->gt requires exactly one argument")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn gt_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->gt($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [10, 17],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/gte.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/gte.rs
@@ -138,6 +138,8 @@ fn gte_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -347,6 +349,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->gte requires exactly one argument")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn gte_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->gte($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [11, 18],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/in.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/in.rs
@@ -173,6 +173,8 @@ fn in_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -424,6 +426,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->in requires an array argument, but got: 123")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn in_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->in($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [10, 17],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/lt.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/lt.rs
@@ -138,6 +138,8 @@ fn lt_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -351,6 +353,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->lt requires exactly one argument")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn lt_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->lt($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [10, 17],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/lte.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/lte.rs
@@ -138,6 +138,8 @@ fn lte_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -347,6 +349,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->lte requires exactly one argument")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn lte_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->lte($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [11, 18],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
@@ -116,6 +116,8 @@ fn ne_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -349,6 +351,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->ne requires exactly one argument")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn ne_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->ne($.missing)", spec).apply_to(&json!({
+                "a": 5,
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [10, 17],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/or.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/or.rs
@@ -77,7 +77,9 @@ fn or_method(
                     spec,
                 )]);
             }
-            None => {}
+            None => {
+                return (None, errors);
+            }
         }
     }
 
@@ -138,6 +140,8 @@ fn or_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -210,6 +214,26 @@ mod method_tests {
             result.1[0]
                 .message()
                 .contains("Method ->or requires arguments")
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn or_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->or($.missing)", spec).apply_to(&json!({
+                "a": false,
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [10, 17],
+                    "spec": spec.to_string(),
+                }))]
+            ),
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
@@ -236,6 +236,8 @@ fn parse_int_shape(
 mod method_tests {
     use serde_json_bytes::json;
 
+    use crate::connectors::ConnectSpec;
+    use crate::connectors::json_selection::ApplyToError;
     use crate::selection;
 
     #[test]
@@ -736,6 +738,26 @@ mod method_tests {
                     "result": 16,
                 })),
                 vec![],
+            ),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    fn parse_int_should_return_none_when_argument_evaluates_to_none(#[case] spec: ConnectSpec) {
+        assert_eq!(
+            selection!("$.a->parseInt($.missing)", spec).apply_to(&json!({
+                "a": "42",
+            })),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Property .missing not found in object",
+                    "path": ["missing"],
+                    "range": [16, 23],
+                    "spec": spec.to_string(),
+                }))]
             ),
         );
     }

--- a/apollo-federation/src/connectors/json_selection/methods/public/size.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/size.rs
@@ -118,6 +118,7 @@ fn size_shape(
                 Shape::int(method_name.shape_location(context.source_id()))
             }
         }
+        ShapeCase::Unknown => Shape::int(method_name.shape_location(context.source_id())),
         _ => Shape::error(
             format!(
                 "Method ->{} requires an array, string, or object input",

--- a/apollo-federation/src/connectors/json_selection/methods/public/slice.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/slice.rs
@@ -134,6 +134,7 @@ fn slice_shape(
         }
         ShapeCase::String(_) => Shape::string(input_shape.locations),
         ShapeCase::Name(_, _) => input_shape, // TODO: add a way to validate inputs after name resolution
+        ShapeCase::Unknown => Shape::unknown(input_shape.locations),
         _ => Shape::error(
             format!(
                 "Method ->{} requires an array or string input",

--- a/apollo-federation/src/connectors/validation/expression.rs
+++ b/apollo-federation/src/connectors/validation/expression.rs
@@ -761,6 +761,7 @@ mod tests {
     #[case::first("$args.array->first.bool")]
     #[case::last("$args.array->last.bool")]
     #[case::multi_level_input("$args.multiLevel.inner.nested")]
+    #[case::entries_when_type_unknown("$config.something->entries->first.value")]
     #[case::methods_with_unknown_input(r#"$config->get("something")->slice(0, 1)"#)]
     fn valid_expressions(#[case] selection: &str) {
         // If this fails, another ConnectSpec version has probably been added,

--- a/apollo-federation/src/connectors/validation/expression.rs
+++ b/apollo-federation/src/connectors/validation/expression.rs
@@ -760,6 +760,7 @@ mod tests {
     #[case::first("$args.array->first.bool")]
     #[case::last("$args.array->last.bool")]
     #[case::multi_level_input("$args.multiLevel.inner.nested")]
+    #[case::methods_with_unknown_input(r#"$config->get("something")->slice(0, 1)"#)]
     fn valid_expressions(#[case] selection: &str) {
         // If this fails, another ConnectSpec version has probably been added,
         // and should be accounted for in the loop below.

--- a/apollo-federation/src/connectors/validation/expression.rs
+++ b/apollo-federation/src/connectors/validation/expression.rs
@@ -85,6 +85,7 @@ impl<'schema> Context<'schema> {
             } => {
                 let mut var_lookup: IndexMap<Namespace, Shape> = [
                     (Namespace::Args, shape_for_arguments(field_def)),
+                    // TODO Should these be Dict<Unknown> instead of Unknown?
                     (Namespace::Config, Shape::unknown([])),
                     (Namespace::Context, Shape::unknown([])),
                     (Namespace::Request, REQUEST_SHAPE.clone()),


### PR DESCRIPTION
Similar in spirit to the `Unknown` audit I did in PR #8298 (whose branch this PR targets), this PR audits all arrow methods to ensure they evaluate to `None` (at runtime and at shape processing time) if any of their **arguments** evaluate to `None`.

Previously and currently, arrow methods follow a policy of never executing if their input value is `None`/missing, but this PR strengthens that promise to apply to arguments as well.

Remember that you can use `??` to default a `None` value to anything else (see #8082, #8090).