### PR TITLE
chore: exclude Rhai from the >= 1.0 renovate group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -144,6 +144,9 @@
       matchPackageNames: ['/^rhai$/'],
       automerge: false,
       prBodyNotes: ["> [!IMPORTANT]\n> Rhai updates can cause breaking changes for users. Make sure to add a [`feat_`-prefixed changeset](https://github.com/apollographql/router/blob/dev/.changesets/README.md#conventions-used-in-this-changesets-directory) to alert users of the upgrade!"]
+      // Exclude Rhai from the >= 1.0 group
+      groupName: null,
+      groupSlug: null,
     },
   ],
 }


### PR DESCRIPTION
Rhai upgrades require manual intervention, so it prevents automerging
the >= 1.0 update group (see https://github.com/apollographql/router/pull/8882)
and can block updates for a long time.

Let's exclude it from the >= 1.0 group so those can be landed easier and
more often!
