### PR TITLE
[REG-1601] Hot-reloading with graph artifact tag

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -49,6 +49,7 @@ pub(crate) static APOLLO_TELEMETRY_DISABLED: AtomicBool = AtomicBool::new(false)
 pub(crate) static APOLLO_ROUTER_LISTEN_ADDRESS: Mutex<Option<SocketAddr>> = Mutex::new(None);
 
 const INITIAL_UPLINK_POLL_INTERVAL: Duration = Duration::from_secs(10);
+const INITIAL_OCI_POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Subcommands
 #[derive(Subcommand, Debug)]
@@ -248,15 +249,18 @@ impl Opt {
                     .clone()
                     .ok_or(Self::err_require_opt("APOLLO_GRAPH_ARTIFACT_REFERENCE"))?,
             )?,
+            poll_interval: INITIAL_OCI_POLL_INTERVAL,
         })
     }
 
     pub fn validate_oci_reference(reference: &str) -> std::result::Result<String, anyhow::Error> {
-        // Currently only shas are allowed to be passed as graph artifact references
-        // TODO Update when tag reloading is implemented
-        let valid_regex = Regex::new(r"@sha256:[0-9a-fA-F]{64}$").unwrap();
-        if valid_regex.is_match(reference) {
-            tracing::debug!("validated OCI configuration");
+        tracing::debug!("validating reference: {}", reference.to_string());
+        // Accepts both SHA256 digest and tag format
+        let sha256_regex =
+            Regex::new(r"^[\w.-]+(?::\d+)?(?:/[\w.-]+)+@sha256:[0-9a-fA-F]{64}$").unwrap();
+        let tag_regex = Regex::new(r"^[\w.-]+(?::\d+)?(?:/[\w.-]+)+:[\w][\w.-]{0,127}$").unwrap();
+        if sha256_regex.is_match(reference) || tag_regex.is_match(reference) {
+            tracing::debug!("validated OCI configuration: {}", reference.to_string());
             Ok(reference.to_string())
         } else {
             Err(anyhow!("invalid graph artifact reference: {reference}"))
@@ -826,11 +830,25 @@ mod tests {
     fn test_validate_oci_reference_valid_cases() {
         // Test valid OCI references with different hash values
         let valid_hashes = vec![
-            "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            "@sha256:ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890",
-            "@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-            "@sha256:0000000000000000000000000000000000000000000000000000000000000000",
-            "@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "artifact.api.apollographql.com/summit-demo-test-4df260ae9be61e7a@sha256:142067152bd8e2c1411c87ef872cb27d2d5053f55a5a70b00068c5789dc27682",
+            "registry.example.com/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "docker.io/library/ubuntu@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "ghcr.io/org/project@sha256:1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd",
+            "registry.example.com/repo/image@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "my.custom.registry:5000/team/app@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "us.gcr.io/project/image@sha256:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+            "artifact.api.apollographql.com/summit-demo-test-4df260ae9be61e7a:test-9f86d081884c7d65",
+            "registry.example.com/alpine:latest",
+            "docker.io/library/ubuntu:22.04",
+            "ghcr.io/org/project:v1.2.3",
+            "my.custom.registry:5000/app/service:prod-build.1",
+            "registry.example.com/ns/image:dev",
+            "us.gcr.io/project/api:v0.0.0-alpha",
+            "quay.io/org/myapp:release-2025",
+            "registry.example.com/x/y:z",
+            "registry.example.com/app:LATEST",
+            "registry.example.com/app:ProdBuild",
+            "registry.example.com/app:RC_1",
         ];
 
         for hash in valid_hashes {
@@ -844,35 +862,59 @@ mod tests {
     fn test_validate_oci_reference_invalid_cases() {
         let invalid_references = vec![
             // Missing @sha256: prefix
-            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "artifact.api.apollographql.com/summit-demo-test-4df21234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
             // Wrong prefix
-            "@sha1:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            "@sha512:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha1:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha512:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
             // Too short
-            "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcde",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcde",
             // Too long
-            "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1",
             // Invalid characters
-            "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeg",
-            "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcde!",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeg",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcde!",
             // Empty string
             "",
             // Just the prefix
-            "@sha256:",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:",
             // Hash with spaces
-            "@sha256: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef ",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef ",
             // Hash with dashes
-            "@sha256:12345678-90abcdef-12345678-90abcdef-12345678-90abcdef-12345678-90abcdef",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:12345678-90abcdef-12345678-90abcdef-12345678-90abcdef-12345678-90abcdef",
             // Hash with colons
-            "@sha256:12345678:90abcdef:12345678:90abcdef:12345678:90abcdef:12345678:90abcdef",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:12345678:90abcdef:12345678:90abcdef:12345678:90abcdef:12345678:90abcdef",
             // Missing hash entirely
-            "@sha256",
-            // Wrong format entirely
-            "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256",
             // Extra characters at the end
-            "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef:latest",
-            "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef@tag",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef:latest",
+            "artifact.api.apollographql.com/summit-demo-test-4df2@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef@tag",
+            // no image name
+            "registry.example.com/@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "registry.example.com//@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            // tag begins with invalid character
+            "registry.example.com/app:-latest",
+            "registry.example.com/app:.123",
+            "registry.example.com/app:!boom",
+            "registry.example.com/app: latest",
+            // tag contains invalid chars
+            "registry.example.com/app:my tag",      // spaces
+            "registry.example.com/app:ver#1",       // # not allowed
+            "registry.example.com/app:hello/world", // / not allowed
+            "registry.example.com/app:alpha@beta",  // @ not allowed
+            "registry.example.com/app:tag?test",    // ? not allowed
+            // missing tag after colon
+            "registry.example.com/app:",
+            "registry.example.com/app::",
+            "registry.example.com/app:",
+            // tag exceeds chars
+            "registry.example.com/app:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            // missing image name
+            "registry.example.com/:latest",
+            "registry.example.com:latest",
+            "registry.example.com/app@sha1:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "registry.example.com/app@shaXYZ:abcd",
+            "registry.example.com/app@sha256:ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
         ];
 
         for reference in invalid_references {

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -1,7 +1,10 @@
 use std::string::FromUtf8Error;
+use std::time::Duration;
 
 use docker_credential::CredentialRetrievalError;
 use docker_credential::DockerCredential;
+use futures::Stream;
+use futures::StreamExt;
 use oci_client::Client;
 use oci_client::Reference;
 use oci_client::client::ClientConfig;
@@ -9,6 +12,11 @@ use oci_client::client::ClientProtocol;
 use oci_client::errors::OciDistributionError;
 use oci_client::secrets::RegistryAuth;
 use thiserror::Error;
+use tokio::sync::mpsc::channel;
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::instrument::WithSubscriber;
+
+use crate::uplink::schema::SchemaState;
 
 /// Configuration for fetching an OCI Bundle
 /// This struct does not change on router reloads - they are all sourced from CLI options.
@@ -19,6 +27,9 @@ pub struct OciConfig {
 
     /// OCI Compliant URL pointing to the release bundle
     pub reference: String,
+
+    /// The duration between polling
+    pub poll_interval: Duration,
 }
 
 #[derive(Debug, Clone)]
@@ -134,8 +145,24 @@ async fn infer_oci_protocol(registry: &str) -> ClientProtocol {
     }
 }
 
+/// Fetch just the manifest digest without fetching the full manifest
+pub(crate) async fn fetch_oci_manifest_digest(oci_config: &OciConfig) -> Result<String, OciError> {
+    let reference: Reference = oci_config.reference.as_str().parse()?;
+    let auth = build_auth(&reference, &oci_config.apollo_key);
+    let protocol = infer_oci_protocol(reference.resolve_registry()).await;
+
+    let client = Client::new(ClientConfig {
+        protocol,
+        ..Default::default()
+    });
+
+    let digest = client.fetch_manifest_digest(&reference, &auth).await?;
+
+    Ok(digest)
+}
+
 /// Fetch an OCI bundle
-pub(crate) async fn fetch_oci(oci_config: OciConfig) -> Result<OciContent, OciError> {
+pub(crate) async fn fetch_oci(oci_config: &OciConfig) -> Result<OciContent, OciError> {
     let reference: Reference = oci_config.reference.as_str().parse()?;
     let auth = build_auth(&reference, &oci_config.apollo_key);
     let protocol = infer_oci_protocol(reference.registry()).await;
@@ -157,8 +184,78 @@ pub(crate) async fn fetch_oci(oci_config: OciConfig) -> Result<OciContent, OciEr
     .await
 }
 
+/// Regularly fetch from OCI registry at the configured polling interval
+pub(crate) fn stream_from_oci(
+    oci_config: OciConfig,
+) -> impl Stream<Item = Result<SchemaState, OciError>> {
+    let (sender, receiver) = channel(2);
+
+    let task = async move {
+        let mut last_digest: Option<String> = None;
+        loop {
+            match fetch_oci_manifest_digest(&oci_config).await {
+                Ok(current_digest) => {
+                    if last_digest.as_deref() == Some(current_digest.as_str()) {
+                        // Digest unchanged, skip fetching the full schema
+                        tracing::debug!("oci manifest digest unchanged, skipping schema fetch");
+                    } else {
+                        // Digest changed, fetch the full schema
+                        tracing::debug!("oci manifest digest changed, fetching schema");
+                        last_digest = Some(current_digest);
+
+                        match fetch_oci(&oci_config).await {
+                            Ok(oci_result) => {
+                                tracing::debug!("fetched schema from oci registry");
+                                let schema_state = SchemaState {
+                                    sdl: oci_result.schema,
+                                    launch_id: None, //TODO: Add launch_id
+                                };
+                                if let Err(e) = sender.send(Ok(schema_state)).await {
+                                    tracing::debug!(
+                                        "failed to push to stream. This is likely to be because the router is shutting down: {e}"
+                                    );
+                                    break;
+                                }
+                            }
+                            Err(err) => {
+                                tracing::error!("error fetching schema from oci registry: {}", err);
+                                if let Err(e) = sender.send(Err(err)).await {
+                                    tracing::debug!(
+                                        "failed to send error to oci stream. This is likely to be because the router is shutting down: {e}"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    tracing::error!("error fetching manifest digest from oci registry: {}", err);
+                    if let Err(e) = sender.send(Err(err)).await {
+                        tracing::debug!(
+                            "failed to send error to oci stream. This is likely to be because the router is shutting down: {e}"
+                        );
+                        break;
+                    }
+                }
+            }
+
+            tokio::time::sleep(oci_config.poll_interval).await;
+        }
+    };
+    drop(tokio::task::spawn(task.with_current_subscriber()));
+
+    ReceiverStream::new(receiver).boxed()
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use futures::StreamExt;
     use futures::future::join_all;
     use oci_client::client::ClientConfig;
     use oci_client::client::ClientProtocol;
@@ -168,15 +265,108 @@ mod tests {
     use oci_client::manifest::OciDescriptor;
     use oci_client::manifest::OciImageManifest;
     use oci_client::manifest::OciManifest;
+    use parking_lot::Mutex;
+    use sha2::Digest;
+    use sha2::Sha256;
+    use tokio::time::timeout;
     use url::Url;
     use wiremock::Mock;
     use wiremock::MockServer;
+    use wiremock::Request;
+    use wiremock::Respond;
     use wiremock::ResponseTemplate;
     use wiremock::matchers::method;
     use wiremock::matchers::path;
 
     use super::*;
     use crate::registry::OciError::LayerMissingTitle;
+
+    fn calculate_manifest_digest(manifest: &OciManifest) -> String {
+        let manifest_bytes = serde_json::to_vec(manifest).unwrap();
+        let hash = Sha256::digest(&manifest_bytes);
+        format!("sha256:{:x}", hash)
+    }
+
+    fn mock_oci_config_with_reference(reference: String) -> OciConfig {
+        OciConfig {
+            apollo_key: "test-api-key".to_string(),
+            reference,
+            poll_interval: Duration::from_millis(10),
+        }
+    }
+
+    struct SchemaLayerManifest {
+        oci_manifest: OciManifest,
+        manifest_digest: String,
+        blob_digest: String,
+        schema_data: Vec<u8>,
+    }
+
+    fn create_manifest_from_schema_layer(schema_data: &str) -> SchemaLayerManifest {
+        let schema_layer = ImageLayer {
+            data: schema_data.to_string().into_bytes(),
+            media_type: APOLLO_SCHEMA_MEDIA_TYPE.to_string(),
+            annotations: None,
+        };
+        let blob_digest = schema_layer.sha256_digest();
+        let oci_manifest = OciManifest::Image(OciImageManifest {
+            schema_version: 2,
+            media_type: Some(IMAGE_MANIFEST_MEDIA_TYPE.to_string()),
+            config: Default::default(),
+            layers: vec![OciDescriptor {
+                media_type: schema_layer.media_type.clone(),
+                digest: blob_digest.clone(),
+                size: schema_layer.data.len().try_into().unwrap(),
+                urls: None,
+                annotations: None,
+            }],
+            subject: None,
+            artifact_type: None,
+            annotations: None,
+        });
+        let manifest_digest = calculate_manifest_digest(&oci_manifest);
+        SchemaLayerManifest {
+            oci_manifest,
+            manifest_digest,
+            blob_digest,
+            schema_data: schema_layer.data,
+        }
+    }
+
+    struct SequentialManifestDigests {
+        digests: Mutex<VecDeque<String>>,
+    }
+
+    impl Respond for SequentialManifestDigests {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            let digest = self
+                .digests
+                .lock()
+                .pop_front()
+                .expect("should have enough digests");
+            ResponseTemplate::new(200)
+                .append_header("Docker-Content-Digest", digest)
+                .append_header(http::header::CONTENT_TYPE, OCI_IMAGE_MEDIA_TYPE)
+        }
+    }
+
+    struct SequentialManifests {
+        manifests: Mutex<VecDeque<(String, Vec<u8>)>>,
+    }
+
+    impl Respond for SequentialManifests {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            let (digest, body) = self
+                .manifests
+                .lock()
+                .pop_front()
+                .expect("should have enough manifests");
+            ResponseTemplate::new(200)
+                .append_header("Docker-Content-Digest", digest)
+                .append_header(http::header::CONTENT_TYPE, OCI_IMAGE_MEDIA_TYPE)
+                .set_body_bytes(body)
+        }
+    }
 
     #[test]
     fn test_build_auth_apollo_registry() {
@@ -262,10 +452,25 @@ mod tests {
             artifact_type: None,
             annotations: None,
         });
+        let manifest_digest = calculate_manifest_digest(&oci_manifest);
+
+        // Set up HEAD request for manifest digest (used by fetch_oci_manifest_digest)
+        let _ = Mock::given(method("HEAD"))
+            .and(path(manifest_url.path()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .append_header("Docker-Content-Digest", manifest_digest.clone())
+                    .append_header(http::header::CONTENT_TYPE, OCI_IMAGE_MEDIA_TYPE),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // Set up GET request for full manifest (used by pull_image_manifest)
         let _ = Mock::given(method("GET"))
             .and(path(manifest_url.path()))
             .respond_with(
                 ResponseTemplate::new(200)
+                    .append_header("Docker-Content-Digest", manifest_digest)
                     .append_header(http::header::CONTENT_TYPE, OCI_IMAGE_MEDIA_TYPE)
                     .set_body_bytes(serde_json::to_vec(&oci_manifest).unwrap()),
             )
@@ -411,5 +616,247 @@ mod tests {
         // included here as a second layer of security.
         let result = infer_oci_protocol("").await;
         assert_eq!(result, ClientProtocol::Https);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_oci_success() {
+        let mock_server = MockServer::start().await;
+        let schema_layer = ImageLayer {
+            data: "test schema".to_string().into_bytes(),
+            media_type: APOLLO_SCHEMA_MEDIA_TYPE.to_string(),
+            annotations: None,
+        };
+        let image_reference = setup_mocks(mock_server, vec![schema_layer]).await;
+        let oci_config = mock_oci_config_with_reference(image_reference.to_string());
+
+        let results = stream_from_oci(oci_config)
+            .take(1)
+            .collect::<Vec<_>>()
+            .await;
+
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            Ok(schema_state) => {
+                assert_eq!(schema_state.sdl, "test schema");
+                assert_eq!(schema_state.launch_id, None);
+            }
+            Err(e) => panic!("expected success, got error: {e}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_oci_digest_unchanged_no_fetch() {
+        let mock_server = MockServer::start().await;
+        let graph_id = "test-graph-id";
+        let reference = "latest";
+        let manifest_info = create_manifest_from_schema_layer("test schema");
+        let blob_url = Url::parse(&format!(
+            "{}/v2/{graph_id}/blobs/{}",
+            mock_server.uri(),
+            manifest_info.blob_digest
+        ))
+        .expect("url must be valid");
+
+        // Track blob requests - should only be called once (on first poll)
+        let blob_request_count = Arc::new(AtomicUsize::new(0));
+        let blob_count = blob_request_count.clone();
+        let schema_data = manifest_info.schema_data;
+        Mock::given(method("GET"))
+            .and(path(blob_url.path()))
+            .respond_with(move |_request: &wiremock::Request| {
+                blob_count.fetch_add(1, Ordering::Relaxed);
+                ResponseTemplate::new(200)
+                    .append_header(http::header::CONTENT_TYPE, "application/octet-stream")
+                    .set_body_bytes(schema_data.clone())
+            })
+            .mount(&mock_server)
+            .await;
+
+        let manifest_url = Url::parse(&format!(
+            "{}/v2/{}/manifests/{}",
+            mock_server.uri(),
+            graph_id,
+            reference
+        ))
+        .expect("url must be valid");
+
+        // HEAD requests always return the same digest (unchanged)
+        let _ = Mock::given(method("HEAD"))
+            .and(path(manifest_url.path()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .append_header("Docker-Content-Digest", &manifest_info.manifest_digest)
+                    .append_header(http::header::CONTENT_TYPE, OCI_IMAGE_MEDIA_TYPE),
+            )
+            .mount(&mock_server)
+            .await;
+
+        // GET requests for manifest
+        let _ = Mock::given(method("GET"))
+            .and(path(manifest_url.path()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .append_header("Docker-Content-Digest", &manifest_info.manifest_digest)
+                    .append_header(http::header::CONTENT_TYPE, OCI_IMAGE_MEDIA_TYPE)
+                    .set_body_bytes(serde_json::to_vec(&manifest_info.oci_manifest).unwrap()),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let image_reference = format!("{}/{graph_id}:{reference}", mock_server.address())
+            .parse::<Reference>()
+            .expect("url must be valid");
+        let oci_config = mock_oci_config_with_reference(image_reference.to_string());
+
+        let mut stream = stream_from_oci(oci_config);
+
+        // first poll: digest is new, so schema should be fetched
+        let first_result = stream.next().await;
+        assert!(first_result.is_some());
+        match first_result.unwrap() {
+            Ok(schema_state) => {
+                assert_eq!(schema_state.sdl, "test schema");
+            }
+            Err(e) => panic!("expected success, got error: {e}"),
+        }
+        assert_eq!(
+            blob_request_count.load(Ordering::Relaxed),
+            1,
+            "Blob should be fetched once on first poll"
+        );
+
+        // second poll: digest is unchanged, so schema should not be fetched, wait for interval
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let timeout_result = timeout(Duration::from_millis(100), stream.next()).await;
+        // should time out, it means no new result was produced since digest is unchanged
+        assert!(
+            timeout_result.is_err(),
+            "Expected no new result when digest is unchanged"
+        );
+        assert_eq!(
+            blob_request_count.load(Ordering::Relaxed),
+            1,
+            "Blob should not be fetched again when digest is unchanged"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_oci_digest_changed_fetches_schema() {
+        let mock_server = MockServer::start().await;
+        let graph_id = "test-graph-id";
+        let reference = "latest";
+        let blob_request_count = Arc::new(AtomicUsize::new(0));
+
+        let manifest_info1 = create_manifest_from_schema_layer("schema 1");
+        let blob_url1 = Url::parse(&format!(
+            "{}/v2/{graph_id}/blobs/{}",
+            mock_server.uri(),
+            manifest_info1.blob_digest
+        ))
+        .expect("url must be valid");
+
+        let blob_count1 = blob_request_count.clone();
+        Mock::given(method("GET"))
+            .and(path(blob_url1.path()))
+            .respond_with(move |_request: &Request| {
+                blob_count1.fetch_add(1, Ordering::Relaxed);
+                ResponseTemplate::new(200)
+                    .append_header(http::header::CONTENT_TYPE, "application/octet-stream")
+                    .set_body_bytes(manifest_info1.schema_data.clone())
+            })
+            .mount(&mock_server)
+            .await;
+
+        let manifest_info2 = create_manifest_from_schema_layer("schema 2");
+        let blob_url2 = Url::parse(&format!(
+            "{}/v2/{graph_id}/blobs/{}",
+            mock_server.uri(),
+            manifest_info2.blob_digest
+        ))
+        .expect("url must be valid");
+        let blob_count2 = blob_request_count.clone();
+        Mock::given(method("GET"))
+            .and(path(blob_url2.path()))
+            .respond_with(move |_request: &Request| {
+                blob_count2.fetch_add(1, Ordering::Relaxed);
+                ResponseTemplate::new(200)
+                    .append_header(http::header::CONTENT_TYPE, "application/octet-stream")
+                    .set_body_bytes(manifest_info2.schema_data.clone())
+            })
+            .mount(&mock_server)
+            .await;
+
+        let manifest_url = Url::parse(&format!(
+            "{}/v2/{}/manifests/{}",
+            mock_server.uri(),
+            graph_id,
+            reference
+        ))
+        .expect("url must be valid");
+
+        // mock returns digest1, then digest2 sequentially
+        let _ = Mock::given(method("HEAD"))
+            .and(path(manifest_url.path()))
+            .respond_with(SequentialManifestDigests {
+                digests: Mutex::new(VecDeque::from([
+                    manifest_info1.manifest_digest.clone(),
+                    manifest_info2.manifest_digest.clone(),
+                ])),
+            })
+            .expect(2..=3)
+            .mount(&mock_server)
+            .await;
+
+        // mock requests for manifest1 then manifest2
+        let _ = Mock::given(method("GET"))
+            .and(path(manifest_url.path()))
+            .respond_with(SequentialManifests {
+                manifests: Mutex::new(VecDeque::from([
+                    (
+                        manifest_info1.manifest_digest,
+                        serde_json::to_vec(&manifest_info1.oci_manifest).unwrap(),
+                    ),
+                    (
+                        manifest_info2.manifest_digest,
+                        serde_json::to_vec(&manifest_info2.oci_manifest).unwrap(),
+                    ),
+                ])),
+            })
+            .expect(2..=3)
+            .mount(&mock_server)
+            .await;
+
+        let image_reference = format!("{}/{graph_id}:{reference}", mock_server.address())
+            .parse::<Reference>()
+            .expect("url must be valid");
+        let oci_config = mock_oci_config_with_reference(image_reference.to_string());
+
+        let mut stream = stream_from_oci(oci_config);
+
+        // first poll: digest1 is new, so schema1 should be fetched
+        let first_result = stream.next().await;
+        assert!(first_result.is_some());
+        match first_result.unwrap() {
+            Ok(schema_state) => {
+                assert_eq!(schema_state.sdl, "schema 1");
+            }
+            Err(e) => panic!("expected success, got error: {e}"),
+        }
+
+        // second poll: digest2 is different, so schema2 should be fetched
+        let second_result = stream.next().await;
+        assert!(second_result.is_some());
+        match second_result.unwrap() {
+            Ok(schema_state) => {
+                assert_eq!(schema_state.sdl, "schema 2");
+            }
+            Err(e) => panic!("expected success, got error: {e}"),
+        }
+        assert_eq!(
+            blob_request_count.load(Ordering::Relaxed),
+            2,
+            "Both blobs should be fetched when digest changes"
+        );
     }
 }

--- a/apollo-router/tests/integration/oci.rs
+++ b/apollo-router/tests/integration/oci.rs
@@ -21,8 +21,7 @@ use crate::integration::IntegrationTest;
 use crate::integration::common::graph_os_enabled;
 
 const APOLLO_SCHEMA_MEDIA_TYPE: &str = "application/apollo.schema";
-const ARTIFACT_REFERENCE_404: &str =
-    "@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+const ARTIFACT_REFERENCE_404: &str = "artifact.api.apollographql.com/test@sha256:0000000000000000000000000000000000000000000000000000000000000000";
 const MIN_CONFIG: &str = include_str!("fixtures/minimal-oci.router.yaml");
 const LOCAL_SCHEMA: &str = include_str!("../../../examples/graphql/local.graphql");
 
@@ -184,7 +183,7 @@ async fn test_router_oci_cannot_fetch_schema() -> Result<(), BoxError> {
 
     router.start().await;
     router
-        .wait_for_log_message("no valid schema was supplied")
+        .wait_for_log_message("error fetching manifest digest from oci registry")
         .await;
     Ok(())
 }


### PR DESCRIPTION
### **NOTE: Please use the below PR description when merging (squash) as the commit message.** 

Associated [JIRA](https://apollographql.atlassian.net/browse/REG-1601)

[Problem]
Graph artifacts does not currently support hot reloading from the router. Instead, it just fetches a single digest passed in at start up. We want to maintain this functionality but add the additional option to hot reload from a specified tag for customer who want to continue to use hot reloading but move to the newer graph artifacts backend infrastructure.

[Solution]
Added hot reloading functionality for graph artifacts if tag is passed. Command line arguments and documentation will be included in a separate PR being worked on by @sirdodger in [REG-1529](https://apollographql.atlassian.net/browse/REG-1529). Importantly, uplink supported a mechanism of recognizing calls from the same client  and being able to pass back UpdateSchema events *only* when an the available schema changed from the last sent schema. This has been maintained for the OCI reload source. The hot reload loop stores and validates the previous and currently fetched OCI digest and only when it has changed it fetches the new schema.

[Testing]
Tested locally by running router binary locally and fetching artifacts for test graph. Also added unit tests.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

Command line arguments have not been changed yet. If the passed GRAPH_ARTIFACT_REFERENCE uses a tag and matches the expected regex, the hot-reloading flow will be used. The actual command line changes and associated customer documentation will be completed in [REG-1529](https://apollographql.atlassian.net/browse/REG-1529)

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavor to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[REG-1529]: https://apollographql.atlassian.net/browse/REG-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[REG-1529]: https://apollographql.atlassian.net/browse/REG-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ