### PR TITLE
fix(composition): Do not skip built-in directives when merging applications into the supergraph

### DIFF
--- a/apollo-federation/src/merger/merge_links.rs
+++ b/apollo-federation/src/merger/merge_links.rs
@@ -265,24 +265,12 @@ impl Merger {
                 } else {
                     None
                 };
-                let Some(definition) = self
-                    .merged
-                    .schema()
-                    .directive_definitions
-                    .get(&supergraph_core_directive.name_in_supergraph)
-                else {
-                    bail!(
-                        "Could not find directive definition for @{} in supergraph schema",
-                        supergraph_core_directive.name_in_supergraph
-                    );
-                };
                 self.merged_federation_directive_names
                     .insert(supergraph_core_directive.name_in_supergraph.to_string());
                 self.merged_federation_directive_in_supergraph_by_directive_name
                     .insert(
                         supergraph_core_directive.name_in_supergraph.clone(),
                         MergedDirectiveInfo {
-                            definition: (**definition).clone(),
                             arguments_merger,
                             static_argument_transform: supergraph_core_directive
                                 .composition_spec

--- a/apollo-federation/tests/composition/compose_directive_sharing.rs
+++ b/apollo-federation/tests/composition/compose_directive_sharing.rs
@@ -1,18 +1,18 @@
+use apollo_federation::composition::compose;
+use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
+use test_log::test;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
 use super::compose_as_fed2_subgraphs;
 use super::print_sdl;
-use apollo_federation::composition::compose;
-use apollo_federation::subgraph::typestate::Subgraph;
 
 // =============================================================================
 // DIRECTIVE MERGING - Tests for GraphQL built-in directive merging
 // =============================================================================
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn directive_merging_propagates_graphql_built_in_directives() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",
@@ -45,7 +45,6 @@ fn directive_merging_propagates_graphql_built_in_directives() {
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn directive_merging_merges_graphql_built_in_directives() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",
@@ -78,7 +77,6 @@ fn directive_merging_merges_graphql_built_in_directives() {
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn directive_merging_propagates_built_in_directives_even_if_redefined() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",


### PR DESCRIPTION
Enables and fixes the tests in `compose_directive_sharing.rs`. Almost all of the tests were already correct and passing, one had ported the wrong schema fixtures. The code changes fix an issue where we were skipping built-in directives in `merge_applied_directive` because we early-exited when there was no definition in our core directive map.

The fix for this is that we only early-exit if the supergraph does not have a definition for that directive. We are allowed to not have it in our core directive map, but now we have to handle when it's not present. This primarily affected the code for applying static argument transforms to directives prior to merging them in, which I've cleaned up and co-located with the only call-site.

<!-- [FED-827] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary

[FED-827]: https://apollographql.atlassian.net/browse/FED-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ