### PR TITLE
ci: update macOS runners to m4pro.large (1.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ executors:
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: "15.4.0"
-    resource_class: macos.m1.large.gen1
+    resource_class: m4pro.large
     environment:
       MISE_ENV: ci,ci-mac
   macos_test: &macos_test_executor
@@ -63,7 +63,7 @@ executors:
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: "15.4.0"
-    resource_class: macos.m1.large.gen1
+    resource_class: m4pro.large
     environment:
       MISE_ENV: ci,ci-mac
   windows_build: &windows_build_executor


### PR DESCRIPTION
CircleCI is deprecating macos.m1.large.gen1 resource classes on Feb 16, 2026 — brownouts start Dec 15.

Simple swap to m4pro.large keeps CI running.

Companion to #8508 for the 1.x branch.