### PR TITLE
docs: change MCP's default port from 5000 to 8000

### DIFF
--- a/docs/source/routing/self-hosted/containerization/docker.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker.mdx
@@ -39,12 +39,12 @@ Make sure to replace `<your-graph-ref>` and `<your-graph-api-key>` with your gra
 
 ## Enabling MCP
 
-To serve MCP requests, enable the [Apollo MCP Server](/apollo-mcp-server) using the `MCP_ENABLE` environment variable. You'll also need to export container port `5000` for Streamable HTTP connections to the MCP server, using the `-p 5050:5000` flag.
+To serve MCP requests, enable the [Apollo MCP Server](/apollo-mcp-server) using the `MCP_ENABLE` environment variable. You'll also need to export container port `5000` for Streamable HTTP connections to the MCP server, using the `-p 8000:8000` flag.
 
 ```bash title="Docker" {3, 6}
 docker run \
   -p 4000:4000 \
-  -p 5050:5000 \
+  -p 8000:8000 \
   --env APOLLO_GRAPH_REF="<your-graph-ref>" \
   --env APOLLO_KEY="<your-graph-api-key>" \
   --env MCP_ENABLE=1 \


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AIR-42 -->

MCP's default port is change from 5000 to 5000.

(Keep this open until https://github.com/apollographql/apollo-mcp-server/pull/417 is released)