### PR TITLE
Support multiple listSize directives

### DIFF
--- a/.changesets/feat_multiple_list_size_directives.md
+++ b/.changesets/feat_multiple_list_size_directives.md
@@ -1,0 +1,17 @@
+### Support multiple `@listSize` directives on the same field
+
+> [!WARNING]
+>
+> Multiple `@listSize` directives on a field will only take effect once **Federation** supports repeatable `@listSize` in the supergraph schema. Until then, composition will continue to expose at most one directive per field. This change makes the router ready for that Federation release.
+
+The router now supports multiple `@listSize` directives on a single field, allowing more flexible cost estimation when directives from different subgraphs are combined during federation composition.
+
+**Key changes:**
+
+- **Multiple directive handling:** The router now processes all `@listSize` directives on a field (stored as `Vec<ListSizeDirective>` instead of `Option<ListSizeDirective>`)
+- **Maximum value selection:** When multiple directives specify `assumedSize` values, the router uses the maximum value for cost calculation
+- **Backward compatible:** Existing schemas with single directives continue to work exactly as before
+
+This change prepares the router for federation's upcoming support for repeatable `@listSize` directives, while maintaining full compatibility with current non-repeatable directive schemas.
+
+By [@cmorris](https://github.com/cmorris) in https://github.com/apollographql/router/pull/8872

--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -248,6 +248,25 @@ impl CostSpecDefinition {
         }
     }
 
+    /// Returns all `@listSize` directives from a field definition.
+    pub fn list_size_directives_from_field_definition(
+        schema: &FederationSchema,
+        field: &FieldDefinition,
+    ) -> Result<Vec<ListSizeDirective>, FederationError> {
+        let directive_name = Self::list_size_directive_name(schema)?;
+        let Some(name) = directive_name.as_ref() else {
+            return Ok(Vec::new());
+        };
+        // get_all() returns all instances of the directive (for repeatable directives)
+        let directives: Vec<ListSizeDirective> = field
+            .directives
+            .get_all(name)
+            .map(Node::as_ref)
+            .map(ListSizeDirective::from_directive)
+            .collect();
+        Ok(directives)
+    }
+
     fn cost_directive_specification() -> DirectiveSpecification {
         DirectiveSpecification::new(
             COST_DIRECTIVE_NAME,
@@ -395,23 +414,24 @@ pub struct ListSizeDirective {
 }
 
 impl ListSizeDirective {
+    /// Creates a ListSizeDirective from a single directive instance.
+    /// Used by the plural API to process each directive individually.
+    pub fn from_directive(directive: &Directive) -> Self {
+        Self {
+            assumed_size: Self::assumed_size(directive),
+            slicing_argument_names: Self::slicing_argument_names(directive),
+            sized_fields: Self::sized_fields(directive),
+            require_one_slicing_argument: Self::require_one_slicing_argument(directive)
+                .unwrap_or(true),
+        }
+    }
+
     pub fn from_field_definition(
         directive_name: &Name,
         definition: &FieldDefinition,
     ) -> Option<Self> {
         let directive = definition.directives.get(directive_name)?;
-        let assumed_size = Self::assumed_size(directive);
-        let slicing_argument_names = Self::slicing_argument_names(directive);
-        let sized_fields = Self::sized_fields(directive);
-        let require_one_slicing_argument =
-            Self::require_one_slicing_argument(directive).unwrap_or(true);
-
-        Some(Self {
-            assumed_size,
-            slicing_argument_names,
-            sized_fields,
-            require_one_slicing_argument,
-        })
+        Some(Self::from_directive(directive))
     }
 
     fn assumed_size(directive: &Directive) -> Option<i32> {

--- a/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
@@ -64,12 +64,18 @@ impl InputDefinition {
     }
 }
 
+/// One `@listSize` directive and its pre-parsed sizedFields (for demand control cost calculation).
+/// `parsed_sized_fields` is `None` when the directive has no `sizedFields` argument.
+pub(in crate::plugins::demand_control) struct ListSizeDirectiveEntry {
+    pub(in crate::plugins::demand_control) directive: ListSizeDirective,
+    pub(in crate::plugins::demand_control) parsed_sized_fields: Option<Arc<SizedFields>>,
+}
+
 pub(in crate::plugins::demand_control) struct FieldDefinition {
     ty: ExtendedType,
     cost_directive: Option<CostDirective>,
-    list_size_directive: Option<ListSizeDirective>,
-    /// Parsed at schema load so invalid sizedFields fail startup, not first request.
-    parsed_sized_fields: Option<Arc<SizedFields>>,
+    /// All `@listSize` directives on this field, each with its parsed sizedFields (if any).
+    list_size_directive_entries: Vec<ListSizeDirectiveEntry>,
     requires_directive: Option<RequiresDirective>,
     arguments: HashMap<Name, InputDefinition>,
 }
@@ -90,46 +96,48 @@ impl FieldDefinition {
                     field_definition.name,
                 ))
             })?;
-        let mut processed_field_definition = Self {
-            ty: field_type.clone(),
-            cost_directive: None,
-            list_size_directive: None,
-            parsed_sized_fields: None,
-            requires_directive: None,
-            arguments: HashMap::new(),
-        };
-
-        processed_field_definition.cost_directive =
+        let cost_directive =
             CostSpecDefinition::cost_directive_from_field(schema, field_definition, field_type)?;
-        processed_field_definition.list_size_directive =
-            CostSpecDefinition::list_size_directive_from_field_definition(
-                schema,
-                field_definition,
-            )?;
-        if let Some(ref list_size) = processed_field_definition.list_size_directive
-            && let Some(ref field_names) = list_size.sized_fields
-        {
-            processed_field_definition.parsed_sized_fields =
-                Some(Arc::new(SizedFields::from_strings(
+        let directives = CostSpecDefinition::list_size_directives_from_field_definition(
+            schema,
+            field_definition,
+        )?;
+        let mut list_size_directive_entries = Vec::with_capacity(directives.len());
+        for directive in directives {
+            let parsed_sized_fields = match &directive.sized_fields {
+                Some(field_names) => Some(Arc::new(SizedFields::from_strings(
                     schema.schema(),
                     field_definition.ty.inner_named_type(),
                     field_names,
-                )?));
+                )?)),
+                None => None,
+            };
+            list_size_directive_entries.push(ListSizeDirectiveEntry {
+                directive,
+                parsed_sized_fields,
+            });
         }
-        processed_field_definition.requires_directive = RequiresDirective::from_field_definition(
+        let requires_directive = RequiresDirective::from_field_definition(
             field_definition,
             parent_type_name,
             schema.schema(),
         )?;
 
+        let mut arguments = HashMap::new();
         for argument in &field_definition.arguments {
-            processed_field_definition.arguments.insert(
+            arguments.insert(
                 argument.name.clone(),
                 InputDefinition::new(schema, argument)?,
             );
         }
 
-        Ok(processed_field_definition)
+        Ok(Self {
+            ty: field_type.clone(),
+            cost_directive,
+            list_size_directive_entries,
+            requires_directive,
+            arguments,
+        })
     }
 
     pub(in crate::plugins::demand_control) fn ty(&self) -> &ExtendedType {
@@ -140,16 +148,11 @@ impl FieldDefinition {
         self.cost_directive.as_ref()
     }
 
-    pub(in crate::plugins::demand_control) fn list_size_directive(
+    /// All `@listSize` directives on this field, each with its parsed sizedFields (if any).
+    pub(in crate::plugins::demand_control) fn list_size_directive_entries(
         &self,
-    ) -> Option<&ListSizeDirective> {
-        self.list_size_directive.as_ref()
-    }
-
-    pub(in crate::plugins::demand_control) fn parsed_sized_fields(
-        &self,
-    ) -> Option<&Arc<SizedFields>> {
-        self.parsed_sized_fields.as_ref()
+    ) -> &[ListSizeDirectiveEntry] {
+        &self.list_size_directive_entries
     }
 
     pub(in crate::plugins::demand_control) fn requires_directive(

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -190,7 +190,7 @@ impl StaticCostCalculator {
         field: &Field,
         parent_type: &NamedType,
         list_size_from_upstream: Option<i32>,
-        inherited_list_size: Option<ListSizeDirective>,
+        inherited_list_sizes: &[ListSizeDirective],
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         // When we pre-process the schema, __typename isn't included. So, we short-circuit here to avoid failed lookups.
@@ -210,30 +210,31 @@ impl StaticCostCalculator {
                     field.name
                 ))
             })?;
-        let own_list_size_directive = match definition.list_size_directive() {
-            Some(dir) => Some(ListSizeDirective::new(
-                dir,
-                field,
-                ctx.variables,
-                definition.parsed_sized_fields().map(Arc::clone),
-            )?),
-            None => None,
-        };
+        let own_list_size_directives: Vec<ListSizeDirective> = definition
+            .list_size_directive_entries()
+            .iter()
+            .map(|entry| {
+                ListSizeDirective::new(
+                    &entry.directive,
+                    field,
+                    ctx.variables,
+                    entry.parsed_sized_fields.clone(),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let effective_expected_size = own_list_size_directives
+            .iter()
+            .chain(inherited_list_sizes)
+            .filter_map(|dir| dir.expected_size)
+            .max();
 
         let instance_count = if !field.ty().is_list() {
             1
         } else if let Some(value) = list_size_from_upstream {
             // This is a sized field whose length is defined by the `@listSize` directive on the parent field
             value
-        } else if let Some(expected_size) = own_list_size_directive
-            .as_ref()
-            .and_then(|dir| dir.expected_size)
-        {
-            expected_size
-        } else if let Some(expected_size) = inherited_list_size
-            .as_ref()
-            .and_then(|dir| dir.expected_size)
-        {
+        } else if let Some(expected_size) = effective_expected_size {
             expected_size
         } else if let Some(subgraph_list_size) = self.subgraph_list_size(subgraph) {
             subgraph_list_size as i32
@@ -257,8 +258,8 @@ impl StaticCostCalculator {
             ctx,
             &field.selection_set,
             field.ty().inner_named_type(),
-            own_list_size_directive.as_ref(),
-            inherited_list_size,
+            &own_list_size_directives,
+            inherited_list_sizes,
             subgraph,
         )?;
 
@@ -290,8 +291,8 @@ impl StaticCostCalculator {
                     ctx,
                     selection_set,
                     parent_type,
-                    own_list_size_directive.as_ref(),
-                    None,
+                    &own_list_size_directives,
+                    &[],
                     subgraph,
                 )?;
             }
@@ -315,8 +316,8 @@ impl StaticCostCalculator {
         &self,
         ctx: &ScoringContext,
         fragment_spread: &FragmentSpread,
-        list_size_directive: Option<&ListSizeDirective>,
-        inherited_list_size: Option<&ListSizeDirective>,
+        list_size_directives: &[ListSizeDirective],
+        inherited_list_sizes: &[ListSizeDirective],
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         let fragment = fragment_spread.fragment_def(ctx.query).ok_or_else(|| {
@@ -329,8 +330,8 @@ impl StaticCostCalculator {
             ctx,
             &fragment.selection_set,
             fragment.type_condition(),
-            list_size_directive,
-            inherited_list_size.cloned(),
+            list_size_directives,
+            inherited_list_sizes,
             subgraph,
         )
     }
@@ -340,8 +341,8 @@ impl StaticCostCalculator {
         ctx: &ScoringContext,
         inline_fragment: &InlineFragment,
         parent_type: &NamedType,
-        list_size_directive: Option<&ListSizeDirective>,
-        inherited_list_size: Option<&ListSizeDirective>,
+        list_size_directives: &[ListSizeDirective],
+        inherited_list_sizes: &[ListSizeDirective],
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         self.score_selection_set(
@@ -351,8 +352,8 @@ impl StaticCostCalculator {
                 .type_condition
                 .as_ref()
                 .unwrap_or(parent_type),
-            list_size_directive,
-            inherited_list_size.cloned(),
+            list_size_directives,
+            inherited_list_sizes,
             subgraph,
         )
     }
@@ -376,8 +377,8 @@ impl StaticCostCalculator {
             ctx,
             &operation.selection_set,
             root_type_name,
-            None,
-            None,
+            &[],
+            &[],
             subgraph,
         )?;
 
@@ -389,46 +390,55 @@ impl StaticCostCalculator {
         ctx: &ScoringContext,
         selection: &Selection,
         parent_type: &NamedType,
-        list_size_directive: Option<&ListSizeDirective>,
-        inherited_list_size: Option<&ListSizeDirective>,
+        list_size_directives: &[ListSizeDirective],
+        inherited_list_sizes: &[ListSizeDirective],
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         match selection {
             Selection::Field(f) => {
                 // We need two things for scoring this field: (1) the list size to use for
                 // instance_count if this field is a list (list_size_from_upstream), and (2) the
-                // directive to pass to this field's selection set so nested lists (e.g. "page" under
-                // "results") get the right sizing (descended).
-                let size_from_parent = list_size_directive.and_then(|dir| dir.size_of(f));
-                let size_from_inherited = inherited_list_size.and_then(|dir| dir.size_of(f));
+                // directive(s) to pass to this field's selection set so nested lists (e.g. "page"
+                // under "results") get the right sizing (descended). With repeatable @listSize,
+                // multiple directives can descend to the same field, so we collect all of them.
+                let size_from_parent = list_size_directives
+                    .iter()
+                    .filter_map(|dir| dir.size_of(f))
+                    .max();
+                let size_from_inherited = inherited_list_sizes
+                    .iter()
+                    .filter_map(|dir| dir.size_of(f))
+                    .max();
                 let list_size_from_upstream = size_from_parent.or(size_from_inherited);
 
-                let descended = list_size_directive
-                    .and_then(|dir| dir.descend(f.name.as_str()))
-                    .or_else(|| inherited_list_size.and_then(|dir| dir.descend(f.name.as_str())));
+                let descended: Vec<ListSizeDirective> = list_size_directives
+                    .iter()
+                    .chain(inherited_list_sizes.iter())
+                    .filter_map(|dir| dir.descend(f.name.as_str()))
+                    .collect();
 
                 self.score_field(
                     ctx,
                     f,
                     parent_type,
                     list_size_from_upstream,
-                    descended,
+                    &descended,
                     subgraph,
                 )
             }
             Selection::FragmentSpread(s) => self.score_fragment_spread(
                 ctx,
                 s,
-                list_size_directive,
-                inherited_list_size,
+                list_size_directives,
+                inherited_list_sizes,
                 subgraph,
             ),
             Selection::InlineFragment(i) => self.score_inline_fragment(
                 ctx,
                 i,
                 parent_type,
-                list_size_directive,
-                inherited_list_size,
+                list_size_directives,
+                inherited_list_sizes,
                 subgraph,
             ),
         }
@@ -439,8 +449,8 @@ impl StaticCostCalculator {
         ctx: &ScoringContext,
         selection_set: &SelectionSet,
         parent_type_name: &NamedType,
-        list_size_directive: Option<&ListSizeDirective>,
-        inherited_list_size: Option<ListSizeDirective>,
+        list_size_directives: &[ListSizeDirective],
+        inherited_list_sizes: &[ListSizeDirective],
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
         let mut cost = 0.0;
@@ -449,8 +459,8 @@ impl StaticCostCalculator {
                 ctx,
                 selection,
                 parent_type_name,
-                list_size_directive,
-                inherited_list_size.as_ref(),
+                list_size_directives,
+                inherited_list_sizes,
                 subgraph,
             )?;
         }
@@ -1300,6 +1310,49 @@ mod tests {
         assert_eq!(estimated_cost(schema, query, variables), 1.0);
         assert_eq!(planned_cost_js(schema, query, variables).await, 1.0);
         assert_eq!(planned_cost_rust(schema, query, variables), 1.0);
+    }
+
+    /// Tests to ensure Vec-based implementation (for supporting multiple @listSize directives)
+    /// maintains backward compatibility with existing single-directive behavior
+    mod backward_compatibility_tests {
+        use super::estimated_cost;
+
+        const SCHEMA: &str = include_str!("./fixtures/custom_cost_schema.graphql");
+
+        #[rstest::rstest]
+        #[case::no_directive("query { enumWithCost }", "{}", 15.0)]
+        #[case::single_slicing_argument_with_array(
+            r#"query { itemsByIds(ids: ["a", "b"]) { id } }"#,
+            "{}",
+            2.0
+        )]
+        #[case::slicing_argument_with_variable(
+            r#"query Q($ids: [ID!]!) { itemsByIds(ids: $ids) { id } }"#,
+            r#"{"ids": ["x", "y", "z"]}"#,
+            3.0
+        )]
+        #[case::nested_sized_fields(
+            r#"query { containerWithNestedList(first: 5) { page { id } } }"#,
+            "{}",
+            6.0
+        )]
+        #[case::assumed_size_fallback(
+            r#"query Q($ids: [ID!]) { itemsByIdsWithAssumedSize(ids: $ids) { id } }"#,
+            r#"{"ids": null}"#,
+            50.0
+        )]
+        #[case::sized_fields_propagate_to_nested_lists(
+            r#"query { fieldWithDynamicListSize { items { id } } }"#,
+            "{}",
+            11.0  // SizedField: 1, items: 10 * 1 = 10 (from default first: 10)
+        )]
+        fn vec_based_implementation_maintains_backward_compatibility(
+            #[case] query: &str,
+            #[case] variables: &str,
+            #[case] expected_cost: f64,
+        ) {
+            assert_eq!(estimated_cost(SCHEMA, query, variables), expected_cost);
+        }
     }
 
     /// Tests for array-based slicing arguments in @listSize directive


### PR DESCRIPTION
This is the final change on the router in the `listSize` enhancements. This PR allows the `listSize` directive to be used multiple times per field. The router aggregates the cost (e.g. takes the max expected_size) so cost stays safe across all usages. Single-directive behavior is unchanged.

Why
* One field, multiple usage patterns – e.g. pagination via first/last vs fetch-by-ids vs no args with a fallback size. Each pattern can have its own @listSize; cost reflects the worst case.
* Different nested fields – One directive can size by sizedFields: ["items"], another by sizedFields: ["totalCount"]. Aggregating avoids undercounting when different selections are used.
* Fallback + dynamic – Combine assumedSize (when no arg is provided) with slicingArguments (when the client sends a value). Cost uses the max so both cases are covered.

How (example)
```graphql
products(first: Int, last: Int, ids: [ID!]): [Product!]!
  @listSize(slicingArguments: ["first", "last"], sizedFields: ["items"], requireOneSlicingArgument: false)
  @listSize(assumedSize: 20, sizedFields: ["totalCount"])
```
Cost is computed from all directives (e.g. max of their sizes), so limits and budgeting stay correct for every way the field is used.

A federation change will be needed to leverage this feature, which will come at a later date.

<!-- start metadata -->

<!-- [GRAPHOS-12](https://apollographql.atlassian.net/browse/GRAPHOS-12) -->
<!-- [[ROUTER-1607](https://apollographql.atlassian.net/browse/ROUTER-1607) -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

A subsequent PR will contain docs, and the PR to merge the feature branch into `dev` will contain the changeset

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[GRAPHOS-12]: https://apollographql.atlassian.net/browse/GRAPHOS-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ