### PR TITLE
[do not merge] test: create test that demonstrates that HTTP/2 uses one connection

### DIFF
--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -1120,3 +1120,173 @@ mod pool_idle_timeout {
         );
     }
 }
+
+mod http_connection_pool {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    #[derive(Copy, Clone)]
+    enum ServerMode {
+        Http1,
+        Http2 { max_concurrent_streams: u32 },
+    }
+
+    /// Test server that counts accepted TCP connections and responds with a minimal GraphQL
+    /// response. Supports both HTTP/1 and HTTP/2 via `ServerMode`; in HTTP/2 mode the
+    /// server advertises the given `max_concurrent_streams` limit.
+    async fn connection_counting_server(
+        server_mode: ServerMode,
+        listener: TcpListener,
+        connection_count: Arc<AtomicUsize>,
+    ) -> Result<(), std::io::Error> {
+        loop {
+            let (stream, _) = listener.accept().await?;
+            connection_count.fetch_add(1, Ordering::SeqCst);
+            let io = TokioIo::new(stream);
+
+            // spawn thread to handle this connection
+            tokio::spawn(async move {
+                let svc = hyper::service::service_fn(|_req| async {
+                    Ok::<_, Infallible>(
+                        http::Response::builder()
+                            .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                            .status(StatusCode::OK)
+                            .body::<Body>(r#"{"data":null}"#.into())
+                            .unwrap(),
+                    )
+                });
+
+                let mut builder =
+                    hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+
+                match server_mode {
+                    ServerMode::Http1 => {
+                        builder.http1();
+                    }
+                    ServerMode::Http2 {
+                        max_concurrent_streams,
+                    } => {
+                        builder
+                            .http2()
+                            .max_concurrent_streams(max_concurrent_streams);
+                    }
+                }
+
+                let _ = builder.serve_connection(io, svc).await;
+            });
+        }
+    }
+
+    /// Confirms that HTTP/1 opens a new TCP connection for each concurrent request.
+    /// This is the expected baseline behavior — HTTP/1 has no multiplexing, so
+    /// 50 concurrent requests produce 50 connections. Used as a control to contrast
+    /// with the HTTP/2 single-connection behavior demonstrated in
+    /// `test_http2_uses_multiple_connections`.
+    #[rstest::rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_http1_uses_multiple_connections(
+        #[values(Some(Http2Config::Disable), Some(Http2Config::Enable), None)]
+        experimental_http2_config: Option<Http2Config>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+        let connection_count = Arc::new(AtomicUsize::new(0));
+
+        tokio::task::spawn(connection_counting_server(
+            ServerMode::Http1,
+            listener,
+            connection_count.clone(),
+        ));
+
+        let service = HttpClientService::test_new(
+            "test",
+            rustls::ClientConfig::builder()
+                .with_native_roots()
+                .expect("read native TLS root certificates")
+                .with_no_client_auth(),
+            crate::configuration::shared::Client {
+                experimental_http2: experimental_http2_config,
+                ..Default::default()
+            },
+        )
+        .expect("can create HttpClientService");
+
+        let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
+
+        const NUM_REQUESTS: usize = 50;
+
+        // Send concurrent requests — all should not share one TCP connection
+        let futs: Vec<_> = (0..NUM_REQUESTS)
+            .map(|_| send_request(service.clone(), url.clone(), r#"{"query":"{ a }"}"#))
+            .collect();
+
+        let results = futures::future::join_all(futs).await;
+        assert!(
+            results
+                .into_iter()
+                .all(|r| r.http_response.status().is_success())
+        );
+
+        assert_eq!(
+            connection_count.load(Ordering::SeqCst),
+            NUM_REQUESTS,
+            "HTTP/1 should not multiplex so each request should open a connection"
+        );
+    }
+
+    /// Demonstrates ROUTER-779: hyper's HTTP/2 client only ever opens one TCP connection
+    /// per host, multiplexing all requests as streams over it. Even when the server
+    /// advertises a low `max_concurrent_streams` limit, hyper queues excess requests
+    /// on the single connection rather than opening additional connections.
+    ///
+    /// This test currently fails — the assertion that `connection_count > 1` is never
+    /// satisfied because hyper always uses exactly one HTTP/2 connection.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_http2_uses_multiple_connections() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+        let connection_count = Arc::new(AtomicUsize::new(0));
+
+        tokio::task::spawn(connection_counting_server(
+            ServerMode::Http2 {
+                max_concurrent_streams: 5,
+            },
+            listener,
+            connection_count.clone(),
+        ));
+
+        let service = HttpClientService::test_new(
+            "test",
+            rustls::ClientConfig::builder()
+                .with_native_roots()
+                .expect("read native TLS root certificates")
+                .with_no_client_auth(),
+            crate::configuration::shared::Client {
+                experimental_http2: Some(Http2Config::Http2Only),
+                ..Default::default()
+            },
+        )
+        .expect("can create HttpClientService");
+
+        let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
+
+        // Send 5000 concurrent requests — all should not share one TCP connection
+        let futs: Vec<_> = (0..50)
+            .map(|_| send_request(service.clone(), url.clone(), r#"{"query":"{ a }"}"#))
+            .collect();
+
+        let results = futures::future::join_all(futs).await;
+        assert!(
+            results
+                .into_iter()
+                .all(|r| r.http_response.status().is_success())
+        );
+
+        assert!(
+            connection_count.load(Ordering::SeqCst) > 1,
+            "HTTP/2 should not multiplex all requests over a single TCP connection"
+        );
+    }
+}


### PR DESCRIPTION
Implements a test for #2063.

HTTP/2 uses multiplexing over a single connection rather than creating multiple connections.

<!-- start metadata -->

<!-- [ROUTER-779] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-779]: https://apollographql.atlassian.net/browse/ROUTER-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ