### PR TITLE
Remove docs CODEOWNER for /.changesets/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 /docs/ @apollographql/docs
-/.changesets/ @apollographql/docs
 /apollo-federation/ @apollographql/orchestration-language
 /apollo-router/ @apollographql/graphos
 /apollo-router/src/plugins/connectors @apollographql/orchestration-language


### PR DESCRIPTION
Removed docs CODEOWNER for the `.changesets/` directory.

The docs team doesn't really need to review our release changesets at this point, even if that made sense at a previous time.

Without removing this though, we effectively can't merge any PR that adds a changeset without a docs team review.  Getting the docs team involved on every changeset will easily bottleneck our PR merges, which I don't think we want.  The thing which materially has changed is that we do actually require codeowners reviews as a merge requirement now, which wasn't the case before.

Motivated by https://github.com/apollographql/router/pull/8845