### PR TITLE
Errors while publishing coverage shouldn't block nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1039,7 +1039,6 @@ workflows:
       - build_release:
           requires:
             - test
-            - coverage
             - check_helm
             - check_compliance
           nightly: true


### PR DESCRIPTION
Right now, a failure to publish our codecov for a nightly build will fail the nightly build entirely.

 Note I am *not* saying "failure to meet codecov requirements", but rather "when codecov cannot be transmitted, right now it fails the nightly and doesn't publish it.".

Transient failures here are acceptable, and we get notificiations when those are failed.  They are also very rare, but it would be better to always and consistently publish the nightly.

## Before

<img width="2434" height="1626" alt="image" src="https://github.com/user-attachments/assets/7165dcee-09bf-4d87-9c4d-60df6451891e" />

## After

<img width="1602" height="1186" alt="image" src="https://github.com/user-attachments/assets/eeaacbc6-9ed7-4922-a6d2-1aa5802df017" />
