### PR TITLE
helm(chart): render PDB only when minAvailable or maxUnavailable is set

### DIFF
--- a/helm/chart/router/templates/pdb.yaml
+++ b/helm/chart/router/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget -}}
+{{- if or .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable -}}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
<!-- ROUTER-#### (n/a) -->

**What**
- Render the Helm PodDisruptionBudget (PDB) only when at least one of the fields is set:
  - `.Values.podDisruptionBudget.minAvailable`
  - `.Values.podDisruptionBudget.maxUnavailable`

**Why**
- With `podDisruptionBudget: {}` (empty object), the template previously emitted a PDB with neither field set, which is invalid. This change prevents generating an empty/invalid PDB.

**How**
- Change the top-level conditional in `helm/chart/router/templates/pdb.yaml` from:
  - `{{- if .Values.podDisruptionBudget -}}`
  to:
  - `{{- if or .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable -}}`

**Behavior change**
- Before:
  - `podDisruptionBudget: {}` → emitted an invalid PDB
- After:
  - `podDisruptionBudget: {}` → emits nothing (no PDB)
  - `podDisruptionBudget: { minAvailable: 1 }` → emits valid PDB
  - `podDisruptionBudget: { maxUnavailable: 1 }` → emits valid PDB

**Docs**
- Existing README/values already describe `podDisruptionBudget`. No doc changes required.

**Testing**
- Template render check (examples):
  - `helm template . --set podDisruptionBudget={}` → no PDB rendered
  - `helm template . --set podDisruptionBudget.minAvailable=1` → PDB rendered with `minAvailable: 1`
  - `helm template . --set podDisruptionBudget.maxUnavailable=1` → PDB rendered with `maxUnavailable: 1`

**Files changed**
- `helm/chart/router/templates/pdb.yaml`

References:
- Issues list you asked to contribute to: https://github.com/apollographql/router/issues