### PR TITLE
Visibility tweaks for the connectors mapping playground

### DIFF
--- a/apollo-federation/src/connectors/header.rs
+++ b/apollo-federation/src/connectors/header.rs
@@ -17,10 +17,7 @@ use crate::connectors::string_template::StringTemplate;
 pub struct HeaderValue(StringTemplate);
 
 impl HeaderValue {
-    pub(crate) fn parse_with_spec(
-        s: &str,
-        spec: ConnectSpec,
-    ) -> Result<Self, string_template::Error> {
+    pub fn parse_with_spec(s: &str, spec: ConnectSpec) -> Result<Self, string_template::Error> {
         let template = StringTemplate::parse_with_spec(s, spec)?;
         // Validate that any constant parts are valid header values.
         for part in &template.parts {

--- a/apollo-federation/src/connectors/mod.rs
+++ b/apollo-federation/src/connectors/mod.rs
@@ -26,7 +26,7 @@ use std::hash::Hasher;
 use apollo_compiler::Name;
 
 pub mod expand;
-mod header;
+pub mod header;
 mod id;
 mod json_selection;
 mod models;

--- a/apollo-federation/src/connectors/spec/source.rs
+++ b/apollo-federation/src/connectors/spec/source.rs
@@ -143,7 +143,7 @@ pub struct SourceHTTPArguments {
 }
 
 impl SourceHTTPArguments {
-    fn from_directive(
+    pub fn from_directive(
         values: &[(Name, Node<Value>)],
         directive_name: &Name,
         sources: &SourceMap,


### PR DESCRIPTION
We can deploy https://connectors-mapping.netlify.app from a local branch if we have to, but it would be nice to have a stable `apollo-federation` version that is fully usable by the playground, as-is. We are about to cut a final preview build from the `dev` branch of this repository, so I'm hoping we can still get this PR in.

The last time I investigated updating the playground to `ConnectSpec::V0_3` (to enable the new language features), I found these changes to be necessary: https://github.com/apollographql/connectors-mapping-playground/pull/76

Those changes in turn require making `HeaderValue::parse_with_spec` and `SourceHTTPArguments::from_directive` public in the `apollo-federation` crate, so they can be used by the mapping playground.