### PR TITLE
Fix plugin name in response caching migration steps

### DIFF
--- a/docs/source/routing/performance/caching/response-caching/faq.mdx
+++ b/docs/source/routing/performance/caching/response-caching/faq.mdx
@@ -94,7 +94,7 @@ If you're currently using the `preview_entity_caching` plugin, migrate to respon
 
 Follow these steps to migrate your configuration:
 
-1. **Update the plugin name:** Replace `preview_entity_caching` with `preview_response_caching` in your router configuration.
+1. **Update the plugin name:** Replace `preview_entity_cache` with `preview_response_cache` in your router configuration. 
 
 2. **Remove the `scan_count` setting:** Delete the `redis.scan_count` configuration option if you have it set. Response caching uses an approach that doesn't require Redis `SCAN` operations, eliminating a key performance bottleneck from the previous entity caching version.
 


### PR DESCRIPTION
Corrected the plugin name in migration steps from 'preview_entity_caching' to 'preview_entity_cache'. 'preview_response_caching' to 'preview_response_cache'

preview_response_caching or preview_entity_caching don't exist.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing