### PR TITLE
chore: add a renovate dependency group for jemalloc

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -121,6 +121,12 @@
       matchManagers: ['cargo'],
       matchPackageNames: ['/^axum$/', '/^axum-extra$/'],
     },
+    {
+      groupName: 'jemalloc crates',
+      groupSlug: 'rust-jemalloc',
+      matchManagers: ['cargo'],
+      matchPackageNames: ['/^tikv-jemallocator$/', '/^tikv-jemalloc-/'],
+    },
     // Handle exact version pins (versions starting with =) in Cargo.toml files
     // separately. Put them in individual PRs and require dashboard approval
     // since they were explicitly pinned for a reason.


### PR DESCRIPTION
these are interdependent PRs:
https://github.com/apollographql/router/pull/8440
https://github.com/apollographql/router/pull/8439

so we should make renovate combine them.
