### PR TITLE
chore: exclude Rhai from the >= 1.0 renovate group (backport #9061)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -138,5 +138,18 @@
       groupName: null,
       groupSlug: null,
     },
+<<<<<<< HEAD
+=======
+    // Add a note to the Rhai update PR to add a changeset
+    {
+      matchManagers: ['cargo'],
+      matchPackageNames: ['/^rhai$/'],
+      automerge: false,
+      prBodyNotes: ["> [!IMPORTANT]\n> Rhai updates can cause breaking changes for users. Make sure to add a [`feat_`-prefixed changeset](https://github.com/apollographql/router/blob/dev/.changesets/README.md#conventions-used-in-this-changesets-directory) to alert users of the upgrade!"]
+      // Exclude Rhai from the >= 1.0 group
+      groupName: null,
+      groupSlug: null,
+    },
+>>>>>>> 1256bf3e (chore: exclude Rhai from the >= 1.0 renovate group (#9061))
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -138,8 +138,6 @@
       groupName: null,
       groupSlug: null,
     },
-<<<<<<< HEAD
-=======
     // Add a note to the Rhai update PR to add a changeset
     {
       matchManagers: ['cargo'],
@@ -150,6 +148,5 @@
       groupName: null,
       groupSlug: null,
     },
->>>>>>> 1256bf3e (chore: exclude Rhai from the >= 1.0 renovate group (#9061))
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -143,7 +143,7 @@
       matchManagers: ['cargo'],
       matchPackageNames: ['/^rhai$/'],
       automerge: false,
-      prBodyNotes: ["> [!IMPORTANT]\n> Rhai updates can cause breaking changes for users. Make sure to add a [`feat_`-prefixed changeset](https://github.com/apollographql/router/blob/dev/.changesets/README.md#conventions-used-in-this-changesets-directory) to alert users of the upgrade!"]
+      prBodyNotes: ["> [!IMPORTANT]\n> Rhai updates can cause breaking changes for users. Make sure to add a [`feat_`-prefixed changeset](https://github.com/apollographql/router/blob/dev/.changesets/README.md#conventions-used-in-this-changesets-directory) to alert users of the upgrade!"],
       // Exclude Rhai from the >= 1.0 group
       groupName: null,
       groupSlug: null,


### PR DESCRIPTION
Rhai upgrades require manual intervention, so it prevents automerging
the >= 1.0 update group (see https://github.com/apollographql/router/pull/8882)
and can block updates for a long time.

Let's exclude it from the >= 1.0 group so those can be landed easier and
more often!
<hr>This is an automatic backport of pull request #9061 done by [Mergify](https://mergify.com).