### PR TITLE
Alter CODEOWNER for apollo-router-benchmarks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,6 @@
 /apollo-router/ @apollographql/graphos
 /apollo-router/src/plugins/connectors @apollographql/orchestration-language
 /apollo-router/src/plugins/fleet_detector.rs @apollographql/runtime-readiness
+/apollo-router-benchmarks/ @apollographql/graphos @apollographql/orchestration-language
 /examples/ @apollographql/graphos
 /.github/CODEOWNERS @apollographql/graphos


### PR DESCRIPTION
Removed CODEOWNER for apollo-router-benchmarks.  Given the amount of movement on apollo-router-benchmarks, I'm not sure if CODEOWNER attribution is applicable right now.  @dariuszkuc Had also tried to remove fed core from it in https://github.com/apollographql/router/pull/8852#discussion_r2757855559 but I pushed back a bit.  My proposal is to either remove it, or to switch it to `graphos` like the other team names.