### PR TITLE
fix(response_cache): display cache tags generated from subgraph response in debugger (backport #8531)

### DIFF
--- a/.changesets/fix_bnjjj_router_1512.md
+++ b/.changesets/fix_bnjjj_router_1512.md
@@ -1,0 +1,7 @@
+### fix(response_cache): display cache tags generated from subgraph response in debugger ([PR #8531](https://github.com/apollographql/router/pull/8531))
+
+Get generated cache tags from subgraph response (in `extensions`) when using the debugger.
+
+> For performance reasons. These generated cache tags will only be displayed if the data has been cached in debug mode
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/8531

--- a/apollo-router/src/plugins/response_cache/storage/mod.rs
+++ b/apollo-router/src/plugins/response_cache/storage/mod.rs
@@ -3,6 +3,7 @@ mod error;
 pub(super) mod redis;
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -28,6 +29,7 @@ pub(super) struct Document {
     pub(super) control: CacheControl,
     pub(super) invalidation_keys: Vec<String>,
     pub(super) expire: Duration,
+    pub(super) debug: bool,
 }
 
 /// A `CacheEntry` is a unit of data returned from the cache. It contains the cache key, value, and
@@ -37,6 +39,8 @@ pub(super) struct CacheEntry {
     pub(super) key: String,
     pub(super) data: serde_json_bytes::Value,
     pub(super) control: CacheControl,
+    // Only set in debug mode
+    pub(super) cache_tags: Option<HashSet<String>>,
 }
 
 /// The `CacheStorage` trait defines an API that the backing storage layer must implement for

--- a/apollo-router/src/plugins/response_cache/storage/redis.rs
+++ b/apollo-router/src/plugins/response_cache/storage/redis.rs
@@ -42,6 +42,8 @@ pub(crate) type Config = super::config::Config;
 struct CacheValue {
     data: serde_json_bytes::Value,
     cache_control: CacheControl,
+    // Only set in debug mode
+    cache_tags: Option<HashSet<String>>,
 }
 
 impl ValueType for CacheValue {}
@@ -52,6 +54,7 @@ impl From<(&str, CacheValue)> for CacheEntry {
             key: cache_key.to_string(),
             data: cache_value.data,
             control: cache_value.cache_control,
+            cache_tags: cache_value.cache_tags,
         }
     }
 }
@@ -258,9 +261,16 @@ impl CacheStorage for Storage {
 
         let now = now();
 
+        // Only useful for caching debugger, it will only contains entries if the doc is set to debug
+        let mut original_cache_tags = Vec::with_capacity(batch_docs.len());
         // phase 1
         for document in &mut batch_docs {
             document.key = self.make_key(&document.key);
+            if document.debug {
+                original_cache_tags.push(document.invalidation_keys.clone());
+            } else {
+                original_cache_tags.push(Vec::new());
+            }
             document.invalidation_keys =
                 self.namespaced_cache_tags(&document.invalidation_keys, subgraph_name);
         }
@@ -336,10 +346,11 @@ impl CacheStorage for Storage {
 
         // phase 3
         let pipeline = self.storage.client().pipeline().with_options(&options);
-        for document in batch_docs.into_iter() {
+        for (document, cache_tags) in batch_docs.into_iter().zip(original_cache_tags.into_iter()) {
             let value = CacheValue {
                 data: document.data,
                 cache_control: document.control,
+                cache_tags: document.debug.then(|| cache_tags.into_iter().collect()),
             };
             let _: () = pipeline
                 .set::<(), _, _>(
@@ -567,6 +578,7 @@ mod tests {
             control: Default::default(),
             invalidation_keys: vec!["invalidate".to_string()],
             expire: Duration::from_secs(60),
+            debug: true,
         }
     }
 

--- a/apollo-router/src/plugins/response_cache/tests.rs
+++ b/apollo-router/src/plugins/response_cache/tests.rs
@@ -1,3 +1,4 @@
+#![cfg(test)]
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;

--- a/apollo-router/tests/integration/response_cache.rs
+++ b/apollo-router/tests/integration/response_cache.rs
@@ -174,6 +174,20 @@ async fn make_graphql_request(router: &mut HttpService) -> (HeaderMap<String>, g
     make_http_request(router, request.into()).await
 }
 
+async fn make_debug_graphql_request(
+    router: &mut HttpService,
+) -> (HeaderMap<String>, graphql::Response) {
+    let query = "{ topProducts { reviews { id } } }";
+    let request = graphql_request(query);
+    let mut request: http::Request<router::Body> = request.into();
+    request.headers_mut().insert(
+        HeaderName::from_static("apollo-cache-debugging"),
+        HeaderValue::from_static("true"),
+    );
+
+    make_http_request(router, request).await
+}
+
 fn graphql_request(query: &str) -> router::Request {
     supergraph::Request::fake_builder()
         .query(query)
@@ -247,6 +261,96 @@ async fn basic_cache_skips_subgraph_request() {
         - reviews:
             - id: r2
     ");
+    // Unchanged, everything is in cache so we don’t need to make more subgraph requests:
+    insta::assert_yaml_snapshot!(subgraph_request_counters, @r"
+    products: 1
+    reviews: 1
+    ");
+}
+
+fn check_cache_tags(response: &graphql::Response, cache_tags: Vec<Vec<String>>) {
+    let mut debugger_entries = response
+        .extensions
+        .get("apolloCacheDebugging")
+        .unwrap()
+        .as_object()
+        .unwrap()
+        .get("data")
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .iter();
+
+    for debug_cache_tags in cache_tags {
+        let entry = debugger_entries.next().unwrap().as_object().unwrap();
+        assert_eq!(
+            entry.get("invalidationKeys"),
+            Some(&serde_json_bytes::Value::Array(
+                debug_cache_tags
+                    .into_iter()
+                    .map(|cache_tag| serde_json_bytes::Value::String(cache_tag.into()))
+                    .collect()
+            ))
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_cache_tags_from_debugger_data() {
+    if !graph_os_enabled() {
+        return;
+    }
+
+    let (mut router, subgraph_request_counters) = harness(base_config(), base_subgraphs()).await;
+    insta::assert_yaml_snapshot!(subgraph_request_counters, @r"
+    products: 0
+    reviews: 0
+    ");
+    let (headers, body) = make_debug_graphql_request(&mut router).await;
+    assert!(headers["cache-control"].contains("public"));
+    assert!(body.errors.is_empty());
+    insta::assert_yaml_snapshot!(body.data, @r"
+    topProducts:
+      - reviews:
+          - id: r1a
+          - id: r1b
+      - reviews:
+          - id: r2
+    ");
+    check_cache_tags(
+        &body,
+        vec![
+            vec!["topProducts".to_string()],
+            vec!["product-1".to_string()],
+            vec!["product-2".to_string()],
+        ],
+    );
+    insta::assert_yaml_snapshot!(subgraph_request_counters, @r"
+    products: 1
+    reviews: 1
+    ");
+    // Needed because insert in the cache is async
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (headers, body) = make_debug_graphql_request(&mut router).await;
+    assert!(headers["cache-control"].contains("public"));
+    assert!(body.errors.is_empty());
+    insta::assert_yaml_snapshot!(body.data, @r"
+    topProducts:
+      - reviews:
+          - id: r1a
+          - id: r1b
+      - reviews:
+          - id: r2
+    ");
+
+    check_cache_tags(
+        &body,
+        vec![
+            vec!["topProducts".to_string()],
+            vec!["product-1".to_string()],
+            vec!["product-2".to_string()],
+        ],
+    );
     // Unchanged, everything is in cache so we don’t need to make more subgraph requests:
     insta::assert_yaml_snapshot!(subgraph_request_counters, @r"
     products: 1

--- a/docs/source/routing/performance/caching/response-caching/faq.mdx
+++ b/docs/source/routing/performance/caching/response-caching/faq.mdx
@@ -86,8 +86,35 @@ The 2024 preview used a linear scan approach for active invalidation that scaled
 
 ### How does the current release affect existing users?
 
+<<<<<<< HEAD
 All changes are backward-compatible. If you're using the `preview_entity_caching` plugin, you're automatically migrated to `preview_response_caching` with no action required.
+=======
+Response caching is backward-compatible with entity caching. You can switch to response caching without breaking changes.
+
+If you're currently using the `preview_entity_caching` plugin, migrate to response caching as soon as possible. The new implementation provides better performance and more flexible caching controls.
+
+### How do I migrate from entity caching to response caching?
+
+Follow these steps to migrate your configuration:
+
+1. **Update the plugin name:** Replace `preview_entity_cache` with `preview_response_cache` in your router configuration.
+
+2. **Remove the `scan_count` setting:** Delete the `redis.scan_count` configuration option if you have it set. Response caching uses an approach that doesn't require Redis `SCAN` operations, eliminating a key performance bottleneck from the previous entity caching version.
+
+3. **Update timeout configuration:** Replace the single `redis.timeout` setting with more granular timeout options as appropriate:
+   - `redis.fetch_timeout`: Controls how long to wait when retrieving data from cache
+   - `redis.insert_timeout`: Controls how long to wait when storing new data in cache
+   - `redis.invalidate_timeout`: Controls how long to wait when removing data from cache
+
+   All timeout settings are optional. Set timeouts based on your application's performance requirements for specific cache operations.
+
+4. **Update your metrics and monitoring:** Response caching introduces new metric names and additional observability options. Check the [observability documentation](/graphos/routing/performance/caching/response-caching/observability) for the complete list of available metrics and their updated names. The new implementation also provides additional metrics for better insight into cache performance.
+>>>>>>> 3c16634b (fix(response_cache): display cache tags generated from subgraph response in debugger (#8531))
 
 ### Can I use response caching in production with earlier router versions?
 
 TTL-based caching works in earlier versions. For API-based invalidation, use the current router version.
+
+### Why can't I see my cache tags generated from subgraph response in the debugger once cached?
+
+For performance, cache tags derived from a subgraph response are written to Redis in a debugger‑readable form only when the cache‑populating request runs in debug mode. Cache tags coming from subgraph responses written outside debug mode aren’t visible in the debugger.

--- a/docs/source/routing/performance/caching/response-caching/invalidation.mdx
+++ b/docs/source/routing/performance/caching/response-caching/invalidation.mdx
@@ -424,7 +424,7 @@ type Country {
 
 If you need to set cache tags programmatically (for example, if the tag depends on neither root field arguments nor entity keys), create the cache tags in your subgraph and set them in the response extensions.
 
-Example of response payload if you want to set cache tags for different entities returned by subgraph:
+For cache tags on _entities_, set `apolloEntityCacheTags` in `extensions`. The following example shows a response payload that sets cache tags for entities returned by a subgraph:
 
 ```json
 {
@@ -441,14 +441,14 @@ Example of response payload if you want to set cache tags for different entities
 }
 ```
 
-Example of response payload if you want to set cache tags for root fields returned by subgraph:
+For cache tags on _root fields_, set `apolloCacheTags` in `extensions`. The following example shows a response payload that sets cache tags for root fields returned by a subgraph:
 
 ```json
 {
    "data": {
        "someField": {...}
    },
-   "extensions": {"apolloEntityCacheTags": ["homepage", "user-9001-homepage"]}
+   "extensions": {"apolloCacheTags": ["homepage", "user-9001-homepage"]}
 }
 ```
 
@@ -509,8 +509,8 @@ directive @cacheControl(
   scope: CacheControlScope
 ) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
 
-type User @key(fields: "id") 
-         @cacheControl(maxAge: 60) 
+type User @key(fields: "id")
+         @cacheControl(maxAge: 60)
          @cacheTag(format: "user-{$key.id}") {
   id: ID!
   name: String!

--- a/docs/source/routing/performance/caching/response-caching/overview.mdx
+++ b/docs/source/routing/performance/caching/response-caching/overview.mdx
@@ -25,7 +25,7 @@ Response caching enables the router to cache origin responses and reuse them acr
 - **Root query fields**: Cached as complete units (the entire response for that root field)
 - **Entity representations**: Cached independently—each origin's contribution to an entity is cached separately and can be reused across different queries. (See [_entities query](/federation/subgraph-spec/#understanding-query_entities).)
 
-The router uses Redis to cache data from origin query responses. The cache organizes data by origin and entity representation, so different clients requesting the same data hit shared cache entries. You can use the [cache debugger](/router/performance/caching/response-caching/observability#cache-debugger) to see exactly what's being cached during development.
+The router uses Redis to cache data from origin query responses. The cache organizes data by origin and entity representation, so different clients requesting the same data hit shared cache entries. You can use the [cache debugger](/graphos/routing/performance/caching/response-caching/observability#cache-debugger) to see exactly what's being cached during development.
 
 ### Goals
 


### PR DESCRIPTION
Get generated cache tags from subgraph response (in `extensions`) when using the debugger.

> For performance reasons. These generated cache tags will only be displayed if the data has been cached in debug mode


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1512]: https://apollographql.atlassian.net/browse/ROUTER-1512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #8531 done by [Mergify](https://mergify.com).