### PR TITLE
chore: update codeowners to reflect new team names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 /docs/ @apollographql/docs
 /.changesets/ @apollographql/docs
-/apollo-federation/ @apollographql/orchestration-language
+/apollo-federation/ @apollographql/orchestration-language @apollographql/rust-platform
 /apollo-router/ @apollographql/router-core
 /apollo-router/src/plugins/connectors @apollographql/orchestration-language
 /apollo-router/src/plugins/fleet_detector.rs @apollographql/runtime-readiness


### PR DESCRIPTION
Updated CODEOWNERS to reflect new ownership assignments for various directories.