### PR TITLE
refactor(entity-cache): merged duplicate representation hash code

### DIFF
--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -1456,6 +1456,7 @@ fn extract_cache_keys(
 // * representation: key fields & other required fields
 // * selection_set: key fields selection set (if any)
 // * if selection_set is provided, only fields present in the selection set are hashed.
+// Note: This function mirrors `get_entity_key_from_selection_set` in response_cache/plugin.rs.
 fn hash_representation_inner(
     representation: &serde_json_bytes::Map<ByteString, Value>,
     selection_set: Option<&apollo_compiler::executable::SelectionSet>,

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -1987,12 +1987,11 @@ fn collect_key_field_sets(
 }
 
 /// Whether the entity, represented as JSON, matches the parsed @key fields (`selection_set`)
-/// * This function mirrors `take_selection_set` and make sure the representation matches the
-///   the shape of `selection_set`.
-/// * This function and `take_selection_set` are separate because this is called for multiple
-///   possible `@key` fields to find the matching one, while `take_selection_set` is only called
-///   once the matching `@key` fields is found.
-// WARN: if you make changes to this fn, make the same changes to the one in response_cache/plugin.rs!
+/// * This function mirrors `get_entity_key_from_selection_set` and make sure the representation
+///   matches the the shape of `selection_set`.
+/// * This function and `get_entity_key_from_selection_set` are separate because this is called for
+///   multiple possible `@key` fields to find the matching one, while
+///   `get_entity_key_from_selection_set` is only called once the matching `@key` fields is found.
 pub(in crate::plugins) fn matches_selection_set(
     // the JSON representation of the entity data
     representation: &serde_json_bytes::Map<ByteString, Value>,
@@ -2073,6 +2072,7 @@ fn matches_array_of_objects(
 
 // Get the selection set from `representation` and returns the value corresponding to it.
 // - Returns None if the representation doesn't match the selection set.
+// Note: This function mirrors `hash_representation_inner` in cache/entity.rs.
 fn get_entity_key_from_selection_set(
     representation: &serde_json_bytes::Map<ByteString, Value>,
     selection_set: &apollo_compiler::executable::SelectionSet,


### PR DESCRIPTION
A refactoring suggestion on top of  PR https://github.com/apollographql/router/pull/8367.

* `hash_representation` and `hash_entity_key` functions are symmetric.
* This PR merged them into one for maintainability.
* Added some more comments.