### PR TITLE
feat(response_caching): give the ability to create custom cache key per subgraph (backport #8543)

### DIFF
--- a/.changesets/feat_bnjjj_router_1517.md
+++ b/.changesets/feat_bnjjj_router_1517.md
@@ -1,0 +1,24 @@
+### Response caching: support customizing cache key per subgraph via context ([PR #8543](https://github.com/apollographql/router/pull/8543))
+
+The response cache key can be customized by the context entry `apollo::response_cache::key`. Previously, customization was supported per operation name or for all subgraph requests. This change introduces the ability to customize cache keys for individual subgraphs by using the new `subgraphs` field, where you can define separate entries for each subgraph name. 
+
+Please note that data for a specific subgraph takes precedence over data in the `all` field, and the router doesn't merge data between them. To set common data when providing subgraph-specific data, add it to the subgraph-specific section.
+
+Example payload:
+
+```json
+{
+    "all": 1,
+    "subgraph_operation1": "key1",
+    "subgraph_operation2": {
+      "data": "key2"
+    },
+    "subgraphs": {
+      "my_subgraph": {
+        "locale": "be"
+      }
+    }
+}
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/8543

--- a/apollo-router/src/plugins/response_cache/cache_key.rs
+++ b/apollo-router/src/plugins/response_cache/cache_key.rs
@@ -41,7 +41,8 @@ impl<'a> PrimaryCacheKeyRoot<'a> {
         } = self;
 
         let query_hash = hash_query(subgraph_query_hash);
-        let additional_data_hash = hash_additional_data(body, context, auth_cache_key_metadata);
+        let additional_data_hash =
+            hash_additional_data(subgraph_name, body, context, auth_cache_key_metadata);
 
         // - response cache version: current version of the hash
         // - subgraph name: subgraph name
@@ -115,6 +116,7 @@ pub(super) fn hash_query(query_hash: &QueryHash) -> String {
 }
 
 pub(super) fn hash_additional_data(
+    subgraph_name: &str,
     body: &graphql::Request,
     context: &Context,
     cache_key: &CacheKeyMetadata,
@@ -133,8 +135,16 @@ pub(super) fn hash_additional_data(
         .serialize(Blake3Serializer::new(&mut hasher))
         .expect("this serializer doesn't throw any errors; qed");
 
+    // Takes value specific for a subgraph, if it doesn't exist take value for all subgraphs, and if you have data specific for an operation name add it in the hash
     if let Ok(Some(cache_data)) = context.get::<&str, Object>(CONTEXT_CACHE_KEY) {
-        if let Some(v) = cache_data.get("all") {
+        if let Some(v) = cache_data
+            .get("subgraphs")
+            .and_then(|s| s.as_object())
+            .and_then(|subgraph_data| subgraph_data.get(subgraph_name))
+        {
+            v.serialize(Blake3Serializer::new(&mut hasher))
+                .expect("this serializer doesn't throw any errors; qed");
+        } else if let Some(v) = cache_data.get("all") {
             v.serialize(Blake3Serializer::new(&mut hasher))
                 .expect("this serializer doesn't throw any errors; qed");
         }
@@ -181,4 +191,71 @@ where
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_additional_data() {
+        let context = Context::new();
+        context.insert_json_value(
+            CONTEXT_CACHE_KEY,
+            serde_json_bytes::json!({
+                "all": {
+                  "locale": "be"
+                },
+                "subgraphs": {
+                    "test": {
+                        "foo": "bar"
+                    },
+                    "test_2": {
+                        "bar": "foo"
+                    }
+                }
+            }),
+        );
+        let hashed_data = hash_additional_data(
+            "test",
+            &graphql::Request::builder()
+                .query("{ me { name } }")
+                .variable("key", "value")
+                .build(),
+            &context,
+            &Default::default(),
+        );
+        let hashed_data_2 = hash_additional_data(
+            "test_2",
+            &graphql::Request::builder()
+                .query("{ me { name } }")
+                .variable("key", "value")
+                .build(),
+            &context,
+            &Default::default(),
+        );
+        // Because it takes different data from context
+        assert!(hashed_data != hashed_data_2);
+
+        let hashed_data_3 = hash_additional_data(
+            "test_3",
+            &graphql::Request::builder()
+                .query("{ me { name } }")
+                .variable("key", "value")
+                .build(),
+            &context,
+            &Default::default(),
+        );
+        let hashed_data_4 = hash_additional_data(
+            "test_4",
+            &graphql::Request::builder()
+                .query("{ me { name } }")
+                .variable("key", "value")
+                .build(),
+            &context,
+            &Default::default(),
+        );
+        // Because it takes the same data from context `all`
+        assert_eq!(hashed_data_3, hashed_data_4);
+    }
 }

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -1742,8 +1742,12 @@ fn extract_cache_keys(
     // hash the query and operation name
     let query_hash = hash_query(&request.query_hash);
     // hash more data like variables and authorization status
-    let additional_data_hash =
-        hash_additional_data(request.subgraph_request.body_mut(), context, authorization);
+    let additional_data_hash = hash_additional_data(
+        subgraph_name,
+        request.subgraph_request.body_mut(),
+        context,
+        authorization,
+    );
 
     let representations = request
         .subgraph_request

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_custom_key-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_custom_key-3.snap
@@ -1,0 +1,81 @@
+---
+source: apollo-router/src/plugins/response_cache/tests.rs
+description: "Make sure everything is in status 'new' because we didn't pass the context and we have all the entities and root fields"
+expression: cache_keys
+---
+[
+  {
+    "key": "version:1.0:subgraph:user:type:Query:hash:fa8ff6a034f5ccb3f49e51bc30ff031104ba420310e67764f9e9f82702437592:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "invalidationKeys": [
+      "currentUser"
+    ],
+    "kind": {
+      "rootFields": [
+        "currentUser"
+      ]
+    },
+    "subgraphName": "user",
+    "subgraphRequest": {
+      "query": "{ currentUser { activeOrganization { __typename id } } }"
+    },
+    "source": "subgraph",
+    "cacheControl": {
+      "created": 0,
+      "maxAge": 86400,
+      "public": true
+    },
+    "shouldStore": true,
+    "data": {
+      "data": {
+        "currentUser": {
+          "activeOrganization": {
+            "__typename": "Organization",
+            "id": "1"
+          }
+        }
+      }
+    },
+    "warnings": []
+  },
+  {
+    "key": "version:1.0:subgraph:orga:type:Organization:representation:07f0ad9351c409fd3acfae0be59e64f218dc486d6dbe0081e68794673b96df73:hash:f6acbaaee10175327fa6a7882704a4e85b732d7561e7c399fd49069486da68b8:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "invalidationKeys": [
+      "organization",
+      "organization-1"
+    ],
+    "kind": {
+      "typename": "Organization",
+      "entityKey": {
+        "id": "1"
+      }
+    },
+    "subgraphName": "orga",
+    "subgraphRequest": {
+      "query": "query($representations: [_Any!]!) { _entities(representations: $representations) { ... on Organization { creatorUser { __typename id } } } }",
+      "variables": {
+        "representations": [
+          {
+            "id": "1",
+            "__typename": "Organization"
+          }
+        ]
+      }
+    },
+    "source": "subgraph",
+    "cacheControl": {
+      "created": 0,
+      "maxAge": 86400,
+      "public": true
+    },
+    "shouldStore": true,
+    "data": {
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
+      }
+    },
+    "warnings": []
+  }
+]

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_custom_key.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_custom_key.snap
@@ -1,0 +1,81 @@
+---
+source: apollo-router/src/plugins/response_cache/tests.rs
+description: "Make sure everything is in status 'new' and we have all the entities and root fields"
+expression: cache_keys
+---
+[
+  {
+    "key": "version:1.0:subgraph:user:type:Query:hash:fa8ff6a034f5ccb3f49e51bc30ff031104ba420310e67764f9e9f82702437592:data:ecc81b2358c367ea0a3bd386922f484496ab74203218df9ce230e6b7c8dbf28a",
+    "invalidationKeys": [
+      "currentUser"
+    ],
+    "kind": {
+      "rootFields": [
+        "currentUser"
+      ]
+    },
+    "subgraphName": "user",
+    "subgraphRequest": {
+      "query": "{ currentUser { activeOrganization { __typename id } } }"
+    },
+    "source": "subgraph",
+    "cacheControl": {
+      "created": 0,
+      "maxAge": 86400,
+      "public": true
+    },
+    "shouldStore": true,
+    "data": {
+      "data": {
+        "currentUser": {
+          "activeOrganization": {
+            "__typename": "Organization",
+            "id": "1"
+          }
+        }
+      }
+    },
+    "warnings": []
+  },
+  {
+    "key": "version:1.0:subgraph:orga:type:Organization:representation:07f0ad9351c409fd3acfae0be59e64f218dc486d6dbe0081e68794673b96df73:hash:f6acbaaee10175327fa6a7882704a4e85b732d7561e7c399fd49069486da68b8:data:512b8af55ea384e083ac903edb6c05ea23659dffdde5c97d418e01c986ee3003",
+    "invalidationKeys": [
+      "organization",
+      "organization-1"
+    ],
+    "kind": {
+      "typename": "Organization",
+      "entityKey": {
+        "id": "1"
+      }
+    },
+    "subgraphName": "orga",
+    "subgraphRequest": {
+      "query": "query($representations: [_Any!]!) { _entities(representations: $representations) { ... on Organization { creatorUser { __typename id } } } }",
+      "variables": {
+        "representations": [
+          {
+            "id": "1",
+            "__typename": "Organization"
+          }
+        ]
+      }
+    },
+    "source": "subgraph",
+    "cacheControl": {
+      "created": 0,
+      "maxAge": 86400,
+      "public": true
+    },
+    "shouldStore": true,
+    "data": {
+      "data": {
+        "creatorUser": {
+          "__typename": "User",
+          "id": 2
+        }
+      }
+    },
+    "warnings": []
+  }
+]

--- a/apollo-router/src/plugins/response_cache/tests.rs
+++ b/apollo-router/src/plugins/response_cache/tests.rs
@@ -21,7 +21,11 @@ use crate::plugin::test::MockSubgraph;
 use crate::plugin::test::MockSubgraphService;
 use crate::plugins::response_cache::invalidation::InvalidationRequest;
 use crate::plugins::response_cache::plugin::CACHE_DEBUG_HEADER_NAME;
+<<<<<<< HEAD
 use crate::plugins::response_cache::plugin::CacheKeysContext;
+=======
+use crate::plugins::response_cache::plugin::CONTEXT_CACHE_KEY;
+>>>>>>> c5af7ac4 (feat(response_caching): give the ability to create custom cache key per subgraph (#8543))
 use crate::plugins::response_cache::plugin::Subgraph;
 use crate::plugins::response_cache::storage::CacheStorage;
 use crate::plugins::response_cache::storage::redis::Config;
@@ -271,6 +275,186 @@ async fn insert() {
     let cache_keys = get_cache_keys_context(&response).expect("missing cache keys");
     insta::with_settings!({
         description => "Make sure everything is in status 'cached' and we have all the entities and root fields"
+    }, {
+        insta::assert_json_snapshot!(cache_keys);
+    });
+
+    let mut response = response.next_response().await.unwrap();
+    assert!(remove_debug_extensions_key(&mut response));
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "currentUser": {
+          "activeOrganization": {
+            "id": "1",
+            "creatorUser": {
+              "__typename": "User",
+              "id": 2
+            }
+          }
+        }
+      }
+    }
+    "#);
+}
+
+#[tokio::test]
+async fn insert_with_custom_key() {
+    let valid_schema = Arc::new(Schema::parse_and_validate(SCHEMA, "test.graphql").unwrap());
+    let query = "query { currentUser { activeOrganization { id creatorUser { __typename id } } } }";
+
+    let subgraphs = serde_json::json!({
+        "user": {
+            "query": {
+                "currentUser": {
+                    "activeOrganization": {
+                        "__typename": "Organization",
+                        "id": "1",
+                    }
+                }
+            },
+            "headers": {"cache-control": "public"},
+        },
+        "orga": {
+            "entities": [
+                {
+                    "__typename": "Organization",
+                    "id": "1",
+                    "creatorUser": {
+                        "__typename": "User",
+                        "id": 2
+                    }
+                }
+            ],
+            "headers": {"cache-control": "public"},
+        },
+    });
+
+    let (drop_tx, drop_rx) = tokio::sync::broadcast::channel(2);
+    let storage = Storage::new(&Config::test(false, "insert_with_custom_key"), drop_rx)
+        .await
+        .unwrap();
+    let map = [
+        (
+            "user".to_string(),
+            Subgraph {
+                redis: None,
+                private_id: Some("sub".to_string()),
+                enabled: true.into(),
+                ttl: None,
+                ..Default::default()
+            },
+        ),
+        (
+            "orga".to_string(),
+            Subgraph {
+                redis: None,
+                private_id: Some("sub".to_string()),
+                enabled: true.into(),
+                ttl: None,
+                ..Default::default()
+            },
+        ),
+    ]
+    .into_iter()
+    .collect();
+    let response_cache =
+        ResponseCache::for_test(storage.clone(), map, valid_schema.clone(), true, drop_tx)
+            .await
+            .unwrap();
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+            "experimental_mock_subgraphs": subgraphs,
+        }))
+        .unwrap()
+        .schema(SCHEMA)
+        .extra_private_plugin(response_cache.clone())
+        .build_supergraph()
+        .await
+        .unwrap();
+    let context = Context::new();
+    context.insert_json_value(
+        CONTEXT_CACHE_KEY,
+        serde_json_bytes::json!({
+            "all": {
+              "locale": "be"
+            },
+            "subgraphs": {
+                "user": {
+                    "foo": "bar"
+                }
+            }
+        }),
+    );
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .context(context.clone())
+        .header(
+            HeaderName::from_static(CACHE_DEBUG_HEADER_NAME),
+            HeaderValue::from_static("true"),
+        )
+        .build()
+        .unwrap();
+    let mut response = service.oneshot(request).await.unwrap();
+    let cache_keys = get_cache_keys_context(&response).expect("missing cache keys");
+    insta::with_settings!({
+        description => "Make sure everything is with source 'subgraph' and we have all the entities and root fields"
+    }, {
+        insta::assert_json_snapshot!(cache_keys);
+    });
+
+    let cache_control_header = get_cache_control_header(&response).expect("missing header");
+    assert!(cache_control_contains_max_age(&cache_control_header));
+    assert!(cache_control_contains_public(&cache_control_header));
+
+    let mut response = response.next_response().await.unwrap();
+    assert!(remove_debug_extensions_key(&mut response));
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "currentUser": {
+          "activeOrganization": {
+            "id": "1",
+            "creatorUser": {
+              "__typename": "User",
+              "id": 2
+            }
+          }
+        }
+      }
+    }
+    "#);
+
+    wait_for_cache(&storage, expected_cached_keys(&cache_keys)).await;
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true }, "experimental_mock_subgraphs": subgraphs, }))
+        .unwrap()
+        .schema(SCHEMA)
+        .extra_private_plugin(response_cache.clone())
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .context(Context::new())
+        .header(
+            HeaderName::from_static(CACHE_DEBUG_HEADER_NAME),
+            HeaderValue::from_static("true"),
+        )
+        .build()
+        .unwrap();
+    let mut response = service.oneshot(request).await.unwrap();
+
+    let cache_control_header = get_cache_control_header(&response).expect("missing header");
+    assert!(cache_control_contains_max_age(&cache_control_header));
+    assert!(cache_control_contains_public(&cache_control_header));
+
+    let cache_keys = get_cache_keys_context(&response).expect("missing cache keys");
+    insta::with_settings!({
+        description => "Make sure everything is with source 'subgraph' because we didn't pass the context and we have all the entities and root fields"
     }, {
         insta::assert_json_snapshot!(cache_keys);
     });

--- a/docs/source/routing/performance/caching/response-caching/customization.mdx
+++ b/docs/source/routing/performance/caching/response-caching/customization.mdx
@@ -99,7 +99,16 @@ Use custom cache keys when you need to:
 
 ### Configure cache keys
 
-This entry contains an object with an `all` field to affect all subgraph requests under one client request, and fields named after subgraph operation names to affect individual subgraph queries. The field's value can be any valid JSON value, such as an object or a string.
+You can customize the response cache key with the `apollo::response_cache::key` context entry. Data in this entry modifies the data used to generate the cache key, and it can be any valid JSON.
+
+You can apply customizations at multiple scales using different fields in `apollo::response_cache::key`:
+- An `all` field, which affects all subgraph requests
+- A `subgraphs` field, which contains an object with per-subgraph customization
+- A field for each operation name, which affects only a specific operation
+
+Data within these customizations are _not_ merged. The router chooses data in order of precedence: operation name, subgraph, then `all`. To set common data, you must also add it to the more specific sections.
+
+Example:
 
 ```json
 {
@@ -107,6 +116,11 @@ This entry contains an object with an `all` field to affect all subgraph request
     "subgraph_operation1": "key1",
     "subgraph_operation2": {
       "data": "key2"
+    },
+    "subgraphs": {
+      "my_subgraph": {
+        "locale": "be"
+      }
     }
 }
 ```


### PR DESCRIPTION
To customize a cache key, use the context entry `apollo::response_cache::key`, which allows you to specify data to include when generating the primary cache key. Previously, customization was supported per operation name or for all subgraph requests. This update introduces the ability to customize cache keys for individual subgraphs by using the `subgraphs` field, where you can define separate entries for each subgraph name. Example payload:

```json
{
    "all": 1,
    "subgraph_operation1": "key1",
    "subgraph_operation2": {
      "data": "key2"
    },
    "subgraphs": {
      "my_subgraph": {
        "locale": "be"
      }
    }
}
```



---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1517]: https://apollographql.atlassian.net/browse/ROUTER-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #8543 done by [Mergify](https://mergify.com).