### PR TITLE
ci: do not publish 2.10.x releases as latest on GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -909,8 +909,8 @@ jobs:
                     # This is in-line with SemVer's expectations/designations!
                     *-*) gh release create $VERSION --prerelease --notes-file /dev/null --title $VERSION artifacts/* ;;
 
-                    # In all other cases, publish it as the latest version.
-                    *) gh release create $VERSION --notes-file /dev/null --title $VERSION artifacts/* ;;
+                    # LTS branch: don't publish it as latest, but don't publish it as a pre-release either.
+                    *) gh release create $VERSION --latest=false --notes-file /dev/null --title $VERSION artifacts/* ;;
 
                   esac
             - run:


### PR DESCRIPTION
<!-- [ROUTER-1661] -->

The 2.10.x line is an LTS/maintenance branch.  Releases from it should never displace the current GA release as "latest" on GitHub.

The `gh release create` command defaults `--latest` to `true` for non-prerelease tags, so without this flag a 2.10.x patch would silently become the latest release on GitHub.

This is the same fix applied to the 1.x branch in 2dc3a700 (part of #7558).  The comment is also updated to include "LTS branch" as a searchable token for future maintenance branches.

## Test plan

- Verify CI passes on this branch.
- After the next 2.10.x release, confirm on GitHub that the release is not marked "Latest", but honestly, it will be fine.

[ROUTER-1661]: https://apollographql.atlassian.net/browse/ROUTER-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ