### PR TITLE
Revert "Add config schema generation to the artifact publish (copy #8594)"

### DIFF
--- a/.changesets/feat_config_schema_release_artifact.md
+++ b/.changesets/feat_config_schema_release_artifact.md
@@ -1,8 +1,0 @@
-### Add config schema JSON as a build artifact in GitHub releases ([PR #8594](https://github.com/apollographql/router/pull/8594))
-
-The router configuration schema JSON file is now automatically generated and included as a build artifact in GitHub releases. This allows users to reference the schema for a specific version via URLs like `https://github.com/apollographql/router/releases/download/v{VERSION}/config-schema.json`.
-
-The schema is generated using the same `router config schema` command that users can run locally, ensuring consistency between the released schema and what users see when running the command.
-
-By [@shanemyrick](https://github.com/shanemyrick) in https://github.com/apollographql/router/pull/8594
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -881,11 +881,6 @@ jobs:
             - attach_workspace:
                 at: artifacts
             - run:
-                name: Generate config schema
-                command: |
-                  cargo build --release --bin router
-                  ./target/release/router config schema > artifacts/config-schema.json
-            - run:
                 command: >
                   cd artifacts && sha256sum *.tar.gz > sha256sums.txt
             - run:


### PR DESCRIPTION
Reverts apollographql/router#8609

This added 18 minutes to the release process for the full cost of a Rust build, which is a 180% increase overall.  Unfortunately, it doesn't even look like it was added at a point where cache restoration of a previous step can be used in an obvious/clean way.  We're going to need to figure out an approach that uses a configuration that is built earlier, and persisted through to the end.  That should be possible, particularly since we build all those release artifacts in earlier steps.