### PR TITLE
chore: try to fix flaky tests in plugins::telemetry::reload::builder

### DIFF
--- a/apollo-router/src/plugins/telemetry/reload/activation.rs
+++ b/apollo-router/src/plugins/telemetry/reload/activation.rs
@@ -269,12 +269,10 @@ impl Drop for Activation {
 
         #[cfg(not(test))]
         {
-            for meter_provider in meter_providers.into_values() {
-                spawn_blocking(move || drop(meter_provider));
-            }
-            if let Some(tracer_provider) = tracer_provider {
-                spawn_blocking(move || drop(tracer_provider));
-            }
+            spawn_blocking(|| {
+                drop(meter_providers);
+                drop(tracer_provider);
+            });
         }
     }
 }

--- a/apollo-router/src/plugins/telemetry/reload/activation.rs
+++ b/apollo-router/src/plugins/telemetry/reload/activation.rs
@@ -31,6 +31,7 @@ use opentelemetry::trace::TracerProvider;
 use parking_lot::Mutex;
 use prometheus::Registry;
 use tokio::task::block_in_place;
+#[cfg(not(test))]
 use tokio::task::spawn_blocking;
 use tracing_subscriber::Layer;
 
@@ -247,14 +248,33 @@ impl Activation {
 /// 2. **If preparation fails**: Drops the new providers that were never activated
 impl Drop for Activation {
     fn drop(&mut self) {
-        // Drop all meter providers in blocking tasks to avoid runtime deadlocks
-        for meter_provider in std::mem::take(&mut self.new_meter_providers).into_values() {
-            spawn_blocking(move || drop(meter_provider));
+        let meter_providers = std::mem::take(&mut self.new_meter_providers);
+        let tracer_provider = self.new_trace_provider.take();
+
+        // In tests, drop providers synchronously via block_in_place. This avoids a race
+        // condition between spawn_blocking and Runtime::drop: when the tokio test runtime
+        // shuts down, it cancels async tasks (including PeriodicReader background tasks)
+        // and then waits indefinitely for blocking tasks. A race in
+        // futures_channel::mpsc::Receiver::drop can cause the PeriodicReader's shutdown
+        // message to be lost, leaving the blocking task's futures_executor::block_on call
+        // stuck forever. By using block_in_place, we shut down providers while the runtime
+        // is still fully alive, so background tasks process shutdown messages normally.
+        #[cfg(test)]
+        {
+            block_in_place(|| {
+                drop(meter_providers);
+                drop(tracer_provider);
+            });
         }
 
-        // Drop tracer provider in blocking task if present
-        if let Some(tracer_provider) = self.new_trace_provider.take() {
-            spawn_blocking(move || drop(tracer_provider));
+        #[cfg(not(test))]
+        {
+            for meter_provider in meter_providers.into_values() {
+                spawn_blocking(move || drop(meter_provider));
+            }
+            if let Some(tracer_provider) = tracer_provider {
+                spawn_blocking(move || drop(tracer_provider));
+            }
         }
     }
 }


### PR DESCRIPTION
We've seen these tests failing on CI due to hanging, using block_in_place only for test profiles seems to fix this for me locally. I can reproduce this on dev by running the test binary 10 times in parallel which makes at least one instance hang, which doesn't happen with this change.

<!-- start metadata -->

<!-- [ROUTER-1677] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1677]: https://apollographql.atlassian.net/browse/ROUTER-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ