### PR TITLE
fix(composition): update connect spec logic to match JS

### DIFF
--- a/apollo-federation/src/connectors/expand/snapshots/apollo_federation__connectors__expand__carryover__tests__carryover_fixes_empty_graphs.snap
+++ b/apollo-federation/src/connectors/expand/snapshots/apollo_federation__connectors__expand__carryover__tests__carryover_fixes_empty_graphs.snap
@@ -63,10 +63,26 @@ scalar connect__JSONSelection @join__type(graph: CONNECTOR)
 
 scalar connect__URLTemplate @join__type(graph: CONNECTOR)
 
+input connect__ConnectorErrors @join__type(graph: CONNECTOR) {
+  message: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
+  extensions: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
+}
+
 input connect__HTTPHeaderMapping @join__type(graph: CONNECTOR) {
   name: String! @join__field(graph: CONNECTOR, type: "String!")
   from: String @join__field(graph: CONNECTOR, type: "String")
-  value: [String!] @join__field(graph: CONNECTOR, type: "[String!]")
+  value: String @join__field(graph: CONNECTOR, type: "String")
+}
+
+input connect__ConnectBatch @join__type(graph: CONNECTOR) {
+  maxSize: Int @join__field(graph: CONNECTOR, type: "Int")
+}
+
+input connect__SourceHTTP @join__type(graph: CONNECTOR) {
+  baseURL: String! @join__field(graph: CONNECTOR, type: "String!")
+  headers: [connect__HTTPHeaderMapping!] @join__field(graph: CONNECTOR, type: "[connect__HTTPHeaderMapping!]")
+  path: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
+  queryParams: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
 }
 
 input connect__ConnectHTTP @join__type(graph: CONNECTOR) {
@@ -76,22 +92,6 @@ input connect__ConnectHTTP @join__type(graph: CONNECTOR) {
   PATCH: connect__URLTemplate @join__field(graph: CONNECTOR, type: "connect__URLTemplate")
   DELETE: connect__URLTemplate @join__field(graph: CONNECTOR, type: "connect__URLTemplate")
   body: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
-  headers: [connect__HTTPHeaderMapping!] @join__field(graph: CONNECTOR, type: "[connect__HTTPHeaderMapping!]")
-  path: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
-  queryParams: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
-}
-
-input connect__ConnectBatch @join__type(graph: CONNECTOR) {
-  maxSize: Int @join__field(graph: CONNECTOR, type: "Int")
-}
-
-input connect__ConnectorErrors @join__type(graph: CONNECTOR) {
-  message: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
-  extensions: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
-}
-
-input connect__SourceHTTP @join__type(graph: CONNECTOR) {
-  baseURL: String! @join__field(graph: CONNECTOR, type: "String!")
   headers: [connect__HTTPHeaderMapping!] @join__field(graph: CONNECTOR, type: "[connect__HTTPHeaderMapping!]")
   path: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")
   queryParams: connect__JSONSelection @join__field(graph: CONNECTOR, type: "connect__JSONSelection")

--- a/apollo-federation/src/connectors/spec/connect.rs
+++ b/apollo-federation/src/connectors/spec/connect.rs
@@ -481,7 +481,7 @@ mod tests {
 
         insta::assert_snapshot!(
             actual_definition.to_string(),
-            @"directive @connect(source: String, http: connect__ConnectHTTP, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection, selection: connect__JSONSelection!, entity: Boolean = false, id: String) repeatable on FIELD_DEFINITION | OBJECT"
+            @"directive @connect(source: String, id: String, http: connect__ConnectHTTP!, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, selection: connect__JSONSelection!, entity: Boolean = false, isSuccess: connect__JSONSelection) repeatable on FIELD_DEFINITION | OBJECT"
         );
 
         let fields = schema

--- a/apollo-federation/src/connectors/spec/source.rs
+++ b/apollo-federation/src/connectors/spec/source.rs
@@ -280,7 +280,7 @@ mod tests {
             .get(subgraph.schema.schema())
             .unwrap();
 
-        insta::assert_snapshot!(actual_definition.to_string(), @"directive @source(name: String!, http: connect__SourceHTTP, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA");
+        insta::assert_snapshot!(actual_definition.to_string(), @"directive @source(name: String!, http: connect__SourceHTTP!, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA");
 
         insta::assert_debug_snapshot!(
             subgraph.schema

--- a/apollo-federation/src/connectors/spec/type_and_directive_specifications.rs
+++ b/apollo-federation/src/connectors/spec/type_and_directive_specifications.rs
@@ -35,10 +35,11 @@ use super::source::BaseUrl;
 use super::source::SOURCE_DIRECTIVE_NAME_IN_SPEC;
 use super::source::SOURCE_HTTP_NAME_IN_SPEC;
 use super::source::SOURCE_NAME_ARGUMENT_NAME;
-use crate::connectors::spec::ConnectSpec;
-use crate::error::SingleFederationError;
+use crate::bail;
+use crate::error::FederationError;
 use crate::link::Link;
 use crate::schema::FederationSchema;
+use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::type_and_directive_specification::ArgumentSpecification;
 use crate::schema::type_and_directive_specification::DirectiveArgumentSpecification;
 use crate::schema::type_and_directive_specification::DirectiveSpecification;
@@ -46,39 +47,70 @@ use crate::schema::type_and_directive_specification::InputObjectTypeSpecificatio
 use crate::schema::type_and_directive_specification::ScalarTypeSpecification;
 use crate::schema::type_and_directive_specification::TypeAndDirectiveSpecification;
 
-macro_rules! internal {
-    ($s:expr) => {
-        SingleFederationError::Internal {
-            message: $s.to_string(),
-        }
-    };
-}
-
-fn link(s: &FederationSchema) -> Result<Arc<Link>, SingleFederationError> {
-    s.metadata()
-        .ok_or_else(|| internal!("missing metadata"))?
-        .for_identity(&ConnectSpec::identity())
-        .ok_or_else(|| internal!("missing connect spec"))
-}
-
 pub(crate) const JSON_SELECTION_SCALAR_NAME: Name = name!("JSONSelection");
 
+pub(crate) fn type_specifications() -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
+    vec![
+        Box::new(json_selection_spec()),
+        Box::new(url_path_template_spec()),
+        Box::new(connector_errors_spec()),
+        Box::new(http_header_mapping_spec()),
+        Box::new(connect_batch_spec()),
+        Box::new(source_http_spec()),
+        Box::new(connect_http_spec()),
+    ]
+}
+
+// scalar JSONSelection
 fn json_selection_spec() -> ScalarTypeSpecification {
     ScalarTypeSpecification {
         name: JSON_SELECTION_SCALAR_NAME,
     }
 }
 
+// scalar URLPathTemplate
 fn url_path_template_spec() -> ScalarTypeSpecification {
     ScalarTypeSpecification {
         name: URL_PATH_TEMPLATE_SCALAR_NAME,
     }
 }
 
+// input ConnectorErrors {
+//   message: JSONSelection
+//   extensions: JSONSelection
+// }
+fn connector_errors_spec() -> InputObjectTypeSpecification {
+    InputObjectTypeSpecification {
+        name: ERRORS_NAME_IN_SPEC,
+        fields: |_| {
+            Vec::from_iter([
+                ArgumentSpecification {
+                    name: name!(message),
+                    get_type: |schema, link| {
+                        let json_selection_name =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_selection_name))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: name!(extensions),
+                    get_type: |schema, link| {
+                        let json_selection_name =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_selection_name))
+                    },
+                    default_value: Default::default(),
+                },
+            ])
+        },
+    }
+}
+
 // input HTTPHeaderMapping {
 //   name: String!
-//   as: String
-//   value: [String!]
+//   from: String
+//   value: String
 // }
 fn http_header_mapping_spec() -> InputObjectTypeSpecification {
     InputObjectTypeSpecification {
@@ -97,100 +129,7 @@ fn http_header_mapping_spec() -> InputObjectTypeSpecification {
                 },
                 ArgumentSpecification {
                     name: HTTP_HEADER_MAPPING_VALUE_ARGUMENT_NAME,
-                    get_type: |_, _| Ok(ty!([String!])),
-                    default_value: Default::default(),
-                },
-            ])
-        },
-    }
-}
-
-// input ConnectHTTP {
-//   GET: URLTemplate
-//   POST: URLTemplate
-//   PUT: URLTemplate
-//   PATCH: URLTemplate
-//   DELETE: URLTemplate
-//   body: JSONSelection
-//   headers: [HTTPHeaderMapping!]
-//   path: JSONSelection
-//   queryParams: JSONSelection
-// }
-fn connect_http_spec() -> InputObjectTypeSpecification {
-    InputObjectTypeSpecification {
-        name: CONNECT_HTTP_NAME_IN_SPEC,
-        fields: |_| {
-            Vec::from_iter([
-                ArgumentSpecification {
-                    name: name!(GET),
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: name!(POST),
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: name!(PUT),
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: name!(PATCH),
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: name!(DELETE),
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: CONNECT_BODY_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: HEADERS_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&HTTP_HEADER_MAPPING_NAME_IN_SPEC);
-                        Ok(Type::List(Box::new(Type::NonNullNamed(name))))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: PATH_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: QUERY_PARAMS_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
+                    get_type: |_, _| Ok(ty!(String)),
                     default_value: Default::default(),
                 },
             ])
@@ -214,39 +153,11 @@ fn connect_batch_spec() -> InputObjectTypeSpecification {
     }
 }
 
-// input ConnectorErrors {
-//   message: JSONSelection
-//   extensions: JSONSelection
-// }
-fn connector_errors_spec() -> InputObjectTypeSpecification {
-    InputObjectTypeSpecification {
-        name: ERRORS_NAME_IN_SPEC,
-        fields: |_| {
-            Vec::from_iter([
-                ArgumentSpecification {
-                    name: name!(message),
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-                ArgumentSpecification {
-                    name: name!(extensions),
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: Default::default(),
-                },
-            ])
-        },
-    }
-}
-
 // input SourceHTTP {
 //   baseURL: String!
 //   headers: [HTTPHeaderMapping!]
+//
+//   # added in v0.2
 //   path: JSONSelection
 //   queryParams: JSONSelection
 // }
@@ -262,25 +173,33 @@ fn source_http_spec() -> InputObjectTypeSpecification {
                 },
                 ArgumentSpecification {
                     name: HEADERS_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&HTTP_HEADER_MAPPING_NAME_IN_SPEC);
-                        Ok(Type::List(Box::new(Type::NonNullNamed(name))))
+                    get_type: |schema, link| {
+                        let http_header_mapping = lookup_input_object_in_schema(
+                            &HTTP_HEADER_MAPPING_NAME_IN_SPEC,
+                            schema,
+                            link,
+                        )?;
+                        Ok(Type::List(Box::new(Type::NonNullNamed(
+                            http_header_mapping,
+                        ))))
                     },
                     default_value: Default::default(),
                 },
                 ArgumentSpecification {
                     name: PATH_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
+                    get_type: |schema, link| {
+                        let json_scalar_name =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_scalar_name))
                     },
                     default_value: Default::default(),
                 },
                 ArgumentSpecification {
                     name: QUERY_PARAMS_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
+                    get_type: |schema, link| {
+                        let json_scalar_name =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_scalar_name))
                     },
                     default_value: Default::default(),
                 },
@@ -289,15 +208,119 @@ fn source_http_spec() -> InputObjectTypeSpecification {
     }
 }
 
-pub(crate) fn type_specifications() -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
+// input ConnectHTTP {
+//   GET: URLPathTemplate
+//   POST: URLPathTemplate
+//   PUT: URLPathTemplate
+//   PATCH: URLPathTemplate
+//   DELETE: URLPathTemplate
+//   body: JSONSelection
+//   headers: [HTTPHeaderMapping!]
+//
+//   # added in v0.2
+//   path: JSONSelection
+//   queryParams: JSONSelection
+// }
+fn connect_http_spec() -> InputObjectTypeSpecification {
+    InputObjectTypeSpecification {
+        name: CONNECT_HTTP_NAME_IN_SPEC,
+        fields: |_| {
+            Vec::from_iter([
+                ArgumentSpecification {
+                    name: name!(GET),
+                    get_type: |schema, link| {
+                        let url_path_template_scalar =
+                            lookup_scalar_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(url_path_template_scalar))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: name!(POST),
+                    get_type: |schema, link| {
+                        let url_path_template_scalar =
+                            lookup_scalar_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(url_path_template_scalar))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: name!(PUT),
+                    get_type: |schema, link| {
+                        let url_path_template_scalar =
+                            lookup_scalar_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(url_path_template_scalar))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: name!(PATCH),
+                    get_type: |schema, link| {
+                        let url_path_template_scalar =
+                            lookup_scalar_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(url_path_template_scalar))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: name!(DELETE),
+                    get_type: |schema, link| {
+                        let url_path_template_scalar =
+                            lookup_scalar_in_schema(&URL_PATH_TEMPLATE_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(url_path_template_scalar))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: CONNECT_BODY_ARGUMENT_NAME,
+                    get_type: |schema, link| {
+                        let json_selection_scalar =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_selection_scalar))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: HEADERS_ARGUMENT_NAME,
+                    get_type: |schema, link| {
+                        let http_header_mapping = lookup_input_object_in_schema(
+                            &HTTP_HEADER_MAPPING_NAME_IN_SPEC,
+                            schema,
+                            link,
+                        )?;
+                        Ok(Type::List(Box::new(Type::NonNullNamed(
+                            http_header_mapping,
+                        ))))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: PATH_ARGUMENT_NAME,
+                    get_type: |schema, link| {
+                        let json_selection_scalar =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_selection_scalar))
+                    },
+                    default_value: Default::default(),
+                },
+                ArgumentSpecification {
+                    name: QUERY_PARAMS_ARGUMENT_NAME,
+                    get_type: |schema, link| {
+                        let json_selection_scalar =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_selection_scalar))
+                    },
+                    default_value: Default::default(),
+                },
+            ])
+        },
+    }
+}
+
+pub(crate) fn directive_specifications() -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
     vec![
-        Box::new(json_selection_spec()),
-        Box::new(url_path_template_spec()),
-        Box::new(http_header_mapping_spec()),
-        Box::new(connect_http_spec()),
-        Box::new(connect_batch_spec()),
-        Box::new(connector_errors_spec()),
-        Box::new(source_http_spec()),
+        Box::new(connect_directive_spec()),
+        Box::new(source_directive_spec()),
     ]
 }
 
@@ -311,13 +334,14 @@ pub(crate) fn type_specifications() -> Vec<Box<dyn TypeAndDirectiveSpecification
 //
 // connect/v0.2:
 // directive @connect(
-//   id: String
 //   source: String
-//   http: ConnectHTTP
+//   id: String
+//   http: ConnectHTTP!
+//   batch: ConnectBatch
+//   errors: ConnectorErrors
 //   selection: JSONSelection!
 //   entity: Boolean = false
-//   batch: ConnectBatch
-//   errors: ConnectErrors
+//   isSuccess: JSONSelection
 // ) repeatable on FIELD_DEFINITION | OBJECT
 fn connect_directive_spec() -> DirectiveSpecification {
     DirectiveSpecification::new(
@@ -332,11 +356,23 @@ fn connect_directive_spec() -> DirectiveSpecification {
                 composition_strategy: None,
             },
             DirectiveArgumentSpecification {
+                composition_strategy: None,
+                base_spec: ArgumentSpecification {
+                    name: CONNECT_ID_ARGUMENT_NAME,
+                    get_type: |_, _| Ok(ty!(String)),
+                    default_value: None,
+                },
+            },
+            DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: HTTP_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&CONNECT_HTTP_NAME_IN_SPEC);
-                        Ok(Type::Named(name))
+                    get_type: |schema, link| {
+                        let connect_http_input = lookup_input_object_in_schema(
+                            &CONNECT_HTTP_NAME_IN_SPEC,
+                            schema,
+                            link,
+                        )?;
+                        Ok(Type::NonNullNamed(connect_http_input))
                     },
                     default_value: None,
                 },
@@ -345,9 +381,13 @@ fn connect_directive_spec() -> DirectiveSpecification {
             DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: BATCH_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&CONNECT_BATCH_NAME_IN_SPEC);
-                        Ok(Type::Named(name))
+                    get_type: |schema, link| {
+                        let batch_argument_input = lookup_input_object_in_schema(
+                            &CONNECT_BATCH_NAME_IN_SPEC,
+                            schema,
+                            link,
+                        )?;
+                        Ok(Type::Named(batch_argument_input))
                     },
                     default_value: None,
                 },
@@ -356,20 +396,10 @@ fn connect_directive_spec() -> DirectiveSpecification {
             DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: ERRORS_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&ERRORS_NAME_IN_SPEC);
-                        Ok(Type::Named(name))
-                    },
-                    default_value: None,
-                },
-                composition_strategy: None,
-            },
-            DirectiveArgumentSpecification {
-                base_spec: ArgumentSpecification {
-                    name: IS_SUCCESS_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
+                    get_type: |schema, link| {
+                        let connector_errors_input =
+                            lookup_input_object_in_schema(&ERRORS_NAME_IN_SPEC, schema, link)?;
+                        Ok(Type::Named(connector_errors_input))
                     },
                     default_value: None,
                 },
@@ -378,9 +408,10 @@ fn connect_directive_spec() -> DirectiveSpecification {
             DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: CONNECT_SELECTION_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::NonNullNamed(name))
+                    get_type: |schema, link| {
+                        let json_selection_scalar =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::NonNullNamed(json_selection_scalar))
                     },
                     default_value: None,
                 },
@@ -389,18 +420,22 @@ fn connect_directive_spec() -> DirectiveSpecification {
             DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: CONNECT_ENTITY_ARGUMENT_NAME,
-                    get_type: |_, _| Ok(Type::Named(name!(Boolean))),
+                    get_type: |_, _| Ok(ty!(Boolean)),
                     default_value: Some(Value::Boolean(false)),
                 },
                 composition_strategy: None,
             },
             DirectiveArgumentSpecification {
-                composition_strategy: None,
                 base_spec: ArgumentSpecification {
-                    name: CONNECT_ID_ARGUMENT_NAME,
-                    get_type: |_, _| Ok(ty!(String)),
+                    name: IS_SUCCESS_ARGUMENT_NAME,
+                    get_type: |schema, link| {
+                        let json_selection_scalar =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_selection_scalar))
+                    },
                     default_value: None,
                 },
+                composition_strategy: None,
             },
         ],
         true,
@@ -408,14 +443,24 @@ fn connect_directive_spec() -> DirectiveSpecification {
             DirectiveLocation::FieldDefinition,
             DirectiveLocation::Object,
         ],
+        // TODO connectors use custom logic to merge them using join_directive
+        //  we should update this logic to a more generic mechanism introduced with @cacheTag
         None,
+        // Some(DirectiveCompositionOptions {
+        //     supergraph_specification: &|v| {
+        //         CONNECT_VERSIONS.get_dyn_minimum_required_version(v)
+        //     },
+        //     static_argument_transform: None,
+        //     use_join_directive: true,
+        // }),
     )
 }
 
 // directive @source(
 //   name: String!
-//   http: SourceHTTP
+//   http: SourceHTTP!
 //   errors: ConnectorErrors
+//   isSuccess: JSONSelection
 // ) repeatable on SCHEMA
 fn source_directive_spec() -> DirectiveSpecification {
     DirectiveSpecification::new(
@@ -432,9 +477,10 @@ fn source_directive_spec() -> DirectiveSpecification {
             DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: HTTP_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&SOURCE_HTTP_NAME_IN_SPEC);
-                        Ok(Type::Named(name))
+                    get_type: |schema, link| {
+                        let source_http_input =
+                            lookup_input_object_in_schema(&SOURCE_HTTP_NAME_IN_SPEC, schema, link)?;
+                        Ok(Type::NonNullNamed(source_http_input))
                     },
                     default_value: None,
                 },
@@ -443,9 +489,10 @@ fn source_directive_spec() -> DirectiveSpecification {
             DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: ERRORS_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&ERRORS_NAME_IN_SPEC);
-                        Ok(Type::Named(name))
+                    get_type: |schema, link| {
+                        let connector_errors_input =
+                            lookup_input_object_in_schema(&ERRORS_NAME_IN_SPEC, schema, link)?;
+                        Ok(Type::Named(connector_errors_input))
                     },
                     default_value: None,
                 },
@@ -454,9 +501,10 @@ fn source_directive_spec() -> DirectiveSpecification {
             DirectiveArgumentSpecification {
                 base_spec: ArgumentSpecification {
                     name: IS_SUCCESS_ARGUMENT_NAME,
-                    get_type: |s, _| {
-                        let name = link(s)?.type_name_in_schema(&JSON_SELECTION_SCALAR_NAME);
-                        Ok(Type::Named(name))
+                    get_type: |schema, link| {
+                        let json_selection_scalar =
+                            lookup_scalar_in_schema(&JSON_SELECTION_SCALAR_NAME, schema, link)?;
+                        Ok(Type::Named(json_selection_scalar))
                     },
                     default_value: None,
                 },
@@ -469,77 +517,160 @@ fn source_directive_spec() -> DirectiveSpecification {
     )
 }
 
-pub(crate) fn directive_specifications() -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
-    vec![
-        Box::new(connect_directive_spec()),
-        Box::new(source_directive_spec()),
-    ]
+fn lookup_feature_type_in_schema(
+    name: &Name,
+    schema: &FederationSchema,
+    link: Option<&Arc<Link>>,
+) -> Result<TypeDefinitionPosition, FederationError> {
+    let Some(link) = link else {
+        bail!("Type {name} shouldn't be added without being attached to a @connect spec")
+    };
+    let actual_name = link.type_name_in_schema(name);
+    schema.get_type(actual_name)
+}
+
+fn lookup_scalar_in_schema(
+    name: &Name,
+    schema: &FederationSchema,
+    link: Option<&Arc<Link>>,
+) -> Result<Name, FederationError> {
+    let actual_type = lookup_feature_type_in_schema(name, schema, link)?;
+    if !matches!(actual_type, TypeDefinitionPosition::Scalar(_)) {
+        bail!("Expected type {name} to be Scalar but it was {actual_type}")
+    }
+    Ok(actual_type.type_name().clone())
+}
+
+fn lookup_input_object_in_schema(
+    name: &Name,
+    schema: &FederationSchema,
+    link: Option<&Arc<Link>>,
+) -> Result<Name, FederationError> {
+    let actual_type = lookup_feature_type_in_schema(name, schema, link)?;
+    if !matches!(actual_type, TypeDefinitionPosition::InputObject(_)) {
+        bail!("Expected type {name} to be InputObject but it was {actual_type}")
+    }
+    Ok(actual_type.type_name().clone())
 }
 
 #[cfg(test)]
 mod tests {
-    use apollo_compiler::Schema;
     use insta::assert_snapshot;
 
-    use crate::connectors::spec::CONNECT_VERSIONS;
-    use crate::connectors::spec::ConnectSpec;
-    use crate::link::spec_definition::SpecDefinition;
-    use crate::schema::FederationSchema;
+    use crate::subgraph::typestate::Subgraph;
 
     #[test]
-    fn test() {
-        let schema = Schema::parse(r#"
-        type Query { hello: String }
-        extend schema
-          @link(url: "https://specs.apollo.dev/link/v1.0")
-          @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"])
-        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-        enum link__Purpose { SECURITY EXECUTION }
-        scalar link__Import
-        "#, "schema.graphql").unwrap();
+    fn expands_connect_v01() {
+        let sdl = r#"
+            type Query { hello: String }
+            extend schema
+              @link(url: "https://specs.apollo.dev/federation/v2.10")
+              @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"])
+        "#;
 
-        let mut federation_schema = FederationSchema::new(schema).unwrap();
-        let link = federation_schema
-            .metadata()
-            .unwrap()
-            .for_identity(&ConnectSpec::identity())
-            .unwrap();
-
-        let spec = CONNECT_VERSIONS.find(&link.url.version).unwrap();
-        spec.add_elements_to_schema(&mut federation_schema).unwrap();
-
-        assert_snapshot!(federation_schema.schema().serialize().to_string(), @r#"
+        let subgraph = Subgraph::parse("s1", "http://s1", sdl)
+            .expect("parsed successfully")
+            .expand_links()
+            .expect("expanded successfully");
+        assert_snapshot!(subgraph.schema_string(), @r#"
         schema {
           query: Query
         }
 
-        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"])
+        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.10") @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"])
 
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-        directive @connect(source: String, http: connect__ConnectHTTP, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection, selection: connect__JSONSelection!, entity: Boolean = false, id: String) repeatable on FIELD_DEFINITION | OBJECT
+        directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-        directive @source(name: String!, http: connect__SourceHTTP, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA
+        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+        directive @federation__extends on OBJECT | INTERFACE
+
+        directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+
+        directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+        directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+        directive @federation__interfaceObject on OBJECT
+
+        directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+        directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+        directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+        directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+        directive @connect(source: String, id: String, http: connect__ConnectHTTP!, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, selection: connect__JSONSelection!, entity: Boolean = false, isSuccess: connect__JSONSelection) repeatable on FIELD_DEFINITION | OBJECT
+
+        directive @source(name: String!, http: connect__SourceHTTP!, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA
 
         type Query {
           hello: String
+          _service: _Service!
         }
 
         enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
           SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
           EXECUTION
         }
 
         scalar link__Import
 
+        scalar federation__FieldSet
+
+        scalar federation__Scope
+
+        scalar federation__Policy
+
+        scalar federation__ContextFieldValue
+
         scalar connect__JSONSelection
 
         scalar connect__URLTemplate
 
+        input connect__ConnectorErrors {
+          message: connect__JSONSelection
+          extensions: connect__JSONSelection
+        }
+
         input connect__HTTPHeaderMapping {
           name: String!
           from: String
-          value: [String!]
+          value: String
+        }
+
+        input connect__ConnectBatch {
+          maxSize: Int
+        }
+
+        input connect__SourceHTTP {
+          baseURL: String!
+          headers: [connect__HTTPHeaderMapping!]
+          path: connect__JSONSelection
+          queryParams: connect__JSONSelection
         }
 
         input connect__ConnectHTTP {
@@ -554,13 +685,119 @@ mod tests {
           queryParams: connect__JSONSelection
         }
 
-        input connect__ConnectBatch {
-          maxSize: Int
+        scalar _Any
+
+        type _Service {
+          sdl: String
         }
+        "#);
+    }
+
+    #[test]
+    fn expands_connect_v0_2() {
+        let sdl = r#"
+        type Query { hello: String }
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.11")
+          @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@source"])
+        "#;
+
+        let subgraph = Subgraph::parse("s1", "http://s1", sdl)
+            .expect("parsed successfully")
+            .expand_links()
+            .expect("expanded successfully");
+        assert_snapshot!(subgraph.schema_string(), @r#"
+        schema {
+          query: Query
+        }
+
+        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@source"])
+
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+        directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+        directive @federation__extends on OBJECT | INTERFACE
+
+        directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+
+        directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+        directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+        directive @federation__interfaceObject on OBJECT
+
+        directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+        directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+        directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+        directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+        directive @connect(source: String, id: String, http: connect__ConnectHTTP!, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, selection: connect__JSONSelection!, entity: Boolean = false, isSuccess: connect__JSONSelection) repeatable on FIELD_DEFINITION | OBJECT
+
+        directive @source(name: String!, http: connect__SourceHTTP!, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA
+
+        type Query {
+          hello: String
+          _service: _Service!
+        }
+
+        enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
+
+        scalar link__Import
+
+        scalar federation__FieldSet
+
+        scalar federation__Scope
+
+        scalar federation__Policy
+
+        scalar federation__ContextFieldValue
+
+        scalar connect__JSONSelection
+
+        scalar connect__URLTemplate
 
         input connect__ConnectorErrors {
           message: connect__JSONSelection
           extensions: connect__JSONSelection
+        }
+
+        input connect__HTTPHeaderMapping {
+          name: String!
+          from: String
+          value: String
+        }
+
+        input connect__ConnectBatch {
+          maxSize: Int
         }
 
         input connect__SourceHTTP {
@@ -569,32 +806,41 @@ mod tests {
           path: connect__JSONSelection
           queryParams: connect__JSONSelection
         }
+
+        input connect__ConnectHTTP {
+          GET: connect__URLTemplate
+          POST: connect__URLTemplate
+          PUT: connect__URLTemplate
+          PATCH: connect__URLTemplate
+          DELETE: connect__URLTemplate
+          body: connect__JSONSelection
+          headers: [connect__HTTPHeaderMapping!]
+          path: connect__JSONSelection
+          queryParams: connect__JSONSelection
+        }
+
+        scalar _Any
+
+        type _Service {
+          sdl: String
+        }
         "#);
     }
 
     #[test]
-    fn test_v0_2() {
-        let schema = Schema::parse(r#"
-        type Query { hello: String }
-        extend schema
-          @link(url: "https://specs.apollo.dev/link/v1.0")
-          @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@source"])
-        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-        enum link__Purpose { SECURITY EXECUTION }
-        scalar link__Import
-        "#, "schema.graphql").unwrap();
+    fn expands_connect_v0_2_with_explicit_link_spec_no_federation() {
+        let sdl = r#"
+            type Query { hello: String }
+            extend schema
+              @link(url: "https://specs.apollo.dev/link/v1.0")
+              @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@source"])
+        "#;
 
-        let mut federation_schema = FederationSchema::new(schema).unwrap();
-        let link = federation_schema
-            .metadata()
-            .unwrap()
-            .for_identity(&ConnectSpec::identity())
-            .unwrap();
-
-        let spec = CONNECT_VERSIONS.find(&link.url.version).unwrap();
-        spec.add_elements_to_schema(&mut federation_schema).unwrap();
-
-        assert_snapshot!(federation_schema.schema().serialize().to_string(), @r#"
+        let subgraph = Subgraph::parse("s1", "http://s1", sdl)
+            .expect("parsed successfully")
+            .expand_links()
+            .expect("expanded successfully");
+        assert_snapshot!(subgraph.schema_string(), @r#"
         schema {
           query: Query
         }
@@ -603,29 +849,66 @@ mod tests {
 
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-        directive @connect(source: String, http: connect__ConnectHTTP, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection, selection: connect__JSONSelection!, entity: Boolean = false, id: String) repeatable on FIELD_DEFINITION | OBJECT
+        directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-        directive @source(name: String!, http: connect__SourceHTTP, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA
+        directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+        directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+        directive @external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        directive @extends on OBJECT | INTERFACE
+
+        directive @connect(source: String, id: String, http: connect__ConnectHTTP!, batch: connect__ConnectBatch, errors: connect__ConnectorErrors, selection: connect__JSONSelection!, entity: Boolean = false, isSuccess: connect__JSONSelection) repeatable on FIELD_DEFINITION | OBJECT
+
+        directive @source(name: String!, http: connect__SourceHTTP!, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA
 
         type Query {
           hello: String
+          _service: _Service!
         }
 
         enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
           SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
           EXECUTION
         }
 
         scalar link__Import
 
+        scalar _FieldSet
+
         scalar connect__JSONSelection
 
         scalar connect__URLTemplate
 
+        input connect__ConnectorErrors {
+          message: connect__JSONSelection
+          extensions: connect__JSONSelection
+        }
+
         input connect__HTTPHeaderMapping {
           name: String!
           from: String
-          value: [String!]
+          value: String
+        }
+
+        input connect__ConnectBatch {
+          maxSize: Int
+        }
+
+        input connect__SourceHTTP {
+          baseURL: String!
+          headers: [connect__HTTPHeaderMapping!]
+          path: connect__JSONSelection
+          queryParams: connect__JSONSelection
         }
 
         input connect__ConnectHTTP {
@@ -640,83 +923,131 @@ mod tests {
           queryParams: connect__JSONSelection
         }
 
-        input connect__ConnectBatch {
-          maxSize: Int
-        }
+        scalar _Any
 
-        input connect__ConnectorErrors {
-          message: connect__JSONSelection
-          extensions: connect__JSONSelection
-        }
-
-        input connect__SourceHTTP {
-          baseURL: String!
-          headers: [connect__HTTPHeaderMapping!]
-          path: connect__JSONSelection
-          queryParams: connect__JSONSelection
+        type _Service {
+          sdl: String
         }
         "#);
     }
 
     #[test]
     fn test_v0_2_renames() {
-        let schema = Schema::parse(r#"
-        type Query { hello: String }
-        extend schema
-          @link(url: "https://specs.apollo.dev/link/v1.0")
-          @link(url: "https://specs.apollo.dev/connect/v0.2", import: [
-            { name: "@source" as: "@api" }
-            { name: "JSONSelection" as: "Mapping" }
-            { name: "ConnectorErrors" as: "ErrorMappings" }
-            "ConnectHTTP"
-          ])
-        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-        enum link__Purpose { SECURITY EXECUTION }
-        scalar link__Import
-        "#, "schema.graphql").unwrap();
+        let sdl = r#"
+            type Query { hello: String }
+            extend schema
+              @link(url: "https://specs.apollo.dev/federation/v2.11")
+              @link(url: "https://specs.apollo.dev/connect/v0.2", import: [
+                { name: "@source" as: "@api" }
+                { name: "JSONSelection" as: "Mapping" }
+                { name: "ConnectorErrors" as: "ErrorMappings" }
+                "ConnectHTTP"
+              ])
+        "#;
 
-        let mut federation_schema = FederationSchema::new(schema).unwrap();
-        let link = federation_schema
-            .metadata()
-            .unwrap()
-            .for_identity(&ConnectSpec::identity())
-            .unwrap();
-
-        let spec = CONNECT_VERSIONS.find(&link.url.version).unwrap();
-        spec.add_elements_to_schema(&mut federation_schema).unwrap();
-
-        assert_snapshot!(federation_schema.schema().serialize().to_string(), @r#"
+        let subgraph = Subgraph::parse("s1", "http://s1", sdl)
+            .expect("parsed successfully")
+            .expand_links()
+            .expect("expanded successfully");
+        assert_snapshot!(subgraph.schema_string(), @r#"
         schema {
           query: Query
         }
 
-        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/connect/v0.2", import: [{name: "@source", as: "@api"}, {name: "JSONSelection", as: "Mapping"}, {name: "ConnectorErrors", as: "ErrorMappings"}, "ConnectHTTP"])
+        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2", import: [{name: "@source", as: "@api"}, {name: "JSONSelection", as: "Mapping"}, {name: "ConnectorErrors", as: "ErrorMappings"}, "ConnectHTTP"])
 
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-        directive @connect(source: String, http: ConnectHTTP, batch: connect__ConnectBatch, errors: ErrorMappings, isSuccess: Mapping, selection: Mapping!, entity: Boolean = false, id: String) repeatable on FIELD_DEFINITION | OBJECT
+        directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-        directive @api(name: String!, http: connect__SourceHTTP, errors: ErrorMappings, isSuccess: Mapping) repeatable on SCHEMA
+        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+        directive @federation__extends on OBJECT | INTERFACE
+
+        directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+
+        directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+        directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+        directive @federation__interfaceObject on OBJECT
+
+        directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+        directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+        directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+        directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+        directive @connect(source: String, id: String, http: ConnectHTTP!, batch: connect__ConnectBatch, errors: ErrorMappings, selection: Mapping!, entity: Boolean = false, isSuccess: Mapping) repeatable on FIELD_DEFINITION | OBJECT
+
+        directive @api(name: String!, http: connect__SourceHTTP!, errors: ErrorMappings, isSuccess: Mapping) repeatable on SCHEMA
 
         type Query {
           hello: String
+          _service: _Service!
         }
 
         enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
           SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
           EXECUTION
         }
 
         scalar link__Import
 
+        scalar federation__FieldSet
+
+        scalar federation__Scope
+
+        scalar federation__Policy
+
+        scalar federation__ContextFieldValue
+
         scalar Mapping
 
         scalar connect__URLTemplate
 
+        input ErrorMappings {
+          message: Mapping
+          extensions: Mapping
+        }
+
         input connect__HTTPHeaderMapping {
           name: String!
           from: String
-          value: [String!]
+          value: String
+        }
+
+        input connect__ConnectBatch {
+          maxSize: Int
+        }
+
+        input connect__SourceHTTP {
+          baseURL: String!
+          headers: [connect__HTTPHeaderMapping!]
+          path: Mapping
+          queryParams: Mapping
         }
 
         input ConnectHTTP {
@@ -731,98 +1062,130 @@ mod tests {
           queryParams: Mapping
         }
 
-        input connect__ConnectBatch {
-          maxSize: Int
-        }
+        scalar _Any
 
-        input ErrorMappings {
-          message: Mapping
-          extensions: Mapping
-        }
-
-        input connect__SourceHTTP {
-          baseURL: String!
-          headers: [connect__HTTPHeaderMapping!]
-          path: Mapping
-          queryParams: Mapping
+        type _Service {
+          sdl: String
         }
         "#);
     }
 
     #[test]
     fn test_v0_2_compatible_defs() {
-        let schema = Schema::parse(r#"
-        type Query { hello: String }
-        extend schema
-          @link(url: "https://specs.apollo.dev/link/v1.0")
-          @link(url: "https://specs.apollo.dev/connect/v0.2")
-        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-        enum link__Purpose { SECURITY EXECUTION }
-        scalar link__Import
+        // @connect does not have all the fields and is only applicable on FIELD_DEFINITION
+        let sdl = r#"
+            type Query { hello: String }
+            extend schema
+              @link(url: "https://specs.apollo.dev/federation/v2.11")
+              @link(url: "https://specs.apollo.dev/connect/v0.2")
 
-        scalar connect__URLTemplate
-        scalar connect__JSONSelection
-        input connect__ConnectHTTP {
-          GET: connect__URLTemplate
-        }
-        directive @connect(source: String, http: connect__ConnectHTTP, selection: connect__JSONSelection!) repeatable on FIELD_DEFINITION
-        "#, "schema.graphql").unwrap();
+            scalar connect__JSONSelection
+            input connect__ConnectHTTP {
+              GET: connect__URLTemplate
+            }
+            directive @connect(source: String, http: connect__ConnectHTTP!, selection: connect__JSONSelection!) repeatable on FIELD_DEFINITION
+        "#;
 
-        let mut federation_schema = FederationSchema::new(schema).unwrap();
-        let link = federation_schema
-            .metadata()
-            .unwrap()
-            .for_identity(&ConnectSpec::identity())
-            .unwrap();
-
-        let spec = CONNECT_VERSIONS.find(&link.url.version).unwrap();
-        spec.add_elements_to_schema(&mut federation_schema).unwrap();
-
-        assert_snapshot!(federation_schema.schema().serialize().to_string(), @r#"
+        let subgraph = Subgraph::parse("s1", "http://s1", sdl)
+            .expect("parsed successfully")
+            .expand_links()
+            .expect("expanded successfully");
+        assert_snapshot!(subgraph.schema_string(), @r#"
         schema {
           query: Query
         }
 
-        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/connect/v0.2")
+        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2")
+
+        directive @connect(source: String, http: connect__ConnectHTTP!, selection: connect__JSONSelection!) repeatable on FIELD_DEFINITION
 
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-        directive @connect(source: String, http: connect__ConnectHTTP, selection: connect__JSONSelection!) repeatable on FIELD_DEFINITION
+        directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-        directive @connect__source(name: String!, http: connect__SourceHTTP, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA
+        directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+        directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+        directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+        directive @federation__extends on OBJECT | INTERFACE
+
+        directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+
+        directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+        directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+        directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+        directive @federation__interfaceObject on OBJECT
+
+        directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+        directive @federation__context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+        directive @federation__fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+        directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+        directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+        directive @connect__source(name: String!, http: connect__SourceHTTP!, errors: connect__ConnectorErrors, isSuccess: connect__JSONSelection) repeatable on SCHEMA
 
         type Query {
           hello: String
+          _service: _Service!
+        }
+
+        scalar connect__JSONSelection
+
+        input connect__ConnectHTTP {
+          GET: connect__URLTemplate
         }
 
         enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
           SECURITY
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
           EXECUTION
         }
 
         scalar link__Import
 
+        scalar federation__FieldSet
+
+        scalar federation__Scope
+
+        scalar federation__Policy
+
+        scalar federation__ContextFieldValue
+
         scalar connect__URLTemplate
 
-        scalar connect__JSONSelection
-
-        input connect__ConnectHTTP {
-          GET: connect__URLTemplate
+        input connect__ConnectorErrors {
+          message: connect__JSONSelection
+          extensions: connect__JSONSelection
         }
 
         input connect__HTTPHeaderMapping {
           name: String!
           from: String
-          value: [String!]
+          value: String
         }
 
         input connect__ConnectBatch {
           maxSize: Int
-        }
-
-        input connect__ConnectorErrors {
-          message: connect__JSONSelection
-          extensions: connect__JSONSelection
         }
 
         input connect__SourceHTTP {
@@ -831,37 +1194,38 @@ mod tests {
           path: connect__JSONSelection
           queryParams: connect__JSONSelection
         }
+
+        scalar _Any
+
+        type _Service {
+          sdl: String
+        }
         "#);
     }
 
     #[test]
     fn test_v0_2_incompatible_defs() {
-        let schema = Schema::parse(r#"
-        type Query { hello: String }
-        extend schema
-          @link(url: "https://specs.apollo.dev/link/v1.0")
-          @link(url: "https://specs.apollo.dev/connect/v0.2")
-        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-        enum link__Purpose { SECURITY EXECUTION }
-        scalar link__Import
+        // @connect entity is a Boolean but redefined as a String!
+        let sdl = r#"
+            type Query { hello: String }
+            extend schema
+              @link(url: "https://specs.apollo.dev/federation/v2.11")
+              @link(url: "https://specs.apollo.dev/connect/v0.2")
 
-        scalar connect__URLTemplate
-        scalar connect__JSONSelection
-        input connect__ConnectHTTP {
-          GET: connect__URLTemplate
-        }
-        directive @connect(source: String, http: connect__ConnectHTTP, selection: connect__JSONSelection!, entity: String!) repeatable on FIELD_DEFINITION
-        "#, "schema.graphql").unwrap();
+            scalar connect__JSONSelection
+            input connect__ConnectHTTP {
+              GET: connect__URLTemplate
+            }
+            directive @connect(source: String, http: connect__ConnectHTTP!, selection: connect__JSONSelection!, entity: String!) repeatable on FIELD_DEFINITION
+        "#;
 
-        let mut federation_schema = FederationSchema::new(schema).unwrap();
-        let link = federation_schema
-            .metadata()
-            .unwrap()
-            .for_identity(&ConnectSpec::identity())
-            .unwrap();
-
-        let spec = CONNECT_VERSIONS.find(&link.url.version).unwrap();
-        let err = spec.add_elements_to_schema(&mut federation_schema).err();
-        assert_snapshot!(err.unwrap().to_string(), @r###"Invalid definition for directive "@connect": argument "entity" should have type "Boolean" but found type "String""###)
+        let subgraph_error = Subgraph::parse("s1", "http://s1", sdl)
+            .expect("parsed successfully")
+            .expand_links()
+            .expect_err("should fail");
+        assert_eq!(
+            subgraph_error.to_string().trim(),
+            r###"DIRECTIVE_DEFINITION_INVALID [s1] Invalid definition for directive "@connect": argument "entity" should have type "Boolean" but found type "String""###
+        );
     }
 }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -83,6 +83,7 @@ use crate::schema::position::SchemaDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::referencer::DirectiveReferencers;
+use crate::schema::same_type;
 use crate::schema::type_and_directive_specification::ArgumentMerger;
 use crate::schema::type_and_directive_specification::StaticArgumentsTransform;
 use crate::schema::validators::access_control::validate_transitive_access_control_requirements_in_the_supergraph;
@@ -1918,7 +1919,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                 continue;
             };
 
-            if Self::same_type(ty, source_ty) {
+            if same_type(ty, source_ty) {
                 trace!("Types are identical");
                 continue;
             } else if let Ok(true) = self.is_strict_subtype(ty, source_ty) {
@@ -2090,18 +2091,6 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
             // Store updated usage
             self.enum_usages_mut()
                 .insert(base_type_name.to_string(), new_usage);
-        }
-    }
-
-    fn same_type(dest_type: &Type, source_type: &Type) -> bool {
-        match (dest_type, source_type) {
-            (Type::Named(n1), Type::Named(n2)) => n1 == n2,
-            (Type::NonNullNamed(n1), Type::NonNullNamed(n2)) => n1 == n2,
-            (Type::List(inner1), Type::List(inner2)) => Self::same_type(inner1, inner2),
-            (Type::NonNullList(inner1), Type::NonNullList(inner2)) => {
-                Self::same_type(inner1, inner2)
-            }
-            _ => false,
         }
     }
 

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -9,6 +9,7 @@ use apollo_compiler::Node;
 use apollo_compiler::Schema;
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::ast::Type;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::FieldSet;
@@ -1446,5 +1447,15 @@ impl SchemaElement for SchemaDefinition {
 impl SchemaElement for ExtendedType {
     fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
         self.iter_origins()
+    }
+}
+
+pub(crate) fn same_type(t1: &Type, t2: &Type) -> bool {
+    match (t1, t2) {
+        (Type::Named(n1), Type::Named(n2)) => n1 == n2,
+        (Type::NonNullNamed(n1), Type::NonNullNamed(n2)) => n1 == n2,
+        (Type::List(inner1), Type::List(inner2)) => same_type(inner1, inner2),
+        (Type::NonNullList(inner1), Type::NonNullList(inner2)) => same_type(inner1, inner2),
+        _ => false,
     }
 }

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -45,9 +45,9 @@ use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::ScalarTypeDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::position::UnionTypeDefinitionPosition;
+use crate::schema::same_type;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Validated;
-
 //////////////////////////////////////////////////////////////////////////////
 // Field and Argument Specifications
 
@@ -429,11 +429,21 @@ impl TypeAndDirectiveSpecification for EnumTypeSpecification {
     }
 }
 
+// **** WARNING: DO NOT USE ****
+//
+// Subgraph schema building, at this time of writing, does not really support
+// input objects in specs. We did a number of one-off things to support them in
+// the connect spec's case, and it will be non-maintainable/bug-prone to do them
+// again.
+//
+// There's work to be done to support input objects more generally; please see
+// https://github.com/apollographql/federation/pull/3311 for more information.
 pub(crate) struct InputObjectTypeSpecification {
     pub(crate) name: Name,
     pub(crate) fields: fn(&FederationSchema) -> Vec<ArgumentSpecification>,
 }
 
+// **** WARNING: DO NOT USE ****
 impl TypeAndDirectiveSpecification for InputObjectTypeSpecification {
     fn name(&self) -> &Name {
         &self.name
@@ -446,60 +456,118 @@ impl TypeAndDirectiveSpecification for InputObjectTypeSpecification {
     ) -> Result<(), FederationError> {
         let actual_name = actual_type_name(&self.name, link);
         let field_specs = (self.fields)(schema);
+        let resolved_specs: IndexMap<Name, ResolvedArgumentSpecification> = field_specs
+            .into_iter()
+            .map(|spec| {
+                spec.resolve(schema, link)
+                    .and_then(|r| Ok((r.name.clone(), r)))
+            })
+            .collect::<Result<IndexMap<Name, ResolvedArgumentSpecification>, FederationError>>()?;
         let existing = schema.try_get_type(actual_name.clone());
         if let Some(existing) = existing {
+            let mut errors: Vec<SingleFederationError> = vec![];
             // ensure existing definition is InputObject
             ensure_expected_type_kind(TypeKind::InputObject, &existing)?;
             let existing_type = existing.get(schema.schema())?;
-            let ExtendedType::InputObject(existing_obj_type) = existing_type else {
+            let ExtendedType::InputObject(existing_input_obj_type) = existing_type else {
                 return Err(FederationError::internal(format!(
                     "Expected ExtendedType::InputObject but got {}",
                     TypeKind::from(existing_type)
                 )));
             };
-
-            // ensure all expected fields are present in the existing object type
-            let mut new_definition_fields = Vec::with_capacity(field_specs.len());
-            for field_spec in field_specs {
-                let field_def = field_spec.resolve(schema, link)?;
-                new_definition_fields.push(field_def);
+            // the following mimics `ensure_same_arguments()`, but with some changes.
+            for ResolvedArgumentSpecification {
+                name: field_name,
+                ty,
+                default_value,
+            } in resolved_specs.values()
+            {
+                if let Some(existing_field) = existing_input_obj_type.fields.get(field_name) {
+                    let mut existing_field_type = (*existing_field.ty).clone();
+                    if existing_field.ty.is_non_null() && !ty.is_non_null() {
+                        // It's ok to redefine an optional input field as mandatory. For
+                        // instance, if you want to force people on your team to provide a
+                        // "maxSize", you can redefine ConnectBatch as
+                        // `input ConnectBatch { maxSize: Int! }` to get validation. In
+                        // other words, you are allowed to always pass an input field that
+                        // is optional if you so wish.
+                        existing_field_type = existing_field_type.nullable();
+                    }
+                    // Note that while `ensureSameArguments()` allows input type
+                    // redefinitions (e.g. allowing users to declare `String` instead of a
+                    // custom scalar), this behavior can be confusing/error-prone more
+                    // generally, so we forbid this for now. We can relax this later on a
+                    // case-by-case basis if needed.
+                    //
+                    // Further, `ensureSameArguments()` would skip default value checking
+                    // if the input type was non-nullable. It's unclear why this is there;
+                    // it may have been a mistake due to the impression that non-nullable
+                    // inputs can't have default values (they can), or this may have been
+                    // to avoid some breaking change, but there's no such limitation in
+                    // the case of input objects, so we always validate default values
+                    // here.
+                    if !same_type(&ty, &existing_field_type) {
+                        errors.push(
+                            SingleFederationError::TypeDefinitionInvalid {
+                                message: format!("Invalid definition for type {}: input field \"{field_name}\" should have type \"{ty}\" but found type \"{}\"", self.name, existing_field.ty)
+                            }
+                        )
+                    } else if default_value.as_ref() != existing_field.default_value.as_deref() {
+                        errors.push(
+                            SingleFederationError::TypeDefinitionInvalid {
+                                message: format!("Invalid definition for type {}: input field \"{field_name}\" should have default value \"{}\" but found default value \"{}\"",
+                                    self.name,
+                                    default_value.as_ref().unwrap_or(&Value::Null),
+                                    existing_field.default_value.as_deref().unwrap_or(&Value::Null),
+                                )
+                            }
+                        )
+                    }
+                } else {
+                    // Not declaring an optional input field is ok: that means you won't
+                    // be able to pass a non-default value in your schema, but we allow
+                    // you that. But missing a required input field it not ok.
+                    if ty.is_non_null() && default_value.is_none() {
+                        errors.push(
+                            SingleFederationError::TypeDefinitionInvalid {
+                                message: format!("Invalid definition for type {}: missing required input field \"{field_name}\"", self.name)
+                            }
+                        )
+                    }
+                    continue;
+                }
             }
-            let existing_definition_fields: Vec<_> = existing_obj_type
-                .fields
-                .values()
-                .map(|v| v.node.clone())
+            for (existing_field_name, _) in &existing_input_obj_type.fields {
+                // If it's an expected input field, we already validated it. But we
+                // still need to reject unknown input fields.
+                if !resolved_specs.contains_key(existing_field_name) {
+                    errors.push(
+                        SingleFederationError::TypeDefinitionInvalid {
+                            message: format!("Invalid definition for type {}: unknown/unsupported input field \"{existing_field_name}\"", self.name)
+                        }
+                    )
+                }
+            }
+            MultipleFederationErrors::from_iter(errors).into_result()
+        } else {
+            let field_map: IndexMap<Name, Component<InputValueDefinition>> = resolved_specs
+                .into_iter()
+                .map(|(k, v)| (k, Component::new(v.into())))
                 .collect();
-            let errors = ensure_same_arguments(
-                new_definition_fields.as_slice(),
-                existing_definition_fields.as_slice(),
+            let type_pos = InputObjectTypeDefinitionPosition {
+                type_name: actual_name,
+            };
+            type_pos.pre_insert(schema)?;
+            type_pos.insert(
                 schema,
-                format!("input object type {actual_name}").as_str(),
-                |s| SingleFederationError::TypeDefinitionInvalid {
-                    message: s.to_string(),
-                },
-            );
-            return MultipleFederationErrors::from_iter(errors).into_result();
+                Node::new(InputObjectType {
+                    description: None,
+                    name: type_pos.type_name.clone(),
+                    directives: Default::default(),
+                    fields: field_map,
+                }),
+            )
         }
-
-        let mut field_map = IndexMap::default();
-        for field_spec in field_specs {
-            let field_def: InputValueDefinition = field_spec.resolve(schema, link)?.into();
-            field_map.insert(field_def.name.clone(), Component::new(field_def));
-        }
-
-        let type_pos = InputObjectTypeDefinitionPosition {
-            type_name: actual_name,
-        };
-        type_pos.pre_insert(schema)?;
-        type_pos.insert(
-            schema,
-            Node::new(InputObjectType {
-                description: None,
-                name: type_pos.type_name.clone(),
-                directives: Default::default(),
-                fields: field_map,
-            }),
-        )
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -458,10 +458,7 @@ impl TypeAndDirectiveSpecification for InputObjectTypeSpecification {
         let field_specs = (self.fields)(schema);
         let resolved_specs: IndexMap<Name, ResolvedArgumentSpecification> = field_specs
             .into_iter()
-            .map(|spec| {
-                spec.resolve(schema, link)
-                    .and_then(|r| Ok((r.name.clone(), r)))
-            })
+            .map(|spec| spec.resolve(schema, link).map(|r| (r.name.clone(), r)))
             .collect::<Result<IndexMap<Name, ResolvedArgumentSpecification>, FederationError>>()?;
         let existing = schema.try_get_type(actual_name.clone());
         if let Some(existing) = existing {
@@ -506,7 +503,7 @@ impl TypeAndDirectiveSpecification for InputObjectTypeSpecification {
                     // to avoid some breaking change, but there's no such limitation in
                     // the case of input objects, so we always validate default values
                     // here.
-                    if !same_type(&ty, &existing_field_type) {
+                    if !same_type(ty, &existing_field_type) {
                         errors.push(
                             SingleFederationError::TypeDefinitionInvalid {
                                 message: format!("Invalid definition for type {}: input field \"{field_name}\" should have type \"{ty}\" but found type \"{}\"", self.name, existing_field.ty)

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -443,9 +443,8 @@ impl SubgraphError {
 
 impl Display for SubgraphError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let subgraph = &self.subgraph;
         for (code, message) in self.format_errors() {
-            writeln!(f, "{code} [{subgraph}] {message}")?;
+            writeln!(f, "{code} {message}")?;
         }
         Ok(())
     }

--- a/apollo-federation/tests/composition/connectors.rs
+++ b/apollo-federation/tests/composition/connectors.rs
@@ -488,4 +488,86 @@ mod tests {
 
         assert_snapshot!(api_schema_string);
     }
+
+    #[test]
+    fn composes_v0_4() {
+        let with_connectors_v0_3 = ServiceDefinition {
+            name: "with-connectors-v0_3",
+            type_defs: r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.3"
+                    import: ["@connect", "@source"]
+                )
+                @source(
+                  name: "v1"
+                  http: {
+                    baseURL: "http://v1"
+                    path: ""
+                    queryParams: ""
+                  }
+                  errors: { message: "" extensions: "" }
+                  isSuccess: ""
+                )
+
+                type Query {
+                    resources: [Resource!]!
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                }
+
+                type Resource @key(fields: "id")
+                  @connect(
+                    id: "conn_id",
+                    source: "v1"
+                    http: {
+                      GET: "/resources"
+                      path: ""
+                      queryParams: ""
+                    }
+                    batch: { maxSize: 5 }
+                    errors: { message: "" extensions: "" }
+                    isSuccess: ""
+                    selection: ""
+                  ) {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+        };
+
+        let with_connectors_v0_4 = ServiceDefinition {
+            name: "with-connectors-v0_4",
+            type_defs: r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.4"
+                    import: ["@connect", "@source"]
+                )
+                @source(name: "v4", http: { baseURL: "http://v4" })
+
+                type Query {
+                    widgets: [Widget!]!
+                    @connect(source: "v4", http: { GET: "/widgets" }, selection: "")
+                }
+
+                type Widget @key(fields: "id") {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[with_connectors_v0_3, with_connectors_v0_4]);
+        let supergraph = result.expect("Expected composition to succeed");
+        let schema_string = supergraph.schema().schema().to_string();
+
+        assert_snapshot!(schema_string);
+
+        let api_schema = supergraph
+            .to_api_schema(Default::default())
+            .expect("Expected API schema generation to succeed");
+        let api_schema_string = api_schema.schema().to_string();
+
+        assert_snapshot!(api_schema_string);
+    }
 }

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4-2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4-2.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-federation/tests/composition/connectors.rs
+expression: api_schema_string
+---
+type Query {
+  resources: [Resource!]!
+  widgets: [Widget!]!
+}
+
+type Resource {
+  id: ID!
+  name: String!
+}
+
+type Widget {
+  id: ID!
+  name: String!
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4.snap
@@ -1,0 +1,69 @@
+---
+source: apollo-federation/tests/composition/connectors.rs
+expression: schema_string
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_4_], args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_4_], args: {name: "v4", http: {baseURL: "http://v4"}}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  WITH_CONNECTORS_V0_3_ @join__graph(name: "with-connectors-v0_3", url: "http://with-connectors-v0_3")
+  WITH_CONNECTORS_V0_4_ @join__graph(name: "with-connectors-v0_4", url: "http://with-connectors-v0_4")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+type Query @join__type(graph: WITH_CONNECTORS_V0_3_) @join__type(graph: WITH_CONNECTORS_V0_4_) {
+  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+  widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_4_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_4_], args: {source: "v4", http: {GET: "/widgets"}, selection: ""})
+}
+
+type Resource @join__type(graph: WITH_CONNECTORS_V0_3_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {id: "conn_id", source: "v1", http: {GET: "/resources", path: "", queryParams: ""}, batch: {maxSize: 5}, errors: {message: "", extensions: ""}, isSuccess: "", selection: ""}) {
+  id: ID!
+  name: String!
+}
+
+type Widget @join__type(graph: WITH_CONNECTORS_V0_4_, key: "id") {
+  id: ID!
+  name: String!
+}

--- a/apollo-router/src/plugins/connectors/tests/query_plan.rs
+++ b/apollo-router/src/plugins/connectors/tests/query_plan.rs
@@ -97,7 +97,7 @@ async fn basic_batch() {
                   "inputRewrites": null,
                   "outputRewrites": null,
                   "contextRewrites": null,
-                  "schemaAwareHash": "1d2ea8e43431108212ddb7fae517f1ee57e4e803fdb1317c3b39a4d4b128b13c",
+                  "schemaAwareHash": "af53b5c9b5ea144f97ef31f30a6bf6165fab8f6cd54a188ad01ef7cf76bac8f7",
                   "authorization": {
                     "is_authenticated": false,
                     "scopes": [],
@@ -137,7 +137,7 @@ async fn basic_batch() {
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "9a6bcbe1be4a229df90fcc1133b0ff5550162303965c1ccf0d7a1be8db9e3bfe",
+                    "schemaAwareHash": "883911aa54859965333aedf2b3bd35a871ea351e335b561bdfcdfc741783d8a3",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],


### PR DESCRIPTION
Updates `InputObjectTypeSpecification` to match JS.

Updates connect spec definitions to match JS (few nullability differences and list -> string return type). Updates connector tests to use new typestate API to test schema expansion through general `expand_links` logic.

Fixed `SubgraphError` serialization by removing redundant subgraph name.

<!-- start metadata -->

<!-- [FED-993] -->


[FED-993]: https://apollographql.atlassian.net/browse/FED-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ