### PR TITLE
Update documentation to match APM template changes

### DIFF
--- a/docs/source/routing/observability/router-telemetry-otel/apm-guides/datadog/router-instrumentation.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/apm-guides/datadog/router-instrumentation.mdx
@@ -61,6 +61,7 @@ telemetry:
       default_requirement_level: required
 
       router:
+        apollo.router.overhead: true
         http.server.request.duration:
           attributes:
             graphql.errors:

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -232,7 +232,7 @@ Similar to the initial call to Uplink, the router does not record metrics for ca
 
 </Note>
 
-### Subscriptions
+## Subscriptions
 
 <Tip>
 


### PR DESCRIPTION
The template now includes the overhead metric as a default so we include
it in the recommended configuration.

Also fix the Subscriptions heading to be at the correct nesting level
instead of being a subheader under Uplink.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
