### PR TITLE
fix(response_cache): do not raise an error when using enum in cacheTag directive format (backport #8496)

### DIFF
--- a/.changesets/fix_bnjjj_fix_enum_in_cache_tag.md
+++ b/.changesets/fix_bnjjj_fix_enum_in_cache_tag.md
@@ -1,0 +1,13 @@
+### Do not raise an error when using enum in cacheTag directive format ([PR #8496](https://github.com/apollographql/router/pull/8496))
+
+Fix composition validation when checking `@cacheTag` format used with an enum.
+
+Example:
+
+```graphql
+type Query {
+    testByCountry(id: ID!, country: Country!): Test @cacheTag(format: "test-{$args.id}-{$args.country}" ) # This was throwing an error because of Country being an enum and not a Scalar type
+}
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/8496

--- a/apollo-federation/src/schema/validators/cache_tag.rs
+++ b/apollo-federation/src/schema/validators/cache_tag.rs
@@ -170,6 +170,16 @@ fn validate_args_selection(
     fields: &IndexMap<Name, &Type>,
     selection: &SelectionTrie,
 ) -> Result<(), CacheTagValidationError> {
+    // Check the format selection is just a single selection. The `StringTemplate` allows multiple
+    // selections like `{$args { a b }}`, but cache tags don't support that.
+    let num_selections = selection.iter().count();
+    if num_selections != 1 {
+        return Err(CacheTagValidationError::CacheTagInvalidFormat {
+            message: format!(
+                "invalid path element at \"{selection}\", which is not a single selection"
+            ),
+        });
+    }
     for (key, sel) in selection.iter() {
         let name = Name::new(key).map_err(|_| CacheTagValidationError::CacheTagInvalidFormat {
             message: format!("invalid field selection name \"{key}\""),
@@ -180,7 +190,7 @@ fn validate_args_selection(
                 .ok_or_else(|| CacheTagValidationError::CacheTagInvalidFormat {
                     message: format!("unknown field \"{name}\""),
                 })?;
-        if !field.is_non_null() {
+        if !is_fully_non_null(field) {
             if let Some(parent_type_name) = parent_type_name {
                 return Err(CacheTagValidationError::CacheTagFormatNullableField {
                     field_name: name.clone(),
@@ -217,17 +227,37 @@ fn validate_args_selection(
                 .collect::<Result<IndexMap<_, _>, _>>()?;
             validate_args_selection(schema, Some(type_name), &next_fields, sel)?;
         } else {
+            // A leaf field must not be a list.
+            if field.is_list() {
+                return Err(CacheTagValidationError::CacheTagInvalidFormat {
+                    message: format!("invalid path ending at \"{name}\", which is a list type"),
+                });
+            }
             // A leaf field should have a scalar type.
-            if !matches!(&type_def, TypeDefinitionPosition::Scalar(_)) {
+            if !matches!(
+                &type_def,
+                TypeDefinitionPosition::Scalar(_) | TypeDefinitionPosition::Enum(_)
+            ) {
                 return Err(CacheTagValidationError::CacheTagInvalidFormat {
                     message: format!(
-                        "invalid path ending at \"{name}\", which is not a scalar type"
+                        "invalid path ending at \"{name}\", which is not a scalar type or an enum"
                     ),
                 });
             }
         }
     }
     Ok(())
+}
+
+/// Similar to `Type::is_non_null`, but checks if the type is non-null at all nested levels of
+/// lists.
+fn is_fully_non_null(ty: &Type) -> bool {
+    match ty {
+        Type::Named(_) => false,
+        Type::List(_) => false,
+        Type::NonNullNamed(_) => true,
+        Type::NonNullList(inner) => is_fully_non_null(inner),
+    }
 }
 
 fn validate_args_on_object_type(
@@ -342,6 +372,16 @@ fn build_selection_set(
     schema: &FederationSchema,
     selection: &SelectionTrie,
 ) -> Result<(), CacheTagValidationError> {
+    // Check the format selection is just a single selection. The `StringTemplate` allows multiple
+    // selections like `{$key { a b }}`, but cache tags don't support that.
+    let num_selections = selection.iter().count();
+    if num_selections != 1 {
+        return Err(CacheTagValidationError::CacheTagInvalidFormat {
+            message: format!(
+                "invalid path element at \"{selection}\", which is not a single selection"
+            ),
+        });
+    }
     for (key, sel) in selection.iter() {
         let name = Name::new(key).map_err(|_| CacheTagValidationError::CacheTagInvalidFormat {
             message: format!("invalid field selection name \"{key}\""),
@@ -357,7 +397,7 @@ fn build_selection_set(
                 message: format!("invalid field selection name \"{key}\""),
             })?;
 
-        if !new_field.ty().is_non_null() {
+        if !is_fully_non_null(new_field.ty()) {
             return Err(CacheTagValidationError::CacheTagFormatNullableField {
                 field_name: name.clone(),
                 parent_type: selection_set.ty.to_string(),
@@ -374,11 +414,20 @@ fn build_selection_set(
             )?;
             build_selection_set(&mut new_field.selection_set, schema, sel)?;
         } else {
+            // A leaf field must not be a list.
+            if new_field.ty().is_list() {
+                return Err(CacheTagValidationError::CacheTagInvalidFormat {
+                    message: format!("invalid path ending at \"{name}\", which is a list type"),
+                });
+            }
             // A leaf field should have a scalar type.
-            if !matches!(&new_field_type_def, TypeDefinitionPosition::Scalar(_)) {
+            if !matches!(
+                &new_field_type_def,
+                TypeDefinitionPosition::Scalar(_) | TypeDefinitionPosition::Enum(_)
+            ) {
                 return Err(CacheTagValidationError::CacheTagInvalidFormat {
                     message: format!(
-                        "invalid path ending at \"{name}\", which is not a scalar type"
+                        "invalid path ending at \"{name}\", which is not a scalar type or an enum"
                     ),
                 });
             }
@@ -548,6 +597,11 @@ mod tests {
         let subgraph = build_inner_expanded(schema, BuildOption::AsFed2).unwrap();
         let mut errors = Vec::new();
         validate_cache_tag_directives(subgraph.schema(), &mut errors).unwrap();
+        if !errors.is_empty() {
+            for error in &errors {
+                println!("Error: {}", error);
+            }
+        }
         assert!(errors.is_empty());
     }
 
@@ -562,17 +616,31 @@ mod tests {
     #[test]
     fn test_valid_format_string() {
         const SCHEMA: &str = r#"
-            type Product @key(fields: "upc")
+            type Product @key(fields: "upc age")
                          @cacheTag(format: "product-{$key.upc}")
             {
                 upc: String!
+                age: Int!
                 name: String
+            }
+
+            enum Country {
+                BE
+                FR
             }
 
             type Query {
                 topProducts(first: Int! = 5): [Product]
                     @cacheTag(format: "topProducts")
                     @cacheTag(format: "topProducts-{$args.first}")
+                topProductsByCountry(first: Int! = 5, country: Country!): [Product]
+                    @cacheTag(format: "topProducts")
+                    @cacheTag(format: "topProducts-{$args.first}-{$args.country}")
+            }
+
+            type Test @key(fields: "id country") @cacheTag(format: "test-{$key.id}-{$key.country}") {
+                id: ID!
+                country: Country!
             }
         "#;
         build_and_validate(SCHEMA);
@@ -592,6 +660,8 @@ mod tests {
                 topProducts(first: Int): [Product]
                     @cacheTag(format: "topProducts")
                     @cacheTag(format: "topProducts-{$args.first}")
+                productsByCountry(country: [String]!): [Product]
+                    @cacheTag(format: "productsByCountry-{$args.country}")
             }
         "#;
         assert_eq!(
@@ -599,6 +669,32 @@ mod tests {
             vec![
                 "@cacheTag format references a nullable field \"Product.name\"",
                 "@cacheTag format references a nullable argument \"first\"",
+                "@cacheTag format references a nullable argument \"country\"",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_invalid_format_string_list_args() {
+        const SCHEMA: &str = r#"
+            type Product @key(fields: "upc names")
+                         @cacheTag(format: "product-{$key.upc}-{$key.names}")
+            {
+                upc: String!
+                names: [String!]!
+            }
+
+            type Query {
+                topProducts(groups: [Int!]!): [Product]
+                    @cacheTag(format: "topProducts")
+                    @cacheTag(format: "topProducts-{$args.groups}")
+            }
+        "#;
+        assert_eq!(
+            build_for_errors(SCHEMA),
+            vec![
+                "cacheTag format is invalid: invalid path ending at \"names\", which is a list type",
+                "cacheTag format is invalid: invalid path ending at \"groups\", which is a list type",
             ]
         );
     }
@@ -655,17 +751,44 @@ mod tests {
             type Query {
                 topProducts(first: Int = 5): [Product]
                     @cacheTag(format: "topProducts")
-                    @cacheTag(format: "topProducts-{$args.second}")
+                    @cacheTag(format: "topProducts-{$args { second }}")
             }
         "#;
         assert_eq!(
             build_for_errors(SCHEMA),
             vec![
                 "cacheTag format is invalid: cannot create selection set with \"somethingElse\"",
-                "cacheTag format is invalid: invalid path ending at \"test\", which is not a scalar type",
+                "cacheTag format is invalid: invalid path ending at \"test\", which is not a scalar type or an enum",
                 "Each entity field referenced in a @cacheTag format (applied on entity type) must be a member of every @key field set. In other words, when there are multiple @key fields on the type, the referenced field(s) must be limited to their intersection. Bad cacheTag format \"product-{$key.test.b}\" on type \"Product\"",
                 "@cacheTag format references a nullable field \"Test.c\"",
                 "cacheTag format is invalid: unknown field \"second\""
+            ]
+        );
+    }
+
+    #[test]
+    fn test_invalid_format_string_multiple_selections() {
+        const SCHEMA: &str = r#"
+            type Product @key(fields: "upc name")
+                         @cacheTag(format: "product-{$key { upc name }}")
+                         @cacheTag(format: "product-{$key {}}")
+            {
+                upc: String!
+                name: String
+            }
+
+            type Query {
+                topProducts(first: Int): [Product]
+                    @cacheTag(format: "topProducts")
+                    @cacheTag(format: "topProducts-{$args { first country }}")
+            }
+        "#;
+        assert_eq!(
+            build_for_errors(SCHEMA),
+            vec![
+                "cacheTag format is invalid: invalid path element at \"upc name\", which is not a single selection",
+                "cacheTag format is invalid: invalid path element at \"\", which is not a single selection",
+                "cacheTag format is invalid: invalid path element at \"first country\", which is not a single selection",
             ]
         );
     }

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -2445,6 +2445,7 @@ async fn reattempt_connection(
     any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux"))
 ))]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -2455,8 +2456,16 @@ mod tests {
     use super::Ttl;
     use crate::configuration::subgraph::SubgraphConfiguration;
     use crate::plugins::response_cache::plugin::ResponseCache;
+<<<<<<< HEAD
+=======
+    use crate::plugins::response_cache::plugin::get_entity_key_from_selection_set;
+    use crate::plugins::response_cache::plugin::get_invalidation_root_keys_from_schema;
+    use crate::plugins::response_cache::plugin::matches_selection_set;
+>>>>>>> 176a6c2a (fix(response_cache): do not raise an error when using enum in cacheTag directive format (#8496))
     use crate::plugins::response_cache::storage::redis::Config;
     use crate::plugins::response_cache::storage::redis::Storage;
+    use crate::services::OperationKind;
+    use crate::services::subgraph;
 
     const SCHEMA: &str = include_str!("../../testdata/orga_supergraph_cache_key.graphql");
 
@@ -2587,4 +2596,491 @@ mod tests {
             Some(Duration::from_millis(5000))
         );
     }
+<<<<<<< HEAD
+=======
+
+    #[test]
+    fn test_matches_selection_set_handles_arrays() {
+        // Simulate the real-world Availability type scenario
+        let schema_text = r#"
+            type Query {
+                test: Test
+            }
+            type Test {
+                id: ID!
+                locale: String!
+                lists: [List!]!
+                list: [List!]!
+            }
+            type List {
+                id: ID!
+                date: Int!
+                quantity: Int!
+                location: String!
+            }
+        "#;
+        let schema = Schema::parse_and_validate(schema_text, "test.graphql").unwrap();
+
+        let mut parser = Parser::new();
+        let field_set = parser
+            .parse_field_set(
+                &schema,
+                apollo_compiler::ast::NamedType::new("Test").unwrap(),
+                "id locale lists { id date quantity location } list { id date quantity location }",
+                "test.graphql",
+            )
+            .unwrap();
+
+        // Test with complex nested array structure
+        let representation = json!({
+            "id": "TEST123",
+            "locale": "en_US",
+            "lists": [
+                {
+                    "id": "LIST1",
+                    "date": 20240101,
+                    "quantity": 50,
+                    "location": "WAREHOUSE_A"
+                }
+            ],
+            "list": [
+                {
+                    "id": "LIST2",
+                    "date": 20240101,
+                    "quantity": 100,
+                    "location": "WAREHOUSE_A"
+                },
+                {
+                    "id": "LIST3",
+                    "date": 20240102,
+                    "quantity": 75,
+                    "location": "WAREHOUSE_B"
+                }
+            ]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        assert!(
+            matches_selection_set(&representation, &field_set.selection_set),
+            "complex nested arrays should match"
+        );
+    }
+
+    #[test]
+    fn test_matches_selection_subset_handles_arrays() {
+        // Simulate the real-world Availability type scenario
+        let schema_text = r#"
+            type Query {
+                test: Test
+            }
+            type Test {
+                id: ID!
+                locale: String!
+                lists: [List!]!
+                list: [List!]!
+            }
+            type List {
+                id: ID!
+                date: Int!
+                quantity: Int!
+                location: String!
+            }
+        "#;
+        let schema = Schema::parse_and_validate(schema_text, "test.graphql").unwrap();
+
+        let mut parser = Parser::new();
+        let field_set = parser
+            .parse_field_set(
+                &schema,
+                apollo_compiler::ast::NamedType::new("Test").unwrap(),
+                "id locale lists { id date quantity location } list { id date quantity location }",
+                "test.graphql",
+            )
+            .unwrap();
+
+        // Test with complex nested array structure
+        let representation = json!({
+            "id": "TEST123",
+            "locale": "en_US",
+            "lists": [
+                {
+                    "id": "LIST1",
+                    "date": 20240101,
+                    "quantity": 50
+                }
+            ],
+            "list": [
+                {
+                    "id": "LIST2",
+                    "date": 20240101,
+                    "quantity": 100,
+                    "location": "WAREHOUSE_A"
+                },
+                {
+                    "id": "LIST3",
+                    "date": 20240102,
+                    "quantity": 75,
+                    "location": "WAREHOUSE_B"
+                }
+            ]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        assert!(!matches_selection_set(
+            &representation,
+            &field_set.selection_set
+        ),);
+
+        let field_set = parser
+            .parse_field_set(
+                &schema,
+                apollo_compiler::ast::NamedType::new("Test").unwrap(),
+                "id locale lists { id date quantity } list { id date quantity location }",
+                "test.graphql",
+            )
+            .unwrap();
+
+        assert!(
+            matches_selection_set(&representation, &field_set.selection_set),
+            "complex nested arrays should match"
+        );
+    }
+
+    #[test]
+    fn test_take_selection_set_handles_arrays() {
+        // Simulate the real-world Availability type scenario
+        let schema_text = r#"
+            type Query {
+                test: Test
+            }
+            type Test {
+                id: ID!
+                locale: String!
+                lists: [List!]!
+                list: [List!]!
+            }
+            type List {
+                id: ID!
+                date: Int!
+                quantity: Int!
+                location: String!
+            }
+        "#;
+        let schema = Schema::parse_and_validate(schema_text, "test.graphql").unwrap();
+
+        let mut parser = Parser::new();
+        let field_set = parser
+            .parse_field_set(
+                &schema,
+                apollo_compiler::ast::NamedType::new("Test").unwrap(),
+                "id locale lists { id date quantity location } list { id date quantity location }",
+                "test.graphql",
+            )
+            .unwrap();
+
+        // Test with complex nested array structure
+        let representation = json!({
+            "id": "TEST123",
+            "locale": "en_US",
+            "lists": [
+                {
+                    "id": "LIST1",
+                    "date": 20240101,
+                    "quantity": 50,
+                    "location": "WAREHOUSE_A"
+                }
+            ],
+            "list": [
+                {
+                    "id": "LIST2",
+                    "date": 20240101,
+                    "quantity": 100,
+                    "location": "WAREHOUSE_A"
+                },
+                {
+                    "id": "LIST3",
+                    "date": 20240102,
+                    "quantity": 75,
+                    "location": "WAREHOUSE_B"
+                }
+            ]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        assert!(matches_selection_set(
+            &representation,
+            &field_set.selection_set
+        ));
+        let entity_key =
+            get_entity_key_from_selection_set(&representation, &field_set.selection_set);
+        assert_eq!(
+            &entity_key,
+            json!({
+                "id": "TEST123",
+                "locale": "en_US",
+                "lists": [
+                    {
+                        "id": "LIST1",
+                        "date": 20240101,
+                        "quantity": 50,
+                        "location": "WAREHOUSE_A"
+                    }
+                ],
+                "list": [
+                    {
+                        "id": "LIST2",
+                        "date": 20240101,
+                        "quantity": 100,
+                        "location": "WAREHOUSE_A"
+                    },
+                    {
+                        "id": "LIST3",
+                        "date": 20240102,
+                        "quantity": 75,
+                        "location": "WAREHOUSE_B"
+                    }
+                ]
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_take_selection_subset_handles_arrays() {
+        // Simulate the real-world Availability type scenario
+        let schema_text = r#"
+            type Query {
+                test: Test
+            }
+            type Test {
+                id: ID!
+                locale: String!
+                lists: [List!]!
+                list: [List!]!
+            }
+            type List {
+                id: ID!
+                date: Int!
+                quantity: Int!
+                location: String!
+            }
+        "#;
+        let schema = Schema::parse_and_validate(schema_text, "test.graphql").unwrap();
+
+        let mut parser = Parser::new();
+        let field_set = parser
+            .parse_field_set(
+                &schema,
+                apollo_compiler::ast::NamedType::new("Test").unwrap(),
+                "id locale lists { id date quantity } list { id quantity location }",
+                "test.graphql",
+            )
+            .unwrap();
+
+        // Test with complex nested array structure
+        let representation = json!({
+            "id": "TEST123",
+            "locale": "en_US",
+            "lists": [
+                {
+                    "id": "LIST1",
+                    "date": 20240101,
+                    "quantity": 50,
+                    "location": "WAREHOUSE_A"
+                }
+            ],
+            "list": [
+                {
+                    "id": "LIST2",
+                    "date": 20240101,
+                    "quantity": 100,
+                    "location": "WAREHOUSE_A"
+                },
+                {
+                    "id": "LIST3",
+                    "date": 20240102,
+                    "quantity": 75,
+                    "location": "WAREHOUSE_B"
+                }
+            ]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        assert!(matches_selection_set(
+            &representation,
+            &field_set.selection_set
+        ));
+        let entity_key =
+            get_entity_key_from_selection_set(&representation, &field_set.selection_set);
+        assert_eq!(
+            &entity_key,
+            json!({
+                "id": "TEST123",
+                "locale": "en_US",
+                "lists": [
+                    {
+                        "id": "LIST1",
+                        "date": 20240101,
+                        "quantity": 50
+                    }
+                ],
+                "list": [
+                    {
+                        "id": "LIST2",
+                        "quantity": 100,
+                        "location": "WAREHOUSE_A"
+                    },
+                    {
+                        "id": "LIST3",
+                        "quantity": 75,
+                        "location": "WAREHOUSE_B"
+                    }
+                ]
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_get_invalidation_root_keys_from_schema() {
+        // Simulate the real-world Availability type scenario
+        let schema_text = r#"
+            directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+            directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+            directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+            directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+            directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+            input join__ContextArgument {
+              name: String!
+              type: String!
+              context: String!
+              selection: join__FieldValue!
+            }
+
+            scalar join__DirectiveArguments
+
+            scalar join__FieldSet
+
+            scalar join__FieldValue
+
+            enum join__Graph {
+              USER @join__graph(name: "USER", url: "none")
+              TEST @join__graph(name: "TEST", url: "none")
+            }
+
+            scalar link__Import
+
+            enum link__Purpose {
+              """
+              `SECURITY` features provide metadata necessary to securely resolve fields.
+              """
+              SECURITY
+
+              """
+              `EXECUTION` features provide metadata necessary for operation execution.
+              """
+              EXECUTION
+            }
+
+            type Query {
+                test: Test
+                testByCountry(id: ID!, country: Country!): Test @join__directive(
+                    graphs: [USER]
+                    name: "federation__cacheTag"
+                    args: { format: "test-{$args.id}-{$args.country}" }
+                )
+                @join__directive(
+                    graphs: [USER]
+                    name: "federation__cacheTag"
+                    args: { format: "test-{$args.country}" }
+                )
+                @join__directive(
+                    graphs: [USER]
+                    name: "federation__cacheTag"
+                    args: { format: "test" }
+                )
+            }
+
+            enum Country {
+                BE
+                FR
+            }
+
+            type Test {
+                id: ID!
+                locale: String!
+                lists: [List!]!
+                list: [List!]!
+            }
+            type List {
+                id: ID!
+                date: Int!
+                quantity: Int!
+                location: String!
+            }
+        "#;
+        let schema = Arc::new(Schema::parse_and_validate(schema_text, "test.graphql").unwrap());
+        let query = r#"query Test {
+          testByCountry(id: "2", country: BE) {
+            locale
+          }
+        }"#;
+        let mut sub_request = subgraph::Request::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query(query)
+                            .operation_name("Test")
+                            .build(),
+                    )
+                    .unwrap(),
+            )
+            .operation_kind(OperationKind::Query)
+            .subgraph_name("USER")
+            .build();
+        sub_request.executable_document = Some(Arc::new(
+            apollo_compiler::ExecutableDocument::parse_and_validate(&schema, query, "test.graphql")
+                .unwrap(),
+        ));
+        let subgraph_enums: HashMap<String, String> = [("USER".to_string(), "USER".to_string())]
+            .into_iter()
+            .collect();
+        let cache_tags =
+            get_invalidation_root_keys_from_schema(&sub_request, &subgraph_enums, schema.clone())
+                .unwrap();
+
+        assert_eq!(
+            cache_tags,
+            [
+                "test".to_string(),
+                "test-BE".to_string(),
+                "test-2-BE".to_string()
+            ]
+            .into_iter()
+            .collect()
+        );
+    }
+>>>>>>> 176a6c2a (fix(response_cache): do not raise an error when using enum in cacheTag directive format (#8496))
 }


### PR DESCRIPTION
Fix composition validation when checking `@cacheTag` format used with an enum.

Example:

```graphql
type Query {
    testByCountry(id: ID!, country: Country!): Test @cacheTag(format: "test-{$args.id}-{$args.country}" ) # This was throwing an error because of Country being an enum and not a Scalar type
}
```


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1508]: https://apollographql.atlassian.net/browse/ROUTER-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #8496 done by [Mergify](https://mergify.com).