### PR TITLE
test: fix flaky validation timing and Redis cache metrics

### DIFF
--- a/.changesets/maint_smyrick_ci_flaky_tests.md
+++ b/.changesets/maint_smyrick_ci_flaky_tests.md
@@ -1,0 +1,5 @@
+### Reduce flaky CI in federation validation and Redis cache metrics tests ([PR #9102](https://github.com/apollographql/router/pull/9102))
+
+Removes a wall-clock performance assertion from connector validation snapshot tests (timing is unreliable under CI load) and replaces a fixed sleep in Redis cache metrics tests with polling until `command_queue_length` reports zero before asserting gauges.
+
+By [@smyrick](https://github.com/smyrick) in https://github.com/apollographql/router/pull/9102

--- a/apollo-federation/src/connectors/validation/mod.rs
+++ b/apollo-federation/src/connectors/validation/mod.rs
@@ -320,9 +320,7 @@ mod test_validate_source {
         insta::with_settings!({prepend_module_to_snapshot => false}, {
             glob!("test_data", "**/*.graphql", |path| {
                 let schema = read_to_string(path).unwrap();
-                let start_time = std::time::Instant::now();
                 let result = validate(schema.clone(), path.to_str().unwrap());
-                let end_time = std::time::Instant::now();
                 assert_debug_snapshot!(result.errors);
                 if path.parent().is_some_and(|parent| parent.ends_with("transformed")) {
                     assert_snapshot!(&diff::lines(&schema, &result.transformed).into_iter().filter_map(|res| match res {
@@ -333,8 +331,6 @@ mod test_validate_source {
                 } else {
                     assert_str_eq!(schema, result.transformed, "Schema should not have been transformed by validations")
                 }
-
-                assert!(end_time - start_time < std::time::Duration::from_millis(100));
             });
         });
     }

--- a/apollo-router/src/cache/metrics.rs
+++ b/apollo-router/src/cache/metrics.rs
@@ -234,6 +234,7 @@ mod tests {
     use crate::cache::redis::RedisKey;
     use crate::cache::redis::RedisValue;
     use crate::metrics::test_utils::MetricType;
+    use opentelemetry::KeyValue;
 
     #[test]
     fn test_weighted_sum_average() {
@@ -325,8 +326,20 @@ mod tests {
             assert!(retrieved.is_ok(), "Should have retrieved value from mock");
             assert_eq!(retrieved.unwrap().0.data, "test_value");
 
-            // Pause to ensure that queue length is zero & metrics have been exported
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            // Poll until command queue length is zero (fixed sleeps are flaky under CI load).
+            let queue_attrs = &[KeyValue::new("kind", "test")];
+            for _ in 0..50 {
+                if crate::metrics::collect_metrics().assert(
+                    "apollo.router.cache.redis.command_queue_length",
+                    MetricType::Gauge,
+                    0.0,
+                    false,
+                    queue_attrs,
+                ) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
 
             // Verify Redis connection metrics are emitted.
             // Since this metric is based on a global AtomicU64, it's not unique across tests - so

--- a/apollo-router/src/cache/metrics.rs
+++ b/apollo-router/src/cache/metrics.rs
@@ -229,12 +229,13 @@ impl RedisMetricsCollector {
 
 #[cfg(test)]
 mod tests {
+    use opentelemetry::KeyValue;
+
     use super::*;
     use crate::cache::redis::RedisCacheStorage;
     use crate::cache::redis::RedisKey;
     use crate::cache::redis::RedisValue;
     use crate::metrics::test_utils::MetricType;
-    use opentelemetry::KeyValue;
 
     #[test]
     fn test_weighted_sum_average() {


### PR DESCRIPTION
## Summary
Addresses flaky CI tests:

1. **apollo-federation** (`connectors/validation/mod.rs`): Remove the `< 100ms` wall-clock assertion on validation snapshot tests. Timing is unreliable under CI load; this was previously approved by @goto-bus-stop from https://github.com/apollographql/router/pull/8925

2. **apollo-router** (`cache/metrics.rs`): Replace a fixed `100ms` sleep with polling (up to 50 × 40ms) until `command_queue_length` is reported as `0` before asserting Redis metrics.

## Testing
- `cargo test -p apollo-federation validation_tests`
- `cargo test -p apollo-router test_redis_storage_with_mocks`

Made with [Cursor](https://cursor.com)