### PR TITLE
update bnf to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
  "mime",
  "multi_try",
  "multimap 0.10.1",
- "nom",
+ "nom 7.1.3",
  "nom_locate",
  "parking_lot",
  "percent-encoding",
@@ -1387,13 +1387,14 @@ dependencies = [
 
 [[package]]
 name = "bnf"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c09ea5795b3dd735ff47c4b8adf64c46e3ce056fa3c4880b865a352e4c40a2"
+checksum = "35b77b055f8cb1d566fa4ef55bc699f60eefb17927dc25fa454a05b6fabf7aa4"
 dependencies = [
- "getrandom 0.2.16",
- "nom",
- "rand 0.8.5",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nom 8.0.0",
+ "rand 0.9.2",
  "serde",
  "serde_json",
 ]
@@ -2270,7 +2271,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2486,7 +2487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3486,7 +3487,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3758,7 +3759,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4333,6 +4334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom_locate"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4340,7 +4350,7 @@ checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
 dependencies = [
  "bytecount",
  "memchr",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4381,7 +4391,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5256,7 +5266,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -5364,7 +5374,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5513,7 +5523,7 @@ dependencies = [
  "cookie-factory",
  "crc16",
  "log",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5817,7 +5827,6 @@ dependencies = [
  "http 1.4.0",
  "libfuzzer-sys",
  "log",
- "rand 0.8.5",
  "reqwest",
  "schemars",
  "serde",
@@ -5952,7 +5961,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6191,9 +6200,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.12.1",
  "itoa",
@@ -6645,7 +6654,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -7733,7 +7742,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,11 +14,9 @@ libfuzzer-sys = "=0.4.10"
 apollo-federation = { path = "../apollo-federation" }
 apollo-parser.workspace = true
 apollo-smith.workspace = true
-bnf = "0.5.0"
+bnf = "0.6"
 env_logger = "0.11.0"
 log = "0.4"
-# Required until https://github.com/shnewto/bnf/pull/175, remove when bnf 0.6 is out
-rand = "=0.8.5"
 reqwest = { workspace = true, features = ["json", "blocking"] }
 serde_json.workspace = true
 

--- a/fuzz/fuzz_targets/connector_selection_parse.rs
+++ b/fuzz/fuzz_targets/connector_selection_parse.rs
@@ -3,23 +3,26 @@
 use std::sync::LazyLock;
 
 use apollo_federation::connectors::JSONSelection;
+use bnf::CoverageGuided;
 use bnf::Grammar;
 use libfuzzer_sys::arbitrary;
 use libfuzzer_sys::arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 use libfuzzer_sys::Corpus;
-use rand::rngs::StdRng;
 
-fuzz_target!(|input: GeneratedSelection| -> Corpus {
-    // Generating a selection might choose a path which recurses too deeply, so
-    // we just mark those traversals as being rejected since they would require
-    // seeding and iterating the Rng.
-    let Some(selection) = input.0 else {
+/// Generations per fuzz input. CoverageGuided prefers grammar productions
+/// not yet exercised; multiple generations let that coverage accumulate.
+const GENERATIONS_PER_INPUT: usize = 8;
+
+fuzz_target!(|input: GeneratedSelections| -> Corpus {
+    if input.0.is_empty() {
         return Corpus::Reject;
-    };
+    }
 
-    let parsed = JSONSelection::parse(&selection).unwrap();
-    drop(parsed);
+    for selection in &input.0 {
+        let parsed = JSONSelection::parse(selection).unwrap();
+        drop(parsed);
+    }
 
     Corpus::Keep
 });
@@ -84,29 +87,30 @@ const BNF_GRAMMAR: &str = r##"
     "##;
 static GRAMMAR: LazyLock<Grammar> = LazyLock::new(|| BNF_GRAMMAR.parse().unwrap());
 
-struct GeneratedSelection(Option<String>);
-impl<'a> Arbitrary<'a> for GeneratedSelection {
+/// One fuzz input: a seed produces multiple grammar-generated strings via
+/// CoverageGuided, which prefers productions not yet used so we exercise
+/// more of the grammar per input.
+struct GeneratedSelections(Vec<String>);
+impl<'a> Arbitrary<'a> for GeneratedSelections {
     fn arbitrary(u: &mut libfuzzer_sys::arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let bytes = <[u8; 32] as Arbitrary>::arbitrary(u)?;
-        let mut rng: StdRng = rand::SeedableRng::from_seed(bytes);
+        let mut strategy = CoverageGuided::from_seed(bytes);
 
-        let selection = GRAMMAR.generate_seeded(&mut rng).ok();
-        Ok(GeneratedSelection(selection))
+        let selections: Vec<String> = (0..GENERATIONS_PER_INPUT)
+            .filter_map(|_| GRAMMAR.generate_seeded_with_strategy(&mut strategy).ok())
+            .collect();
+        Ok(GeneratedSelections(selections))
     }
 }
 
-impl std::fmt::Debug for GeneratedSelection {
+impl std::fmt::Debug for GeneratedSelections {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0
-            .as_deref()
-            .map(|selection| {
-                write!(f, "```original\n{}\n```", selection)?;
-                if let Ok(parsed) = JSONSelection::parse(selection) {
-                    write!(f, "\n\n```pretty\n{}\n```", parsed)?;
-                }
-
-                Ok(())
-            })
-            .unwrap_or(Ok(()))
+        for selection in &self.0 {
+            write!(f, "```original\n{}\n```", selection)?;
+            if let Ok(parsed) = JSONSelection::parse(selection) {
+                write!(f, "\n\n```pretty\n{}\n```", parsed)?;
+            }
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
# Summary

- **Upgrade `bnf` to 0.6** and remove the `rand` version pin that was required until bnf 0.6 (see [#7897](https://github.com/apollographql/router/pull/7897)).
- **Use coverage-guided grammar generation** in the `connector_selection_parse` fuzz target: switch to bnf's `CoverageGuided` strategy and run multiple generations per fuzz input so we exercise more grammar productions per seed.

## Motivation

- bnf 0.6 re-exports `rand` and uses rand 0.9, so the fuzz crate no longer needs a pinned `rand` dependency.
- The `connector_selection_parse` target previously used a single grammar generation per input; `CoverageGuided` only helps when the same strategy is reused across generations. Running several generations per input (same seed, same strategy) lets the strategy prefer previously unused productions, improving grammar coverage for the JSON selection parser fuzz run.

## Changes

- `fuzz/Cargo.toml`: bump `bnf` from `0.5.0` to `0.6`, remove `rand = "=0.8.5"` and the comment about bnf PR #175.
- `fuzz/fuzz_targets/connector_selection_parse.rs`: use `bnf::CoverageGuided` and `bnf::rand` (no direct `rand` dep); generate up to 8 selections per fuzz input via `generate_seeded_with_strategy` and parse each; keep `Corpus::Reject` when no generation succeeds (e.g. non-terminating expansion).

---

<!-- start metadata -->

<!-- [ROUTER-1621] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

- **Changeset:** Not included; changes are limited to the fuzz crate and do not affect router behavior or user-facing APIs.
- **Documentation:** N/A; no configuration or user-facing behavior changed.
- **Metrics and logs:** N/A; no new observability added.
- **Tests:** No new unit or integration tests. Verified with `cargo check -p router-fuzz` and by running the `connector_selection_parse` fuzz target.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1621]: https://apollographql.atlassian.net/browse/ROUTER-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ