### PR TITLE
federation/CLI: Accept CLI option `compose --config -`

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -303,14 +303,7 @@ fn compose_files_inner(
 fn compose_from_config_inner(
     config_path: &Path,
 ) -> Result<composition::Supergraph<composition::Satisfiable>, Vec<CompositionError>> {
-    let config_str = std::fs::read_to_string(config_path).map_err(|e| {
-        vec![CompositionError::MergeError {
-            error: SingleFederationError::Internal {
-                message: format!("Failed to read config file: {}", e),
-            },
-        }]
-    })?;
-
+    let config_str = read_input(config_path);
     let config: SupergraphConfig = serde_yaml::from_str(&config_str).map_err(|e| {
         vec![CompositionError::MergeError {
             error: SingleFederationError::Internal {


### PR DESCRIPTION
This PR updates the `compose` CLI command to accept the `--config -` option, where `-` stands for `stdin`.

For example, `fetch-supergraph-config-yaml.sh | apollo-federation-cli compose --config -`

This is for consistency with other tools:
* Rover accepts `--config -` like `rover supergraph compose --config -`.
* FBP accepts `-` like `fbp compose -`.

<!-- start metadata -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is a minor update to an internal CLI command.