### PR TITLE
feat(composition): propagate access control directives to/from abstract types

### DIFF
--- a/apollo-federation/src/link/policy_spec_definition.rs
+++ b/apollo-federation/src/link/policy_spec_definition.rs
@@ -56,7 +56,7 @@ impl PolicySpecDefinition {
                     },
                     default_value: None,
                 },
-                composition_strategy: Some(ArgumentCompositionStrategy::Union),
+                composition_strategy: Some(ArgumentCompositionStrategy::DnfConjunction),
             }],
             false, // not repeatable
             &[

--- a/apollo-federation/src/link/requires_scopes_spec_definition.rs
+++ b/apollo-federation/src/link/requires_scopes_spec_definition.rs
@@ -58,7 +58,7 @@ impl RequiresScopesSpecDefinition {
                     },
                     default_value: None,
                 },
-                composition_strategy: Some(ArgumentCompositionStrategy::Union),
+                composition_strategy: Some(ArgumentCompositionStrategy::DnfConjunction),
             }],
             false, // not repeatable
             &[

--- a/apollo-federation/src/merger/merge_argument.rs
+++ b/apollo-federation/src/merger/merge_argument.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::fmt::Debug;
 use std::fmt::Display;
 
 use apollo_compiler::Name;
@@ -76,7 +77,7 @@ impl Merger {
         dest: &T,
     ) -> Result<IndexSet<Name>, FederationError>
     where
-        T: HasArguments + std::fmt::Debug + Display,
+        T: HasArguments + Debug + Display,
         <T as HasArguments>::ArgumentPosition: Display,
     {
         let mut arg_types: IndexMap<Name, Node<Type>> = Default::default();
@@ -259,7 +260,8 @@ impl Merger {
             + HasDefaultValue
             + HasDescription
             + HasType
-            + Into<DirectiveTargetPosition>,
+            + Into<DirectiveTargetPosition>
+            + Debug,
     {
         trace!("Merging argument \"{dest}\"");
         self.merge_description(sources, dest)?;

--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast::Argument;
@@ -6,13 +8,17 @@ use apollo_compiler::ast::DirectiveDefinition;
 use apollo_compiler::ast::DirectiveLocation;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
-use indexmap::IndexSet;
+use apollo_compiler::collections::IndexSet;
 use itertools::Itertools;
 use tracing::instrument;
 use tracing::trace;
 
 use crate::bail;
 use crate::error::FederationError;
+use crate::link::authenticated_spec_definition::AUTHENTICATED_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::policy_spec_definition::POLICY_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::requires_scopes_spec_definition::REQUIRES_SCOPES_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::spec_definition::SpecDefinition;
 use crate::merger::hints::HintCode;
 use crate::merger::merge::Merger;
 use crate::merger::merge::Sources;
@@ -20,6 +26,7 @@ use crate::merger::merge::map_sources;
 use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::DirectiveTargetPosition;
 use crate::schema::position::HasAppliedDirectives;
+use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::type_and_directive_specification::StaticArgumentsTransform;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Validated;
@@ -36,7 +43,9 @@ pub(crate) struct AppliedDirectiveToMergeEntry {
 
 pub(crate) type AppliedDirectivesToMerge = Vec<AppliedDirectiveToMergeEntry>;
 
-#[allow(dead_code)]
+pub(in crate::merger) type AdditionalDirectiveSources =
+    IndexMap<usize, IndexSet<DirectiveTargetPosition>>;
+
 impl Merger {
     pub(in crate::merger) fn record_applied_directives_to_merge<T>(
         &mut self,
@@ -49,7 +58,7 @@ impl Merger {
         let inaccessible_name = self.inaccessible_directive_name_in_supergraph.clone();
         let mut directive_sources: Sources<DirectiveTargetPosition> =
             IndexMap::with_capacity_and_hasher(sources.len(), Default::default());
-        let mut names = IndexSet::with_capacity(sources.len());
+        let mut names = IndexSet::with_capacity_and_hasher(sources.len(), Default::default());
 
         // This loop corresponds to `gatherAppliedDirectivesToMerge` in the JS implementation.
         for (idx, source) in sources {
@@ -74,6 +83,32 @@ impl Merger {
             names.shift_remove(inaccessible);
         }
 
+        // PORT NOTE: in JS we were capturing additional sources in record_applied_directives_to_merge.
+        // JS was recording an array/vec of FieldDefinition/ObjectTypeDefinition/InterfaceTypeDefinition
+        // but this doesn't work in RS implementations as we record lightweight references to the target
+        // directive positions instead. Since we cannot just update source map with additional sources
+        // (as it would overwrite the existing entries for the subgraphs), we make sure that target access
+        // control directive will be merged.
+        if matches!(
+            dest,
+            DirectiveTargetPosition::InterfaceField(_)
+                | DirectiveTargetPosition::ObjectField(_)
+                | DirectiveTargetPosition::InterfaceType(_)
+        ) {
+            for (name, name_in_supergraph) in &self.access_control_directives_in_supergraph {
+                if names.contains(name_in_supergraph) {
+                    // access control directive is already in the list of directives to be merged
+                    continue;
+                } else if self
+                    .access_control_additional_sources()?
+                    .contains_key(&format!("{dest}_{name}"))
+                {
+                    // need to add access control directive to the list of directives to be merged
+                    names.insert(name_in_supergraph.clone());
+                }
+            }
+        }
+
         if names.is_empty() {
             trace!("No applied directives to merge at {dest}");
         } else {
@@ -95,7 +130,7 @@ impl Merger {
     /// Note that this logic relies on the fact that the directive must have the same name across
     /// all subgraphs.
     #[instrument(skip(self, sources))]
-    fn merge_applied_directive(
+    pub(in crate::merger) fn merge_applied_directive(
         &mut self,
         name: &Name,
         sources: &Sources<DirectiveTargetPosition>,
@@ -117,7 +152,7 @@ impl Merger {
             .merged_federation_directive_in_supergraph_by_directive_name
             .get(name);
 
-        let directive_counts: IndexMap<Directive, usize> = sources
+        let mut directive_counts: IndexMap<Directive, usize> = sources
             .iter()
             .flat_map(|(idx, source)| {
                 let Some(source) = source else {
@@ -155,6 +190,61 @@ impl Merger {
                 }
                 acc
             });
+
+        // PORT NOTE: in JS version we were populating additional sources for access control in record_applied_directives_to_merge
+        // without any changes in the merge_applied_directive_logic.
+        // We need to explicitly look up the target schema element in RS so we handle this logic here directly
+        if matches!(
+            dest,
+            DirectiveTargetPosition::InterfaceField(_)
+                | DirectiveTargetPosition::ObjectField(_)
+                | DirectiveTargetPosition::InterfaceType(_)
+        ) {
+            for (access_control_directive_name, access_control_directive_name_in_supergraph) in
+                &self.access_control_directives_in_supergraph
+            {
+                if name == access_control_directive_name_in_supergraph
+                    && let Some(additional_sources_for_position) = self
+                        .access_control_additional_sources()?
+                        .get(&format!("{dest}_{access_control_directive_name}"))
+                {
+                    // we need to propagate access control
+                    // - upwards from object types to interfaces
+                    // - upwards from object fields to interface fields
+                    // - downwards from interface object fields to object fields
+                    additional_sources_for_position
+                        .iter()
+                        .flat_map(|(index, sources)| {
+                            let subgraph = &self.subgraphs[*index];
+                            let mut applications = sources
+                                .iter()
+                                .flat_map(|source| {
+                                    source
+                                        .get_applied_directives(subgraph.schema(), name)
+                                        .into_iter()
+                                        .map(|d| (**d).clone())
+                                })
+                                .collect_vec();
+                            if let Some(transform) = &directive_in_supergraph
+                                .and_then(|d| d.static_argument_transform.as_ref())
+                            {
+                                for application in &mut applications {
+                                    self.transform_arguments(
+                                        application,
+                                        subgraph,
+                                        transform.as_ref(),
+                                    );
+                                }
+                            }
+                            applications
+                        })
+                        .for_each(|d| {
+                            // access control directives don't have default args so we don't need to transform them
+                            *directive_counts.entry(d).or_insert(0) += 1;
+                        });
+                }
+            }
+        }
 
         if definition.repeatable {
             trace!(
@@ -540,6 +630,125 @@ impl Merger {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn access_control_additional_sources(
+        &self,
+    ) -> Result<&HashMap<String, AdditionalDirectiveSources>, FederationError> {
+        self.access_control_additional_sources.get_or_try_init(|| {
+            let mut sources: HashMap<String, AdditionalDirectiveSources> = HashMap::default();
+            for (index, subgraph) in self.subgraphs.iter().enumerate() {
+                let metadata = subgraph.metadata();
+                let federation_spec = metadata.federation_spec_definition();
+                let subgraph_referencers = subgraph.schema().referencers();
+                for access_control_directive in [
+                    &AUTHENTICATED_DIRECTIVE_NAME_IN_SPEC,
+                    &REQUIRES_SCOPES_DIRECTIVE_NAME_IN_SPEC,
+                    &POLICY_DIRECTIVE_NAME_IN_SPEC,
+                ] {
+                    if let Some(directive) = federation_spec
+                        .directive_definition(subgraph.schema(), access_control_directive)?
+                    {
+                        let referencers = subgraph_referencers.get_directive(&directive.name);
+                        for type_position in &referencers.object_types {
+                            // we will be propagating access control from objects up to the interfaces
+                            let object_type = type_position.get(self.merged.schema())?;
+                            for interface in &object_type.implements_interfaces {
+                                let key = format!("{}_{}", interface, access_control_directive);
+                                let existing_sources = sources.entry(key).or_default();
+                                existing_sources.entry(index).or_default().insert(
+                                    DirectiveTargetPosition::ObjectType(type_position.clone()),
+                                );
+                            }
+                        }
+                        for field_definition_position in &referencers.object_fields {
+                            if metadata.is_field_external(&field_definition_position.clone().into())
+                            {
+                                continue;
+                            }
+
+                            if metadata
+                                .is_interface_object_type(&field_definition_position.type_name)
+                            {
+                                // we need to propagate field access control downwards from interface object fields to object fields
+                                // we need to look up the interface in the merged supergraph to find all its implementations
+                                let supergraph_type: InterfaceTypeDefinitionPosition =
+                                    InterfaceTypeDefinitionPosition {
+                                        type_name: field_definition_position.type_name.clone(),
+                                    };
+                                for implementation in
+                                    self.merged.all_implementation_types(&supergraph_type)?
+                                {
+                                    let key = format!(
+                                        "{}.{}_{}",
+                                        implementation,
+                                        &field_definition_position.field_name,
+                                        access_control_directive
+                                    );
+                                    sources
+                                        .entry(key)
+                                        .or_default()
+                                        .entry(index)
+                                        .or_default()
+                                        .insert(DirectiveTargetPosition::ObjectField(
+                                            field_definition_position.clone(),
+                                        ));
+
+                                    // we now need to propagate field access control upwards from @interfaceObject fields to any
+                                    // other interfaces implemented by the given implementation type
+                                    for other_interface in
+                                        implementation.implemented_interfaces(&self.merged)?
+                                    {
+                                        if other_interface.name
+                                            == field_definition_position.type_name
+                                        {
+                                            // skip current @interfaceObject
+                                            continue;
+                                        }
+                                        let key = format!(
+                                            "{}.{}_{}",
+                                            other_interface,
+                                            &field_definition_position.field_name,
+                                            access_control_directive
+                                        );
+                                        sources
+                                            .entry(key)
+                                            .or_default()
+                                            .entry(index)
+                                            .or_default()
+                                            .insert(DirectiveTargetPosition::ObjectField(
+                                                field_definition_position.clone(),
+                                            ));
+                                    }
+                                }
+                            } else {
+                                // we need to propagate field access control upwards from object fields to the interface fields
+                                let merged_object_type = field_definition_position
+                                    .parent()
+                                    .get(self.merged.schema())?;
+                                for interface in &merged_object_type.implements_interfaces {
+                                    let key = format!(
+                                        "{}.{}_{}",
+                                        interface,
+                                        field_definition_position.field_name,
+                                        access_control_directive
+                                    );
+                                    sources
+                                        .entry(key)
+                                        .or_default()
+                                        .entry(index)
+                                        .or_default()
+                                        .insert(DirectiveTargetPosition::ObjectField(
+                                            field_definition_position.clone(),
+                                        ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(sources)
+        })
     }
 }
 

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -311,6 +311,7 @@ pub(crate) mod tests {
     use crate::merger::merge::CompositionOptions;
     use crate::schema::FederationSchema;
     use crate::schema::position::EnumTypeDefinitionPosition;
+    use crate::utils::FallibleOnceCell;
 
     fn insert_enum_type(schema: &mut FederationSchema, name: Name) -> Result<(), FederationError> {
         let status_pos = EnumTypeDefinitionPosition {
@@ -452,6 +453,7 @@ pub(crate) mod tests {
             latest_federation_version_used: FEDERATION_VERSIONS.latest().version().clone(),
             applied_directives_to_merge: Default::default(),
             access_control_directives_in_supergraph: Default::default(),
+            access_control_additional_sources: FallibleOnceCell::new(),
         })
     }
 }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt::Debug;
 use std::fmt::Display;
 use std::rc::Rc;
 use std::sync::LazyLock;
@@ -53,6 +54,7 @@ use crate::link::spec_definition::SpecDefinition;
 use crate::merger::compose_directive_manager::ComposeDirectiveManager;
 use crate::merger::error_reporter::ErrorReporter;
 use crate::merger::hints::HintCode;
+use crate::merger::merge_directive::AdditionalDirectiveSources;
 use crate::merger::merge_directive::AppliedDirectivesToMerge;
 use crate::merger::merge_enum::EnumExample;
 use crate::merger::merge_enum::EnumExampleAst;
@@ -85,6 +87,7 @@ use crate::schema::validators::merged::validate_merged_schema;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Validated;
 use crate::supergraph::CompositionHint;
+use crate::utils::FallibleOnceCell;
 use crate::utils::MultiIndexMap;
 use crate::utils::first_max_by_key;
 use crate::utils::human_readable::human_readable_subgraph_names;
@@ -162,6 +165,8 @@ pub(crate) struct Merger {
     pub(in crate::merger) latest_federation_version_used: Version,
     pub(in crate::merger) applied_directives_to_merge: AppliedDirectivesToMerge,
     pub(in crate::merger) access_control_directives_in_supergraph: Vec<(Name, Name)>,
+    pub(in crate::merger) access_control_additional_sources:
+        FallibleOnceCell<HashMap<String, AdditionalDirectiveSources>>,
 }
 
 #[allow(dead_code)]
@@ -235,6 +240,7 @@ impl Merger {
             latest_federation_version_used,
             applied_directives_to_merge: Vec::new(),
             access_control_directives_in_supergraph: Vec::new(),
+            access_control_additional_sources: FallibleOnceCell::new(),
         };
 
         // Now call prepare_supergraph as a member function
@@ -1709,14 +1715,22 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
     fn add_missing_interface_object_fields_to_implementations(
         &mut self,
     ) -> Result<(), FederationError> {
-        let mut fields_to_insert: HashMap<
-            ObjectOrInterfaceFieldDefinitionPosition,
-            FieldDefinition,
-        > = HashMap::new();
+        let mut fields_to_insert: HashMap<ObjectFieldDefinitionPosition, FieldDefinition> =
+            HashMap::new();
+
+        let access_control_directive_names: IndexSet<Name> = self
+            .access_control_directives_in_supergraph
+            .iter()
+            .map(|(_, name)| name.clone())
+            .collect();
+        let mut access_control_sources: IndexMap<
+            ObjectFieldDefinitionPosition,
+            Sources<DirectiveTargetPosition>,
+        > = IndexMap::default();
         // For each merged object types, we check if we're missing a field from one of the implemented interface.
         // If we do, then we look if one of the subgraph provides that field as a (non-external) interface object
         // type, and if that's the case, we add the field to the object.
-        for subgraph in self.subgraphs.iter() {
+        for (index, subgraph) in self.subgraphs.iter().enumerate() {
             // Note that we don't blindly add the field yet, that would be incorrect in many cases (and we
             // have a specific validation that return a user-friendly error in such incorrect cases, see
             // `post_merge_validations`). We must first check that there is some subgraph that implement
@@ -1752,6 +1766,8 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                                 .schema()
                                 .directive_definitions
                                 .contains_key(&d.name)
+                            // filter access control directives for now as they will be merged later one
+                            && !access_control_directive_names.contains(&d.name)
                         });
                         missing_obj_node.arguments.iter_mut().for_each(|arg| {
                             arg.make_mut().directives.retain(|d| {
@@ -1769,15 +1785,15 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                         missing_obj_node
                             .directives
                             .push(JoinFieldBuilder::new().build());
-
-                        fields_to_insert.insert(
-                            ObjectFieldDefinitionPosition {
-                                type_name: implementer.type_name().clone(),
-                                field_name: itf_obj_field.field_name.clone(),
-                            }
-                            .into(),
-                            missing_obj_node,
-                        );
+                        let merged_field = ObjectFieldDefinitionPosition {
+                            type_name: implementer.type_name().clone(),
+                            field_name: itf_obj_field.field_name.clone(),
+                        };
+                        access_control_sources
+                            .entry(merged_field.clone())
+                            .or_default()
+                            .insert(index, Some(itf_obj_field.clone().into()));
+                        fields_to_insert.insert(merged_field, missing_obj_node);
                     }
                 }
             }
@@ -1786,6 +1802,15 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
         for (dest, ast_node) in fields_to_insert {
             trace!("Filling in missing interface object field {dest} with {ast_node}",);
             dest.insert(&mut self.merged, Component::new(ast_node))?;
+            // now we can merge access control directives
+            for directive_name in &access_control_directive_names {
+                self.merge_applied_directive(
+                    directive_name,
+                    access_control_sources.entry(dest.clone()).or_default(),
+                    &dest.clone().into(),
+                )?;
+            }
+
             // If we had to add a field here, it means that, for this particular implementation, the
             // field is only provided through the @interfaceObject. But because the field wasn't
             // merged, it also means we haven't validated field sharing for that field, and we could
@@ -1804,7 +1829,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                 .collect();
             self.validate_field_sharing(
                 &sources,
-                &dest,
+                &dest.clone().into(),
                 &FieldMergeContext::new(sources.keys().copied()),
             )?;
         }
@@ -1840,7 +1865,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
         is_input_position: bool,
     ) -> Result<bool, FederationError>
     where
-        T: Display + HasType,
+        T: Display + HasType + Debug,
     {
         if sources.is_empty() {
             self.error_reporter_mut()

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -7825,6 +7825,25 @@ impl From<ObjectOrInterfaceFieldDefinitionPosition> for DirectiveTargetPosition 
     }
 }
 
+impl From<ObjectFieldDefinitionPosition> for DirectiveTargetPosition {
+    fn from(pos: ObjectFieldDefinitionPosition) -> Self {
+        DirectiveTargetPosition::ObjectField(pos)
+    }
+}
+
+impl From<ObjectOrInterfaceTypeDefinitionPosition> for DirectiveTargetPosition {
+    fn from(pos: ObjectOrInterfaceTypeDefinitionPosition) -> Self {
+        match pos {
+            ObjectOrInterfaceTypeDefinitionPosition::Object(pos) => {
+                DirectiveTargetPosition::ObjectType(pos)
+            }
+            ObjectOrInterfaceTypeDefinitionPosition::Interface(pos) => {
+                DirectiveTargetPosition::InterfaceType(pos)
+            }
+        }
+    }
+}
+
 impl From<ObjectTypeDefinitionPosition> for DirectiveTargetPosition {
     fn from(pos: ObjectTypeDefinitionPosition) -> Self {
         DirectiveTargetPosition::ObjectType(pos)

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -111,7 +111,7 @@ impl Supergraph<Merged> {
     }
 
     pub fn assume_satisfiable(self) -> Supergraph<Satisfiable> {
-        todo!("unimplemented")
+        Supergraph::new(self.state.schema, vec![])
     }
 
     /// Supergraph schema

--- a/apollo-federation/src/utils/mod.rs
+++ b/apollo-federation/src/utils/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod multi_index_map;
 pub mod normalize_schema;
 pub(crate) mod serde_bridge;
 
+use std::cell::OnceCell;
+
 // Re-exports
 pub(crate) use fallible_iterator::*;
 pub(crate) use multi_index_map::MultiIndexMap;
@@ -41,4 +43,31 @@ pub(crate) fn first_max_by_key<T, O: Ord>(
     }
 
     Some(max_item)
+}
+
+/// Wrapper around OnceCell that allows fallible instantiation.
+///
+/// NOTE: This is a temporary workaround until `OnceCell#get_or_try_init` stabilizes
+pub(crate) struct FallibleOnceCell<T>(OnceCell<T>);
+
+impl<T: std::fmt::Debug> FallibleOnceCell<T> {
+    pub(crate) fn new() -> Self {
+        Self(OnceCell::new())
+    }
+
+    pub(crate) fn get_or_try_init<F, E>(&self, f: F) -> Result<&T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        let value = match self.0.get() {
+            Some(value) => value,
+            None => {
+                let value = f()?;
+                self.0.set(value).unwrap();
+                // we just set the value so this should never return None
+                self.0.get().unwrap()
+            }
+        };
+        Ok(value)
+    }
 }

--- a/apollo-federation/tests/composition/compose_auth.rs
+++ b/apollo-federation/tests/composition/compose_auth.rs
@@ -1,6 +1,5 @@
 use apollo_compiler::coord;
 use insta::assert_snapshot;
-use test_log::test;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
@@ -781,7 +780,6 @@ mod transitive_auth {
     }
 
     #[test]
-    #[ignore = "FED-961"]
     fn requires_does_not_work_when_missing_explicit_auth_on_an_interface_field_selection() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -835,7 +833,6 @@ mod transitive_auth {
     }
 
     #[test]
-    #[ignore = "FED-961"]
     fn requires_does_not_work_when_missing_inherited_auth_on_an_interface_field_selection() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -889,7 +886,6 @@ mod transitive_auth {
     }
 
     #[test]
-    #[ignore = "FED-961"]
     fn requires_does_not_work_when_missing_auth_on_type_condition_in_a_field_selection() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -1143,7 +1139,6 @@ mod transitive_auth {
     }
 
     #[test]
-    #[ignore = "FED-963"]
     fn verifies_requires_on_interface_object_without_auth() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -1447,5 +1442,936 @@ mod transitive_auth {
                 r#"[Subgraph1] Field "U.field" does not specify necessary @authenticated, @requiresScopes and/or @policy auth requirements to access the transitive data in context Subgraph1__context from @fromContext selection set."#,
             )],
         );
+    }
+}
+
+mod propagate_auth {
+    use apollo_compiler::Name;
+    use apollo_compiler::Node;
+    use apollo_compiler::Schema;
+    use apollo_compiler::ast::Value;
+    use apollo_compiler::collections::IndexMap;
+    use apollo_compiler::schema::Component;
+    use apollo_compiler::schema::FieldDefinition;
+    use apollo_federation::composition::compose;
+    use apollo_federation::subgraph::typestate::Subgraph;
+
+    use crate::composition::ServiceDefinition;
+    use crate::composition::compose_as_fed2_subgraphs;
+
+    #[test]
+    fn propagates_authenticated_from_type_to_interface() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I!
+              }
+
+              interface I {
+                id: ID
+              }
+
+              type T implements I @key(fields: "id") @authenticated {
+                id: ID
+                value1: String
+              }
+
+              type U implements I @key(fields: "id") {
+                id: ID
+                value2: String
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              type Query {
+                t: T
+              }
+
+              type T @key(fields: "id") {
+                id: ID!
+                other: Int
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        let interface_i = supergraph
+            .schema()
+            .schema()
+            .get_interface("I")
+            .expect("interface I exists in schema");
+        assert!(
+            interface_i
+                .directives
+                .iter()
+                .any(|d| d.name == "authenticated")
+        );
+    }
+
+    #[test]
+    fn propagates_requires_scopes_from_type_to_interface() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I!
+              }
+
+              interface I {
+                id: ID
+              }
+
+              type T implements I @key(fields: "id") @requiresScopes(scopes: [["S1"], ["S2"]]) {
+                id: ID
+                vT: String
+              }
+
+              type U implements I @key(fields: "id") @requiresScopes(scopes: [["S1"], ["S2", "S3"]]) {
+                id: ID
+                vU: String
+              }
+
+              type V implements I @key(fields: "id") {
+                id: ID
+                vV: String
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              type Query {
+                t: T
+              }
+
+              type T @key(fields: "id") {
+                id: ID!
+                other: Int
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        verify_type_access_control(
+            supergraph.schema().schema(),
+            "I",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S1"], vec!["S2", "S3"]],
+        );
+    }
+
+    #[test]
+    fn propagates_policy_from_type_to_interface() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I!
+              }
+
+              interface I {
+                id: ID
+              }
+
+              type T implements I @key(fields: "id") @policy(policies: [["P1"]]) {
+                id: ID
+                vT: String
+              }
+
+              type U implements I @key(fields: "id") @policy(policies: [["P2"]]) {
+                id: ID
+                vU: String
+              }
+
+              type V implements I @key(fields: "id") {
+                id: ID
+                vV: String
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              type Query {
+                t: T
+              }
+
+              type T @key(fields: "id") {
+                id: ID!
+                other: Int
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        verify_type_access_control(
+            supergraph.schema().schema(),
+            "I",
+            "policy",
+            "policies",
+            vec![vec!["P1", "P2"]],
+        );
+    }
+
+    #[test]
+    fn propagates_authenticated_from_object_field_to_interface_field() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I!
+              }
+
+              interface I {
+                id: ID
+                i1: Int
+                i2: String
+                i3: String
+              }
+
+              type T1 implements I @key(fields: "id") {
+                id: ID
+                i1: Int
+                i2: String @shareable
+                i3: String
+                value1: String
+              }
+
+              type T2 implements I @key(fields: "id") {
+                id: ID
+                i1: Int @authenticated
+                i2: String
+                i3: String
+                value2: String
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              type Query {
+                t: T1
+              }
+
+              type T1 @key(fields: "id") {
+                id: ID!
+                i2: String @shareable @authenticated
+                other: Int
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        let interface_i = supergraph
+            .schema()
+            .schema()
+            .get_interface("I")
+            .expect("interface I exists in schema");
+        let field_i1 = interface_i.fields.get("i1").expect("field i1 exists");
+        assert!(
+            field_i1
+                .directives
+                .iter()
+                .any(|d| d.name == "authenticated")
+        );
+        let field_i2 = interface_i.fields.get("i2").expect("field i2 exists");
+        assert!(
+            field_i2
+                .directives
+                .iter()
+                .any(|d| d.name == "authenticated")
+        );
+    }
+
+    #[test]
+    fn propagates_requires_scopes_from_object_field_to_interface_field() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I!
+              }
+
+              interface I {
+                id: ID
+                i1: Int
+                i2: String
+                i3: String
+              }
+
+              type T1 implements I @key(fields: "id") {
+                id: ID
+                i1: Int @requiresScopes(scopes: [["S1"]])
+                i2: String @shareable
+                i3: String
+                value1: String
+              }
+
+              type T2 implements I @key(fields: "id") {
+                id: ID
+                i1: Int @requiresScopes(scopes: [["S1", "S2"]])
+                i2: String
+                i3: String
+                value2: String
+              }
+
+              type T3 implements I @key(fields: "id") {
+                id: ID
+                i1: Int
+                i2: String
+                i3: String
+                value2: String
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              type Query {
+                t: T1
+              }
+
+              type T1 @key(fields: "id") {
+                id: ID!
+                i2: String @shareable @requiresScopes(scopes: [["S3"]])
+                other: Int
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        let interface_i = supergraph
+            .schema()
+            .schema()
+            .get_interface("I")
+            .expect("interface I exists in schema");
+        verify_field_access_control(
+            &interface_i.fields,
+            "i1",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S1", "S2"]],
+        );
+        verify_field_access_control(
+            &interface_i.fields,
+            "i2",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S3"]],
+        );
+    }
+
+    #[test]
+    fn propagates_policy_from_object_field_to_interface_field() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I!
+              }
+
+              interface I {
+                id: ID
+                i1: Int
+                i2: String
+                i3: String
+              }
+
+              type T1 implements I @key(fields: "id") {
+                id: ID
+                i1: Int @policy(policies: [["P1"], ["P2"]])
+                i2: String @shareable
+                i3: String
+                value1: String
+              }
+
+              type T2 implements I @key(fields: "id") {
+                id: ID
+                i1: Int @policy(policies: [["P1"], ["P2", "P3"]])
+                i2: String
+                i3: String
+                value2: String
+              }
+
+              type T3 implements I @key(fields: "id") {
+                id: ID
+                i1: Int
+                i2: String
+                i3: String
+                value2: String
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              type Query {
+                t: T1
+              }
+
+              type T1 @key(fields: "id") {
+                id: ID!
+                i2: String @shareable @policy(policies: [["P4"]])
+                other: Int
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        let interface_i = supergraph
+            .schema()
+            .schema()
+            .get_interface("I")
+            .expect("interface I exists in schema");
+        verify_field_access_control(
+            &interface_i.fields,
+            "i1",
+            "policy",
+            "policies",
+            vec![vec!["P1"], vec!["P2", "P3"]],
+        );
+        verify_field_access_control(
+            &interface_i.fields,
+            "i2",
+            "policy",
+            "policies",
+            vec![vec!["P4"]],
+        );
+    }
+
+    #[test]
+    fn propagates_access_control_from_interface_object() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I
+              }
+
+              type I @interfaceObject @key(fields: "id") {
+                id: ID!
+                secret: String @requiresScopes(scopes: [["S1"]])
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              interface I @key(fields: "id") {
+                id: ID!
+                extra: String
+              }
+
+              type T implements I @key(fields: "id") {
+                id: ID!
+                extra: String @authenticated
+              }
+
+              type U implements I @key(fields: "id") {
+                id: ID!
+                extra: String
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        let interface_i = supergraph
+            .schema()
+            .schema()
+            .get_interface("I")
+            .expect("interface I exists in schema");
+        let field_extra = interface_i
+            .fields
+            .get("extra")
+            .expect("field extra exists on interface I");
+        assert!(
+            field_extra
+                .directives
+                .iter()
+                .any(|d| d.name == "authenticated")
+        );
+
+        let type_t = supergraph
+            .schema()
+            .schema()
+            .get_object("T")
+            .expect("type T exists in schema");
+        verify_field_access_control(
+            &type_t.fields,
+            "secret",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S1"]],
+        );
+    }
+
+    #[test]
+    fn works_with_shareable_interface_object_field() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I
+              }
+
+              type I @interfaceObject @key(fields: "id") {
+                id: ID!
+                secret: String @requiresScopes(scopes: [["S1"]]) @shareable
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              interface I @key(fields: "id") {
+                id: ID!
+                extra: String
+              }
+
+              type T implements I @key(fields: "id") {
+                id: ID!
+                extra: String @authenticated
+              }
+
+              type U implements I @key(fields: "id") {
+                id: ID!
+                extra: String
+              }
+            "#,
+        };
+
+        let subgraph3 = ServiceDefinition {
+            name: "Subgraph3",
+            type_defs: r#"
+              type T @key(fields: "id") {
+                id: ID!
+                secret: String @requiresScopes(scopes: [["S2"]]) @shareable
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2, subgraph3]);
+        let supergraph = result.expect("Expected composition to succeed");
+        // interface I {
+        //   id: ID!
+        //   extra: String @authenticated
+        //   secret: String @requiresScopes(scopes: [["S1", "S2"]])
+        // }
+        let interface_i = supergraph
+            .schema()
+            .schema()
+            .get_interface("I")
+            .expect("interface I exists in schema");
+        let field_extra = interface_i
+            .fields
+            .get("extra")
+            .expect("field extra exists on interface I");
+        assert!(
+            field_extra
+                .directives
+                .iter()
+                .any(|d| d.name == "authenticated")
+        );
+        verify_field_access_control(
+            &interface_i.fields,
+            "secret",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S1", "S2"]],
+        );
+
+        // type T implements I {
+        //   id: ID!
+        //   extra: String @authenticated
+        //   secret: String @requiresScopes(scopes: [["S1", "S2"]])
+        // }
+        let type_t = supergraph
+            .schema()
+            .schema()
+            .get_object("T")
+            .expect("type T exists in schema");
+        let field_extra = type_t
+            .fields
+            .get("extra")
+            .expect("field extra exists on type T");
+        assert!(
+            field_extra
+                .directives
+                .iter()
+                .any(|d| d.name == "authenticated")
+        );
+        verify_field_access_control(
+            &type_t.fields,
+            "secret",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S1", "S2"]],
+        );
+
+        // type U implements I {
+        //   id: ID!
+        //   extra: String
+        //   secret: String @requiresScopes(scopes: [["S1"]])
+        // }
+        let type_u = supergraph
+            .schema()
+            .schema()
+            .get_object("U")
+            .expect("type U exists in schema");
+        let field_extra = type_u
+            .fields
+            .get("extra")
+            .expect("field extra exists on type U");
+        assert!(
+            !field_extra
+                .directives
+                .iter()
+                .any(|d| d.name == "authenticated")
+        );
+        verify_field_access_control(
+            &type_u.fields,
+            "secret",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S1"]],
+        );
+    }
+
+    #[test]
+    fn propagates_type_access_control_on_interface_chains() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                node(id: ID!): Node
+              }
+
+              interface Node {
+                id: ID!
+              }
+
+              interface I implements Node {
+                id: ID!
+                intf: String
+              }
+
+              type T implements Node & I @key(fields: "id") @policy(policies: [["P1"]]) {
+                id: ID!
+                intf: String
+                vT: String
+              }
+
+              type U implements Node & I @key(fields: "id") @policy(policies: [["P2"]]) {
+                id: ID!
+                intf: String
+                vU: String
+              }
+
+              type V implements Node & I @key(fields: "id") {
+                id: ID!
+                intf: String
+                vV: String
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              type Query {
+                t: T
+              }
+
+              type T @key(fields: "id") {
+                id: ID!
+                other: Int
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        verify_type_access_control(
+            supergraph.schema().schema(),
+            "Node",
+            "policy",
+            "policies",
+            vec![vec!["P1", "P2"]],
+        );
+        verify_type_access_control(
+            supergraph.schema().schema(),
+            "I",
+            "policy",
+            "policies",
+            vec![vec!["P1", "P2"]],
+        );
+    }
+
+    #[test]
+    fn propagates_field_access_control_on_interface_chains_with_interface_object() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              type Query {
+                i: I
+              }
+
+              type I @interfaceObject @key(fields: "id") {
+                id: ID!
+                secret: String @requiresScopes(scopes: [["S1"]])
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              interface Node {
+                id: ID!
+                secret: String
+              }
+
+              interface I implements Node @key(fields: "id") {
+                id: ID!
+                extra: String
+                secret: String
+              }
+
+              type T implements Node & I @key(fields: "id") {
+                id: ID!
+                extra: String @authenticated
+                secret: String @external
+              }
+
+              type U implements Node & I @key(fields: "id") {
+                id: ID!
+                extra: String
+                secret: String @external
+              }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let supergraph = result.expect("Expected composition to succeed");
+        println!("{}", supergraph.schema().schema());
+
+        let interface_node = supergraph
+            .schema()
+            .schema()
+            .get_interface("Node")
+            .expect("interface Node exists in the schema");
+        verify_field_access_control(
+            &interface_node.fields,
+            "secret",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S1"]],
+        );
+
+        let interface_i = supergraph
+            .schema()
+            .schema()
+            .get_interface("I")
+            .expect("interface I exists in the schema");
+        verify_field_access_control(
+            &interface_i.fields,
+            "secret",
+            "requiresScopes",
+            "scopes",
+            vec![vec!["S1"]],
+        );
+        let field_extra_i = interface_i
+            .fields
+            .get("extra")
+            .expect("field extra exists on interface I");
+        assert!(
+            field_extra_i
+                .directives
+                .iter()
+                .any(|d| d.name == "authenticated")
+        );
+    }
+
+    #[test]
+    fn access_control_propagation_handles_renames() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.9",
+                import: [ "@key", { name: "@policy", as: "@apolloPolicy" }]
+              )
+
+              type Query {
+                i: I!
+              }
+
+              interface I {
+                id: ID
+              }
+
+              type T implements I @key(fields: "id") @apolloPolicy(policies: [["P1"]]) {
+                id: ID
+                vT: String
+              }
+
+              type U implements I @key(fields: "id") @apolloPolicy(policies: [["P2"]]) {
+                id: ID
+                vU: String
+              }
+
+              type V implements I @key(fields: "id") {
+                id: ID
+                vV: String
+              }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.9",
+                import: [ "@key", { name: "@authenticated", as: "@apolloAuthenticated" }]
+              )
+
+              type Query {
+                t: T
+              }
+
+              type T @key(fields: "id") {
+                id: ID!
+                other: Int @apolloAuthenticated
+              }
+            "#,
+        };
+
+        let subgraphs = vec![
+            Subgraph::parse(
+                subgraph1.name,
+                &format!("http://{}", subgraph1.name),
+                subgraph1.type_defs,
+            )
+            .expect("valid subgraph"),
+            Subgraph::parse(
+                subgraph2.name,
+                &format!("http://{}", subgraph2.name),
+                subgraph2.type_defs,
+            )
+            .expect("valid subgraph"),
+        ];
+        let result = compose(subgraphs);
+        let supergraph = result.expect("Expected composition to succeed");
+
+        verify_type_access_control(
+            supergraph.schema().schema(),
+            "I",
+            "apolloPolicy",
+            "policies",
+            vec![vec!["P1", "P2"]],
+        );
+        let type_t = supergraph
+            .schema()
+            .schema()
+            .get_object("T")
+            .expect("type T exists in the schema");
+        let field_other_t = type_t
+            .fields
+            .get("other")
+            .expect("field other exists on type T");
+        assert!(
+            field_other_t
+                .directives
+                .iter()
+                .any(|d| d.name == "apolloAuthenticated")
+        );
+    }
+
+    // this is a copy of a test util method from argument_composition_strategies.rs
+    // we need this duplicated as
+    // - this should not be a public API
+    // - the arg composition strategy tests should be unit tests
+    fn parse_into_ast_value_list(value: Vec<Vec<&str>>) -> Value {
+        // outer array is interpreted as the disjunction (an OR) of the inner arrays.
+        let mut disjunctions = vec![];
+        for inner_array in value {
+            // inner array is interpreted as the conjunction (an AND) of the conditions in the array.
+            let mut conjunctions = vec![];
+            for value in inner_array {
+                conjunctions.push(Node::new(Value::String(value.to_string())));
+            }
+            disjunctions.push(Node::new(Value::List(conjunctions)));
+        }
+        Value::List(disjunctions)
+    }
+
+    fn verify_type_access_control(
+        schema: &Schema,
+        target_type: &str,
+        target_directive: &str,
+        arg_name: &str,
+        expected: Vec<Vec<&str>>,
+    ) {
+        let extended_type = schema
+            .types
+            .get(target_type)
+            .unwrap_or_else(|| panic!("{target_type} exists in schema"));
+        let directive = extended_type
+            .directives()
+            .iter()
+            .find(|d| d.name == target_directive)
+            .unwrap_or_else(|| panic!("@{target_directive} is applied on target {target_type}"));
+        let arg = directive
+            .specified_argument_by_name(arg_name)
+            .unwrap_or_else(|| {
+                panic!("{arg_name} argument should exist on directive {target_directive}")
+            });
+        let expected = parse_into_ast_value_list(expected);
+        assert_eq!(arg.as_ref(), &expected);
+    }
+
+    fn verify_field_access_control(
+        fields: &IndexMap<Name, Component<FieldDefinition>>,
+        field_name: &str,
+        target_directive: &str,
+        arg_name: &str,
+        expected: Vec<Vec<&str>>,
+    ) {
+        let field = fields
+            .get(field_name)
+            .unwrap_or_else(|| panic!("field {field_name} exists"));
+        let directive = field
+            .directives
+            .iter()
+            .find(|d| d.name == target_directive)
+            .unwrap_or_else(|| {
+                panic!("@{target_directive} is applied on target {field_name} field")
+            });
+        let arg = directive
+            .specified_argument_by_name(arg_name)
+            .unwrap_or_else(|| {
+                panic!("{arg_name} argument should exist on directive {target_directive}")
+            });
+        let expected = parse_into_ast_value_list(expected);
+        assert_eq!(arg.as_ref(), &expected);
     }
 }

--- a/apollo-federation/tests/composition/directive_argument_merge_strategies.rs
+++ b/apollo-federation/tests/composition/directive_argument_merge_strategies.rs
@@ -110,8 +110,8 @@ mod tests {
     }
 
     #[test]
-    fn works_for_union_argument_merge_strategy() {
-        // NOTE: @requiresScopes uses the UNION strategy for merging arguments
+    fn works_for_dnf_conjunction_merge_strategy() {
+        // NOTE: @requiresScopes uses the DNF_CONJUNCTION strategy for merging arguments
 
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",
@@ -151,14 +151,14 @@ mod tests {
             CompositionHint {
                 code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
                 message: String::from(
-                    r#"Directive @requiresScopes is applied to "T" in multiple subgraphs with different arguments. Merging strategies used by arguments: { scopes: UNION }"#,
+                    r#"Directive @requiresScopes is applied to "T" in multiple subgraphs with different arguments. Merging strategies used by arguments: { scopes: DNF_CONJUNCTION }"#,
                 ),
                 locations: Vec::new(),
             },
             CompositionHint {
                 code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
                 message: String::from(
-                    r#"Directive @requiresScopes is applied to "T.k" in multiple subgraphs with different arguments. Merging strategies used by arguments: { scopes: UNION }"#,
+                    r#"Directive @requiresScopes is applied to "T.k" in multiple subgraphs with different arguments. Merging strategies used by arguments: { scopes: DNF_CONJUNCTION }"#,
                 ),
                 locations: Vec::new(),
             },
@@ -182,7 +182,7 @@ mod tests {
             .expect("@requiresScopes directive should be present on T");
         assert_eq!(
             t_requires_scopes_directive.to_string(),
-            r#"@requiresScopes(scopes: [["foo"], ["bar"]])"#
+            r#"@requiresScopes(scopes: [["foo"]])"#
         );
 
         let k = coord!(T.k)


### PR DESCRIPTION
Updates composition merge logic to propagate access control directives
* upwards from object types to interface types
* upwards from object fields to interface fields fields
* upwards from interface object fields to other interface fields
* downwards from interface object fields to object fields

Updated `@requiresScopes` and `@policy` argument merge strategies to use DNF conjunction.

<!-- FED-961 -->