### PR TITLE
prep release: v2.13.1

### DIFF
--- a/.changesets/fix_unconstrained_buffer_router_1669.md
+++ b/.changesets/fix_unconstrained_buffer_router_1669.md
@@ -1,7 +1,0 @@
-### Fix spurious `REQUEST_RATE_LIMITED` errors when no rate limiting is configured ([PR #9034](https://github.com/apollographql/router/pull/9034))
-
-Under sustained load, the router could return `REQUEST_RATE_LIMITED` (429) errors even when no rate limiting was configured. An internal queue had an implicit limit that could trigger load shedding, even if the queue was not _actually_ overloaded.
-
-This fix removes that implicit limit, so requests are shed only when the queue is genuinely full. The queue still has explicit limits to ensure quality of service.
-
-By [@jhrldev](https://github.com/jhrldev) in https://github.com/apollographql/router/pull/9034

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+# [2.13.1] - 2026-04-03
+
+## 🐛 Fixes
+
+### Fix spurious `REQUEST_RATE_LIMITED` errors when no rate limiting is configured ([PR #9034](https://github.com/apollographql/router/pull/9034))
+
+Under sustained load, the router could return `REQUEST_RATE_LIMITED` (429) errors even when no rate limiting was configured. An internal queue had an implicit limit that could trigger load shedding, even if the queue was not _actually_ overloaded.
+
+This fix removes that implicit limit, so requests are shed only when the queue is genuinely full. The queue still has explicit limits to ensure quality of service.
+
+By [@jhrldev](https://github.com/jhrldev) in https://github.com/apollographql/router/pull/9034
+
+
+
 # [2.13.0] - 2026-03-31
 
 ## 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.13.1-rc.0"
+version = "2.13.1"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "2.13.1-rc.0"
+version = "2.13.1"
 dependencies = [
  "addr2line 0.25.1",
  "ahash",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "2.13.1-rc.0"
+version = "2.13.1"
 dependencies = [
  "apollo-parser",
  "apollo-router",

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation"
-version = "2.13.1-rc.0"
+version = "2.13.1"
 authors = ["The Apollo GraphQL Contributors"]
 edition = "2024"
 description = "Apollo Federation"

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "2.13.1-rc.0"
+version = "2.13.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "2.13.1-rc.0"
+version = "2.13.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"
@@ -59,7 +59,7 @@ snapshot = []
 addr2line = "0.25.0"
 anyhow = "1.0.86"
 apollo-compiler.workspace = true
-apollo-federation = { path = "../apollo-federation", version = "=2.13.1-rc.0" }
+apollo-federation = { path = "../apollo-federation", version = "=2.13.1" }
 async-compression = { version = "0.4.6", features = [
     "tokio",
     "futures-io",

--- a/docs/shared/k8s-manual-config.mdx
+++ b/docs/shared/k8s-manual-config.mdx
@@ -6,10 +6,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-2.13.1-rc.0
+    helm.sh/chart: router-2.13.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.13.1-rc.0"
+    app.kubernetes.io/version: "v2.13.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: router/templates/secret.yaml
@@ -18,10 +18,10 @@ kind: Secret
 metadata:
   name: "release-name-router"
   labels:
-    helm.sh/chart: router-2.13.1-rc.0
+    helm.sh/chart: router-2.13.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.13.1-rc.0"
+    app.kubernetes.io/version: "v2.13.1"
     app.kubernetes.io/managed-by: Helm
 data:
   managedFederationApiKey: "UkVEQUNURUQ="
@@ -32,10 +32,10 @@ kind: ConfigMap
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-2.13.1-rc.0
+    helm.sh/chart: router-2.13.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.13.1-rc.0"
+    app.kubernetes.io/version: "v2.13.1"
     app.kubernetes.io/managed-by: Helm
 data:
   configuration.yaml: |
@@ -55,10 +55,10 @@ kind: Service
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-2.13.1-rc.0
+    helm.sh/chart: router-2.13.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.13.1-rc.0"
+    app.kubernetes.io/version: "v2.13.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -81,10 +81,10 @@ kind: Deployment
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-2.13.1-rc.0
+    helm.sh/chart: router-2.13.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.13.1-rc.0"
+    app.kubernetes.io/version: "v2.13.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
   
@@ -103,10 +103,10 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: router
       labels:
-        helm.sh/chart: router-2.13.1-rc.0
+        helm.sh/chart: router-2.13.1
         app.kubernetes.io/name: router
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v2.13.1-rc.0"
+        app.kubernetes.io/version: "v2.13.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: release-name-router
@@ -117,7 +117,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v2.13.1-rc.0"
+          image: "ghcr.io/apollographql/router:v2.13.1"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload
@@ -171,10 +171,10 @@ kind: Pod
 metadata:
   name: "release-name-router-test-connection"
   labels:
-    helm.sh/chart: router-2.13.1-rc.0
+    helm.sh/chart: router-2.13.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v2.13.1-rc.0"
+    app.kubernetes.io/version: "v2.13.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 2.13.1-rc.0
+version: 2.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.13.1-rc.0"
+appVersion: "v2.13.1"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 2.13.1-rc.0](https://img.shields.io/badge/Version-2.13.1--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.13.1-rc.0](https://img.shields.io/badge/AppVersion-v2.13.1--rc.0-informational?style=flat-square)
+![Version: 2.13.1](https://img.shields.io/badge/Version-2.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.13.1](https://img.shields.io/badge/AppVersion-v2.13.1-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 2.13.1-rc.0
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 2.13.1
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 2.13.1-rc.0
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 2.13.1-rc.0 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 2.13.1 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="${APOLLO_ROUTER_BINARY_DOWNLOAD_PREFIX:="https://github.
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v2.13.1-rc.0"
+PACKAGE_VERSION="v2.13.1"
 
 download_binary() {
     downloader --check


### PR DESCRIPTION
> **Note**
>
> When approved, this PR will merge into **the `2.13.1` branch** which will — upon being approved itself — merge into `main`.
>
> **Things to review in this PR**:
>  - Changelog correctness (There is a preview below, but it is not necessarily the most up to date.  See the _Files Changed_ for the true reality.)
>  - Version bumps
>  - That it targets the right release branch (`2.13.1` in this case!).
>
---
## 🐛 Fixes

### Fix spurious `REQUEST_RATE_LIMITED` errors when no rate limiting is configured ([PR #9034](https://github.com/apollographql/router/pull/9034))

Under sustained load, the router could return `REQUEST_RATE_LIMITED` (429) errors even when no rate limiting was configured. An internal queue had an implicit limit that could trigger load shedding, even if the queue was not _actually_ overloaded.

This fix removes that implicit limit, so requests are shed only when the queue is genuinely full. The queue still has explicit limits to ensure quality of service.

By [@jhrldev](https://github.com/jhrldev) in https://github.com/apollographql/router/pull/9034
