### PR TITLE
chore: Use correct GitHub tag for contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,13 +192,13 @@ The documentation previously stated that subscription support was an Enterprise-
 
 Updated both the configuration and overview pages to remove the misleading Enterprise-only requirement and clarify the actual requirements.
 
-By [@gigi](https://github.com/the-gigi-apollo) in https://github.com/apollographql/router/pull/8726
+By [@the-gigi-apollo](https://github.com/the-gigi-apollo) in https://github.com/apollographql/router/pull/8726
 
 ### Clarify traffic shaping compression headers in documentation ([PR #8773](https://github.com/apollographql/router/pull/8773))
 
 The traffic shaping documentation now clearly explains how the router handles HTTP compression headers for subgraph requests. It clarifies that `content-encoding` is set when compression is configured via `traffic_shaping`, while `accept-encoding` is automatically set on all subgraph requests to indicate the router can accept compressed responses (`gzip`, `br`, or `deflate`). The documentation also notes that these headers are added after requests are added to the debug stack, so they won't appear in the Connectors Debugger.
 
-By [@gigi](https://github.com/the-gigi-apollo) in https://github.com/apollographql/router/pull/8773
+By [@the-gigi-apollo](https://github.com/the-gigi-apollo) in https://github.com/apollographql/router/pull/8773
 
 ### Document default histogram buckets and their relationship to timeout settings ([PR #8783](https://github.com/apollographql/router/pull/8783))
 


### PR DESCRIPTION
Accidentally, this was using `@gigi` rather than @the-gigi-apollo, causing the wrong contributor to be pinged.  I edited the release manually, this just updates the CHANGELOG.md
