### PR TITLE
docs: add apollo_router_session_count_total to apollo.router.open_connections to migration guide

### DIFF
--- a/docs/source/routing/upgrade/from-router-v1.mdx
+++ b/docs/source/routing/upgrade/from-router-v1.mdx
@@ -57,8 +57,8 @@ Multiple metrics have been removed in router v2.x as part of evolving towards Op
   `http.server.request.duration` metric for requests from clients to router and
   `http.client.request.duration` for requests from router to subgraphs.
 
-- Removed `apollo_router_session_count_total`. This does not have an equivalent in 2.0.0,
-  though one may be introduced in a point release.
+- Removed `apollo_router_session_count_total`. This is replaced by
+  `apollo.router.open_connections`, which was introduced in v2.1.0.
 
 - Removed `apollo_router_session_count_active`. This is replaced by
   `http.server.active_requests`.


### PR DESCRIPTION
This PR updates the migration guide to properly document that `apollo.router.open_connections` is the replacement for the deprecated `apollo_router_session_count_total` metric. 

The deprecated metric was removed in v2.0.0, but its replacement was introduced in v2.1.0. The migration guide previously stated there was no equivalent, which was only true initially.

<!-- [ROUTER-1460] -->

[ROUTER-1460]: https://apollographql.atlassian.net/browse/ROUTER-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ