### PR TITLE
Merge user-configured metrics views into defaults

### DIFF
--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -187,44 +187,46 @@ impl MetricView {
         }
     }
 
+    /// Builds a Stream from this view configuration.
+    /// Use this when you've already matched the instrument by name.
+    pub(crate) fn into_stream(self) -> Stream {
+        let mut stream = Stream::builder();
+        if let Some(new_name) = self.rename {
+            stream = stream.with_name(new_name);
+        }
+        if let Some(desc) = self.description {
+            stream = stream.with_description(desc);
+        }
+        if let Some(u) = self.unit {
+            stream = stream.with_unit(u);
+        }
+        if let Some(agg) = self.aggregation {
+            let aggregation = match agg {
+                MetricAggregation::Histogram { buckets } => Aggregation::ExplicitBucketHistogram {
+                    boundaries: buckets,
+                    record_min_max: true,
+                },
+                MetricAggregation::Drop => Aggregation::Drop,
+            };
+            stream = stream.with_aggregation(aggregation);
+        }
+        if let Some(keys) = self.allowed_attribute_keys {
+            stream = stream.with_allowed_attribute_keys(keys.into_iter().map(Key::new));
+        }
+        stream.build().expect("Failed to build metric view")
+    }
+
     /// Converts this MetricView into a view function for OTel SDK 0.31+
     pub(crate) fn into_view_fn(
         self,
     ) -> impl Fn(&Instrument) -> Option<Stream> + Send + Sync + 'static {
-        let name = self.name;
-        let rename = self.rename;
-        let description = self.description;
-        let unit = self.unit;
-        let aggregation = self.aggregation.map(|agg| match agg {
-            MetricAggregation::Histogram { buckets } => Aggregation::ExplicitBucketHistogram {
-                boundaries: buckets,
-                record_min_max: true,
-            },
-            MetricAggregation::Drop => Aggregation::Drop,
-        });
-        let allowed_attribute_keys = self.allowed_attribute_keys;
-
+        let name = self.name.clone();
+        let view = self;
         move |instrument: &Instrument| {
             if instrument.name() != name {
                 return None;
             }
-            let mut stream = Stream::builder();
-            if let Some(ref new_name) = rename {
-                stream = stream.with_name(new_name.clone());
-            }
-            if let Some(ref desc) = description {
-                stream = stream.with_description(desc.clone());
-            }
-            if let Some(ref u) = unit {
-                stream = stream.with_unit(u.clone());
-            }
-            if let Some(ref agg) = aggregation {
-                stream = stream.with_aggregation(agg.clone());
-            }
-            if let Some(ref keys) = allowed_attribute_keys {
-                stream = stream.with_allowed_attribute_keys(keys.iter().cloned().map(Key::new));
-            }
-            Some(stream.build().expect("Failed to build metric view"))
+            Some(view.clone().into_stream())
         }
     }
 }
@@ -874,7 +876,6 @@ impl Conf {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
     use opentelemetry::metrics::MeterProvider;
     use opentelemetry_sdk::metrics::InMemoryMetricExporter;
     use opentelemetry_sdk::metrics::MeterProviderBuilder;
@@ -882,6 +883,8 @@ mod tests {
     use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader;
     use opentelemetry_sdk::runtime;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn test_attribute_value_from_json() {
@@ -1130,17 +1133,13 @@ mod tests {
         for resource_metrics in metrics {
             for scope_metrics in resource_metrics.scope_metrics() {
                 for metric in scope_metrics.metrics() {
-                    if metric.name() == metric_name {
-                        match metric.data() {
-                            opentelemetry_sdk::metrics::data::AggregatedMetrics::F64(data) => {
-                                if let MetricData::Histogram(histogram) = data {
-                                    if let Some(dp) = histogram.data_points().next() {
-                                        return Some(dp.bounds().collect());
-                                    }
-                                }
-                            }
-                            _ => {}
-                        }
+                    if metric.name() == metric_name
+                        && let opentelemetry_sdk::metrics::data::AggregatedMetrics::F64(
+                            MetricData::Histogram(histogram),
+                        ) = metric.data()
+                        && let Some(dp) = histogram.data_points().next()
+                    {
+                        return Some(dp.bounds().collect());
                     }
                 }
             }

--- a/apollo-router/src/plugins/telemetry/reload/metrics.rs
+++ b/apollo-router/src/plugins/telemetry/reload/metrics.rs
@@ -194,42 +194,37 @@ impl<'a> MetricsBuilder<'a> {
 
     pub(crate) fn configure_views(&mut self, meter_provider_type: MeterProviderType) {
         let boundaries = self.metrics_common().buckets.clone();
-        let user_views: HashMap<String, MetricView> = self
+
+        // Pre-merge user views with default histogram aggregation
+        let merged_views: HashMap<String, MetricView> = self
             .metrics_common()
             .views
             .clone()
             .into_iter()
-            .map(|v| (v.name.clone(), v))
+            .map(|v| {
+                let name = v.name.clone();
+                let default_view = MetricView::default_histogram(name.clone(), boundaries.clone());
+                (name, default_view.merge(v))
+            })
             .collect();
-        let user_view_names: HashSet<String> = user_views.keys().cloned().collect();
 
-        // Merge each user-configured view with default histogram aggregation.
-        // This ensures user views inherit default buckets when no custom aggregation
-        // is specified, while still allowing user overrides for any field.
-        for (name, user_view) in user_views {
-            let default_view = MetricView::default_histogram(name, boundaries.clone());
-            let merged = default_view.merge(user_view);
-            self.with_view(meter_provider_type, merged.into_view_fn());
-        }
-
-        // Apply default histogram buckets to all histograms without user-configured views
+        // Single view that handles both user-configured and default histogram views
         self.with_view(meter_provider_type, move |instrument: &Instrument| {
-            if user_view_names.contains(instrument.name()) {
-                return None;
-            }
-            if instrument.kind() == InstrumentKind::Histogram {
-                Some(
-                    Stream::builder()
-                        .with_aggregation(Aggregation::ExplicitBucketHistogram {
-                            boundaries: boundaries.clone(),
-                            record_min_max: true,
-                        })
-                        .build()
-                        .expect("Failed to create stream for default histogram bucket view"),
-                )
-            } else {
-                None
-            }
+            merged_views
+                .get(instrument.name())
+                .cloned()
+                .map(|view| view.into_stream())
+                .or_else(|| {
+                    (instrument.kind() == InstrumentKind::Histogram).then(|| {
+                        Stream::builder()
+                            .with_aggregation(Aggregation::ExplicitBucketHistogram {
+                                boundaries: boundaries.clone(),
+                                record_min_max: true,
+                            })
+                            .build()
+                            .expect("Failed to create stream for default histogram bucket view")
+                    })
+                })
         });
     }
 }


### PR DESCRIPTION
Opus 4.6 summary of changes:

config.rs — Two new methods on MetricView:
* `MetricView::default_histogram(name, boundaries)` — Creates a default view for a named instrument with histogram aggregation using the given bucket boundaries. This represents the "default view config" for any metric.
* `MetricView::merge(self, user)` — Merges user-provided overrides on top of a default view. User-specified (Some) fields take precedence; unspecified (None) fields retain the default values. This is the `default_config.merge(user_config)` pattern.

metrics.rs — Refactored configure_views:
The old approach had the merge logic spread across the method body — it collected custom view names into a `HashSet`, used that set to skip those names in the default histogram view closure, then registered custom views separately. This meant two views could never coexist for the same metric but the coordination was external.
The new approach:
1. For each user-configured view: creates a `MetricView::default_histogram` with the configured default buckets, then calls `.merge(user_view)`. The merged view is registered as a single view function. This means if a user only configures `allowed_attribute_keys` for a histogram, they still inherit the default bucket boundaries — previously, they'd silently get the OTel SDK's built-in defaults instead.
2. For all remaining histograms: a catch-all view applies the default buckets (skipping user-configured names to avoid duplicates).
The result is a single view per metric with no duplicate output risk, and the merge semantics are encapsulated cleanly in `MetricView::merge`.

