### PR TITLE
Editorial pass on .changesets for 2.10.1

### DIFF
--- a/.changesets/exp_hoist_orphan_errors.md
+++ b/.changesets/exp_hoist_orphan_errors.md
@@ -1,8 +1,12 @@
-### Add `experimental_hoist_orphan_errors` configuration for controlling orphan error path assignment
+### Add `experimental_hoist_orphan_errors` to control orphan error path assignment
 
-Adds a new `experimental_hoist_orphan_errors` configuration that controls how entity-less ("orphan") errors from subgraphs are assigned paths in the response. When enabled for a subgraph, orphan errors are assigned to the nearest non-array ancestor in the response path, preventing them from being duplicated across every element in an array. This can be enabled globally via `all` or per-subgraph via the `subgraphs` map. Per-subgraph settings override `all`.
+The GraphQL specification requires that errors include a `path` pointing to the most specific field where the error occurred. When a subgraph returns entity errors without valid paths, the router's default behavior is its closest attempt at spec compliance: it assigns each error to every matching entity path in the response. This is the correct behavior when subgraphs respond correctly.
 
-Here's an example when targeting a specific subgraph, `my_subgraph`:
+However, when a subgraph returns a large number of entity errors without valid paths — for example, 2000 errors for 2000 expected entities — this causes a multiplicative explosion in the error array that can lead to significant memory pressure and out-of-memory kills. The root cause is the subgraph: a spec-compliant subgraph includes correct paths on its entity errors, and fixing the subgraph is the right long-term solution.
+
+The new `experimental_hoist_orphan_errors` configuration provides an important mitigation while you work toward that fix. When enabled, the router assigns each orphaned error to the nearest non-array ancestor path instead of duplicating it across every entity. This trades spec-precise path assignment for substantially reduced error volume in the response — a conscious trade-off, not a strict improvement.
+
+To target a specific subgraph:
 
 ```yaml
 experimental_hoist_orphan_errors:
@@ -11,7 +15,7 @@ experimental_hoist_orphan_errors:
       enabled: true
 ```
 
-An example when targeting all subgraphs:
+To target all subgraphs:
 
 ```yaml
 experimental_hoist_orphan_errors:
@@ -19,7 +23,7 @@ experimental_hoist_orphan_errors:
     enabled: true
 ```
 
-And an example enabling for all subgraphs except one:
+To target all subgraphs except one:
 
 ```yaml
 experimental_hoist_orphan_errors:
@@ -30,7 +34,10 @@ experimental_hoist_orphan_errors:
       enabled: false
 ```
 
-Using this feature should only happen if you know you have subgraphs that don't respond with the correct paths when making entity calls. If you're unsure, you probably don't need this!
+Per-subgraph settings override `all`. Note that this feature reduces the number of propagated errors but doesn't impose a hard cap — if your subgraph returns an extremely large number of errors, the router still processes all of them.
 
+You'll likely know if you need this. Use it sparingly, and enable it only if you're affected and have been advised to do so. The behavior of this option is expected to change in a future release.
+
+For full configuration reference and additional examples, see the [`experimental_hoist_orphan_errors` documentation](https://www.apollographql.com/docs/graphos/routing/configuration/yaml#experimental_hoist_orphan_errors).
 
 By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/8998

--- a/.changesets/fix_aaron_non_greedy_path_application_for_errors.md
+++ b/.changesets/fix_aaron_non_greedy_path_application_for_errors.md
@@ -1,7 +1,0 @@
-### Don't apply entity-less errors from subgraphs greedily
-
-When making an entity resolution, if for some reason we failed to get an entity (eg, the path was malformed from the subgraph), we'd apply any errors to _everything_ in the list of entities we expected. So, for example, if we were to get 2000 entities and instead received 2000 errors, we'd apply each error to every entity we expected to exist. That causes an explosion of errors and leads to significant memory allocations that almost certainly lead to OOMKills.
-
-Now, when we don't know where an error should be applied, we apply it to the most immediate parent of the targeted entity (so in the case of a list of users, it'd apply to the list itself rather than to each index of that list).
-
-By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/8962

--- a/.changesets/fix_license_handling.md
+++ b/.changesets/fix_license_handling.md
@@ -1,7 +1,7 @@
-### Fix: Proper handling of licenses in a warning state
+### Enforce feature restrictions for warning-state licenses
 
-We allowed licenses in a warning state to bypass enforcement because we weren't returning an error, only the limits. This was happening, I think, because there's middleware handling expired licenses but not licenses in a warning state. So, we assumed that there'd be same kind of handling for licenses in a warning state. Alas, there's not.
+The router now enforces license restrictions even when a license is in a warning state. Previously, warning-state licenses could bypass enforcement for restricted features.
 
-We now error out if there are restricted features in use.
+If your deployment uses restricted features, the router returns an error instead of continuing to run.
 
-By [@aaronarinder](https://github.com/aaronarinder) in https://github.com/apollographql/router/pull/8768
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/8768


### PR DESCRIPTION
## Summary

- Merges `fix_aaron_non_greedy_path_application_for_errors` into `exp_hoist_orphan_errors` — the underlying fix is now opt-in via the experimental config, so both changesets tell a single story. Deletes the standalone fix file.
- Reframes `exp_hoist_orphan_errors` around the GraphQL spec requirement (errors must point to the most specific field), subgraph responsibility as the root cause, the conscious spec trade-off the option makes, a predicted docs URL, and a "behavior expected to change" caveat.
- Rewrites `fix_license_handling` to match the dev-branch CHANGELOG entry: removes first-person prose, drops the title prefix, tightens to two clear sentences.

## Review notes

- The `experimental_hoist_orphan_errors` docs link points to the predicted URL from PR #8999 — confirm that URL is correct before this ships.
- No code changes; changeset copy only.