### PR TITLE
docs: add notes about OTEL environment variable precedence

### DIFF
--- a/docs/source/routing/observability/graphos/graphos-reporting.mdx
+++ b/docs/source/routing/observability/graphos/graphos-reporting.mdx
@@ -67,6 +67,12 @@ telemetry:
         sampler: 0.01
 ```
 
+<Note>
+
+If your environment defines `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, they take precedence over your Router settings and may send traces to a different destination. Verify whether these variables are set and unset them if needed. For details, see the [OTLP exporter documentation](/router/configuration/telemetry/exporters/tracing/otlp).
+
+</Note>
+
 ## Reporting field-level traces
 
 In their responses to your router, your subgraphs can include [field-level traces](/federation/metrics) that indicate how long the subgraph took to resolve each field in an operation. By analyzing this data in GraphOS Studio, you can identify and optimize your slower fields:

--- a/docs/source/routing/observability/router-telemetry-otel/telemetry-pipelines/metrics-exporters/otlp.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/telemetry-pipelines/metrics-exporters/otlp.mdx
@@ -69,6 +69,12 @@ Defaults to:
 * http://127.0.0.1:4317 for gRPC
 * http://127.0.0.1:4318 for HTTP
 
+<Note>
+
+If your environment sets `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, these variables take precedence over the `endpoint` configured in your `router.yaml`. If metrics aren't appearing at your expected endpoint, check if these environment variables are set and unset them if necessary.
+
+</Note>
+
 ### `grpc`
 
 Settings specific to the gRPC protocol for setting a custom SSL certificate, domain name, and metadata.

--- a/docs/source/routing/observability/router-telemetry-otel/telemetry-pipelines/trace-exporters/otlp.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/telemetry-pipelines/trace-exporters/otlp.mdx
@@ -65,6 +65,12 @@ Specify only the base URL in the endpoint parameter. The router automatically ad
 
 </Note>
 
+<Note>
+
+If your environment sets `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, these variables take precedence over the `endpoint` configured in your `router.yaml`. If traces aren't appearing at your expected endpoint, check if these environment variables are set and unset them if necessary.
+
+</Note>
+
 ### `grpc`
 Settings specific to the gRPC protocol for setting a custom SSL certificate, domain name, and metadata.
 


### PR DESCRIPTION
<!-- start metadata -->

<!-- Related to customer support case - environment variable precedence issue -->
---

## Description

This PR adds documentation notes about OpenTelemetry environment variables that can override the router's YAML configuration, causing traces and metrics to be sent to unintended destinations instead of the configured endpoint.

### Motivation

A customer reported that traces were not appearing in GraphOS Studio despite correct `router.yaml` configuration. Root cause: their environment automatically set `OTEL_EXPORTER_OTLP_ENDPOINT`, which took precedence over the router configuration and sent traces to their internal collector instead of GraphOS. This behavior is due to OpenTelemetry SDK versions prior to 0.29.0 giving precedence to environment variables over programmatic configuration. The current router uses OpenTelemetry SDK 0.24.1, so this issue still affects users.

### Changes

Added `<Note>` components to three documentation files warning users about this behavior:

1. **trace-exporters/otlp.mdx** - Warning about `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
2. **graphos-reporting.mdx** - Context-specific note for users trying to send traces to GraphOS Studio
3. **metrics-exporters/otlp.mdx** - Warning about `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`

### References

- CHANGELOG entry documenting the environment variable support: lines 1110-1120
- Related upstream issue: https://github.com/open-telemetry/opentelemetry-collector/issues/10952
- Current router OpenTelemetry SDK version: 0.24.1 (apollo-router/Cargo.toml line 165)

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

- **Changeset**: Not needed - documentation-only change
- **Metrics/logs**: Not applicable - updating documentation about existing environment variable behavior
- **Tests**: Not applicable - documentation changes only, no code modifications

**Notes**

This is a documentation improvement to help users troubleshoot a common configuration issue related to OpenTelemetry environment variable precedence. The environment variables mentioned (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`) are documented in the CHANGELOG as being supported but having known precedence issues.

[^1]: Documentation-only change, no compatibility concerns
[^2]: This PR is the documentation update itself
[^3]: No new metrics or logs - documenting existing environment variable behavior
[^4]: Documentation changes don't require code tests