### PR TITLE
fix(composition): Ensure logic to remove provides from non-composites executes correctly

### DIFF
--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -157,7 +157,7 @@ impl SchemaUpgrader {
         self.remove_directives_on_interface(&upgrade_metadata, &mut schema)?;
 
         // Note that this rule rely on being after `remove_directives_on_interface` in practice (in that it doesn't check interfaces).
-        self.remove_provides_on_non_composite(&mut schema)?;
+        self.remove_provides_on_non_composite(&subgraph, &mut schema)?;
 
         // Note that this should come _after_ all the other changes that may remove/update federation directives, since those may create unused
         // externals. Which is why this is toward  the end.
@@ -688,32 +688,33 @@ impl SchemaUpgrader {
 
     fn remove_provides_on_non_composite(
         &self,
+        subgraph: &Subgraph<Expanded>,
         schema: &mut FederationSchema,
     ) -> Result<(), FederationError> {
-        let Some(metadata) = &schema.subgraph_metadata else {
+        let Some(provides_directive) = subgraph.provides_directive_name()? else {
             return Ok(());
         };
-
-        let provides_directive = metadata
-            .federation_spec_definition()
-            .provides_directive_definition(schema)?;
-
-        #[allow(clippy::iter_overeager_cloned)] // TODO: remove this
-        let references_to_remove: Vec<_> = schema
+        let Some(targets) = subgraph
+            .schema()
             .referencers()
-            .get_directive(provides_directive.name.as_str())?
-            .object_fields
-            .iter()
-            .cloned()
-            .filter(|ref_field| {
-                schema
-                    .get_type(ref_field.type_name.clone())
-                    .map(|t| !t.is_composite_type())
-                    .unwrap_or(false)
-            })
-            .collect();
-        for reference in &references_to_remove {
-            reference.remove(schema)?;
+            .directives
+            .get(&provides_directive)
+        else {
+            return Ok(());
+        };
+        for obj_field_pos in targets.object_fields.iter() {
+            let field = obj_field_pos.make_mut(&mut schema.schema)?;
+            let return_type = field.ty.inner_named_type();
+            if subgraph
+                .schema()
+                .try_get_type(return_type.clone())
+                .is_some_and(|t| !t.is_composite_type())
+            {
+                let field = field.make_mut();
+                field
+                    .directives
+                    .retain(|d| d.name != provides_directive.as_str());
+            }
         }
         Ok(())
     }
@@ -1729,8 +1730,7 @@ mod tests {
     }
 
     #[test]
-    fn ignore_error_for_provides_field_set_on_scalar_field() {
-        // This used to generate a wrong error.
+    fn removes_provides_on_non_composite_fields() {
         let subgraphs = vec![
             (
                 "subgraph1",
@@ -1765,11 +1765,14 @@ mod tests {
                     .expect("expands schema")
             })
             .collect::<Vec<_>>();
-        let errors = upgrade_subgraphs_if_necessary(expanded).expect_err("fails to upgrade schema");
-        assert_eq!(errors.len(), 1);
-        assert_eq!(
-            errors[0].to_string(),
-            r#"[subgraph1] Cannot have both @provides and @external on field "User.id""#
+        let upgraded = upgrade_subgraphs_if_necessary(expanded).expect("failed to upgrade schema");
+        let changed_schema = upgraded[0].schema().schema();
+        let id_field = coord!(User.id)
+            .lookup_field(changed_schema)
+            .expect("field exists");
+        assert!(
+            id_field.directives.get("provides").is_none(),
+            "User.id in subgraph1 should not have @provides"
         );
     }
 


### PR DESCRIPTION
The schema upgrader was trying to use the subgraph metadata from the `FederationSchema` and early-exiting if it did not exist. However, we are switching to using `Subgraph::metadata()` because the compiler guarantees it always exists. 

<!-- [FED-875] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [X] Unit tests
    - [ ] Integration tests
    - [X] Manual tests, as necessary


[FED-875]: https://apollographql.atlassian.net/browse/FED-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ