### PR TITLE
Response reformatting and coercion tests

### DIFF
--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure.snap
@@ -164,7 +164,7 @@ snapshot_kind: text
         ]
       },
       {
-        "message": "Cannot return null for non-nullable field Query.t",
+        "message": "Cannot return null for non-nullable field T!.t",
         "path": [
           "t"
         ]

--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
@@ -161,7 +161,7 @@ expression: response
         ]
       },
       {
-        "message": "Cannot return null for non-nullable field Query.t",
+        "message": "Cannot return null for non-nullable field T!.t",
         "path": [
           "t"
         ]


### PR DESCRIPTION
Before any changes to response reformatting and validation can take place, the existing logic needs to be tested to track how closely it adheres to the spec.

Much of the behavior (mostly around the lack of errors in result coercion) is expected to change. These expectations are noted in code.

In testing this, there is seemingly strange behavior around abstract types that was discovered. This behavior is expected and noted in code, but router, in general, should work to avoid those code paths as it can lead to unexpected results on the client's side.

<!-- [ROUTER-887] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-887]: https://apollographql.atlassian.net/browse/ROUTER-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ