### PR TITLE
feat(traffic_shaping): add diagnostic counters for subgraph timeout and load shed errors

### DIFF
--- a/.changesets/feat_playful_wolf_980.md
+++ b/.changesets/feat_playful_wolf_980.md
@@ -1,0 +1,8 @@
+### Add metrics for traffic_shaping ([Issue #ISSUE_NUMBER](https://github.com/apollographql/router/issues/ISSUE_NUMBER))
+
+Adds the following metrics for traffic_shaping activity:
+- apollo.router.operations.traffic_shaping.timeout
+- apollo.router.operations.traffic_shaping.load_shed
+Both counters include a subgraph.service.name attribute so consumers of the metric can break down error rates by subgraph.
+
+By [@theJC](https://github.com/theJC) in https://github.com/apollographql/router/pull/8905

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -366,12 +366,18 @@ impl PluginPrivate for TrafficShaping {
             ServiceBuilder::new()
                 .map_future_with_request_data(
                     |req: &subgraph::Request| (req.context.clone(), req.subgraph_name.clone()),
-                    move |(ctx, subgraph_name), future| {
+                    move |(ctx, subgraph_name): (crate::Context, String), future| {
                         async {
                             let response: Result<SubgraphResponse, BoxError> = future.await;
                             match response {
                                 Err(err) if err.is::<Elapsed>() => {
-                                    // TODO add metrics
+                                    u64_counter_with_unit!(
+                                        "apollo.router.operations.traffic_shaping.timeout",
+                                        "Requests timed out by traffic_shaping timeout layer",
+                                        "{request}",
+                                        1,
+                                        subgraph.service.name = subgraph_name.to_string()
+                                    );
                                     Ok(SubgraphResponse::error_builder()
                                         .status_code(StatusCode::GATEWAY_TIMEOUT)
                                         .subgraph_name(subgraph_name)
@@ -380,7 +386,13 @@ impl PluginPrivate for TrafficShaping {
                                         .build())
                                 }
                                 Err(err) if err.is::<Overloaded>() => {
-                                    // TODO add metrics
+                                    u64_counter_with_unit!(
+                                        "apollo.router.operations.traffic_shaping.load_shed",
+                                        "Requests shed by traffic_shaping load_shed due to buffer saturation",
+                                        "{request}",
+                                        1,
+                                        subgraph.service.name = subgraph_name.to_string()
+                                    );
                                     Ok(SubgraphResponse::error_builder()
                                         .status_code(StatusCode::TOO_MANY_REQUESTS)
                                         .subgraph_name(subgraph_name)
@@ -583,6 +595,7 @@ mod test {
     use crate::Configuration;
     use crate::Context;
     use crate::json_ext::Object;
+    use crate::metrics::FutureMetricsExt;
     use crate::plugin::DynPlugin;
     use crate::plugin::test::MockConnector;
     use crate::plugin::test::MockRouterService;
@@ -1071,6 +1084,91 @@ mod test {
                 .errors
                 .is_empty()
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn it_emits_load_shed_metric_for_subgraph_requests() {
+        async {
+            let config = serde_yaml::from_str::<serde_json::Value>(
+                r#"
+            subgraphs:
+                test:
+                    global_rate_limit:
+                        capacity: 1
+                        interval: 100ms
+                    timeout: 500ms
+            "#,
+            )
+            .unwrap();
+
+            let plugin = get_traffic_shaping_plugin(&config).await;
+            let test_service = MockSubgraph::new(hashmap! {
+                graphql::Request::default() => graphql::Response::default()
+            });
+            let mut svc = plugin.subgraph_service("test", test_service.boxed());
+
+            // First request: succeeds, fills the rate limit bucket
+            svc.ready()
+                .await
+                .expect("it is ready")
+                .call(SubgraphRequest::fake_builder().subgraph_name("test".to_string()).build())
+                .await
+                .unwrap();
+
+            // Second request: shed by the rate limiter → emits the counter
+            svc.ready()
+                .await
+                .expect("it is ready")
+                .call(SubgraphRequest::fake_builder().subgraph_name("test".to_string()).build())
+                .await
+                .unwrap();
+
+            assert_counter!(
+                "apollo.router.operations.traffic_shaping.load_shed",
+                1,
+                "subgraph.service.name" = "test"
+            );
+        }
+        .with_metrics()
+        .await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn it_emits_timeout_metric_for_subgraph_requests() {
+        async {
+            let config = serde_yaml::from_str::<serde_json::Value>(
+                r#"
+            subgraphs:
+                test:
+                    timeout: 1ns
+            "#,
+            )
+            .unwrap();
+
+            let plugin = get_traffic_shaping_plugin(&config).await;
+            let slow_service = ServiceBuilder::new()
+                .service_fn(|_req: SubgraphRequest| async {
+                    tokio::time::sleep(Duration::from_millis(300)).await;
+                    Ok::<SubgraphResponse, BoxError>(SubgraphResponse::fake_builder().build())
+                })
+                .boxed();
+            let mut svc = plugin.subgraph_service("test", slow_service);
+
+            svc.ready()
+                .await
+                .expect("it is ready")
+                .call(SubgraphRequest::fake_builder().subgraph_name("test".to_string()).build())
+                .await
+                .unwrap();
+
+            assert_counter!(
+                "apollo.router.operations.traffic_shaping.timeout",
+                1,
+                "subgraph.service.name" = "test"
+            );
+        }
+        .with_metrics()
+        .await
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -152,6 +152,14 @@ The `apollo.router.cache.redis.errors` metric also includes an `error_type` attr
 - `apollo.router.operations.coprocessor.duration` - Time spent waiting for the coprocessor to answer, in seconds.
   - `coprocessor.stage`: string (`RouterRequest`, `RouterResponse`, `SubgraphRequest`, `SubgraphResponse`)
 
+## Traffic shaping
+
+- `apollo.router.operations.traffic_shaping.timeout` - Requests that were terminated by the traffic shaping timeout layer.
+  - `subgraph.service.name`: string (set to name of the subgraph if terminated at subgraph layer)
+
+- `apollo.router.operations.traffic_shaping.load_shed` - Requests that were shed by the traffic shaping load shed layer due to buffer saturation.
+  - `subgraph.service.name`: string (set to name of the subgraph if terminated at subgraph layer)
+
 ## Performance
 
 - `apollo_router_schema_load_duration` - Time spent loading the schema in seconds.


### PR DESCRIPTION
[Provide a backpressure enabled pipeline PR6486](https://github.com/apollographql/router/pull/6486) left several TODOs for metrics

This MR replaces those TODO comments with u64_counter_with_unit! calls at the Elapsed and Overloaded error sites in subgraph_service, emitting:
  - apollo.router.operations.traffic_shaping.timeout
  - apollo.router.operations.traffic_shaping.load_shed

Both counters include a subgraph.service.name attribute so Datadog queries can break down error rates by subgraph. 

These metrics are required for diagnosing rate limit errors seen as part of TSH-22080

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
