### PR TITLE
Update subgraph insights GA changeset to point to correct PR

### DIFF
--- a/.changesets/config_david_subgraph_metrics_ga.md
+++ b/.changesets/config_david_subgraph_metrics_ga.md
@@ -1,4 +1,4 @@
-### [Subgraph Insights] Subgraph metrics config flag now GA ([PR #8200](https://github.com/apollographql/router/pull/8200))
+### [Subgraph Insights] Subgraph metrics config flag now GA ([PR #8392](https://github.com/apollographql/router/pull/8392))
 
 The `subgraph_metrics` config flag which powers the Studio `Subgraph Insights` feature is being promoted from `preview` to [general availability](https://www.apollographql.com/docs/graphos/resources/feature-launch-stages#general-availability). 
 The flag name has been updated from `preview_subgraph_metrics` to 
@@ -8,4 +8,4 @@ telemetry:
     subgraph_metrics: true
 ```
 
-By [@david_castaneda](https://github.com/david_castaneda) in https://github.com/apollographql/router/pull/8200
+By [@david_castaneda](https://github.com/david_castaneda) in https://github.com/apollographql/router/pull/8392


### PR DESCRIPTION
<!-- start metadata -->

The subgraph insights GA changeset was pointing to the wrong PR. 

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
