### PR TITLE
deps: remove axum-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,6 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-types",
  "axum 0.8.6",
- "axum-server",
  "base64 0.22.1",
  "blake3",
  "bloomfilter",
@@ -1245,22 +1244,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-server"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
-dependencies = [
- "bytes",
- "fs-err",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper",
- "hyper-util",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -2786,16 +2769,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "fs-err"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
-dependencies = [
- "autocfg",
- "tokio",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -53,7 +53,7 @@ telemetry_next = []
 ci = []
 
 # Enables the HTTP snapshot server for testing
-snapshot = ["axum-server"]
+snapshot = []
 
 [dependencies]
 addr2line = "0.25.0"
@@ -69,7 +69,6 @@ async-compression = { version = "0.4.6", features = [
 ] }
 async-trait.workspace = true
 axum = { version = "0.8.1", features = ["http2"] }
-axum-server = { version = "0.7.1", optional = true }
 base64 = "0.22.0"
 bloomfilter = "3.0.0"
 buildstructor = "0.6.0"
@@ -303,7 +302,6 @@ tikv-jemalloc-sys = { version = "0.6.0", features = ["profiling"] }
 
 [dev-dependencies]
 axum = { version = "0.8.1", features = ["http2", "ws"] }
-axum-server = "0.7.1"
 ctor = "0.6.0"
 ecdsa = { version = "0.16.9", features = ["signing", "pem", "pkcs8"] }
 encoding_rs.workspace = true


### PR DESCRIPTION
axum comes with a basic server implementation. axum-server allows much
more configuration, but we don't use any of it, so just `axum::serve`
will do!

`axum::serve` requires a `tokio::net::TcpListener` instead of a
`std::net::TcpListener` so some minor refactoring was required. The
public API of the snapshot server hasn't changed.

Practically this unblocks the `hyper` 1.8 upgrade, which has a breaking
change inside that's incompatible with `axum-server`.
