### PR TITLE
fix(connectors): handle 204 responses without Content-Length header

### DIFF
--- a/.changesets/fix_mateuswgoettems_connector_204_empty_body.md
+++ b/.changesets/fix_mateuswgoettems_connector_204_empty_body.md
@@ -1,0 +1,8 @@
+### Fix connector handling of 204 responses without `Content-Length` header
+
+Connectors now correctly handle HTTP 204 (No Content) responses from spec-compliant servers that do not include a `Content-Length` header.
+
+Previously, empty body detection relied on the presence of a `Content-Length: 0` header. Since the HTTP spec explicitly forbids including this header in 204 responses, connectors would fail to recognize empty bodies from compliant servers. The fix checks
+`body.is_empty()` directly, with `Content-Length: 0` kept as a fallback for non-compliant servers.
+
+By [@apollo-mateuswgoettems](https://github.com/apollo-mateuswgoettems) in https://github.com/apollographql/router/pull/9141

--- a/apollo-federation/src/connectors/runtime/responses.rs
+++ b/apollo-federation/src/connectors/runtime/responses.rs
@@ -39,12 +39,17 @@ pub enum HandleResponseError {
 
 /// Converts a response body into a json Value based on the Content-Type header.
 pub fn deserialize_response(body: &[u8], headers: &HeaderMap) -> Result<Value, DeserializeError> {
-    // If the body is obviously empty, don't try to parse it
-    if headers
-        .get(CONTENT_LENGTH)
-        .and_then(|len| len.to_str().ok())
-        .and_then(|s| s.parse::<usize>().ok())
-        .is_some_and(|content_length| content_length == 0)
+    // If the body is empty, there's nothing to parse. We check body.is_empty()
+    // directly because spec-compliant HTTP 204 responses must not include a
+    // Content-Length header — so we can't rely on that header alone to detect
+    // empty bodies. The Content-Length: 0 check is kept for non-compliant
+    // servers that do send it, but body.is_empty() covers both cases.
+    if body.is_empty()
+        || headers
+            .get(CONTENT_LENGTH)
+            .and_then(|len| len.to_str().ok())
+            .and_then(|s| s.parse::<usize>().ok())
+            .is_some_and(|content_length| content_length == 0)
     {
         return Ok(Value::Null);
     }

--- a/apollo-federation/src/connectors/runtime/responses.rs
+++ b/apollo-federation/src/connectors/runtime/responses.rs
@@ -699,3 +699,39 @@ impl MappedResponse {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use http::HeaderMap;
+    use http::HeaderValue;
+    use serde_json_bytes::Value;
+
+    use super::deserialize_response;
+
+    fn headers_with(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (k, v) in pairs {
+            map.insert(
+                http::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn empty_body_no_content_length_returns_null() {
+        // Spec-compliant 204: no Content-Length header, no body.
+        let headers = HeaderMap::new();
+        let result = deserialize_response(b"", &headers).unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn empty_body_with_content_length_zero_returns_null() {
+        // Non-compliant server that sends Content-Length: 0 on a 204.
+        let headers = headers_with(&[("content-length", "0")]);
+        let result = deserialize_response(b"", &headers).unwrap();
+        assert_eq!(result, Value::Null);
+    }
+}


### PR DESCRIPTION
### Connectors were failing to handle HTTP 204 (No Content) responses from spec-compliant servers.                                    
                                                                                                                                    
 The previous implementation relied on the `Content-Length: 0` header to detect empty response bodies. However, the HTTP spec states that 204 responses must not include a `Content-Length` header, making spec-compliant servers incompatible with the connector. 

The fix checks `body.is_empty()` directly as the primary signal for an empty body, keeping `Content-Length: 0` as a fallback for non-compliant servers.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.                                
 
- [x] PR description explains the motivation for the change and relevant context for reviewing                                    
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible                                                                                                      
- [x] Documentation completed
- [x] Performance impact assessed and acceptable                                                                                  
- [x] Metrics and logs are added and documented           
- Tests added and passing
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary                                                                                              
 
**Exceptions**                                                                                                                    
                                                          
- No documentation changes required — this is a bug fix for spec-compliant HTTP behavior with no configuration surface.
- No new metrics or logs added — the fix is in the deserialization path and does not introduce new observable behavior.
- No integration tests added — the fix is isolated to a pure function (`deserialize_response`) with no external dependencies; unit tests cover both scenarios.