### PR TITLE
fix(composition): fixed merging interface object fields

### DIFF
--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -363,8 +363,13 @@ impl Merger {
         let mut interface_object_fields = Vec::new();
         let parent_name_in_supergraph = dest_field.type_name();
         let subgraph = &self.subgraphs[source_idx];
-        if matches!(dest_field, ObjectOrInterfaceFieldDefinitionPosition::Interface(_))
-            || subgraph.schema().try_get_type(parent_name_in_supergraph.clone()).is_some()
+        if matches!(
+            dest_field,
+            ObjectOrInterfaceFieldDefinitionPosition::Interface(_)
+        ) || subgraph
+            .schema()
+            .try_get_type(parent_name_in_supergraph.clone())
+            .is_some()
         {
             return Ok(interface_object_fields);
         }
@@ -697,7 +702,7 @@ impl Merger {
                         );
                         categorize_field(*idx, subgraph_str, &field.into());
                     }
-                },
+                }
                 Some(source) => {
                     if !merge_context.is_used_overridden(*idx)
                         && !merge_context.is_unused_overridden(*idx)

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -87,7 +87,8 @@ use crate::subgraph::typestate::Validated;
 use crate::supergraph::CompositionHint;
 use crate::utils::MultiIndexMap;
 use crate::utils::first_max_by_key;
-use crate::utils::human_readable::{human_readable_subgraph_names, human_readable_types};
+use crate::utils::human_readable::human_readable_subgraph_names;
+use crate::utils::human_readable::human_readable_types;
 use crate::utils::iter_into_single_item;
 
 static NON_MERGED_CORE_FEATURES: LazyLock<[Identity; 4]> = LazyLock::new(|| {
@@ -1124,17 +1125,21 @@ impl Merger {
                                 is_interface_object: false,
                                 interface_object_abstracting_fields,
                                 override_directive: None,
-                            }
+                            },
                         );
                     }
-                },
+                }
                 Some(source) => {
                     let subgraph = &self.subgraphs[*idx];
-                    let is_interface_field = subgraph.schema()
-                        .schema().get_interface(source.type_name()).is_some();
-                    let candidate_intf_object_in_subgraph = TypeDefinitionPosition::Object(
-                        ObjectTypeDefinitionPosition { type_name: dest.type_name().clone() }
-                    );
+                    let is_interface_field = subgraph
+                        .schema()
+                        .schema()
+                        .get_interface(source.type_name())
+                        .is_some();
+                    let candidate_intf_object_in_subgraph =
+                        TypeDefinitionPosition::Object(ObjectTypeDefinitionPosition {
+                            type_name: dest.type_name().clone(),
+                        });
                     let is_interface_object =
                         subgraph.is_interface_object_type(&candidate_intf_object_in_subgraph);
                     let override_directive = self.get_override_directive(*idx, source)?;
@@ -1150,7 +1155,7 @@ impl Merger {
                             is_interface_object,
                             interface_object_abstracting_fields: Vec::new(),
                             override_directive,
-                        }
+                        },
                     );
                 }
             }
@@ -1240,7 +1245,10 @@ impl Merger {
                 let source_mapped = subgraph_map.get(&source_subgraph_name).unwrap();
                 if !source_mapped.interface_object_abstracting_fields.is_empty() {
                     let abstracting_types = human_readable_types(
-                        source_mapped.interface_object_abstracting_fields.iter().map(|f| f.type_name.clone())
+                        source_mapped
+                            .interface_object_abstracting_fields
+                            .iter()
+                            .map(|f| f.type_name.clone()),
                     );
                     self.error_reporter.add_error(CompositionError::OverrideCollisionWithAnotherDirective {
                         message: format!(
@@ -1358,7 +1366,7 @@ impl Merger {
                     }
                 }
             }
-            }
+        }
 
         Ok(result)
     }
@@ -1785,14 +1793,20 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
             // So we validate field sharing now (it's convenient to wait until now as now that
             // the field is part of the supergraph, we can just call `validate_field_sharing` with
             // all sources `undefined` and it wil still find and check the `@interfaceObject`).
-            let sources: Sources<ObjectOrInterfaceFieldDefinitionPosition> = self.names.iter()
+            let sources: Sources<ObjectOrInterfaceFieldDefinitionPosition> = self
+                .names
+                .iter()
                 .enumerate()
                 // We don't usually want undefined sources in our Sources maps,
                 // but both validate_field_sharing and FieldMergeContext need the
                 // undefined sources to be registered in order to do their work.
                 .map(|(index, _)| (index, None))
                 .collect();
-            self.validate_field_sharing(&sources, &dest, &FieldMergeContext::new(sources.keys().copied()))?;
+            self.validate_field_sharing(
+                &sources,
+                &dest,
+                &FieldMergeContext::new(sources.keys().copied()),
+            )?;
         }
 
         Ok(())

--- a/apollo-federation/tests/composition/override_directive.rs
+++ b/apollo-federation/tests/composition/override_directive.rs
@@ -775,14 +775,16 @@ mod interface_object {
         let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
         assert_composition_errors(
             &result,
-            &[(
-                "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
-                r#"@override is not yet supported on fields of @interfaceObject types: cannot be used on field "I.a" on subgraph "Subgraph1"."#,
-            ),
-            (
-                "INVALID_FIELD_SHARING",
-                r#"Non-shareable field "A.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1 (through @interfaceObject field "I.a")" and "Subgraph2" and defined as non-shareable in all of them"#
-            )],
+            &[
+                (
+                    "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
+                    r#"@override is not yet supported on fields of @interfaceObject types: cannot be used on field "I.a" on subgraph "Subgraph1"."#,
+                ),
+                (
+                    "INVALID_FIELD_SHARING",
+                    r#"Non-shareable field "A.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1 (through @interfaceObject field "I.a")" and "Subgraph2" and defined as non-shareable in all of them"#,
+                ),
+            ],
         );
     }
 
@@ -830,14 +832,16 @@ mod interface_object {
         let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
         assert_composition_errors(
             &result,
-            &[(
-                "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
-                r#"Invalid @override on field "A.a" of subgraph "Subgraph2": source subgraph "Subgraph1" does not have field "A.a" but abstracts it in type "I" and overriding abstracted fields is not supported."#,
-            ),
-            (
-                "INVALID_FIELD_SHARING",
-                r#"Non-shareable field "A.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1 (through @interfaceObject field "I.a")" and "Subgraph2" and defined as non-shareable in all of them"#,
-            )],
+            &[
+                (
+                    "OVERRIDE_COLLISION_WITH_ANOTHER_DIRECTIVE",
+                    r#"Invalid @override on field "A.a" of subgraph "Subgraph2": source subgraph "Subgraph1" does not have field "A.a" but abstracts it in type "I" and overriding abstracted fields is not supported."#,
+                ),
+                (
+                    "INVALID_FIELD_SHARING",
+                    r#"Non-shareable field "A.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1 (through @interfaceObject field "I.a")" and "Subgraph2" and defined as non-shareable in all of them"#,
+                ),
+            ],
         );
     }
 }


### PR DESCRIPTION
Interface fields and `@interfaceObject` fields should be merged using regular logic.

* fixed `add_fields_shallow` logic to correctly handle `@interfaceObject` fields for interfaces (previously if an `@interfaceObject` was found in the subgraph we would skip processing that subgraph altogether)
* fixed `add_missing_interface_object_fields_to_implementations` to only propagate `@interfaceObject` fields to objects if they don't declare those fields (otherwise they would already be merged accordingly, interface fields are already merged)
* added missing filtering of arg directives on `@interfaceObject` field to object fields propagation
* fixed `validate_override` logic
* fixed `validate_field_sharing` logic to use correct source
* fixed `add_missing_interface_object_fields_to_implementations` to invoke field sharing validation for propagate fields 
* also fixed the merge order of types to match JS

<!-- FED-973 -->