### PR TITLE
Add support for emitting Apollo OTLP metrics and traces via HTTP

### DIFF
--- a/.changesets/exp_http_otel_producer.md
+++ b/.changesets/exp_http_otel_producer.md
@@ -1,0 +1,9 @@
+### Add support for sending Apollo OTel metrics and traces via HTTP ([PR #9055](https://github.com/apollographql/router/pull/9055))
+
+Adds experimental support for sending Apollo OTLP metrics and traces via HTTP. This can be enabled using the config values:
+- telemetry.apollo.experimental_otlp_tracing_protocol
+- telemetry.apollo.experimental_otlp_metrics_protocol
+
+GRPC is still the preferred method of sending OTLP metrics to Apollo, but we are adding this to support customers who cannot use GRPC.
+
+By [@bonnici](https://github.com/bonnici) in https://github.com/apollographql/router/pull/9055

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,6 +4520,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
+ "flate2",
  "http 1.4.0",
  "opentelemetry",
  "opentelemetry-http",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -183,6 +183,7 @@ opentelemetry-jaeger-propagator = "0.31"
 opentelemetry-otlp = { version = "0.31", default-features = false, features = [
     "grpc-tonic",
     "gzip-tonic",
+    "gzip-http",
     "tonic",
     "tls",
     "http-proto",

--- a/apollo-router/src/plugins/telemetry/apollo_otlp_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_otlp_exporter.rs
@@ -66,17 +66,19 @@ impl ApolloOtlpExporter {
     ) -> Result<ApolloOtlpExporter, BoxError> {
         tracing::debug!(endpoint = %endpoint, "creating Apollo OTLP traces exporter");
 
-        let mut metadata = MetadataMap::new();
-        metadata.insert("apollo.api.key", MetadataValue::try_from(apollo_key)?);
         let mut otlp_exporter = match protocol {
-            Protocol::Grpc => SpanExporterBuilder::new()
-                .with_tonic()
-                .with_tls_config(ClientTlsConfig::new().with_native_roots())
-                .with_timeout(batch_config.max_export_timeout)
-                .with_endpoint(endpoint.to_string())
-                .with_metadata(metadata)
-                .with_compression(opentelemetry_otlp::Compression::Gzip)
-                .build()?,
+            Protocol::Grpc => {
+                let mut metadata = MetadataMap::new();
+                metadata.insert("apollo.api.key", MetadataValue::try_from(apollo_key)?);
+                SpanExporterBuilder::new()
+                    .with_tonic()
+                    .with_tls_config(ClientTlsConfig::new().with_native_roots())
+                    .with_timeout(batch_config.max_export_timeout)
+                    .with_endpoint(endpoint.to_string())
+                    .with_metadata(metadata)
+                    .with_compression(opentelemetry_otlp::Compression::Gzip)
+                    .build()?
+            }
             Protocol::Http => {
                 let endpoint_str = process_endpoint(
                     &Some(endpoint.to_string()),

--- a/apollo-router/src/plugins/telemetry/apollo_otlp_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_otlp_exporter.rs
@@ -8,6 +8,7 @@ use opentelemetry::trace::TraceFlags;
 use opentelemetry::trace::TraceState;
 use opentelemetry_otlp::SpanExporterBuilder;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_otlp::WithHttpConfig;
 use opentelemetry_otlp::WithTonicConfig;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::OTelSdkResult;
@@ -25,6 +26,8 @@ use url::Url;
 use super::apollo::ErrorsConfiguration;
 use super::config_new::subgraph::attributes::SUBGRAPH_NAME;
 use super::otlp::Protocol;
+use super::otlp::TelemetryDataKind;
+use super::otlp::process_endpoint;
 use super::tracing::apollo_telemetry::APOLLO_PRIVATE_FTV1;
 use super::tracing::apollo_telemetry::LightSpanData;
 use super::tracing::apollo_telemetry::encode_ftv1_trace;
@@ -74,12 +77,23 @@ impl ApolloOtlpExporter {
                 .with_metadata(metadata)
                 .with_compression(opentelemetry_otlp::Compression::Gzip)
                 .build()?,
-            // So far only using HTTP path for testing - the Studio backend only accepts GRPC today.
-            Protocol::Http => SpanExporterBuilder::new()
-                .with_http()
-                .with_timeout(batch_config.max_export_timeout)
-                .with_endpoint(endpoint.to_string())
-                .build()?,
+            Protocol::Http => {
+                let endpoint_str = process_endpoint(
+                    &Some(endpoint.to_string()),
+                    &TelemetryDataKind::Traces,
+                    &Protocol::Http,
+                )?
+                .ok_or("A valid HTTP OTLP endpoint is required when using the HTTP protocol")?;
+                let mut headers = std::collections::HashMap::new();
+                headers.insert("x-api-key".to_string(), apollo_key.to_string());
+                SpanExporterBuilder::new()
+                    .with_http()
+                    .with_timeout(batch_config.max_export_timeout)
+                    .with_compression(opentelemetry_otlp::Compression::Gzip)
+                    .with_headers(headers)
+                    .with_endpoint(endpoint_str)
+                    .build()?
+            }
         };
 
         otlp_exporter.set_resource(

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -1,4 +1,5 @@
 //! Apollo metrics
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -130,18 +131,34 @@ impl Config {
         batch_config: &OtlpMetricsBatchProcessorConfiguration,
     ) -> Result<(), BoxError> {
         tracing::info!("configuring Apollo OTLP metrics: {}", batch_config);
-        let mut metadata = MetadataMap::new();
-        metadata.insert("apollo.api.key", key.parse()?);
-        let exporter = match otlp_protocol {
-            Protocol::Grpc => MetricExporter::builder()
-                .with_tonic()
-                .with_tls_config(ClientTlsConfig::new().with_native_roots())
-                .with_endpoint(endpoint.as_str())
-                .with_timeout(batch_config.max_export_timeout)
-                .with_metadata(metadata.clone())
-                .with_compression(opentelemetry_otlp::Compression::Gzip)
-                .with_temporality(Temporality::Delta)
-                .build()?,
+
+        let (exporter, realtime_exporter) = match otlp_protocol {
+            Protocol::Grpc => {
+                let mut metadata = MetadataMap::new();
+                metadata.insert("apollo.api.key", key.parse()?);
+
+                let exporter = MetricExporter::builder()
+                    .with_tonic()
+                    .with_tls_config(ClientTlsConfig::new().with_native_roots())
+                    .with_endpoint(endpoint.as_str())
+                    .with_timeout(batch_config.max_export_timeout)
+                    .with_metadata(metadata.clone())
+                    .with_compression(opentelemetry_otlp::Compression::Gzip)
+                    .with_temporality(Temporality::Delta)
+                    .build()?;
+
+                // MetricExporter builder does not implement Clone, so we need to create a new builder for the realtime exporter
+                let realtime_exporter = MetricExporter::builder()
+                    .with_tonic()
+                    .with_tls_config(ClientTlsConfig::new().with_native_roots())
+                    .with_endpoint(endpoint.as_str())
+                    .with_timeout(batch_config.max_export_timeout)
+                    .with_metadata(metadata.clone())
+                    .with_compression(opentelemetry_otlp::Compression::Gzip)
+                    .with_temporality(Temporality::Delta)
+                    .build()?;
+                (exporter, realtime_exporter)
+            }
             Protocol::Http => {
                 let endpoint_str = process_endpoint(
                     &Some(endpoint.to_string()),
@@ -149,48 +166,30 @@ impl Config {
                     &Protocol::Http,
                 )?
                 .ok_or("A valid HTTP OTLP endpoint is required when using the HTTP protocol")?;
-                let mut headers = std::collections::HashMap::new();
-                headers.insert("x-api-key".to_string(), key.to_string());
-                MetricExporter::builder()
+                let headers = HashMap::from([("x-api-key".to_string(), key.to_string())]);
+
+                let exporter = MetricExporter::builder()
+                    .with_http()
+                    .with_timeout(batch_config.max_export_timeout)
+                    .with_temporality(Temporality::Delta)
+                    .with_compression(opentelemetry_otlp::Compression::Gzip)
+                    .with_headers(headers.clone())
+                    .with_endpoint(endpoint_str.clone())
+                    .build()?;
+
+                // MetricExporter builder does not implement Clone, so we need to create a new builder for the realtime exporter
+                let realtime_exporter = MetricExporter::builder()
                     .with_http()
                     .with_timeout(batch_config.max_export_timeout)
                     .with_temporality(Temporality::Delta)
                     .with_compression(opentelemetry_otlp::Compression::Gzip)
                     .with_headers(headers)
                     .with_endpoint(endpoint_str)
-                    .build()?
+                    .build()?;
+                (exporter, realtime_exporter)
             }
         };
-        // MetricExporter builder does not implement Clone, so we need to create a new builder for the realtime exporter
-        let realtime_exporter = match otlp_protocol {
-            Protocol::Grpc => MetricExporter::builder()
-                .with_tonic()
-                .with_tls_config(ClientTlsConfig::new().with_native_roots())
-                .with_endpoint(endpoint.as_str())
-                .with_timeout(batch_config.max_export_timeout)
-                .with_metadata(metadata.clone())
-                .with_compression(opentelemetry_otlp::Compression::Gzip)
-                .with_temporality(Temporality::Delta)
-                .build()?,
-            Protocol::Http => {
-                let endpoint_str = process_endpoint(
-                    &Some(endpoint.to_string()),
-                    &TelemetryDataKind::Metrics,
-                    &Protocol::Http,
-                )?
-                .ok_or("A valid HTTP OTLP endpoint is required when using the HTTP protocol")?;
-                let mut headers = std::collections::HashMap::new();
-                headers.insert("x-api-key".to_string(), key.to_string());
-                MetricExporter::builder()
-                    .with_http()
-                    .with_timeout(batch_config.max_export_timeout)
-                    .with_temporality(Temporality::Delta)
-                    .with_compression(opentelemetry_otlp::Compression::Gzip)
-                    .with_headers(headers)
-                    .with_endpoint(endpoint_str)
-                    .build()?
-            }
-        };
+
         // Wrap with retry, then overflow detection, then error prefixing
         let named_exporter = NamedMetricExporter::new(
             OverflowMetricExporter::new_push(RetryMetricExporter::new(exporter)),

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/mod.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::MetricExporter;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_otlp::WithHttpConfig;
 use opentelemetry_otlp::WithTonicConfig;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::Aggregation;
@@ -140,22 +141,23 @@ impl Config {
                 .with_compression(opentelemetry_otlp::Compression::Gzip)
                 .with_temporality(Temporality::Delta)
                 .build()?,
-            // While Apollo doesn't use the HTTP protocol, we support it here for
-            // use in tests to enable WireMock.
             Protocol::Http => {
-                let maybe_endpoint = process_endpoint(
+                let endpoint_str = process_endpoint(
                     &Some(endpoint.to_string()),
                     &TelemetryDataKind::Metrics,
                     &Protocol::Http,
-                )?;
-                let mut builder = MetricExporter::builder()
+                )?
+                .ok_or("A valid HTTP OTLP endpoint is required when using the HTTP protocol")?;
+                let mut headers = std::collections::HashMap::new();
+                headers.insert("x-api-key".to_string(), key.to_string());
+                MetricExporter::builder()
                     .with_http()
                     .with_timeout(batch_config.max_export_timeout)
-                    .with_temporality(Temporality::Delta);
-                if let Some(endpoint) = maybe_endpoint {
-                    builder = builder.with_endpoint(endpoint);
-                }
-                builder.build()?
+                    .with_temporality(Temporality::Delta)
+                    .with_compression(opentelemetry_otlp::Compression::Gzip)
+                    .with_headers(headers)
+                    .with_endpoint(endpoint_str)
+                    .build()?
             }
         };
         // MetricExporter builder does not implement Clone, so we need to create a new builder for the realtime exporter
@@ -170,19 +172,22 @@ impl Config {
                 .with_temporality(Temporality::Delta)
                 .build()?,
             Protocol::Http => {
-                let maybe_endpoint = process_endpoint(
+                let endpoint_str = process_endpoint(
                     &Some(endpoint.to_string()),
                     &TelemetryDataKind::Metrics,
                     &Protocol::Http,
-                )?;
-                let mut builder = MetricExporter::builder()
+                )?
+                .ok_or("A valid HTTP OTLP endpoint is required when using the HTTP protocol")?;
+                let mut headers = std::collections::HashMap::new();
+                headers.insert("x-api-key".to_string(), key.to_string());
+                MetricExporter::builder()
                     .with_http()
                     .with_timeout(batch_config.max_export_timeout)
-                    .with_temporality(Temporality::Delta);
-                if let Some(endpoint) = maybe_endpoint {
-                    builder = builder.with_endpoint(endpoint);
-                }
-                builder.build()?
+                    .with_temporality(Temporality::Delta)
+                    .with_compression(opentelemetry_otlp::Compression::Gzip)
+                    .with_headers(headers)
+                    .with_endpoint(endpoint_str)
+                    .build()?
             }
         };
         // Wrap with overflow detection, then error prefixing

--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -34,7 +34,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tower::Service;
 use tower::ServiceExt;
-use tower_http::decompression::DecompressionLayer;
+use tower_http::decompression::RequestDecompressionLayer;
 
 mod tracing_common;
 
@@ -53,9 +53,16 @@ async fn config(
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
+    // The OTLP HTTP exporter sends gzip-compressed protobuf to /v1/traces, so we need
+    // RequestDecompressionLayer on that route. The Apollo protobuf reporter sends to / with gzip
+    // too, but we intentionally don't decompress there so those bytes fail to decode as OTLP proto
+    // and are ignored.
+    let otlp_routes = axum::Router::new()
+        .route("/v1/traces", post(traces_handler))
+        .layer(RequestDecompressionLayer::new());
     let app = axum::Router::new()
         .route("/", post(traces_handler))
-        .layer(DecompressionLayer::new())
+        .merge(otlp_routes)
         .layer(tower_http::add_extension::AddExtensionLayer::new(reports));
 
     let task = ROUTER_SERVICE_RUNTIME.spawn(async move {

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -39,6 +39,7 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use parking_lot::Mutex;
+use flate2::read::GzDecoder;
 use prost::Message;
 use regex::Regex;
 use reqwest::Request;
@@ -694,9 +695,27 @@ impl IntegrationTest {
         Mock::given(method(Method::POST))
             .and(path("/v1/metrics"))
             .and(move |req: &wiremock::Request| {
-                // Decode the OTLP request and forward to the channel
-                if let Ok(msg) = ExportMetricsServiceRequest::decode(req.body.as_ref()) {
-                    let _ = apollo_otlp_metrics_tx.try_send(msg);
+                // Decompress gzip body if Content-Encoding indicates it, then decode as protobuf
+                let body: &[u8] = req.body.as_ref();
+                let is_gzip = req
+                    .headers
+                    .get("content-encoding")
+                    .and_then(|v| v.to_str().ok())
+                    .map(|v| v.contains("gzip"))
+                    .unwrap_or(false);
+                let decoded = if is_gzip {
+                    let mut decoder = GzDecoder::new(body);
+                    let mut buf = Vec::new();
+                    std::io::Read::read_to_end(&mut decoder, &mut buf)
+                        .ok()
+                        .map(|_| buf)
+                } else {
+                    Some(body.to_vec())
+                };
+                if let Some(bytes) = decoded {
+                    if let Ok(msg) = ExportMetricsServiceRequest::decode(bytes.as_slice()) {
+                        let _ = apollo_otlp_metrics_tx.try_send(msg);
+                    }
                 }
                 // Always match so we return 200 OK
                 true

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -12,6 +12,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use buildstructor::buildstructor;
+use flate2::read::GzDecoder;
 use fred::clients::Client as RedisClient;
 use fred::interfaces::ClientLike;
 use fred::interfaces::KeysInterface;
@@ -39,7 +40,6 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use parking_lot::Mutex;
-use flate2::read::GzDecoder;
 use prost::Message;
 use regex::Regex;
 use reqwest::Request;

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -712,10 +712,10 @@ impl IntegrationTest {
                 } else {
                     Some(body.to_vec())
                 };
-                if let Some(bytes) = decoded {
-                    if let Ok(msg) = ExportMetricsServiceRequest::decode(bytes.as_slice()) {
-                        let _ = apollo_otlp_metrics_tx.try_send(msg);
-                    }
+                if let Some(bytes) = decoded
+                    && let Ok(msg) = ExportMetricsServiceRequest::decode(bytes.as_slice())
+                {
+                    let _ = apollo_otlp_metrics_tx.try_send(msg);
                 }
                 // Always match so we return 200 OK
                 true


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-####] -->

Adds experimental support for sending Apollo OTLP metrics and traces via HTTP. This can be enabled using the config values:
- `telemetry.apollo.experimental_otlp_tracing_protocol`
- `telemetry.apollo.experimental_otlp_metrics_protocol`

GRPC is still the preferred method of sending OTLP metrics to Apollo, but we are adding this to support customers who cannot use GRPC.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
