### PR TITLE
fix(response_cache): remove graphql.type attribute from 'apollo.router.operations.response_cache.fetch.entity' metric

### DIFF
--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -1836,7 +1836,7 @@ fn extract_cache_keys(
 
     // Get entity key to only get the right fields in representations
     let mut res = Vec::with_capacity(representations.len());
-    let mut entities = HashMap::new();
+    let entities = representations.len() as u64;
     let mut typenames = HashSet::new();
     for representation in representations {
         let representation =
@@ -1858,12 +1858,6 @@ fn extract_cache_keys(
                 reason: "__typename in representation is not a string".to_string(),
             })?;
         typenames.insert(typename.to_string());
-        match entities.get_mut(typename) {
-            Some(entity_nb) => *entity_nb += 1,
-            None => {
-                entities.insert(typename.to_string(), 1u64);
-            }
-        }
 
         // Get the entity key from `representation`, only needed in debug for the cache debugger
         let representation_entity_key = if debug {
@@ -1927,16 +1921,13 @@ fn extract_cache_keys(
         ),
     );
 
-    for (typename, entity_nb) in entities {
-        u64_histogram_with_unit!(
-            "apollo.router.operations.response_cache.fetch.entity",
-            "Number of entities per subgraph fetch node",
-            "{entity}",
-            entity_nb,
-            "subgraph.name" = subgraph_name.to_string(),
-            "graphql.type" = typename
-        );
-    }
+    u64_histogram_with_unit!(
+        "apollo.router.operations.response_cache.fetch.entity",
+        "Number of entities per subgraph fetch node",
+        "{entity}",
+        entities,
+        "subgraph.name" = subgraph_name.to_string()
+    );
 
     Ok(res)
 }

--- a/apollo-router/src/plugins/response_cache/tests.rs
+++ b/apollo-router/src/plugins/response_cache/tests.rs
@@ -2920,7 +2920,7 @@ async fn invalidate_by_cache_tag() {
           }
         }
         "#);
-        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 1u64, "subgraph.name" = "orga", "graphql.type" = "Organization");
+        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 1u64, "subgraph.name" = "orga");
 
         // Now testing without any mock subgraphs, all the data should come from the cache
         wait_for_cache(&storage, expected_cached_keys(&cache_keys)).await;
@@ -2950,7 +2950,7 @@ async fn invalidate_by_cache_tag() {
         assert!(cache_control_contains_public(&cache_control_header));
         let mut response = response.next_response().await.unwrap();
         assert!(remove_debug_extensions_key(&mut response));
-        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 2u64, "subgraph.name" = "orga", "graphql.type" = "Organization");
+        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 2u64, "subgraph.name" = "orga");
 
         insta::assert_json_snapshot!(response, @r#"
         {
@@ -3022,7 +3022,7 @@ async fn invalidate_by_cache_tag() {
           }
         }
         "#);
-        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 3u64, "subgraph.name" = "orga", "graphql.type" = "Organization");
+        assert_histogram_sum!("apollo.router.operations.response_cache.fetch.entity", 3u64, "subgraph.name" = "orga");
     }.with_metrics().await;
 }
 


### PR DESCRIPTION
Remove `graphql.type` attribute from `apollo.router.operations.response_cache.fetch.entity` metric to avoid potential high cardinality issue.

<!-- [ROUTER-1543] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1543]: https://apollographql.atlassian.net/browse/ROUTER-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ