### PR TITLE
fix: fix renaming of root types with directives

### DIFF
--- a/apollo-federation/src/schema/referencer.rs
+++ b/apollo-federation/src/schema/referencer.rs
@@ -255,7 +255,6 @@ impl Referencers {
                 old_name,
                 new_name,
             );
-
             Self::update_object_field_positions(
                 &mut directive_refs.object_fields,
                 old_name,

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -376,3 +376,45 @@ fn composes_input_field_with_int_to_float_coercible_defaults() {
     let _supergraph = result
         .expect("Expected composition to succeed with Int default coercible to Float default");
 }
+
+#[test]
+fn composes_subgraphs_with_directives_on_renamed_root_types() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraph-a",
+        type_defs: r#"
+            schema {
+                query: MyQuery
+                mutation: MyMutation
+            }
+
+            type MyQuery @tag(name: "custom") {
+                hello(name: String! @tag(name: "custom")): String @tag(name: "custom")
+            }
+
+            type MyMutation @tag(name: "custom") {
+                bye(name: String! @tag(name: "custom")): String! @tag(name: "custom")
+            }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraph-b",
+        type_defs: r#"
+            schema {
+                query: Query
+                mutation: Mutation
+            }
+
+            type Query {
+                helloWorld: String
+            }
+
+            type Mutation {
+                goodbyeWorld: String
+            }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    let _supergraph = result.expect("Expected composition to succeed");
+}


### PR DESCRIPTION
Directives can be applied on the object type, its fields and their field arguments. When renaming root object types (Query, Mutation and/or Subscription) we were not updating directive references to the types.

<!-- FED-871 -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
