### PR TITLE
Limit cargo parallelism on Windows CI to prevent OOM flakiness.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ executors:
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
+      CARGO_BUILD_JOBS: 4
   windows_test: &windows_test_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
@@ -94,6 +95,7 @@ executors:
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
+      CARGO_BUILD_JOBS: 4
 
 # We don't use {{ arch }} because on windows it is unstable https://discuss.circleci.com/t/value-of-arch-unstable-on-windows/40079
 parameters:


### PR DESCRIPTION
Windows executors were missing `CARGO_BUILD_JOBS`, causing cargo to use all available cores. On `windows.2xlarge` (32 vCPUs), this led to memory exhaustion during compilation, as each `rustc` process can consume 4-8GB+ for large crates with debug symbols.

PR #8103 switched to the (much) larger Windows machines but inadvertently made the OOM risk greater by having so many more vCPUs compiling simultaneously.

Your mileage may vary, but for me this change has fixed a major source of CI flakiness.