### PR TITLE
reconfiguring fred to not ignore conn errs, sets a max attempts

### DIFF
--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -413,6 +413,14 @@ impl RedisCacheStorage {
                 config.internal_command_timeout = DEFAULT_INTERNAL_REDIS_TIMEOUT;
                 config.max_command_buffer_len = 10_000;
                 config.reconnect_on_auth_error = true;
+                // NOTE: this defaults to true in fred but we're intentionally paying attention to
+                // errors becomes sometimes fred gets into a funky state with its redis
+                // connections. Sometimes, eg, a brief network outage in whatever cloud provider folks are
+                // using can destabilize what fred views as routeable nodes--ignoring errors can
+                // get us into a state where fred can't connect to those nodes and we don't know
+                // that we're unable to connect to them; it's much better to let fred abort and
+                // then recreate the client with a fresh view of the infrastructure
+                config.replica.ignore_reconnection_errors = false;
                 config.tcp = TcpConfig {
                     #[cfg(target_os = "linux")]
                     user_timeout: Some(self.redis_client_config.timeout),
@@ -425,6 +433,7 @@ impl RedisCacheStorage {
 
                 config.replica.filter = Some(Arc::new(RouteableReplicaFilter::default()));
 
+                // TODO: update comment
                 // PR-8405: must not use lazy connections or else commands will queue rather than being sent
                 // PR-8671: must only disable lazy connections in cluster mode. otherwise, fred will
                 //  try to connect to unreachable replicas and fall over.
@@ -436,7 +445,10 @@ impl RedisCacheStorage {
             .with_performance_config(|config| {
                 config.default_command_timeout = self.redis_client_config.timeout;
             })
-            .set_policy(ReconnectPolicy::new_exponential(0, 1, 2000, 5))
+            // NOTE: we give fred 15 attempts to reconnect; once reconnected, fred resets its
+            // counter and we have another 15 attempts. If reconnection fails, fred aborts and _we_
+            // recreate the redis client. Currently, we attempt recreation indefinitely
+            .set_policy(ReconnectPolicy::new_exponential(15, 1, 2000, 5))
             .build_pool(self.redis_client_config.pool_size)?;
 
         for client in client_pool.clients() {

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -432,15 +432,6 @@ impl RedisCacheStorage {
                 };
 
                 config.replica.filter = Some(Arc::new(RouteableReplicaFilter::default()));
-
-                // TODO: update comment
-                // PR-8405: must not use lazy connections or else commands will queue rather than being sent
-                // PR-8671: must only disable lazy connections in cluster mode. otherwise, fred will
-                //  try to connect to unreachable replicas and fall over.
-                //  https://github.com/aembke/fred.rs/blob/f222ad7bfba844dbdc57e93da61b0a5483858df9/src/router/replicas.rs#L34
-                if self.is_cluster {
-                    config.replica.lazy_connections = false;
-                }
             })
             .with_performance_config(|config| {
                 config.default_command_timeout = self.redis_client_config.timeout;

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -421,6 +421,16 @@ impl RedisCacheStorage {
                 // that we're unable to connect to them; it's much better to let fred abort and
                 // then recreate the client with a fresh view of the infrastructure
                 config.replica.ignore_reconnection_errors = false;
+                config.replica.primary_fallback = true;
+                // NOTE: lazy_connections must be true (fred's default). With eager connections,
+                // a replica connection failure during add_connection propagates via ? through
+                // sync_replicas and can trigger the reconnection policy pool-wide. With lazy
+                // connections, failures are deferred to per-command time and isolated. The
+                // RouteableReplicaFilter prevents ghost replicas from entering the routing
+                // table at topology sync time regardless, but lazy connections provide
+                // additional blast-radius isolation for replicas that pass the TCP probe but
+                // fail Redis protocol setup (AUTH, HELLO, etc).
+                config.replica.lazy_connections = true;
                 config.tcp = TcpConfig {
                     #[cfg(target_os = "linux")]
                     user_timeout: Some(self.redis_client_config.timeout),


### PR DESCRIPTION
- reconn policy to max attempts 15
- no longer ignoring reconn errs

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
