### PR TITLE
Fix option of error_type attribute list

### DIFF
--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -115,6 +115,7 @@ The `apollo.router.cache.redis.errors` metric also includes an `error_type` attr
 - `io` - Network I/O errors
 - `invalid_command` - Invalid Redis commands
 - `invalid_argument` - Invalid command arguments
+- `not_found` - Missing key in Redis
 - `url` - Invalid Redis URL format
 - `protocol` - Redis protocol errors
 - `tls` - TLS/SSL connection errors


### PR DESCRIPTION
Add `'not_found'` option of `apollo.router.cache.redis.errors` attribute `error_type`, on list as:

- **Missing key in Redis**

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing