### PR TITLE
fix: response cache and registry improvements

### DIFF
--- a/apollo-router/src/plugins/telemetry/config_new/conditions.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditions.rs
@@ -98,7 +98,11 @@ where
             }
             Condition::Exists(sel) => match restricted_stage {
                 Some(stage) => {
-                    if sel.is_active(stage) {
+                    // Allow selectors that are active at the current stage OR at the request stage.
+                    // Request-stage selectors are valid in response-stage events because
+                    // evaluate_request() pre-resolves them before the event is stored for
+                    // response-time evaluation.
+                    if sel.is_active(stage) || sel.is_active(Stage::Request) {
                         Ok(())
                     } else {
                         Err(format!(
@@ -886,6 +890,13 @@ mod test {
         assert!(exists(Req).validate(None).is_ok());
         assert!(exists(Req).validate(Some(Stage::Request)).is_ok());
         assert!(exists(Resp).validate(None).is_ok());
+        // Request-stage selectors are valid in Exists conditions for response-stage events
+        // because evaluate_request() pre-resolves them before response-time evaluation.
+        assert!(exists(Req).validate(Some(Stage::Response)).is_ok());
+        assert!(exists(Req).validate(Some(Stage::ResponseEvent)).is_ok());
+        // Response-stage selectors still work at response stage
+        assert!(exists(Resp).validate(Some(Stage::Response)).is_ok());
+        assert!(exists(Resp).validate(Some(Stage::ResponseEvent)).is_ok());
     }
 
     #[test]

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
@@ -281,6 +281,54 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_supergraph_events_with_request_header_response_condition() {
+        let test_harness: PluginTestHarness<Telemetry> = PluginTestHarness::builder()
+            .config(include_str!(
+                "../../testdata/custom_events_request_header_response.router.yaml"
+            ))
+            .build()
+            .await
+            .expect("test harness");
+
+        async {
+            // With the request header present, the response event should fire
+            test_harness
+                .supergraph_service(|_r| async {
+                    supergraph::Response::fake_builder()
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                })
+                .call(
+                    supergraph::Request::fake_builder()
+                        .query("query { foo }")
+                        .header("x-log-request", HeaderValue::from_static("enabled"))
+                        .build()
+                        .unwrap(),
+                )
+                .await
+                .expect("expecting successful response");
+            // Without the request header, the response event should not fire
+            test_harness
+                .supergraph_service(|_r| async {
+                    Ok(supergraph::Response::fake_builder()
+                        .data(serde_json::json!({"data": "res"}).to_string())
+                        .build()
+                        .expect("expecting valid response"))
+                })
+                .call(
+                    supergraph::Request::fake_builder()
+                        .query("query { foo }")
+                        .build()
+                        .unwrap(),
+                )
+                .await
+                .expect("expecting successful response");
+        }
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_supergraph_events_on_response() {
         let test_harness: PluginTestHarness<Telemetry> = PluginTestHarness::builder()
             .config(include_str!("../../testdata/custom_events.router.yaml"))

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/snapshots/apollo_router__plugins__telemetry__config_new__supergraph__events__tests__supergraph_events_with_request_header_response_condition@logs.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/snapshots/apollo_router__plugins__telemetry__config_new__supergraph__events__tests__supergraph_events_with_request_header_response_condition@logs.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/src/plugins/telemetry/config_new/supergraph/events.rs
+expression: yaml
+---
+- fields:
+    kind: my.response.event
+  level: INFO
+  message: Response triggered by request header
+  span:
+    apollo_private.field_level_instrumentation_ratio: 0.01
+    apollo_private.graphql.variables: "{}"
+    name: supergraph
+    otel.kind: INTERNAL
+  spans:
+    - apollo_private.field_level_instrumentation_ratio: 0.01
+      apollo_private.graphql.variables: "{}"
+      name: supergraph
+      otel.kind: INTERNAL

--- a/apollo-router/src/plugins/telemetry/testdata/custom_events_request_header_response.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/custom_events_request_header_response.router.yaml
@@ -1,0 +1,11 @@
+telemetry:
+  instrumentation:
+    events:
+      supergraph:
+        my.response.event:
+          message: "Response triggered by request header"
+          level: info
+          on: response
+          condition:
+            exists:
+              request_header: x-log-request


### PR DESCRIPTION
## Changes

### Response Cache Fixes
- **no-store on errors**: Set `Cache-Control: no-store` when response contains GraphQL errors to prevent intermediate caches from serving partial/error responses (#8933)
- **Correct no-store/no-cache semantics**: Fixed cache behavior to properly distinguish between `no-store` (allows serving from cache, prohibits storing) and `no-cache` (prohibits serving without revalidation, allows storing) per RFC 9111 (#8948)
- **Request cache-control propagation**: Propagate request-level cache-control directives to response handling

### Registry & Artifacts
- **Unsecure registry support**: Allow Router to pull graph artifacts from non-SSL registries via `APOLLO_GRAPH_ARTIFACT_UNSECURE_HOSTS` env var (#8919)
- **Better host extraction**: Improved hostname parsing to support IPv6 addresses and various URL formats

### Composition
- **Type implements fix**: Emit `implements` on type definition instead of extend type when merging subgraphs (#8931)

### Telemetry
- **Request header in response conditions**: Allow `request_header` selectors in `Exists` conditions for response-stage events (#8848)

### Infrastructure
- **Service builder refactor**: Use `tower::ServiceBuilder` for cleaner axum layer composition (#8928)
- **BNF dependency update**: Update bnf to 0.6 (#8935)
- **Documentation**: Add proxy certificate instructions for containerized deployments (#8947)

### Dependencies
- Removed obsolete advisory exemptions from deny.toml
- Updated Cargo.lock with dependency version changes