### PR TITLE
add github copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,38 +33,24 @@ jobs:
         with:
           node-version: "24.x"
 
-      - name: Get upstream skills repository HEAD
-        id: skills-head
-        run: |
-          SKILLS_SHA=$(git ls-remote https://github.com/apollographql/skills.git HEAD | cut -f1)
-          echo "sha=${SKILLS_SHA}" >> $GITHUB_OUTPUT
-          echo "Upstream skills repository HEAD: ${SKILLS_SHA}"
-
-      - name: Cache downloaded skills and instructions
-        id: cache-skills
-        uses: actions/cache@v4
+      - name: Checkout skills repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: |
-            ~/.copilot
-          key: skills-${{ steps.skills-head.outputs.sha }}
-          restore-keys: |
-            skills-
+          repository: apollographql/skills
+          path: .tmp/skills
 
       - name: Install Rust Best Practices Skill
-        if: steps.cache-skills.outputs.cache-hit != 'true'
         run: |
           echo "Installing Rust Best Practices skill using npx skills CLI"
-          npx --yes skills add apollographql/skills --skill rust-best-practices --agent github-copilot --global --yes
+          npx --yes skills add .tmp/skills --skill rust-best-practices --agent github-copilot --global --yes
           echo "Rust Best Practices skill installed successfully"
 
       - name: Copy Documentation Instructions
-        if: steps.cache-skills.outputs.cache-hit != 'true'
         run: |
-          echo "Copying documentation instructions from apollographql/skills"
+          echo "Copying documentation instructions from cloned skills repository"
           mkdir -p ~/.copilot/instructions
-          # Download the docs instructions from the skills repository
-          curl -fsSL https://raw.githubusercontent.com/apollographql/skills/main/.github/instructions/docs.instructions.md \
-            -o ~/.copilot/instructions/docs.instructions.md
+          # Copy the docs instructions from the cloned repository
+          cp .tmp/skills/.github/instructions/docs.instructions.md ~/.copilot/instructions/docs.instructions.md
           echo "Documentation instructions copied to ~/.copilot/instructions/docs.instructions.md"
 
       - name: Install dev environment

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ fuzz/slow-unit-*
 fuzz/timeout-*
 
 .config/mise/mise.local.toml
+
+# Temporary skills checkout directory for GitHub Copilot setup
+.tmp/


### PR DESCRIPTION
Basing this on https://github.com/apollographql/apollo-client/blob/6912dad3b85e4ccbdfb8716ccb605c5e000653ba/.github/workflows/copilot-setup-steps.yml, but with a bit of a difference:
This does a "global installation", so to `~/.copilot` instead of `<repo>/.github`.
That way, **if** this gets picked up, we don't need as many `.gitignore`d files.

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
