### PR TITLE
fix(composition): Fix type compatibility check when combining list and non-null wrappers

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -2081,9 +2081,16 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
             (Type::List(inner_sub), Type::List(inner_super)) => {
                 self.is_strict_subtype(inner_super, inner_sub)
             }
-            // NonNullablePropagation and NonNullableDowngrade
-            (Type::NonNullList(inner_sub), Type::NonNullList(inner_super))
-            | (Type::NonNullList(inner_sub), Type::List(inner_super)) => {
+            // NonNullableDowngrade: [T]! is subtype of [T]
+            (Type::NonNullList(inner_sub), Type::List(inner_super)) if inner_sub == inner_super => {
+                Ok(true)
+            }
+            // NonNullablePropagation: [T]! is subtype of [U]! if T is subtype of U
+            (Type::NonNullList(inner_sub), Type::NonNullList(inner_super)) => {
+                self.is_strict_subtype(inner_super, inner_sub)
+            }
+            // NonNullablePropagation + NonNullableDowngrade: [T]! is subtype of [U] if T is subtype of U
+            (Type::NonNullList(inner_sub), Type::List(inner_super)) => {
                 self.is_strict_subtype(inner_super, inner_sub)
             }
 


### PR DESCRIPTION
When merging fields with type `[T]` and `[T]!`, we were wrongly reporting that these two types were incompatible because `T` is not a strict subtype of itself. Now, we correctly recognize that these containers are compatible if the inner type is the same for both. This resolves several wrongly reported `FIELD_TYPE_MISMATCH` errors from the merge phase.

<!-- [FED-895] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary


[FED-895]: https://apollographql.atlassian.net/browse/FED-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ