### PR TITLE
fix(composition): Numbered names for sanitized subgraphs

### DIFF
--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -1112,12 +1112,12 @@ impl JoinSpecDefinition {
         // Process each sanitized name and its subgraphs
         for (sanitized_name, subgraphs_for_name) in sanitized_name_to_subgraphs {
             for (index, subgraph) in subgraphs_for_name.iter().enumerate() {
-                let enum_name = if index == 0 {
-                    // First subgraph gets the base sanitized name
+                let enum_name = if subgraphs_for_name.len() == 1 {
+                    // Only one subgraph with this sanitized name gets the base name
                     sanitized_name.clone()
                 } else {
-                    // Subsequent subgraphs get _1, _2, etc.
-                    format!("{sanitized_name}_{index}")
+                    // Multiple subgraphs with same sanitized name get _1, _2, etc.
+                    format!("{sanitized_name}_{}", index + 1)
                 };
 
                 let enum_value_name = Name::new(enum_name.as_str())?;

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -418,3 +418,37 @@ fn composes_subgraphs_with_directives_on_renamed_root_types() {
     let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
     let _supergraph = result.expect("Expected composition to succeed");
 }
+
+#[test]
+fn misc_conflicting_subgraph_names_sanitization() {
+    let sg1 = ServiceDefinition {
+        name: "mysubgraph",
+        type_defs: r#"
+        type Query {
+          foo: String
+        }
+        "#,
+    };
+
+    let sg2 = ServiceDefinition {
+        name: "MySubgraph",
+        type_defs: r#"
+        type Query {
+          bar: String
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[sg1, sg2]);
+    let supergraph = result.expect("Expected composition to succeed");
+
+    let schema_str = supergraph.schema().schema().to_string();
+    assert!(
+        schema_str.contains("MYSUBGRAPH_1"),
+        "Expected MYSUBGRAPH_1 in schema"
+    );
+    assert!(
+        schema_str.contains("MYSUBGRAPH_2"),
+        "Expected MYSUBGRAPH_2 in schema"
+    );
+}


### PR DESCRIPTION
When two subgraphs have the same name with only capitalization differences, the original TS version of composition appends a number to both subgraphs. In Rust, the first one would have no number. So, we would produce `SUBGRAPH`, `SUBGRAPH_1` instead of `SUBGRAPH_1`, `SUBGRAPH_2`.

<!-- [FED-943] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [X] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [X] Integration tests
    - [x] Manual tests, as necessary


[FED-943]: https://apollographql.atlassian.net/browse/FED-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ