### PR TITLE
`ReplicaFilter` to filter out replicas that aren't routeable (eg, centralized, HA)

### DIFF
--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -15,6 +15,7 @@ use crate::configuration::RedisCache;
 
 mod metrics;
 pub(crate) mod redis;
+mod replica_filter;
 mod size_estimation;
 pub(crate) mod storage;
 use std::convert::Infallible;

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -423,7 +423,6 @@ impl RedisCacheStorage {
                     interval: Duration::from_secs(2),
                 };
 
-                // TODO: notes on wtf this does/is
                 config.replica.filter = Some(Arc::new(RouteableReplicaFilter::default()));
 
                 // PR-8405: must not use lazy connections or else commands will queue rather than being sent

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -43,6 +43,7 @@ use url::Url;
 use super::KeyType;
 use super::ValueType;
 use super::metrics::RedisMetricsCollector;
+use crate::cache::replica_filter::RouteableReplicaFilter;
 use crate::configuration::RedisCache;
 use crate::services::generate_tls_client_config;
 
@@ -421,6 +422,9 @@ impl RedisCacheStorage {
                     max_timeout: Some(DEFAULT_INTERNAL_REDIS_TIMEOUT),
                     interval: Duration::from_secs(2),
                 };
+
+                // TODO: notes on wtf this does/is
+                config.replica.filter = Some(Arc::new(RouteableReplicaFilter::default()));
 
                 // PR-8405: must not use lazy connections or else commands will queue rather than being sent
                 // PR-8671: must only disable lazy connections in cluster mode. otherwise, fred will

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -1731,6 +1731,7 @@ mod test {
         async fn pool_shutdown_marks_inner_for_recreation(
             #[values(true, false)] clustered: bool,
         ) -> Result<(), BoxError> {
+            let _guard = lock_for_static().lock().await;
             let storage = RedisCacheStorage::new(redis_config(clustered), "test").await?;
             storage.create_client_pool().await?;
             assert!(storage.inner.read().is_some());

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -413,6 +413,24 @@ impl RedisCacheStorage {
                 config.internal_command_timeout = DEFAULT_INTERNAL_REDIS_TIMEOUT;
                 config.max_command_buffer_len = 10_000;
                 config.reconnect_on_auth_error = true;
+                // NOTE: this defaults to true in fred but we're intentionally paying attention to
+                // errors becomes sometimes fred gets into a funky state with its redis
+                // connections. Sometimes, eg, a brief network outage in whatever cloud provider folks are
+                // using can destabilize what fred views as routeable nodes--ignoring errors can
+                // get us into a state where fred can't connect to those nodes and we don't know
+                // that we're unable to connect to them; it's much better to let fred abort and
+                // then recreate the client with a fresh view of the infrastructure
+                config.replica.ignore_reconnection_errors = false;
+                config.replica.primary_fallback = true;
+                // NOTE: lazy_connections must be true (fred's default). With eager connections,
+                // a replica connection failure during add_connection propagates via ? through
+                // sync_replicas and can trigger the reconnection policy pool-wide. With lazy
+                // connections, failures are deferred to per-command time and isolated. The
+                // RouteableReplicaFilter prevents ghost replicas from entering the routing
+                // table at topology sync time regardless, but lazy connections provide
+                // additional blast-radius isolation for replicas that pass the TCP probe but
+                // fail Redis protocol setup (AUTH, HELLO, etc).
+                config.replica.lazy_connections = true;
                 config.tcp = TcpConfig {
                     #[cfg(target_os = "linux")]
                     user_timeout: Some(self.redis_client_config.timeout),
@@ -424,19 +442,14 @@ impl RedisCacheStorage {
                 };
 
                 config.replica.filter = Some(Arc::new(RouteableReplicaFilter::default()));
-
-                // PR-8405: must not use lazy connections or else commands will queue rather than being sent
-                // PR-8671: must only disable lazy connections in cluster mode. otherwise, fred will
-                //  try to connect to unreachable replicas and fall over.
-                //  https://github.com/aembke/fred.rs/blob/f222ad7bfba844dbdc57e93da61b0a5483858df9/src/router/replicas.rs#L34
-                if self.is_cluster {
-                    config.replica.lazy_connections = false;
-                }
             })
             .with_performance_config(|config| {
                 config.default_command_timeout = self.redis_client_config.timeout;
             })
-            .set_policy(ReconnectPolicy::new_exponential(0, 1, 2000, 5))
+            // NOTE: we give fred 15 attempts to reconnect; once reconnected, fred resets its
+            // counter and we have another 15 attempts. If reconnection fails, fred aborts and _we_
+            // recreate the redis client. Currently, we attempt recreation indefinitely
+            .set_policy(ReconnectPolicy::new_exponential(15, 1, 2000, 5))
             .build_pool(self.redis_client_config.pool_size)?;
 
         for client in client_pool.clients() {

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -1727,7 +1727,6 @@ mod test {
         async fn pool_shutdown_marks_inner_for_recreation(
             #[values(true, false)] clustered: bool,
         ) -> Result<(), BoxError> {
-            let _guard = lock_for_static().lock().await;
             let storage = RedisCacheStorage::new(redis_config(clustered), "test").await?;
             storage.create_client_pool().await?;
             assert!(storage.inner.read().is_some());

--- a/apollo-router/src/cache/replica_filter.rs
+++ b/apollo-router/src/cache/replica_filter.rs
@@ -1,0 +1,260 @@
+use fred::types::config::{ReplicaFilter, Server};
+use parking_lot::RwLock;
+use tokio::time::Instant;
+use tracing::{debug, warn};
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+/// Filters calls to replicas based on a filter() fn that returns true if there's a routeable
+/// replica in the replicas cache. Replicas are routeable when we're able to make a TCP Connection
+/// to them. We cache whether we were able to connect for 5 minutes. This applies to each replica,
+/// not all replicas as a unit, so we can have some replicas fail and yet still route to the others
+///
+/// NOTE: filtering happens before any actual connections are made by our redis client (fred), so
+/// we shouldn't see any connections errors from replicas that have been filtered out
+#[derive(Default, Debug)]
+pub(crate) struct RouteableReplicaFilter {
+    replicas: Arc<RwLock<HashMap<String, Replica>>>,
+}
+
+#[derive(Debug)]
+struct Replica {
+    expires: Instant,
+    routeable: bool,
+}
+
+#[async_trait::async_trait]
+impl ReplicaFilter for RouteableReplicaFilter {
+    // WARN: this is a hot path for fred, keep the instrumentation to trace-level
+    #[tracing::instrument(level = "trace")]
+    async fn filter(&self, _primary: &Server, replica: &Server) -> bool {
+        let addr = format!("{}:{}", replica.host, replica.port);
+        // guard block so we drop the read guard before crossing the await boundary below (RwLock
+        // not Send)
+        let cached = {
+            let replicas = self.replicas.read();
+            replicas.get(&addr).map(|rep| (rep.expires, rep.routeable))
+        };
+
+        // if we have a replica
+        if let Some((expires, routeable)) = cached {
+            // that hasn't expired yet
+            if expires > Instant::now() {
+                // return its saved routeability
+                return routeable;
+            }
+            debug!("redis replica filter cache: entry for {addr} expired");
+        }
+
+        // otherwise, we try to test routeability via tcp connect
+        let routeable = tokio::time::timeout(
+            // with a short timeout, 250ms
+            Duration::from_millis(250),
+            tokio::net::TcpStream::connect(&addr),
+        )
+        .await
+        .map(|res| res.is_ok())
+        .inspect_err(|_e| debug!("{addr} is being broadcast as part of redis but is not currently routeable, which may be intentional if using centralized or high-availabitliy setups with internal IPs for certain nodes or might represent a misconfiguration or infrastructure failure"))
+        .unwrap_or(false);
+
+        let mut replicas = self.replicas.write();
+        replicas.insert(
+            addr,
+            Replica {
+                // 5 minute cache
+                expires: Instant::now() + Duration::from_secs(300),
+                routeable,
+            },
+        );
+
+        routeable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    fn dummy_primary() -> Server {
+        Server::new("127.0.0.1", 6379)
+    }
+
+    fn server(port: u16) -> Server {
+        Server::new("127.0.0.1", port)
+    }
+
+    fn seed_cache(filter: &RouteableReplicaFilter, port: u16, routeable: bool, expires: Instant) {
+        let addr = format!("127.0.0.1:{port}");
+        filter
+            .replicas
+            .write()
+            .insert(addr, Replica { expires, routeable });
+    }
+
+    #[tokio::test]
+    async fn reachable_replica_returns_true() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let filter = RouteableReplicaFilter::default();
+        assert!(filter.filter(&dummy_primary(), &server(port)).await);
+    }
+
+    #[tokio::test]
+    async fn unreachable_replica_returns_false() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let filter = RouteableReplicaFilter::default();
+        assert!(!filter.filter(&dummy_primary(), &server(port)).await);
+    }
+
+    #[tokio::test]
+    async fn cached_result_is_returned_without_reconnect() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let filter = RouteableReplicaFilter::default();
+        assert!(filter.filter(&dummy_primary(), &server(port)).await);
+
+        // drop the listener — port is now unreachable
+        drop(listener);
+
+        // should still return true from cache
+        assert!(filter.filter(&dummy_primary(), &server(port)).await);
+    }
+
+    #[tokio::test]
+    async fn result_is_cached_after_filter() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let filter = RouteableReplicaFilter::default();
+        filter.filter(&dummy_primary(), &server(port)).await;
+
+        let replicas = filter.replicas.read();
+        let addr = format!("127.0.0.1:{port}");
+        let entry = replicas.get(&addr).expect("entry should be cached");
+        assert!(entry.routeable);
+        assert!(entry.expires > Instant::now());
+    }
+
+    #[tokio::test]
+    async fn expired_cache_triggers_fresh_connect() {
+        // seed with an already-expired entry that says routeable=true
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let filter = RouteableReplicaFilter::default();
+        let expired = Instant::now() - Duration::from_secs(1);
+        seed_cache(&filter, port, true, expired);
+
+        // cache says true, but it's expired — fresh connect will fail
+        assert!(!filter.filter(&dummy_primary(), &server(port)).await);
+    }
+
+    #[tokio::test]
+    async fn unexpired_cache_is_used() {
+        // seed with a not-yet-expired entry, no listener needed
+        let filter = RouteableReplicaFilter::default();
+        let port = 1; // doesn't matter, cache will be hit
+        let future = Instant::now() + Duration::from_secs(300);
+        seed_cache(&filter, port, true, future);
+
+        assert!(filter.filter(&dummy_primary(), &server(port)).await);
+    }
+
+    #[tokio::test]
+    async fn unexpired_false_cache_is_used() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // seed with routeable=false even though the port is actually reachable
+        let filter = RouteableReplicaFilter::default();
+        let future = Instant::now() + Duration::from_secs(300);
+        seed_cache(&filter, port, false, future);
+
+        // cache wins — returns false despite the port being open
+        assert!(!filter.filter(&dummy_primary(), &server(port)).await);
+    }
+
+    #[tokio::test]
+    async fn separate_replicas_cached_independently() {
+        let listener_a = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port_a = listener_a.local_addr().unwrap().port();
+
+        let listener_b = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port_b = listener_b.local_addr().unwrap().port();
+        drop(listener_b);
+
+        let filter = RouteableReplicaFilter::default();
+        assert!(filter.filter(&dummy_primary(), &server(port_a)).await);
+        assert!(!filter.filter(&dummy_primary(), &server(port_b)).await);
+
+        let replicas = filter.replicas.read();
+        assert_eq!(replicas.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn expired_entry_gets_replaced() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let filter = RouteableReplicaFilter::default();
+        let expired = Instant::now() - Duration::from_secs(1);
+        seed_cache(&filter, port, false, expired);
+
+        // expired false entry should be replaced by a fresh true result
+        assert!(filter.filter(&dummy_primary(), &server(port)).await);
+
+        let replicas = filter.replicas.read();
+        let addr = format!("127.0.0.1:{port}");
+        let entry = replicas.get(&addr).unwrap();
+        assert!(entry.routeable);
+        assert!(entry.expires > Instant::now());
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_returns_false() {
+        let filter = RouteableReplicaFilter::default();
+        let primary = dummy_primary();
+        // this is a special non-routeable address (designated for use in documentaton/examples),
+        // rfc 5737, but if this flakes a bunch in ci/cd, we can mark it ignore and just keep it
+        // locally
+        let replica = Server::new("192.0.2.1", 1);
+
+        let start = Instant::now();
+        let result = filter.filter(&primary, &replica).await;
+        let elapsed = start.elapsed();
+
+        assert!(!result);
+        // Should have waited for the 250ms timeout, not returned instantly
+        assert!(
+            elapsed >= Duration::from_millis(200),
+            "expected timeout (~250ms), but returned in {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_result_is_cached() {
+        let filter = RouteableReplicaFilter::default();
+        let primary = dummy_primary();
+        let replica = Server::new("192.0.2.1", 1);
+
+        filter.filter(&primary, &replica).await;
+
+        // Second call should return from cache instantly, not wait for timeout
+        let start = Instant::now();
+        let result = filter.filter(&primary, &replica).await;
+        let elapsed = start.elapsed();
+
+        assert!(!result);
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "expected instant cache hit, but took {elapsed:?}"
+        );
+    }
+}

--- a/apollo-router/src/cache/replica_filter.rs
+++ b/apollo-router/src/cache/replica_filter.rs
@@ -1,9 +1,13 @@
-use fred::types::config::{ReplicaFilter, Server};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use fred::types::config::ReplicaFilter;
+use fred::types::config::Server;
 use parking_lot::RwLock;
 use tokio::time::Instant;
-use tracing::{debug, warn};
-
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use tracing::debug;
+use tracing::warn;
 
 /// Filters calls to replicas based on a filter() fn that returns true if there's a routeable
 /// replica in the replicas cache. Replicas are routeable when we're able to make a TCP Connection
@@ -73,8 +77,9 @@ impl ReplicaFilter for RouteableReplicaFilter {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use tokio::net::TcpListener;
+
+    use super::*;
 
     fn dummy_primary() -> Server {
         Server::new("127.0.0.1", 6379)

--- a/apollo-router/src/cache/replica_filter.rs
+++ b/apollo-router/src/cache/replica_filter.rs
@@ -7,7 +7,6 @@ use fred::types::config::Server;
 use parking_lot::RwLock;
 use tokio::time::Instant;
 use tracing::debug;
-use tracing::warn;
 
 /// Filters calls to replicas based on a filter() fn that returns true if there's a routeable
 /// replica in the replicas cache. Replicas are routeable when we're able to make a TCP Connection


### PR DESCRIPTION
- adds ReplicaFilter to filter out replicas we can't route to (this skips attemping to make connections in fred, though we still attempt a tcp connection from our side)
- tests for ^

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
