### PR TITLE
fix(compliance): temporarily exempt several non-impactful advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,10 @@ ignore = [
     # Temporary exemption: the CRL matching bug requires a compromised trusted CA to exploit, and the
     # router does not enable CRL revocation checking, so this code path is not reachable in practice.
     "RUSTSEC-2026-0049", # TODO: update rustls-webpki (ROUTER-1675)
+
+    # Temporary exemption: the router doesn't unpack or parse existing tarballs.
+    "RUSTSEC-2026-0067", # TODO: update tar (ROUTER-1676)
+    "RUSTSEC-2026-0068", # TODO: update tar (ROUTER-1676)
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
`cargo xtask check-compliance` now passes locally via mise (cargo-deny 0.19.0).