### PR TITLE
docs: update Redis metric from connections to clients

### DIFF
--- a/docs/source/routing/performance/caching/response-caching/observability.mdx
+++ b/docs/source/routing/performance/caching/response-caching/observability.mdx
@@ -84,7 +84,7 @@ telemetry:
 The latency metrics are marked as experimental because Apollo might change them if there is an upstream change in one of our dependencies.
 
 #### Connection and performance metrics
-  - `apollo.router.cache.redis.connections`: Number of active Redis connections
+  - `apollo.router.cache.redis.clients`: Number of Redis clients active
   - `apollo.router.cache.redis.command_queue_length`: Commands waiting to be sent to Redis
   - `apollo.router.cache.redis.commands_executed`: Total number of Redis commands executed
   - `apollo.router.cache.redis.redelivery_count`: Commands retried due to connection issues


### PR DESCRIPTION
<!-- start metadata -->

<!-- No Jira ticket required - documentation fix -->
---

## Description

This PR updates the Redis cache metrics documentation to use the correct metric name `apollo.router.cache.redis.clients` instead of the deprecated `apollo.router.cache.redis.connections`.

### Motivation

The `apollo.router.cache.redis.connections` metric was replaced with `apollo.router.cache.redis.clients` in PR #8161. The observability documentation for response caching still referenced the old metric name.

### Changes

- Updated `docs/source/routing/performance/caching/response-caching/observability.mdx` to reference `apollo.router.cache.redis.clients`
- Description changed from "Number of active Redis connections" to "Number of Redis clients active" to match the standard-instruments.mdx documentation

### References

- Original metric replacement: PR #8161
- CHANGELOG entry documenting the change (line 174)

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

- **Changeset**: Not needed - documentation-only fix for already released changes
- **Metrics/logs**: Not applicable - updating existing metric documentation
- **Tests**: Not applicable - documentation change only

**Notes**

This is a straightforward documentation fix to align with the metric name change that was already implemented in the codebase.

[^1]: No compatibility concerns - documentation only
[^2]: This PR is the documentation update itself
[^3]: No new metrics - updating reference to existing metric
[^4]: Documentation changes don't require code tests