### PR TITLE
federation/composition: disable `EXTENSION_WITH_NO_BASE` checks

### DIFF
--- a/apollo-federation/src/merger/merge_type.rs
+++ b/apollo-federation/src/merger/merge_type.rs
@@ -30,7 +30,8 @@ impl Merger {
             .map(|(idx, subgraph)| (idx, subgraph.schema().get_type(type_def.clone()).ok()))
             .collect();
 
-        self.check_for_extension_with_no_base(&sources, &dest);
+        // FED-877: Disabled until apollo-compiler 2.0 is released.
+        // self.check_for_extension_with_no_base(&sources, &dest);
         self.merge_description(&sources, &dest)?;
         self.add_join_type(&sources, &dest)?;
         self.record_applied_directives_to_merge(&sources, &dest)?;
@@ -95,6 +96,7 @@ impl Merger {
     /// Records errors if this type is defined as an extension in all subgraphs where it is
     /// present. This is a good candidate to move to the pre-merge validations phase, but we
     /// currently check during merge because it requires visiting all types in the schema.
+    #[allow(dead_code)]
     fn check_for_extension_with_no_base(
         &mut self,
         sources: &Sources<TypeDefinitionPosition>,

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -122,7 +122,8 @@ impl SchemaUpgrader {
             extends_directive_name: subgraph.extends_directive_name()?.clone(),
             metadata: subgraph.metadata().clone(),
         };
-        self.pre_upgrade_validations(&upgrade_metadata, &subgraph)?;
+        // FED-877: Disabled until apollo-compiler 2.0 is released.
+        // self.pre_upgrade_validations(&upgrade_metadata, &subgraph)?;
 
         // TODO avoid cloning the schema here
         let mut schema = self.upgrade_spec_links(subgraph.schema().clone())?;
@@ -185,6 +186,7 @@ impl SchemaUpgrader {
     }
 
     // integrates checkForExtensionWithNoBase from the JS code
+    #[allow(dead_code)]
     fn pre_upgrade_validations(
         &self,
         upgrade_metadata: &UpgradeMetadata,


### PR DESCRIPTION
Due the https://github.com/apollographql/apollo-rs/issues/1010 in apollo-compiler, `has_non_extension_elements` methods are not always correct.  As a consequence, composition is generating incorrect `EXTENSION_WITH_NO_BASE` errors.

Fixing apollo-compiler will be a breaking change and may require a design change. We may need some more time to figure out the right fix. In the mean time, this PR disables the `EXTENSION_WITH_NO_BASE` checks.

<!-- start metadata -->

<!-- [FED-772] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is an incremental update of an unreleased feature.

[FED-772]: https://apollographql.atlassian.net/browse/FED-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ