### PR TITLE
fix: restore HTTP/2 auto-detection and enforce H2 header configurations

### DIFF
--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -420,7 +420,7 @@ pub(super) fn serve_router_on_listen_addr(
                                             .expect(
                                                 "this should not fail unless the socket is invalid",
                                             );
-
+                                        
                                         let hyper_service = hyper::service::service_fn(move |request| {
                                             app.clone().call(request)
                                         });
@@ -428,6 +428,16 @@ pub(super) fn serve_router_on_listen_addr(
                                         let tokio_stream = TokioIo::new(stream);
 
                                         let mut builder = Builder::new(TokioExecutor::new());
+                                        // --- START FIX ---
+                                        // 1. Detect if the TLS handshake negotiated HTTP/2
+                                        let is_http2 = tokio_stream.inner().get_ref().1.alpn_protocol() == Some(&b"h2"[..]);
+                                    
+                                        // 2. If yes, FORCE the builder to use your H2 config explicitly
+                                        if is_http2 {
+                                            builder = builder.http2_only();
+                                        }
+                                        // --- END FIX ---
+                                        
                                         let config = configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
                                         let connection = config
                                             .serve_connection_with_upgrades(tokio_stream, hyper_service);

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -377,23 +377,6 @@ pub(super) fn serve_router_on_listen_addr(
                                 match res {
                                     NetworkStream::Tcp(stream) => {
                                         let received_first_request = Arc::new(AtomicBool::new(false));
-                                        // -----------------------------------------------------------------
-                                        // FIX: Manually peek at the TCP stream to detect HTTP/2
-                                        // This allows us to apply the Large Header Config BEFORE the buffer fills up.
-                                        // -----------------------------------------------------------------
-                                        let mut is_http2 = false;
-                                        let mut buf = [0u8; 24]; 
-                                        // The Standard HTTP/2 Connection Preface
-                                        const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
-                                    
-                                        // Peek (look at data without removing it)
-                                        if let Ok(n) = stream.peek(&mut buf).await {
-                                            if n >= 24 && &buf[..24] == H2_PREFACE {
-                                                is_http2 = true;
-                                            }
-                                        }
-                                        // -----------------------------------------------------------------
-                                        
                                         let app = InjectConnectionInfo::new(app, ConnectionInfo {
                                             peer_address: stream.peer_addr().ok(),
                                             server_address: stream.local_addr().ok(),
@@ -411,11 +394,12 @@ pub(super) fn serve_router_on_listen_addr(
                                         });
 
                                         let mut builder = Builder::new(TokioExecutor::new());
-                                        if is_http2 {
-                                            builder = builder.http2_only();
-                                        }
-                                        let config = configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
-                                        let connection = config.serve_connection_with_upgrades(tokio_stream, hyper_service);
+
+                                        // Just call the function to mutate the builder in-place. Do not assign the result.
+                                        configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
+                                        
+                                        // Call serve on the PARENT builder
+                                        let connection = builder.serve_connection_with_upgrades(tokio_stream, hyper_service);
                                         handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
                                     }
                                     #[cfg(unix)]
@@ -427,8 +411,12 @@ pub(super) fn serve_router_on_listen_addr(
                                             app.clone().call(request)
                                         });
                                         let mut builder = Builder::new(TokioExecutor::new());
-                                        let config = configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
-                                        let connection = config.serve_connection_with_upgrades(tokio_stream, hyper_service);
+
+                                        // Just call the function to mutate the builder in-place. Do not assign the result.
+                                        configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
+                                        
+                                        // Call serve on the PARENT builder
+                                        let connection = builder.serve_connection_with_upgrades(tokio_stream, hyper_service);
                                         handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
                                     },
                                     NetworkStream::Tls(stream) => {
@@ -448,19 +436,12 @@ pub(super) fn serve_router_on_listen_addr(
                                         let tokio_stream = TokioIo::new(stream);
 
                                         let mut builder = Builder::new(TokioExecutor::new());
-                                        // --- START FIX ---
-                                        // 1. Detect if the TLS handshake negotiated HTTP/2
-                                        let is_http2 = tokio_stream.inner().get_ref().1.alpn_protocol() == Some(&b"h2"[..]);
-                                    
-                                        // 2. If yes, FORCE the builder to use your H2 config explicitly
-                                        if is_http2 {
-                                            builder = builder.http2_only();
-                                        }
-                                        // --- END FIX ---
+
+                                        // Just call the function to mutate the builder in-place. Do not assign the result.
+                                        configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
                                         
-                                        let config = configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
-                                        let connection = config
-                                            .serve_connection_with_upgrades(tokio_stream, hyper_service);
+                                        // Call serve on the PARENT builder
+                                        let connection = builder.serve_connection_with_upgrades(tokio_stream, hyper_service);
 
                                         handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
 
@@ -489,12 +470,12 @@ pub(super) fn serve_router_on_listen_addr(
 /// NOTE: centralize all connection configuration changes here so that the behavior of the
 /// connections remains in-step
 fn configure_connection(
-    conn_builder: &mut Builder<TokioExecutor>,
+    conn_builder: &mut Builder<TokioExecutor>, // The Parent
     header_read_timeout: Duration,
     opt_max_http1_headers: Option<usize>,
     opt_max_http1_buf_size: Option<ByteSize>,
     opt_max_http2_headers_list_bytes: Option<ByteSize>,
-) -> Http1Builder<'_, TokioExecutor> {
+) { // No return value needed, we mutate conn_builder in place
     // NOTE: this is a builder that auto-detects http1/http2, so we can configure both and rely on
     // it to figure out whether we have an http1 or http2 connection
     let mut builder = conn_builder.http2();

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -504,7 +504,6 @@ fn configure_connection(
         builder.max_buf_size(max_buf_size);
     }
 
-    builder
 }
 
 #[derive(Clone)]

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -377,6 +377,23 @@ pub(super) fn serve_router_on_listen_addr(
                                 match res {
                                     NetworkStream::Tcp(stream) => {
                                         let received_first_request = Arc::new(AtomicBool::new(false));
+                                        // -----------------------------------------------------------------
+                                        // FIX: Manually peek at the TCP stream to detect HTTP/2
+                                        // This allows us to apply the Large Header Config BEFORE the buffer fills up.
+                                        // -----------------------------------------------------------------
+                                        let mut is_http2 = false;
+                                        let mut buf = [0u8; 24]; 
+                                        // The Standard HTTP/2 Connection Preface
+                                        const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+                                    
+                                        // Peek (look at data without removing it)
+                                        if let Ok(n) = stream.peek(&mut buf).await {
+                                            if n >= 24 && &buf[..24] == H2_PREFACE {
+                                                is_http2 = true;
+                                            }
+                                        }
+                                        // -----------------------------------------------------------------
+                                        
                                         let app = InjectConnectionInfo::new(app, ConnectionInfo {
                                             peer_address: stream.peer_addr().ok(),
                                             server_address: stream.local_addr().ok(),
@@ -394,6 +411,9 @@ pub(super) fn serve_router_on_listen_addr(
                                         });
 
                                         let mut builder = Builder::new(TokioExecutor::new());
+                                        if is_http2 {
+                                            builder = builder.http2_only();
+                                        }
                                         let config = configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
                                         let connection = config.serve_connection_with_upgrades(tokio_stream, hyper_service);
                                         handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-####] -->
---
### Summary
This PR fixes a bug in the connection setup logic where HTTP/2 configurations (specifically `http2_max_headers_list_bytes`) were being ignored.

### Root Cause Analysis
The issue stems from how the `hyper_util` builders were being used. The `configure_connection` helper function was returning an `Http1Builder` (the result of `.http1()`) rather than the parent `auto::Builder`.

By calling `.serve_connection()` on the child `Http1Builder` instance, the application effectively started a standard HTTP/1.1 server. This has two specific consequences:
1.  **Protocol Sniffing Bypassed:** The logic that detects the protocol (HTTP/1 vs HTTP/2) resides in the Parent builder. By serving from the Child, this detection logic is skipped.
2.  **Configuration Ignored:** Since the server was running as a strictly HTTP/1 instance, any configuration applied to the HTTP/2 builder (such as `max_header_list_size`) was dropped and never applied to the active connection.

**Visualizing the Issue:**

```text
       [Current Buggy Flow]                        [Corrected Flow]

  auto::Builder (Parent)                      auto::Builder (Parent) 
  [Holds H2 Config]                           [Holds H2 Config] <--- Config Applied
         |                                           |
         +--> .http1()                               |
         |    [Child Builder]                        |
         |          |                                |
         |          +--> serve_connection()          +--> serve_connection()
         |               (Bypasses Parent)                (Uses Sniffing Logic)
         |               (H2 Config Lost)                 (H2 Config Active)
         |
         X (Path taken by code)
```

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
