### PR TITLE
fix(composition): Record cloned directive applications when there is no static transform

### DIFF
--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -1064,6 +1064,10 @@ pub(crate) static FEDERATION_VERSIONS: LazyLock<SpecDefinitions<FederationSpecDe
     LazyLock::new(|| {
         let mut definitions = SpecDefinitions::new(Identity::federation_identity());
         definitions.add(FederationSpecDefinition::new(Version {
+            major: 1,
+            minor: 0,
+        }));
+        definitions.add(FederationSpecDefinition::new(Version {
             major: 2,
             minor: 0,
         }));

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -26,6 +26,7 @@ use crate::error::SingleFederationError;
 use crate::link::Import;
 use crate::link::Link;
 use crate::link::Purpose;
+use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
 use crate::link::spec::Version;
@@ -335,6 +336,7 @@ pub(crate) static SPEC_REGISTRY: LazyLock<SpecRegistry> = LazyLock::new(|| {
     registry.extend(&CONNECT_VERSIONS);
     registry.extend(&CONTEXT_VERSIONS);
     registry.extend(&COST_VERSIONS);
+    registry.extend(&FEDERATION_VERSIONS);
     registry.extend(&INACCESSIBLE_VERSIONS);
     registry.extend(&POLICY_VERSIONS);
     registry.extend(&REQUIRES_SCOPES_VERSIONS);

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1206,6 +1206,12 @@ impl Merger {
                     .collect();
                 applications.push(transformed_application);
             }
+        } else {
+            applications.extend(
+                pos.get_applied_directives(subgraph.schema(), &merge_info.definition.name)
+                    .into_iter()
+                    .map(|n| (**n).clone()),
+            );
         }
         applications
     }


### PR DESCRIPTION
This enables the first of the `compose_auth` integration tests and applies the following fixes:

- If there is no static argument transform registered for a directive, record the existing unchanged applications for merging (they were being dropped)
- When validating interface keys, gracefully exit if there is no `@key` directive in the schema
- Added the federation spec to the spec registry because we need to look up the composition/merge strategy for imported directives
- Added Fed v1.0 to the static federation versions to fix schema upgrader errors after adding federation to the spec registry

<!-- [FED-825] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary

[FED-825]: https://apollographql.atlassian.net/browse/FED-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ