### PR TITLE
chore(subgraph): improve error message for lone Unicode surrogate in subgraph response

### DIFF
--- a/apollo-router/src/graphql/response.rs
+++ b/apollo-router/src/graphql/response.rs
@@ -516,4 +516,48 @@ mod tests {
             Response::builder().data(Some(Value::Null)).build(),
         );
     }
+
+    /// Tests for Unicode / emoji handling in subgraph responses.
+    ///
+    /// Non-BMP characters (U+10000 and above, e.g. 💰 U+1F4B0) require two UTF-16 code units
+    /// when encoded as \uXXXX JSON escapes: a high surrogate (\uD800–\uDBFF) followed immediately
+    /// by a low surrogate (\uDC00–\uDFFF). serde_json enforces this strictly; a lone high
+    /// surrogate is rejected as malformed JSON (RFC 8259 §7).
+    mod unicode {
+        use rstest::rstest;
+
+        use super::*;
+
+        // Valid encodings — all should parse successfully and round-trip to the same data.
+        #[rstest]
+        // Raw UTF-8 bytes: the most common and correct encoding.
+        #[case::raw_utf8("{ \"data\": { \"greeting\": \"hello 💰💕\" } }", bjson!({ "greeting": "hello 💰💕" }))]
+        // \uD83D\uDCB0 = 💰, \uD83D\uDC95 = 💕: valid surrogate pairs as emitted by Java's Jackson
+        // (ensure_ascii=true) or Python's json.dumps(ensure_ascii=True).
+        #[case::surrogate_pairs(r#"{"data":{"greeting":"hello \uD83D\uDCB0\uD83D\uDC95"}}"#, bjson!({ "greeting": "hello 💰💕" }))]
+        // ❤ is U+2764 (BMP, single \uXXXX); 😀 is U+1F600 (non-BMP, surrogate pair \uD83D\uDE00).
+        #[case::bmp_and_surrogate_pair(r#"{"data":{"greeting":"\u2764 \uD83D\uDE00"}}"#, bjson!({ "greeting": "❤ 😀" }))]
+        fn valid_emoji(#[case] json: &str, #[case] expected: Value) {
+            let resp = Response::from_bytes(Bytes::copy_from_slice(json.as_bytes())).unwrap();
+            assert_eq!(resp.data, Some(expected));
+        }
+
+        // Invalid encodings — lone high surrogates must be rejected with a helpful hint.
+        #[rstest]
+        // \uD83D followed by a space: high surrogate with no following \uDCxx (first serde_json branch).
+        #[case::lone_surrogate_space(r#"{"data":{"greeting":"hello \uD83D end"}}"#)]
+        // \uD83D\n: high surrogate followed by a valid escape that isn't \u (second branch).
+        #[case::lone_surrogate_non_u_escape(r#"{"data":{"greeting":"hello \uD83D\n end"}}"#)]
+        fn lone_surrogate_rejected(#[case] json: &str) {
+            let err = Response::from_bytes(Bytes::copy_from_slice(json.as_bytes())).unwrap_err();
+            assert!(
+                err.reason.contains("unexpected end of hex escape"),
+                "expected base serde_json error, got: {err}"
+            );
+            assert!(
+                err.reason.contains("unpaired Unicode surrogate"),
+                "expected surrogate hint in error, got: {err}"
+            );
+        }
+    }
 }

--- a/apollo-router/src/graphql/response.rs
+++ b/apollo-router/src/graphql/response.rs
@@ -119,11 +119,7 @@ impl Response {
             if error.classify() == serde_json::error::Category::Syntax
                 && reason.contains("unexpected end of hex escape")
             {
-                reason.push_str(
-                    "; the subgraph response contains an unpaired Unicode surrogate \
-                    (e.g. \\uD83D without a following \\uDCxx). Fix the subgraph to emit \
-                    raw UTF-8 or correctly paired surrogate escapes.",
-                );
+                reason.push_str("; the subgraph response contains an unpaired Unicode surrogate");
             }
             MalformedResponseError { reason }
         })?;

--- a/apollo-router/src/graphql/response.rs
+++ b/apollo-router/src/graphql/response.rs
@@ -105,8 +105,27 @@ impl Response {
     ///
     /// This will return an error (identifying the faulty service) if the input is invalid.
     pub(crate) fn from_bytes(b: Bytes) -> Result<Response, MalformedResponseError> {
-        let value = Value::from_bytes(b).map_err(|error| MalformedResponseError {
-            reason: error.to_string(),
+        let value = Value::from_bytes(b).map_err(|error| {
+            let mut reason = error.to_string();
+
+            // RFC 8259 §7 requires that non-BMP characters encoded as \uXXXX escapes use
+            // a surrogate pair: a high surrogate (\uD800–\uDBFF) immediately followed by a
+            // low surrogate (\uDC00–\uDFFF). A lone high surrogate is invalid JSON.
+            // https://www.rfc-editor.org/rfc/rfc8259#section-7
+            //
+            // In serde_json, `UnexpectedEndOfHexEscape` is only reachable from the
+            // surrogate-parsing code path, so this message string uniquely identifies a
+            // lone-surrogate error — no additional byte-level check is needed.
+            if error.classify() == serde_json::error::Category::Syntax
+                && reason.contains("unexpected end of hex escape")
+            {
+                reason.push_str(
+                    "; the subgraph response contains an unpaired Unicode surrogate \
+                    (e.g. \\uD83D without a following \\uDCxx). Fix the subgraph to emit \
+                    raw UTF-8 or correctly paired surrogate escapes.",
+                );
+            }
+            MalformedResponseError { reason }
         })?;
         Response::from_value(value)
     }

--- a/apollo-router/src/graphql/response.rs
+++ b/apollo-router/src/graphql/response.rs
@@ -119,7 +119,7 @@ impl Response {
             if error.classify() == serde_json::error::Category::Syntax
                 && reason.contains("unexpected end of hex escape")
             {
-                reason.push_str("; the subgraph response contains an unpaired Unicode surrogate");
+                reason.push_str("; the response contains an unpaired Unicode surrogate");
             }
             MalformedResponseError { reason }
         })?;


### PR DESCRIPTION
When a subgraph returns JSON containing a lone Unicode high surrogate (e.g. `\uD83D` not followed by a low surrogate `\uDCxx`), the router rejects the response with `SUBREQUEST_MALFORMED_RESPONSE` and a raw `serde_json` error:

```
unexpected end of hex escape at line 1 column N
```

This is correct behaviour — lone surrogates are invalid JSON per [RFC 8259 §7](https://www.rfc-editor.org/rfc/rfc8259#section-7) — but the error gives no indication of what caused it or how to fix it. This is produced by libraries that encode non-BMP characters (emoji above `U+FFFF`) incorrectly, emitting only the high surrogate half of what should be a surrogate pair.

This PR detects the `UnexpectedEndOfHexEscape` `serde_json` syntax error in `Response::from_bytes` and appends a plain-language explanation pointing at the subgraph as the source of the problem:

```
unexpected end of hex escape at line 1 column N; the subgraph response contains
an unpaired Unicode surrogate (e.g. \uD83D without a following \uDCxx). Fix the
subgraph to emit raw UTF-8 or correctly paired surrogate escapes.
```

No behaviour change — the response is still rejected. Only the error message is improved.

Also adds a `mod unicode` test suite covering valid encodings (raw UTF-8, proper surrogate pairs, BMP+non-BMP mix) and the two lone-surrogate failure cases.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
