### PR TITLE
fix: add comma in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -143,7 +143,7 @@
       matchManagers: ['cargo'],
       matchPackageNames: ['/^rhai$/'],
       automerge: false,
-      prBodyNotes: ["> [!IMPORTANT]\n> Rhai updates can cause breaking changes for users. Make sure to add a [`feat_`-prefixed changeset](https://github.com/apollographql/router/blob/dev/.changesets/README.md#conventions-used-in-this-changesets-directory) to alert users of the upgrade!"]
+      prBodyNotes: ["> [!IMPORTANT]\n> Rhai updates can cause breaking changes for users. Make sure to add a [`feat_`-prefixed changeset](https://github.com/apollographql/router/blob/dev/.changesets/README.md#conventions-used-in-this-changesets-directory) to alert users of the upgrade!"],
       // Exclude Rhai from the >= 1.0 group
       groupName: null,
       groupSlug: null,


### PR DESCRIPTION
Oops! I forgot a comma!

Fixes https://github.com/apollographql/router/issues/9063

I have already addressed this in https://github.com/apollographql/router/pull/9064. We don't need to backport this new PR.