### PR TITLE
feat(composition): Implement add_missing_interface_object_fields_to_implementations

### DIFF
--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -1185,19 +1185,19 @@ impl Merger {
 
 /// Simple builder for join__field directives (minimal version for compatibility)
 #[allow(dead_code)]
-struct JoinFieldBuilder {
+pub(crate) struct JoinFieldBuilder {
     arguments: Vec<Node<Argument>>,
 }
 
 #[allow(dead_code)]
 impl JoinFieldBuilder {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             arguments: Vec::new(),
         }
     }
 
-    fn arg<T: Into<Value>>(mut self, key: &Name, value: T) -> Self {
+    pub(crate) fn arg<T: Into<Value>>(mut self, key: &Name, value: T) -> Self {
         self.arguments.push(Node::new(Argument {
             name: key.clone(),
             value: Node::new(value.into()),
@@ -1205,7 +1205,7 @@ impl JoinFieldBuilder {
         self
     }
 
-    fn maybe_arg<T: Into<Value>>(self, key: &Name, value: Option<T>) -> Self {
+    pub(crate) fn maybe_arg<T: Into<Value>>(self, key: &Name, value: Option<T>) -> Self {
         if let Some(v) = value {
             self.arg(key, v)
         } else {
@@ -1213,7 +1213,7 @@ impl JoinFieldBuilder {
         }
     }
 
-    fn maybe_bool_arg(self, key: &Name, condition: bool) -> Self {
+    pub(crate) fn maybe_bool_arg(self, key: &Name, condition: bool) -> Self {
         if condition {
             self.arg(key, Value::Boolean(true))
         } else {
@@ -1221,7 +1221,7 @@ impl JoinFieldBuilder {
         }
     }
 
-    fn build(self) -> Directive {
+    pub(crate) fn build(self) -> Directive {
         Directive {
             name: name!("join__field"),
             arguments: self.arguments,

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1201,11 +1201,17 @@ impl Merger {
                         // more likely to be what user expects.
                         let mut new_field = itf_field.as_ref().clone();
                         new_field.directives.retain(|d| {
-                            !self
-                                .join_spec_definition
+                            self.join_spec_definition
                                 .is_spec_directive_name(&self.merged, &d.name)
-                                .is_ok_and(|b| b)
+                                .is_ok_and(|from_join_spec| !from_join_spec)
                         });
+                        for arg in new_field.arguments.iter_mut() {
+                            arg.make_mut().directives.retain(|d| {
+                                self.join_spec_definition
+                                    .is_spec_directive_name(&self.merged, &d.name)
+                                    .is_ok_and(|from_join_spec| !from_join_spec)
+                            });
+                        }
                         // We add a special @join__field for those added field with no `graph` target. This
                         // clarify to the later extraction process that this particular field doesn't come
                         // from any particular subgraph.

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -61,6 +61,7 @@ use crate::schema::position::HasDescription;
 use crate::schema::position::HasType;
 use crate::schema::position::InputObjectTypeDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
+use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
@@ -74,6 +75,8 @@ use crate::subgraph::typestate::Validated;
 use crate::supergraph::CompositionHint;
 use crate::utils::human_readable::human_readable_subgraph_names;
 use crate::utils::iter_into_single_item;
+
+use super::merge_field::JoinFieldBuilder;
 
 static NON_MERGED_CORE_FEATURES: LazyLock<[Identity; 4]> = LazyLock::new(|| {
     [
@@ -462,7 +465,7 @@ impl Merger {
         self.merge_all_applied_directives()?;
 
         // Add missing interface object fields to implementations
-        self.add_missing_interface_object_fields_to_implementations();
+        self.add_missing_interface_object_fields_to_implementations()?;
 
         // Post-merge validations if no errors so far
         if !self.error_reporter.has_errors() {
@@ -1155,8 +1158,97 @@ impl Merger {
         applications
     }
 
-    fn add_missing_interface_object_fields_to_implementations(&mut self) {
-        todo!("Implement adding missing interface object fields to implementations")
+    fn add_missing_interface_object_fields_to_implementations(
+        &mut self,
+    ) -> Result<(), FederationError> {
+        let mut fields_to_insert = HashMap::new();
+        // For each merged object types, we check if we're missing a field from one of the implemented interface.
+        // If we do, then we look if one of the subgraph provides that field as a (non-external) interface object
+        // type, and if that's the case, we add the field to the object.
+        for obj_ty_name in self.merged.referencers().object_types.keys() {
+            let Some(obj_ty) = self.merged.schema().get_object(obj_ty_name) else {
+                bail!(
+                    "Referencers contains Object type named \"{obj_ty_name}\", but that Object type does not exist in the schema."
+                )
+            };
+            for implemented_itf_name in obj_ty.implements_interfaces.iter() {
+                let Some(implemented_itf) =
+                    self.merged.schema().get_interface(implemented_itf_name)
+                else {
+                    bail!(
+                        "Object type \"{obj_ty_name}\" implements interface \"{implemented_itf_name}\", but that Interface type does not exist in the schema."
+                    )
+                };
+                for itf_field in implemented_itf.fields.values() {
+                    if obj_ty.fields.contains_key(&itf_field.name) {
+                        continue;
+                    }
+
+                    // Note that we don't blindly add the field yet, that would be incorrect in many cases (and we
+                    // have a specific validation that return a user-friendly error in such incorrect cases, see
+                    // `postMergeValidations`). We must first check that there is some subgraph that implement
+                    // that field as an "interface object", since in that case the field will genuinely be provided
+                    // by that subgraph at runtime.
+                    if self.is_field_provided_by_an_interface_object(
+                        &itf_field.name,
+                        implemented_itf_name,
+                    ) {
+                        // Note it's possible that interface is abstracted away (as an interface object) in multiple
+                        // subgraphs, so we don't bother with the field definition in those subgraphs, but rather
+                        // just copy the merged definition from the interface.
+                        //
+                        // Cases could probably be made for both either copying or not copying the description
+                        // and applied directives from the interface field, but we copy both here as it feels
+                        // more likely to be what user expects.
+                        let mut new_field = itf_field.as_ref().clone();
+                        new_field.directives.retain(|d| {
+                            !self
+                                .join_spec_definition
+                                .is_spec_directive_name(&self.merged, &d.name)
+                                .is_ok_and(|b| b)
+                        });
+                        // We add a special @join__field for those added field with no `graph` target. This
+                        // clarify to the later extraction process that this particular field doesn't come
+                        // from any particular subgraph.
+                        new_field.directives.push(JoinFieldBuilder::new().build());
+                        fields_to_insert.insert(
+                            ObjectFieldDefinitionPosition {
+                                type_name: obj_ty_name.clone(),
+                                field_name: itf_field.name.clone(),
+                            },
+                            new_field,
+                        );
+                    }
+                }
+            }
+        }
+
+        let sources: Sources<()> = (0..self.subgraphs.len()).map(|idx| (idx, None)).collect();
+        for (pos, field) in fields_to_insert {
+            pos.insert(&mut self.merged, Component::new(field))?;
+            // If we had to add a field here, it means that, for this particular implementation, the
+            // field is only provided through the @interfaceObject. But because the field wasn't
+            // merged, it also mean we haven't validated field sharing for that field, and we could
+            // have field sharing concerns if the field is provided by multiple @interfaceObject.
+            // So we validate field sharing now (it's convenient to wait until now as now that
+            // the field is part of the supergraph, we can just call `validateFieldSharing` with
+            // all sources `undefined` and it wil still find and check the `@interfaceObject`).
+            self.validate_field_sharing(&sources, &pos.into(), &FieldMergeContext::default())?;
+        }
+        Ok(())
+    }
+
+    fn is_field_provided_by_an_interface_object(&self, field_name: &Name, itf_name: &Name) -> bool {
+        self.subgraphs.iter().any(|subgraph| {
+            let obj_pos = ObjectTypeDefinitionPosition {
+                type_name: itf_name.clone(),
+            };
+            let field_pos = obj_pos.field(field_name.clone());
+
+            subgraph.is_interface_object_type(&obj_pos.into())
+                && field_pos.try_get(subgraph.schema().schema()).is_some()
+                && !subgraph.metadata().is_field_external(&field_pos.into())
+        })
     }
 
     fn post_merge_validations(&mut self) {

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -52,6 +52,7 @@ use crate::merger::merge_enum::EnumExample;
 use crate::merger::merge_enum::EnumExampleAst;
 use crate::merger::merge_enum::EnumTypeUsage;
 use crate::merger::merge_field::FieldMergeContext;
+use crate::merger::merge_field::JoinFieldBuilder;
 use crate::schema::FederationSchema;
 use crate::schema::directive_location::DirectiveLocationExt;
 use crate::schema::position::DirectiveDefinitionPosition;
@@ -75,8 +76,6 @@ use crate::subgraph::typestate::Validated;
 use crate::supergraph::CompositionHint;
 use crate::utils::human_readable::human_readable_subgraph_names;
 use crate::utils::iter_into_single_item;
-
-use super::merge_field::JoinFieldBuilder;
 
 static NON_MERGED_CORE_FEATURES: LazyLock<[Identity; 4]> = LazyLock::new(|| {
     [


### PR DESCRIPTION
Ports [Merger.addMissingInterfaceObjectFieldsToImplementations](https://github.com/apollographql/federation/blob/8cdd1f01f663f77c921e261d3704830152dd7587/composition-js/src/merging/merge.ts#L1165) from JS. After merging objects and interfaces, we need to make sure that interface objects correctly contribute their fields to relevant object types. We do this by looping over all object types, checking if their interfaces are actually interface objects, and then merging any fields which haven't already been copied over.

<!-- [FED-795] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary


[FED-795]: https://apollographql.atlassian.net/browse/FED-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ