### PR TITLE
Docs: Safelisting with PQ moving content

### DIFF
--- a/docs/source/routing/configuration/yaml.mdx
+++ b/docs/source/routing/configuration/yaml.mdx
@@ -232,7 +232,7 @@ If you need to override the subgraph URL at runtime on a per-request basis, you 
 
 You can enhance your graph's security with GraphOS Router by maintaining a persisted query list (PQL), an operation safelist made by your first-party apps. As opposed to automatic persisted queries (APQ) where operations are automatically cached, operations must be preregistered to the PQL. Once configured, the router checks incoming requests against the PQL.
 
-Learn more in [Safelisting with persisted queries](/graphos/platform/security/persisted-queries).
+Learn more about [safelisting with persisted queries](/graphos/platform/security/persisted-queries).
 
 ---
 

--- a/docs/source/routing/query-planning/caching.mdx
+++ b/docs/source/routing/query-planning/caching.mdx
@@ -51,7 +51,7 @@ supergraph:
     warmed_up_queries: 100
 ```
 
-In addition, the router can use the contents of the [persisted query list](/graphos/platform/security/persisted-queries) to prewarm the cache. By default, it does this when loading a new schema but not on startup; you can [configure](/graphos/platform/security/persisted-queries#experimental_prewarm_query_plan_cache) it to change either of these defaults.
+Additionally, the router can use the [persisted query list](/graphos/platform/security/persisted-queries) to prewarm the cache. By default, the router prewarms the cache when loading a new schema but not on startup. You can [configure](/graphos/platform/security/persisted-queries#experimental_prewarm_query_plan_cache) the router to change these defaults.
 
 #### Cache warm-up with headers
 

--- a/docs/source/routing/security/index.mdx
+++ b/docs/source/routing/security/index.mdx
@@ -10,7 +10,7 @@ Its security features contribute to a defense-in-depth approach, where different
 The features covered in this section include:
 
 - [**Authorization**](/graphos/routing/security/authorization) - define authorized access to GraphQL fields and types by annotating schemas with authorization primitives
-- [**Persisted Queries**](/graphos/platform/security/persisted-queries) - configure the router to allow clients to register and persist cached lists of safe GraphQL queries and operations 
+- [**Persisted Queries**](/graphos/platform/security/persisted-queries) - configure the router to enable clients to register and persist lists of safe GraphQL queries and operations 
 - [**Best Practices**](/graphos/platform/security/overview) - best practices for securing supergraphs
 - [**CORS**](/graphos/routing/security/cors) - control router access from browser-based clients 
 - [**CSRF Prevention**](/graphos/routing/security/csrf) - configure cross-site request forgery (CSRF) prevention in the router 

--- a/docs/source/routing/security/persisted-queries.mdx
+++ b/docs/source/routing/security/persisted-queries.mdx
@@ -12,6 +12,6 @@ Developer and Standard plans require Router v2.6.0 or later.
 
 </PlanRequired>
 
-Persisted queries let you maintain an allowlist of trusted operations and optionally require clients to send operation IDs instead of full operation strings. The GraphOS Router enforces safelisting and fetches the persisted query list (PQL) from GraphOS.
+Persisted queries enable you to maintain an allowlist of trusted operations and optionally require clients to send operation IDs instead of full operation strings. The GraphOS Router enforces safelisting and fetches the persisted query list (PQL) from GraphOS.
 
-For the complete implementation guide, including PQL creation, operation registration, client updates, and incremental adoption, see [Safelisting with Persisted Queries](/graphos/platform/security/persisted-queries) in the GraphOS Platform docs.
+For the complete implementation guide, including PQL creation, operation registration, client updates, and incremental adoption, see [Safelisting with Persisted Queries](/graphos/platform/security/persisted-queries).


### PR DESCRIPTION
We've received feedback in the past that having 2 separate pages with the same title "Safelisting with persisted queries" located in different docs sections containing overlapping content has been confusing.

Our solution is to keep just one canonical source of information (in the GraphOS Platform docs) and have the other one (Router docs) point to it.

We have a [separate docs PR](https://github.com/apollographql/docs-rewrite/pull/752) here that moves all the router configuration and other unique content over to the GraphOS Platform docs.

This particular PR (to be merged _after_ the other one) removes all the duplicated information, provides a small description to introduce the reader to the feature, then redirects them to the other docs page. Also fixes a few links where it makes sense.

<!-- start metadata -->




<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
