### PR TITLE
fix(composition): Enable hints test suite and fix override validation hints

### DIFF
--- a/apollo-federation/src/error/suggestion.rs
+++ b/apollo-federation/src/error/suggestion.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use levenshtein::levenshtein;
 
 use crate::utils::human_readable;
@@ -27,19 +28,26 @@ pub(crate) fn suggestion_list(
 
 const MAX_SUGGESTIONS: usize = 5;
 
+/// Given [ A, B ], returns "Did you mean A or B?".
 /// Given [ A, B, C ], returns "Did you mean A, B, or C?".
 pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> String {
     const MESSAGE: &str = "Did you mean ";
-
+    let suggestions = suggestions
+        .into_iter()
+        .take(MAX_SUGGESTIONS)
+        .map(|s| format!("\"{s}\""))
+        .collect_vec();
+    let last_separator = if suggestions.len() > 2 {
+        Some(", or ")
+    } else {
+        Some(" or ")
+    };
     let suggestion_str = human_readable::join_strings(
-        suggestions
-            .into_iter()
-            .take(MAX_SUGGESTIONS)
-            .map(|s| format!("\"{s}\"")),
+        suggestions.iter(),
         human_readable::JoinStringsOptions {
             separator: ", ",
             first_separator: None,
-            last_separator: Some(", or "),
+            last_separator,
             output_length_limit: None,
         },
     );

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -909,7 +909,6 @@ mod override_directive_hints {
     use super::*;
 
     #[test]
-    #[ignore = "Hints for @override to be implemented in FED-555"]
     fn hint_when_from_subgraph_does_not_exist() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -943,7 +942,6 @@ mod override_directive_hints {
     }
 
     #[test]
-    #[ignore = "Hints for @override to be implemented in FED-555"]
     fn hint_when_override_directive_can_be_removed() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -977,7 +975,6 @@ mod override_directive_hints {
     }
 
     #[test]
-    #[ignore = "Hints for @override to be implemented in FED-555"]
     fn hint_overridden_field_can_be_removed() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -1012,7 +1009,6 @@ mod override_directive_hints {
     }
 
     #[test]
-    #[ignore = "Hints for @override to be implemented in FED-555"]
     fn hint_overridden_field_can_be_made_external() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -1045,7 +1041,6 @@ mod override_directive_hints {
     }
 
     #[test]
-    #[ignore = "Hints for @override to be implemented in FED-555"]
     fn hint_when_override_directive_can_be_removed_because_overridden_field_has_been_marked_external()
      {
         let subgraph1 = ServiceDefinition {
@@ -1080,7 +1075,6 @@ mod override_directive_hints {
     }
 
     #[test]
-    #[ignore = "Hints for @override to be implemented in FED-555"]
     fn hint_when_progressive_override_migration_is_in_progress() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -1117,7 +1111,6 @@ mod override_directive_hints {
     }
 
     #[test]
-    #[ignore = "Hints for @override to be implemented in FED-555"]
     fn hint_when_progressive_override_migration_is_in_progress_for_referenced_field() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -12,6 +12,7 @@ mod compose_validation;
 mod connectors;
 mod demand_control;
 mod directive_argument_merge_strategies;
+mod hints;
 // TODO: remove #[ignore] from tests once all fns called by Merger::merge() are implemented
 mod external;
 mod override_directive;


### PR DESCRIPTION
The two changes for override hints were:
- The `did_you_mean` utility now outputs "A or B" instead of "A, or B" when there are two elements
- The override collision check is updated to match [Merger.overrideConflictsWithOtherDirective](https://github.com/apollographql/federation/blob/c1549fdab489ead31520fc90cfdbcfe589122500/composition-js/src/merging/merge.ts#L1428)

<!-- start metadata -->

<!-- [FED-863] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary


[FED-863]: https://apollographql.atlassian.net/browse/FED-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ