### PR TITLE
chore: remove postgres/sqlx build settings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,3 @@ fed = "run -p apollo-federation-cli --"
 [profile.profiling]
 inherits = "release"
 debug = true
-
-[env]
-# Unset this if you want to change sql queries for caching
-SQLX_OFFLINE = "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,15 +7,6 @@ services:
     read_only: true
     ports:
       - 6379:6379
-  postgres:
-    image: cimg/postgres:17.6
-    security_opt:
-      - no-new-privileges:true
-    environment:
-      POSTGRES_USER: ${USER}
-      POSTGRES_DB: ${USER}
-    ports:
-      - 5432:5432
   zipkin:
     image: openzipkin/zipkin:latest
     security_opt:


### PR DESCRIPTION
the response cache plugin no longer uses postgres or sqlx.

closes https://github.com/apollographql/router/pull/8434
and https://github.com/apollographql/router/pull/8369
