### PR TITLE
Add test for `remove_unused_externals()` fix

### DIFF
--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -1053,8 +1053,9 @@ fn is_interface_object_used(subgraph: &Subgraph<Expanded>) -> Result<bool, Feder
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use test_log::test;
+
+    use super::*;
 
     const FEDERATION2_LINK_WITH_AUTO_EXPANDED_IMPORTS_UPGRADED: &str = r#"@link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"])"#;
 


### PR DESCRIPTION
Adding tests for a previous bug fix: [PR#8540](https://github.com/apollographql/router/pull/8540)

Confirms that `remove_unused_externals()` removes types that end up with no fields after all unused externals have been removed by using `upgrade_subgraphs_if_needed()` as a proxy.
 - Pre-upgrade shows that expanding links will maintain unused externals on a type.
 - Post-upgrade shows that the upgrade (1) removes the unused externals and (2) removes the empty type definitions afterward.

<!-- [FED-873] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- Tests added and passing[^4]
    - [x] Unit tests

[FED-873]: https://apollographql.atlassian.net/browse/FED-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ