### PR TITLE
test: verify genuine buffer exhaustion still causes LoadShed to shed

### DIFF
--- a/apollo-router/src/layers/unconstrained_buffer.rs
+++ b/apollo-router/src/layers/unconstrained_buffer.rs
@@ -378,6 +378,75 @@ mod tests {
             .await;
     }
 
+    /// Confirms that genuine buffer exhaustion still causes [`LoadShed`] to shed requests.
+    ///
+    /// [`UnconstrainedBuffer`] bypasses the coop budget check but must still propagate genuine
+    /// [`Poll::Pending`] from a full semaphore so that real backpressure is preserved.
+    #[tokio::test(flavor = "current_thread")]
+    async fn full_buffer_should_still_cause_load_shedding() {
+        use std::sync::Arc;
+
+        use tokio::sync::Semaphore;
+
+        // A gate that holds the inner service blocked until we release it.
+        let gate = Arc::new(Semaphore::new(0));
+        let gate_clone = gate.clone();
+
+        let inner = tower::service_fn(move |_: ()| {
+            let gate = gate_clone.clone();
+            async move {
+                // Block until explicitly released.
+                let _permit = gate.acquire().await.unwrap();
+                Ok::<_, BoxError>("ok")
+            }
+        });
+
+        // Capacity 1: the worker holds 1 in-flight; 1 more can queue. A third makes the buffer full.
+        let inner_buffered = UnconstrainedBuffer::new(inner, 1);
+        let mut load_shed = LoadShed::new(inner_buffered);
+
+        // Request 1: accepted, worker picks it up and blocks at the gate.
+        poll_fn(|cx| load_shed.poll_ready(cx)).await.unwrap();
+        drop(load_shed.call(()));
+
+        // Yield so the worker task runs and drains request 1 from the channel.
+        tokio::task::yield_now().await;
+
+        // Request 2: fills the channel while the worker is blocked on request 1.
+        poll_fn(|cx| load_shed.poll_ready(cx)).await.unwrap();
+        drop(load_shed.call(()));
+
+        // Request 3: the channel is now full. Buffer::poll_ready returns genuine Pending
+        // (not coop-induced), LoadShed must shed this request.
+        poll_fn(|cx| {
+            // LoadShed::poll_ready always returns Ready — it absorbs the inner Pending.
+            assert!(matches!(load_shed.poll_ready(cx), Poll::Ready(Ok(()))));
+
+            let fut = load_shed.call(());
+            let mut fut = std::pin::pin!(fut);
+
+            // Overloaded resolves immediately in one poll.
+            let is_overloaded = match fut.as_mut().poll(cx) {
+                Poll::Ready(Err(ref e)) => e
+                    .downcast_ref::<tower::load_shed::error::Overloaded>()
+                    .is_some(),
+                _ => false,
+            };
+
+            assert!(
+                is_overloaded,
+                "Expected Overloaded when buffer is genuinely full; \
+                 UnconstrainedBuffer must not suppress real backpressure"
+            );
+
+            Poll::Ready(())
+        })
+        .await;
+
+        // Release the gate so the worker can drain and the runtime can shut down cleanly.
+        gate.add_permits(2);
+    }
+
     /// Load-based test: ensure that shedding never happens under load with the
     /// real Buffer Worker loop.
     ///

--- a/apollo-router/src/layers/unconstrained_buffer.rs
+++ b/apollo-router/src/layers/unconstrained_buffer.rs
@@ -382,7 +382,7 @@ mod tests {
     ///
     /// [`UnconstrainedBuffer`] bypasses the coop budget check but must still propagate genuine
     /// [`Poll::Pending`] from a full semaphore so that real backpressure is preserved.
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test]
     async fn full_buffer_should_still_cause_load_shedding() {
         use std::sync::Arc;
 
@@ -406,6 +406,8 @@ mod tests {
         let mut load_shed = LoadShed::new(inner_buffered);
 
         // Request 1: accepted, worker picks it up and blocks at the gate.
+        // Buffer::call() enqueues synchronously; dropping the ResponseFuture only discards
+        // the response receiver — the request is already in the channel.
         poll_fn(|cx| load_shed.poll_ready(cx)).await.unwrap();
         drop(load_shed.call(()));
 
@@ -413,6 +415,7 @@ mod tests {
         tokio::task::yield_now().await;
 
         // Request 2: fills the channel while the worker is blocked on request 1.
+        // Same as above — drop only the response receiver, not the enqueued request.
         poll_fn(|cx| load_shed.poll_ready(cx)).await.unwrap();
         drop(load_shed.call(()));
 
@@ -427,7 +430,7 @@ mod tests {
 
             // Overloaded resolves immediately in one poll.
             let is_overloaded = match fut.as_mut().poll(cx) {
-                Poll::Ready(Err(ref e)) => e
+                Poll::Ready(Err(e)) => e
                     .downcast_ref::<tower::load_shed::error::Overloaded>()
                     .is_some(),
                 _ => false,


### PR DESCRIPTION
## Summary

- Adds `full_buffer_should_still_cause_load_shedding` to `unconstrained_buffer` tests
- Confirms that `UnconstrainedBuffer` only bypasses the coop budget check — genuine semaphore exhaustion (buffer physically full) still propagates as `Poll::Pending` through `unconstrained`, causing `LoadShed` to correctly shed the request as `Overloaded`
- Uses a gate semaphore to hold the inner service blocked deterministically, then fills the buffer channel to capacity before asserting the third request is shed

## Motivation

The existing tests verify the fix (no spurious shedding when buffer has capacity). This test covers the complementary case: real backpressure must still work. Without it, a future refactor that accidentally suppressed genuine `Pending` would go undetected.

Note: the existing `traffic_shaping` rate-limit tests exercise load shedding at the `RateLimitLayer` level, not at the `Buffer` semaphore level — this test fills a different gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)