### PR TITLE
entity-cache: fixed `matches_selection_set` to match array values

### DIFF
--- a/apollo-router/src/plugins/cache/invalidation.rs
+++ b/apollo-router/src/plugins/cache/invalidation.rs
@@ -18,7 +18,7 @@ use tracing::Instrument;
 use super::entity::Storage as EntityStorage;
 use crate::cache::redis::RedisCacheStorage;
 use crate::plugins::cache::entity::ENTITY_CACHE_VERSION;
-use crate::plugins::cache::entity::hash_entity_key;
+use crate::plugins::cache::entity::hash_representation;
 
 #[derive(Clone)]
 pub(crate) struct Invalidation {
@@ -243,7 +243,7 @@ impl InvalidationRequest {
                 r#type,
                 key,
             } => {
-                let entity_key = hash_entity_key(key);
+                let entity_key = hash_representation(key);
                 format!(
                     "version:{ENTITY_CACHE_VERSION}:subgraph:{subgraph}:type:{type}:entity:{entity_key}:*"
                 )


### PR DESCRIPTION
Also, fixed `hash_representation` to hash array values better (warning: hash signature would change)
Also, reorganized code not to "take" and "merge", which may be expensive
  - added `hash_representation_filtered` to compute hash only for key fields

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This PR is stacked on top of PR (https://github.com/apollographql/router/pull/8367)