### PR TITLE
fix(composition): Full vs partial external check in merger

### DIFF
--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -98,11 +98,11 @@ impl SubgraphMetadata {
     }
 
     pub(crate) fn is_field_fully_external(&self, field: &FieldDefinitionPosition) -> bool {
-        self.is_field_external(field) && self.provided_fields.contains(field)
+        self.is_field_external(field) && !self.provided_fields.contains(field)
     }
 
     pub(crate) fn is_field_partially_external(&self, field: &FieldDefinitionPosition) -> bool {
-        self.is_field_external(field) && !self.provided_fields.contains(field)
+        self.is_field_external(field) && self.provided_fields.contains(field)
     }
 
     pub(crate) fn is_field_shareable(&self, field: &FieldDefinitionPosition) -> bool {

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -106,7 +106,6 @@ fn preserves_descriptions() {
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn no_hint_raised_when_merging_empty_description() {
     let subgraph1 = ServiceDefinition {
         name: "Subgraph1",
@@ -153,7 +152,6 @@ fn no_hint_raised_when_merging_empty_description() {
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn include_types_from_different_subgraphs() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",
@@ -184,7 +182,7 @@ fn include_types_from_different_subgraphs() {
     let api_schema = supergraph
         .to_api_schema(Default::default())
         .expect("Expected API schema generation to succeed");
-    assert_snapshot!(print_sdl(api_schema.schema()));
+    assert_snapshot!(api_schema.schema());
 
     // Validate extracted subgraphs contain proper federation directives
     let extracted_subgraphs = extract_subgraphs_from_supergraph_result(&supergraph)
@@ -193,16 +191,15 @@ fn include_types_from_different_subgraphs() {
     let subgraph_a_extracted = extracted_subgraphs
         .get("subgraphA")
         .expect("Expected subgraphA to be present in extracted subgraphs");
-    assert_snapshot!(print_sdl(subgraph_a_extracted.schema.schema()));
+    assert_snapshot!(subgraph_a_extracted.schema.schema());
 
     let subgraph_b_extracted = extracted_subgraphs
         .get("subgraphB")
         .expect("Expected subgraphB to be present in extracted subgraphs");
-    assert_snapshot!(print_sdl(subgraph_b_extracted.schema.schema()));
+    assert_snapshot!(subgraph_b_extracted.schema.schema());
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn doesnt_leave_federation_directives_in_the_final_schema() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",
@@ -233,7 +230,7 @@ fn doesnt_leave_federation_directives_in_the_final_schema() {
     let api_schema = supergraph
         .to_api_schema(Default::default())
         .expect("Expected API schema generation to succeed");
-    assert_snapshot!(print_sdl(api_schema.schema()));
+    assert_snapshot!(api_schema.schema());
 
     // Validate that federation directives (@provides, @key, @external, @shareable)
     // are properly rebuilt in the extracted subgraphs
@@ -243,16 +240,15 @@ fn doesnt_leave_federation_directives_in_the_final_schema() {
     let subgraph_a_extracted = extracted_subgraphs
         .get("subgraphA")
         .expect("Expected subgraphA to be present in extracted subgraphs");
-    assert_snapshot!(print_sdl(subgraph_a_extracted.schema.schema()));
+    assert_snapshot!(subgraph_a_extracted.schema.schema());
 
     let subgraph_b_extracted = extracted_subgraphs
         .get("subgraphB")
         .expect("Expected subgraphB to be present in extracted subgraphs");
-    assert_snapshot!(print_sdl(subgraph_b_extracted.schema.schema()));
+    assert_snapshot!(subgraph_b_extracted.schema.schema());
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn merges_default_arguments_when_they_are_arrays() {
     let subgraph_a = ServiceDefinition {
         name: "subgraph-a",

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema-2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema-2.snap
@@ -1,0 +1,85 @@
+---
+source: apollo-federation/tests/composition/compose_basic.rs
+expression: subgraph_a_extracted.schema.schema()
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.12")
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @federation__cacheTag(format: String!) repeatable on INTERFACE | OBJECT | FIELD_DEFINITION
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar federation__ContextFieldValue
+
+scalar federation__FieldSet
+
+scalar federation__Scope
+
+type Query {
+  products: [Product!] @federation__provides(fields: "name")
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+}
+
+type Product @federation__key(fields: "sku", resolvable: true) {
+  sku: String! @federation__shareable
+  name: String! @federation__external
+}
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}
+
+union _Entity = Product

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema-3.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema-3.snap
@@ -1,0 +1,84 @@
+---
+source: apollo-federation/tests/composition/compose_basic.rs
+expression: subgraph_b_extracted.schema.schema()
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.12")
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @federation__cacheTag(format: String!) repeatable on INTERFACE | OBJECT | FIELD_DEFINITION
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar federation__ContextFieldValue
+
+scalar federation__FieldSet
+
+scalar federation__Scope
+
+type Product @federation__key(fields: "sku", resolvable: true) {
+  sku: String! @federation__shareable
+  name: String!
+}
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}
+
+union _Entity = Product
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-federation/tests/composition/compose_basic.rs
+expression: api_schema.schema()
+---
+type Query {
+  products: [Product!]
+}
+
+type Product {
+  sku: String!
+  name: String!
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__include_types_from_different_subgraphs-2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__include_types_from_different_subgraphs-2.snap
@@ -1,0 +1,82 @@
+---
+source: apollo-federation/tests/composition/compose_basic.rs
+expression: subgraph_a_extracted.schema.schema()
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.12")
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @federation__cacheTag(format: String!) repeatable on INTERFACE | OBJECT | FIELD_DEFINITION
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar federation__ContextFieldValue
+
+scalar federation__FieldSet
+
+scalar federation__Scope
+
+type Query {
+  products: [Product!]
+  _service: _Service!
+}
+
+type Product {
+  sku: String!
+  name: String!
+}
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__include_types_from_different_subgraphs-3.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__include_types_from_different_subgraphs-3.snap
@@ -1,0 +1,81 @@
+---
+source: apollo-federation/tests/composition/compose_basic.rs
+expression: subgraph_b_extracted.schema.schema()
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.12")
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @federation__cacheTag(format: String!) repeatable on INTERFACE | OBJECT | FIELD_DEFINITION
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar federation__ContextFieldValue
+
+scalar federation__FieldSet
+
+scalar federation__Scope
+
+type User {
+  name: String
+  email: String!
+}
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}
+
+type Query {
+  _service: _Service!
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__include_types_from_different_subgraphs.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__include_types_from_different_subgraphs.snap
@@ -1,0 +1,17 @@
+---
+source: apollo-federation/tests/composition/compose_basic.rs
+expression: api_schema.schema()
+---
+type Query {
+  products: [Product!]
+}
+
+type Product {
+  sku: String!
+  name: String!
+}
+
+type User {
+  name: String
+  email: String!
+}


### PR DESCRIPTION
This enables several of the basic composition integration tests and accepts their snapshots (confirmed they are correct compared to the JS expectations). There are two small changes:

1. The snapshots for the subgraph schemas extracted by the QP include all federation directive definitions in Rust, but in JS they only include the link statement. These are functionally equivalent, so I consider it to be correct. Note that the SDL and API schemas coming out of merge are exact matches with JS.
2. There was a small bug where we flipped a boolean condition in our `is_fully_external` and `is_partially_external` checks. That is now updated to match [the original implementation](https://github.com/apollographql/federation/blob/8c7a2cd655ad3060e9f5c3b106cfbdb59251701c/internals-js/src/federation.ts#L2765)

<!-- [FED-820] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
