### PR TITLE
Support nested input paths in @listSize slicingArguments

### DIFF
--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -17,6 +17,25 @@ use crate::json_ext::Object;
 use crate::json_ext::ValueExt;
 use crate::plugins::demand_control::DemandControlError;
 
+// Traverses a nested AST value by path segments.
+// Given path `["pagination", "count"]`, returns the value at `{pagination: {count: <value>}}`.
+fn traverse_ast_value<'a>(value: &'a AstValue, path: &[&str]) -> Option<&'a AstValue> {
+    path.iter()
+        .try_fold(value, |current, segment| match current {
+            AstValue::Object(fields) => fields
+                .iter()
+                .find(|(name, _)| name.as_str() == *segment)
+                .map(|(_, node)| node.as_ref()),
+            _ => None,
+        })
+}
+
+// Traverses a nested JSON value by path segments.
+fn traverse_json_value<'a>(value: &'a JsonValue, path: &[&str]) -> Option<&'a JsonValue> {
+    path.iter()
+        .try_fold(value, |current, segment| current.get(segment))
+}
+
 // Infers a size value from an AST argument value.
 //
 // Returns:
@@ -41,30 +60,61 @@ fn infer_size_from_variable(value: Option<&JsonValue>) -> Option<i32> {
     }
 }
 
+fn resolve_nested_size(value: &AstValue, path: &[&str], variables: &Object) -> Option<i32> {
+    match value {
+        AstValue::Object(_) => infer_size_from_argument(traverse_ast_value(value, path), variables),
+        AstValue::Variable(var_name) => infer_size_from_variable(
+            variables
+                .get(var_name.as_str())
+                .and_then(|v| traverse_json_value(v, path)),
+        ),
+        _ => None,
+    }
+}
+
+// Resolves a slicing argument path to its size value.
+// Supports nested paths like "input.count" which traverse into input objects.
+fn resolve_slicing_value(
+    args: &HashMap<&str, &AstValue>,
+    slicing_path: &str,
+    variables: &Object,
+) -> Option<i32> {
+    let segments: Vec<&str> = slicing_path.split('.').collect();
+    let (arg_name, nested_path) = segments.split_first()?;
+    let value = args.get(*arg_name)?;
+
+    if nested_path.is_empty() {
+        infer_size_from_argument(Some(*value), variables)
+    } else {
+        resolve_nested_size(value, nested_path, variables)
+    }
+}
+
 // Collects slicing argument sizes from both default values and actual query arguments.
 // Actual values override defaults when both are present.
 fn collect_slicing_sizes<'a>(
-    field: &'a Field,
-    slicing_argument_names: &IndexSet<String>,
+    field: &Field,
+    slicing_argument_names: &'a IndexSet<String>,
     variables: &Object,
 ) -> HashMap<&'a str, i32> {
-    let is_slicing_arg = |name: &str| slicing_argument_names.contains(name);
+    // Merge default and actual argument values (actuals take precedence)
+    let defaults = field
+        .definition
+        .arguments
+        .iter()
+        .filter_map(|arg| arg.default_value.as_deref().map(|v| (arg.name.as_str(), v)));
+    let actuals = field
+        .arguments
+        .iter()
+        .map(|arg| (arg.name.as_str(), arg.value.as_ref()));
+    let args: HashMap<&str, &AstValue> = defaults.chain(actuals).collect();
 
-    let defaults = field.definition.arguments.iter().filter_map(|arg| {
-        is_slicing_arg(arg.name.as_str())
-            .then(|| infer_size_from_argument(arg.default_value.as_deref(), variables))
-            .flatten()
-            .map(|size| (arg.name.as_str(), size))
-    });
-
-    let actuals = field.arguments.iter().filter_map(|arg| {
-        is_slicing_arg(arg.name.as_str())
-            .then(|| infer_size_from_argument(Some(&arg.value), variables))
-            .flatten()
-            .map(|size| (arg.name.as_str(), size))
-    });
-
-    defaults.chain(actuals).collect()
+    slicing_argument_names
+        .iter()
+        .filter_map(|path| {
+            resolve_slicing_value(&args, path, variables).map(|size| (path.as_str(), size))
+        })
+        .collect()
 }
 
 pub(in crate::plugins::demand_control) struct IncludeDirective {
@@ -280,6 +330,178 @@ mod tests {
                 infer_size_from_argument(value.as_ref(), &Object::new()),
                 None
             );
+        }
+    }
+
+    mod traverse_ast_value_tests {
+        use apollo_compiler::Node;
+        use apollo_compiler::ast::Value as AstValue;
+
+        use super::traverse_ast_value;
+
+        fn make_object(fields: Vec<(&str, AstValue)>) -> AstValue {
+            AstValue::Object(
+                fields
+                    .into_iter()
+                    .map(|(name, value)| {
+                        (apollo_compiler::Name::new_unchecked(name), Node::new(value))
+                    })
+                    .collect(),
+            )
+        }
+
+        #[test]
+        fn empty_path_returns_value() {
+            let value = AstValue::Int(apollo_compiler::ast::IntValue::new_parsed("42"));
+            assert!(matches!(
+                traverse_ast_value(&value, &[]),
+                Some(AstValue::Int(_))
+            ));
+        }
+
+        #[test]
+        fn single_level_traversal() {
+            let value = make_object(vec![(
+                "count",
+                AstValue::Int(apollo_compiler::ast::IntValue::new_parsed("10")),
+            )]);
+            let result = traverse_ast_value(&value, ["count"].as_slice());
+            assert!(matches!(result, Some(AstValue::Int(_))));
+        }
+
+        #[test]
+        fn nested_traversal() {
+            let inner = make_object(vec![(
+                "first",
+                AstValue::Int(apollo_compiler::ast::IntValue::new_parsed("5")),
+            )]);
+            let outer = make_object(vec![("pagination", inner)]);
+            let result = traverse_ast_value(&outer, ["pagination", "first"].as_slice());
+            assert!(matches!(result, Some(AstValue::Int(_))));
+        }
+
+        #[test]
+        fn missing_field_returns_none() {
+            let value = make_object(vec![(
+                "other",
+                AstValue::Int(apollo_compiler::ast::IntValue::new_parsed("10")),
+            )]);
+            assert!(traverse_ast_value(&value, &["missing"]).is_none());
+        }
+
+        #[test]
+        fn non_object_with_path_returns_none() {
+            let value = AstValue::Int(apollo_compiler::ast::IntValue::new_parsed("42"));
+            assert!(traverse_ast_value(&value, &["field"]).is_none());
+        }
+
+        /// Edge case: empty segment in path won't match any field
+        #[test]
+        fn empty_segment_returns_none() {
+            let value = make_object(vec![(
+                "count",
+                AstValue::Int(apollo_compiler::ast::IntValue::new_parsed("10")),
+            )]);
+            // An empty string segment won't match "count"
+            assert!(traverse_ast_value(&value, &[""]).is_none());
+        }
+
+        /// Edge case: path with empty segment in middle fails at that point
+        #[test]
+        fn empty_segment_in_middle_returns_none() {
+            let inner = make_object(vec![(
+                "first",
+                AstValue::Int(apollo_compiler::ast::IntValue::new_parsed("5")),
+            )]);
+            let outer = make_object(vec![("pagination", inner)]);
+            assert!(traverse_ast_value(&outer, &["pagination", "", "first"]).is_none());
+        }
+    }
+
+    mod traverse_json_value_tests {
+        use serde_json_bytes::json;
+
+        use super::traverse_json_value;
+
+        #[test]
+        fn empty_path_returns_value() {
+            let value = json!(42);
+            assert_eq!(traverse_json_value(&value, &[]), Some(&value));
+        }
+
+        #[test]
+        fn single_level_traversal() {
+            let value = json!({"count": 10});
+            let result = traverse_json_value(&value, ["count"].as_slice());
+            assert_eq!(result, Some(&json!(10)));
+        }
+
+        #[test]
+        fn nested_traversal() {
+            let value = json!({"pagination": {"first": 5}});
+            let result = traverse_json_value(&value, ["pagination", "first"].as_slice());
+            assert_eq!(result, Some(&json!(5)));
+        }
+
+        #[test]
+        fn deeply_nested_traversal() {
+            let value = json!({"level1": {"level2": {"level3": {"count": 99}}}});
+            let result =
+                traverse_json_value(&value, ["level1", "level2", "level3", "count"].as_slice());
+            assert_eq!(result, Some(&json!(99)));
+        }
+
+        #[test]
+        fn missing_field_returns_none() {
+            let value = json!({"other": 10});
+            assert!(traverse_json_value(&value, &["missing"]).is_none());
+        }
+
+        #[test]
+        fn non_object_with_path_returns_none() {
+            let value = json!(42);
+            assert!(traverse_json_value(&value, &["field"]).is_none());
+        }
+
+        #[test]
+        fn partial_path_missing_returns_none() {
+            let value = json!({"level1": {"other": 5}});
+            assert!(traverse_json_value(&value, &["level1", "level2", "count"]).is_none());
+        }
+
+        /// Edge case: empty segment won't match any field
+        #[test]
+        fn empty_segment_returns_none() {
+            let value = json!({"count": 10});
+            assert!(traverse_json_value(&value, &[""]).is_none());
+        }
+
+        /// Edge case: path with empty segment in middle fails at that point
+        #[test]
+        fn empty_segment_in_middle_returns_none() {
+            let value = json!({"pagination": {"first": 5}});
+            assert!(traverse_json_value(&value, &["pagination", "", "first"]).is_none());
+        }
+
+        /// Edge case: whitespace in segment name won't match trimmed field names
+        #[test]
+        fn whitespace_segment_returns_none() {
+            let value = json!({"count": 10});
+            assert!(traverse_json_value(&value, &[" count"]).is_none());
+        }
+
+        /// Edge case: null values in the path
+        #[test]
+        fn null_value_in_path_returns_none() {
+            let value = json!({"pagination": null});
+            assert!(traverse_json_value(&value, &["pagination", "first"]).is_none());
+        }
+
+        /// Edge case: array in the path (not supported for simple traversal)
+        #[test]
+        fn array_value_in_path_returns_none() {
+            let value = json!({"items": [{"first": 5}]});
+            assert!(traverse_json_value(&value, &["items", "first"]).is_none());
         }
     }
 }

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/custom_cost_schema.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/custom_cost_schema.graphql
@@ -150,8 +150,49 @@ type Query
       assumedSize: 50
       requireOneSlicingArgument: false
     )
+  search(input: SearchInput!): [A]
+    @join__field(graph: SUBGRAPHWITHLISTSIZE)
+    @listSize(
+      slicingArguments: ["input.pagination.first"]
+      requireOneSlicingArgument: true
+    )
+  searchWithAssumedSize(input: SearchInput): [A]
+    @join__field(graph: SUBGRAPHWITHLISTSIZE)
+    @listSize(
+      slicingArguments: ["input.pagination.first"]
+      assumedSize: 25
+      requireOneSlicingArgument: false
+    )
+  deeplyNested(input: DeeplyNestedInput!): [A]
+    @join__field(graph: SUBGRAPHWITHLISTSIZE)
+    @listSize(
+      slicingArguments: ["input.level1.level2.count"]
+      requireOneSlicingArgument: true
+    )
 }
 
 type SizedField @join__type(graph: SUBGRAPHWITHLISTSIZE) {
   items: [A]
+}
+
+input PaginationInput @join__type(graph: SUBGRAPHWITHLISTSIZE) {
+  first: Int
+  after: String
+}
+
+input SearchInput @join__type(graph: SUBGRAPHWITHLISTSIZE) {
+  pagination: PaginationInput
+  query: String
+}
+
+input DeeplyNestedInput @join__type(graph: SUBGRAPHWITHLISTSIZE) {
+  level1: NestedLevel1Input
+}
+
+input NestedLevel1Input @join__type(graph: SUBGRAPHWITHLISTSIZE) {
+  level2: NestedLevel2Input
+}
+
+input NestedLevel2Input @join__type(graph: SUBGRAPHWITHLISTSIZE) {
+  count: Int
 }

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -1216,4 +1216,102 @@ mod tests {
             assert_eq!(estimated_cost(SCHEMA, query, variables), 50.0);
         }
     }
+
+    /// Tests for nested input path resolution in @listSize slicingArguments
+    ///
+    /// Note: Expected costs include the cost of input objects (1 per nested object).
+    /// For inline objects: SearchInput (1) + PaginationInput (1) = 2 base cost
+    /// For variables: input objects are costed based on their nesting level
+    mod nested_input_path_tests {
+        use super::estimated_cost;
+
+        const SCHEMA: &str = include_str!("./fixtures/custom_cost_schema.graphql");
+
+        // Input object costs:
+        // - SearchInput: 1
+        // - PaginationInput: 1
+        // Total input cost for search queries: 2
+
+        #[rstest::rstest]
+        #[case::inline_nested_first_10(
+            r#"query { search(input: {pagination: {first: 10}}) { id } }"#,
+            "{}",
+            12.0  // 10 (list size) + 2 (input objects: SearchInput + PaginationInput)
+        )]
+        #[case::inline_nested_first_5(
+            r#"query { search(input: {pagination: {first: 5}, query: "test"}) { id } }"#,
+            "{}",
+            7.0  // 5 (list size) + 2 (input objects)
+        )]
+        #[case::variable_nested_object(
+            r#"query Q($input: SearchInput!) { search(input: $input) { id } }"#,
+            r#"{"input": {"pagination": {"first": 7}, "query": "test"}}"#,
+            9.0  // 7 (list size) + 2 (input objects)
+        )]
+        #[case::variable_nested_first_only(
+            r#"query Q($input: SearchInput!) { search(input: $input) { id } }"#,
+            r#"{"input": {"pagination": {"first": 3}}}"#,
+            5.0  // 3 (list size) + 2 (input objects)
+        )]
+        fn nested_path_determines_list_size(
+            #[case] query: &str,
+            #[case] variables: &str,
+            #[case] expected_cost: f64,
+        ) {
+            assert_eq!(estimated_cost(SCHEMA, query, variables), expected_cost);
+        }
+
+        // Input object costs for searchWithAssumedSize:
+        // - SearchInput: 1
+        // - PaginationInput: 1 (if present)
+        // When path not found, falls back to assumedSize (25)
+
+        #[rstest::rstest]
+        #[case::missing_nested_value(
+            r#"{"input": {"pagination": {}}}"#,
+            27.0  // 25 (assumed size) + 2 (SearchInput + PaginationInput)
+        )]
+        #[case::missing_pagination(
+            r#"{"input": {}}"#,
+            26.0  // 25 (assumed size) + 1 (SearchInput only)
+        )]
+        #[case::null_input(
+            r#"{"input": null}"#,
+            25.0  // 25 (assumed size) + 0 (null is not scored)
+        )]
+        fn missing_nested_path_falls_back_to_assumed_size(
+            #[case] variables: &str,
+            #[case] expected_cost: f64,
+        ) {
+            let query =
+                r#"query Q($input: SearchInput) { searchWithAssumedSize(input: $input) { id } }"#;
+            assert_eq!(estimated_cost(SCHEMA, query, variables), expected_cost);
+        }
+
+        // DeeplyNestedInput has 3 levels: DeeplyNestedInput(1) + NestedLevel1Input(1) + NestedLevel2Input(1) = 3
+
+        #[test]
+        fn deeply_nested_path_inline() {
+            let query = r#"query { deeplyNested(input: {level1: {level2: {count: 15}}}) { id } }"#;
+            // 15 (list size) + 3 (input objects: DeeplyNestedInput + NestedLevel1Input + NestedLevel2Input)
+            assert_eq!(estimated_cost(SCHEMA, query, "{}"), 18.0);
+        }
+
+        #[test]
+        fn deeply_nested_path_variable() {
+            let query =
+                r#"query Q($input: DeeplyNestedInput!) { deeplyNested(input: $input) { id } }"#;
+            let variables = r#"{"input": {"level1": {"level2": {"count": 12}}}}"#;
+            // 12 (list size) + 3 (input objects)
+            assert_eq!(estimated_cost(SCHEMA, query, variables), 15.0);
+        }
+
+        #[test]
+        fn inline_nested_object_with_other_fields() {
+            // Ensure other fields in the nested object don't affect the size resolution
+            let query = r#"query { search(input: {pagination: {first: 8, after: "cursor"}, query: "search term"}) { id } }"#;
+            // 8 (list size) + 2 (input objects: SearchInput + PaginationInput)
+            assert_eq!(estimated_cost(SCHEMA, query, "{}"), 10.0);
+        }
+    }
 }


### PR DESCRIPTION
Add support nested input paths in @listSize slicingArguments.

[GRAPHOS-10](https://apollographql.atlassian.net/browse/GRAPHOS-10)

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*
- this is being added to a feature branch. changeset/docs will be added in a later PR
- no additional metrics or logs here, following the existing pattern we have.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[GRAPHOS-10]: https://apollographql.atlassian.net/browse/GRAPHOS-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ