### PR TITLE
fix(composition): update scalar type directive referencers on rename

### DIFF
--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -1160,7 +1160,17 @@ impl TypeDefinitionPosition {
                     .referencers
                     .rename_interface_type(&old_name, &new_name);
             }
-            _ => {}
+            TypeDefinitionPosition::Union(_) => {
+                schema.referencers.rename_union_type(&old_name, &new_name);
+            }
+            TypeDefinitionPosition::Enum(_) => {
+                schema.referencers.rename_enum_type(&old_name, &new_name);
+            }
+            TypeDefinitionPosition::InputObject(_) => {
+                schema
+                    .referencers
+                    .rename_input_object_type(&old_name, &new_name);
+            }
         }
 
         Ok(())

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -1149,6 +1149,9 @@ impl TypeDefinitionPosition {
         }
 
         match self {
+            TypeDefinitionPosition::Scalar(_) => {
+                schema.referencers.rename_scalar_type(&old_name, &new_name);
+            }
             TypeDefinitionPosition::Object(_) => {
                 schema.referencers.rename_object_type(&old_name, &new_name);
             }

--- a/apollo-federation/src/schema/referencer.rs
+++ b/apollo-federation/src/schema/referencer.rs
@@ -317,6 +317,33 @@ impl Referencers {
         arguments.extend(updated_arguments);
     }
 
+    pub(crate) fn rename_scalar_type(&mut self, old_name: &Name, new_name: &Name) {
+        for (_directive_name, directive_refs) in self.directives.iter_mut() {
+            Self::update_scalar_type_positions(
+                &mut directive_refs.scalar_types,
+                old_name,
+                new_name,
+            );
+        }
+    }
+
+    fn update_scalar_type_positions(
+        types: &mut IndexSet<ScalarTypeDefinitionPosition>,
+        old_type_name: &Name,
+        new_type_name: &Name,
+    ) {
+        let updated_types: Vec<_> = types
+            .iter()
+            .filter(|t| &t.type_name == old_type_name)
+            .map(|_| ScalarTypeDefinitionPosition {
+                type_name: new_type_name.clone(),
+            })
+            .collect();
+
+        types.retain(|t| &t.type_name != old_type_name);
+        types.extend(updated_types);
+    }
+
     pub(crate) fn rename_interface_type(&mut self, old_name: &Name, new_name: &Name) {
         for (_scalar_name, scalar_refs) in self.scalar_types.iter_mut() {
             Self::update_interface_field_positions(

--- a/apollo-federation/src/schema/referencer.rs
+++ b/apollo-federation/src/schema/referencer.rs
@@ -344,6 +344,133 @@ impl Referencers {
         types.extend(updated_types);
     }
 
+    pub(crate) fn rename_union_type(&mut self, old_name: &Name, new_name: &Name) {
+        for (_directive_name, directive_refs) in self.directives.iter_mut() {
+            Self::update_union_type_positions(
+                &mut directive_refs.union_types,
+                old_name,
+                new_name,
+            );
+        }
+    }
+
+    fn update_union_type_positions(
+        types: &mut IndexSet<UnionTypeDefinitionPosition>,
+        old_type_name: &Name,
+        new_type_name: &Name,
+    ) {
+        let updated_types: Vec<_> = types
+            .iter()
+            .filter(|t| &t.type_name == old_type_name)
+            .map(|_| UnionTypeDefinitionPosition {
+                type_name: new_type_name.clone(),
+            })
+            .collect();
+
+        types.retain(|t| &t.type_name != old_type_name);
+        types.extend(updated_types);
+    }
+
+    pub(crate) fn rename_enum_type(&mut self, old_name: &Name, new_name: &Name) {
+        for (_directive_name, directive_refs) in self.directives.iter_mut() {
+            Self::update_enum_type_positions(
+                &mut directive_refs.enum_types,
+                old_name,
+                new_name,
+            );
+            Self::update_enum_value_positions(
+                &mut directive_refs.enum_values,
+                old_name,
+                new_name,
+            );
+        }
+    }
+
+    fn update_enum_type_positions(
+        types: &mut IndexSet<EnumTypeDefinitionPosition>,
+        old_type_name: &Name,
+        new_type_name: &Name,
+    ) {
+        let updated_types: Vec<_> = types
+            .iter()
+            .filter(|t| &t.type_name == old_type_name)
+            .map(|_| EnumTypeDefinitionPosition {
+                type_name: new_type_name.clone(),
+            })
+            .collect();
+
+        types.retain(|t| &t.type_name != old_type_name);
+        types.extend(updated_types);
+    }
+
+    fn update_enum_value_positions(
+        values: &mut IndexSet<EnumValueDefinitionPosition>,
+        old_type_name: &Name,
+        new_type_name: &Name,
+    ) {
+        let updated_values: Vec<_> = values
+            .iter()
+            .filter(|v| &v.type_name == old_type_name)
+            .map(|v| EnumValueDefinitionPosition {
+                type_name: new_type_name.clone(),
+                value_name: v.value_name.clone(),
+            })
+            .collect();
+
+        values.retain(|v| &v.type_name != old_type_name);
+        values.extend(updated_values);
+    }
+
+    pub(crate) fn rename_input_object_type(&mut self, old_name: &Name, new_name: &Name) {
+        for (_directive_name, directive_refs) in self.directives.iter_mut() {
+            Self::update_input_object_type_positions(
+                &mut directive_refs.input_object_types,
+                old_name,
+                new_name,
+            );
+            Self::update_input_object_field_positions(
+                &mut directive_refs.input_object_fields,
+                old_name,
+                new_name,
+            );
+        }
+    }
+
+    fn update_input_object_type_positions(
+        types: &mut IndexSet<InputObjectTypeDefinitionPosition>,
+        old_type_name: &Name,
+        new_type_name: &Name,
+    ) {
+        let updated_types: Vec<_> = types
+            .iter()
+            .filter(|t| &t.type_name == old_type_name)
+            .map(|_| InputObjectTypeDefinitionPosition {
+                type_name: new_type_name.clone(),
+            })
+            .collect();
+
+        types.retain(|t| &t.type_name != old_type_name);
+        types.extend(updated_types);
+    }
+
+    fn update_input_object_field_positions(
+        fields: &mut IndexSet<InputObjectFieldDefinitionPosition>,
+        old_type_name: &Name,
+        new_type_name: &Name,
+    ) {
+        let updated_fields: Vec<_> = fields
+            .iter()
+            .filter(|f| &f.type_name == old_type_name)
+            .map(|f| InputObjectFieldDefinitionPosition {
+                type_name: new_type_name.clone(),
+                field_name: f.field_name.clone(),
+            })
+            .collect();
+
+        fields.retain(|f| &f.type_name != old_type_name);
+        fields.extend(updated_fields);
+    }
+
     pub(crate) fn rename_interface_type(&mut self, old_name: &Name, new_name: &Name) {
         for (_scalar_name, scalar_refs) in self.scalar_types.iter_mut() {
             Self::update_interface_field_positions(

--- a/apollo-federation/src/schema/referencer.rs
+++ b/apollo-federation/src/schema/referencer.rs
@@ -346,11 +346,7 @@ impl Referencers {
 
     pub(crate) fn rename_union_type(&mut self, old_name: &Name, new_name: &Name) {
         for (_directive_name, directive_refs) in self.directives.iter_mut() {
-            Self::update_union_type_positions(
-                &mut directive_refs.union_types,
-                old_name,
-                new_name,
-            );
+            Self::update_union_type_positions(&mut directive_refs.union_types, old_name, new_name);
         }
     }
 
@@ -373,16 +369,8 @@ impl Referencers {
 
     pub(crate) fn rename_enum_type(&mut self, old_name: &Name, new_name: &Name) {
         for (_directive_name, directive_refs) in self.directives.iter_mut() {
-            Self::update_enum_type_positions(
-                &mut directive_refs.enum_types,
-                old_name,
-                new_name,
-            );
-            Self::update_enum_value_positions(
-                &mut directive_refs.enum_values,
-                old_name,
-                new_name,
-            );
+            Self::update_enum_type_positions(&mut directive_refs.enum_types, old_name, new_name);
+            Self::update_enum_value_positions(&mut directive_refs.enum_values, old_name, new_name);
         }
     }
 

--- a/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
@@ -87,6 +87,45 @@ fn fed1_preserves_federation_directive_descriptions() {
     "#);
 }
 
+/// Fed1 schema with @tag on _FieldSet scalar - should upgrade successfully.
+#[test]
+fn fed1_fieldset_with_tag_upgrades_successfully() {
+    let subgraph = Subgraph::parse(
+        "subgraph",
+        "",
+        r#"
+            scalar _FieldSet @tag(name: "a")
+
+            directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+            directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+            type Query {
+                start(id: ID!): S
+            }
+
+            type S @key(fields: "id") @tag(name: "b") {
+                id: ID!
+                name: String
+            }
+        "#,
+    )
+    .expect("parses schema")
+    .expand_links()
+    .expect("expands schema");
+
+    let [upgraded]: [Subgraph<_>; 1] = upgrade_subgraphs_if_necessary(vec![subgraph])
+        .expect("upgrades schema")
+        .try_into()
+        .expect("Upgrade subgraphs");
+
+    // Verify the upgraded schema has federation__FieldSet, not _FieldSet
+    let schema = upgraded.validated_schema().schema();
+    assert!(
+        schema.types.contains_key("federation__FieldSet"),
+        "Expected federation__FieldSet type in upgraded schema"
+    );
+}
+
 // =============================================================================
 // Fed2 Schema Passthrough Tests
 // =============================================================================


### PR DESCRIPTION
### Summary

Fixes an INTERNAL error during composition when a fed1 subgraph has a directive (like @tag) applied to the _FieldSet scalar. The error manifests as Schema has no type '_FieldSet'.

During fed1→fed2 upgrade, _FieldSet is renamed to federation__FieldSet. The rename logic correctly updated the type in the schema and its type references, but did not update the directive application referencers for scalar types. This left stale entries pointing to _FieldSet in the @tag directive's referencers, which later caused a lookup failure in tag_directive_applications().

The fix adds a rename_scalar_type method to Referencers and wires it into TypeDefinitionPosition::rename() for the Scalar variant, matching what was already done for Object and Interface types. A reproducer test is included.

### Test plan

- Added fed1_fieldset_with_tag_upgrades_successfully test that reproduces the bug (fails without fix, passes with fix)

<!-- start metadata -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is an on-going incremental development of Rust composition.