### PR TITLE
chore(composition): Make assert_composition_errors a strict equality check

### DIFF
--- a/apollo-federation/tests/composition/compose_directive_sharing.rs
+++ b/apollo-federation/tests/composition/compose_directive_sharing.rs
@@ -311,7 +311,7 @@ fn field_sharing_applies_shareable_on_type_only_to_fields_within_definition() {
         &result,
         &[(
             "INVALID_FIELD_SHARING",
-            r#"Non-shareable field "A.x" is resolved from multiple subgraphs"#,
+            r#"Non-shareable field "A.x" is resolved from multiple subgraphs: it is resolved from subgraphs "subgraphA" and "subgraphB" and defined as non-shareable in subgraph "subgraphB""#,
         )],
     );
 }
@@ -454,7 +454,7 @@ fn interface_object_field_requires_shareable() {
         &result,
         &[(
             "INVALID_FIELD_SHARING",
-            r#"Non-shareable field "Entity.sku" is resolved from multiple subgraphs"#,
+            r#"Non-shareable field "Entity.sku" is resolved from multiple subgraphs: it is resolved from subgraphs "subgraphA", "subgraphB (through @interfaceObject field "Node.sku")" and "subgraphC" and defined as non-shareable in subgraph "subgraphB (through @interfaceObject field "Node.sku")""#,
         )],
     );
 }

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -39,7 +39,8 @@ fn merge_validations_errors_when_a_subgraph_is_invalid() {
  3 │           a: A
    │              ┬  
    │              ╰── not found in this scope
-───╯"#,
+───╯
+"#,
         )],
     );
 }
@@ -75,7 +76,8 @@ fn merge_validations_errors_when_subgraph_has_introspection_reserved_name() {
  3 │           __someQuery: Int
    │           ─────┬─────  
    │                ╰─────── Pick a different name here
-───╯"#,
+───╯
+"#,
         )],
     );
 }

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -116,16 +116,16 @@ pub(crate) mod test_helpers {
 
             // Check error code
             assert!(
-                error_code.contains(expected_code),
-                "Error at index {} does not contain expected code.\n\nEXPECTED:\n{}\nACTUAL:\n{}",
+                error_code == expected_code,
+                "Error at index {} does not equal expected code.\n\nEXPECTED:\n{}\nACTUAL:\n{}",
                 i,
                 format_args!("code: {}\nmessage: {}\n", expected_code, expected_message),
                 format_args!("code: {}\nmessage: {}\n", error_code, error_str)
             );
             // Check error message
             assert!(
-                error_str.contains(expected_message),
-                "Error at index {} does not contain expected message.\n\nEXPECTED:\n{}\nACTUAL:\n{}",
+                error_str == expected_message,
+                "Error at index {} does not equal expected message.\n\nEXPECTED:\n{}\nACTUAL:\n{}",
                 i,
                 format_args!("code: {}\nmessage: {}\n", expected_code, expected_message),
                 format_args!("code: {}\nmessage: {}\n", error_code, error_str)


### PR DESCRIPTION

When we make error assertions, we should assert the whole error string, not just containment.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary
