### PR TITLE
Remove docs team from CODEOWNERS for branch management reasons

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-/docs/ @apollographql/docs
-/.changesets/ @apollographql/docs
 /apollo-federation/ @apollographql/fed-core @apollographql/rust-platform
 /apollo-federation/src/connectors @apollographql/graph-dev
 /apollo-router/ @apollographql/router-core


### PR DESCRIPTION
We do want the docs team input on things, but GitHub's CODEOWNERS required
thing makes it difficult to do slightly useful stuff that Git lets
you do natively, like use branches to move things around.

It used to be that you used signed commits or annotations to encode that
stuff, but we're stuck with this now.  We can't have docs re-approve everything
that has ever had docs changes in parts of git trees.

Removing. And we'll forward port, too.
