### PR TITLE
chore: remove obsolete advisory exemptions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,8 +23,6 @@ git-fetch-with-cli = true
 # rustsec advisory exemptions
 ignore = [
     "RUSTSEC-2023-0071",
-    "RUSTSEC-2024-0376", # we do not use tonic::transport::Server
-    "RUSTSEC-2024-0421", # we only resolve trusted subgraphs
 
     # protobuf is used only through prometheus crates, enforced by
     # a `[bans]` entry below. in the prometheus crates, only the protobuf


### PR DESCRIPTION
While working on the otel upgrade, I found that these two advisories already don't trigger anymore. We probably have updated to newer versions since the exemptions were introduced.

The `protobuf` exemption will also be removed in #8922.

<!-- [ROUTER-1650] -->

<!-- start metadata -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

No tests, documentation, or changeset for a CI change.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1650]: https://apollographql.atlassian.net/browse/ROUTER-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ