### PR TITLE
feat(composition): Description merging for enum values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,6 @@ version = "2.7.0"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
- "countmap",
  "derive_more",
  "dhat",
  "diff",
@@ -344,7 +343,7 @@ dependencies = [
  "multimap 0.9.1",
  "notify",
  "nu-ansi-term",
- "num-traits 0.2.19",
+ "num-traits",
  "oci-client",
  "once_cell",
  "opentelemetry",
@@ -624,7 +623,7 @@ dependencies = [
  "indexmap 2.11.4",
  "mime",
  "multer",
- "num-traits 0.2.19",
+ "num-traits",
  "pin-project-lite",
  "regex",
  "serde",
@@ -1592,7 +1591,7 @@ checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.19",
+ "num-traits",
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.0",
@@ -1884,15 +1883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "countmap"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef2a403c4af585607826502480ab6e453f320c230ef67255eee21f0cc72c0a6"
-dependencies = [
- "num-traits 0.1.43",
-]
-
-[[package]]
 name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,7 +1925,7 @@ dependencies = [
  "criterion-plot",
  "futures",
  "itertools 0.13.0",
- "num-traits 0.2.19",
+ "num-traits",
  "oorandom",
  "plotters",
  "rayon",
@@ -2648,7 +2638,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -3225,7 +3215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
  "byteorder",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -3937,7 +3927,7 @@ dependencies = [
  "idna",
  "itoa",
  "num-cmp",
- "num-traits 0.2.19",
+ "num-traits",
  "once_cell",
  "percent-encoding",
  "referencing",
@@ -4439,7 +4429,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4449,7 +4439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4464,7 +4454,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4479,7 +4469,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4490,7 +4480,7 @@ checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4501,16 +4491,7 @@ checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits 0.2.19",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4859,7 +4840,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -4868,7 +4849,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
 ]
 
 [[package]]
@@ -5081,7 +5062,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
- "num-traits 0.2.19",
+ "num-traits",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -5723,7 +5704,7 @@ dependencies = [
  "bitflags 2.9.3",
  "instant",
  "no-std-compat",
- "num-traits 0.2.19",
+ "num-traits",
  "once_cell",
  "rhai_codegen",
  "serde",
@@ -5824,7 +5805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
 dependencies = [
  "byteorder",
- "num-traits 0.2.19",
+ "num-traits",
  "paste",
 ]
 
@@ -6418,7 +6399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.19",
+ "num-traits",
  "thiserror 2.0.16",
  "time",
 ]

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -23,7 +23,6 @@ apollo-compiler.workspace = true
 time = { version = "0.3.34", default-features = false, features = [
   "local-offset",
 ] }
-countmap = "0.2.0"
 derive_more = { version = "2.0.0", features = [
   "display",
   "from",

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -14,6 +14,7 @@ use crate::link::inaccessible_spec_definition::IsInaccessibleExt;
 use crate::merger::hints::HintCode;
 use crate::merger::merge::Merger;
 use crate::merger::merge::Sources;
+use crate::merger::merge::map_sources;
 use crate::schema::position::EnumTypeDefinitionPosition;
 use crate::schema::position::EnumValueDefinitionPosition;
 use crate::supergraph::CompositionHint;
@@ -138,9 +139,9 @@ impl Merger {
             directives: Default::default(),
         });
         value_pos.insert(&mut self.merged, dest)?;
-        // TODO: Implement these helper methods - for now skip the actual merging
-        // self.merge_description(&value_sources, &mut dest);
-        // self.record_applied_directives_to_merge(&value_sources, &mut dest);
+        let pos_sources = map_sources(sources, |source| source.as_ref().map(|_| value_pos.clone()));
+        self.merge_description(&pos_sources, value_pos)?;
+        self.record_applied_directives_to_merge(&pos_sources, value_pos)?;
         self.add_join_enum_value(&value_sources, value_pos)?;
 
         let is_inaccessible = match &self.inaccessible_directive_name_in_supergraph {
@@ -273,7 +274,6 @@ pub(crate) mod tests {
     use apollo_compiler::Schema;
     use apollo_compiler::name;
     use apollo_compiler::schema::ComponentName;
-    use apollo_compiler::schema::ComponentOrigin;
     use apollo_compiler::schema::InterfaceType;
     use apollo_compiler::schema::ObjectType;
     use apollo_compiler::schema::UnionType;
@@ -281,7 +281,6 @@ pub(crate) mod tests {
     use super::*;
     use crate::JOIN_VERSIONS;
     use crate::SpecDefinition;
-    use crate::error::ErrorCode;
     use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
     use crate::link::link_spec_definition::LINK_VERSIONS;
     use crate::link::spec::Version;
@@ -290,7 +289,6 @@ pub(crate) mod tests {
     use crate::merger::merge::CompositionOptions;
     use crate::schema::FederationSchema;
     use crate::schema::position::EnumTypeDefinitionPosition;
-    use crate::schema::position::PositionLookupError;
 
     fn insert_enum_type(schema: &mut FederationSchema, name: Name) -> Result<(), FederationError> {
         let status_pos = EnumTypeDefinitionPosition {
@@ -432,275 +430,5 @@ pub(crate) mod tests {
             latest_federation_version_used: FEDERATION_VERSIONS.latest().version().clone(),
             applied_directives_to_merge: Default::default(),
         })
-    }
-
-    // Helper function to create enum type with values
-    fn create_enum_type(name: &str, values: &[&str]) -> Node<EnumType> {
-        let mut enum_type = EnumType {
-            name: Name::new(name).expect("Valid enum type name"),
-            description: None,
-            directives: Default::default(),
-            values: Default::default(),
-        };
-
-        for value_name in values {
-            let value_name_obj = Name::new(value_name).expect("Valid enum value name");
-            let value_def = Component {
-                origin: ComponentOrigin::Definition,
-                node: Node::new(EnumValueDefinition {
-                    description: None,
-                    value: value_name_obj.clone(),
-                    directives: Default::default(),
-                }),
-            };
-            enum_type.values.insert(value_name_obj, value_def);
-        }
-
-        Node::new(enum_type)
-    }
-
-    fn get_enum_values(
-        merger: &Merger,
-        enum_name: &str,
-    ) -> Result<Vec<String>, PositionLookupError> {
-        let enum_pos = EnumTypeDefinitionPosition {
-            type_name: Name::new_unchecked(enum_name),
-        };
-        Ok(enum_pos
-            .get(merger.merged.schema())?
-            .values
-            .keys()
-            .map(|key| key.to_string())
-            .collect::<Vec<String>>())
-    }
-
-    #[test]
-    fn test_merge_enum_output_only_enum_includes_all_values() {
-        let mut merger = create_test_merger().expect("valid Merger object");
-
-        // Create enum types from different subgraphs
-        let enum1 = create_enum_type("Status", &["ACTIVE", "INACTIVE"]);
-        let enum2 = create_enum_type("Status", &["ACTIVE", "PENDING"]);
-
-        let sources: Sources<Node<EnumType>> =
-            [(0, Some(enum1)), (1, Some(enum2))].into_iter().collect();
-
-        let dest = EnumTypeDefinitionPosition {
-            type_name: Name::new("Status").expect("Valid enum name"),
-        };
-
-        // Set up usage as output-only (union strategy)
-        merger.enum_usages.insert(
-            "Status".to_string(),
-            EnumTypeUsage::Output {
-                output_example: EnumExample {
-                    coordinate: "field1".to_string(),
-                    element_ast: None,
-                },
-            },
-        );
-
-        // Merge should include all values from all subgraphs for output-only enum
-        let result = merger.merge_enum(sources, &dest);
-
-        assert!(result.is_ok());
-        let enum_vals =
-            get_enum_values(&merger, "Status").expect("enum should exist in the supergraph");
-        assert_eq!(enum_vals.len(), 3); // ACTIVE, INACTIVE, PENDING
-        assert!(enum_vals.contains(&"ACTIVE".to_string()));
-        assert!(enum_vals.contains(&"INACTIVE".to_string()));
-        assert!(enum_vals.contains(&"PENDING".to_string()));
-    }
-
-    #[test]
-    fn test_merge_enum_input_only_enum_includes_intersection() {
-        let mut merger = create_test_merger().expect("valid Merger object");
-
-        // Create enum types from different subgraphs
-        let enum1 = create_enum_type("Status", &["ACTIVE", "INACTIVE"]);
-        let enum2 = create_enum_type("Status", &["ACTIVE", "PENDING"]);
-
-        let sources: Sources<Node<EnumType>> =
-            [(0, Some(enum1)), (1, Some(enum2))].into_iter().collect();
-
-        let dest = EnumTypeDefinitionPosition {
-            type_name: Name::new("Status").expect("Valid enum name"),
-        };
-
-        // Set up usage as input-only (intersection strategy)
-        merger.enum_usages.insert(
-            "Status".to_string(),
-            EnumTypeUsage::Input {
-                input_example: EnumExample {
-                    coordinate: "field1".to_string(),
-                    element_ast: None,
-                },
-            },
-        );
-
-        // Merge should only include common values for input-only enum
-        let result = merger.merge_enum(sources, &dest);
-
-        assert!(result.is_ok());
-        // Only ACTIVE should remain (intersection)
-        // INACTIVE and PENDING should be removed with hints
-        let enum_vals =
-            get_enum_values(&merger, "Status").expect("enum should exist in the supergraph");
-        assert_eq!(enum_vals.len(), 1);
-        assert!(enum_vals.contains(&"ACTIVE".to_string()));
-    }
-
-    #[test]
-    fn test_merge_enum_both_input_output_requires_all_values_consistent() {
-        let mut merger = create_test_merger().expect("valid Merger object");
-
-        // Create enum types from different subgraphs with inconsistent values
-        let enum1 = create_enum_type("Status", &["ACTIVE", "INACTIVE"]);
-        let enum2 = create_enum_type("Status", &["ACTIVE", "PENDING"]);
-
-        let sources: Sources<Node<EnumType>> =
-            [(0, Some(enum1)), (1, Some(enum2))].into_iter().collect();
-
-        let dest = EnumTypeDefinitionPosition {
-            type_name: Name::new("Status").expect("Valid enum name"),
-        };
-
-        // Set up usage as both input and output (requires consistency)
-        let usage = EnumTypeUsage::Both {
-            input_example: EnumExample {
-                coordinate: "field1".to_string(),
-                element_ast: None,
-            },
-            output_example: EnumExample {
-                coordinate: "field2".to_string(),
-                element_ast: None,
-            },
-        };
-
-        merger.enum_usages.insert("Status".to_string(), usage);
-
-        // This should generate an error for inconsistent values
-        let result = merger.merge_enum(sources, &dest);
-
-        // The function should complete but the error reporter should have errors
-        assert!(result.is_ok());
-        assert!(
-            merger.error_reporter.has_errors(),
-            "Expected errors to be reported for inconsistent enum values"
-        );
-    }
-
-    #[test]
-    fn test_merge_enum_empty_result_generates_error() {
-        let mut merger = create_test_merger().expect("valid Merger object");
-
-        // Create enum types that will result in empty enum after merging
-        let enum1 = create_enum_type("Status", &["INACTIVE"]);
-        let enum2 = create_enum_type("Status", &["PENDING"]);
-
-        let sources: Sources<Node<EnumType>> =
-            [(0, Some(enum1)), (1, Some(enum2))].into_iter().collect();
-
-        let dest = EnumTypeDefinitionPosition {
-            type_name: Name::new("Status").expect("Valid enum name"),
-        };
-
-        // Set up usage as input-only (intersection strategy)
-        merger.enum_usages.insert(
-            "Status".to_string(),
-            EnumTypeUsage::Input {
-                input_example: EnumExample {
-                    coordinate: "field1".to_string(),
-                    element_ast: None,
-                },
-            },
-        );
-
-        let result = merger.merge_enum(sources, &dest);
-
-        assert!(result.is_ok());
-        // Should be empty after merging
-        let enum_vals =
-            get_enum_values(&merger, "Status").expect("enum should exist in the supergraph");
-        assert_eq!(enum_vals.len(), 0);
-
-        // Error reporter should have an EmptyMergedEnumType error
-        let (errors, _hints) = merger.error_reporter.into_errors_and_hints();
-        assert!(errors.len() == 1);
-        assert!(errors[0].code() == ErrorCode::EmptyMergedEnumType);
-    }
-
-    #[test]
-    fn test_merge_enum_unused_enum_treated_as_output() {
-        let mut merger = create_test_merger().expect("valid Merger object");
-
-        // Create enum types from different subgraphs
-        let enum1 = create_enum_type("UnusedStatus", &["ACTIVE", "INACTIVE"]);
-        let enum2 = create_enum_type("UnusedStatus", &["ACTIVE", "PENDING"]);
-
-        let sources: Sources<Node<EnumType>> =
-            [(0, Some(enum1)), (1, Some(enum2))].into_iter().collect();
-
-        let dest = EnumTypeDefinitionPosition {
-            type_name: Name::new("UnusedStatus").expect("Valid enum name"),
-        };
-
-        // Don't set usage - this should trigger the unused enum path
-        // which treats it as output-only
-
-        let result = merger.merge_enum(sources, &dest);
-
-        assert!(result.is_ok());
-        // Should include all values (treated as output-only)
-        let enum_vals =
-            get_enum_values(&merger, "UnusedStatus").expect("enum should exist in the supergraph");
-        assert_eq!(enum_vals.len(), 3); // ACTIVE, INACTIVE, PENDING
-        assert!(enum_vals.contains(&"ACTIVE".to_string()));
-        assert!(enum_vals.contains(&"INACTIVE".to_string()));
-        assert!(enum_vals.contains(&"PENDING".to_string()));
-        // Should generate an UnusedEnumType hint
-    }
-
-    #[test]
-    fn test_merge_enum_identical_values_across_subgraphs() {
-        let mut merger = create_test_merger().expect("valid Merger object");
-
-        // Create identical enum types from different subgraphs
-        let enum1 = create_enum_type("Status", &["ACTIVE", "INACTIVE", "PENDING"]);
-        let enum2 = create_enum_type("Status", &["ACTIVE", "INACTIVE", "PENDING"]);
-
-        let sources: Sources<Node<EnumType>> =
-            [(0, Some(enum1)), (1, Some(enum2))].into_iter().collect();
-
-        let dest = EnumTypeDefinitionPosition {
-            type_name: Name::new("Status").expect("Valid enum name"),
-        };
-
-        // Set up usage as both input and output
-        merger.enum_usages.insert(
-            "Status".to_string(),
-            EnumTypeUsage::Both {
-                input_example: EnumExample {
-                    coordinate: "field1".to_string(),
-                    element_ast: None,
-                },
-                output_example: EnumExample {
-                    coordinate: "field2".to_string(),
-                    element_ast: None,
-                },
-            },
-        );
-
-        let result = merger.merge_enum(sources, &dest);
-
-        assert!(result.is_ok());
-        // Should include all values since they're consistent
-        let enum_vals =
-            get_enum_values(&merger, "Status").expect("enum should exist in the supergraph");
-        assert_eq!(enum_vals.len(), 3); // ACTIVE, INACTIVE, PENDING
-        assert!(enum_vals.contains(&"ACTIVE".to_string()));
-        assert!(enum_vals.contains(&"INACTIVE".to_string()));
-        assert!(enum_vals.contains(&"PENDING".to_string()));
-        // Should not generate any errors or hints
     }
 }

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -7058,12 +7058,15 @@ impl DirectiveDefinitionPosition {
     pub(crate) fn add_locations(
         &self,
         schema: &mut FederationSchema,
-        locations: &Vec<DirectiveLocation>,
+        locations: Vec<DirectiveLocation>,
     ) -> Result<(), FederationError> {
-        self.make_mut(&mut schema.schema)?
-            .make_mut()
-            .locations
-            .extend(locations);
+        let existing = self.make_mut(&mut schema.schema)?.make_mut();
+
+        for location in locations {
+            if !existing.locations.contains(&location) {
+                existing.locations.push(location);
+            }
+        }
         Ok(())
     }
 }
@@ -7585,6 +7588,12 @@ impl DirectiveTargetPosition {
 impl From<DirectiveArgumentDefinitionPosition> for DirectiveTargetPosition {
     fn from(pos: DirectiveArgumentDefinitionPosition) -> Self {
         DirectiveTargetPosition::DirectiveArgument(pos)
+    }
+}
+
+impl From<EnumValueDefinitionPosition> for DirectiveTargetPosition {
+    fn from(pos: EnumValueDefinitionPosition) -> Self {
+        DirectiveTargetPosition::EnumValue(pos)
     }
 }
 

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -4,7 +4,6 @@ use test_log::test;
 use super::ServiceDefinition;
 use super::compose_as_fed2_subgraphs;
 use super::extract_subgraphs_from_supergraph_result;
-use super::print_sdl; // TODO: Remove after rebasing onto merge commit of pull/8380
 
 #[test]
 fn generates_a_valid_supergraph() {

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -4,6 +4,7 @@ use test_log::test;
 use super::ServiceDefinition;
 use super::compose_as_fed2_subgraphs;
 use super::extract_subgraphs_from_supergraph_result;
+use super::print_sdl; // TODO: Remove after rebasing onto merge commit of pull/8380
 
 #[test]
 fn generates_a_valid_supergraph() {

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -4,7 +4,6 @@ use test_log::test;
 use super::ServiceDefinition;
 use super::compose_as_fed2_subgraphs;
 use super::extract_subgraphs_from_supergraph_result;
-use super::print_sdl;
 
 #[test]
 fn generates_a_valid_supergraph() {
@@ -54,7 +53,6 @@ fn generates_a_valid_supergraph() {
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn preserves_descriptions() {
     let subgraph1 = ServiceDefinition {
         name: "Subgraph1",
@@ -102,7 +100,7 @@ fn preserves_descriptions() {
     let api_schema = supergraph
         .to_api_schema(Default::default())
         .expect("Expected API schema generation to succeed");
-    assert_snapshot!(print_sdl(api_schema.schema()));
+    assert_snapshot!(api_schema.schema());
 }
 
 #[test]

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__preserves_descriptions.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__preserves_descriptions.snap
@@ -1,0 +1,31 @@
+---
+source: apollo-federation/tests/composition/compose_basic.rs
+expression: api_schema.schema()
+---
+"""A cool schema"""
+schema {
+  query: Query
+}
+
+"""The foo directive description"""
+directive @foo(url: String) on FIELD
+
+"""
+Available queries
+Not much yet
+"""
+type Query {
+  """Returns tea"""
+  t(
+    """An argument that is very important"""
+    x: String!,
+  ): String
+}
+
+"""An enum"""
+enum E {
+  """The A value"""
+  A
+  """The B value"""
+  B
+}


### PR DESCRIPTION
This change reintroduces the calls to `merge_description` and `record_applied_directives_to_merge` inside the `merge_enum` logic. The enum merging logic operates on AST nodes, which diverges from our position-based APIs in other locations. While not ideal, I have re-created positions from the AST nodes for use with these two new helper calls.

Including the call to `merge_descriptions` meant that we were now trying to index into `Merger::subgraphs`, which unfortunately wasn't populated inside the test merger created for the enum tests, resulting in index out of bounds errors for all of those. Since these were difficult to set up and primarily operating in-memory (instead of on schemas), I have removed these tests in favor of our integration tests. The description merging logic is verified by the newly enabled `compose_basic::preserves_descriptions` test.

Additionally, I made one small refactor to remove the `countmap` dependency in favor of using `.counts()` from the more commonly used `itertools` crate.

<!-- [FED-800] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary

[FED-800]: https://apollographql.atlassian.net/browse/FED-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ