### PR TITLE
Suggestions for #8915

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -289,7 +289,7 @@ impl Opt {
         anyhow!("Use of Apollo Graph OS requires setting the {env_var} environment variable")
     }
 
-    fn prohibit_env_vars(env_vars: &[&str]) -> Result<(), anyhow::Error> {
+    fn prohibit_env_vars(env_vars: &[&'static str]) -> Result<(), anyhow::Error> {
         reject_environment_variables(&env_variables_set(env_vars))
     }
 }


### PR DESCRIPTION
I was having a hard time verbalizing my suggestions and found it easier to put them in code.

The key idea is tho separate the `validate_otel_envs_not_present` into a few parts:
1. Define which environment variables should be rejected programmatically
2. Check for which variables are present in a separate function
3. Create an error based on variables present in a separate function

This is primarily to allow better testing - using `unsafe {}` code blocks is widely discouraged and separating the pieces allows them to be tested without the use of unsafe blocks.

This change also uses `std::env::var` rather than `std::env::var_os` as we need to prohibit non-unicode OTEL vars as well.