### PR TITLE
Refactor noop meter providers, remove filter and return if no readers

### DIFF
--- a/apollo-router/src/metrics/filter.rs
+++ b/apollo-router/src/metrics/filter.rs
@@ -198,11 +198,11 @@ macro_rules! filter_observable_instrument_fn {
                 (_, _) => false,
             };
 
-            // For filtered observable instruments, return noop immediately.
+            // For filtered observable instruments, route through the noop meter.
             // This avoids registering callbacks with the SDK which would log
             // errors about views not producing measures in OTel 0.31+.
             if is_filtered {
-                return $wrapper::new();
+                return self.noop.$name(builder.name.clone()).build();
             }
 
             // Extract builder fields before consuming callbacks

--- a/apollo-router/src/plugins/telemetry/reload/builder.rs
+++ b/apollo-router/src/plugins/telemetry/reload/builder.rs
@@ -33,7 +33,6 @@ use tower::ServiceExt;
 use crate::Endpoint;
 use crate::ListenAddr;
 use crate::metrics::aggregation::MeterProviderType;
-use crate::metrics::filter::FilterMeterProvider;
 use crate::plugins::telemetry::apollo;
 use crate::plugins::telemetry::apollo_exporter::Sender;
 use crate::plugins::telemetry::config::Conf;
@@ -106,15 +105,9 @@ impl<'a> Builder<'a> {
             );
             builder.configure_views(MeterProviderType::Public);
 
-            let (prometheus_registry, mut meter_providers, _) = builder.build();
+            let (prometheus_registry, meter_providers, _) = builder.build();
             self.activation
                 .with_prometheus_registry(prometheus_registry);
-
-            // If no exporters are configured, we still need to set a noop provider
-            // to replace any previously configured provider during hot reload.
-            meter_providers
-                .entry(MeterProviderType::Public)
-                .or_insert_with(FilterMeterProvider::noop);
 
             self.activation.add_meter_providers(meter_providers);
         }

--- a/apollo-router/src/plugins/telemetry/reload/metrics.rs
+++ b/apollo-router/src/plugins/telemetry/reload/metrics.rs
@@ -76,11 +76,12 @@ impl<'a> MetricsBuilder<'a> {
             self.prometheus_registry,
             self.meter_provider_builders
                 .into_iter()
-                // Only include providers that have readers configured.
-                // Providers with only views but no readers would cause OTel SDK to emit
-                // errors when observable instruments are registered.
-                .filter(|(k, _)| self.providers_with_readers.contains(k))
                 .map(|(k, v)| {
+                    // Providers without readers get a noop to avoid OTel SDK errors
+                    // when observable instruments are registered.
+                    if !self.providers_with_readers.contains(&k) {
+                        return (k, FilterMeterProvider::noop());
+                    }
                     (
                         k,
                         match k {


### PR DESCRIPTION
Applied these 3 changes that Opus 4.6 suggested:

- The`filter_observable_instrument_fn` macro now routes filtered instruments through `self.noop.$name(builder.name.clone()).build()` instead of calling `$wrapper::new()` directly. This makes noop creation consistent `with how filter_instrument_fn` handles sync instruments — all noop paths flow through `NoopInstrumentProvider`.
- apollo-router/src/plugins/telemetry/reload/metrics.rs — `MetricsBuilder::build` no longer filters out provider types without readers. Instead, it maps them to `FilterMeterProvider::noop()`. This means `build()` always returns entries for every configured provider type, and `SdkMeterProvider::build()` is still skipped for types without readers (avoiding wasted SDK providers).
- apollo-router/src/plugins/telemetry/reload/builder.rs — Removed the `or_insert_with(FilterMeterProvider::noop)` workaround in `setup_public_metrics` and the now-unused `FilterMeterProvider` import. The caller no longer needs to compensate for missing entries since `build()` always produces a complete map.