### PR TITLE
Promote connector_request_service to public plugin interface to allow it to be used in custom rust plugins

### DIFF
--- a/.changesets/feat_am_connectors_public_plugin.md
+++ b/.changesets/feat_am_connectors_public_plugin.md
@@ -1,0 +1,3 @@
+### Promote connector_request_service to public plugin interface to allow it to be used in custom rust plugins ([PR #8937](https://github.com/apollographql/router/pull/8937))
+
+Promote connector_request_service to public plugin interface to allow it to be used in custom rust plugins.

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -492,6 +492,15 @@ pub trait PluginUnstable: Send + Sync + 'static {
         service
     }
 
+    /// This service handles individual requests to Apollo Connectors
+    fn connector_request_service(
+        &self,
+        service: crate::services::connector::request_service::BoxService,
+        _source_name: String,
+    ) -> crate::services::connector::request_service::BoxService {
+        service
+    }
+
     /// Return the name of the plugin.
     fn name(&self) -> &'static str
     where
@@ -543,6 +552,14 @@ where
         service: subgraph::BoxService,
     ) -> subgraph::BoxService {
         Plugin::subgraph_service(self, subgraph_name, service)
+    }
+
+    fn connector_request_service(
+        &self,
+        service: crate::services::connector::request_service::BoxService,
+        source_name: String,
+    ) -> crate::services::connector::request_service::BoxService {
+        Plugin::connector_request_service(self, service, source_name)
     }
 
     /// Return the name of the plugin.
@@ -692,6 +709,14 @@ where
         service: subgraph::BoxService,
     ) -> subgraph::BoxService {
         PluginUnstable::subgraph_service(self, subgraph_name, service)
+    }
+
+    fn connector_request_service(
+        &self,
+        service: crate::services::connector::request_service::BoxService,
+        source_name: String,
+    ) -> crate::services::connector::request_service::BoxService {
+        PluginUnstable::connector_request_service(self, service, source_name)
     }
 
     /// Return the name of the plugin.

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -407,6 +407,17 @@ pub trait Plugin: Send + Sync + 'static {
         service
     }
 
+    /// This service handles individual requests to Apollo Connectors
+    /// Define `connector_request_service` to configure this communication (for example, to dynamically add headers to pass to a REST API).
+    /// The `_source_name` parameter is useful if you need to apply a customization only specific connectors.
+    fn connector_request_service(
+        &self,
+        service: crate::services::connector::request_service::BoxService,
+        _source_name: String,
+    ) -> crate::services::connector::request_service::BoxService {
+        service
+    }
+
     /// Return the name of the plugin.
     fn name(&self) -> &'static str
     where

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -37,12 +37,12 @@ use crate::graphql;
 use crate::json_ext::Value;
 use crate::layers::ServiceBuilderExt;
 use crate::layers::async_checkpoint::AsyncCheckpointLayer;
+use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
-use crate::plugin::PluginPrivate;
 use crate::plugins::telemetry::config_new::conditions::Condition;
 use crate::plugins::telemetry::config_new::router::selectors::RouterSelector;
 use crate::plugins::telemetry::config_new::subgraph::selectors::SubgraphSelector;
-use crate::register_private_plugin;
+use crate::register_plugin;
 use crate::services;
 use crate::services::external::Control;
 use crate::services::external::DEFAULT_EXTERNALIZATION_TIMEOUT;
@@ -71,7 +71,7 @@ const COPROCESSOR_DESERIALIZATION_ERROR_EXTENSION: &str = "EXTERNAL_DESERIALIZAT
 type HTTPClientService = tower::timeout::Timeout<crate::services::http::HttpClientService>;
 
 #[async_trait::async_trait]
-impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
+impl Plugin for CoprocessorPlugin<HTTPClientService> {
     type Config = Conf;
 
     async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
@@ -235,7 +235,7 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
 //
 // In order to keep the plugin names consistent,
 // we use using the `Reverse domain name notation`
-register_private_plugin!(
+register_plugin!(
     "apollo",
     "coprocessor",
     CoprocessorPlugin<HTTPClientService>

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -231,7 +231,7 @@ impl Plugin for CoprocessorPlugin<HTTPClientService> {
 }
 
 // This macro allows us to use it in our plugin registry!
-// register_private_plugin takes a group name, and a plugin name.
+// register_plugin takes a group name, and a plugin name.
 //
 // In order to keep the plugin names consistent,
 // we use using the `Reverse domain name notation`

--- a/apollo-router/src/services/connector.rs
+++ b/apollo-router/src/services/connector.rs
@@ -1,1 +1,1 @@
-pub(crate) mod request_service;
+pub mod request_service;

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -1,4 +1,5 @@
 //! Service which makes individual requests to Apollo Connectors over some transport
+#![allow(missing_docs)] // FIXME
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -46,8 +47,8 @@ use crate::services::Plugins;
 use crate::services::http::HttpClientServiceFactory;
 use crate::services::router;
 
-pub(crate) type BoxService = tower::util::BoxService<Request, Response, BoxError>;
-pub(crate) type ServiceResult = Result<Response, BoxError>;
+pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
+pub type ServiceResult = Result<Response, BoxError>;
 
 assert_impl_all!(Request: Send);
 assert_impl_all!(Response: Send);
@@ -56,7 +57,7 @@ assert_impl_all!(Response: Send);
 #[derive(Debug)]
 pub struct Request {
     /// The request context
-    pub(crate) context: Context,
+    pub context: Context,
 
     /// The connector associated with this request
     // If this service moves into the public API, consider whether this exposes too much
@@ -65,7 +66,7 @@ pub struct Request {
     pub(crate) connector: Arc<Connector>,
 
     /// The request to the underlying transport
-    pub(crate) transport_request: TransportRequest,
+    pub transport_request: TransportRequest,
 
     /// Information about how to map the response to GraphQL
     pub(crate) key: ResponseKey,
@@ -74,7 +75,7 @@ pub struct Request {
     pub(crate) mapping_problems: Vec<Problem>,
 
     /// Original request to the Router.
-    pub(crate) supergraph_request: Arc<http::Request<graphql::Request>>,
+    pub supergraph_request: Arc<http::Request<graphql::Request>>,
 
     /// The operation being executed. Together with
     /// req.connector.schema_subtypes_map, this document enables GraphQL
@@ -86,7 +87,7 @@ pub struct Request {
 #[derive(Debug)]
 pub struct Response {
     /// The result of the transport request
-    pub(crate) transport_result: Result<TransportResponse, Error>,
+    pub transport_result: Result<TransportResponse, Error>,
 
     /// The mapped response, including any mapping problems encountered when processing the response
     pub(crate) mapped_response: MappedResponse,

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -30,7 +30,8 @@ pub(crate) use crate::services::supergraph::Response as SupergraphResponse;
 pub(crate) use crate::services::supergraph::service::SupergraphCreator;
 
 pub(crate) mod connect;
-pub(crate) mod connector;
+/// Services for Apollo Connectors.
+pub mod connector;
 pub(crate) mod connector_service;
 pub mod execution;
 pub(crate) mod external;


### PR DESCRIPTION
Promote connector_request_service to public plugin interface to allow it to be used in custom rust plugins.

<!-- start metadata -->

<!-- [ROUTER-1622] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1622]: https://apollographql.atlassian.net/browse/ROUTER-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ