### PR TITLE
tests(composition): Enable subscription tests

### DIFF
--- a/apollo-federation/tests/composition/subscription.rs
+++ b/apollo-federation/tests/composition/subscription.rs
@@ -1,7 +1,6 @@
 use crate::composition::ServiceDefinition;
 use crate::composition::test_helpers::compose_as_fed2_subgraphs;
 
-#[ignore = "until merge implementation completed"]
 #[test]
 fn type_subscription_appears_in_the_supergraph() {
     let subgraph_a = ServiceDefinition {
@@ -44,7 +43,6 @@ fn type_subscription_appears_in_the_supergraph() {
     );
 }
 
-#[ignore = "until merge implementation completed"]
 #[test]
 fn directives_incompatible_with_subscriptions_wont_compose() {
     let subgraph_a = ServiceDefinition {
@@ -87,7 +85,6 @@ fn directives_incompatible_with_subscriptions_wont_compose() {
     );
 }
 
-#[ignore = "until merge implementation completed"]
 #[test]
 fn subscription_name_collisions_across_subgraphs_should_not_compose() {
     let subgraph_a = ServiceDefinition {


### PR DESCRIPTION
No new code changes; just enables 3 tests which were previously ignored.

<!-- [FED-837] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary


[FED-837]: https://apollographql.atlassian.net/browse/FED-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ