### PR TITLE
[docs] Update native plugin notice with support details

### DIFF
--- a/docs/shared/native-plugin-notice.mdx
+++ b/docs/shared/native-plugin-notice.mdx
@@ -6,7 +6,7 @@
 
 For most router customizations, Apollo recommends creating either a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). Both options provide strong separation of concerns and fault isolation. Both options are also officially supported by Apollo.
 
-While you can still use native plugins and custom router binaries, Apollo Support cannot provide troubleshooting support or fixes for these customizations. 
+Although you can still use native plugins and custom router binaries, Apollo Support cannot provide troubleshooting support or fixes for these customizations.
 
 If you must create a native plugin, please [open a GitHub issue](https://github.com/apollographql/router/issues), and Apollo can investigate adding the custom capability to the stock router binary.
 

--- a/docs/shared/native-plugin-notice.mdx
+++ b/docs/shared/native-plugin-notice.mdx
@@ -3,9 +3,10 @@
 
 - Native plugins require familiarity with programming in Rust.
 - Native plugins require compiling a custom router binary from source, which can introduce unexpected behavior in your router that's difficult to diagnose and support.
-- Custom router binaries are not covered by GraphOS commercial support.
 
-Instead, for most router customizations, Apollo recommends creating either a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). _Both of these customizations are supported by Apollo_ and provide strong separation of concerns and fault isolation.
+For most router customizations, Apollo recommends creating either a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). Both options provide strong separation of concerns and fault isolation. Both options are also officially supported by Apollo.
+
+While you can still use native plugins and custom router binaries, Apollo Support cannot provide troubleshooting support or fixes for these customizations. 
 
 If you must create a native plugin, please [open a GitHub issue](https://github.com/apollographql/router/issues), and Apollo can investigate adding the custom capability to the stock router binary.
 

--- a/docs/shared/native-plugin-notice.mdx
+++ b/docs/shared/native-plugin-notice.mdx
@@ -4,7 +4,7 @@
 - Native plugins require familiarity with programming in Rust.
 - Native plugins require compiling a custom router binary from source, which can introduce unexpected behavior in your router that's difficult to diagnose and support.
 
-The recommended approach for router customizations is to use a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). Both options are officially supported by Apollo and provide strong separation of concerns and fault isolation.
+The recommended approach for router customizations is to use a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/). For more advanced use cases, you can use an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). Both options are officially supported by Apollo and provide strong separation of concerns and fault isolation.
 
 Although you can still use native plugins and custom router binaries, Apollo Support can't provide troubleshooting support or fixes for these customizations.
 

--- a/docs/shared/native-plugin-notice.mdx
+++ b/docs/shared/native-plugin-notice.mdx
@@ -1,8 +1,12 @@
+<Note>
 ⚠️ Apollo doesn't recommend creating native plugins for the Apollo Router Core or GraphOS Router, for the following reasons:
 
 - Native plugins require familiarity with programming in Rust.
 - Native plugins require compiling a custom router binary from source, which can introduce unexpected behavior in your router that's difficult to diagnose and support.
+- Custom router binaries are not covered by GraphOS commercial support.
 
-Instead, for most router customizations, Apollo recommends creating either a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). Both of these customizations are supported by Apollo and provide strong separation of concerns and fault isolation.
+Instead, for most router customizations, Apollo recommends creating either a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). _Both of these customizations are supported by Apollo_ and provide strong separation of concerns and fault isolation.
 
 If you must create a native plugin, please [open a GitHub issue](https://github.com/apollographql/router/issues), and Apollo can investigate adding the custom capability to the stock router binary.
+
+</Note>

--- a/docs/shared/native-plugin-notice.mdx
+++ b/docs/shared/native-plugin-notice.mdx
@@ -4,9 +4,9 @@
 - Native plugins require familiarity with programming in Rust.
 - Native plugins require compiling a custom router binary from source, which can introduce unexpected behavior in your router that's difficult to diagnose and support.
 
-For most router customizations, Apollo recommends creating either a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). Both options provide strong separation of concerns and fault isolation. Both options are also officially supported by Apollo.
+The recommended approach for router customizations is to use a [Rhai script](https://www.apollographql.com/docs/graphos/routing/customization/rhai/) or an [external coprocessor](https://www.apollographql.com/docs/router/customizations/coprocessor). Both options are officially supported by Apollo and provide strong separation of concerns and fault isolation.
 
-Although you can still use native plugins and custom router binaries, Apollo Support cannot provide troubleshooting support or fixes for these customizations.
+Although you can still use native plugins and custom router binaries, Apollo Support can't provide troubleshooting support or fixes for these customizations.
 
 If you must create a native plugin, please [open a GitHub issue](https://github.com/apollographql/router/issues), and Apollo can investigate adding the custom capability to the stock router binary.
 


### PR DESCRIPTION
Emphasize that Apollo supports Rhai scripts and external coprocessors for router customizations, but not custom binaries