### PR TITLE
implement validate_query_root

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -236,6 +236,8 @@ pub enum CompositionError {
     OverrideOnInterface { message: String },
     #[error("{message}")]
     OverrideSourceHasOverride { message: String },
+    #[error("{message}")]
+    QueryRootMissing { message: String },
 }
 
 impl CompositionError {
@@ -289,6 +291,7 @@ impl CompositionError {
             Self::OverrideLabelInvalid { .. } => ErrorCode::OverrideLabelInvalid,
             Self::OverrideOnInterface { .. } => ErrorCode::OverrideOnInterface,
             Self::OverrideSourceHasOverride { .. } => ErrorCode::OverrideSourceHasOverride,
+            Self::QueryRootMissing { .. } => ErrorCode::QueryRootMissing,
         }
     }
 
@@ -397,7 +400,8 @@ impl CompositionError {
             | Self::OverrideFromSelfError { .. }
             | Self::OverrideLabelInvalid { .. }
             | Self::OverrideOnInterface { .. }
-            | Self::OverrideSourceHasOverride { .. } => self,
+            | Self::OverrideSourceHasOverride { .. }
+            | Self::QueryRootMissing { .. } => self,
         }
     }
 
@@ -749,6 +753,8 @@ pub enum SingleFederationError {
     ListSizeInvalidSizedField { message: String },
     #[error("{message}")]
     InvalidTagName { message: String },
+    #[error("{message}")]
+    QueryRootMissing { message: String },
 }
 
 impl SingleFederationError {
@@ -973,6 +979,7 @@ impl SingleFederationError {
             #[allow(unused)]
             SingleFederationError::InvalidFieldSharing { .. } => ErrorCode::InvalidFieldSharing,
             SingleFederationError::InvalidTagName { .. } => ErrorCode::InvalidTagName,
+            SingleFederationError::QueryRootMissing { .. } => ErrorCode::QueryRootMissing,
         }
     }
 
@@ -2269,6 +2276,17 @@ static INVALID_TAG_NAME: LazyLock<ErrorCodeDefinition> = LazyLock::new(|| {
     )
 });
 
+static QUERY_ROOT_MISSING: LazyLock<ErrorCodeDefinition> = LazyLock::new(|| {
+    ErrorCodeDefinition::new(
+        "QUERY_ROOT_MISSING".to_owned(),
+        "The schema has no query root type.".to_owned(),
+        Some(ErrorCodeMetadata {
+            added_in: "2.0.0",
+            replaces: &[],
+        }),
+    )
+});
+
 #[derive(Debug, PartialEq, strum_macros::EnumIter)]
 pub enum ErrorCode {
     ErrorCodeMissing,
@@ -2369,6 +2387,7 @@ pub enum ErrorCode {
     ContextSelectionInvalid,
     InvalidTagName,
     OverrideLabelInvalid,
+    QueryRootMissing,
 }
 
 impl ErrorCode {
@@ -2488,6 +2507,7 @@ impl ErrorCode {
             ErrorCode::InvalidTagName => &INVALID_TAG_NAME,
             ErrorCode::ErrorCodeMissing => &ERROR_CODE_MISSING,
             ErrorCode::OverrideLabelInvalid => &OVERRIDE_LABEL_INVALID,
+            ErrorCode::QueryRootMissing => &QUERY_ROOT_MISSING,
         }
     }
 }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1056,7 +1056,12 @@ impl Merger {
     }
 
     fn validate_query_root(&mut self) {
-        todo!("Implement query root validation")
+        if self.merged.schema().schema_definition.query.is_none() {
+            self.error_reporter_mut()
+                .add_error(CompositionError::QueryRootMissing {
+                    message: "Query root is missing from the merged schema".to_string(),
+                });
+        }
     }
 
     pub(in crate::merger) fn directive_applications_with_transformed_arguments(


### PR DESCRIPTION
 This was inlined in the JS version in the Merger constructor and has no direct analog