### PR TITLE
chore: use a service builder for axum layers

### DIFF
--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -30,6 +30,7 @@ use serde_json::json;
 use tokio::net::UnixListener;
 use tokio::sync::mpsc;
 use tokio_rustls::TlsAcceptor;
+use tower::ServiceBuilder;
 use tower::ServiceExt;
 use tower_http::trace::TraceLayer;
 use tracing::Instrument;
@@ -354,20 +355,28 @@ where
         .br(true)
         .gzip(true)
         .deflate(true);
-    let mut main_route = main_router::<RF>(configuration)
-        .layer(decompression)
-        .layer(middleware::from_fn_with_state(
-            (license.clone(), Instant::now(), Arc::new(AtomicU64::new(0))),
-            license_handler,
-        ))
-        .layer(Extension(service_factory))
-        .layer(cors)
-        // Telemetry layers MUST be last. This means that they will be hit first during execution of the pipeline
-        // Adding layers after telemetry will cause us to lose metrics and spans.
-        .layer(
-            TraceLayer::new_for_http().make_span_with(PropagatingMakeSpan { license, span_mode }),
-        )
-        .layer(middleware::from_fn(metrics_handler));
+
+    let mut main_route = main_router::<RF>(configuration).layer(
+        ServiceBuilder::new()
+            // Telemetry layers MUST be first. This means that they will be hit first during execution of the pipeline
+            // Adding layers before telemetry will cause us to lose metrics and spans.
+            .layer(middleware::from_fn(metrics_handler))
+            .layer(
+                TraceLayer::new_for_http().make_span_with(PropagatingMakeSpan {
+                    license: license.clone(),
+                    span_mode,
+                }),
+            )
+            // CORS layer must be before any layer that can short-circuit with an error response, else
+            // browser clients will not be able to view the error response body.
+            .layer(cors)
+            .layer(Extension(service_factory))
+            .layer(middleware::from_fn_with_state(
+                (license, Instant::now(), Arc::new(AtomicU64::new(0))),
+                license_handler,
+            ))
+            .layer(decompression),
+    );
 
     if let Some(main_endpoint_layer) = ENDPOINT_CALLBACK.get() {
         main_route = main_endpoint_layer(main_route);


### PR DESCRIPTION
A quick drive-by PR. I was trying to answer a question about CORS ordering and got a bit confused by this.

By chaining `.layer`s directly onto an axum router, each next layer "wraps" the previous, so conceptually a request flows from the bottom to the top. tower has a `ServiceBuilder` where `.layer`s are applied in the opposite order, and this is kind of the common way to do things with tower. I think this is more intuitive because requests go through the layers in the order that you read them (and then responses go back up). axum also recommends doing it this way: https://docs.rs/axum/latest/axum/middleware/index.html#applying-multiple-middleware

It's fundamentally not that important so feel free to close if deemed at all risky / not worth reviewer time. IMO, there is no risk to this change as long as reviewers agree that I've flipped the order exactly.

<!-- start metadata -->

<!-- [ROUTER-1619] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

It's a benign internal change.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1619]: https://apollographql.atlassian.net/browse/ROUTER-1619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ