### PR TITLE
chore: fix renovate config warning

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -45,7 +45,6 @@
       ],
       matchManagers: 'regex',
       groupName: 'rustc',
-      branchName: '{{{branchPrefix}}}rustc',
     },
     // Keep serde_yaml at 0.8.x - version 0.9.x has breaking changes and the
     // underlying package is deprecated. The package works as-is and we can


### PR DESCRIPTION
We're not supposed to use `branchName` directly anymore. We could change
to `branchTopic` but honestly I'm not convinced there's any point
customising this in the first place.

<img width="2400" height="776" alt="image" src="https://github.com/user-attachments/assets/7603110f-0839-40d5-9e43-5a34f93074aa" />

