### PR TITLE
Support nested sizeFields for calculating cost

### DIFF
--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -1,10 +1,13 @@
+use std::sync::Arc;
+
 use ahash::HashMap;
-use ahash::HashSet;
+use ahash::HashMapExt;
 use apollo_compiler::Schema;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::ast::NamedType;
 use apollo_compiler::ast::Value as AstValue;
 use apollo_compiler::executable::Field;
+use apollo_compiler::executable::Selection;
 use apollo_compiler::executable::SelectionSet;
 use apollo_compiler::parser::Parser;
 use apollo_compiler::validation::Valid;
@@ -136,16 +139,176 @@ impl IncludeDirective {
     }
 }
 
-pub(in crate::plugins::demand_control) struct ListSizeDirective<'schema> {
-    pub(in crate::plugins::demand_control) expected_size: Option<i32>,
-    pub(in crate::plugins::demand_control) sized_fields: Option<HashSet<&'schema str>>,
+#[derive(Clone, Debug)]
+pub(in crate::plugins::demand_control) struct SizedFields {
+    /// Field names we treat as the list (apply size to) at this level.
+    list_field_names: IndexSet<String>,
+    /// Precomputed nested SizedFields per field name. Built once at schema load; descend() is a lookup.
+    descend_map: HashMap<String, Arc<SizedFields>>,
 }
 
-impl<'schema> ListSizeDirective<'schema> {
+impl SizedFields {
+    /// Validates one path: at every level, at most one leaf (field with no sub-selections).
+    fn validate_one_leaf_per_path(
+        selection_set: &SelectionSet,
+        field_set_str: &str,
+    ) -> Result<(), DemandControlError> {
+        let leaf_count = selection_set
+            .selections
+            .iter()
+            .filter(|s| matches!(s, Selection::Field(f) if f.selection_set.selections.is_empty()))
+            .count();
+        if leaf_count > 1 {
+            return Err(DemandControlError::QueryParseFailure(format!(
+                "sizedFields entry '{}' must specify at most one list field per path (found {}).",
+                field_set_str, leaf_count
+            )));
+        }
+        for s in &selection_set.selections {
+            if let Selection::Field(f) = s
+                && !f.selection_set.selections.is_empty()
+            {
+                Self::validate_one_leaf_per_path(&f.selection_set, field_set_str)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(in crate::plugins::demand_control) fn from_strings(
+        schema: &Valid<Schema>,
+        return_type: &NamedType,
+        field_names: &IndexSet<String>,
+    ) -> Result<Self, DemandControlError> {
+        let selections: Vec<SelectionSet> = field_names
+            .iter()
+            .map(|field_set_str| {
+                let parsed = Parser::new()
+                    .parse_field_set(schema, return_type.clone(), field_set_str, "")
+                    .map_err(|e| {
+                        DemandControlError::QueryParseFailure(format!(
+                            "Failed to parse sizedFields entry '{}': {}",
+                            field_set_str, e
+                        ))
+                    })?;
+                let selection_set = parsed.selection_set.clone();
+                Self::validate_one_leaf_per_path(&selection_set, field_set_str)?;
+                Ok(selection_set)
+            })
+            .collect::<Result<Vec<SelectionSet>, DemandControlError>>()?;
+
+        let raw_descend = Self::build_descend_map_raw(&selections);
+        let list_field_names = Self::list_field_names_from_selections(&selections, &raw_descend);
+        let descend_map = Self::build_nested_sized_fields(raw_descend);
+        Ok(SizedFields {
+            list_field_names,
+            descend_map,
+        })
+    }
+
+    /// Build list_field_names from selections, excluding any name that is also a container.
+    fn list_field_names_from_selections(
+        selection_sets: &[SelectionSet],
+        raw_descend: &HashMap<String, Vec<SelectionSet>>,
+    ) -> IndexSet<String> {
+        let leaf_field_names = Self::collect_leaf_names(selection_sets);
+        leaf_field_names
+            .iter()
+            .filter(|name| !raw_descend.contains_key(name.as_str()))
+            .cloned()
+            .collect()
+    }
+
+    /// Recursively build SizedFields for each nested level so descend() is a lookup at request time.
+    fn build_nested_sized_fields(
+        raw_descend: HashMap<String, Vec<SelectionSet>>,
+    ) -> HashMap<String, Arc<SizedFields>> {
+        raw_descend
+            .into_iter()
+            .filter_map(|(name, nested_selections)| {
+                if nested_selections.is_empty() {
+                    return None;
+                }
+                let nested_raw = Self::build_descend_map_raw(&nested_selections);
+                let list_field_names =
+                    Self::list_field_names_from_selections(&nested_selections, &nested_raw);
+                let descend_map = Self::build_nested_sized_fields(nested_raw);
+                Some((
+                    name,
+                    Arc::new(SizedFields {
+                        list_field_names,
+                        descend_map,
+                    }),
+                ))
+            })
+            .collect()
+    }
+
+    fn collect_leaf_names(selection_sets: &[SelectionSet]) -> IndexSet<String> {
+        let mut names = IndexSet::new();
+        for selection_set in selection_sets {
+            Self::collect_leaf_names_from_set(selection_set, &mut names);
+        }
+        names
+    }
+
+    fn collect_leaf_names_from_set(selection_set: &SelectionSet, out: &mut IndexSet<String>) {
+        for s in &selection_set.selections {
+            if let Selection::Field(f) = s {
+                if f.selection_set.selections.is_empty() {
+                    out.insert(f.name.as_str().to_string());
+                } else {
+                    Self::collect_leaf_names_from_set(&f.selection_set, out);
+                }
+            }
+        }
+    }
+
+    /// Shallow pass: field name -> nested selection sets (one level only).
+    fn build_descend_map_raw(
+        selection_sets: &[SelectionSet],
+    ) -> HashMap<String, Vec<SelectionSet>> {
+        let mut map = HashMap::new();
+        for selection_set in selection_sets {
+            for s in &selection_set.selections {
+                if let Selection::Field(f) = s
+                    && !f.selection_set.selections.is_empty()
+                {
+                    map.entry(f.name.as_str().to_string())
+                        .or_insert_with(Vec::new)
+                        .push(f.selection_set.clone());
+                }
+            }
+        }
+        map
+    }
+
+    /// True only if this field name is a leaf in our paths and not also a container at this level.
+    pub(in crate::plugins::demand_control) fn is_leaf(&self, field_name: &str) -> bool {
+        self.list_field_names.contains(field_name)
+    }
+
+    /// Returns nested SizedFields for the given field (for descending into "results { page }").
+    pub(in crate::plugins::demand_control) fn descend(
+        &self,
+        field_name: &str,
+    ) -> Option<Arc<Self>> {
+        self.descend_map.get(field_name).cloned()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::plugins::demand_control) struct ListSizeDirective {
+    pub(in crate::plugins::demand_control) expected_size: Option<i32>,
+    pub(in crate::plugins::demand_control) sized_fields: Option<Arc<SizedFields>>,
+}
+
+impl ListSizeDirective {
+    /// Build a ListSizeDirective at request time using pre-parsed sizedFields from schema load.
     pub(in crate::plugins::demand_control) fn new(
-        parsed: &'schema ParsedListSizeDirective,
+        parsed: &ParsedListSizeDirective,
         field: &Field,
         variables: &Object,
+        pre_parsed_sized_fields: Option<Arc<SizedFields>>,
     ) -> Result<Self, DemandControlError> {
         let expected_size = match parsed.slicing_argument_names.as_ref() {
             Some(slicing_argument_names) => {
@@ -165,23 +328,29 @@ impl<'schema> ListSizeDirective<'schema> {
 
         Ok(Self {
             expected_size,
-            sized_fields: parsed
-                .sized_fields
-                .as_ref()
-                .map(|set| set.iter().map(|s| s.as_str()).collect()),
+            sized_fields: pre_parsed_sized_fields,
         })
     }
 
     pub(in crate::plugins::demand_control) fn size_of(&self, field: &Field) -> Option<i32> {
         if self
             .sized_fields
-            .as_ref()
-            .is_some_and(|sf| sf.contains(field.name.as_str()))
+            .as_deref()
+            .is_some_and(|sf| sf.is_leaf(field.name.as_str()))
         {
             self.expected_size
         } else {
             None
         }
+    }
+
+    /// Returns a directive scoped to the given nested field (e.g. from `results { page }` to the selection under `results`).
+    pub(in crate::plugins::demand_control) fn descend(&self, field_name: &str) -> Option<Self> {
+        let nested = self.sized_fields.as_ref()?.descend(field_name)?;
+        Some(ListSizeDirective {
+            expected_size: self.expected_size,
+            sized_fields: Some(nested),
+        })
     }
 }
 

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/custom_cost_schema.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/custom_cost_schema.graphql
@@ -169,6 +169,39 @@ type Query
       slicingArguments: ["input.level1.level2.count"]
       requireOneSlicingArgument: true
     )
+  containerWithNestedList(first: Int): ResultContainer!
+    @join__field(graph: SUBGRAPHWITHLISTSIZE)
+    @listSize(
+      slicingArguments: ["first"]
+      sizedFields: ["page"]
+      requireOneSlicingArgument: false
+    )
+  deepContainerWithNestedList(first: Int = 10): DeepContainer!
+    @join__field(graph: SUBGRAPHWITHLISTSIZE)
+    @listSize(
+      slicingArguments: ["first"]
+      sizedFields: ["results { page }"]
+      requireOneSlicingArgument: false
+    )
+  deepContainerWithMixedSizedFields(first: Int = 10): DeepContainer!
+    @join__field(graph: SUBGRAPHWITHLISTSIZE)
+    @listSize(
+      slicingArguments: ["first"]
+      sizedFields: ["page", "results { page }"]
+      requireOneSlicingArgument: false
+    )
+}
+
+type ResultContainer @join__type(graph: SUBGRAPHWITHLISTSIZE) {
+  page: [A]
+  metadata: String
+}
+
+type DeepContainer @join__type(graph: SUBGRAPHWITHLISTSIZE) {
+  page: [A]
+  results: ResultContainer
+  total: Int
+  metadata: String
 }
 
 type SizedField @join__type(graph: SUBGRAPHWITHLISTSIZE) {

--- a/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
@@ -15,6 +15,7 @@ use apollo_federation::schema::ValidFederationSchema;
 
 use crate::plugins::demand_control::DemandControlError;
 use crate::plugins::demand_control::cost_calculator::directives::RequiresDirective;
+use crate::plugins::demand_control::cost_calculator::directives::SizedFields;
 
 pub(in crate::plugins::demand_control) struct InputDefinition {
     name: Name,
@@ -67,6 +68,8 @@ pub(in crate::plugins::demand_control) struct FieldDefinition {
     ty: ExtendedType,
     cost_directive: Option<CostDirective>,
     list_size_directive: Option<ListSizeDirective>,
+    /// Parsed at schema load so invalid sizedFields fail startup, not first request.
+    parsed_sized_fields: Option<Arc<SizedFields>>,
     requires_directive: Option<RequiresDirective>,
     arguments: HashMap<Name, InputDefinition>,
 }
@@ -91,6 +94,7 @@ impl FieldDefinition {
             ty: field_type.clone(),
             cost_directive: None,
             list_size_directive: None,
+            parsed_sized_fields: None,
             requires_directive: None,
             arguments: HashMap::new(),
         };
@@ -102,6 +106,16 @@ impl FieldDefinition {
                 schema,
                 field_definition,
             )?;
+        if let Some(ref list_size) = processed_field_definition.list_size_directive
+            && let Some(ref field_names) = list_size.sized_fields
+        {
+            processed_field_definition.parsed_sized_fields =
+                Some(Arc::new(SizedFields::from_strings(
+                    schema.schema(),
+                    field_definition.ty.inner_named_type(),
+                    field_names,
+                )?));
+        }
         processed_field_definition.requires_directive = RequiresDirective::from_field_definition(
             field_definition,
             parent_type_name,
@@ -130,6 +144,12 @@ impl FieldDefinition {
         &self,
     ) -> Option<&ListSizeDirective> {
         self.list_size_directive.as_ref()
+    }
+
+    pub(in crate::plugins::demand_control) fn parsed_sized_fields(
+        &self,
+    ) -> Option<&Arc<SizedFields>> {
+        self.parsed_sized_fields.as_ref()
     }
 
     pub(in crate::plugins::demand_control) fn requires_directive(

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -190,6 +190,7 @@ impl StaticCostCalculator {
         field: &Field,
         parent_type: &NamedType,
         list_size_from_upstream: Option<i32>,
+        inherited_list_size: Option<ListSizeDirective>,
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         // When we pre-process the schema, __typename isn't included. So, we short-circuit here to avoid failed lookups.
@@ -209,16 +210,27 @@ impl StaticCostCalculator {
                     field.name
                 ))
             })?;
-        let list_size_directive = match definition.list_size_directive() {
-            Some(dir) => ListSizeDirective::new(dir, field, ctx.variables).map(Some),
-            None => Ok(None),
-        }?;
+        let own_list_size_directive = match definition.list_size_directive() {
+            Some(dir) => Some(ListSizeDirective::new(
+                dir,
+                field,
+                ctx.variables,
+                definition.parsed_sized_fields().map(Arc::clone),
+            )?),
+            None => None,
+        };
+
         let instance_count = if !field.ty().is_list() {
             1
         } else if let Some(value) = list_size_from_upstream {
             // This is a sized field whose length is defined by the `@listSize` directive on the parent field
             value
-        } else if let Some(expected_size) = list_size_directive
+        } else if let Some(expected_size) = own_list_size_directive
+            .as_ref()
+            .and_then(|dir| dir.expected_size)
+        {
+            expected_size
+        } else if let Some(expected_size) = inherited_list_size
             .as_ref()
             .and_then(|dir| dir.expected_size)
         {
@@ -245,7 +257,8 @@ impl StaticCostCalculator {
             ctx,
             &field.selection_set,
             field.ty().inner_named_type(),
-            list_size_directive.as_ref(),
+            own_list_size_directive.as_ref(),
+            inherited_list_size,
             subgraph,
         )?;
 
@@ -277,7 +290,8 @@ impl StaticCostCalculator {
                     ctx,
                     selection_set,
                     parent_type,
-                    list_size_directive.as_ref(),
+                    own_list_size_directive.as_ref(),
+                    None,
                     subgraph,
                 )?;
             }
@@ -302,6 +316,7 @@ impl StaticCostCalculator {
         ctx: &ScoringContext,
         fragment_spread: &FragmentSpread,
         list_size_directive: Option<&ListSizeDirective>,
+        inherited_list_size: Option<&ListSizeDirective>,
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         let fragment = fragment_spread.fragment_def(ctx.query).ok_or_else(|| {
@@ -315,6 +330,7 @@ impl StaticCostCalculator {
             &fragment.selection_set,
             fragment.type_condition(),
             list_size_directive,
+            inherited_list_size.cloned(),
             subgraph,
         )
     }
@@ -325,6 +341,7 @@ impl StaticCostCalculator {
         inline_fragment: &InlineFragment,
         parent_type: &NamedType,
         list_size_directive: Option<&ListSizeDirective>,
+        inherited_list_size: Option<&ListSizeDirective>,
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         self.score_selection_set(
@@ -335,6 +352,7 @@ impl StaticCostCalculator {
                 .as_ref()
                 .unwrap_or(parent_type),
             list_size_directive,
+            inherited_list_size.cloned(),
             subgraph,
         )
     }
@@ -359,6 +377,7 @@ impl StaticCostCalculator {
             &operation.selection_set,
             root_type_name,
             None,
+            None,
             subgraph,
         )?;
 
@@ -371,22 +390,47 @@ impl StaticCostCalculator {
         selection: &Selection,
         parent_type: &NamedType,
         list_size_directive: Option<&ListSizeDirective>,
+        inherited_list_size: Option<&ListSizeDirective>,
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         match selection {
-            Selection::Field(f) => self.score_field(
+            Selection::Field(f) => {
+                // We need two things for scoring this field: (1) the list size to use for
+                // instance_count if this field is a list (list_size_from_upstream), and (2) the
+                // directive to pass to this field's selection set so nested lists (e.g. "page" under
+                // "results") get the right sizing (descended).
+                let size_from_parent = list_size_directive.and_then(|dir| dir.size_of(f));
+                let size_from_inherited = inherited_list_size.and_then(|dir| dir.size_of(f));
+                let list_size_from_upstream = size_from_parent.or(size_from_inherited);
+
+                let descended = list_size_directive
+                    .and_then(|dir| dir.descend(f.name.as_str()))
+                    .or_else(|| inherited_list_size.and_then(|dir| dir.descend(f.name.as_str())));
+
+                self.score_field(
+                    ctx,
+                    f,
+                    parent_type,
+                    list_size_from_upstream,
+                    descended,
+                    subgraph,
+                )
+            }
+            Selection::FragmentSpread(s) => self.score_fragment_spread(
                 ctx,
-                f,
-                parent_type,
-                list_size_directive.and_then(|dir| dir.size_of(f)),
+                s,
+                list_size_directive,
+                inherited_list_size,
                 subgraph,
             ),
-            Selection::FragmentSpread(s) => {
-                self.score_fragment_spread(ctx, s, list_size_directive, subgraph)
-            }
-            Selection::InlineFragment(i) => {
-                self.score_inline_fragment(ctx, i, parent_type, list_size_directive, subgraph)
-            }
+            Selection::InlineFragment(i) => self.score_inline_fragment(
+                ctx,
+                i,
+                parent_type,
+                list_size_directive,
+                inherited_list_size,
+                subgraph,
+            ),
         }
     }
 
@@ -396,6 +440,7 @@ impl StaticCostCalculator {
         selection_set: &SelectionSet,
         parent_type_name: &NamedType,
         list_size_directive: Option<&ListSizeDirective>,
+        inherited_list_size: Option<ListSizeDirective>,
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         let mut cost = 0.0;
@@ -405,6 +450,7 @@ impl StaticCostCalculator {
                 selection,
                 parent_type_name,
                 list_size_directive,
+                inherited_list_size.as_ref(),
                 subgraph,
             )?;
         }
@@ -1392,6 +1438,92 @@ mod tests {
             let query = r#"query { search(input: {pagination: {first: 8, after: "cursor"}, query: "search term"}) { id } }"#;
             // 8 (list size) + 2 (input objects: SearchInput + PaginationInput)
             assert_eq!(estimated_cost(SCHEMA, query, "{}"), 10.0);
+        }
+    }
+
+    /// Nested sizedFields in @listSize (e.g. "results { page }")
+    mod nested_sized_fields_tests {
+        use super::estimated_cost;
+
+        const SCHEMA: &str = include_str!("./fixtures/custom_cost_schema.graphql");
+
+        #[rstest::rstest]
+        #[case::simple_sized_fields_on_nested_type(
+            r#"query { containerWithNestedList(first: 5) { page { id } metadata } }"#,
+            "{}",
+            6.0  // ResultContainer: 1, page: 5 * 1 = 5, metadata: 0
+        )]
+        #[case::nested_sized_fields_two_levels(
+            r#"query { deepContainerWithNestedList(first: 7) { results { page { id } } } }"#,
+            "{}",
+            9.0  // DeepContainer: 1, results: 1, page: 7 * 1 = 7
+        )]
+        #[case::nested_sized_fields_with_variable(
+            r#"query Q($n: Int!) { deepContainerWithNestedList(first: $n) { results { page { id } } } }"#,
+            r#"{"n": 3}"#,
+            5.0
+        )]
+        #[case::nested_sized_fields_with_default_value(
+            r#"query { deepContainerWithNestedList { results { page { id } } } }"#,
+            "{}",
+            12.0  // default first: 10
+        )]
+        #[case::nested_sized_fields_not_selected(
+            r#"query { deepContainerWithNestedList(first: 100) { total } }"#,
+            "{}",
+            1.0
+        )]
+        #[case::intermediate_container_without_sized_field(
+            r#"query { deepContainerWithNestedList(first: 100) { results { metadata } } }"#,
+            "{}",
+            2.0
+        )]
+        #[case::mixed_sized_fields_single_and_nested(
+            r#"query {
+                deepContainerWithMixedSizedFields(first: 5) {
+                    page { id }
+                    results { page { id } }
+                }
+            }"#,
+            "{}",
+            12.0  // DeepContainer: 1, page: 5 * 1 = 5, results: 1, page: 5 * 1 = 5
+        )]
+        fn nested_sized_fields_cases(
+            #[case] query: &str,
+            #[case] variables: &str,
+            #[case] expected_cost: f64,
+        ) {
+            assert_eq!(estimated_cost(SCHEMA, query, variables), expected_cost);
+        }
+
+        /// Schema load fails when a sizedFields path has more than one leaf (one-leaf-per-path rule).
+        #[test]
+        fn multiple_leaves_in_one_path_fails_at_schema_load() {
+            use std::sync::Arc;
+
+            use crate::plugins::demand_control::cost_calculator::schema::DemandControlledSchema;
+            use crate::spec;
+
+            // Schema with sizedFields: ["results { page metadata }"] - two leaves in one path
+            let schema_str = include_str!("./fixtures/custom_cost_schema.graphql").replace(
+                r#"sizedFields: ["results { page }"]"#,
+                r#"sizedFields: ["results { page metadata }"]"#,
+            );
+            // ResultContainer has page: [A] and metadata: String. So "results { page metadata }"
+            // has two top-level selections with no sub-selections (page is a leaf, metadata is a leaf).
+            let schema = spec::Schema::parse(&schema_str, &Default::default()).unwrap();
+            let result = DemandControlledSchema::new(Arc::new(schema.supergraph_schema().clone()));
+
+            match &result {
+                Err(e) => assert!(
+                    e.to_string().contains("at most one list field per path"),
+                    "expected error about one list field per path, got: {}",
+                    e
+                ),
+                Ok(_) => {
+                    panic!("expected schema load to fail for multiple list fields in one path")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Support nested sizeFields for calculating cost

This PR expands the use of `sizeFields` for the `@listSize` directive to specify a nested field to be costed based on a slicing argument:

```gql
@listSize(slicingArguments: ["first"], sizedFields: ["results { page }"])
```

<!-- start metadata -->
[GRAPHOS-11](https://apollographql.atlassian.net/browse/GRAPHOS-11)
<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*
* This will merge into a feature branch. Documentation & Changeset will come when a PR is submitted for the feature branch

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[GRAPHOS-11]: https://apollographql.atlassian.net/browse/GRAPHOS-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ