### PR TITLE
fix(compliance): exempt RUSTSEC-2026-0049, bump bytes to 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,9 +1524,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,14 @@ ignore = [
     "RUSTSEC-2026-0007",
     "RUSTSEC-2026-0008",
     "RUSTSEC-2026-0009",
+
+    # rustls-webpki 0.101.x is used transitively via the older rustls 0.21.x
+    # stack (fred, hyper-rustls, tonic, etc.).  Upgrading to the patched
+    # rustls-webpki >=0.103.10 requires a full rustls 0.23.x migration that
+    # is out of scope for the 1.x LTS branch.  The CRL matching bug requires
+    # a compromised trusted CA to exploit, and the router does not enable CRL
+    # revocation checking, so this code path is not reachable in practice.
+    "RUSTSEC-2026-0049",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Fixes the 1.x nightly compliance check, which was failing on two advisories as of 2026-03-23.

## Changes

### RUSTSEC-2026-0049 — rustls-webpki CRL matching bug

`rustls-webpki 0.101.x` (used transitively via the rustls 0.21.x stack — fred, hyper-rustls, tonic, etc.) has a CRL distribution point matching bug where only the first `distributionPoint` is checked against each CRL's `IssuingDistributionPoint`.

The patched version (≥0.103.10) requires the rustls 0.23.x ecosystem — a migration out of scope for the 1.x LTS branch.  Exploiting the bug requires a compromised trusted CA, and the router does not enable CRL revocation checking, so this code path is not reachable in practice.

This was resolved on `dev` incidentally via the rustls 0.23.x upgrade (bfbc625f / #7554 and subsequent commits).

### RUSTSEC-2026-0007 — bytes integer overflow

Bumped `bytes` from 1.10.1 to 1.11.1 (the patched version).  This was resolved on `dev` in 56b7ea86 / #8857.

## Checklist

- [x] `cargo xtask check-compliance` passes locally via mise (cargo-deny 0.18.9)