### PR TITLE
Remove tonic-build dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,6 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tonic",
- "tonic-build",
  "tonic-prost-build",
  "tower",
  "tower-http",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -374,7 +374,6 @@ hyperlocal = { version = "0.9.1", default-features = false, features = [
 ] }
 
 [build-dependencies]
-tonic-build = "0.14.5"
 tonic-prost-build = "0.14.0"
 serde_json.workspace = true
 


### PR DESCRIPTION
tonic-prost-build is used instead, so its no longer needed