### PR TITLE
(fix) Prevent log on rhai scripts that short circuit

### DIFF
--- a/.changesets/fix_bryn_rhai_logging.md
+++ b/.changesets/fix_bryn_rhai_logging.md
@@ -1,6 +1,6 @@
 ### (fix) Rhai short circuit responses will not log if a body is present ([PR #8364](https://github.com/apollographql/router/pull/8364))
 
-Rhai scripts that short circuited the pipeline by throwing would now only log an error if a response is not present. 
+Rhai scripts that short circuited the pipeline by throwing would now only log an error if a response body is not present. 
 
 For example the following will NOT log:
 ```

--- a/.changesets/fix_bryn_rhai_logging.md
+++ b/.changesets/fix_bryn_rhai_logging.md
@@ -1,0 +1,24 @@
+### (fix) Rhai short circuit responses will not log if a body is present ([PR #8364](https://github.com/apollographql/router/pull/8364))
+
+Rhai scripts that short circuited the pipeline by throwing would now only log an error if a response is not present. 
+
+For example the following will NOT log:
+```
+    throw #{
+        status: 403,
+        body: #{
+            errors: [#{
+                message: "Custom error with body",
+                extensions: #{
+                    code: "FORBIDDEN"
+                }
+            }]
+        }
+    };
+```
+
+For example the following WILL log:
+```
+throw "An error occurred without a body";
+```
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/8364

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -530,7 +530,7 @@ macro_rules! gen_map_deferred_response {
                         execute(&$rhai_service, &$callback, (shared_response.clone(),));
                     if let Err(error) = result {
                         let error_details = process_error(error);
-                                                if error_details.body.is_none() {
+                        if error_details.body.is_none() {
                             tracing::error!("map_request callback failed: {error_details:#?}");
                         }
                         let mut guard = shared_response.lock();

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -222,7 +222,10 @@ macro_rules! gen_map_request {
                         execute(&$rhai_service, &$callback, (shared_request.clone(),));
                     if let Err(error) = result {
                         let error_details = process_error(error);
-                        tracing::error!("map_request callback failed: {error_details:#?}");
+                        if error_details.body.is_none() {
+                            tracing::error!("map_request callback failed: {error_details:#?}");
+                        }
+
                         let mut guard = shared_request.lock();
                         let request_opt = guard.take();
                         return $base::request_failure(request_opt.unwrap().context, error_details);
@@ -269,8 +272,10 @@ macro_rules! gen_map_router_deferred_request {
                     let result = execute(&$rhai_service, &$callback, (shared_request.clone(),));
 
                     if let Err(error) = result {
-                        tracing::error!("map_request callback failed: {error}");
                         let error_details = process_error(error);
+                        if error_details.body.is_none() {
+                            tracing::error!("map_request callback failed: {error_details:#?}");
+                        }
                         let mut guard = shared_request.lock();
                         let request_opt = guard.take();
                         return $base::request_failure(request_opt.unwrap().context, error_details);
@@ -356,8 +361,10 @@ macro_rules! gen_map_response {
                         execute(&$rhai_service, &$callback, (shared_response.clone(),));
 
                     if let Err(error) = result {
-                        tracing::error!("map_response callback failed: {error}");
                         let error_details = process_error(error);
+                        if error_details.body.is_none() {
+                            tracing::error!("map_request callback failed: {error_details:#?}");
+                        }
                         let mut guard = shared_response.lock();
                         let response_opt = guard.take();
                         return $base::response_failure(
@@ -402,8 +409,11 @@ macro_rules! gen_map_router_deferred_response {
                     let result =
                         execute(&$rhai_service, &$callback, (shared_response.clone(),));
                     if let Err(error) = result {
-                        tracing::error!("map_response callback failed: {error}");
+
                         let error_details = process_error(error);
+                        if error_details.body.is_none() {
+                            tracing::error!("map_request callback failed: {error_details:#?}");
+                        }
                         let response_opt = shared_response.lock().take();
                         return Ok($base::response_failure(
                             response_opt.unwrap().context,
@@ -519,8 +529,10 @@ macro_rules! gen_map_deferred_response {
                     let result =
                         execute(&$rhai_service, &$callback, (shared_response.clone(),));
                     if let Err(error) = result {
-                        tracing::error!("map_response callback failed: {error}");
                         let error_details = process_error(error);
+                                                if error_details.body.is_none() {
+                            tracing::error!("map_request callback failed: {error_details:#?}");
+                        }
                         let mut guard = shared_response.lock();
                         let response_opt = guard.take();
                         return Ok($base::response_failure(
@@ -554,8 +566,10 @@ macro_rules! gen_map_deferred_response {
                                 (shared_response.clone(),),
                             );
                             if let Err(error) = result {
-                                tracing::error!("map_response callback failed: {error}");
                                 let error_details = process_error(error);
+                                if error_details.body.is_none() {
+                                    tracing::error!("map_request callback failed: {error_details:#?}");
+                                }
                                 let mut guard = shared_response.lock();
                                 let response_opt = guard.take();
                                 let $base::DeferredResponse { mut response, .. } = response_opt.unwrap();

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__error_logging_with_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__error_logging_with_body@logs.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+[]

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__error_logging_without_body@logs.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 7, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                7,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "supergraph :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "supergraph :: Request"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__execution_error_logging_with_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__execution_error_logging_with_body@logs.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+[]

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__execution_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__execution_error_logging_without_body@logs.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "execution :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "execution :: Request"
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__router_error_logging_with_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__router_error_logging_with_body@logs.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+[]

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__router_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__router_error_logging_without_body@logs.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "router :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "router :: Request"
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__subgraph_error_logging_with_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__subgraph_error_logging_with_body@logs.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+[]

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__subgraph_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__subgraph_error_logging_without_body@logs.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "subgraph :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "subgraph :: Request"
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__supergraph_error_logging_with_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__supergraph_error_logging_with_body@logs.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+[]

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__supergraph_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__supergraph_error_logging_without_body@logs.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "supergraph :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "supergraph :: Request"
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -33,6 +33,8 @@ use crate::graphql::Request;
 use crate::http_ext;
 use crate::plugin::DynPlugin;
 use crate::plugin::test::MockExecutionService;
+use crate::plugin::test::MockRouterService;
+use crate::plugin::test::MockSubgraphService;
 use crate::plugin::test::MockSupergraphService;
 use crate::plugins::rhai::engine::RhaiExecutionDeferredResponse;
 use crate::plugins::rhai::engine::RhaiExecutionResponse;
@@ -911,4 +913,139 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
     );
 
     Ok(())
+}
+
+async fn test_supergraph_error_logging(script_name: &str) -> Result<(), BoxError> {
+    let mut mock_service = MockSupergraphService::new();
+    mock_service.expect_call().never();
+
+    let dyn_plugin = create_plugin(script_name).await?;
+
+    let mut service = dyn_plugin.supergraph_service(BoxService::new(mock_service));
+    let req = SupergraphRequest::fake_builder()
+        .context(Context::new())
+        .build()?;
+
+    let _response = service.ready().await?.call(req).await?;
+    Ok(())
+}
+
+async fn create_plugin(script_name: &str) -> Result<Box<dyn DynPlugin>, BoxError> {
+    let config = format!(
+        r#"{{"scripts":"tests/fixtures", "main":"{}"}}"#,
+        script_name
+    );
+    let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
+        .find(|factory| factory.name == "apollo.rhai")
+        .expect("Plugin not found")
+        .create_instance_without_schema(&Value::from_str(&config)?)
+        .await?;
+    Ok(dyn_plugin)
+}
+
+async fn test_execution_error_logging(script_name: &str) -> Result<(), BoxError> {
+    let mut mock_service = MockExecutionService::new();
+    mock_service.expect_clone().return_once(move || {
+        let mut mock_service = MockExecutionService::new();
+        mock_service.expect_call().never();
+        mock_service
+    });
+    let dyn_plugin = create_plugin(script_name).await?;
+    let mut service = dyn_plugin.execution_service(BoxService::new(mock_service));
+    let fake_req = http_ext::Request::fake_builder()
+        .body(Request::builder().query(String::new()).build())
+        .build()?;
+    let req = ExecutionRequest::fake_builder()
+        .context(Context::new())
+        .supergraph_request(fake_req)
+        .build();
+
+    let _response = service.ready().await?.call(req).await?;
+    Ok(())
+}
+
+async fn test_router_error_logging(script_name: &str) -> Result<(), BoxError> {
+    let mut mock_service = MockRouterService::new();
+    mock_service.expect_call().never();
+
+    let dyn_plugin = create_plugin(script_name).await?;
+
+    let mut service = dyn_plugin.router_service(BoxService::new(mock_service));
+    let req = crate::services::RouterRequest::fake_builder()
+        .context(Context::new())
+        .build()?;
+
+    let _response = service.ready().await?.call(req).await?;
+    Ok(())
+}
+
+async fn test_subgraph_error_logging(script_name: &str) -> Result<(), BoxError> {
+    let mut mock_service = MockSubgraphService::new();
+    mock_service.expect_call().never();
+
+    let dyn_plugin = create_plugin(script_name).await?;
+
+    let mut service = dyn_plugin.subgraph_service("test_subgraph", BoxService::new(mock_service));
+    let req = SubgraphRequest::fake_builder()
+        .context(Context::new())
+        .build();
+
+    let _response = service.ready().await?.call(req).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_supergraph_error_logging_without_body() -> Result<(), BoxError> {
+    test_supergraph_error_logging("error_without_body.rhai")
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
+}
+
+#[tokio::test]
+async fn test_supergraph_error_logging_with_body() -> Result<(), BoxError> {
+    test_supergraph_error_logging("error_with_body.rhai")
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
+}
+
+#[tokio::test]
+async fn test_execution_error_logging_without_body() -> Result<(), BoxError> {
+    test_execution_error_logging("error_without_body.rhai")
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
+}
+
+#[tokio::test]
+async fn test_execution_error_logging_with_body() -> Result<(), BoxError> {
+    test_execution_error_logging("error_with_body.rhai")
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
+}
+
+#[tokio::test]
+async fn test_router_error_logging_without_body() -> Result<(), BoxError> {
+    test_router_error_logging("error_without_body.rhai")
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
+}
+
+#[tokio::test]
+async fn test_router_error_logging_with_body() -> Result<(), BoxError> {
+    test_router_error_logging("error_with_body.rhai")
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
+}
+
+#[tokio::test]
+async fn test_subgraph_error_logging_without_body() -> Result<(), BoxError> {
+    test_subgraph_error_logging("error_without_body.rhai")
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
+}
+
+#[tokio::test]
+async fn test_subgraph_error_logging_with_body() -> Result<(), BoxError> {
+    test_subgraph_error_logging("error_with_body.rhai")
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
 }

--- a/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
+++ b/apollo-router/src/services/layers/persisted_queries/snapshots/apollo_router__services__layers__persisted_queries__tests__pq_layer_freeform_graphql_with_safelist_log_unknown_true@logs.snap
@@ -6,6 +6,19 @@ expression: yaml
   level: INFO
   message: Loaded 2 persisted queries.
 - fields:
+    queue_capacity: 14000
+    threads: 14
+  level: INFO
+  message: compute job thread pool created
+  span:
+    job.type: query_parsing
+    name: compute_job
+  spans:
+    - name: parse_query
+      otel.kind: INTERNAL
+    - job.type: query_parsing
+      name: compute_job
+- fields:
     enforcement_skipped: false
     operation_body: "query SomeQuery { me { id } }"
   level: WARN

--- a/apollo-router/tests/fixtures/error_with_body.rhai
+++ b/apollo-router/tests/fixtures/error_with_body.rhai
@@ -1,0 +1,47 @@
+fn router_service(service) {
+    service.map_request(Fn("process_request"));
+    service.map_response(Fn("process_response"));
+}
+
+fn supergraph_service(service) {
+    service.map_request(Fn("process_request"));
+    service.map_response(Fn("process_response"));
+}
+
+fn execution_service(service) {
+    service.map_request(Fn("process_request"));
+    service.map_response(Fn("process_response"));
+}
+
+fn subgraph_service(service, subgraph) {
+    service.map_request(Fn("process_request"));
+    service.map_response(Fn("process_response"));
+}
+
+fn process_request(obj) {
+    throw #{
+        status: 403,
+        body: #{
+            errors: [#{
+                message: "Custom error with body",
+                extensions: #{
+                    code: "FORBIDDEN"
+                }
+            }]
+        }
+    };
+}
+
+fn process_response(obj) {
+    throw #{
+        status: 403,
+        body: #{
+            errors: [#{
+                message: "Custom error with body",
+                extensions: #{
+                    code: "FORBIDDEN"
+                }
+            }]
+        }
+    };
+}

--- a/apollo-router/tests/fixtures/error_without_body.rhai
+++ b/apollo-router/tests/fixtures/error_without_body.rhai
@@ -1,0 +1,27 @@
+fn router_service(service) {
+    service.map_request(Fn("process_request"));
+    service.map_response(Fn("process_response"));
+}
+
+fn supergraph_service(service) {
+    service.map_request(Fn("process_request"));
+    service.map_response(Fn("process_response"));
+}
+
+fn execution_service(service) {
+    service.map_request(Fn("process_request"));
+    service.map_response(Fn("process_response"));
+}
+
+fn subgraph_service(service, subgraph) {
+    service.map_request(Fn("process_request"));
+    service.map_response(Fn("process_response"));
+}
+
+fn process_request(obj) {
+    throw "An error occurred without a body";
+}
+
+fn process_response(obj) {
+    throw "An error occurred without a body";
+}

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -551,7 +551,7 @@ When a Rhai callback function throws an error, the router automatically logs the
 
 #### Errors without custom body
 
-When a callback throws a simple error (a string), the router logs the full error details at ERROR level:
+When a callback throws a simple error (a string), the router logs the full error details at <code>ERROR</code> level:
 
 ```rhai
 fn supergraph_service(service) {
@@ -562,13 +562,13 @@ fn supergraph_service(service) {
 ```
 
 The log output includes:
-- HTTP status code (defaults to 500)
+- HTTP status code (defaults to <code>500</code>)
 - Error message
 - Line number and position where the error occurred
 
 #### Errors with custom body
 
-When a callback throws an error with a custom GraphQL response body, the router does **not** log the error details:
+When a callback throws an error with a custom GraphQL response body, the router does _not_ log the error details:
 
 ```rhai
 fn supergraph_service(service) {

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -545,6 +545,50 @@ Syntax highlighting can make it easier to spot errors in a script. We recommend 
 
 For tracking down runtime errors, insert [logging](/graphos/reference/router/rhai#logging) statements to narrow down the issue.
 
+### Error logging behavior
+
+When a Rhai callback function throws an error, the router automatically logs the error details to help with debugging. However, the logging behavior depends on whether you provide a custom error body:
+
+#### Errors without custom body
+
+When a callback throws a simple error (a string), the router logs the full error details at ERROR level:
+
+```rhai
+fn supergraph_service(service) {
+    service.map_request(|request| {
+        throw "Something went wrong"; // This error will be logged
+    });
+}
+```
+
+The log output includes:
+- HTTP status code (defaults to 500)
+- Error message
+- Line number and position where the error occurred
+
+#### Errors with custom body
+
+When a callback throws an error with a custom GraphQL response body, the router does **not** log the error details:
+
+```rhai
+fn supergraph_service(service) {
+    service.map_request(|request| {
+        // This error will NOT be logged (to avoid duplication)
+        throw #{
+            status: 403,
+            body: #{
+                errors: [#{
+                    message: "Unauthorized",
+                    extensions: #{
+                        code: "UNAUTHORIZED"
+                    }
+                }]
+            }
+        };
+    });
+}
+```
+
 ## Additional resources
 
 You can use the Apollo Solutions [router extensibility load testing repository](https://github.com/apollosolutions/router-extensibility-load-testing) to load test Rhai scripts as well as router configurations.


### PR DESCRIPTION
In Rhai we use throw to indicate that the pipeline should no longer proceed and should instead immediately return to the user.

Previously wherever this happened this would log an error.

However, when a user wants to return an error response it is not helpful to always log the entire body as an error, and causes a flood of logs.

This PR adds logic to only log if there is no body associated with the response.

For example the following will NOT log
```
    throw #{
        status: 403,
        body: #{
            errors: [#{
                message: "Custom error with body",
                extensions: #{
                    code: "FORBIDDEN"
                }
            }]
        }
    };
```

For example the following WILL log
```
throw "An error occurred without a body";
```

<!-- start metadata -->

<!-- [ROUTER-823] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

No perf impact as code is simple and reduces logging
No metrics needed
Unit tests cover all scenarios

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-823]: https://apollographql.atlassian.net/browse/ROUTER-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ