### PR TITLE
docs: add noZoom prop to deploy button images

### DIFF
--- a/docs/source/routing/self-hosted/managed-hosting/railway.mdx
+++ b/docs/source/routing/self-hosted/managed-hosting/railway.mdx
@@ -19,7 +19,7 @@ You will need:
 The fastest way to deploy the Apollo Router on Railway is using the official template:
 
 1. Deploy using the template:
-    <a href="https://railway.com/deploy/apollo-router?utm_medium=integration&utm_source=button&utm_campaign=apollo">
+    <a href="https://railway.com/deploy/apollo-router?utm_medium=integration&utm_source=button&utm_campaign=apollo" hideExternalIcon className="inline-block">
       <img src="https://railway.app/button.svg" alt="Deploy to Railway" width="200px" noZoom />
     </a>
 

--- a/docs/source/routing/self-hosted/managed-hosting/render.mdx
+++ b/docs/source/routing/self-hosted/managed-hosting/render.mdx
@@ -19,7 +19,7 @@ You will need:
 The fastest way to deploy the Apollo Router on Render is using the official template:
 
 1. Deploy using the template:
-    <a href="https://render.com/deploy?repo=github.com/apollographql/router-template">
+    <a href="https://render.com/deploy?repo=github.com/apollographql/router-template" hideExternalIcon className="inline-block">
       <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" width="200px" noZoom />
     </a>
 


### PR DESCRIPTION
The Render and Railway deploy buttons were zooming in unnecessarily. Adding the `noZoom` prop prevents that behaviour.

Also removes the redundant external icon link and fixes the hover click area using css classes.

Docs-only change!

<img width="1446" height="480" alt="Screenshot 2025-10-30 at 1 45 02 PM" src="https://github.com/user-attachments/assets/d5a942ec-24ca-41cd-8938-d76d6a1f882f" />

<img width="1504" height="556" alt="Screenshot 2025-10-30 at 1 44 54 PM" src="https://github.com/user-attachments/assets/835567d3-97f7-41fa-979b-306c960246d8" />