### PR TITLE
Trace and metrics exporter wrappers to append details to errors

### DIFF
--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -24,6 +24,7 @@ use crate::plugins::telemetry::apollo_exporter::ApolloExporter;
 use crate::plugins::telemetry::apollo_exporter::get_uname;
 use crate::plugins::telemetry::config::ApolloMetricsReferenceMode;
 use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::error_handler::NamedMetricsExporter;
 use crate::plugins::telemetry::metrics::CustomAggregationSelector;
 use crate::plugins::telemetry::metrics::MetricsBuilder;
 use crate::plugins::telemetry::metrics::MetricsConfigurator;
@@ -198,12 +199,15 @@ impl Config {
                     .build(),
             ),
         )?;
-        let default_reader = PeriodicReader::builder(exporter, runtime::Tokio)
+        let named_exporter = NamedMetricsExporter::new(exporter, "apollo");
+        let named_realtime_exporter = NamedMetricsExporter::new(realtime_exporter, "apollo");
+
+        let default_reader = PeriodicReader::builder(named_exporter, runtime::Tokio)
             .with_interval(Duration::from_secs(60))
             .with_timeout(batch_config.max_export_timeout)
             .build();
 
-        let realtime_reader = PeriodicReader::builder(realtime_exporter, runtime::Tokio)
+        let realtime_reader = PeriodicReader::builder(named_realtime_exporter, runtime::Tokio)
             .with_interval(batch_config.scheduled_delay)
             .with_timeout(batch_config.max_export_timeout)
             .build();

--- a/apollo-router/src/plugins/telemetry/metrics/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/otlp.rs
@@ -5,6 +5,7 @@ use opentelemetry_sdk::runtime;
 use tower::BoxError;
 
 use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::error_handler::NamedMetricsExporter;
 use crate::plugins::telemetry::metrics::CustomAggregationSelector;
 use crate::plugins::telemetry::metrics::MetricsBuilder;
 use crate::plugins::telemetry::metrics::MetricsConfigurator;
@@ -33,8 +34,10 @@ impl MetricsConfigurator for super::super::otlp::Config {
             ),
         )?;
 
+        let named_exporter = NamedMetricsExporter::new(exporter, "otlp");
+
         builder.public_meter_provider_builder = builder.public_meter_provider_builder.with_reader(
-            PeriodicReader::builder(exporter, runtime::Tokio)
+            PeriodicReader::builder(named_exporter, runtime::Tokio)
                 .with_interval(self.batch_processor.scheduled_delay)
                 .with_timeout(self.batch_processor.max_export_timeout)
                 .build(),

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -9,6 +9,7 @@ use crate::plugins::telemetry::apollo::router_id;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::Trace;
 use crate::plugins::telemetry::config;
 use crate::plugins::telemetry::config_new::spans::Spans;
+use crate::plugins::telemetry::error_handler::NamedSpanExporter;
 use crate::plugins::telemetry::otel::named_runtime_channel::NamedTokioRuntime;
 use crate::plugins::telemetry::span_factory::SpanMode;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
@@ -50,8 +51,9 @@ impl TracingConfigurator for Config {
             .use_legacy_request_span(matches!(spans_config.mode, SpanMode::Deprecated))
             .metrics_reference_mode(self.metrics_reference_mode)
             .build()?;
+        let named_exporter = NamedSpanExporter::new(exporter, "apollo");
         Ok(builder.with_span_processor(
-            BatchSpanProcessor::builder(exporter, NamedTokioRuntime::new("apollo-tracing"))
+            BatchSpanProcessor::builder(named_exporter, NamedTokioRuntime::new("apollo-tracing"))
                 .with_batch_config(self.tracing.batch_processor.clone().into())
                 .build(),
         ))

--- a/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog/mod.rs
@@ -42,6 +42,7 @@ use crate::plugins::telemetry::consts::SUBGRAPH_REQUEST_SPAN_NAME;
 use crate::plugins::telemetry::consts::SUBGRAPH_SPAN_NAME;
 use crate::plugins::telemetry::consts::SUPERGRAPH_SPAN_NAME;
 use crate::plugins::telemetry::endpoint::UriEndpoint;
+use crate::plugins::telemetry::error_handler::NamedSpanExporter;
 use crate::plugins::telemetry::otel::named_runtime_channel::NamedTokioRuntime;
 use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 use crate::plugins::telemetry::tracing::SpanProcessorExt;
@@ -220,11 +221,14 @@ impl TracingConfigurator for Config {
         let mut span_metrics = default_span_metrics();
         span_metrics.extend(self.span_metrics.clone());
 
+        let wrapper = ExporterWrapper {
+            delegate: exporter,
+            span_metrics,
+        };
+        let named_exporter = NamedSpanExporter::new(wrapper, "datadog");
+
         let batch_processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(
-            ExporterWrapper {
-                delegate: exporter,
-                span_metrics,
-            },
+            named_exporter,
             NamedTokioRuntime::new("datadog-tracing"),
         )
         .with_batch_config(self.batch_processor.clone().into())

--- a/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
@@ -13,6 +13,7 @@ use crate::plugins::telemetry::config::GenericWith;
 use crate::plugins::telemetry::config::TracingCommon;
 use crate::plugins::telemetry::config_new::spans::Spans;
 use crate::plugins::telemetry::endpoint::UriEndpoint;
+use crate::plugins::telemetry::error_handler::NamedSpanExporter;
 use crate::plugins::telemetry::otel::named_runtime_channel::NamedTokioRuntime;
 use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 use crate::plugins::telemetry::tracing::SpanProcessorExt;
@@ -64,8 +65,10 @@ impl TracingConfigurator for Config {
             .with_trace_config(common)
             .init_exporter()?;
 
+        let named_exporter = NamedSpanExporter::new(exporter, "zipkin");
+
         Ok(builder.with_span_processor(
-            BatchSpanProcessor::builder(exporter, NamedTokioRuntime::new("zipkin-tracing"))
+            BatchSpanProcessor::builder(named_exporter, NamedTokioRuntime::new("zipkin-tracing"))
                 .with_batch_config(self.batch_processor.clone().into())
                 .build()
                 .filtered(),


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-1283] -->

Adds a wrapper around `MetricsExporter`s and `SpanExporter`s so that the exporter type can be appended to error messages. This allows us to differentiate between e.g. "Apollo OTel" errors and "OTLP exporter" errors.

Error messages will now look like:
```
ERROR  OpenTelemetry trace error occurred: [apollo traces] Exporter otlp encountered the following error(s): the grpc server returns error (The service is currently unavailable): , detailed error message: dns error
ERROR  OpenTelemetry trace error occurred: [apollo traces] Exporter ApolloExporter encountered the following error(s): Apollo exporter unavailable error: error sending request for url (https://usage-reporting.api.dev0.c0.gql.zone/api/ingress/traces)
ERROR  OpenTelemetry trace error occurred: [zipkin traces] error sending request for url (http://0.0.0.1:4100/api/v2/spans)
ERROR  OpenTelemetry trace error occurred: [otlp traces] Exporter otlp encountered the following error(s): the grpc server returns error (The service is currently unavailable): , detailed error message: tcp connect error
ERROR  OpenTelemetry metric error occurred: Metrics error: [apollo metrics] the grpc server returns error (Unknown error): , detailed error message: transport error tonic::transport::Error(Transport, hyper::Error(Io, Kind(TimedOut)))
ERROR  OpenTelemetry metric error occurred: Metrics error: [otlp metrics] the grpc server returns error (The service is currently unavailable): , detailed error message: tcp connect error
```


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
