### PR TITLE
chore(compliance): add missed advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,7 @@ ignore = [
     "RUSTSEC-2026-0049", # TODO: update rustls-webpki (ROUTER-1675)
 
     # Temporary exemption: the router doesn't unpack or parse existing tarballs.
+    "RUSTSEC-2026-0066", # TODO: update tar (ROUTER-1676)
     "RUSTSEC-2026-0067", # TODO: update tar (ROUTER-1676)
     "RUSTSEC-2026-0068", # TODO: update tar (ROUTER-1676)
 ]


### PR DESCRIPTION
Same as #9045 and #9046 - missed a non-impactful advisory on dev. 
