### PR TITLE
Add regression tests for `->match` with nested subselections

### DIFF
--- a/apollo-federation/src/connectors/json_selection/methods/public/match.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/match.rs
@@ -237,6 +237,162 @@ mod tests {
         );
     }
 
+    // TSH-22359: Reproduction of reported parse failure with nested object
+    // subselections inside ->match branches. The user wrote comma-separated
+    // properties inside a SubSelection context (e.g. `address { street: street,
+    // city: city }`), but SubSelection is whitespace-delimited, not
+    // comma-delimited. LitObject uses commas; SubSelection does not.
+
+    #[test]
+    fn tsh_22359_flat_scalars_in_match_with_commas_parses_ok() {
+        // Test 1 from the ticket (verbatim): flat scalar fields inside ->match.
+        // Commas separate LitObject properties, which is correct.
+        let sel = selection!(
+            r#"
+            $.results {
+                ... resultType->match(
+                    ["book", { __typename: "FlatBook", id: id, title: title }],
+                    ["author", { __typename: "FlatAuthor", id: id, name: name }]
+                )
+            }
+            "#,
+            ConnectSpec::V0_4
+        );
+        let (result, errors) = sel.apply_to(&json!({
+            "results": [
+                { "resultType": "book", "id": "1", "title": "Great Expectations" },
+                { "resultType": "author", "id": "2", "name": "Dickens" }
+            ]
+        }));
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+        assert_eq!(
+            result,
+            Some(json!([
+                { "__typename": "FlatBook", "id": "1", "title": "Great Expectations" },
+                { "__typename": "FlatAuthor", "id": "2", "name": "Dickens" }
+            ]))
+        );
+    }
+
+    #[test]
+    fn tsh_22359_flat_scalars_simplified_with_shorthand() {
+        // Same as ticket Test 1, but using V0_4 shorthand: `id` instead of
+        // `id: id`, `title` instead of `title: title`, etc.
+        let sel = selection!(
+            r#"
+            $.results {
+                ... resultType->match(
+                    ["book", { __typename: "FlatBook", id, title }],
+                    ["author", { __typename: "FlatAuthor", id, name }]
+                )
+            }
+            "#,
+            ConnectSpec::V0_4
+        );
+        let (result, errors) = sel.apply_to(&json!({
+            "results": [
+                { "resultType": "book", "id": "1", "title": "Great Expectations" },
+                { "resultType": "author", "id": "2", "name": "Dickens" }
+            ]
+        }));
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+        assert_eq!(
+            result,
+            Some(json!([
+                { "__typename": "FlatBook", "id": "1", "title": "Great Expectations" },
+                { "__typename": "FlatAuthor", "id": "2", "name": "Dickens" }
+            ]))
+        );
+    }
+
+    #[test]
+    fn tsh_22359_nested_subselection_with_commas_fails_to_parse() {
+        // Test 2 from the ticket: nested object fields inside ->match.
+        // The user wrote `address: address { street: street, city: city }`
+        // which fails because `address` parses as a LitExpr (bare identifier)
+        // and the following `{ ... }` is not consumed as part of it.
+        let input = r#"
+            $.results {
+                ... resultType->match(
+                    ["book", { __typename: "NestedBook", id: id, title: title, address: address { street: street, city: city } }],
+                    ["author", { __typename: "NestedAuthor", id: id, name: name, address: address { street: street, city: city } }]
+                )
+            }
+        "#;
+        let result = crate::connectors::json_selection::JSONSelection::parse_with_spec(
+            input,
+            ConnectSpec::V0_4,
+        );
+        assert!(
+            result.is_err(),
+            "expected parse error, but it parsed successfully"
+        );
+    }
+
+    #[test]
+    fn tsh_22359_fix_litobj_commas_with_subselection_spaces() {
+        // Fix option 1: outer LitObject uses commas, inner SubSelection uses
+        // spaces. `address: address { street city }` parses as
+        // LitExpr::Path(PathList::Key("address", PathList::Selection(...))).
+        let sel = selection!(
+            r#"
+            $.results {
+                ... resultType->match(
+                    ["book", { __typename: "NestedBook", id: id, title: title, address: address { street city } }],
+                    ["author", { __typename: "NestedAuthor", id: id, name: name, address: address { street city } }]
+                )
+            }
+            "#,
+            ConnectSpec::V0_4
+        );
+        let (result, errors) = sel.apply_to(&json!({
+            "results": [
+                { "resultType": "book", "id": "1", "title": "Great Expectations", "address": { "street": "48 Doughty St", "city": "London" } },
+                { "resultType": "author", "id": "2", "name": "Dickens", "address": { "street": "1 Gads Hill", "city": "Higham" } }
+            ]
+        }));
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+        assert_eq!(
+            result,
+            Some(json!([
+                { "__typename": "NestedBook", "id": "1", "title": "Great Expectations", "address": { "street": "48 Doughty St", "city": "London" } },
+                { "__typename": "NestedAuthor", "id": "2", "name": "Dickens", "address": { "street": "1 Gads Hill", "city": "Higham" } }
+            ]))
+        );
+    }
+
+    #[test]
+    fn tsh_22359_fix_shorthand_with_nested_subselection() {
+        // Fix option 2 (cleanest): V0_4 shorthand properties. `id` means
+        // `id: id`, and `address { street city }` is a shorthand property
+        // whose value is a path with SubSelection.
+        let sel = selection!(
+            r#"
+            $.results {
+                ... resultType->match(
+                    ["book", { __typename: "NestedBook", id, title, address { street city } }],
+                    ["author", { __typename: "NestedAuthor", id, name, address { street city } }]
+                )
+            }
+            "#,
+            ConnectSpec::V0_4
+        );
+        let (result, errors) = sel.apply_to(&json!({
+            "results": [
+                { "resultType": "book", "id": "1", "title": "Great Expectations", "address": { "street": "48 Doughty St", "city": "London" } },
+                { "resultType": "author", "id": "2", "name": "Dickens", "address": { "street": "1 Gads Hill", "city": "Higham" } }
+            ]
+        }));
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+        assert_eq!(
+            result,
+            Some(json!([
+                { "__typename": "NestedBook", "id": "1", "title": "Great Expectations", "address": { "street": "48 Doughty St", "city": "London" } },
+                { "__typename": "NestedAuthor", "id": "2", "name": "Dickens", "address": { "street": "1 Gads Hill", "city": "Higham" } }
+            ]))
+        );
+    }
+
     #[rstest::rstest]
     #[case::v0_2(ConnectSpec::V0_2)]
     #[case::v0_3(ConnectSpec::V0_3)]


### PR DESCRIPTION
## Summary
- Adds regression tests for `->match` with nested object subselections, covering a reported parse failure when commas are used inside SubSelection contexts
- Demonstrates the syntax distinction: LitObject uses commas, SubSelection uses whitespace
- Shows V0_4 shorthand as the cleanest approach for passthrough fields with nested subselections

## Test plan
- [x] `cargo test --lib tsh_22359` passes (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)