### PR TITLE
feat(response_cache): add selectors for telemetry to create metrics based on cache-control values (backport #8524)

### DIFF
--- a/.changesets/feat_bnjjj_router_1506.md
+++ b/.changesets/feat_bnjjj_router_1506.md
@@ -1,0 +1,34 @@
+### Add selectors for telemetry to create metrics based on cache-control values ([PR #8524](https://github.com/apollographql/router/pull/8524))
+
+New selector `response_cache_control` added in telemetry for subgraph service to know what's the content of the computed [`Cache-Control` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) from the subgraph response.
+
+Example of attributes added to metrics:
+
+```yaml
+telemetry:
+  exporters:
+    metrics:
+      common:
+        service_name: apollo-router
+        views:
+          - name: subgraph.response.cache_control.max_age # This is to make sure it will use the correct buckets for the max age histogram
+            aggregation:
+              histogram:
+                buckets: # Override default buckets configured for this histogram
+                - 10
+                - 100
+                - 1000
+                - 10000
+                - 100000
+  instrumentation:
+    instruments:
+      subgraph:
+        subgraph.response.cache_control.max_age:
+          value:
+            response_cache_control: max_age
+          type: histogram
+          unit: s # Seconds
+          description: A histogram of the computed TTL for a subgraph response
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/8524

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -783,6 +783,25 @@ expression: "&schema"
       },
       "type": "object"
     },
+    "CacheControlSelector": {
+      "oneOf": [
+        {
+          "const": "scope",
+          "description": "Returns the scope, either `public` or `private`",
+          "type": "string"
+        },
+        {
+          "const": "no_store",
+          "description": "Boolean to know the value of no-store",
+          "type": "string"
+        },
+        {
+          "const": "max_age",
+          "description": "Value of s-maxage or max-age in cache-control",
+          "type": "string"
+        }
+      ]
+    },
     "CacheKind": {
       "enum": [
         "hit",
@@ -10155,6 +10174,23 @@ expression: "&schema"
           },
           "required": [
             "response_cache_status"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "response_cache_control": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CacheControlSelector"
+                }
+              ],
+              "description": "Select data you want from the computed cache control from response caching"
+            }
+          },
+          "required": [
+            "response_cache_control"
           ],
           "type": "object"
         }

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -480,6 +480,7 @@ impl Plugin for DemandControl {
                                     err.into_graphql_errors()
                                         .expect("must be able to convert to graphql error"),
                                 )
+                                .id(req.id)
                                 .context(req.context.clone())
                                 .extensions(crate::json_ext::Object::new())
                                 .subgraph_name(subgraph_name.clone())
@@ -507,6 +508,7 @@ impl Plugin for DemandControl {
                                     err.into_graphql_errors()
                                         .expect("must be able to convert to graphql error"),
                                 )
+                                .id(resp.id)
                                 .subgraph_name(subgraph_name)
                                 .context(resp.context.clone())
                                 .extensions(Object::new())

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -75,6 +75,7 @@ use crate::plugins::telemetry::dynamic_attribute::SpanDynAttribute;
 use crate::plugins::telemetry::span_ext::SpanMarkError;
 use crate::query_planner::OperationKind;
 use crate::services::subgraph;
+use crate::services::subgraph::SubgraphRequestId;
 use crate::services::supergraph;
 use crate::spec::QueryHash;
 use crate::spec::TYPENAME;
@@ -719,6 +720,7 @@ impl CacheService {
                 Err(err) => {
                     return Ok(subgraph::Response::builder()
                         .subgraph_name(request.subgraph_name)
+                        .id(request.id)
                         .context(request.context)
                         .error(
                             graphql::Error::builder()
@@ -896,6 +898,12 @@ impl CacheService {
                                 CacheControl::no_store()
                             };
 
+                        save_original_cache_control(
+                            response.id.clone(),
+                            &response.context,
+                            cache_control.clone(),
+                        );
+
                         if cache_control.private() {
                             // we did not know in advance that this was a query with a private scope, so we update the cache key
                             if !is_known_private {
@@ -1057,7 +1065,7 @@ impl CacheService {
                             },
                         )?;
                     }
-
+                    let req_id = request.id.clone();
                     let mut response = match self.service.call(request).await {
                         Ok(response) => response,
                         Err(e) => {
@@ -1090,6 +1098,7 @@ impl CacheService {
                             let mut response = subgraph::Response::builder()
                                 .context(context)
                                 .data(Value::Object(data))
+                                .id(req_id)
                                 .errors(new_errors)
                                 .subgraph_name(self.name)
                                 .extensions(Object::new())
@@ -1109,6 +1118,12 @@ impl CacheService {
                     } else {
                         CacheControl::no_store()
                     };
+
+                    save_original_cache_control(
+                        response.id.clone(),
+                        &response.context,
+                        cache_control.clone(),
+                    );
 
                     if let Some(control_from_cached) = cache_result.1 {
                         cache_control = cache_control.merge(&control_from_cached);
@@ -1189,6 +1204,8 @@ async fn cache_lookup_root(
         Ok(value) => {
             if value.control.can_use() {
                 let control = value.control.clone();
+                // Keep original cache control for every subgraph request (useful for telemetry)
+                save_original_cache_control(request.id.clone(), &request.context, control.clone());
                 update_cache_control(&request.context, &control);
                 if debug {
                     let root_operation_fields: Vec<String> = request
@@ -1240,6 +1257,7 @@ async fn cache_lookup_root(
                 let mut response = subgraph::Response::builder()
                     .data(value.data)
                     .extensions(Object::new())
+                    .id(request.id)
                     .context(request.context)
                     .subgraph_name(request.subgraph_name.clone())
                     .build();
@@ -1461,6 +1479,7 @@ async fn cache_lookup_entities(
     // remove from representations the entities we already obtained from the cache
     let (new_representations, cache_result, cache_control) = filter_representations(
         &name,
+        &request.id,
         representations,
         cache_metadata,
         cache_result,
@@ -1529,6 +1548,7 @@ async fn cache_lookup_entities(
 
         let mut response = subgraph::Response::builder()
             .data(data)
+            .id(request.id.clone())
             .extensions(Object::new())
             .subgraph_name(request.subgraph_name)
             .context(request.context)
@@ -1554,6 +1574,18 @@ fn update_cache_control(context: &Context, cache_control: &CacheControl) {
             lock.insert(new_cache_control);
         }
     })
+}
+
+// Keep original cache control for every subgraph request (useful for telemetry)
+fn save_original_cache_control(
+    req_id: SubgraphRequestId,
+    context: &Context,
+    cache_control: CacheControl,
+) {
+    context.extensions().with_lock(|l| {
+        l.get_or_default_mut::<CacheControls>()
+            .insert(req_id, cache_control)
+    });
 }
 
 async fn cache_store_root_from_response(
@@ -2067,6 +2099,7 @@ struct IntermediateResult {
 #[allow(clippy::type_complexity)]
 fn filter_representations(
     subgraph_name: &str,
+    subgraph_req_id: &SubgraphRequestId,
     representations: &mut Vec<Value>,
     // keys: Vec<(String, Vec<String>)>,
     keys: Vec<CacheMetadata>,
@@ -2077,6 +2110,8 @@ fn filter_representations(
     let mut result = Vec::new();
     let mut cache_hit: HashMap<String, CacheHitMiss> = HashMap::new();
     let mut cache_control = None;
+    // Useful for telemetry
+    let mut non_updated_cache_control = None;
 
     for (
         (
@@ -2122,6 +2157,10 @@ fn filter_representations(
                     None => cache_control = Some(entry.control.clone()),
                     Some(c) => *c = c.merge(&entry.control),
                 }
+                match non_updated_cache_control.as_mut() {
+                    None => non_updated_cache_control = Some(entry.control.clone()),
+                    Some(c) => *c = c.merge_without_update(&entry.control),
+                }
             }
         }
 
@@ -2132,6 +2171,10 @@ fn filter_representations(
             cache_entry,
             entity_key,
         });
+    }
+
+    if let Some(non_updated_cache_control) = non_updated_cache_control {
+        save_original_cache_control(subgraph_req_id.clone(), context, non_updated_cache_control);
     }
 
     let _ = context.insert(
@@ -2439,6 +2482,8 @@ async fn reattempt_connection(
         }
     }
 }
+
+pub(crate) type CacheControls = HashMap<SubgraphRequestId, CacheControl>;
 
 #[cfg(all(
     test,

--- a/apollo-router/src/plugins/telemetry/config_new/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/selectors.rs
@@ -95,3 +95,14 @@ pub(crate) enum CacheStatus {
     PartialHit,
     Status,
 }
+
+#[derive(Deserialize, JsonSchema, Clone, PartialEq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CacheControlSelector {
+    /// Returns the scope, either `public` or `private`
+    Scope,
+    /// Boolean to know the value of no-store
+    NoStore,
+    /// Value of s-maxage or max-age in cache-control
+    MaxAge,
+}

--- a/apollo-router/src/plugins/telemetry/config_new/subgraph/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/subgraph/selectors.rs
@@ -22,6 +22,7 @@ use crate::plugins::telemetry::config_new::get_baggage;
 use crate::plugins::telemetry::config_new::instruments::InstrumentValue;
 use crate::plugins::telemetry::config_new::instruments::Standard;
 use crate::plugins::telemetry::config_new::selectors::All;
+use crate::plugins::telemetry::config_new::selectors::CacheControlSelector;
 use crate::plugins::telemetry::config_new::selectors::CacheKind;
 use crate::plugins::telemetry::config_new::selectors::CacheStatus;
 use crate::plugins::telemetry::config_new::selectors::EntityType;
@@ -277,6 +278,10 @@ pub(crate) enum SubgraphSelector {
         response_cache_status: CacheStatus,
         /// Specify the entity type on which you want the cache data status. (default: all)
         entity_type: Option<EntityType>,
+    },
+    ResponseCacheControl {
+        /// Select data you want from the computed cache control from response caching
+        response_cache_control: CacheControlSelector,
     },
 }
 
@@ -651,6 +656,26 @@ impl Selector for SubgraphSelector {
                     }
                 }
             }
+            SubgraphSelector::ResponseCacheControl {
+                response_cache_control,
+            } => response.context.extensions().with_lock(|cc| {
+                let cc = cc
+                    .get::<response_cache::plugin::CacheControls>()?
+                    .get(&response.id)?;
+                match response_cache_control {
+                    CacheControlSelector::Scope => {
+                        if cc.private() {
+                            Some(opentelemetry::Value::String("private".to_string().into()))
+                        } else {
+                            Some(opentelemetry::Value::String("public".to_string().into()))
+                        }
+                    }
+                    CacheControlSelector::NoStore => Some(cc.get_no_store().into()),
+                    CacheControlSelector::MaxAge => cc
+                        .ttl()
+                        .and_then(|ttl| Some(opentelemetry::Value::I64(i64::try_from(ttl).ok()?))),
+                }
+            }),
             SubgraphSelector::ResponseCacheStatus {
                 response_cache_status,
                 entity_type,
@@ -796,6 +821,7 @@ impl Selector for SubgraphSelector {
                     | SubgraphSelector::StaticField { .. }
                     | SubgraphSelector::Cache { .. }
                     | SubgraphSelector::ResponseCache { .. }
+                    | SubgraphSelector::ResponseCacheControl { .. }
             ),
             Stage::ResponseEvent => false,
             Stage::ResponseField => false,
@@ -819,10 +845,14 @@ impl Selector for SubgraphSelector {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
     use std::str::FromStr;
     use std::sync::Arc;
 
+    use http::HeaderMap;
+    use http::HeaderValue;
     use http::StatusCode;
+    use http::header::CACHE_CONTROL;
     use opentelemetry::Context;
     use opentelemetry::KeyValue;
     use opentelemetry::StringValue;
@@ -846,9 +876,11 @@ mod test {
     use crate::plugins::cache::entity::CacheSubgraph;
     use crate::plugins::cache::metrics::CacheMetricContextKey;
     use crate::plugins::response_cache;
+    use crate::plugins::response_cache::plugin::CacheControls;
     use crate::plugins::telemetry::config::AttributeValue;
     use crate::plugins::telemetry::config_new::Selector;
     use crate::plugins::telemetry::config_new::selectors::All;
+    use crate::plugins::telemetry::config_new::selectors::CacheControlSelector;
     use crate::plugins::telemetry::config_new::selectors::CacheKind;
     use crate::plugins::telemetry::config_new::selectors::CacheStatus;
     use crate::plugins::telemetry::config_new::selectors::EntityType;
@@ -1644,6 +1676,59 @@ mod test {
                     .build(),
             ),
             Some(opentelemetry::Value::I64(2))
+        );
+    }
+
+    #[test]
+    fn response_cache_control() {
+        let mut header_map = HeaderMap::new();
+        header_map.insert(CACHE_CONTROL, HeaderValue::from_static("public,max-age=60"));
+
+        let cache_control =
+            crate::plugins::response_cache::cache_control::CacheControl::new(&header_map, None)
+                .unwrap();
+        let context = crate::context::Context::new();
+        let mut cache_controls: CacheControls = HashMap::new();
+        let subgraph_request_id = SubgraphRequestId("test".to_string());
+        cache_controls.insert(subgraph_request_id.clone(), cache_control);
+        context.extensions().with_lock(|l| l.insert(cache_controls));
+
+        let selector = SubgraphSelector::ResponseCacheControl {
+            response_cache_control: CacheControlSelector::MaxAge,
+        };
+
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .build(),
+            ),
+            None
+        );
+
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .id(subgraph_request_id.clone())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::I64(60))
+        );
+
+        let selector = SubgraphSelector::ResponseCacheControl {
+            response_cache_control: CacheControlSelector::Scope,
+        };
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .subgraph_name("test".to_string())
+                    .id(subgraph_request_id.clone())
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some(opentelemetry::Value::String("public".to_string().into()))
         );
     }
 

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -1189,6 +1189,7 @@ mod tests {
                         queries.push('\n');
                         Ok(subgraph::Response::builder()
                             .extensions(crate::json_ext::Object::new())
+                            .id(request.id)
                             .context(request.context)
                             .subgraph_name(String::default())
                             .build())

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -119,6 +119,7 @@ fn allocate_port(name: &str) -> std::io::Result<u16> {
     ))
 }
 
+#[derive(Clone)]
 pub struct Query {
     traced: bool,
     psr: Option<&'static str>,

--- a/apollo-router/tests/integration/telemetry/fixtures/response_cache.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/response_cache.router.yaml
@@ -1,0 +1,82 @@
+telemetry:
+  instrumentation:
+    instruments:
+      subgraph:
+        http.client.request.duration:
+          attributes:
+            subgraph.name: true
+            cache_control.max_age:
+              response_cache_control: max_age
+            cache_control.scope:
+              response_cache_control: scope
+  exporters:
+    metrics:
+      prometheus:
+        listen: 127.0.0.1:4000
+        enabled: true
+        path: /metrics
+override_subgraph_url:
+  products: http://localhost:4005
+include_subgraph_errors:
+  all: true
+preview_response_cache:
+  enabled: true
+  debug: true
+  invalidation:
+    listen: 127.0.0.1:4000
+    path: "/invalidation"
+  subgraph:
+    all:
+      enabled: true
+      redis:
+        urls:
+          - redis://127.0.0.1:6379
+        namespace: test_response_cache_metrics
+        pool_size: 3
+    subgraphs:
+      products:
+        enabled: true
+        ttl: 60s
+      reviews:
+        enabled: true
+        ttl: 10s
+experimental_mock_subgraphs:
+  products:
+    query:
+      topProducts:
+        - __typename: Product
+          upc: "1"
+          name: chair
+        - __typename: Product
+          upc: "2"
+          name: table
+        - __typename: Product
+          upc: "3"
+          name: plate
+    headers:
+      cache-control: public
+  reviews:
+    entities:
+      - __typename: Product
+        upc: "1"
+        reviews:
+          - __typename: Review
+            body: I can sit on it
+      - __typename: Product
+        upc: "2"
+        reviews:
+          - __typename: Review
+            body: I can sit on it
+          - __typename: Review
+            body: I can sit on it2
+      - __typename: Product
+        upc: "3"
+        reviews:
+          - __typename: Review
+            body: I can sit on it
+          - __typename: Review
+            body: I can sit on it2
+          - __typename: Review
+            body: I can sit on it3
+    headers:
+      cache-control: public

--- a/apollo-router/tests/integration/telemetry/fixtures/subgraph_auth.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/subgraph_auth.router.yaml
@@ -7,18 +7,18 @@ telemetry:
         path: /metrics
       common:
         views:
-        - name: apollo_router_http_request_duration_seconds
-          aggregation:
-            histogram:
-              buckets:
-              - 0.1
-              - 0.5
-              - 1
-              - 2
-              - 3
-              - 4
-              - 5
-              - 100
+          - name: apollo_router_http_request_duration_seconds
+            aggregation:
+              histogram:
+                buckets:
+                  - 0.1
+                  - 0.5
+                  - 1
+                  - 2
+                  - 3
+                  - 4
+                  - 5
+                  - 100
 headers:
   all:
     request:

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -1,5 +1,8 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
 use std::time::Duration;
 
+use regex::Regex;
 use serde_json::json;
 
 use crate::integration::IntegrationTest;
@@ -8,6 +11,7 @@ use crate::integration::common::graph_os_enabled;
 
 const PROMETHEUS_CONFIG: &str = include_str!("fixtures/prometheus.router.yaml");
 const SUBGRAPH_AUTH_CONFIG: &str = include_str!("fixtures/subgraph_auth.router.yaml");
+const RESPONSE_CACHE_CONFIG: &str = include_str!("fixtures/response_cache.router.yaml");
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_metrics_reloading() {
@@ -84,6 +88,62 @@ fn check_metrics_contains(metrics: &str, text: &str) {
     assert!(
         metrics.contains(text),
         "'{text}' not detected in metrics\n{metrics}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_response_cache_metrics() {
+    if !graph_os_enabled() {
+        eprintln!("test skipped");
+        return;
+    }
+    let mut router = IntegrationTest::builder()
+        .config(RESPONSE_CACHE_CONFIG)
+        .supergraph(PathBuf::from("./testing_schema.graphql"))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+    let json_query = json!({"query":"{ topProducts { name reviews { body } } }","variables":{}});
+    let query = Query::builder()
+        // .header("apollo-cache-debugging", "true")
+        .body(json_query.clone())
+        .build();
+    let (_, _resp) = router.execute_query(query.clone()).await;
+    router.execute_query(query.clone()).await;
+    // To make sure to update the TTL and it's not reflected in metrics
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    router.execute_query(query.clone()).await;
+
+    // Get Prometheus metrics.
+    let metrics_response = router.get_metrics_response().await.unwrap();
+
+    // Validate metric headers.
+    let metrics_headers = metrics_response.headers();
+    assert!(
+        "text/plain; version=0.0.4"
+            == metrics_headers
+                .get(http::header::CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap()
+    );
+    let metrics = metrics_response.text().await.unwrap();
+
+    check_metrics_contains(&metrics, r#"cache_control_scope="public""#);
+    let regexp = Regex::new(r#"cache_control_max_age="([0-9]+)""#).unwrap();
+    let captures: BTreeSet<&str> = regexp.find_iter(&metrics).map(|m| m.as_str()).collect();
+    // Checking they all have the same values to avoid computed max age
+    assert_eq!(captures.len(), 2);
+    let mut captures_iter = captures.iter();
+    assert_eq!(
+        captures_iter.next().unwrap(),
+        &"cache_control_max_age=\"10\""
+    );
+    assert_eq!(
+        captures_iter.next().unwrap(),
+        &"cache_control_max_age=\"60\""
     );
 }
 

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/selectors.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/selectors.mdx
@@ -105,7 +105,9 @@ The subgraph service executes multiple times during query execution, with each e
 | `env`                       | Yes         |                  | The name of an environment variable                                            |
 | `static`                    | No          |                  | A static string value                                                          |
 | `error`                     | No          | `reason`         | A string value containing error reason when it's a critical error              |
-| `cache`                     | No          | `hit` \| `miss`    | Returns the number of cache hit or miss for this subgraph request              |
+| `response_cache`            | No          | `hit` \| `miss`    | Returns the number of cache hit or miss for this subgraph request              |
+| `response_cache_status`    | No          | `hit` \| `partial_hit`\| `miss`\| `status`    | Indicates the cache status for the subgraph request: `hit` (all data from cache), `miss` (all data from subgraph), or `partial_hit` (some entities from cache).  |
+| `response_cache_control`    | No          | `max_age` \| `scope`\| `no_store`    | Provides data from the computed `Cache-Control` header, such as `max_age`, `scope` (`public`/`private`), or `no_store` status.  |
 
 ### HTTP Client
 

--- a/docs/source/routing/performance/caching/response-caching/observability.mdx
+++ b/docs/source/routing/performance/caching/response-caching/observability.mdx
@@ -152,6 +152,57 @@ telemetry:
                   - 0
 ```
 
+## Selectors
+
+A [_selector_](/router/configuration/telemetry/instrumentation/selectors) extracts data from the GraphOS Router's request lifecycle (pipeline) and attaches it to telemetry, such as spans, metrics, and logs. For response caching, the subgraph service provides selectors that you can use to create custom metrics or add custom attributes to your telemetry data.
+
+| Selector                    | Defaultable | Values           | Description                                                                    |
+|-----------------------------|-------------|------------------|--------------------------------------------------------------------------------|
+| `response_cache`            | No          | `hit` \| `miss`    | Returns the number of cache hit or miss for this subgraph request              |
+| `response_cache_status`    | No          | `hit` \| `partial_hit`\| `miss`\| `status`    | Indicates the cache status for the subgraph request: `hit` (all data from cache), `miss` (all data from subgraph), or `partial_hit` (some entities from cache).   |
+| `response_cache_control`    | No          | `max_age` \| `scope`\| `no_store`    | Provides data from the computed `Cache-Control` header, such as `max_age`, `scope` (`public`/`private`), or `no_store` status.  |
+
+### Example
+
+- To create a metric that tracks the computed `max-age` (TTL) at the subgraph level, create a custom instrument using the `response_cache_control` selector. For an example, see the `subgraph.response.cache_control.max_age` instrument in the following configuration.
+
+- To determine if a subgraph request was served from the cache, use the `response_cache_status` selector. Setting its value to `status` adds an attribute to the standard `http.client.request.duration` instrument that indicates a `hit`, `partial_hit`, or `miss`.
+
+```yaml title="router.yaml"
+telemetry:
+  exporters:
+    metrics:
+      common:
+        service_name: apollo-router
+        views:
+          - name: subgraph.response.cache_control.max_age # This is to make sure it will use the correct buckets for the max age histogram
+            aggregation:
+              histogram:
+                buckets: # Override default buckets configured for this histogram
+                - 10
+                - 100
+                - 1000
+                - 10000
+                - 100000
+  #highlight-start
+  instrumentation:
+    instruments:
+      subgraph:
+        http.client.request.duration:
+          attributes:
+            subgraph.name: true
+            response.cache.status: # Will be either `hit`, `partial_hit` or `miss`
+              response_cache_status: status
+        subgraph.response.cache_control.max_age:
+          value:
+            response_cache_control: max_age
+          type: histogram
+          unit: s # Seconds
+          description: A histogram of the computed TTL for a subgraph response
+  #highlight-end
+```
+
+
 ## Cache debugger
 
 The cache debugger in Apollo Sandbox helps you understand cache behavior during development.


### PR DESCRIPTION
New selector `response_cache_control` added in telemetry for subgraph service to know what's the content of the computed [`Cache-Control` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) from the subgraph response.

Example of attributes added to metrics:

```yaml
telemetry:
  exporters:
    metrics:
      common:
        service_name: apollo-router
        views:
          - name: subgraph.response.cache_control.max_age # This is to make sure it will use the correct buckets for the max age histogram
            aggregation:
              histogram:
                buckets: # Override default buckets configured for this histogram
                - 10
                - 100
                - 1000
                - 10000
                - 100000
  instrumentation:
    instruments:
      subgraph:
        subgraph.response.cache_control.max_age:
          value:
            response_cache_control: max_age
          type: histogram
          unit: s # Seconds
          description: A histogram of the computed TTL for a subgraph response
```




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.