### PR TITLE
ci: update macOS runners to m4pro.large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ executors:
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: "15.4.0"
-    resource_class: m2pro.large
+    resource_class: m4pro.large
     environment:
       MISE_ENV: ci,ci-mac
   macos_test: &macos_test_executor
@@ -77,7 +77,7 @@ executors:
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: "15.4.0"
-    resource_class: m2pro.large
+    resource_class: m4pro.large
     environment:
       MISE_ENV: ci,ci-mac
   windows_build: &windows_build_executor


### PR DESCRIPTION
CircleCI is deprecating m2pro resource classes on Feb 16, 2026 — brownouts start Dec 15.

Simple swap to m4pro.large keeps CI running.

Same change [just applied to rover](https://github.com/apollographql/rover/commit/b9dd2f700d8e3ef1dc0af39280fe4086b2d811a4).