### PR TITLE
gitleaks rule to exclude Cargo.lock

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,9 @@
+[[ rules ]]
+    id = "generic-api-key"
+    [ rules.allowlist ]
+        paths = [
+            '''Cargo.lock$'''
+        ]
 
 [[ rules ]]
     id = "generic-api-key"


### PR DESCRIPTION
Added a new rule for generic API key with an allowlist for Cargo.lock, which has things that look like API keys, but are definitely just hashes.

Not unlike https://github.com/apollographql/federation-rs/commit/34de10b96c117425505bdf7d3174b8c83768f15d