### PR TITLE
Update CODEOWNERS for fleet_detector file ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /apollo-federation/src/connectors @apollographql/graph-dev
 /apollo-router/ @apollographql/router-core
 /apollo-router/src/plugins/connectors @apollographql/graph-dev
-/apollo-router/src/plugins/fleet_detector.rs @apollographql/cloud-fleet
+/apollo-router/src/plugins/fleet_detector.rs @apollographql/runtime-readiness
 /apollo-router-benchmarks/ @apollographql/router-core @apollographql/fed-core
 /examples/ @apollographql/router-core @apollographql/fed-core
 /.github/CODEOWNERS @apollographql/router-core @apollographql/fed-core


### PR DESCRIPTION
Move Fleet Detector plugin into the purview of Runtime Readiness -> CODEOWNERS only change
