### PR TITLE
Revert "Ensure datadog propagator is exclusively active (#8514)" (backport #8654)

### DIFF
--- a/.changesets/maint_rohan_b99_datadog_propagator_must_be_exclusively_active.md
+++ b/.changesets/maint_rohan_b99_datadog_propagator_must_be_exclusively_active.md
@@ -1,7 +1,0 @@
-### Ensure datadog propagator is exclusively active ([PR #8514](https://github.com/apollographql/router/pull/8514))
-
-Adds validation for propagator configuration, ensuring that:
-- If the datadog propagator is enabled, no other propagators can be enabled (except baggage)
-- If datadog tracing is enabled and other propagators are enabled, the datadog one must be disabled
-
-By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/8514

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -7366,12 +7366,9 @@ expression: "&schema"
           "type": "boolean"
         },
         "datadog": {
-          "default": null,
+          "default": false,
           "description": "Propagate Datadog",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": "boolean"
         },
         "jaeger": {
           "default": false,

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -225,32 +225,6 @@ pub(crate) struct Tracing {
     pub(crate) datadog: tracing::datadog::Config,
 }
 
-impl Tracing {
-    pub(crate) fn is_baggage_propagation_enabled(&self) -> bool {
-        self.propagation.baggage
-    }
-
-    pub(crate) fn is_trace_context_propagation_enabled(&self) -> bool {
-        self.propagation.trace_context || self.otlp.enabled
-    }
-
-    pub(crate) fn is_jaeger_propagation_enabled(&self) -> bool {
-        self.propagation.jaeger
-    }
-
-    pub(crate) fn is_datadog_propagation_enabled(&self) -> bool {
-        self.propagation.datadog.unwrap_or(false) || self.datadog.enabled
-    }
-
-    pub(crate) fn is_zipkin_propagation_enabled(&self) -> bool {
-        self.propagation.zipkin || self.zipkin.enabled
-    }
-
-    pub(crate) fn is_aws_xray_propagation_enabled(&self) -> bool {
-        self.propagation.aws_xray
-    }
-}
-
 #[derive(Clone, Default, Debug, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct ExposeTraceId {
@@ -340,7 +314,7 @@ pub(crate) struct Propagation {
     /// Propagate Jaeger
     pub(crate) jaeger: bool,
     /// Propagate Datadog
-    pub(crate) datadog: Option<bool>,
+    pub(crate) datadog: bool,
     /// Propagate Zipkin
     pub(crate) zipkin: bool,
     /// Propagate AWS X-Ray

--- a/apollo-router/src/plugins/telemetry/reload/builder.rs
+++ b/apollo-router/src/plugins/telemetry/reload/builder.rs
@@ -85,7 +85,7 @@ impl<'a> Builder<'a> {
             self.setup_public_tracing()?;
             self.setup_public_metrics()?;
             self.setup_apollo_metrics()?;
-            self.setup_propagation()?;
+            self.setup_propagation();
             Ok((self.activation, self.endpoints, self.apollo_sender))
         })
     }
@@ -206,13 +206,12 @@ impl<'a> Builder<'a> {
             || previous_config.exporters.tracing.common != self.config.exporters.tracing.common
     }
 
-    fn setup_propagation(&mut self) -> Result<(), BoxError> {
+    fn setup_propagation(&mut self) {
         let propagators = create_propagator(
             &self.config.exporters.tracing.propagation,
             &self.config.exporters.tracing,
-        )?;
+        );
         self.activation.with_tracer_propagator(propagators);
-        Ok(())
     }
 
     fn setup_logging(&mut self) {
@@ -246,7 +245,6 @@ mod tests {
     use crate::plugins::telemetry::config::Exporters;
     use crate::plugins::telemetry::config::Instrumentation;
     use crate::plugins::telemetry::config::Metrics;
-    use crate::plugins::telemetry::config::Propagation;
     use crate::plugins::telemetry::config::Tracing;
 
     fn create_default_config() -> Conf {
@@ -626,244 +624,6 @@ mod tests {
         assert!(
             instr.tracer_provider_set,
             "Tracer provider should reload when span limits change"
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_propagation_only_passes() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert!(builder.build().is_ok());
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_with_baggage_propagation_passes() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            baggage: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert!(builder.build().is_ok());
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_jaeger_propagation_only_passes() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.propagation = Propagation {
-            jaeger: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert!(builder.build().is_ok());
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_with_jaeger_propagation_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            jaeger: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "datadog propagation cannot be used with any other propagator except for baggage",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_with_trace_context_propagation_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            trace_context: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "datadog propagation cannot be used with any other propagator except for baggage",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_with_zipkin_propagation_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            zipkin: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "datadog propagation cannot be used with any other propagator except for baggage",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_with_aws_xray_propagation_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            aws_xray: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "datadog propagation cannot be used with any other propagator except for baggage",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_datadog_propagation_only_passes() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert!(builder.build().is_ok());
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_datadog_baggage_propagation_passes() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            baggage: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert!(builder.build().is_ok());
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_jaeger_propagation_only_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.propagation = Propagation {
-            jaeger: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "datadog propagation must be explicitly disabled if the datadog exporter is enabled and any propagator other than baggage is enabled",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_datadog_jaeger_propagation_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            jaeger: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "if the datadog exporter is enabled and any other propagator is enabled, the datadog propagator must be disabled",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_datadog_trace_context_propagation_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            trace_context: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "if the datadog exporter is enabled and any other propagator is enabled, the datadog propagator must be disabled",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_datadog_zipkin_propagation_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            zipkin: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "if the datadog exporter is enabled and any other propagator is enabled, the datadog propagator must be disabled",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_datadog_aws_xray_propagation_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.propagation = Propagation {
-            datadog: Some(true),
-            aws_xray: true,
-            ..Default::default()
-        };
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "if the datadog exporter is enabled and any other propagator is enabled, the datadog propagator must be disabled",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_otlp_exporter_enabled_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.otlp.enabled = true;
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "datadog propagation must be explicitly disabled if the datadog exporter is enabled and any propagator other than baggage is enabled",
-            builder.build().err().unwrap().to_string()
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_datadog_exporter_enabled_with_zipkin_exporter_enabled_fails() {
-        let mut config = create_config_with_apollo_enabled();
-        config.exporters.tracing.datadog.enabled = true;
-        config.exporters.tracing.zipkin.enabled = true;
-
-        let builder = Builder::new(&None, &config);
-        assert_eq!(
-            "datadog propagation must be explicitly disabled if the datadog exporter is enabled and any propagator other than baggage is enabled",
-            builder.build().err().unwrap().to_string()
         );
     }
 }

--- a/apollo-router/tests/integration/telemetry/otlp/tracing.rs
+++ b/apollo-router/tests/integration/telemetry/otlp/tracing.rs
@@ -192,12 +192,12 @@ async fn test_otlp_request_with_datadog_propagator() -> Result<(), BoxError> {
     if !graph_os_enabled() {
         panic!("Error: test skipped because GraphOS is not enabled");
     }
-    let mock_server_uri = "http://will-never-be-used.local";
+    let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_propagation.router.yaml")
-        .replace("<otel-collector-endpoint>", mock_server_uri);
+        .replace("<otel-collector-endpoint>", &mock_server.uri());
     let mut router = IntegrationTest::builder()
         .telemetry(Telemetry::Otlp {
-            endpoint: Some(format!("{}/v1/traces", mock_server_uri)),
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
         })
         .extra_propagator(Telemetry::Datadog)
         .config(&config)
@@ -205,8 +205,16 @@ async fn test_otlp_request_with_datadog_propagator() -> Result<(), BoxError> {
         .await;
 
     router.start().await;
-    router.wait_for_log_message("could not create router: datadog propagation cannot be used with any other propagator except for baggage").await;
+    router.assert_started().await;
 
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(&mut router, &mock_server, Query::default())
+        .await?;
+    router.graceful_shutdown().await;
     Ok(())
 }
 
@@ -215,20 +223,31 @@ async fn test_otlp_request_with_datadog_propagator_no_agent() -> Result<(), BoxE
     if !graph_os_enabled() {
         panic!("Error: test skipped because GraphOS is not enabled");
     }
-    let mock_server_uri = "http://will-never-be-used.local";
+    let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_propagation_no_agent.router.yaml")
-        .replace("<otel-collector-endpoint>", mock_server_uri);
+        .replace("<otel-collector-endpoint>", &mock_server.uri());
     let mut router = IntegrationTest::builder()
         .telemetry(Telemetry::Otlp {
-            endpoint: Some(format!("{}/v1/traces", mock_server_uri)),
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
         })
         .config(&config)
         .build()
         .await;
 
     router.start().await;
-    router.wait_for_log_message("could not create router: datadog propagation cannot be used with any other propagator except for baggage").await;
+    router.assert_started().await;
 
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).build(),
+        )
+        .await?;
+    router.graceful_shutdown().await;
     Ok(())
 }
 
@@ -238,13 +257,13 @@ async fn test_otlp_request_with_zipkin_trace_context_propagator_with_datadog()
     if !graph_os_enabled() {
         panic!("Error: test skipped because GraphOS is not enabled");
     }
-    let mock_server_uri = "http://will-never-be-used.local";
+    let mock_server = mock_otlp_server(1..).await;
     let config =
         include_str!("../fixtures/otlp_datadog_request_with_zipkin_propagator.router.yaml")
-            .replace("<otel-collector-endpoint>", mock_server_uri);
+            .replace("<otel-collector-endpoint>", &mock_server.uri());
     let mut router = IntegrationTest::builder()
         .telemetry(Telemetry::Otlp {
-            endpoint: Some(format!("{}/v1/traces", mock_server_uri)),
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
         })
         .extra_propagator(Telemetry::Datadog)
         .config(&config)
@@ -252,8 +271,105 @@ async fn test_otlp_request_with_zipkin_trace_context_propagator_with_datadog()
         .await;
 
     router.start().await;
-    router.wait_for_log_message("could not create router: datadog propagation cannot be used with any other propagator except for baggage").await;
+    router.assert_started().await;
 
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).build(),
+        )
+        .await?;
+    // ---------------------- zipkin propagator with unsampled trace
+    // Testing for an unsampled trace, so it should be sent to the otlp exporter with sampling priority set 0
+    // But it shouldn't send the trace to subgraph as the trace is originally not sampled, the main goal is to measure it at the DD agent level
+    TraceSpec::builder()
+        .services(["router"].into())
+        .priority_sampled("0")
+        .subgraph_sampled(false)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder()
+                .traced(false)
+                .header("X-B3-TraceId", "80f198ee56343ba864fe8b2a57d3eff7")
+                .header("X-B3-ParentSpanId", "05e3ac9a4f6e3b90")
+                .header("X-B3-SpanId", "e457b5a2e4d86bd1")
+                .header("X-B3-Sampled", "0")
+                .build(),
+        )
+        .await?;
+    // ---------------------- trace context propagation
+    // Testing for a trace containing the right tracestate with m and psr for DD and a sampled trace, so it should be sent to the otlp exporter with sampling priority set to 1
+    // And it should also send the trace to subgraph as the trace is sampled
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder()
+                .traced(true)
+                .header(
+                    "traceparent",
+                    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                )
+                .header("tracestate", "m=1,psr=1")
+                .build(),
+        )
+        .await?;
+    // ----------------------
+    // Testing for a trace containing the right tracestate with m and psr for DD and an unsampled trace, so it should be sent to the otlp exporter with sampling priority set to 0
+    // But it shouldn't send the trace to subgraph as the trace is originally not sampled, the main goal is to measure it at the DD agent level
+    TraceSpec::builder()
+        .services(["router"].into())
+        .priority_sampled("0")
+        .subgraph_sampled(false)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder()
+                .traced(false)
+                .header(
+                    "traceparent",
+                    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-02",
+                )
+                .header("tracestate", "m=1,psr=0")
+                .build(),
+        )
+        .await?;
+    // ----------------------
+    // Testing for a trace containing a tracestate m and psr with psr set to 1 for DD and an unsampled trace, so it should be sent to the otlp exporter with sampling priority set to 1
+    // It should not send the trace to the subgraph as we didn't use the datadog propagator and therefore the trace will remain unsampled.
+    TraceSpec::builder()
+        .services(["router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder()
+                .traced(false)
+                .header(
+                    "traceparent",
+                    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03",
+                )
+                .header("tracestate", "m=1,psr=1")
+                .build(),
+        )
+        .await?;
+
+    // Be careful if you add the same kind of test crafting your own trace id, make sure to increment the previous trace id by 1 if not you'll receive all the previous spans tested with the same trace id before
+    router.graceful_shutdown().await;
     Ok(())
 }
 
@@ -262,21 +378,33 @@ async fn test_untraced_request_no_sample_datadog_agent() -> Result<(), BoxError>
     if !graph_os_enabled() {
         panic!("Error: test skipped because GraphOS is not enabled");
     }
-    let mock_server_uri = "http://will-never-be-used.local";
+    let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_agent_no_sample.router.yaml")
-        .replace("<otel-collector-endpoint>", mock_server_uri);
+        .replace("<otel-collector-endpoint>", &mock_server.uri());
     let mut router = IntegrationTest::builder()
         .config(&config)
         .telemetry(Telemetry::Otlp {
-            endpoint: Some(format!("{}/v1/traces", mock_server_uri)),
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
         })
         .extra_propagator(Telemetry::Datadog)
         .build()
         .await;
 
     router.start().await;
-    router.wait_for_log_message("could not create router: datadog propagation cannot be used with any other propagator except for baggage").await;
+    router.assert_started().await;
 
+    TraceSpec::builder()
+        .services(["router"].into())
+        .priority_sampled("0")
+        .subgraph_sampled(false)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(false).build(),
+        )
+        .await?;
+    router.graceful_shutdown().await;
     Ok(())
 }
 
@@ -285,21 +413,33 @@ async fn test_untraced_request_sample_datadog_agent() -> Result<(), BoxError> {
     if !graph_os_enabled() {
         panic!("Error: test skipped because GraphOS is not enabled");
     }
-    let mock_server_uri = "http://will-never-be-used.local";
+    let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_agent_sample.router.yaml")
-        .replace("<otel-collector-endpoint>", mock_server_uri);
+        .replace("<otel-collector-endpoint>", &mock_server.uri());
     let mut router = IntegrationTest::builder()
         .config(&config)
         .telemetry(Telemetry::Otlp {
-            endpoint: Some(format!("{}/v1/traces", mock_server_uri)),
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
         })
         .extra_propagator(Telemetry::Datadog)
         .build()
         .await;
 
     router.start().await;
-    router.wait_for_log_message("could not create router: datadog propagation cannot be used with any other propagator except for baggage").await;
+    router.assert_started().await;
 
+    TraceSpec::builder()
+        .services(["router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(false).build(),
+        )
+        .await?;
+    router.graceful_shutdown().await;
     Ok(())
 }
 
@@ -308,12 +448,12 @@ async fn test_untraced_request_sample_datadog_agent_unsampled() -> Result<(), Bo
     if !graph_os_enabled() {
         panic!("Error: test skipped because GraphOS is not enabled");
     }
-    let mock_server_uri = "http://will-never-be-used.local";
+    let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_agent_sample_no_sample.router.yaml")
-        .replace("<otel-collector-endpoint>", mock_server_uri);
+        .replace("<otel-collector-endpoint>", &mock_server.uri());
     let mut router = IntegrationTest::builder()
         .telemetry(Telemetry::Otlp {
-            endpoint: Some(format!("{}/v1/traces", mock_server_uri)),
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
         })
         .extra_propagator(Telemetry::Datadog)
         .config(&config)
@@ -321,8 +461,20 @@ async fn test_untraced_request_sample_datadog_agent_unsampled() -> Result<(), Bo
         .await;
 
     router.start().await;
-    router.wait_for_log_message("could not create router: datadog propagation cannot be used with any other propagator except for baggage").await;
+    router.assert_started().await;
 
+    TraceSpec::builder()
+        .services(["router"].into())
+        .priority_sampled("0")
+        .subgraph_sampled(false)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(false).build(),
+        )
+        .await?;
+    router.graceful_shutdown().await;
     Ok(())
 }
 
@@ -331,13 +483,13 @@ async fn test_priority_sampling_propagated() -> Result<(), BoxError> {
     if !graph_os_enabled() {
         panic!("Error: test skipped because GraphOS is not enabled");
     }
-    let mock_server_uri = "http://will-never-be-used.local";
+    let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_propagation.router.yaml")
-        .replace("<otel-collector-endpoint>", mock_server_uri);
+        .replace("<otel-collector-endpoint>", &mock_server.uri());
     let mut router = IntegrationTest::builder()
         // We're using datadog propagation as this is what we are trying to test.
         .telemetry(Telemetry::Otlp {
-            endpoint: Some(format!("{}/v1/traces", mock_server_uri)),
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
         })
         .extra_propagator(Telemetry::Datadog)
         .config(config)
@@ -345,7 +497,68 @@ async fn test_priority_sampling_propagated() -> Result<(), BoxError> {
         .await;
 
     router.start().await;
-    router.wait_for_log_message("could not create router: datadog propagation cannot be used with any other propagator except for baggage").await;
+    router.assert_started().await;
+
+    // Parent based sampling. psr MUST be populated with the value that we pass in.
+    TraceSpec::builder()
+        .services(["client", "router"].into())
+        .priority_sampled("-1")
+        .subgraph_sampled(false)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).psr("-1").build(),
+        )
+        .await?;
+    TraceSpec::builder()
+        .services(["client", "router"].into())
+        .priority_sampled("0")
+        .subgraph_sampled(false)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).psr("0").build(),
+        )
+        .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).psr("1").build(),
+        )
+        .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("2")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).psr("2").build(),
+        )
+        .await?;
+
+    // No psr was passed in the router is free to set it. This will be 1 as we are going to sample here.
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).build(),
+        )
+        .await?;
+
+    router.graceful_shutdown().await;
 
     Ok(())
 }
@@ -451,12 +664,12 @@ async fn test_priority_sampling_no_parent_propagated() -> Result<(), BoxError> {
     if !graph_os_enabled() {
         return Ok(());
     }
-    let mock_server_uri = "http://will-never-be-used.local";
+    let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_propagation_no_parent_sampler.router.yaml")
-        .replace("<otel-collector-endpoint>", mock_server_uri);
+        .replace("<otel-collector-endpoint>", &mock_server.uri());
     let mut router = IntegrationTest::builder()
         .telemetry(Telemetry::Otlp {
-            endpoint: Some(format!("{}/v1/traces", mock_server_uri)),
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
         })
         .extra_propagator(Telemetry::Datadog)
         .config(config)
@@ -464,7 +677,68 @@ async fn test_priority_sampling_no_parent_propagated() -> Result<(), BoxError> {
         .await;
 
     router.start().await;
-    router.wait_for_log_message("could not create router: datadog propagation cannot be used with any other propagator except for baggage").await;
+    router.assert_started().await;
+
+    // The router will ignore the upstream PSR as parent based sampling is disabled.
+
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).psr("-1").build(),
+        )
+        .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).psr("0").build(),
+        )
+        .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).psr("1").build(),
+        )
+        .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).psr("2").build(),
+        )
+        .await?;
+
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .priority_sampled("1")
+        .subgraph_sampled(true)
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).build(),
+        )
+        .await?;
+
+    router.graceful_shutdown().await;
 
     Ok(())
 }

--- a/docs/source/routing/observability/router-telemetry-otel/telemetry-pipelines/trace-exporters/overview.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/telemetry-pipelines/trace-exporters/overview.mdx
@@ -183,12 +183,6 @@ telemetry:
            format: uuid
 ```
 
-<Note>
-
-You can't use Datadog propagation and other propagation types (except baggage) at the same time. Datadog uses a 64-bit trace ID format while other types use a 128-bit format, which causes conflicts in trace ID handling. If you attempt to enable both, the router returns a configuration error at startup. 
-
-</Note>
-
 #### `request` configuration reference
 
 | Option        | Values                                                        | Default                           | Description                         |


### PR DESCRIPTION
This reverts commit c1337db246d13059d4d1901f64c46ee8c40e8249 due to a bug in OTLP + datadog configuration<hr>This is an automatic backport of pull request #8654 done by [Mergify](https://mergify.com).