### PR TITLE
Raise errors when nullable arguments or keys are used in cacheTag directive

### DIFF
--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -465,7 +465,10 @@ mod test_supergraph {
                 .into_iter()
                 .map(|err| err.to_string())
                 .collect::<Vec<String>>(),
-            vec!["Each entity field referenced in a @cacheTag format (applied on entity type) must be a member of every @key field set. In other words, when there are multiple @key fields on the type, the referenced field(s) must be limited to their intersection. Bad cacheTag format \"product-{$key.upc}\" on type \"Product\"".to_string(), "@cacheTag can only use non nullable field but \"first\" in format is nullable".to_string()]
+            vec![
+                "Each entity field referenced in a @cacheTag format (applied on entity type) must be a member of every @key field set. In other words, when there are multiple @key fields on the type, the referenced field(s) must be limited to their intersection. Bad cacheTag format \"product-{$key.upc}\" on type \"Product\"",
+                "@cacheTag format references a nullable argument \"first\""
+            ]
         );
 
         // valid usage test


### PR DESCRIPTION
Forbid usage of nullable arguments for cacheTag directive on root fields and nullable entity keys for cacheTag on entities.

Example of invalid schema:

```graphql
type Query {
    topProducts(first: Int = 5): [Product]
        @cacheTag(format: "topProducts")
        @cacheTag(format: "topProducts-{$args.first}") # Invalid because first is nullable
}
```

<!-- [ROUTER-1477] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1477]: https://apollographql.atlassian.net/browse/ROUTER-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ