### PR TITLE
fix: `redis.required_to_start` implies `fred.fail_fast`

### DIFF
--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -361,6 +361,10 @@ impl RedisCacheStorage {
                         .set_cluster_discovery_policy(ClusterDiscoveryPolicy::ConfigEndpoint)
                         .inspect_err(|err| record_redis_error(err, caller, "startup"));
                 }
+
+                // if `required_to_start`, then we only want to try connecting once - if we fail, we just return an error now.
+                // if `!required_to_start`, then we should continue trying to connect in the background if the first connection fails.
+                client_config.fail_fast = required_to_start;
             })
             .with_connection_config(|config| {
                 // NOTE: the default internal_command_timeout is 10s, so this line is just to make


### PR DESCRIPTION
The router configuration `redis.required_to_start = false` implies that the router will retry its Redis connection, if the connection cannot be made on startup.

The retry was previously not taking place, and the router would operate as though no Redis connection were configured.

This change fixes this to ensure retries are attempted.

**NOTE**: this does have operation duration implications. Now, if the router can't connect to Redis, queries will wait for `redis.timeout` (whereas before they behaved as if Redis were never there). This does bring parity to how queries behave the rest of the time, but it is a behavior change and I'd like to discuss whether that's appropriate.

<!-- start metadata -->

<!-- [ROUTER-1611] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1611]: https://apollographql.atlassian.net/browse/ROUTER-1611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ