### PR TITLE
support array parsing for listSize directive

### DIFF
--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -1,19 +1,71 @@
 use ahash::HashMap;
-use ahash::HashMapExt;
 use ahash::HashSet;
 use apollo_compiler::Schema;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::ast::NamedType;
+use apollo_compiler::ast::Value as AstValue;
 use apollo_compiler::executable::Field;
 use apollo_compiler::executable::SelectionSet;
 use apollo_compiler::parser::Parser;
 use apollo_compiler::validation::Valid;
 use apollo_federation::link::cost_spec_definition::ListSizeDirective as ParsedListSizeDirective;
+use indexmap::IndexSet;
+use serde_json_bytes::Value as JsonValue;
 use tower::BoxError;
 
 use crate::json_ext::Object;
 use crate::json_ext::ValueExt;
 use crate::plugins::demand_control::DemandControlError;
+
+// Infers a size value from an AST argument value.
+//
+// Returns:
+// - `Some(n)` for integer values (e.g., `first: 10` → 10)
+// - `Some(len)` for array values (e.g., `ids: ["a", "b"]` → 2)
+// - Resolves variable references through the provided variables map
+// - `None` for null, missing, or unsupported value types
+fn infer_size_from_argument(value: Option<&AstValue>, variables: &Object) -> Option<i32> {
+    match value? {
+        AstValue::Int(n) => n.try_to_i32().ok(),
+        AstValue::List(items) => Some(items.len() as i32),
+        AstValue::Variable(var_name) => infer_size_from_variable(variables.get(var_name.as_str())),
+        _ => None,
+    }
+}
+
+// Infers a size value from a JSON variable value.
+fn infer_size_from_variable(value: Option<&JsonValue>) -> Option<i32> {
+    match value? {
+        JsonValue::Array(items) => Some(items.len() as i32),
+        other => other.as_i32(),
+    }
+}
+
+// Collects slicing argument sizes from both default values and actual query arguments.
+// Actual values override defaults when both are present.
+fn collect_slicing_sizes<'a>(
+    field: &'a Field,
+    slicing_argument_names: &IndexSet<String>,
+    variables: &Object,
+) -> HashMap<&'a str, i32> {
+    let is_slicing_arg = |name: &str| slicing_argument_names.contains(name);
+
+    let defaults = field.definition.arguments.iter().filter_map(|arg| {
+        is_slicing_arg(arg.name.as_str())
+            .then(|| infer_size_from_argument(arg.default_value.as_deref(), variables))
+            .flatten()
+            .map(|size| (arg.name.as_str(), size))
+    });
+
+    let actuals = field.arguments.iter().filter_map(|arg| {
+        is_slicing_arg(arg.name.as_str())
+            .then(|| infer_size_from_argument(Some(&arg.value), variables))
+            .flatten()
+            .map(|size| (arg.name.as_str(), size))
+    });
+
+    defaults.chain(actuals).collect()
+}
 
 pub(in crate::plugins::demand_control) struct IncludeDirective {
     pub(in crate::plugins::demand_control) is_included: bool,
@@ -45,46 +97,21 @@ impl<'schema> ListSizeDirective<'schema> {
         field: &Field,
         variables: &Object,
     ) -> Result<Self, DemandControlError> {
-        let mut slicing_arguments: HashMap<&str, i32> = HashMap::new();
-        if let Some(slicing_argument_names) = parsed.slicing_argument_names.as_ref() {
-            // First, collect the default values for each argument
-            for argument in &field.definition.arguments {
-                if slicing_argument_names.contains(argument.name.as_str())
-                    && let Some(numeric_value) =
-                        argument.default_value.as_ref().and_then(|v| v.to_i32())
-                {
-                    slicing_arguments.insert(&argument.name, numeric_value);
-                }
-            }
-            // Then, overwrite any default values with the actual values passed in the query
-            for argument in &field.arguments {
-                if slicing_argument_names.contains(argument.name.as_str()) {
-                    if let Some(numeric_value) = argument.value.to_i32() {
-                        slicing_arguments.insert(&argument.name, numeric_value);
-                    } else if let Some(numeric_value) = argument
-                        .value
-                        .as_variable()
-                        .and_then(|variable_name| variables.get(variable_name.as_str()))
-                        .and_then(|variable| variable.as_i32())
-                    {
-                        slicing_arguments.insert(&argument.name, numeric_value);
-                    }
-                }
-            }
+        let expected_size = match parsed.slicing_argument_names.as_ref() {
+            Some(slicing_argument_names) => {
+                let slicing_sizes = collect_slicing_sizes(field, slicing_argument_names, variables);
 
-            if parsed.require_one_slicing_argument && slicing_arguments.len() != 1 {
-                return Err(DemandControlError::QueryParseFailure(format!(
-                    "Exactly one slicing argument is required, but found {}",
-                    slicing_arguments.len()
-                )));
-            }
-        }
+                if parsed.require_one_slicing_argument && slicing_sizes.len() != 1 {
+                    return Err(DemandControlError::QueryParseFailure(format!(
+                        "Exactly one slicing argument is required, but found {}",
+                        slicing_sizes.len()
+                    )));
+                }
 
-        let expected_size = slicing_arguments
-            .values()
-            .max()
-            .cloned()
-            .or(parsed.assumed_size);
+                slicing_sizes.into_values().max().or(parsed.assumed_size)
+            }
+            None => parsed.assumed_size,
+        };
 
         Ok(Self {
             expected_size,
@@ -153,5 +180,106 @@ impl SkipDirective {
             .map(|cond| Self { is_skipped: cond });
 
         Ok(directive)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod infer_size_from_variable_tests {
+        use serde_json_bytes::json;
+
+        use super::*;
+
+        #[rstest::rstest]
+        #[case::integer_value(json!(42), Some(42))]
+        #[case::zero(json!(0), Some(0))]
+        #[case::negative_integer(json!(-5), Some(-5))]
+        #[case::array_with_items(json!(["a", "b", "c"]), Some(3))]
+        #[case::empty_array(json!([]), Some(0))]
+        #[case::null_value(json!(null), None)]
+        #[case::string_value(json!("not a size"), None)]
+        #[case::boolean_value(json!(true), None)]
+        #[case::object_value(json!({"key": "value"}), None)]
+        #[case::float_value(json!(1.5), None)]
+        fn test_infer_size(#[case] input: JsonValue, #[case] expected: Option<i32>) {
+            assert_eq!(infer_size_from_variable(Some(&input)), expected);
+        }
+
+        #[test]
+        fn none_input_returns_none() {
+            assert_eq!(infer_size_from_variable(None), None);
+        }
+    }
+
+    mod infer_size_from_argument_tests {
+        use apollo_compiler::Node;
+        use apollo_compiler::ast::IntValue;
+        use serde_json_bytes::json;
+
+        use super::*;
+
+        // Helper to create a list with n string items
+        fn list_of_size(n: usize) -> AstValue {
+            let items = (0..n)
+                .map(|i| Node::new(AstValue::String(format!("item{i}"))))
+                .collect();
+            AstValue::List(items)
+        }
+
+        #[rstest::rstest]
+        #[case::integer_10("10", Some(10))]
+        #[case::integer_0("0", Some(0))]
+        #[case::negative("-5", Some(-5))]
+        fn integer_values(#[case] input: &str, #[case] expected: Option<i32>) {
+            let value = AstValue::Int(IntValue::new_parsed(input));
+            assert_eq!(
+                infer_size_from_argument(Some(&value), &Object::new()),
+                expected
+            );
+        }
+
+        #[rstest::rstest]
+        #[case::three_items(3, Some(3))]
+        #[case::one_item(1, Some(1))]
+        #[case::empty(0, Some(0))]
+        fn list_values(#[case] size: usize, #[case] expected: Option<i32>) {
+            let value = list_of_size(size);
+            assert_eq!(
+                infer_size_from_argument(Some(&value), &Object::new()),
+                expected
+            );
+        }
+
+        #[rstest::rstest]
+        #[case::resolves_to_int("count", json!(5), Some(5))]
+        #[case::resolves_to_array("ids", json!(["x", "y", "z"]), Some(3))]
+        #[case::resolves_to_empty_array("empty", json!([]), Some(0))]
+        #[case::resolves_to_null("nullval", json!(null), None)]
+        fn variable_resolution(
+            #[case] var_name: &str,
+            #[case] var_value: serde_json_bytes::Value,
+            #[case] expected: Option<i32>,
+        ) {
+            let value = AstValue::Variable(apollo_compiler::Name::new_unchecked(var_name));
+            let mut variables = Object::new();
+            variables.insert(var_name, var_value);
+            assert_eq!(infer_size_from_argument(Some(&value), &variables), expected);
+        }
+
+        #[rstest::rstest]
+        #[case::none_input(None)]
+        #[case::string_value(Some(AstValue::String("not a size".into())))]
+        #[case::boolean_value(Some(AstValue::Boolean(true)))]
+        #[case::missing_variable(Some(AstValue::Variable(apollo_compiler::Name::new_unchecked(
+            "missing"
+        ))))]
+        fn unsupported_values_return_none(#[case] value: Option<AstValue>) {
+            assert_eq!(
+                infer_size_from_argument(value.as_ref(), &Object::new()),
+                None
+            );
+        }
     }
 }

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/custom_cost_schema.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/custom_cost_schema.graphql
@@ -137,6 +137,19 @@ type Query
       sizedFields: ["items"]
       requireOneSlicingArgument: true
     )
+  itemsByIds(ids: [ID!]!): [A]
+    @join__field(graph: SUBGRAPHWITHLISTSIZE)
+    @listSize(
+      slicingArguments: ["ids"]
+      requireOneSlicingArgument: true
+    )
+  itemsByIdsWithAssumedSize(ids: [ID!]): [A]
+    @join__field(graph: SUBGRAPHWITHLISTSIZE)
+    @listSize(
+      slicingArguments: ["ids"]
+      assumedSize: 50
+      requireOneSlicingArgument: false
+    )
 }
 
 type SizedField @join__type(graph: SUBGRAPHWITHLISTSIZE) {

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -1175,4 +1175,45 @@ mod tests {
         assert_eq!(planned_cost_js(schema, query, variables).await, 1.0);
         assert_eq!(planned_cost_rust(schema, query, variables), 1.0);
     }
+
+    /// Tests for array-based slicing arguments in @listSize directive
+    mod array_slicing_argument_tests {
+        use super::estimated_cost;
+
+        const SCHEMA: &str = include_str!("./fixtures/custom_cost_schema.graphql");
+
+        #[rstest::rstest]
+        #[case::inline_array_of_3(
+            r#"query { itemsByIds(ids: ["a", "b", "c"]) { id } }"#,
+            "{}",
+            3.0
+        )]
+        #[case::empty_inline_array(r#"query { itemsByIds(ids: []) { id } }"#, "{}", 0.0)]
+        #[case::variable_array_of_5(
+            r#"query Q($ids: [ID!]!) { itemsByIds(ids: $ids) { id } }"#,
+            r#"{"ids": ["a", "b", "c", "d", "e"]}"#,
+            5.0
+        )]
+        #[case::variable_empty_array(
+            r#"query Q($ids: [ID!]!) { itemsByIds(ids: $ids) { id } }"#,
+            r#"{"ids": []}"#,
+            0.0
+        )]
+        fn array_length_determines_list_size(
+            #[case] query: &str,
+            #[case] variables: &str,
+            #[case] expected_cost: f64,
+        ) {
+            assert_eq!(estimated_cost(SCHEMA, query, variables), expected_cost);
+        }
+
+        #[rstest::rstest]
+        #[case::null_variable(r#"{"ids": null}"#)]
+        #[case::missing_variable("{}")]
+        fn null_or_missing_array_falls_back_to_assumed_size(#[case] variables: &str) {
+            let query = r#"query Q($ids: [ID!]) { itemsByIdsWithAssumedSize(ids: $ids) { id } }"#;
+            // assumedSize is 50 in the schema
+            assert_eq!(estimated_cost(SCHEMA, query, variables), 50.0);
+        }
+    }
 }


### PR DESCRIPTION
<!-- start metadata -->
First change for enhancing how the `listSize` directive works. This PR merges into the [GRAPHOS-4/cmo/list-size-advanced-parsing](https://github.com/apollographql/router/tree/GRAPHOS-4/cmo/list-size-advanced-parsing) branch, which will hold the feature until complete.

---

Add array parsing support to `listSize` directive to leverage input length in cost calculations, allowing for queries like `itemsByUUID(ids: [ID!])` to be accurately costed

<!-- [ROUTER-####] -->
[GRAPHOS-13](https://apollographql.atlassian.net/browse/GRAPHOS-13)
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*
- Going to skip changeset and documentation until the end of the feature when we merge the feature branch into dev

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[GRAPHOS-13]: https://apollographql.atlassian.net/browse/GRAPHOS-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ