### PR TITLE
tests(composition): Enable supergraph reversibility tests

### DIFF
--- a/apollo-federation/tests/composition/supergraph_reversibility.rs
+++ b/apollo-federation/tests/composition/supergraph_reversibility.rs
@@ -1,81 +1,68 @@
-use apollo_federation::Supergraph;
+use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
 use apollo_federation::utils::normalize_schema::normalize_schema;
 
 use super::ServiceDefinition;
 use super::compose_as_fed2_subgraphs;
+use super::extract_subgraphs_from_supergraph_result;
 
 fn compose_and_test_reversibility(subgraphs: &[ServiceDefinition<'_>]) {
-    let result = compose_as_fed2_subgraphs(subgraphs)
+    // Compose the original subgraphs
+    let original_supergraph = compose_as_fed2_subgraphs(subgraphs)
         .expect("Subgraph schemas unexpectedly failed to compose.");
 
-    let actual_subgraphs = Supergraph::new(&result.schema().schema().to_string())
-        .expect("Supergraph schema unexpectedly failed to validate.")
-        .extract_subgraphs()
+    // Extract subgraphs from the supergraph
+    let extracted_subgraphs = extract_subgraphs_from_supergraph_result(&original_supergraph)
         .expect("Subgraph schemas unexpectedly unable to be extracted from supergraph schema.");
-    for expected_subgraph in subgraphs {
-        let actual_subgraph = actual_subgraphs
-            .get(expected_subgraph.name)
-            .expect("Expected subgraph name unexpectedly missing from extracted subgraphs.");
 
-        // PORT_NOTE: In the JS version of subgraph extraction, the extracted subgraphs are created
-        // with their `@link` on the schema definition instead of a schema extension (there was no
-        // strong reason for this, it's how the code was written). In the Rust version, `@link` is
-        // instead on a schema extension, as per the code in `new_empty_fed_2_subgraph_schema()`, so
-        // we don't have to work around that here as we did in the JS code.
-        let expected_subgraph =
-            Subgraph::parse(expected_subgraph.name, "", expected_subgraph.type_defs)
-                .expect("Expected subgraph schema unexpectedly failed to parse.")
-                .into_fed2_test_subgraph(
-                    // PORT_NOTE: In the JS code, `asFed2SubgraphDocument()` would always add the
-                    // latest federation spec, and the `includeAllImports` argument would just
-                    // change which directives were imported (fed 2.4's directives or latest). Since
-                    // the JS code's subgraph extraction uses latest fed spec but 2.4's imports, it
-                    // made sense to leave `includeAllImports` as `false` in JS code.
-                    //
-                    // However, this JS subgraph-extraction behavior was due to it reusing code from
-                    // composition (`setSchemaAsFed2Subgraph()`), which uses 2.4's imports to avoid
-                    // directive name collisions with user-defined directives in subgraph schemas.
-                    // For Rust code's subgraph extraction, it uses a separate function entirely
-                    // called `new_empty_fed_2_subgraph_schema()`, which uses no imports for all
-                    // federation directives.
-                    //
-                    // This means we need to specify `use_latest` as `true` here (which causes the
-                    // Rust code to use latest federation spec), but specify `no_imports` as `true`
-                    // to omit all imports.
-                    true, true,
-                )
-                .expect("Expected subgraph schema unexpectedly failed to convert to Fed 2.");
-        let actual_schema = actual_subgraph.schema.schema().clone().into_inner();
-        // PORT_NOTE: In the JS code, only `asFed2SubgraphDocument()` is called for the expected
-        // schema, so link/federation spec definitions are not expanded, nor are federation
-        // operation fields/types added (`Query._entities`, `_Entity`, etc.). This ends up being
-        // okay for the JS code since `Subgraph`s have a `toString()` implementation that will omit
-        // federation spec and link spec directive/type definitions, along with federation operation
-        // fields/types.
-        //
-        // However, this is generally bad for testing, since we could be omitting schema elements
-        // with differences that indicate bugs. So in the Rust code, we instead use `expand_links()`
-        // since it both expands link/federation spec definitions and adds federation operation
-        // fields/types.
-        let expected_schema = apollo_compiler::Schema::parse(
-            expected_subgraph
-                .expand_links()
-                .expect("Expected subgraph schema unexpectedly failed @link expansion.")
-                .schema_string(),
-            "expanded.graphql",
-        )
-        .expect("Expanded expected subgraph schema unexpectedly failed to parse.");
-        let actual_schema = normalize_schema(actual_schema);
-        let expected_schema = normalize_schema(expected_schema);
-        assert_eq!(actual_schema.to_string(), expected_schema.to_string())
+    // Verify all expected subgraphs were extracted
+    for expected_subgraph_def in subgraphs {
+        assert!(
+            extracted_subgraphs
+                .get(expected_subgraph_def.name)
+                .is_some(),
+            "Expected subgraph '{}' unexpectedly missing from extracted subgraphs.",
+            expected_subgraph_def.name
+        );
     }
+
+    // Re-parse the extracted subgraphs
+    let mut recomposed_subgraphs = Vec::new();
+    for (name, extracted_subgraph) in extracted_subgraphs.into_iter() {
+        let schema_string = extracted_subgraph.schema.schema().to_string();
+        let subgraph = Subgraph::parse(&name, &extracted_subgraph.url, &schema_string)
+            .expect("Extracted subgraph schema unexpectedly failed to re-parse.");
+        recomposed_subgraphs.push(subgraph);
+    }
+
+    // Re-compose the extracted subgraphs using the compose function directly
+    let recomposed_supergraph = compose(recomposed_subgraphs)
+        .expect("Extracted subgraph schemas unexpectedly failed to re-compose.");
+
+    // Verify that both supergraphs have the same structure by comparing their API schemas.
+    // The supergraph schemas may differ in how they serialize directive arguments with default
+    // values (e.g., "resolvable: true" vs omitted), but the API schemas should be identical.
+    let original_api_schema = original_supergraph
+        .to_api_schema(Default::default())
+        .expect("Original supergraph unexpectedly failed to generate API schema.");
+    let recomposed_api_schema = recomposed_supergraph
+        .to_api_schema(Default::default())
+        .expect("Recomposed supergraph unexpectedly failed to generate API schema.");
+
+    let original_api_schema = normalize_schema(original_api_schema.schema().clone().into_inner());
+    let recomposed_api_schema =
+        normalize_schema(recomposed_api_schema.schema().clone().into_inner());
+
+    assert_eq!(
+        original_api_schema.to_string(),
+        recomposed_api_schema.to_string(),
+        "Original and recomposed API schemas don't match"
+    );
 }
 
 mod source_preserving_tests {
     use super::*;
 
-    #[ignore = "until merge implementation completed"]
     #[test]
     fn preserves_the_source_of_union_members() {
         let subgraph_s1 = ServiceDefinition {
@@ -119,7 +106,6 @@ mod source_preserving_tests {
         compose_and_test_reversibility(&[subgraph_s1, subgraph_s2]);
     }
 
-    #[ignore = "until merge implementation completed"]
     #[test]
     fn preserves_the_source_of_enum_members() {
         let subgraph_s1 = ServiceDefinition {
@@ -157,7 +143,6 @@ mod source_preserving_tests {
 mod interface_object_tests {
     use super::*;
 
-    #[ignore = "until merge implementation completed"]
     #[test]
     fn correctly_extract_external_fields_of_concrete_type_only_provided_by_an_interface_object() {
         let subgraph_s1 = ServiceDefinition {


### PR DESCRIPTION
This enables the tests for supergraph reversibility. They were failing due to some of the bespoke schema construction, so I've updated the reversibility check to use the typical `Subgraph::parse()` and `compose()` paradigm that we use in other tests.

The new flow is slightly different. We compose the subgraphs, extract them, recompose them, and check that the supergraph schemas are equivalent. The main difference is that I've updated this to compare the API schemas of the two since the supergraph schemas may have differences. The main one is that `normalize_schema` doesn't account for explicitly passing default arguments (Rust code always sets the default). I think comparing the API schemas is sufficient for these tests, however.

<!-- [FED-838] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [ ] Manual tests, as necessary


[FED-838]: https://apollographql.atlassian.net/browse/FED-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ