### PR TITLE
fix(compliance): temporarily exempt several non-impactful advisories (backport #9045)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -40,6 +40,7 @@ ignore = [
     "RUSTSEC-2026-0049", # TODO: update rustls-webpki (ROUTER-1675)
 
     # Temporary exemption: the router doesn't unpack or parse existing tarballs.
+    "RUSTSEC-2026-0066", # TODO: update tar (ROUTER-1676)
     "RUSTSEC-2026-0067", # TODO: update tar (ROUTER-1676)
     "RUSTSEC-2026-0068", # TODO: update tar (ROUTER-1676)
 ]


### PR DESCRIPTION
`cargo xtask check-compliance` now passes locally via mise (cargo-deny 0.19.0).<hr>This is an automatic backport of pull request #9045 done by [Mergify](https://mergify.com).