### PR TITLE
feat(response_cache): prevent simultaneous usage of entity and response cache plugins

### DIFF
--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -1267,3 +1267,42 @@ fn find_struct_name(lines: &[&str], line_number: usize) -> Option<String> {
         })
         .next()
 }
+
+#[test]
+fn it_prevents_enablement_of_both_subgraph_caching_plugins() {
+    let make_config = |response_cache_enabled, entity_cache_enabled| {
+        let mut config = json!({});
+        if let Some(enabled) = response_cache_enabled {
+            config.as_object_mut().unwrap().insert(
+                "experimental_response_cache".to_string(),
+                json!({"enabled": enabled}),
+            );
+        }
+        if let Some(enabled) = entity_cache_enabled {
+            config.as_object_mut().unwrap().insert(
+                "preview_entity_cache".to_string(),
+                json!({"enabled": enabled}),
+            );
+        }
+        config
+    };
+
+    let _: Configuration =
+        serde_json::from_value(make_config(None, None)).expect("neither plugin configured");
+
+    let _: Configuration = serde_json::from_value(make_config(Some(true), None))
+        .expect("response cache plugin configured");
+
+    let _: Configuration = serde_json::from_value(make_config(Some(true), Some(false)))
+        .expect("response cache plugin configured");
+
+    let _: Configuration = serde_json::from_value(make_config(None, Some(true)))
+        .expect("entity cache plugin configured");
+
+    let _: Configuration = serde_json::from_value(make_config(Some(false), Some(true)))
+        .expect("entity cache plugin configured");
+
+    let config_result: Result<Configuration, _> =
+        serde_json::from_value(make_config(Some(true), Some(true)));
+    config_result.expect_err("both plugins configured");
+}

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -1654,7 +1654,6 @@ mod test {
     #[case::authorization("authorization")]
     #[case::authentication("authentication")]
     #[case::file_upload("preview_file_uploads")]
-    #[case::entity_cache("preview_entity_cache")]
     #[case::response_cache("experimental_response_cache")]
     #[case::demand_control("demand_control")]
     #[case::connectors("connectors")]

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_allowed_features_empty.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_allowed_features_empty.snap
@@ -9,9 +9,6 @@ Configuration yaml:
 * Authentication plugin
   .authentication.router
 
-* Subgraph entity caching
-  .preview_entity_cache.enabled
-
 * Federated subscriptions
   .subscription.enabled
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_unlicensed.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_unlicensed.snap
@@ -9,9 +9,6 @@ Configuration yaml:
 * Authentication plugin
   .authentication.router
 
-* Subgraph entity caching
-  .preview_entity_cache.enabled
-
 * Federated subscriptions
   .subscription.enabled
 

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -64,21 +64,6 @@ experimental_response_cache:
         url: "postgres://localhost:5432"
       ttl: 360s # overrides the global TTL
 
-preview_entity_cache:
-  enabled: true
-  invalidation:
-    listen: 127.0.0.1:4000
-    path: /invalidation
-  subgraph:
-    all:
-      redis:
-        urls:
-          - https://example.com
-      enabled: false
-    subgraphs:
-      product:
-        enabled: false
-
 telemetry:
   apollo:
     metrics_reference_mode: extended


### PR DESCRIPTION
Entity cache and response cache plugins should not be used simultaneously; enforce this in the router configuration validation process.

<!-- start metadata -->

<!-- [ROUTER-1455] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1455]: https://apollographql.atlassian.net/browse/ROUTER-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ