### PR TITLE
docs: update storage-specific response cache documentation

### DIFF
--- a/docs/source/routing/performance/caching/response-caching/customization.mdx
+++ b/docs/source/routing/performance/caching/response-caching/customization.mdx
@@ -180,7 +180,7 @@ preview_response_cache:
       # Configure Redis globally
       redis:
         urls: ["redis://..."]
-        fetch_timeout: 750ms # Optional, by default: 150ms
+        fetch_timeout: 300ms # Optional, by default: 150ms
         insert_timeout: 750ms # Optional, by default: 500ms
         invalidate_timeout: 750ms # Optional, by default: 1s
     # Configure response caching per subgraph, overrides options from the "all" section
@@ -262,8 +262,7 @@ preview_response_cache:
 
 ### Timeout configuration
 
-Redis connections and commands have default timeouts that you can override. The timeouts are tailored to specific caching operations: fetch, insert, invalidate, and maintenance.
-Setting a lower fetch timeout and a higher insert timeout provides a good balance of reliability and client responsiveness.
+Redis connections and commands have default timeouts that you can override. The timeouts are tailored to specific caching operations: fetch, insert, invalidate, and maintenance. Set a lower fetch timeout and a higher insert timeout for a good balance of reliability and client responsiveness:
 
 ```yaml title="router.yaml"
 preview_response_cache:
@@ -280,7 +279,7 @@ preview_response_cache:
 
 ### TTL for cache entries
 
-The `ttl` option defines the default global expiration for cache entries. A TTL must be set for all enabled subgraphs.
+The `ttl` option defines the default global expiration for cache entries. You must set a TTL for all enabled subgraphs.
 
 To prevent potential cache overflow, consider setting the TTL to 24 hours or twice the median publish interval (whichever is less), and monitor cache utilization in your environment, especially if you cache a lot of different data:
 


### PR DESCRIPTION
Corrects a few errors in the docs surrounding timeouts and TTLs.

I'll create a separate PR to remove the unused `ttl` redis config value for response caching, as the field should be set at the subgraph caching level instead.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
