### PR TITLE
docs: add note about root CA certificates for proxy environments

### DIFF
--- a/docs/source/routing/self-hosted/index.mdx
+++ b/docs/source/routing/self-hosted/index.mdx
@@ -24,6 +24,12 @@ For each version of the Apollo Router, Apollo provides:
 - [A Docker image](#container)
 - [A binary](#local-binary)
 
+<Note>
+
+If your organization uses a transparent or egress proxy (such as Zscaler, Netskope, or similar), you must include the proxy's root CA certificate in your container image. Without it, the router cannot establish TLS connections to Apollo Uplink, resulting in certificate validation errors or "invalid license" failures.
+
+</Note>
+
 ## Kubernetes
 
 ### Apollo GraphOS Operator


### PR DESCRIPTION
## Summary
- Adds a note to the self-hosted router documentation advising users to include their proxy's root CA certificate in container images when using transparent/egress proxies (e.g., Zscaler, Netskope)
- Helps users troubleshoot "invalid license" errors caused by TLS validation failures in proxied environments

## Test plan
- [ ] Verify the note renders correctly in the documentation