### PR TITLE
(@cacheTag) Add field type name in nullable reference error message

### DIFF
--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -465,7 +465,10 @@ mod test_supergraph {
                 .into_iter()
                 .map(|err| err.to_string())
                 .collect::<Vec<String>>(),
-            vec!["Each entity field referenced in a @cacheTag format (applied on entity type) must be a member of every @key field set. In other words, when there are multiple @key fields on the type, the referenced field(s) must be limited to their intersection. Bad cacheTag format \"product-{$key.upc}\" on type \"Product\"".to_string(), "@cacheTag can only use non nullable field but \"first\" in format is nullable".to_string()]
+            vec![
+                "Each entity field referenced in a @cacheTag format (applied on entity type) must be a member of every @key field set. In other words, when there are multiple @key fields on the type, the referenced field(s) must be limited to their intersection. Bad cacheTag format \"product-{$key.upc}\" on type \"Product\"",
+                "@cacheTag format references a nullable argument \"first\""
+            ]
         );
 
         // valid usage test


### PR DESCRIPTION
- to mitigate confusion when you have multiple fields with the same name like "{$arg1.name}-{$arg2.name}" and one of the `name` is nullable.
- added a error case for nullable argument, separate from the field case.
- shortened the errror message.
- simplified code using `is_non_null()` method.

**Exceptions**

This is stacked PR on top of PR #8390.