### PR TITLE
Add documentation and tests for dollar sign escaping in config

### DIFF
--- a/apollo-router/src/configuration/expansion.rs
+++ b/apollo-router/src/configuration/expansion.rs
@@ -536,4 +536,30 @@ mod test {
             assert_yaml_snapshot!(value);
         })
     }
+
+    #[test]
+    fn test_dollar_escape() {
+        // Test that $$ is escaped to a literal $ by shellexpand
+        let expansion = Expansion::builder()
+            .mocked_env_var("API_HOST", "api.example.com")
+            .supported_mode("env")
+            .build();
+
+        let value = json!({
+            // $$ should become a single $
+            "literal_dollar": "some$$api$$key",
+            // $$ alongside ${env.VAR} expansion
+            "mixed": "https://${env.API_HOST}/path?price=$$100",
+            // Multiple $$ in a row
+            "multiple_escapes": "$$first $$second $$third",
+            // $$ at start and end
+            "edges": "$$start and end$$",
+            // No expansion needed (plain string)
+            "plain": "no dollars here"
+        });
+        let result = expansion.expand(&value).expect("expansion must succeed");
+        insta::with_settings!({sort_maps => true}, {
+            assert_yaml_snapshot!(result);
+        })
+    }
 }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__dollar_escape.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__dollar_escape.snap
@@ -1,0 +1,9 @@
+---
+source: apollo-router/src/configuration/expansion.rs
+expression: result
+---
+edges: $start and end$
+literal_dollar: some$api$key
+mixed: "https://api.example.com/path?price=$100"
+multiple_escapes: $first $second $third
+plain: no dollars here

--- a/docs/source/routing/configuration/yaml.mdx
+++ b/docs/source/routing/configuration/yaml.mdx
@@ -841,6 +841,13 @@ headers:
 
 Here, the `name` and `value` entries under `&insert_custom_header` are reused under `*insert_custom_header`.
 
+### Escaping special characters
+
+To include a literal `$` character, double it as `$$`. The router converts each `$$` to a single `$`:
+
+- Config value: `prefix$$suffix`
+- Result: `prefix$suffix`
+
 ## Related topics
 
 - [Checklist for configuring the router for production](/technotes/TN0008-production-readiness-checklist/#apollo-router)


### PR DESCRIPTION
## This is a documentation PR that adds a unit test. No production code changes.    
This PR documents the `$$` escape syntax for including literal dollar signs in router YAML configuration values. This syntax is supported by the underlying shellexpand crate but was previously undocumented, causing user confusion in https://github.com/apollographql/rover/issues/2737 .                                                                                   
                                                                                                                                                                                                                                                                                                                   
  - Adds new "Escaping special characters" section to the YAML configuration reference                                                                                                                                                                                                                             
  - Example: `some$$api$$key` → `some$api$key`                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                   

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**



**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
