### PR TITLE
chore: remove exemption for vulnerable protobuf version

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,11 +26,6 @@ ignore = [
     "RUSTSEC-2024-0376", # we do not use tonic::transport::Server
     "RUSTSEC-2024-0421", # we only resolve trusted subgraphs
 
-    # protobuf is used only through prometheus crates, enforced by
-    # a `[bans]` entry below. in the prometheus crates, only the protobuf
-    # encoder is used, while only the decoder is affected by this advisory.
-    "RUSTSEC-2024-0437",
-
     # The following crates are unmaintained
     "RUSTSEC-2024-0320", # TODO replace the `yaml-rust` crate with a maintained equivalent
     "RUSTSEC-2024-0436", # TODO replace the `paste` crate with a maintained equivalent
@@ -98,12 +93,7 @@ highlight = "all"
 
 # List of crates to deny
 deny = [
-  { crate = "openssl-sys" },
-  # Prevent adding new dependencies on protobuf that may use code with
-  # a security advisory in it (see `[advisories]`).
-  # If you *must* add a new crate to the "wrappers" here, carefully audit
-  # that it is *not* affected by any of the advisories above.
-  { crate = "protobuf:<3.7.2", wrappers = ["prometheus", "opentelemetry-prometheus"] },
+  { name = "openssl-sys" },
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
We've updated `opentelemetry-prometheus`, so we don't use the vulnerable version anymore.

This reverts commit 5384ede615383395bc73ca4b26aac44ffb7819d8.

<!-- start metadata -->

<!-- [ROUTER-1650] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1650]: https://apollographql.atlassian.net/browse/ROUTER-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ