### PR TITLE
fix(response_cache): do not add response cache as an oss plugin (backport #8476)

### DIFF
--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -344,6 +344,15 @@ impl LicenseEnforcementReport {
                     .build(),
             );
         }
+        if !allowed_features.contains(&AllowedFeature::ResponseCaching) {
+            configuration_restrictions.push(
+                ConfigurationRestriction::builder()
+                    .path("$.preview_response_cache.enabled")
+                    .value(true)
+                    .name("Subgraph response caching")
+                    .build(),
+            );
+        }
         if !allowed_features.contains(&AllowedFeature::PersistedQueries) {
             configuration_restrictions.push(
                 ConfigurationRestriction::builder()
@@ -528,6 +537,8 @@ pub enum AllowedFeature {
     DistributedQueryPlanning,
     /// Subgraph entity caching
     EntityCaching,
+    /// Subgraph response caching
+    ResponseCaching,
     /// Experimental features in the router
     Experimental,
     /// Extended reference reporting
@@ -556,6 +567,7 @@ impl From<&str> for AllowedFeature {
             "demand_control" => Self::DemandControl,
             "distributed_query_planning" => Self::DistributedQueryPlanning,
             "entity_caching" => Self::EntityCaching,
+            "response_caching" => Self::ResponseCaching,
             "experimental" => Self::Experimental,
             "extended_reference_reporting" => Self::ExtendedReferenceReporting,
             "persisted_queries" => Self::PersistedQueries,
@@ -577,6 +589,7 @@ impl AllowedFeature {
             "authorization" => Some(AllowedFeature::Authorization),
             "authentication" => Some(AllowedFeature::Authentication),
             "preview_entity_cache" => Some(AllowedFeature::EntityCaching),
+            "preview_response_cache" => Some(AllowedFeature::ResponseCaching),
             "demand_control" => Some(AllowedFeature::DemandControl),
             "coprocessor" => Some(AllowedFeature::Coprocessors),
             _other => None,

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_allowed_features_empty.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_allowed_features_empty.snap
@@ -9,6 +9,9 @@ Configuration yaml:
 * Authentication plugin
   .authentication.router
 
+* Subgraph response caching
+  .preview_response_cache.enabled
+
 * Federated subscriptions
   .subscription.enabled
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_unlicensed.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_unlicensed.snap
@@ -9,6 +9,9 @@ Configuration yaml:
 * Authentication plugin
   .authentication.router
 
+* Subgraph response caching
+  .preview_response_cache.enabled
+
 * Federated subscriptions
   .subscription.enabled
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_with_allowed_features.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config_with_allowed_features.snap
@@ -3,6 +3,9 @@ source: apollo-router/src/uplink/license_enforcement.rs
 expression: report.to_string()
 ---
 Configuration yaml:
+* Subgraph response caching
+  .preview_response_cache.enabled
+
 * Federated subscriptions
   .subscription.enabled
 


### PR DESCRIPTION


[ROUTER-1503]: https://apollographql.atlassian.net/browse/ROUTER-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #8476 done by [Mergify](https://mergify.com).