### PR TITLE
Remove docs team from CODEOWNERS for branch management reasons (backport #9008)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-/docs/ @apollographql/docs
 /apollo-federation/ @apollographql/orchestration-language
 /apollo-router/ @apollographql/graphos
 /apollo-router/src/plugins/connectors @apollographql/orchestration-language
@@ -7,13 +5,3 @@
 /apollo-router-benchmarks/ @apollographql/graphos @apollographql/orchestration-language
 /examples/ @apollographql/graphos
 /.github/CODEOWNERS @apollographql/graphos
-=======
-/apollo-federation/ @apollographql/fed-core @apollographql/rust-platform
-/apollo-federation/src/connectors @apollographql/graph-dev
-/apollo-router/ @apollographql/router-core
-/apollo-router/src/plugins/connectors @apollographql/graph-dev
-/apollo-router/src/plugins/fleet_detector.rs @apollographql/cloud-fleet
-/apollo-router-benchmarks/ @apollographql/router-core @apollographql/fed-core
-/examples/ @apollographql/router-core @apollographql/fed-core
-/.github/CODEOWNERS @apollographql/router-core @apollographql/fed-core
->>>>>>> 2cff3b20 (Remove docs team from CODEOWNERS for branch management reasons (#9008))


### PR DESCRIPTION
We do want the docs team input on things, but GitHub's CODEOWNERS required
thing makes it difficult to do slightly useful stuff that Git lets
you do natively, like use branches to move things around.

It used to be that you used signed commits or annotations to encode that
stuff, but we're stuck with this now.  We can't have docs re-approve everything
that has ever had docs changes in parts of git trees.

Removing. And we'll forward port, too.
<hr>This is an automatic backport of pull request #9008 done by [Mergify](https://mergify.com).