### PR TITLE
fix(plugin/record_replay): log error instead of panic when headers contain non utf-8 characters (backport #8485)

### DIFF
--- a/.changesets/exp_rohan_b99_investigate_record_replay_plugin_utf8_handling.md
+++ b/.changesets/exp_rohan_b99_investigate_record_replay_plugin_utf8_handling.md
@@ -1,0 +1,5 @@
+### Add error to recording JSON file instead of panic when non UTF-8 characters found in header value in record/replay plugin ([PR #8485](https://github.com/apollographql/router/pull/8485))
+
+When externalizing headers in the record/replay plugin, headers with invalid values will now have their keys and the error written to an object called `header_errors` for both requests and responses instead of panicking.
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/8485

--- a/apollo-router/src/plugins/record_replay/recording.rs
+++ b/apollo-router/src/plugins/record_replay/recording.rs
@@ -44,6 +44,8 @@ pub(crate) struct RequestDetails {
     pub(crate) operation_name: Option<String>,
     pub(crate) variables: Map<ByteString, Value>,
     pub(crate) headers: HashMap<String, Vec<String>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub(crate) header_errors: HashMap<String, Vec<String>>,
     pub(crate) method: String,
     pub(crate) uri: String,
 }
@@ -52,6 +54,8 @@ pub(crate) struct RequestDetails {
 pub(crate) struct ResponseDetails {
     pub(crate) chunks: Vec<Response>,
     pub(crate) headers: HashMap<String, Vec<String>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub(crate) header_errors: HashMap<String, Vec<String>>,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION

<!-- [ROUTER-1419] -->
---

To test:
1. Create a file `router.yaml` and paste in:
``` 
plugins:
  experimental.record:
    enabled: true
    storage_path: /tmp/recordings
```
2. Run the router: `cargo run -- -s examples/graphql/local.graphql -c router.yaml`
3. Run a query that sends non-utf 8 data in a header value e.g.:
```
curl 'http://localhost:4000/' \
  -H 'content-type: application/json' \
  -H 'x-apollo-router-record: 1' \
  -H "x-test-header: $(cat /bin/ls)" \
  --data-raw $'{"query":"query { me { id } }"}'
```
5. Observe on `dev` that the router crashes due to a panic
6. Observe on this branch that the error is included in the recording JSON under `header_errors`

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #8485 done by [Mergify](https://mergify.com).

[ROUTER-1419]: https://apollographql.atlassian.net/browse/ROUTER-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ