### PR TITLE
Update CODEOWNERS for apollo-federation path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 /docs/ @apollographql/docs
 /.changesets/ @apollographql/docs
-/apollo-federation/ @apollographql/orchestration-language @apollographql/rust-platform
+/apollo-federation/ @apollographql/orchestration-language
 /apollo-router/ @apollographql/graphos
 /apollo-router/src/plugins/connectors @apollographql/orchestration-language
 /apollo-router/src/plugins/fleet_detector.rs @apollographql/runtime-readiness


### PR DESCRIPTION
This removes `rust-platform`, which is more legacy at this point anyhow.