### PR TITLE
docs: clarify OpenTelemetry 'Recommended' vs Apollo recommendations (backport #8507)

### DIFF
--- a/.changesets/docs_clarify_otel_recommended_attrs.md
+++ b/.changesets/docs_clarify_otel_recommended_attrs.md
@@ -1,0 +1,7 @@
+### Clarify OpenTelemetry "Recommended" attributes guidance in telemetry documentation
+
+Update router telemetry documentation to clarify that OpenTelemetry's "Recommended" attributes from their [development-status GraphQL semantic conventions](https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/) are experimental and still evolving. Apollo recommends using `required` attributes instead of `recommended` due to high cardinality, security, and performance risks with attributes like `graphql.document`.
+
+Learn more in [Router Telemetry](https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel).
+
+By [@abernix](https://github.com/abernix)

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
@@ -188,8 +188,14 @@ The `default_requirement_level` option sets the default attributes to attach to 
 
 Valid values:
 
-* `required` (default) - required attributes will be attached to standard instruments by default.
-* `recommended` - recommended attributes will be attached to standard instruments by default.
+* `required` (default, Apollo recommended) - required attributes will be attached to standard instruments by default.
+* `recommended` - experimental attributes from OpenTelemetry's development-status conventions will be attached to standard instruments by default.
+
+<Note>
+
+Apollo recommends using `required`, rather than `recommended`. Using `recommended` includes experimental attributes from OpenTelemetry's [development-status GraphQL semantic conventions](https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/), such as `graphql.document` and `subgraph.graphql.document`. These attributes can create high cardinality and may contain sensitive information. See the [standard attributes documentation](/router/configuration/telemetry/instrumentation/standard-attributes) for details.
+
+</Note>
 
 ```yaml title="router.yaml"
 telemetry:

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/spans.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/spans.mdx
@@ -92,8 +92,14 @@ The `default_attribute_requirement_level` option sets the default attributes to 
 
 Valid values:
 
-* `required` (default)
-* `recommended`
+* `required` (default, Apollo recommended)
+* `recommended` (experimental attributes from OpenTelemetry's development-status conventions)
+
+<Note>
+
+Apollo recommends using `required`, rather than `recommended`. Using `recommended` includes experimental attributes from OpenTelemetry's [development-status GraphQL semantic conventions](https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/), such as `graphql.document` and `subgraph.graphql.document`. These attributes can create high cardinality and may contain sensitive information. See the [standard attributes documentation](/router/configuration/telemetry/instrumentation/standard-attributes) for details.
+
+</Note>
 
 ```yaml title="router.yaml"
 telemetry:

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-attributes.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-attributes.mdx
@@ -101,6 +101,20 @@ Standard attributes of the `supergraph` service:
 | `graphql.operation.type`    | `query`\|`mutation`\|`subscription` | The operation kind from the subgraph query  |
 | `graphql.document`          |                                     | The GraphQL query to the subgraph (need `spec_compliant` [mode](/router/configuration/telemetry/instrumentation/spans/#mode) to disable it)          |
 
+<Caution>
+
+OpenTelemetry vs Apollo recommendations: OpenTelemetry has experimental attributes in their [GraphQL semantic conventions](https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/) that are currently in [Development status](https://opentelemetry.io/docs/specs/otel/versioning-and-stability/#semantic-conventions-stability) and still evolving. Apollo does not have the same recommendations as the OpenTelemetry group and recommends using our "default" options instead.
+
+Apollo does not recommend using the `graphql.document` attribute (marked as "Recommended" in OpenTelemetry's experimental conventions) due to significant risks:
+
+- High cardinality: Each unique query creates a separate metric series, which can overwhelm your monitoring systems
+- Security concerns: Operations may contain sensitive data in string literals that's difficult to sanitize
+- Performance impact: Large operations (potentially megabytes) significantly increase telemetry overhead and storage costs
+
+Use `graphql.operation.name` instead, which provides correlation capabilities with lower risk.
+
+</Caution>
+
 
 #### Subgraph
 
@@ -113,6 +127,12 @@ Standard attributes of the `subgraph` service:
 | `subgraph.graphql.operation.type`  | `query`\|`mutation`\|`subscription` | The operation kind from the subgraph query     |
 | `subgraph.graphql.document`        |                                     | The GraphQL query to the subgraph  (need `spec_compliant` [mode](/router/configuration/telemetry/instrumentation/spans/#mode) to disable it)             |
 | `http.request.resend_count`        | `true`\|`false`                     | Number of retries for an http request to a subgraph              |
+
+<Caution>
+
+OpenTelemetry vs Apollo recommendations: The `subgraph.graphql.document` attribute has the same risks as the `graphql.document` attribute. While OpenTelemetry marks this as "Recommended" in their [experimental development-status semantic conventions](https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/), Apollo does not recommend using this attribute due to high cardinality, potential sensitive data exposure, and performance impact.
+
+</Caution>
 
 #### Connector
 

--- a/docs/source/routing/observability/router-telemetry-otel/index.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/index.mdx
@@ -68,6 +68,18 @@ Selectors allow you to define custom data points based on the router's request l
 | **Attribute** | Standard data points that can be attached to spans, instruments, and events. |
 | **Selector** | Custom data points extracted from the router's request lifecycle, tailored to specific needs. |
 
+### Attribute security and cardinality considerations
+
+When configuring telemetry attributes, consider the security and performance implications of your choices. Different attribute sets can have varying impacts on:
+
+- High cardinality: Some attributes create many unique values that can overwhelm monitoring systems
+- Privacy and security: Certain attributes may expose sensitive information
+- Performance: Large attribute values can significantly increase telemetry overhead
+
+OpenTelemetry semantic conventions include both stable attributes and experimental attributes that are still evolving. The router's configuration options allow you to choose between different requirement levels, each with different trade-offs.
+
+For detailed guidance on specific attributes and Apollo's recommendations, see the [standard attributes documentation](/router/configuration/telemetry/instrumentation/standard-attributes).
+
 ## Router telemetry signals
 
 The router supports three signal types for collecting and exporting telemetry:


### PR DESCRIPTION
Update router telemetry documentation to clarify that OpenTelemetry's "Recommended" attributes from their development-status GraphQL semantic conventions are experimental and still evolving. Apollo recommends using `required` attributes instead of `recommended` due to high cardinality, security, and performance risks with attributes like `graphql.document`.


<!-- [OE-1036] -->

[OE-1036]: https://apollographql.atlassian.net/browse/OE-1036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ