### PR TITLE
docs: tweak to note on hot-reload

### DIFF
--- a/docs/source/routing/configuration/overview.mdx
+++ b/docs/source/routing/configuration/overview.mdx
@@ -35,4 +35,4 @@ This example command would be for a router with a GraphOS-managed graph and a cu
 APOLLO_KEY="..." APOLLO_GRAPH_REF="..." router --config myrouter.yaml
 ```
 
-> The router can hot-reload updated configuration. When enabled, changes in `router.yaml` trigger the router to restart with its updated configuration.
+> The router can hot-reload updated configuration. When enabled, changes in `router.yaml` trigger the router to reload with the updated configuration.  Existing requests will finish using the existing configuration and new requests will start using the new configuration.


### PR DESCRIPTION
Clarified behavior around hot-reload based on customer feedback. I realize there's more to add here, but this addresses the confusion about how it works. (Even if it's not necessarily the most recommended way and has other non-deterministic concerns, it doesn't inherently cause downtime in the way in which it's implemented, which was the point of confusion; it's not a hard restart)