### PR TITLE
fix(composition): Stop validating @requires(fields:) argument against subgraph schema

### DIFF
--- a/apollo-federation/src/schema/validators/requires.rs
+++ b/apollo-federation/src/schema/validators/requires.rs
@@ -2,7 +2,6 @@ use apollo_compiler::Name;
 use apollo_compiler::ast::DirectiveList;
 use apollo_compiler::executable::Field;
 use apollo_compiler::validation::DiagnosticList;
-use apollo_compiler::validation::Valid;
 use itertools::Itertools;
 
 use crate::error::FederationError;
@@ -51,23 +50,12 @@ pub(crate) fn validate_requires_directives(
                 );
                 match requires.parse_fields(schema.schema()) {
                     Ok(fields) => {
-                        let existing_error_count = errors.errors.len();
                         for rule in fieldset_rules.iter() {
                             rule.visit(requires.target.type_name(), &fields, &requires, errors);
                         }
-
-                        // We apply federation-specific validation rules without validating first to maintain compatibility with existing messaging,
-                        // but if we get to this point without errors, we want to make sure it's still a valid selection.
-                        let did_not_find_errors = existing_error_count == errors.errors.len();
-                        if did_not_find_errors
-                            && let Err(validation_error) =
-                                fields.validate(Valid::assume_valid_ref(schema.schema()))
-                        {
-                            errors.push(invalid_fields_error_from_diagnostics(
-                                &requires,
-                                validation_error,
-                            ));
-                        }
+                        // Note: we intentionally do NOT run `fields.validate()` against the
+                        // subgraph schema here. Full validation is performed post-merge against
+                        // the supergraph schema in `validate_merged_schema`.
                     }
                     Err(e) => {
                         errors.push(invalid_fields_error_from_diagnostics(&requires, e.errors))

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -442,6 +442,65 @@ fn post_merge_errors_if_type_does_not_implement_interface_on_interface() {
     );
 }
 
+#[test]
+fn requires_fields_validated_in_supergraph_schema() {
+    // The @requires fields arguments should be validated against the supergraph schema, not the
+    // subgraph schema. Thus, even if subgraph B's @requires fields argument value is invalid in the
+    // subgraph schema, it's still valid in supergraph after merging.
+
+    // In subgraph A, type B implements interface I.
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          t: T
+        }
+
+        interface I {
+          x: String
+        }
+
+        type B implements I @key(fields: "x") {
+          x: String @shareable
+          y: String
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          i: I
+        }
+        "#,
+    };
+
+    // In subgraph B, type B does NOT implement interface I,
+    // but @requires uses an inline fragment `... on B` within an I-typed field.
+    // This should be valid because B implements I in the supergraph.
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        interface I {
+          x: String
+        }
+
+        type B @key(fields: "x") {
+          x: String @shareable
+          y: String @external
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          i: I @external
+          computed: String @requires(fields: "i { x ... on B { y } }")
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    result.expect(
+        "Expected composition to succeed when type implements interface in another subgraph",
+    );
+}
+
 // =============================================================================
 // MISC VALIDATIONS - Standalone validation tests
 // =============================================================================


### PR DESCRIPTION
It was unnecessary since @requires fields arguments are validated against supergraph schema after merge ([here](https://github.com/apollographql/router/blob/40ac193748560138fba6f39441e7925b2ab71b2b/apollo-federation/src/schema/validators/merged.rs#L148)).

- Removed the validation during the subgraph validation
- Added a test

<!-- start metadata -->

<!-- [FED-874] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary


[FED-874]: https://apollographql.atlassian.net/browse/FED-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ