### PR TITLE
FIX PR-8415 build due to doc issue: Add description in example in instruments.mdx

### DIFF
--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
@@ -434,14 +434,14 @@ telemetry:
           value: duration
           type: histogram
           unit: s
-          description: "Request Duration"
+          description: "Request Duration (s)"
 
         # Only if required by your observability platform
         otheracme.request.duration:
           value: duration
           type: histogram
           unit: ms # Values automatically converted to milliseconds
-          description: "Request Duration in ms"
+          description: "Request Duration (ms)"
 ```
 
 #### `description`


### PR DESCRIPTION
Address build error with instruments.mdx:

```
--- STDERR:              apollo-router configuration::tests::validate_project_config_files ---

thread 'configuration::tests::validate_project_config_files' panicked at apollo-router\src\configuration\tests.rs:469:21:
../docs\source\routing\observability\router-telemetry-otel\enabling-telemetry\instruments.mdx configuration error: 
configuration had errors: 
1. at line 7

    instrumentation:
      instruments:
        router:
          # Recommended: use seconds (values recorded as seconds)
┌         acme.request.duration:
|           value: duration
|           type: histogram
|           unit: s
└-----> "description" is a required property

2. at line 13

            type: histogram
            unit: s
  
          # Only if required by your observability platform
┌         otheracme.request.duration:
|           value: duration
|           type: histogram
|           unit: ms # Values automatically converted to milliseconds
└-----> "description" is a required property
```