### PR TITLE
remove connect 0.3 feature gate

### DIFF
--- a/apollo-federation/src/connectors/json_selection/lit_expr.rs
+++ b/apollo-federation/src/connectors/json_selection/lit_expr.rs
@@ -91,7 +91,7 @@ impl LitExpr {
                 let (input, _) = spaces_or_comments(input)?;
                 Self::parse_primary(input)
             }
-            ConnectSpec::V0_3 => Self::parse_with_operators(input),
+            ConnectSpec::V0_3 | ConnectSpec::V0_4 => Self::parse_with_operators(input),
         }
     }
 

--- a/apollo-federation/src/connectors/json_selection/parser.rs
+++ b/apollo-federation/src/connectors/json_selection/parser.rs
@@ -300,7 +300,7 @@ impl JSONSelection {
     fn parse_span(input: Span) -> ParseResult<Self> {
         match get_connect_spec(&input) {
             ConnectSpec::V0_1 | ConnectSpec::V0_2 => Self::parse_span_v0_2(input),
-            ConnectSpec::V0_3 => Self::parse_span_v0_3(input),
+            ConnectSpec::V0_3 | ConnectSpec::V0_4 => Self::parse_span_v0_3(input),
         }
     }
 
@@ -550,7 +550,7 @@ impl NamedSelection {
     pub(crate) fn parse(input: Span) -> ParseResult<Self> {
         match get_connect_spec(&input) {
             ConnectSpec::V0_1 | ConnectSpec::V0_2 => Self::parse_v0_2(input),
-            ConnectSpec::V0_3 => Self::parse_v0_3(input),
+            ConnectSpec::V0_3 | ConnectSpec::V0_4 => Self::parse_v0_3(input),
         }
     }
 
@@ -1068,7 +1068,7 @@ impl PathList {
                     // a single struct in connect/v0.3, the ambiguity between
                     // single-key paths and field selections is no longer a
                     // problem, since they are now represented the same way.
-                    ConnectSpec::V0_3 => {
+                    ConnectSpec::V0_3 | ConnectSpec::V0_4 => {
                         let full_range = merge_ranges(key.range(), rest.range());
                         Ok((remainder, WithRange::new(Self::Key(key, rest), full_range)))
                     }
@@ -1109,7 +1109,7 @@ impl PathList {
             ConnectSpec::V0_1 | ConnectSpec::V0_2 => {
                 // The ? token was not introduced until connect/v0.3.
             }
-            ConnectSpec::V0_3 => {
+            ConnectSpec::V0_3 | ConnectSpec::V0_4 => {
                 if let Ok((suffix, question)) = ranged_span("?")(input.clone()) {
                     let (remainder, rest) = Self::parse_with_depth(suffix.clone(), depth + 1)?;
 

--- a/apollo-federation/src/connectors/spec/mod.rs
+++ b/apollo-federation/src/connectors/spec/mod.rs
@@ -108,6 +108,7 @@ pub enum ConnectSpec {
     V0_1,
     V0_2,
     V0_3,
+    V0_4,
 }
 
 impl PartialOrd for ConnectSpec {
@@ -138,6 +139,7 @@ impl ConnectSpec {
             Self::V0_1 => "0.1",
             Self::V0_2 => "0.2",
             Self::V0_3 => "0.3",
+            Self::V0_4 => "0.4",
         }
     }
 
@@ -190,6 +192,7 @@ impl TryFrom<&Version> for ConnectSpec {
             (0, 1) => Ok(Self::V0_1),
             (0, 2) => Ok(Self::V0_2),
             (0, 3) => Ok(Self::V0_3),
+            (0, 4) => Ok(Self::V0_4),
             _ => Err(format!("Unknown connect version: {version}")),
         }
     }
@@ -207,6 +210,7 @@ impl From<ConnectSpec> for Version {
             ConnectSpec::V0_1 => Version { major: 0, minor: 1 },
             ConnectSpec::V0_2 => Version { major: 0, minor: 2 },
             ConnectSpec::V0_3 => Version { major: 0, minor: 3 },
+            ConnectSpec::V0_4 => Version { major: 0, minor: 4 },
         }
     }
 }
@@ -290,6 +294,13 @@ pub(crate) static CONNECT_VERSIONS: LazyLock<SpecDefinitions<ConnectSpecDefiniti
             Version {
                 major: 2,
                 minor: 12,
+            },
+        ));
+        definitions.add(ConnectSpecDefinition::new(
+            Version { major: 0, minor: 4 },
+            Version {
+                major: 2,
+                minor: 13,
             },
         ));
         definitions

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@connect_spec_version_error.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@connect_spec_version_error.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/connect_spec_v
 [
     Message {
         code: UnknownConnectorsVersion,
-        message: "Unknown connect version: 0.99; should be one of 0.1, 0.2, 0.3.",
+        message: "Unknown connect version: 0.99; should be one of 0.1, 0.2, 0.3, 0.4.",
         locations: [
             2:3..5:4,
         ],

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/tests.rs
-assertion_line: 28
 expression: "&schema"
 ---
 {
@@ -2500,6 +2499,15 @@ expression: "&schema"
           ]
         },
         "preview_connect_v0_3": {
+          "default": null,
+          "deprecated": true,
+          "description": "Feature gate for Connect spec v0.3. Set to `true` to enable the using\nthe v0.3 spec during the preview phase.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "preview_connect_v0_4": {
           "default": null,
           "description": "Feature gate for Connect spec v0.3. Set to `true` to enable the using\nthe v0.3 spec during the preview phase.",
           "type": [

--- a/apollo-router/src/plugins/connectors/configuration.rs
+++ b/apollo-router/src/plugins/connectors/configuration.rs
@@ -61,7 +61,13 @@ pub(crate) struct ConnectorsConfig {
     /// Feature gate for Connect spec v0.3. Set to `true` to enable the using
     /// the v0.3 spec during the preview phase.
     #[serde(default)]
+    #[deprecated(note = "Connect spec v0.3 is now available.")]
     pub(crate) preview_connect_v0_3: Option<bool>,
+
+    /// Feature gate for Connect spec v0.3. Set to `true` to enable the using
+    /// the v0.3 spec during the preview phase.
+    #[serde(default)]
+    pub(crate) preview_connect_v0_4: Option<bool>,
 }
 
 // TODO: remove this after deprecation period

--- a/apollo-router/src/uplink/feature_gate_enforcement.rs
+++ b/apollo-router/src/uplink/feature_gate_enforcement.rs
@@ -103,27 +103,27 @@ impl FeatureGateEnforcementReport {
     }
 
     fn schema_restrictions() -> Vec<FeatureRestriction> {
-        // @link(url: "https://specs.apollo.dev/connect/v0.3") requires `connectors.preview_connect_v0_3: true`
+        // @link(url: "https://specs.apollo.dev/connect/v0.4") requires `connectors.preview_connect_v0_4: true`
         // This uses join__directives to find specs because the we're looking
         // at links within individual subgraphs.
         vec![FeatureRestriction::SpecInJoinDirective {
-            name: "Connect v0.3".to_string(),
+            name: "Connect v0.4".to_string(),
             spec_url: "https://specs.apollo.dev/connect".to_string(),
             version_req: semver::VersionReq {
                 comparators: vec![semver::Comparator {
                     op: semver::Op::Exact,
                     major: 0,
-                    minor: 3.into(),
+                    minor: 4.into(),
                     patch: 0.into(),
                     pre: semver::Prerelease::EMPTY,
                 }],
             },
-            feature_gate_configuration_path: "$.connectors.preview_connect_v0_3".to_string(),
+            feature_gate_configuration_path: "$.connectors.preview_connect_v0_4".to_string(),
             expected_value: Value::Bool(true),
             to_enable: "  connectors:
-    preview_connect_v0_3: true"
+    preview_connect_v0_4: true"
                 .to_string(),
-            warning: Some("Support for @link(url: \"https://specs.apollo.dev/connect/v0.3\") is in preview. See https://go.apollo.dev/connectors/preview-v0.3 for more information.".to_string())
+            warning: Some("Support for @link(url: \"https://specs.apollo.dev/connect/v0.4\") is in preview. See https://go.apollo.dev/connectors/preview for more information.".to_string())
         }]
     }
 }
@@ -204,7 +204,7 @@ mod test {
     fn feature_gate_connectors_v0_3() {
         let report = check(
             include_str!("testdata/oss.router.yaml"),
-            include_str!("testdata/feature_enforcement_connect_v0_3.graphql"),
+            include_str!("testdata/feature_enforcement_connect_v0_4.graphql"),
         );
 
         assert_eq!(
@@ -214,15 +214,15 @@ mod test {
         );
         let FeatureGateViolation::Spec { url, name, .. } = &report.gated_features_in_use[0];
 
-        assert_eq!("https://specs.apollo.dev/connect/v0.3", url);
-        assert_eq!("Connect v0.3", name);
+        assert_eq!("https://specs.apollo.dev/connect/v0.4", url);
+        assert_eq!("Connect v0.4", name);
     }
 
     #[test]
     fn feature_gate_connectors_v0_3_enabled() {
         let report = check(
-            include_str!("testdata/connectv0_3.router.yaml"),
-            include_str!("testdata/feature_enforcement_connect_v0_3.graphql"),
+            include_str!("testdata/connectv0_4.router.yaml"),
+            include_str!("testdata/feature_enforcement_connect_v0_4.graphql"),
         );
 
         assert_eq!(

--- a/apollo-router/src/uplink/testdata/connectv0_4.router.yaml
+++ b/apollo-router/src/uplink/testdata/connectv0_4.router.yaml
@@ -5,4 +5,4 @@ homepage:
 limits:
   parser_max_recursion: 1000
 connectors:
-  preview_connect_v0_3: true
+  preview_connect_v0_4: true

--- a/apollo-router/src/uplink/testdata/feature_enforcement_connect_v0_4.graphql
+++ b/apollo-router/src/uplink/testdata/feature_enforcement_connect_v0_4.graphql
@@ -1,8 +1,8 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION)
-  @join__directive(graphs: [ONE], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@source", "@connect"]})
+  @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION)
+  @join__directive(graphs: [ONE], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@source", "@connect"]})
 {
   query: Query
 }


### PR DESCRIPTION
similar to https://github.com/apollographql/router/pull/7540, this adds connect 0.4 to keep around the existing gate and tests, which is safe before there's no way to compose a supergraph with connect 0.4

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
