### PR TITLE
config: update cargo-deny version (backport #8778)

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -2,9 +2,15 @@
 rust = "1.85.0"
 "aqua:cargo-bins/cargo-binstall" = "1.12.3"
 "cargo:cargo-nextest" = "0.9.70"
+<<<<<<< HEAD
 "cargo:cargo-deny" = "0.14.21"
 "cargo:cargo-edit" = "0.12.2"
 "cargo:cargo-about" = "0.6.6"
+=======
+"cargo:cargo-deny" = "0.18.9"
+"cargo:cargo-edit" = "0.13.0"
+"cargo:cargo-about" = "0.8.0"
+>>>>>>> 4a26abb2 (config: update cargo-deny version (#8778))
 "cargo:cargo-insta" = "1.38.0"
 "cargo:htmlq" = "0.4.0"
 "cargo:cargo-watch" = "8.5.3"


### PR DESCRIPTION
Compliance checks are failing due to the merge of https://github.com/rustsec/advisory-db/pull/2523

Formalizes fix from https://github.com/rustsec/advisory-db/pull/2525 - need an updated cargo deny to pull a later version of rustsec (https://github.com/EmbarkStudios/cargo-deny/pull/805)




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
<hr>This is an automatic backport of pull request #8778 done by [Mergify](https://mergify.com).