### PR TITLE
ci: allow websocket test flakes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,7 @@
 retries = 2
 filter = '''
    ( binary_id(=apollo-router-benchmarks) & test(=tests::test) )
+or ( binary_id(=apollo-router::integration_tests) & test(#integration::subscriptions::ws_passthrough::*) )
 or ( binary_id(=apollo-router::apollo_otel_traces) & test(=connector_error) )
 or ( binary_id(=apollo-router::apollo_otel_traces) & test(=non_defer) )
 or ( binary_id(=apollo-router::apollo_otel_traces) & test(=test_batch_send_header) )
@@ -115,9 +116,6 @@ or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_is_preserved_for_subgraph_error) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback_pure_error_payload) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_dedup_close_early) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_dedup) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::supergraph::test_supergraph_errors_on_http1_header_that_does_not_fit_inside_buffer) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::telemetry::apollo_otel_metrics::test_connector_request_emits_histogram) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::telemetry::apollo_otel_metrics::test_execution_layer_error_emits_metric) )


### PR DESCRIPTION
These are all flakey right now due to timing races when the websocket
closes. The failures are benign, it's just that the assertion sometimes
happens before the websocket has closed.

I'm not sure how to fix this right now, adding a bunch of artificial
delays doesn't seem ideal, so it seems better to just retry them for the
time being.

(One possible direction could be to refactor the tests so they use a
channel to signal close, and then tests can wait for that signal with a
timeout.)

I manually tested the syntax locally:
```
  TRY 1 FAIL [   5.173s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS

--- TRY 1 STDOUT:        apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS ---

running 1 test
test integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS ... FAILED

failures:

failures:
    integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 333 filtered out; finished in 5.15s


--- TRY 1 STDERR:        apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS ---

thread 'integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS' panicked at apollo-router/tests/integration/subscriptions/ws_passthrough.r
s:429:5:
assertion failed: is_closed.load(std::sync::atomic::Ordering::Relaxed)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

   RETRY 2/3 [         ] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS
        PASS [   5.526s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough::config_2_SUBSCRIPTION_CONFIG_SUBSCRIPTIONS_TRANSPORT_WS
        PASS [   5.537s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_pure_error_payload::config_2_SUBSCRIPTION_CONFIG_SUBSCRIPTIONS_TRANSPORT_WS
        PASS [   5.604s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS
        PASS [   5.663s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_pure_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS
        PASS [   5.732s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_2_SUBSCRIPTION_CONFIG_SUBSCRIPTIONS_TRANSPORT_WS
        PASS [   5.846s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_pure_error_payload_with_coprocessor
        PASS [   5.875s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_with_coprocessor
        PASS [   6.279s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_dedup_close_early
        PASS [   6.819s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_on_config_reload
  TRY 2 PASS [   1.884s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_error_payload::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS
        PASS [   9.214s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_on_schema_reload
        PASS [   9.236s] apollo-router::integration_tests integration::subscriptions::ws_passthrough::test_subscription_ws_passthrough_dedup
```