### PR TITLE
fix(composition): provide better error message for interface objects

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1731,69 +1731,83 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
         // If we do, then we look if one of the subgraph provides that field as a (non-external) interface object
         // type, and if that's the case, we add the field to the object.
         for (index, subgraph) in self.subgraphs.iter().enumerate() {
-            // Note that we don't blindly add the field yet, that would be incorrect in many cases (and we
-            // have a specific validation that return a user-friendly error in such incorrect cases, see
-            // `post_merge_validations`). We must first check that there is some subgraph that implement
-            // that field as an "interface object", since in that case the field will genuinely be provided
-            for itf_obj_field in subgraph.interface_object_fields() {
-                // we skip @external fields as they are provided by other subgraphs
-                if subgraph
-                    .metadata()
-                    .external_metadata()
-                    .is_external(&FieldDefinitionPosition::Object(itf_obj_field.clone()))
-                {
-                    continue;
-                }
-
-                let ast_node_to_add =
-                    (*itf_obj_field.get(subgraph.schema().schema())?.node).clone();
+            for itf_object in subgraph.interface_objects() {
                 let itf = InterfaceTypeDefinitionPosition {
-                    type_name: itf_obj_field.type_name.clone(),
+                    type_name: itf_object.type_name.clone(),
                 };
-
                 // Note it's possible that interface is abstracted away (as an interface object) in multiple
                 // subgraphs, so we don't bother with the field definition in those subgraphs, but rather
                 // just copy the merged definition from the interface.
                 for implementer in itf.implementers(&self.merged)? {
-                    if implementer
-                        .field(itf_obj_field.field_name.clone())
-                        .try_get(self.merged.schema())
-                        .is_none()
-                    {
-                        let mut missing_obj_node = ast_node_to_add.clone();
-                        missing_obj_node.directives.retain(|d| {
-                            self.merged
-                                .schema()
-                                .directive_definitions
-                                .contains_key(&d.name)
-                            // filter access control directives for now as they will be merged later one
-                            && !access_control_directive_names.contains(&d.name)
+                    if matches!(
+                        implementer,
+                        ObjectOrInterfaceTypeDefinitionPosition::Interface(_)
+                    ) {
+                        // @interfaceObject cannot be implemented by other interfaces
+                        self.error_reporter.add_error(CompositionError::InterfaceObjectUsageError {
+                            message: format!(
+                                "Interfaces implementing @interfaceObject are not supported: @interfaceObject \"{itf}\" is implemented by an interface \"{implementer}\".",
+                            ),
                         });
-                        missing_obj_node.arguments.iter_mut().for_each(|arg| {
-                            arg.make_mut().directives.retain(|d| {
+                        continue;
+                    }
+
+                    // Note that we don't blindly add the field yet, that would be incorrect in many cases (and we
+                    // have a specific validation that return a user-friendly error in such incorrect cases, see
+                    // `post_merge_validations`). We must first check that there is some subgraph that implement
+                    // that field as an "interface object", since in that case the field will genuinely be provided
+                    for itf_obj_field in itf_object.fields(subgraph.schema().schema())? {
+                        // we skip @external fields as they are provided by other subgraphs
+                        if subgraph
+                            .metadata()
+                            .external_metadata()
+                            .is_external(&FieldDefinitionPosition::Object(itf_obj_field.clone()))
+                        {
+                            continue;
+                        }
+
+                        let ast_node_to_add =
+                            (*itf_obj_field.get(subgraph.schema().schema())?.node).clone();
+                        if implementer
+                            .field(itf_obj_field.field_name.clone())
+                            .try_get(self.merged.schema())
+                            .is_none()
+                        {
+                            let mut missing_obj_node = ast_node_to_add.clone();
+                            missing_obj_node.directives.retain(|d| {
                                 self.merged
                                     .schema()
                                     .directive_definitions
                                     .contains_key(&d.name)
+                                    // filter access control directives for now as they will be merged later one
+                                    && !access_control_directive_names.contains(&d.name)
                             });
-                        });
+                            missing_obj_node.arguments.iter_mut().for_each(|arg| {
+                                arg.make_mut().directives.retain(|d| {
+                                    self.merged
+                                        .schema()
+                                        .directive_definitions
+                                        .contains_key(&d.name)
+                                });
+                            });
 
-                        // We add a special @join__field for those added field with no `graph` target. This
-                        // clarifies to the later extraction process that this particular field doesn't come
-                        // from any particular subgraph (it comes indirectly from an @interfaceObject type,
-                        // but it's very much indirect so ...).
-                        missing_obj_node
-                            .directives
-                            .push(JoinFieldBuilder::new().build());
-                        let merged_field = ObjectFieldDefinitionPosition {
-                            type_name: implementer.type_name().clone(),
-                            field_name: itf_obj_field.field_name.clone(),
-                        };
-                        access_control_sources
-                            .entry(merged_field.clone())
-                            .or_default()
-                            .insert(index, Some(itf_obj_field.clone().into()));
-                        fields_to_insert.insert(merged_field, missing_obj_node);
+                            // We add a special @join__field for those added field with no `graph` target. This
+                            // clarifies to the later extraction process that this particular field doesn't come
+                            // from any particular subgraph (it comes indirectly from an @interfaceObject type,
+                            // but it's very much indirect so ...).
+                            missing_obj_node
+                                .directives
+                                .push(JoinFieldBuilder::new().build());
+                            let merged_field = ObjectFieldDefinitionPosition {
+                                type_name: implementer.type_name().clone(),
+                                field_name: itf_obj_field.field_name.clone(),
+                            };
+                            access_control_sources
+                                .entry(merged_field.clone())
+                                .or_default()
+                                .insert(index, Some(itf_obj_field.clone().into()));
+                            fields_to_insert.insert(merged_field, missing_obj_node);
+                        }
                     }
                 }
             }

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -49,6 +49,7 @@ use crate::schema::blueprint::FederationBlueprint;
 use crate::schema::compute_subgraph_metadata;
 use crate::schema::position::ObjectFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
+use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
 use crate::schema::position::SchemaRootDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
@@ -656,7 +657,7 @@ impl<S: HasMetadata> Subgraph<S> {
             .directive_name_in_schema(self.schema(), &FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC)
     }
 
-    pub(crate) fn interface_object_fields(&self) -> Vec<ObjectFieldDefinitionPosition> {
+    pub(crate) fn interface_objects(&self) -> Vec<ObjectTypeDefinitionPosition> {
         let Ok(Some(interface_object_def)) = self
             .metadata()
             .federation_spec_definition()
@@ -665,19 +666,12 @@ impl<S: HasMetadata> Subgraph<S> {
             return vec![];
         };
 
-        let itf_objects = &self
-            .schema()
+        self.schema()
             .referencers()
             .get_directive(&interface_object_def.name)
-            .object_types;
-        if itf_objects.is_empty() {
-            return vec![];
-        }
-
-        itf_objects
+            .object_types
             .iter()
-            .filter_map(|obj| obj.fields(self.schema().schema()).ok())
-            .flatten()
+            .cloned()
             .collect()
     }
 

--- a/apollo-federation/tests/composition/compose_interface_object.rs
+++ b/apollo-federation/tests/composition/compose_interface_object.rs
@@ -594,3 +594,49 @@ fn interface_with_non_resolvable_key_does_not_require_all_implementations() {
         "Expected composition to succeed - non-resolvable interface key should not require all implementations"
     );
 }
+
+#[test]
+fn interface_object_chains_are_not_supported() {
+    let s1 = ServiceDefinition {
+        name: "S1",
+        type_defs: r#"
+            type Query {
+              i: I1
+            }
+
+            interface I1 @key(fields: "id") {
+              id: ID!
+              data: String!
+            }
+
+            interface I2 implements I1 @key(fields: "id") {
+              id: ID!
+              data: String!
+              data2: String!
+            }
+
+            type T implements I1 & I2 @key(fields: "id") {
+              id: ID!
+              data: String!
+              data2: String!
+            }
+        "#,
+    };
+    let s2 = ServiceDefinition {
+        name: "S2",
+        type_defs: r#"
+            type I1 @interfaceObject @key(fields: "id") {
+              id: ID!
+              data3: Int
+            }
+        "#,
+    };
+    let result = compose_as_fed2_subgraphs(&[s1, s2]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "INTERFACE_OBJECT_USAGE_ERROR",
+            r#"Interfaces implementing @interfaceObject are not supported: @interfaceObject "I1" is implemented by an interface "I2"."#,
+        )],
+    );
+}


### PR DESCRIPTION
While GraphQL supports interfaces implementing other interfaces, this is currently unsupported when using `@interfaceObject`.

Updates `add_missing_interface_object_fields_to_implementations` logic to verify that we don't have any interface implementing `@interfaceObject`s interface and log more specific `INTERFACE_OBJECT_USAGE_ERROR` message if we do (previously composition would fail with misleading `INTERFACE_FIELD_NO_IMPLEM`).

<!-- FED-919 -->
