### PR TITLE
docs: Update Docker image reference from bullseye to bookworm

### DIFF
--- a/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
@@ -198,4 +198,4 @@ Usage: build_docker_image.sh [-b [-r <repo>]] [-d] [<release>]
 		build_docker_image.sh -d v0.9.1
 ```
 
-The example uses [debian:bullseye-slim image](https://hub.docker.com/_/debian/) for the final image build. Feel free to modify the script to use images which better suit your own needs, but be careful if using the `-d` flag because it makes the assumption that there is a `heaptrack` package available to install.
+The example uses [debian:bookwork-slim image](https://hub.docker.com/_/debian/) for the final image build. Feel free to modify the script to use images which better suit your own needs, but be careful if using the `-d` flag because it makes the assumption that there is a `heaptrack` package available to install.


### PR DESCRIPTION
This is actually outdated, we do already use bookworm, not bullseye, here.
