### PR TITLE
refactor(composition): Remove `pub` from the `state` field of supergraph::Supergraph struct

### DIFF
--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -90,7 +90,7 @@ use crate::utils::FallibleIterator;
 
 #[derive(Debug)]
 pub struct Supergraph<S> {
-    pub state: S,
+    state: S,
 }
 
 impl Supergraph<Merged> {


### PR DESCRIPTION
This PR is a minor refactoring. Making the `state` field private for the `supergraph::Supergraph` struct.

```diff
--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -90,7 +90,7 @@ use crate::utils::FallibleIterator;

 #[derive(Debug)]
 pub struct Supergraph<S> {
-    pub state: S,
+    state: S,
 }
```

I confirmed our downstream repos (like federation-rs, build-plugin-services, etc) are not affected by this change.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

A minor refactoring of an unreleased feature.