### PR TITLE
Fix bug in `schema_upgrader()` preventing empty types from being removed

### DIFF
--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -149,15 +149,7 @@ impl SchemaUpgrader {
 
         // Note that this should come _after_ all the other changes that may remove/update federation directives, since those may create unused
         // externals. Which is why this is toward  the end.
-        tracing::trace!(
-            "Removing unused externals...\nCurrent Subgraph:\n{}",
-            schema.schema()
-        );
         self.remove_unused_externals(&upgrade_metadata, &mut schema)?;
-        tracing::trace!(
-            "Finished removing unused externals...\nCurrent Subgraph:\n{}",
-            schema.schema()
-        );
 
         self.add_shareable(&upgrade_metadata, &mut schema)?;
 


### PR DESCRIPTION
Fixes a bug in Rust composition wherein types which have had all their fields removed still remained in the expanded schemas, causing a composition failure.

Example:
```graphql

#!subgraph A
type T {
  a: Int!
}

type Query {
    start: T
}

#==========

#!subgraph B

type T @extends {
  a: Int! @external
}

```
Running compose on the above two graphs would result in a subgraph B with `type T` declared like so, as opposed to being omitted entirely:

```graphql
type T @extends
```


<!-- [FED-873] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[FED-873]: https://apollographql.atlassian.net/browse/FED-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ