### PR TITLE
feat: support HTTP/2 keep-alive

### DIFF
--- a/apollo-router/src/configuration/shared/mod.rs
+++ b/apollo-router/src/configuration/shared/mod.rs
@@ -119,4 +119,42 @@ mod tests {
         let result: Result<Client, _> = serde_yaml::from_str("bogus_field: true");
         assert!(result.is_err());
     }
+
+    #[rstest]
+    #[case::humantime_seconds(
+        "experimental_http2_keep_alive_interval: 30s",
+        Some(Duration::from_secs(30))
+    )]
+    #[case::humantime_millis(
+        "experimental_http2_keep_alive_interval: 500ms",
+        Some(Duration::from_millis(500))
+    )]
+    #[case::explicit_null("experimental_http2_keep_alive_interval: null", None)]
+    #[case::omitted("{}", None)]
+    fn test_keep_alive_interval_deserialization(
+        #[case] yaml: &str,
+        #[case] expected: Option<Duration>,
+    ) {
+        let client: Client = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(client.experimental_http2_keep_alive_interval, expected);
+    }
+
+    #[rstest]
+    #[case::humantime_seconds(
+        "experimental_http2_keep_alive_timeout: 10s",
+        Some(Duration::from_secs(10))
+    )]
+    #[case::humantime_millis(
+        "experimental_http2_keep_alive_timeout: 500ms",
+        Some(Duration::from_millis(500))
+    )]
+    #[case::explicit_null("experimental_http2_keep_alive_timeout: null", None)]
+    #[case::omitted("{}", None)]
+    fn test_keep_alive_timeout_deserialization(
+        #[case] yaml: &str,
+        #[case] expected: Option<Duration>,
+    ) {
+        let client: Client = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(client.experimental_http2_keep_alive_timeout, expected);
+    }
 }

--- a/apollo-router/src/configuration/shared/mod.rs
+++ b/apollo-router/src/configuration/shared/mod.rs
@@ -12,14 +12,20 @@ use crate::plugins::traffic_shaping::Http2Config;
 /// taste/adjust, but leave a comment giving justification for any new threshold
 const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// TODO: docs
+/// Default of 20s matches hyper_util's default keep-alive timeout
+pub(crate) const DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
+
 /// HTTP client configuration
 #[derive(PartialEq, Debug, Clone, Default, Deserialize, JsonSchema, buildstructor::Builder)]
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct Client {
     /// Use HTTP/2 to communicate with the coprocessor.
     pub(crate) experimental_http2: Option<Http2Config>,
+
     /// Specify a DNS resolution strategy to use when resolving the coprocessor URL.
     pub(crate) dns_resolution_strategy: Option<DnsResolutionStrategy>,
+
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
         default = "default_pool_idle_timeout"
@@ -27,6 +33,20 @@ pub(crate) struct Client {
     #[schemars(with = "String", default = "default_pool_idle_timeout")]
     /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
     pub(crate) pool_idle_timeout: Option<Duration>,
+
+    /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
+    /// unset (the default), keep-alive pings are disabled.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    pub(crate) experimental_http2_keep_alive_interval: Option<Duration>,
+
+    /// Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and
+    /// `experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.
+    // NB: can't make this non-optional due to the builder, but this gets
+    // `unwrap_or(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT)`'ed at the callsite.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    pub(crate) experimental_http2_keep_alive_timeout: Option<Duration>,
 }
 
 /// Returns the hardcoded default pool idle timeout for keep-alive sockets in a client's connection

--- a/apollo-router/src/configuration/shared/mod.rs
+++ b/apollo-router/src/configuration/shared/mod.rs
@@ -12,8 +12,9 @@ use crate::plugins::traffic_shaping::Http2Config;
 /// taste/adjust, but leave a comment giving justification for any new threshold
 const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// TODO: docs
-/// Default of 20s matches hyper_util's default keep-alive timeout
+/// Default timeout for HTTP/2 keep-alive pings in HttpClientService
+///
+/// NOTE: hyper_util's default keep-alive timeout is 20s, so we use the same value here
 pub(crate) const DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// HTTP client configuration

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -927,6 +927,22 @@ expression: "&schema"
           ],
           "description": "Use HTTP/2 to communicate with the coprocessor."
         },
+        "experimental_http2_keep_alive_interval": {
+          "default": null,
+          "description": "Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If\nunset (the default), keep-alive pings are disabled.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "experimental_http2_keep_alive_timeout": {
+          "default": null,
+          "description": "Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and\n`experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "pool_idle_timeout": {
           "default": {
             "nanos": 0,
@@ -2622,6 +2638,22 @@ expression: "&schema"
             }
           ],
           "description": "Enable HTTP2 for connectors"
+        },
+        "experimental_http2_keep_alive_interval": {
+          "default": null,
+          "description": "Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If\nunset (the default), keep-alive pings are disabled.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "experimental_http2_keep_alive_timeout": {
+          "default": null,
+          "description": "Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and\n`experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "global_rate_limit": {
           "anyOf": [
@@ -10625,6 +10657,22 @@ expression: "&schema"
             }
           ],
           "description": "Enable HTTP2 for subgraphs"
+        },
+        "experimental_http2_keep_alive_interval": {
+          "default": null,
+          "description": "Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If\nunset (the default), keep-alive pings are disabled.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "experimental_http2_keep_alive_timeout": {
+          "default": null,
+          "description": "Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and\n`experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "global_rate_limit": {
           "anyOf": [

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -78,6 +78,16 @@ struct Shaping {
     )]
     #[schemars(with = "String", default = "default_pool_idle_timeout")]
     pool_idle_timeout: Option<Duration>,
+    /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
+    /// unset (the default), keep-alive pings are disabled.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    experimental_http2_keep_alive_interval: Option<Duration>,
+    /// Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and
+    /// `experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    experimental_http2_keep_alive_timeout: Option<Duration>,
 }
 
 #[derive(PartialEq, Default, Debug, Clone, Deserialize, JsonSchema)]
@@ -119,6 +129,16 @@ impl Merge for Shaping {
                     .pool_idle_timeout
                     .as_ref()
                     .or(fallback.pool_idle_timeout.as_ref())
+                    .cloned(),
+                experimental_http2_keep_alive_interval: self
+                    .experimental_http2_keep_alive_interval
+                    .as_ref()
+                    .or(fallback.experimental_http2_keep_alive_interval.as_ref())
+                    .cloned(),
+                experimental_http2_keep_alive_timeout: self
+                    .experimental_http2_keep_alive_timeout
+                    .as_ref()
+                    .or(fallback.experimental_http2_keep_alive_timeout.as_ref())
                     .cloned(),
             },
         }
@@ -175,6 +195,16 @@ struct ConnectorShaping {
     )]
     #[schemars(with = "String", default = "default_pool_idle_timeout")]
     pool_idle_timeout: Option<Duration>,
+    /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
+    /// unset (the default), keep-alive pings are disabled.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    experimental_http2_keep_alive_interval: Option<Duration>,
+    /// Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and
+    /// `experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    experimental_http2_keep_alive_timeout: Option<Duration>,
 }
 
 impl Merge for ConnectorShaping {
@@ -203,6 +233,16 @@ impl Merge for ConnectorShaping {
                     .pool_idle_timeout
                     .as_ref()
                     .or(fallback.pool_idle_timeout.as_ref())
+                    .cloned(),
+                experimental_http2_keep_alive_interval: self
+                    .experimental_http2_keep_alive_interval
+                    .as_ref()
+                    .or(fallback.experimental_http2_keep_alive_interval.as_ref())
+                    .cloned(),
+                experimental_http2_keep_alive_timeout: self
+                    .experimental_http2_keep_alive_timeout
+                    .as_ref()
+                    .or(fallback.experimental_http2_keep_alive_timeout.as_ref())
                     .cloned(),
             },
         }
@@ -540,6 +580,12 @@ impl TrafficShaping {
             experimental_http2: config.shaping.experimental_http2,
             dns_resolution_strategy: config.shaping.dns_resolution_strategy,
             pool_idle_timeout: config.shaping.pool_idle_timeout,
+            experimental_http2_keep_alive_interval: config
+                .shaping
+                .experimental_http2_keep_alive_interval,
+            experimental_http2_keep_alive_timeout: config
+                .shaping
+                .experimental_http2_keep_alive_timeout,
         })
         .unwrap_or_default()
     }
@@ -554,6 +600,9 @@ impl TrafficShaping {
                 experimental_http2: config.experimental_http2,
                 dns_resolution_strategy: config.dns_resolution_strategy,
                 pool_idle_timeout: config.pool_idle_timeout,
+                experimental_http2_keep_alive_interval: config
+                    .experimental_http2_keep_alive_interval,
+                experimental_http2_keep_alive_timeout: config.experimental_http2_keep_alive_timeout,
             })
             .unwrap_or_default()
     }
@@ -1022,7 +1071,8 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Enable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv6ThenIpv4),
-                pool_idle_timeout: default_pool_idle_timeout()
+                pool_idle_timeout: default_pool_idle_timeout(),
+                ..Default::default()
             },
         );
         assert_eq!(
@@ -1030,7 +1080,8 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Disable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv4Only),
-                pool_idle_timeout: default_pool_idle_timeout()
+                pool_idle_timeout: default_pool_idle_timeout(),
+                ..Default::default()
             },
         );
         assert_eq!(
@@ -1038,7 +1089,8 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Disable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv6Only),
-                pool_idle_timeout: default_pool_idle_timeout()
+                pool_idle_timeout: default_pool_idle_timeout(),
+                ..Default::default()
             },
         );
     }

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -1450,6 +1450,137 @@ mod test {
         );
     }
 
+    #[tokio::test]
+    async fn test_subgraph_keep_alive_override_and_fallback() {
+        let config = serde_yaml::from_str::<Config>(
+            r#"
+        all:
+          experimental_http2_keep_alive_interval: 30s
+          experimental_http2_keep_alive_timeout: 10s
+        subgraphs:
+          fast:
+            experimental_http2_keep_alive_interval: 5s
+          explicit_null:
+            experimental_http2_keep_alive_interval: null
+        "#,
+        )
+        .unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("fast")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(5)),
+            "subgraph-specific override should win"
+        );
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("explicit_null")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(30)),
+            "explicit null falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("unknown")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(30)),
+            "unknown subgraph falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("unknown")
+                .experimental_http2_keep_alive_timeout,
+            Some(Duration::from_secs(10)),
+            "timeout is inherited from all"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connector_keep_alive_override_and_fallback() {
+        let config = serde_yaml::from_str::<Config>(
+            r#"
+        connector:
+          all:
+            experimental_http2_keep_alive_interval: 30s
+            experimental_http2_keep_alive_timeout: 10s
+          sources:
+            my_source:
+              experimental_http2_keep_alive_interval: 5s
+            explicit_null:
+              experimental_http2_keep_alive_interval: null
+        "#,
+        )
+        .unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("my_source")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(5)),
+            "source-specific override should win"
+        );
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("explicit_null")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(30)),
+            "explicit null falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("unknown")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(30)),
+            "unknown source falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("unknown")
+                .experimental_http2_keep_alive_timeout,
+            Some(Duration::from_secs(10)),
+            "timeout is inherited from all"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_keep_alive_is_none_when_not_configured() {
+        let config = serde_yaml::from_str::<Config>("{}").unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("any")
+                .experimental_http2_keep_alive_interval,
+            None,
+            "keep-alive interval should be None when not configured"
+        );
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("any")
+                .experimental_http2_keep_alive_timeout,
+            None,
+            "keep-alive timeout should be None when not configured"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn it_raises_different_errors_for_timeouts_and_rate_limits() {
         // expected behavior: the first request sent will timeout, the second request will return

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -275,8 +275,14 @@ impl HttpClientService {
             .pool_timer(TokioTimer::new())
             .http2_only(http2 == Http2Config::Http2Only);
         if let Some(interval) = http2_keep_alive_interval {
-            client_builder.http2_keep_alive_interval(Some(interval));
-            client_builder.http2_keep_alive_timeout(http2_keep_alive_timeout);
+            client_builder
+                // WARN: http2 keep-alive requires a timer; don't remove this
+                .timer(TokioTimer::new())
+                .http2_keep_alive_interval(Some(interval))
+                .http2_keep_alive_timeout(http2_keep_alive_timeout)
+                // Send pings even when the connection is idle in the pool, so stale
+                // connections are detected before a request is made on them
+                .http2_keep_alive_while_idle(true);
         }
         let http_client = client_builder.build(connector);
 

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -43,6 +43,7 @@ use super::HttpResponse;
 use crate::Configuration;
 use crate::axum_factory::compression::Compressor;
 use crate::configuration::TlsClientAuth;
+use crate::configuration::shared::DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT;
 use crate::error::FetchError;
 use crate::plugins::authentication::subgraph::SigningParamsConfig;
 use crate::plugins::telemetry::config_new::attributes::ERROR_TYPE;
@@ -250,6 +251,10 @@ impl HttpClientService {
             .https_or_http();
 
         let pool_idle_timeout = client_config.pool_idle_timeout;
+        let http2_keep_alive_interval = client_config.experimental_http2_keep_alive_interval;
+        let http2_keep_alive_timeout = client_config
+            .experimental_http2_keep_alive_timeout
+            .unwrap_or(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT);
 
         let http2 = client_config.experimental_http2.unwrap_or_default();
         let connector = match http2 {
@@ -261,14 +266,19 @@ impl HttpClientService {
             Http2Config::Http2Only => builder.enable_http2().wrap_connector(http_connector),
         };
 
-        let http_client =
-            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                .pool_idle_timeout(pool_idle_timeout)
-                // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
-                // unless you're also removing `pool_idle_timeout`
-                .pool_timer(TokioTimer::new())
-                .http2_only(http2 == Http2Config::Http2Only)
-                .build(connector);
+        let mut client_builder =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
+        client_builder
+            .pool_idle_timeout(pool_idle_timeout)
+            // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
+            // unless you're also removing `pool_idle_timeout`
+            .pool_timer(TokioTimer::new())
+            .http2_only(http2 == Http2Config::Http2Only);
+        if let Some(interval) = http2_keep_alive_interval {
+            client_builder.http2_keep_alive_interval(Some(interval));
+            client_builder.http2_keep_alive_timeout(http2_keep_alive_timeout);
+        }
+        let http_client = client_builder.build(connector);
 
         #[cfg(unix)]
         let unix_client = {

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -651,6 +651,225 @@ mod h2c_cleartext {
     }
 }
 
+mod h2c_keep_alive {
+    // use std::convert::Infallible;
+    // use std::io;
+    use std::pin::Pin;
+    // use std::str::FromStr;
+    // use std::sync::Arc;
+    // use std::sync::Mutex;
+    use std::task::Context;
+    use std::task::Poll;
+    use std::time::Duration;
+
+    // use axum::body::Body;
+    // use http::Request;
+    // use http::StatusCode;
+    // use http::Uri;
+    // use http::header::CONTENT_TYPE;
+    // use hyper::body::Incoming;
+    // use hyper_util::rt::TokioExecutor;
+    // use hyper_util::rt::TokioIo;
+    // use mime::APPLICATION_JSON;
+    // use serde_json_bytes::Value;
+    use tokio::io::AsyncRead;
+    use tokio::io::AsyncWrite;
+    use tokio::io::ReadBuf;
+
+    // use tokio::net::TcpListener;
+    // use tower::BoxError;
+    // use tower::ServiceExt;
+    use super::*;
+    use crate::configuration::shared::Client;
+    // use crate::graphql::Response;
+    // use crate::plugins::traffic_shaping::Http2Config;
+    // use crate::services::http::HttpClientService;
+    // use crate::services::http::HttpRequest;
+
+    /// Wraps a TcpStream and records all bytes the server reads from the client.
+    struct SpyStream {
+        inner: tokio::net::TcpStream,
+        recorded: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl SpyStream {
+        fn new(stream: tokio::net::TcpStream, recorded: Arc<Mutex<Vec<u8>>>) -> Self {
+            Self {
+                inner: stream,
+                recorded,
+            }
+        }
+    }
+
+    impl AsyncRead for SpyStream {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let before = buf.filled().len();
+            let result = Pin::new(&mut self.inner).poll_read(cx, buf);
+            if matches!(result, Poll::Ready(Ok(()))) {
+                let new_bytes = buf.filled()[before..].to_vec();
+                self.recorded.lock().unwrap().extend_from_slice(&new_bytes);
+            }
+            result
+        }
+    }
+
+    impl AsyncWrite for SpyStream {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Pin::new(&mut self.inner).poll_write(cx, buf)
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.inner).poll_shutdown(cx)
+        }
+    }
+
+    /// Count H2 PING frames (not ACKs) in a raw byte slice by parsing H2 frames per RFC 7540.
+    /// * Preface: https://datatracker.ietf.org/doc/html/rfc7540#section-3.5
+    /// * Ping: https://datatracker.ietf.org/doc/html/rfc7540#section-6.7
+    /// * Frame header: https://datatracker.ietf.org/doc/html/rfc7540#section-4.1
+    fn count_h2_ping_frames(data: &[u8]) -> usize {
+        const PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+        const PING_FRAME_TYPE: u8 = 0x06;
+        const ACK_FLAG: u8 = 0x01;
+        const FRAME_HEADER_SIZE: usize = 9;
+
+        if !data.starts_with(PREFACE) {
+            return 0;
+        }
+
+        let mut index = PREFACE.len();
+        let mut count = 0;
+
+        // iterate through each frame
+        while index + FRAME_HEADER_SIZE <= data.len() {
+            let frame_type = data[index + 3];
+            let flags = data[index + 4];
+            if frame_type == PING_FRAME_TYPE && flags & ACK_FLAG == 0 {
+                count += 1;
+            }
+
+            // figure out the next frame start location - length is an unsigned 24-bit integer, so
+            // we do the math manually
+            let length = (data[index] as usize) << 16
+                | (data[index + 1] as usize) << 8
+                | data[index + 2] as usize;
+            index += FRAME_HEADER_SIZE + length;
+        }
+
+        count
+    }
+
+    /// Start a spy H2 server. Returns a handle to the bytes the server read from the client.
+    fn start_spy_server(listener: TcpListener) -> Arc<Mutex<Vec<u8>>> {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let recorded_server = recorded.clone();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let spy_stream = SpyStream::new(stream, recorded_server);
+
+            let svc = hyper::service::service_fn(|_request: Request<Incoming>| async {
+                let response_body = serde_json::to_string(&Response {
+                    data: Some(Value::default()),
+                    ..Response::default()
+                })
+                .unwrap();
+                Ok::<_, Infallible>(
+                    http::Response::builder()
+                        .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                        .status(StatusCode::OK)
+                        .body(Body::from(response_body))
+                        .unwrap(),
+                )
+            });
+
+            // serve_connection drives the h2 connection, including automatic PING ACKs
+            let _ = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                .serve_connection(TokioIo::new(spy_stream), svc)
+                .await;
+        });
+
+        recorded
+    }
+
+    async fn run_server_and_count_keep_alive_pings(
+        client_config: Client,
+    ) -> Result<usize, BoxError> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let socket_addr = listener.local_addr()?;
+        let recorded = start_spy_server(listener);
+
+        let service = HttpClientService::from_client_config(client_config)?;
+
+        let url = Uri::from_str(&format!("http://{socket_addr}"))?;
+        let request = HttpRequest {
+            http_request: Request::builder()
+                .uri(url)
+                .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                .body(router::body::from_bytes(r#"{"query":"{ me }"}"#))?,
+            context: crate::Context::new(),
+        };
+
+        // Clone so the service (and its connection pool) stays alive after the request
+        service.clone().oneshot(request).await?;
+
+        // Wait for several keep-alive intervals while the connection sits idle in the pool
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        drop(service);
+
+        // Give the server task a moment to flush its reads
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let bytes = recorded.lock().unwrap().clone();
+        let ping_count = count_h2_ping_frames(&bytes);
+        Ok(ping_count)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_keep_alive_pings_are_sent() {
+        let client_config = Client::builder()
+            .experimental_http2(Http2Config::Http2Only)
+            .experimental_http2_keep_alive_interval(Duration::from_millis(50))
+            .build();
+
+        let ping_count = run_server_and_count_keep_alive_pings(client_config)
+            .await
+            .unwrap();
+        assert!(
+            ping_count > 0,
+            "expected at least one H2 PING frame from the client, got {ping_count}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_no_pings_without_keep_alive() {
+        let client_config = Client::builder()
+            .experimental_http2(Http2Config::Http2Only)
+            // no keep-alive interval configured
+            .build();
+
+        let ping_count = run_server_and_count_keep_alive_pings(client_config)
+            .await
+            .unwrap();
+        assert_eq!(
+            ping_count, 0,
+            "expected no H2 PING frames when keep-alive is not configured"
+        );
+    }
+}
+
 mod compressed_req_res {
     use super::*;
 

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -652,39 +652,17 @@ mod h2c_cleartext {
 }
 
 mod h2c_keep_alive {
-    // use std::convert::Infallible;
-    // use std::io;
     use std::pin::Pin;
-    // use std::str::FromStr;
-    // use std::sync::Arc;
-    // use std::sync::Mutex;
     use std::task::Context;
     use std::task::Poll;
     use std::time::Duration;
 
-    // use axum::body::Body;
-    // use http::Request;
-    // use http::StatusCode;
-    // use http::Uri;
-    // use http::header::CONTENT_TYPE;
-    // use hyper::body::Incoming;
-    // use hyper_util::rt::TokioExecutor;
-    // use hyper_util::rt::TokioIo;
-    // use mime::APPLICATION_JSON;
-    // use serde_json_bytes::Value;
     use tokio::io::AsyncRead;
     use tokio::io::AsyncWrite;
     use tokio::io::ReadBuf;
 
-    // use tokio::net::TcpListener;
-    // use tower::BoxError;
-    // use tower::ServiceExt;
     use super::*;
     use crate::configuration::shared::Client;
-    // use crate::graphql::Response;
-    // use crate::plugins::traffic_shaping::Http2Config;
-    // use crate::services::http::HttpClientService;
-    // use crate::services::http::HttpRequest;
 
     /// Wraps a TcpStream and records all bytes the server reads from the client.
     struct SpyStream {

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -660,21 +660,25 @@ mod h2c_keep_alive {
     use tokio::io::AsyncRead;
     use tokio::io::AsyncWrite;
     use tokio::io::ReadBuf;
+    use tokio::net::TcpStream;
+    use tokio::sync::mpsc::Sender;
+    use tokio::task::JoinHandle;
 
     use super::*;
     use crate::configuration::shared::Client;
 
-    /// Wraps a TcpStream and records all bytes the server reads from the client.
+    /// Wraps a TcpStream and emits a `()` on the `ping_tx` channel each time the server reads an H2
+    /// PING frame sent by the client.
     struct SpyStream {
-        inner: tokio::net::TcpStream,
-        recorded: Arc<Mutex<Vec<u8>>>,
+        inner: TcpStream,
+        ping_tx: Sender<()>,
     }
 
     impl SpyStream {
-        fn new(stream: tokio::net::TcpStream, recorded: Arc<Mutex<Vec<u8>>>) -> Self {
+        fn new(stream: TcpStream, ping_tx: Sender<()>) -> Self {
             Self {
                 inner: stream,
-                recorded,
+                ping_tx,
             }
         }
     }
@@ -686,11 +690,15 @@ mod h2c_keep_alive {
             buf: &mut ReadBuf<'_>,
         ) -> Poll<io::Result<()>> {
             let before = buf.filled().len();
+
             let result = Pin::new(&mut self.inner).poll_read(cx, buf);
             if matches!(result, Poll::Ready(Ok(()))) {
                 let new_bytes = buf.filled()[before..].to_vec();
-                self.recorded.lock().unwrap().extend_from_slice(&new_bytes);
+                if is_ping_frame(&new_bytes) {
+                    self.ping_tx.try_send(()).unwrap();
+                }
             }
+
             result
         }
     }
@@ -713,50 +721,39 @@ mod h2c_keep_alive {
         }
     }
 
-    /// Count H2 PING frames (not ACKs) in a raw byte slice by parsing H2 frames per RFC 7540.
-    /// * Preface: https://datatracker.ietf.org/doc/html/rfc7540#section-3.5
-    /// * Ping: https://datatracker.ietf.org/doc/html/rfc7540#section-6.7
-    /// * Frame header: https://datatracker.ietf.org/doc/html/rfc7540#section-4.1
-    fn count_h2_ping_frames(data: &[u8]) -> usize {
-        const PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+    /// Check whether a raw byte slice is an H2 PING frame (not an ACK) per RFC 7540.
+    ///
+    /// This assumes the PING frame arrives as its own chunk — it inspects fixed offsets 3 and 4
+    /// for the frame type and flags rather than doing full frame parsing. In practice this works
+    /// because hyper sends keep-alive PINGs as standalone writes.
+    ///
+    /// References: [frame header] (§4.1), [PING frame] (§6.7)
+    ///
+    /// [frame header]: https://datatracker.ietf.org/doc/html/rfc7540#section-4.1
+    /// [PING frame]: https://datatracker.ietf.org/doc/html/rfc7540#section-6.7
+    fn is_ping_frame(data: &[u8]) -> bool {
+        const FRAME_HEADER_SIZE: usize = 9;
         const PING_FRAME_TYPE: u8 = 0x06;
         const ACK_FLAG: u8 = 0x01;
-        const FRAME_HEADER_SIZE: usize = 9;
 
-        if !data.starts_with(PREFACE) {
-            return 0;
+        if data.len() < FRAME_HEADER_SIZE {
+            return false;
         }
 
-        let mut index = PREFACE.len();
-        let mut count = 0;
+        let frame_type = data[3];
+        let flags = data[4];
 
-        // iterate through each frame
-        while index + FRAME_HEADER_SIZE <= data.len() {
-            let frame_type = data[index + 3];
-            let flags = data[index + 4];
-            if frame_type == PING_FRAME_TYPE && flags & ACK_FLAG == 0 {
-                count += 1;
-            }
-
-            // figure out the next frame start location - length is an unsigned 24-bit integer, so
-            // we do the math manually
-            let length = (data[index] as usize) << 16
-                | (data[index + 1] as usize) << 8
-                | data[index + 2] as usize;
-            index += FRAME_HEADER_SIZE + length;
-        }
-
-        count
+        frame_type == PING_FRAME_TYPE && flags & ACK_FLAG == 0
     }
 
-    /// Start a spy H2 server. Returns a handle to the bytes the server read from the client.
-    fn start_spy_server(listener: TcpListener) -> Arc<Mutex<Vec<u8>>> {
-        let recorded = Arc::new(Mutex::new(Vec::new()));
-        let recorded_server = recorded.clone();
+    /// Start a spy H2 server that counts H2 PING frames sent by the client. Returns a
+    /// [`JoinHandle`] that resolves to the total ping count once the server connection closes.
+    fn start_spy_server_and_ping_counter(listener: TcpListener) -> JoinHandle<usize> {
+        let (ping_tx, mut ping_rx) = tokio::sync::mpsc::channel(100);
 
-        tokio::spawn(async move {
+        let _spy_server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
-            let spy_stream = SpyStream::new(stream, recorded_server);
+            let spy_stream = SpyStream::new(stream, ping_tx);
 
             let svc = hyper::service::service_fn(|_request: Request<Incoming>| async {
                 let response_body = serde_json::to_string(&Response {
@@ -779,16 +776,26 @@ mod h2c_keep_alive {
                 .await;
         });
 
-        recorded
+        let ping_counter = tokio::spawn(async move {
+            let mut ping_count = 0;
+            while let Some(()) = ping_rx.recv().await {
+                ping_count += 1;
+            }
+            ping_count
+        });
+
+        ping_counter
     }
 
+    /// Start a spy server, make one request with the given client config, wait for keep-alive
+    /// intervals to fire, then return the number of H2 PING frames the server observed.
     async fn run_server_and_count_keep_alive_pings(
         client_config: Client,
     ) -> Result<usize, BoxError> {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let socket_addr = listener.local_addr()?;
-        let recorded = start_spy_server(listener);
 
+        let ping_counter = start_spy_server_and_ping_counter(listener);
         let service = HttpClientService::from_client_config(client_config)?;
 
         let url = Uri::from_str(&format!("http://{socket_addr}"))?;
@@ -807,12 +814,7 @@ mod h2c_keep_alive {
         tokio::time::sleep(Duration::from_millis(500)).await;
         drop(service);
 
-        // Give the server task a moment to flush its reads
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        let bytes = recorded.lock().unwrap().clone();
-        let ping_count = count_h2_ping_frames(&bytes);
-        Ok(ping_count)
+        Ok(ping_counter.await?)
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -776,15 +776,13 @@ mod h2c_keep_alive {
                 .await;
         });
 
-        let ping_counter = tokio::spawn(async move {
+        tokio::spawn(async move {
             let mut ping_count = 0;
             while let Some(()) = ping_rx.recv().await {
                 ping_count += 1;
             }
             ping_count
-        });
-
-        ping_counter
+        })
     }
 
     /// Start a spy server, make one request with the given client config, wait for keep-alive

--- a/docs/shared/config/traffic_shaping.mdx
+++ b/docs/shared/config/traffic_shaping.mdx
@@ -7,6 +7,8 @@ traffic_shaping:
     deduplicate_query: false
     dns_resolution_strategy: ipv4_only
     experimental_http2: enable
+    experimental_http2_keep_alive_interval: null
+    experimental_http2_keep_alive_timeout: null
     global_rate_limit:
       capacity: 1
       interval: 30s
@@ -16,6 +18,8 @@ traffic_shaping:
       compression: gzip
       dns_resolution_strategy: ipv4_only
       experimental_http2: enable
+      experimental_http2_keep_alive_interval: null
+      experimental_http2_keep_alive_timeout: null
       global_rate_limit:
         capacity: 1
         interval: 30s

--- a/docs/shared/router-config-properties-table.mdx
+++ b/docs/shared/router-config-properties-table.mdx
@@ -1491,6 +1491,8 @@ traffic_shaping:
     deduplicate_query: false
     dns_resolution_strategy: ipv4_only
     experimental_http2: enable
+    experimental_http2_keep_alive_interval: null
+    experimental_http2_keep_alive_timeout: null
     global_rate_limit:
       capacity: 1
       interval: 30s
@@ -1500,6 +1502,8 @@ traffic_shaping:
       compression: gzip
       dns_resolution_strategy: ipv4_only
       experimental_http2: enable
+      experimental_http2_keep_alive_interval: null
+      experimental_http2_keep_alive_timeout: null
       global_rate_limit:
         capacity: 1
         interval: 30s

--- a/docs/source/routing/performance/traffic-shaping.mdx
+++ b/docs/source/routing/performance/traffic-shaping.mdx
@@ -237,6 +237,27 @@ traffic_shaping:
 
 <HttpConnection type="subgraph" />
 
+#### HTTP/2 keep-alive
+
+The router can send periodic HTTP/2 PING frames on idle subgraph connections to detect and close stale connections before they cause request failures. This is particularly useful when connections can become silently broken (for example, due to network timeouts or load balancer idle timeouts).
+
+Use `experimental_http2_keep_alive_interval` to enable keep-alive pings. When set, the router sends a PING frame after a connection has been idle for the specified duration. If the subgraph does not respond within `experimental_http2_keep_alive_timeout` (default: 20 seconds), the connection is closed.
+
+Both options apply under `all`, per-subgraph under `subgraphs`, and per-source under `connector.sources`.
+
+```yaml title="router.yaml"
+traffic_shaping:
+  all:
+    experimental_http2_keep_alive_interval: 30s # Send a PING every 30s on idle connections
+    experimental_http2_keep_alive_timeout: 10s  # Close the connection if no PONG within 10s
+```
+
+<Note>
+
+Keep-alive pings require HTTP/2 to be active. Setting `experimental_http2: disable` will prevent pings from being sent regardless of these settings.
+
+</Note>
+
 ### Ordering
 
 Traffic shaping always executes these steps in the same order, to ensure a consistent behavior. Declaration order in the configuration will not affect the runtime order:

--- a/docs/source/routing/performance/traffic-shaping.mdx
+++ b/docs/source/routing/performance/traffic-shaping.mdx
@@ -239,9 +239,9 @@ traffic_shaping:
 
 #### HTTP/2 keep-alive
 
-The router can send periodic HTTP/2 PING frames on idle subgraph connections to detect and close stale connections before they cause request failures. This is particularly useful when connections can become silently broken (for example, due to network timeouts or load balancer idle timeouts).
+Router can send periodic HTTP/2 PING frames on idle subgraph connections to detect and close stale connections before they cause request failures. This is particularly useful when connections can become silently broken (for example, due to network timeouts or load balancer idle timeouts).
 
-Use `experimental_http2_keep_alive_interval` to enable keep-alive pings. When set, the router sends a PING frame after a connection has been idle for the specified duration. If the subgraph does not respond within `experimental_http2_keep_alive_timeout` (default: 20 seconds), the connection is closed.
+Use `experimental_http2_keep_alive_interval` to enable keep-alive pings. When you set this, the router sends a PING frame after a connection has been idle for the specified duration. If your subgraph does not respond within `experimental_http2_keep_alive_timeout` (default: 20 seconds), the connection is closed.
 
 Both options apply under `all`, per-subgraph under `subgraphs`, and per-source under `connector.sources`.
 


### PR DESCRIPTION
This PR adds a configurable HTTP/2 keep-alive for subgraph and connector connections. Enabling keep-alive causes the router to detect and close dead connections proactively, freeing their connection pool permits.

It adds two new traffic_shaping configuration options for controlling HTTP/2 keep-alive pings on subgraph and connector connections:
* `experimental_http2_keep_alive_interval`: how often to send a PING frame on an idle connection (disabled by default)
* `experimental_http2_keep_alive_timeout`: how long to wait for a PONG before treating the connection as dead (default: 20s, matching hyper's default)

Both options are available under all, per-subgraph, and per-connector-source, with the same merge/fallback behavior as other traffic shaping settings.

#### Implementation notes:
* Keep-alive pings require `http2_keep_alive_while_idle(true)` and a timer to be set on the hyper client builder — without these, pings are never sent on idle connections. Both are configured automatically when the interval is set.
* The behavior is verified with a spy stream test that counts raw H2 PING frames (type 0x06, no ACK flag) received by the server.

<!-- start metadata -->

<!-- [ROUTER-1659] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1659]: https://apollographql.atlassian.net/browse/ROUTER-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ