### PR TITLE
QP execution: avoid redundant entity responses from aliased operations

### DIFF
--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -1,9 +1,9 @@
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::Arc;
 
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::ast;
-use apollo_compiler::collections::HashMap;
 use apollo_compiler::validation::Valid;
 use apollo_federation::query_plan::requires_selection;
 use apollo_federation::query_plan::serializable_document::SerializableDocument;
@@ -230,7 +230,7 @@ impl Variables {
                 return None;
             }
 
-            let representations = Value::Array(Vec::from_iter(values));
+            let representations: Vec<Value> = Vec::from_iter(values);
             let contextual_arguments = match subgraph_context.as_mut() {
                 Some(context) => {
                     context.add_variables_and_get_args(&mut variables, inverted_contexts)
@@ -238,7 +238,22 @@ impl Variables {
                 None => None,
             };
 
-            variables.insert("representations", representations);
+            if let Some(ref ctx_args) = contextual_arguments {
+                // Per-context singleton representation arrays: each `representations_<ctx>`
+                // holds only the single representation needed for that context.
+                for (rep_idx, ctxs) in ctx_args.inverted_contexts.iter().enumerate() {
+                    for &ctx_idx in ctxs {
+                        let key = format!("representations_{ctx_idx}");
+                        let val = Value::Array(vec![representations[rep_idx].clone()]);
+                        variables.insert(key, val);
+                    }
+                }
+            } else {
+                variables.insert(
+                    "representations",
+                    Value::Array(representations),
+                );
+            }
             Some(Variables {
                 variables,
                 inverted_paths,
@@ -308,48 +323,37 @@ fn remap_entity_error(error: &Error, values_path: &Path, entity_error_path: &Pat
 }
 
 enum AliasedErrorHandling {
-    Remap(Vec<Path>),
+    Remap(Path),
     Ignore,
     Fallback,
 }
 
 /// Determine how to handle potentially aliased error paths.
-/// - If `path` is accepted, converts it from subgraph response into the supergraph response paths
+/// - If `path` is accepted, converts it from subgraph response into the supergraph response path
 ///   and returns `Remap`.
 /// - If `path` is from a wrong context path, returns `Ignore`.
 /// - If none of them applies, returns `Fallback`.
+///
+/// With singleton representations, error paths have the form
+/// `["_entities_<context>", 0, "field", ...]` where the index is always 0.
+/// Uses a pre-built `context_to_path` map for O(1) lookup per error.
 fn aliased_error_handling(
     path: &Path,
-    inverted_paths: &[Vec<Path>],
-    inverted_contexts: Option<&Vec<Vec<usize>>>,
+    context_to_path: Option<&HashMap<usize, Path>>,
 ) -> AliasedErrorHandling {
-    match (path.0.first(), path.0.get(1), inverted_contexts) {
+    match (path.0.first(), path.0.get(1), context_to_path) {
         (
             Some(json_ext::PathElement::Key(alias, None)),
-            Some(json_ext::PathElement::Index(entity_index)),
-            Some(inverted_contexts),
+            Some(json_ext::PathElement::Index(_)),
+            Some(context_to_path),
         ) if alias.starts_with("_entities_") => {
-            match (
-                inverted_paths.get(*entity_index),
-                inverted_contexts.get(*entity_index),
-            ) {
-                (Some(paths), Some(contexts)) => {
-                    let matching_paths: Vec<Path> = paths
-                        .iter()
-                        .zip(contexts.iter())
-                        .filter_map(|(values_path, context_index)| {
-                            let expected_alias = format!("_entities_{context_index}");
-                            (alias == &expected_alias).then(|| values_path.clone())
-                        })
-                        .collect();
-
-                    if matching_paths.is_empty() {
-                        AliasedErrorHandling::Ignore
-                    } else {
-                        AliasedErrorHandling::Remap(matching_paths)
-                    }
-                }
-                _ => AliasedErrorHandling::Ignore,
+            // Parse context index from the alias name "_entities_<ctx>"
+            let Some(context_index) = alias["_entities_".len()..].parse::<usize>().ok() else {
+                return AliasedErrorHandling::Fallback;
+            };
+            match context_to_path.get(&context_index) {
+                Some(p) => AliasedErrorHandling::Remap(p.clone()),
+                None => AliasedErrorHandling::Ignore,
             }
         }
         _ => AliasedErrorHandling::Fallback,
@@ -475,6 +479,20 @@ impl FetchNode {
                 current_dir.clone()
             };
 
+            // Pre-build a mapping from context index to its supergraph path so that
+            // aliased error remapping is O(1) per error instead of a linear scan
+            // through inverted_contexts. Each context index maps to exactly one path.
+            let context_to_path: Option<HashMap<usize, Path>> =
+                inverted_contexts.as_ref().map(|inv_contexts| {
+                    let mut map = HashMap::new();
+                    for (paths, contexts) in inverted_paths.iter().zip(inv_contexts.iter()) {
+                        for (path, &ctx_idx) in paths.iter().zip(contexts.iter()) {
+                            map.insert(ctx_idx, path.clone());
+                        }
+                    }
+                    map
+                });
+
             let mut errors: Vec<Error> = vec![];
             for mut error in response.errors {
                 // the locations correspond to the subgraph query and cannot be linked to locations
@@ -502,13 +520,10 @@ impl FetchNode {
                     } else {
                         match aliased_error_handling(
                             path,
-                            &inverted_paths,
-                            inverted_contexts.as_ref(),
+                            context_to_path.as_ref(),
                         ) {
-                            AliasedErrorHandling::Remap(values_paths) => {
-                                for values_path in values_paths {
-                                    errors.push(remap_entity_error(&error, &values_path, path))
-                                }
+                            AliasedErrorHandling::Remap(values_path) => {
+                                errors.push(remap_entity_error(&error, &values_path, path))
                             }
                             AliasedErrorHandling::Ignore => {}
                             AliasedErrorHandling::Fallback => {
@@ -548,14 +563,13 @@ impl FetchNode {
                 let mut value = Value::default();
                 let mut saw_aliases = false;
 
-                // Every `_entities_<i>` response array must match with the `inverted_paths` &
-                // `inverted_contexts` vectors.
-                // - For each `inverted_paths` entry, the correct context index (`i`) is determined by the
-                //   corresponding `inverted_contexts` entry.
-                for (index, (paths, contexts)) in inverted_paths
+                // Every `_entities_<i>` response array is a singleton containing
+                // only the representation needed for that context. For each
+                // `inverted_paths` entry, the correct context index (`i`) is
+                // determined by the corresponding `inverted_contexts` entry.
+                for (paths, contexts) in inverted_paths
                     .into_iter()
                     .zip(inverted_contexts.unwrap_or_default().into_iter())
-                    .enumerate()
                 {
                     for (path, context) in paths.into_iter().zip(contexts.into_iter()) {
                         let alias = format!("_entities_{context}");
@@ -569,7 +583,8 @@ impl FetchNode {
                             return (Value::Null, errors);
                         };
 
-                        let Some(mut entity) = array.into_iter().nth(index) else {
+                        // Each alias's representations array is a singleton.
+                        let Some(mut entity) = array.into_iter().next() else {
                             continue;
                         };
 
@@ -1120,7 +1135,7 @@ mod tests {
     }
 
     #[test]
-    fn entity_fetch_aliased_entities_uses_diagonal_entries() {
+    fn entity_fetch_aliased_entities_uses_singleton_representations() {
         let schema = test_schema();
         let node = make_fetch_node(make_requires());
         let current_dir = Path(vec![key("users"), flatten()]);
@@ -1130,23 +1145,12 @@ mod tests {
             vec![Path(vec![key("users"), index(2)])],
         ];
         let inverted_contexts = vec![vec![0], vec![1], vec![2]];
+        // Each context's representations array is a singleton.
         let response = graphql::Response::builder()
             .data(json!({
-                "_entities_0": [
-                    {"name": "Alice-0"},
-                    {"name": "Bob-0"},
-                    {"name": "Charlie-0"}
-                ],
-                "_entities_1": [
-                    {"name": "Alice-1"},
-                    {"name": "Bob-1"},
-                    {"name": "Charlie-1"}
-                ],
-                "_entities_2": [
-                    {"name": "Alice-2"},
-                    {"name": "Bob-2"},
-                    {"name": "Charlie-2"}
-                ]
+                "_entities_0": [{"name": "Alice-0"}],
+                "_entities_1": [{"name": "Bob-1"}],
+                "_entities_2": [{"name": "Charlie-2"}]
             }))
             .build();
 
@@ -1173,7 +1177,58 @@ mod tests {
     }
 
     #[test]
-    fn entity_fetch_error_with_aliased_entities_path_only_maps_diagonal_entry() {
+    fn entity_fetch_aliased_entities_dedup_uses_singleton_representations() {
+        // Test with deduplication: 4 entities collapse into 3 representations.
+        // Entity 0 -> rep 0, context 0
+        // Entity 1 -> rep 1, context 1
+        // Entity 2 -> rep 2, context 2
+        // Entity 3 -> rep 2, context 3 (shares representation with entity 2)
+        let schema = test_schema();
+        let node = make_fetch_node(make_requires());
+        let current_dir = Path(vec![key("users"), flatten()]);
+        let inverted_paths = vec![
+            vec![Path(vec![key("users"), index(0)])],
+            vec![Path(vec![key("users"), index(1)])],
+            vec![
+                Path(vec![key("users"), index(2)]),
+                Path(vec![key("users"), index(3)]),
+            ],
+        ];
+        let inverted_contexts = vec![vec![0], vec![1], vec![2, 3]];
+        let response = graphql::Response::builder()
+            .data(json!({
+                "_entities_0": [{"name": "Alice-0"}],
+                "_entities_1": [{"name": "Bob-1"}],
+                "_entities_2": [{"name": "Charlie-2"}],
+                "_entities_3": [{"name": "Charlie-3"}]
+            }))
+            .build();
+
+        let (value, errors) = node.response_at_path(
+            &schema,
+            &current_dir,
+            inverted_paths,
+            Some(inverted_contexts),
+            response,
+            false,
+        );
+
+        assert!(errors.is_empty());
+        let arr = value
+            .as_object()
+            .unwrap()
+            .get("users")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(arr[0], json!({"name": "Alice-0"}));
+        assert_eq!(arr[1], json!({"name": "Bob-1"}));
+        assert_eq!(arr[2], json!({"name": "Charlie-2"}));
+        assert_eq!(arr[3], json!({"name": "Charlie-3"}));
+    }
+
+    #[test]
+    fn entity_fetch_error_with_aliased_entities_singleton_representations() {
         let schema = test_schema();
         let node = make_fetch_node(make_requires());
         let current_dir = Path(vec![key("users"), flatten()]);
@@ -1182,21 +1237,16 @@ mod tests {
             vec![Path(vec![key("users"), index(1)])],
         ];
         let inverted_contexts = vec![vec![0], vec![1]];
+        // With singleton representations, error indices are always 0.
         let response = graphql::Response::builder()
             .data(json!({
-                "_entities_0": [null, null],
-                "_entities_1": [null, null]
+                "_entities_0": [null],
+                "_entities_1": [null]
             }))
             .error(
                 graphql::Error::builder()
-                    .message("off diagonal")
+                    .message("error on context 1")
                     .path(Path(vec![key("_entities_1"), index(0), key("name")]))
-                    .build(),
-            )
-            .error(
-                graphql::Error::builder()
-                    .message("diagonal")
-                    .path(Path(vec![key("_entities_1"), index(1), key("name")]))
                     .build(),
             )
             .build();
@@ -1211,7 +1261,7 @@ mod tests {
         );
 
         assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].message, "diagonal");
+        assert_eq!(errors[0].message, "error on context 1");
         assert_eq!(
             errors[0].path.as_ref().unwrap(),
             &Path(vec![key("users"), index(1), key("name")])

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -193,24 +193,34 @@ impl Variables {
             }));
 
             let mut inverted_paths: Vec<Vec<Path>> = Vec::new();
+            let mut inverted_contexts: Vec<Vec<usize>> = Vec::new();
             let mut values: IndexSet<Value> = IndexSet::default();
             data.select_values_and_paths(schema, current_dir, |path, value| {
                 // first get contextual values that are required
-                if let Some(context) = subgraph_context.as_mut() {
-                    context.execute_on_path(path);
-                }
+                // - records its context index
+                let context_index = match subgraph_context.as_mut() {
+                    Some(context) => context.execute_on_path(path),
+                    None => 0,
+                };
 
                 let mut value = execute_selection_set(value, requires, schema, None);
                 if value.as_object().map(|o| !o.is_empty()).unwrap_or(false) {
                     rewrites::apply_rewrites(schema, &mut value, input_rewrites);
                     match values.get_index_of(&value) {
                         Some(index) => {
+                            // Identical representation values are collapsed. Only add the path & context.
                             inverted_paths[index].push(path.clone());
+                            inverted_contexts[index].push(context_index);
+                            debug_assert!(
+                                inverted_paths[index].len() == inverted_contexts[index].len()
+                            );
                         }
                         None => {
                             inverted_paths.push(vec![path.clone()]);
+                            inverted_contexts.push(vec![context_index]);
                             values.insert(value);
                             debug_assert!(inverted_paths.len() == values.len());
+                            debug_assert!(inverted_contexts.len() == values.len());
                         }
                     }
                 }
@@ -222,7 +232,9 @@ impl Variables {
 
             let representations = Value::Array(Vec::from_iter(values));
             let contextual_arguments = match subgraph_context.as_mut() {
-                Some(context) => context.add_variables_and_get_args(&mut variables),
+                Some(context) => {
+                    context.add_variables_and_get_args(&mut variables, inverted_contexts)
+                }
                 None => None,
             };
 
@@ -263,6 +275,87 @@ impl Variables {
     }
 }
 
+fn insert_entity_at_paths(value: &mut Value, paths: &[Path], entity: Value) {
+    if paths.len() > 1 {
+        for path in &paths[1..] {
+            let _ = value.insert(path, entity.clone());
+        }
+    }
+
+    if let Some(path) = paths.first() {
+        let _ = value.insert(path, entity);
+    }
+}
+
+fn remap_entity_error(error: &Error, values_path: &Path, entity_error_path: &Path) -> Error {
+    Error::builder()
+        .locations(error.locations.clone())
+        // Append to the entity's path the error's path without `_entities` (or aliased
+        // `_entities_<context>`) and the entity index.
+        .path(Path::from_iter(
+            values_path
+                .0
+                .iter()
+                .chain(&entity_error_path.0[2..])
+                .cloned(),
+        ))
+        .message(error.message.clone())
+        .and_extension_code(error.extension_code())
+        .extensions(error.extensions.clone())
+        // Re-use the original ID so we don't double count this error.
+        .apollo_id(error.apollo_id())
+        .build()
+}
+
+enum AliasedErrorHandling {
+    Remap(Vec<Path>),
+    Ignore,
+    Fallback,
+}
+
+/// Determine how to handle potentially aliased error paths.
+/// - If `path` is accepted, converts it from subgraph response into the supergraph response paths
+///   and returns `Remap`.
+/// - If `path` is from a wrong context path, returns `Ignore`.
+/// - If none of them applies, returns `Fallback`.
+fn aliased_error_handling(
+    path: &Path,
+    inverted_paths: &[Vec<Path>],
+    inverted_contexts: Option<&Vec<Vec<usize>>>,
+) -> AliasedErrorHandling {
+    match (path.0.first(), path.0.get(1), inverted_contexts) {
+        (
+            Some(json_ext::PathElement::Key(alias, None)),
+            Some(json_ext::PathElement::Index(entity_index)),
+            Some(inverted_contexts),
+        ) if alias.starts_with("_entities_") => {
+            match (
+                inverted_paths.get(*entity_index),
+                inverted_contexts.get(*entity_index),
+            ) {
+                (Some(paths), Some(contexts)) => {
+                    let matching_paths: Vec<Path> = paths
+                        .iter()
+                        .zip(contexts.iter())
+                        .filter_map(|(values_path, context_index)| {
+                            let expected_alias = format!("_entities_{context_index}");
+                            (alias == &expected_alias).then(|| values_path.clone())
+                        })
+                        .collect();
+
+                    if matching_paths.is_empty() {
+                        AliasedErrorHandling::Ignore
+                    } else {
+                        AliasedErrorHandling::Remap(matching_paths)
+                    }
+                }
+                _ => AliasedErrorHandling::Ignore,
+            }
+        }
+        _ => AliasedErrorHandling::Fallback,
+    }
+}
+
 impl FetchNode {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn subgraph_fetch(
@@ -272,6 +365,7 @@ impl FetchNode {
         current_dir: &Path,
         schema: &Schema,
         paths: Vec<Vec<Path>>,
+        contexts: Option<Vec<Vec<usize>>>,
         operation_str: &str,
         variables: Map<ByteString, Value>,
         hoist_orphan_errors: bool,
@@ -302,8 +396,14 @@ impl FetchNode {
             );
         }
 
-        let (value, errors) =
-            self.response_at_path(schema, current_dir, paths, response, hoist_orphan_errors);
+        let (value, errors) = self.response_at_path(
+            schema,
+            current_dir,
+            paths,
+            contexts,
+            response,
+            hoist_orphan_errors,
+        );
 
         (value, errors)
     }
@@ -348,6 +448,7 @@ impl FetchNode {
         schema: &Schema,
         current_dir: &'a Path,
         inverted_paths: Vec<Vec<Path>>,
+        inverted_contexts: Option<Vec<Vec<usize>>>,
         response: graphql::Response,
         hoist_orphan_errors: bool,
     ) -> (Value, Vec<Error>) {
@@ -390,21 +491,7 @@ impl FetchNode {
                                 for values_path in
                                     inverted_paths.get(*i).iter().flat_map(|v| v.iter())
                                 {
-                                    errors.push(
-                                        Error::builder()
-                                            .locations(error.locations.clone())
-                                            // append to the entity's path the error's path without
-                                            //`_entities` and the index
-                                            .path(Path::from_iter(
-                                                values_path.0.iter().chain(&path.0[2..]).cloned(),
-                                            ))
-                                            .message(error.message.clone())
-                                            .and_extension_code(error.extension_code())
-                                            .extensions(error.extensions.clone())
-                                            // re-use the original ID so we don't double count this error
-                                            .apollo_id(error.apollo_id())
-                                            .build(),
-                                    )
+                                    errors.push(remap_entity_error(&error, values_path, path))
                                 }
                             }
                             _ => {
@@ -413,8 +500,22 @@ impl FetchNode {
                             }
                         }
                     } else {
-                        error.path = Some(error_dir.clone());
-                        errors.push(error);
+                        match aliased_error_handling(
+                            path,
+                            &inverted_paths,
+                            inverted_contexts.as_ref(),
+                        ) {
+                            AliasedErrorHandling::Remap(values_paths) => {
+                                for values_path in values_paths {
+                                    errors.push(remap_entity_error(&error, &values_path, path))
+                                }
+                            }
+                            AliasedErrorHandling::Ignore => {}
+                            AliasedErrorHandling::Fallback => {
+                                error.path = Some(error_dir.clone());
+                                errors.push(error);
+                            }
+                        }
                     }
                 } else {
                     error.path = Some(error_dir.clone());
@@ -424,29 +525,60 @@ impl FetchNode {
 
             // we have to nest conditions and do early returns here
             // because we need to take ownership of the inner value
-            if let Some(Value::Object(mut map)) = response.data
-                && let Some(entities) = map.remove("_entities")
-            {
-                tracing::trace!("received entities: {:?}", &entities);
+            if let Some(Value::Object(mut map)) = response.data {
+                if let Some(entities) = map.remove("_entities") {
+                    tracing::trace!("received entities: {:?}", &entities);
 
-                if let Value::Array(array) = entities {
-                    let mut value = Value::default();
+                    // `_entities` response array must match with the `inverted_paths` vector.
+                    if let Value::Array(array) = entities {
+                        let mut value = Value::default();
 
-                    for (index, mut entity) in array.into_iter().enumerate() {
-                        rewrites::apply_rewrites(schema, &mut entity, &self.output_rewrites);
+                        for (index, mut entity) in array.into_iter().enumerate() {
+                            rewrites::apply_rewrites(schema, &mut entity, &self.output_rewrites);
 
-                        if let Some(paths) = inverted_paths.get(index) {
-                            if paths.len() > 1 {
-                                for path in &paths[1..] {
-                                    let _ = value.insert(path, entity.clone());
-                                }
-                            }
-
-                            if let Some(path) = paths.first() {
-                                let _ = value.insert(path, entity);
+                            if let Some(paths) = inverted_paths.get(index) {
+                                insert_entity_at_paths(&mut value, paths, entity);
                             }
                         }
+                        return (value, errors);
                     }
+                }
+
+                // If `_entities` is not present, then check the aliased versions of it.
+                let mut value = Value::default();
+                let mut saw_aliases = false;
+
+                // Every `_entities_<i>` response array must match with the `inverted_paths` &
+                // `inverted_contexts` vectors.
+                // - For each `inverted_paths` entry, the correct context index (`i`) is determined by the
+                //   corresponding `inverted_contexts` entry.
+                for (index, (paths, contexts)) in inverted_paths
+                    .into_iter()
+                    .zip(inverted_contexts.unwrap_or_default().into_iter())
+                    .enumerate()
+                {
+                    for (path, context) in paths.into_iter().zip(contexts.into_iter()) {
+                        let alias = format!("_entities_{context}");
+                        let Some(entities) = map.remove(alias.as_str()) else {
+                            continue;
+                        };
+                        tracing::trace!("received aliased entities (as {alias}): {:?}", &entities);
+                        saw_aliases = true;
+
+                        let Value::Array(array) = entities else {
+                            return (Value::Null, errors);
+                        };
+
+                        let Some(mut entity) = array.into_iter().nth(index) else {
+                            continue;
+                        };
+
+                        rewrites::apply_rewrites(schema, &mut entity, &self.output_rewrites);
+                        insert_entity_at_paths(&mut value, &[path], entity);
+                    }
+                }
+
+                if saw_aliases {
                     return (value, errors);
                 }
             }
@@ -681,7 +813,8 @@ mod tests {
             data,
             ..Default::default()
         };
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert!(errors.is_empty());
         assert_eq!(value, expected);
@@ -730,7 +863,8 @@ mod tests {
             .error(make_error(error_path))
             .build();
 
-        let (_, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (_, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].path.as_ref().unwrap(), &expected_path);
@@ -757,7 +891,8 @@ mod tests {
             .error(graphql::Error::builder().message("error 3").build())
             .build();
 
-        let (_, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (_, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert_eq!(errors.len(), 3);
         assert_eq!(
@@ -786,7 +921,8 @@ mod tests {
             )
             .build();
 
-        let (_, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (_, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].extension_code().as_deref(), Some("UNAUTHORIZED"));
@@ -836,7 +972,8 @@ mod tests {
             .error(make_error(error_path))
             .build();
 
-        let (_, errors) = node.response_at_path(&schema, &current_dir, vec![], response, true);
+        let (_, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, true);
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].path.as_ref().unwrap(), &expected_path);
@@ -871,7 +1008,8 @@ mod tests {
             .error(make_error(error_path))
             .build();
 
-        let (_, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (_, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].path.as_ref().unwrap(), &expected_path);
@@ -896,7 +1034,7 @@ mod tests {
             .build();
 
         let (value, errors) =
-            node.response_at_path(&schema, &current_dir, inverted_paths, response, false);
+            node.response_at_path(&schema, &current_dir, inverted_paths, None, response, false);
 
         assert!(errors.is_empty());
         let top = value.as_object().unwrap().get("topField").unwrap();
@@ -921,7 +1059,7 @@ mod tests {
             .build();
 
         let (value, errors) =
-            node.response_at_path(&schema, &current_dir, inverted_paths, response, false);
+            node.response_at_path(&schema, &current_dir, inverted_paths, None, response, false);
 
         assert!(errors.is_empty());
         let arr = value
@@ -944,7 +1082,8 @@ mod tests {
             .data(json!({"_entities": []}))
             .build();
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert!(errors.is_empty());
         assert_eq!(value, Value::default());
@@ -967,7 +1106,7 @@ mod tests {
             .build();
 
         let (value, errors) =
-            node.response_at_path(&schema, &current_dir, inverted_paths, response, false);
+            node.response_at_path(&schema, &current_dir, inverted_paths, None, response, false);
 
         assert!(errors.is_empty());
         let arr = value
@@ -978,6 +1117,105 @@ mod tests {
             .as_array()
             .unwrap();
         assert_eq!(arr[0], json!({"name": "Alice"}));
+    }
+
+    #[test]
+    fn entity_fetch_aliased_entities_uses_diagonal_entries() {
+        let schema = test_schema();
+        let node = make_fetch_node(make_requires());
+        let current_dir = Path(vec![key("users"), flatten()]);
+        let inverted_paths = vec![
+            vec![Path(vec![key("users"), index(0)])],
+            vec![Path(vec![key("users"), index(1)])],
+            vec![Path(vec![key("users"), index(2)])],
+        ];
+        let inverted_contexts = vec![vec![0], vec![1], vec![2]];
+        let response = graphql::Response::builder()
+            .data(json!({
+                "_entities_0": [
+                    {"name": "Alice-0"},
+                    {"name": "Bob-0"},
+                    {"name": "Charlie-0"}
+                ],
+                "_entities_1": [
+                    {"name": "Alice-1"},
+                    {"name": "Bob-1"},
+                    {"name": "Charlie-1"}
+                ],
+                "_entities_2": [
+                    {"name": "Alice-2"},
+                    {"name": "Bob-2"},
+                    {"name": "Charlie-2"}
+                ]
+            }))
+            .build();
+
+        let (value, errors) = node.response_at_path(
+            &schema,
+            &current_dir,
+            inverted_paths,
+            Some(inverted_contexts),
+            response,
+            false,
+        );
+
+        assert!(errors.is_empty());
+        let arr = value
+            .as_object()
+            .unwrap()
+            .get("users")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(arr[0], json!({"name": "Alice-0"}));
+        assert_eq!(arr[1], json!({"name": "Bob-1"}));
+        assert_eq!(arr[2], json!({"name": "Charlie-2"}));
+    }
+
+    #[test]
+    fn entity_fetch_error_with_aliased_entities_path_only_maps_diagonal_entry() {
+        let schema = test_schema();
+        let node = make_fetch_node(make_requires());
+        let current_dir = Path(vec![key("users"), flatten()]);
+        let inverted_paths = vec![
+            vec![Path(vec![key("users"), index(0)])],
+            vec![Path(vec![key("users"), index(1)])],
+        ];
+        let inverted_contexts = vec![vec![0], vec![1]];
+        let response = graphql::Response::builder()
+            .data(json!({
+                "_entities_0": [null, null],
+                "_entities_1": [null, null]
+            }))
+            .error(
+                graphql::Error::builder()
+                    .message("off diagonal")
+                    .path(Path(vec![key("_entities_1"), index(0), key("name")]))
+                    .build(),
+            )
+            .error(
+                graphql::Error::builder()
+                    .message("diagonal")
+                    .path(Path(vec![key("_entities_1"), index(1), key("name")]))
+                    .build(),
+            )
+            .build();
+
+        let (_, errors) = node.response_at_path(
+            &schema,
+            &current_dir,
+            inverted_paths,
+            Some(inverted_contexts),
+            response,
+            false,
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].message, "diagonal");
+        assert_eq!(
+            errors[0].path.as_ref().unwrap(),
+            &Path(vec![key("users"), index(1), key("name")])
+        );
     }
 
     #[test]
@@ -1000,7 +1238,7 @@ mod tests {
             .build();
 
         let (_, errors) =
-            node.response_at_path(&schema, &current_dir, inverted_paths, response, false);
+            node.response_at_path(&schema, &current_dir, inverted_paths, None, response, false);
 
         assert_eq!(errors.len(), 1);
         assert_eq!(
@@ -1030,6 +1268,7 @@ mod tests {
             &schema,
             &current_dir,
             vec![vec![Path(vec![key("data"), index(0)])]],
+            None,
             response,
             false,
         );
@@ -1058,7 +1297,7 @@ mod tests {
             .build();
 
         let (_, errors) =
-            node.response_at_path(&schema, &current_dir, inverted_paths, response, false);
+            node.response_at_path(&schema, &current_dir, inverted_paths, None, response, false);
 
         assert_eq!(errors.len(), 2);
         assert_eq!(
@@ -1086,7 +1325,8 @@ mod tests {
             )
             .build();
 
-        let (_, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (_, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert!(errors.is_empty());
     }
@@ -1109,7 +1349,7 @@ mod tests {
             .build();
 
         let (_, errors) =
-            node.response_at_path(&schema, &current_dir, inverted_paths, response, false);
+            node.response_at_path(&schema, &current_dir, inverted_paths, None, response, false);
 
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].extension_code().as_deref(), Some("FORBIDDEN"));
@@ -1141,7 +1381,7 @@ mod tests {
             .build();
 
         let (_, errors) =
-            node.response_at_path(&schema, &current_dir, inverted_paths, response, false);
+            node.response_at_path(&schema, &current_dir, inverted_paths, None, response, false);
 
         assert_eq!(errors.len(), 1);
         assert_eq!(
@@ -1164,7 +1404,8 @@ mod tests {
             )
             .build();
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert_eq!(value, Value::Null);
         assert_eq!(errors.len(), 1);
@@ -1180,7 +1421,8 @@ mod tests {
             .data(json!({"something": "else"}))
             .build();
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert_eq!(value, Value::Null);
         assert!(errors.is_empty());
@@ -1195,7 +1437,8 @@ mod tests {
             .error(graphql::Error::builder().message("subgraph error").build())
             .build();
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert_eq!(value, Value::Null);
         assert_eq!(errors.len(), 1);
@@ -1223,7 +1466,8 @@ mod tests {
             )
             .build();
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, true);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, true);
 
         assert_eq!(value, Value::Null);
         assert_eq!(errors.len(), 3);
@@ -1258,7 +1502,8 @@ mod tests {
             )
             .build();
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, true);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, true);
 
         assert_eq!(value, Value::Null);
         assert_eq!(errors.len(), 2);
@@ -1281,7 +1526,8 @@ mod tests {
             .data(json!({"_entities": "not_an_array"}))
             .build();
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, false);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, false);
 
         assert_eq!(value, Value::Null);
         assert!(errors.is_empty());
@@ -1298,7 +1544,8 @@ mod tests {
             .error(graphql::Error::builder().message("bad entities").build())
             .build();
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, true);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, true);
 
         assert_eq!(value, Value::Null);
         assert_eq!(errors.len(), 1);
@@ -1317,7 +1564,8 @@ mod tests {
             ..Default::default()
         };
 
-        let (value, errors) = node.response_at_path(&schema, &current_dir, vec![], response, true);
+        let (value, errors) =
+            node.response_at_path(&schema, &current_dir, vec![], None, response, true);
 
         assert_eq!(value, Value::Null);
         assert_eq!(errors.len(), 1);
@@ -1351,7 +1599,7 @@ mod tests {
             .build();
 
         let (_, errors) =
-            node.response_at_path(&schema, &current_dir, inverted_paths, response, true);
+            node.response_at_path(&schema, &current_dir, inverted_paths, None, response, true);
 
         assert_eq!(errors.len(), 3);
         assert_eq!(

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -249,10 +249,7 @@ impl Variables {
                     }
                 }
             } else {
-                variables.insert(
-                    "representations",
-                    Value::Array(representations),
-                );
+                variables.insert("representations", Value::Array(representations));
             }
             Some(Variables {
                 variables,
@@ -518,10 +515,7 @@ impl FetchNode {
                             }
                         }
                     } else {
-                        match aliased_error_handling(
-                            path,
-                            context_to_path.as_ref(),
-                        ) {
+                        match aliased_error_handling(path, context_to_path.as_ref()) {
                             AliasedErrorHandling::Remap(values_path) => {
                                 errors.push(remap_entity_error(&error, &values_path, path))
                             }

--- a/apollo-router/src/query_planner/subgraph_context.rs
+++ b/apollo-router/src/query_planner/subgraph_context.rs
@@ -252,7 +252,9 @@ fn transform_operation(
     let mut selections: Vec<Selection> = vec![];
     let mut new_variables: Vec<Node<VariableDefinition>> = vec![];
     operation.variables.iter().for_each(|v| {
-        if arguments.contains(v.name.as_str()) {
+        if v.name.as_str() == "representations" || arguments.contains(v.name.as_str()) {
+            // Clone both contextual arguments and the representations variable
+            // into per-context copies (e.g. representations_0, representations_1, ...).
             for i in 0..*count {
                 new_variables.push(Node::new(VariableDefinition {
                     name: Name::new_unchecked(&format!("{}_{}", v.name.as_str(), i)),
@@ -301,6 +303,17 @@ fn transform_operation(
             op = field_selection.name
         )));
 
+        // Rename $representations to $representations_i for this alias
+        for arg in cfs.arguments.iter_mut() {
+            let arg = arg.make_mut();
+            if let Some(v) = arg.value.as_variable() {
+                if v.as_str() == "representations" {
+                    arg.value = Node::new(ast::Value::Variable(Name::new_unchecked(&format!(
+                        "representations_{i}"
+                    ))));
+                }
+            }
+        }
         transform_field_arguments(&mut cfs.arguments, arguments, i);
         transform_selection_set(&mut cfs.selection_set, arguments, i);
         selections.push(Selection::Field(cloned));

--- a/apollo-router/src/query_planner/subgraph_context.rs
+++ b/apollo-router/src/query_planner/subgraph_context.rs
@@ -28,6 +28,7 @@ use crate::spec::Schema;
 pub(crate) struct ContextualArguments {
     pub(crate) arguments: HashSet<String>, // a set of all argument names that will be passed to the subgraph. This is the unmodified name from the query plan
     pub(crate) count: usize, // the number of different sets of arguments that exist. This will either be 1 or the number of entities
+    pub(crate) inverted_contexts: Vec<Vec<usize>>, // Mapping from the representations to their context indices.
 }
 
 pub(crate) struct SubgraphContext<'a> {
@@ -102,7 +103,8 @@ impl<'a> SubgraphContext<'a> {
     // For each of the rewrites, start collecting data for the data at path.
     // Once we find a Value for a given variable, skip additional rewrites that
     // reference the same variable
-    pub(crate) fn execute_on_path(&mut self, path: &Path) {
+    // - Returns the context index (the index of `self.named_args`) to use for this path.
+    pub(crate) fn execute_on_path(&mut self, path: &Path) -> usize {
         let mut found_rewrites: HashSet<String> = HashSet::new();
         let hash_map: HashMap<String, Value> = self
             .context_rewrites
@@ -149,7 +151,9 @@ impl<'a> SubgraphContext<'a> {
                 }
             })
             .collect();
+        let index = self.named_args.len();
         self.named_args.push(hash_map);
+        index
     }
 
     // Once all a value has been extracted for every variable, go ahead and add all
@@ -158,6 +162,7 @@ impl<'a> SubgraphContext<'a> {
     pub(crate) fn add_variables_and_get_args(
         &self,
         variables: &mut Map<ByteString, Value>,
+        inverted_contexts: Vec<Vec<usize>>,
     ) -> Option<ContextualArguments> {
         let (extended_vars, contextual_args) = if let Some(first_map) = self.named_args.first() {
             if self.named_args.iter().all(|map| map == first_map) {
@@ -184,6 +189,7 @@ impl<'a> SubgraphContext<'a> {
                     Some(ContextualArguments {
                         arguments: arg_names,
                         count: self.named_args.len(),
+                        inverted_contexts,
                     }),
                 )
             }
@@ -208,7 +214,11 @@ pub(crate) fn build_operation_with_aliasing(
     contextual_arguments: &ContextualArguments,
     subgraph_schema: &Valid<apollo_compiler::Schema>,
 ) -> Result<Valid<ExecutableDocument>, ContextBatchingError> {
-    let ContextualArguments { arguments, count } = contextual_arguments;
+    let ContextualArguments {
+        arguments,
+        count,
+        inverted_contexts: _,
+    } = contextual_arguments;
     let parsed_document = subgraph_operation.as_parsed();
 
     let mut ed = ExecutableDocument::new();
@@ -284,7 +294,12 @@ fn transform_operation(
         // it is a field selection for _entities, so it's ok to reach in and give it an alias
         let mut cloned = field_selection.clone();
         let cfs = cloned.make_mut();
-        cfs.alias = Some(Name::new_unchecked(&format!("_{i}")));
+        // Prefix the alias with the original operation name to make it clearer, even if it's
+        // expected to always be `_entities`.
+        cfs.alias = Some(Name::new_unchecked(&format!(
+            "{op}_{i}",
+            op = field_selection.name
+        )));
 
         transform_field_arguments(&mut cfs.arguments, arguments, i);
         transform_selection_set(&mut cfs.selection_set, arguments, i);
@@ -449,7 +464,7 @@ mod subgraph_context_unit_tests {
         let count = 3;
         transform_operation(&mut operation, &hash_set, &count).unwrap();
         assert_eq!(
-            "{ _0: f(param: $variable_0) _1: f(param: $variable_1) _2: f(param: $variable_2) }",
+            "{ f_0: f(param: $variable_0) f_1: f(param: $variable_1) f_2: f(param: $variable_2) }",
             operation.serialize().no_indent().to_string()
         );
     }

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -171,6 +171,7 @@ impl FetchService {
                 &schema,
                 &current_dir,
                 paths,
+                None, // Connectors don't use contexts
                 response,
                 hoist_orphan_errors,
             );
@@ -272,6 +273,9 @@ impl FetchService {
                     &current_dir,
                     &schema,
                     variables.inverted_paths,
+                    variables
+                        .contextual_arguments
+                        .map(|ctx| ctx.inverted_contexts),
                     &aqs,
                     variables.variables,
                     hoist_orphan_errors,

--- a/apollo-router/tests/fixtures/set_context/one.json
+++ b/apollo-router/tests/fixtures/set_context/one.json
@@ -155,7 +155,7 @@
     },
     {
       "request": {
-        "query": "query QueryLL__Subgraph1__1($representations: [_Any!]!, $contextualArgument_1_0_0: String, $contextualArgument_1_0_1: String) { _0: _entities(representations: $representations) { ... on U { field(a: $contextualArgument_1_0_0) } } _1: _entities(representations: $representations) { ... on U { field(a: $contextualArgument_1_0_1) } } }",
+        "query": "query QueryLL__Subgraph1__1($representations: [_Any!]!, $contextualArgument_1_0_0: String, $contextualArgument_1_0_1: String) { _entities_0: _entities(representations: $representations) { ... on U { field(a: $contextualArgument_1_0_0) } } _entities_1: _entities(representations: $representations) { ... on U { field(a: $contextualArgument_1_0_1) } } }",
         "operationName": "QueryLL__Subgraph1__1",
         "variables": {
           "contextualArgument_1_0_0": "prop value 1",
@@ -168,7 +168,7 @@
       },
       "response": {
         "data": {
-          "_entities": [
+          "_entities_0": [
             {
               "id": "3",
               "field": 3456
@@ -177,13 +177,23 @@
               "id": "4",
               "field": 4567
             }
+          ],
+          "_entities_1": [
+            {
+              "id": "3",
+              "field": 111
+            },
+            {
+              "id": "4",
+              "field": 222
+            }
           ]
         }
       }
     },
     {
       "request": {
-        "query": "query QueryLL__Subgraph1__1($representations: [_Any!]!, $contextualArgument_1_0_0: String, $contextualArgument_1_0_1: String) { _0: _entities(representations: $representations) { ... on U { field(a: $contextualArgument_1_0_0) } } _1: _entities(representations: $representations) { ... on U { field(a: $contextualArgument_1_0_1) } } }",
+        "query": "query QueryLL__Subgraph1__1($representations: [_Any!]!, $contextualArgument_1_0_0: String, $contextualArgument_1_0_1: String) { _entities_0: _entities(representations: $representations) { ... on U { field(a: $contextualArgument_1_0_0) } } _entities_1: _entities(representations: $representations) { ... on U { field(a: $contextualArgument_1_0_1) } } }",
         "operationName": "QueryLL__Subgraph1__1",
         "variables": {
           "contextualArgument_1_0_1": "prop value 2",
@@ -196,7 +206,7 @@
       },
       "response": {
         "data": {
-          "_entities": [
+          "_entities_0": [
             {
               "id": "3",
               "field": 3456
@@ -204,6 +214,16 @@
             {
               "id": "4",
               "field": 4567
+            }
+          ],
+          "_entities_1": [
+            {
+              "id": "3",
+              "field": 111
+            },
+            {
+              "id": "4",
+              "field": 222
             }
           ]
         }

--- a/apollo-router/tests/snapshots/set_context__set_context_list_of_lists_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_list_of_lists_rust_qp.snap
@@ -17,7 +17,7 @@ expression: response
         "id": "2",
         "uList": [
           {
-            "field": 4567
+            "field": 222
           }
         ]
       }


### PR DESCRIPTION
(This is an add-on optimization on top of PR #9071.)

Eliminate redundant entity responses by splitting $representations per context

When contexts differ across entities, the aliased _entities query
previously shared a single $representations array across all aliases,
producing an N×M response matrix where only N values were needed.

This change gives each `_entities_<i>` alias its own singleton
`$representations_<i>` variable containing only the one representation
needed for that context, reducing subgraph response size from N×M to N.

Also optimizes aliased error remapping by pre-building a
context-to-path HashMap for O(1) lookups instead of linear scans.

<!-- start metadata -->

<!-- [FED-897] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

[FED-897]: https://apollographql.atlassian.net/browse/FED-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ