### PR TITLE
fix(composition): sort subgraphs before composing

### DIFF
--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -27,6 +27,11 @@ pub use crate::supergraph::Supergraph;
 pub fn compose(
     subgraphs: Vec<Subgraph<Initial>>,
 ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+    // explicitly sort subgraphs by their names
+    // this was done automatically in JS as Subgraphs class stored subgraphs in OrderedMap (by name)
+    let mut subgraphs = subgraphs;
+    subgraphs.sort_by(|s1, s2| s1.name.cmp(&s2.name));
+
     tracing::debug!("Expanding subgraphs...");
     let expanded_subgraphs = expand_subgraphs(subgraphs)?;
     tracing::debug!("Upgrading subgraphs...");

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::fmt::Display;
+use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::LazyLock;
 
@@ -93,6 +94,7 @@ use crate::subgraph::typestate::Validated;
 use crate::supergraph::CompositionHint;
 use crate::utils::FallibleOnceCell;
 use crate::utils::MultiIndexMap;
+use crate::utils::first_max_by_key;
 use crate::utils::human_readable::human_readable_subgraph_names;
 use crate::utils::human_readable::human_readable_types;
 use crate::utils::iter_into_single_item;
@@ -2196,96 +2198,80 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
     where
         T: HasLocations + HasDescription + Display,
     {
-        let mut descriptions: IndexMap<&str, (usize, &str)> = Default::default();
-        for (idx, source) in sources.iter() {
-            let desc = source
-                .as_ref()
-                .and_then(|s| s.description(self.subgraphs[*idx].schema()))
-                .map(|d| d.trim())
-                .unwrap_or("");
-            if desc.is_empty() {
-                continue;
-            }
-            descriptions
-                .entry(desc)
-                .and_modify(|(count, _)| *count += 1)
-                .or_insert_with(|| (1, self.names[*idx].as_str()));
-        }
-        // we don't want to raise a hint if a description is ""
-        descriptions.shift_remove("");
+        let descriptions: IndexMap<&str, usize> = sources
+            .iter()
+            .map(|(idx, source)| {
+                source
+                    .as_ref()
+                    .and_then(|s| s.description(self.subgraphs[*idx].schema()))
+                    .map(|s| s.deref())
+                    .unwrap_or("")
+            })
+            // PORT NOTE: JS was keeping empty descriptions but only using them if no other description was provided
+            //  (i.e. we would pick any description over multiple empty descriptions)
+            .filter(|d| !d.is_empty())
+            .fold(Default::default(), |mut acc, desc| {
+                *acc.entry(desc).or_default() += 1;
+                acc
+            });
 
         if !descriptions.is_empty() {
-            let (chosen_description, single) =
-                if let Some((description, _)) = iter_into_single_item(descriptions.iter()) {
-                    (Some((*description).to_string()), true)
-                } else {
-                    // Sort deterministically: by count (desc), then description lex (asc = pick first),
-                    // then subgraph name (asc). First element is the chosen one.
-                    let chosen =
-                        descriptions
-                            .iter()
-                            .max_by(|(description_a, a), (description_b, b)| {
-                                b.0.cmp(&a.0)
-                                    .then_with(|| description_a.cmp(description_b))
-                                    .then_with(|| a.1.cmp(b.1))
-                            });
-                    (
-                        chosen.map(|(description, _)| (*description).to_string()),
-                        false,
-                    )
-                };
-            drop(descriptions);
-            if let Some(chosen_description) = chosen_description {
-                dest.set_description(&mut self.merged, Some(Node::new_str(&chosen_description)))?;
-                if !single {
-                    // TODO: Currently showing full descriptions in the hint
-                    // messages, which is probably fine in some cases. However this
-                    // might get less helpful if the description appears to differ
-                    // by a very small amount (a space, a single character typo) and
-                    // even more so the bigger the description is, and we could
-                    // improve the experience here. For instance, we could print the
-                    // supergraph description but then show other descriptions as
-                    // diffs from that (using, say,
-                    // https://www.npmjs.com/package/diff). And we could even switch
-                    // between diff/non-diff modes based on the levenshtein
-                    // distances between the description we found. That said, we
-                    // should decide if we want to bother here: maybe we can leave
-                    // it to studio so handle a better experience (as it can more UX
-                    // wise).
-                    let name = if T::is_schema_definition() {
-                        "The schema definition".to_string()
-                    } else {
-                        format!("Element \"{dest}\"")
-                    };
-                    self.error_reporter.report_mismatch_hint(
-                        HintCode::InconsistentDescription,
-                        format!("{name} has inconsistent descriptions across subgraphs. "),
-                        dest,
-                        sources,
-                        &self.subgraphs,
-                        |elem| elem.description(&self.merged).map(|desc| desc.to_string()),
-                        |elem, idx| {
-                            elem.description(self.subgraphs[idx].schema())
-                                .map(|desc| desc.to_string())
-                        },
-                        |desc, subgraphs| {
-                            format!(
-                                "The supergraph will use description (from {}):\n{}",
-                                subgraphs.unwrap_or_else(|| "undefined".to_string()),
-                                Self::description_string(desc, "  ")
-                            )
-                        },
-                        |desc, subgraphs| {
-                            format!(
-                                "\nIn {}, the description is:\n{}",
-                                subgraphs,
-                                Self::description_string(desc, "  ")
-                            )
-                        },
-                        false,
-                        true,
-                    );
+            if let Some((description, _)) = iter_into_single_item(descriptions.iter()) {
+                dest.set_description(&mut self.merged, Some(Node::new_str(description)))?;
+            } else {
+                // find the description with the highest count
+                if let Some((description, _)) =
+                    first_max_by_key(descriptions.iter(), |(_, count)| *count)
+                {
+                    dest.set_description(&mut self.merged, Some(Node::new_str(description)))?;
                 }
+                // TODO: Currently showing full descriptions in the hint
+                // messages, which is probably fine in some cases. However this
+                // might get less helpful if the description appears to differ
+                // by a very small amount (a space, a single character typo) and
+                // even more so the bigger the description is, and we could
+                // improve the experience here. For instance, we could print the
+                // supergraph description but then show other descriptions as
+                // diffs from that (using, say,
+                // https://www.npmjs.com/package/diff). And we could even switch
+                // between diff/non-diff modes based on the levenshtein
+                // distances between the description we found. That said, we
+                // should decide if we want to bother here: maybe we can leave
+                // it to studio so handle a better experience (as it can more UX
+                // wise).
+                let name = if T::is_schema_definition() {
+                    "The schema definition".to_string()
+                } else {
+                    format!("Element \"{dest}\"")
+                };
+                self.error_reporter.report_mismatch_hint(
+                    HintCode::InconsistentDescription,
+                    format!("{name} has inconsistent descriptions across subgraphs. "),
+                    dest,
+                    sources,
+                    &self.subgraphs,
+                    |elem| elem.description(&self.merged).map(|desc| desc.to_string()),
+                    |elem, idx| {
+                        elem.description(self.subgraphs[idx].schema())
+                            .map(|desc| desc.to_string())
+                    },
+                    |desc, subgraphs| {
+                        format!(
+                            "The supergraph will use description (from {}):\n{}",
+                            subgraphs.unwrap_or_else(|| "undefined".to_string()),
+                            Self::description_string(desc, "  ")
+                        )
+                    },
+                    |desc, subgraphs| {
+                        format!(
+                            "\nIn {}, the description is:\n{}",
+                            subgraphs,
+                            Self::description_string(desc, "  ")
+                        )
+                    },
+                    false,
+                    true,
+                );
             }
         }
         Ok(())

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -2199,12 +2199,11 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
     {
         let descriptions: IndexMap<&str, usize> = sources
             .iter()
-            .map(|(idx, source)| {
+            .filter_map(|(idx, source)| {
                 source
                     .as_ref()
                     .and_then(|s| s.description(self.subgraphs[*idx].schema()))
             })
-            .flatten()
             // PORT NOTE: JS was keeping empty descriptions but only using them if no other description was provided
             //  (i.e. we would pick any description over multiple empty descriptions)
             .filter(|d| !d.is_empty())

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::fmt::Display;
-use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::LazyLock;
 
@@ -2204,9 +2203,8 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                 source
                     .as_ref()
                     .and_then(|s| s.description(self.subgraphs[*idx].schema()))
-                    .map(|s| s.deref())
-                    .unwrap_or("")
             })
+            .flatten()
             // PORT NOTE: JS was keeping empty descriptions but only using them if no other description was provided
             //  (i.e. we would pick any description over multiple empty descriptions)
             .filter(|d| !d.is_empty())

--- a/apollo-federation/tests/composition/connectors.rs
+++ b/apollo-federation/tests/composition/connectors.rs
@@ -225,22 +225,22 @@ mod tests {
             .expect("Expected API schema generation to succeed");
         let api_schema_string = api_schema.schema().to_string();
 
-        assert_snapshot!(api_schema_string, @r###"
+        assert_snapshot!(api_schema_string, @"
         type Query {
-          resources: [Resource!]!
           widgets: [Widget!]!
-        }
-
-        type Resource {
-          id: ID!
-          name: String!
+          resources: [Resource!]!
         }
 
         type Widget {
           id: ID!
           name: String!
         }
-        "###);
+
+        type Resource {
+          id: ID!
+          name: String!
+        }
+        ");
     }
 
     #[test]

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -857,12 +857,13 @@ In subgraph "Subgraph2", the description is:
             name: "Subgraph1",
             type_defs: r#"
                 type Query {
-                    a: Int
+                  t: T
                 }
 
-                type T @shareable {
-                    "I don't know what I'm doing"
-                    f: Int
+                type T @key(fields: "id") {
+                  id: ID!
+                  "First description"
+                  f: Int @shareable
                 }
             "#,
         };
@@ -870,9 +871,10 @@ In subgraph "Subgraph2", the description is:
         let subgraph2 = ServiceDefinition {
             name: "Subgraph2",
             type_defs: r#"
-                type T @shareable {
-                    "Return a super secret integer"
-                    f: Int
+                type T @key(fields: "id") {
+                  id: ID!
+                  "Second description"
+                  f: Int @shareable
                 }
             "#,
         };
@@ -880,11 +882,12 @@ In subgraph "Subgraph2", the description is:
         let subgraph3 = ServiceDefinition {
             name: "Subgraph3",
             type_defs: r#"
-                type T @shareable {
-                    """
-                    Return a super secret integer
-                    """
-                    f: Int
+                type T @key(fields: "id") {
+                  id: ID!
+                  """
+                  Second description
+                  """
+                  f: Int @shareable
                 }
             "#,
         };
@@ -893,13 +896,13 @@ In subgraph "Subgraph2", the description is:
         assert_has_hint(
             &result,
             "INCONSISTENT_DESCRIPTION",
-            r#"Element "T.f" has inconsistent descriptions across subgraphs. The supergraph will use description (from subgraph "Subgraph1"):
+            r#"Element "T.f" has inconsistent descriptions across subgraphs. The supergraph will use description (from subgraphs "Subgraph2" and "Subgraph3"):
   """
-  I don't know what I'm doing
+  Second description
   """
-In subgraphs "Subgraph2" and "Subgraph3", the description is:
+In subgraph "Subgraph1", the description is:
   """
-  Return a super secret integer
+  First description
   """"#,
         );
     }
@@ -944,13 +947,13 @@ In subgraphs "Subgraph2" and "Subgraph3", the description is:
         assert_has_hint(
             &result,
             "INCONSISTENT_DESCRIPTION",
-            r#"Element "Order" has inconsistent descriptions across subgraphs. The supergraph will use description (from subgraph "Users"):
-  """
-  Represents a user order
-  """
-In subgraph "Orders", the description is:
+            r#"Element "Order" has inconsistent descriptions across subgraphs. The supergraph will use description (from subgraph "Orders"):
   """
   Reference type to order entity in ONE GRAPH
+  """
+In subgraph "Users", the description is:
+  """
+  Represents a user order
   """"#,
         );
 
@@ -965,7 +968,7 @@ In subgraph "Orders", the description is:
         let desc = order_type.description().map(|n| n.as_str()).unwrap_or("");
         assert_eq!(
             desc.trim(),
-            "Represents a user order",
+            "Reference type to order entity in ONE GRAPH",
             "supergraph should use chosen description"
         );
     }
@@ -1014,7 +1017,12 @@ In subgraph "Orders", the description is:
 
         let result =
             compose_as_fed2_subgraphs(&[catalog_subgraph, inventory_subgraph, reviews_subgraph])
-                .unwrap();
+                .expect("successfully composed");
+        assert_has_hint(
+            &result,
+            "INCONSISTENT_DESCRIPTION",
+            "Element \"Product\" has inconsistent descriptions across subgraphs. The supergraph will use description (from subgraph \"Catalog\"):\n  \"\"\"\n  Product in the catalog\n  \"\"\"\nIn subgraph \"Inventory\", the description is:\n  \"\"\"\n  Inventory product entity\n  \"\"\" and \nIn subgraph \"Reviews\", the description is:\n  \"\"\"\n  Product for reviews\n  \"\"\"",
+        );
 
         let api_schema = result
             .to_api_schema(Default::default())
@@ -1023,7 +1031,7 @@ In subgraph "Orders", the description is:
             .schema()
             .types
             .get("Product")
-            .expect("Product type in schema");
+            .expect("Product type exists in schema");
         let desc = product_type.description().map(|n| n.as_str()).unwrap_or("");
         assert_eq!(
             desc.trim(),
@@ -1079,6 +1087,11 @@ In subgraph "Orders", the description is:
         let result =
             compose_as_fed2_subgraphs(&[reviews_subgraph, catalog_subgraph, inventory_subgraph])
                 .unwrap();
+        assert_has_hint(
+            &result,
+            "INCONSISTENT_DESCRIPTION",
+            "Element \"Product\" has inconsistent descriptions across subgraphs. The supergraph will use description (from subgraph \"Catalog\"):\n  \"\"\"\n  Product in the catalog\n  \"\"\"\nIn subgraph \"Inventory\", the description is:\n  \"\"\"\n  Inventory product entity\n  \"\"\" and \nIn subgraph \"Reviews\", the description is:\n  \"\"\"\n  Product for reviews\n  \"\"\"",
+        );
 
         let api_schema = result
             .to_api_schema(Default::default())

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_2.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_2_], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_2_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_2_], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_2_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}}) {
   query: Query
 }
 
@@ -36,8 +36,8 @@ enum link__Purpose {
 scalar link__Import
 
 enum join__Graph {
-  WITH_CONNECTORS_V0_2_ @join__graph(name: "with-connectors-v0_2", url: "http://with-connectors-v0_2")
   WITH_CONNECTORS_V0_1_ @join__graph(name: "with-connectors-v0_1", url: "http://with-connectors-v0_1")
+  WITH_CONNECTORS_V0_2_ @join__graph(name: "with-connectors-v0_2", url: "http://with-connectors-v0_2")
 }
 
 scalar join__FieldSet
@@ -53,17 +53,17 @@ input join__ContextArgument {
   selection: join__FieldValue!
 }
 
-type Query @join__type(graph: WITH_CONNECTORS_V0_2_) @join__type(graph: WITH_CONNECTORS_V0_1_) {
-  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_2_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+type Query @join__type(graph: WITH_CONNECTORS_V0_1_) @join__type(graph: WITH_CONNECTORS_V0_2_) {
   widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_1_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_1_], args: {source: "v1", http: {GET: "/widgets"}, selection: ""})
+  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_2_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
 }
 
-type Resource @join__type(graph: WITH_CONNECTORS_V0_2_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources", path: "", queryParams: ""}, batch: {maxSize: 5}, errors: {message: "", extensions: ""}, selection: ""}) {
+type Widget @join__type(graph: WITH_CONNECTORS_V0_1_, key: "id") {
   id: ID!
   name: String!
 }
 
-type Widget @join__type(graph: WITH_CONNECTORS_V0_1_, key: "id") {
+type Resource @join__type(graph: WITH_CONNECTORS_V0_2_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources", path: "", queryParams: ""}, batch: {maxSize: 5}, errors: {message: "", extensions: ""}, selection: ""}) {
   id: ID!
   name: String!
 }

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3-2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3-2.snap
@@ -3,16 +3,16 @@ source: apollo-federation/tests/composition/connectors.rs
 expression: api_schema_string
 ---
 type Query {
-  resources: [Resource!]!
   widgets: [Widget!]!
+  resources: [Resource!]!
 }
 
-type Resource {
+type Widget {
   id: ID!
   name: String!
 }
 
-type Widget {
+type Resource {
   id: ID!
   name: String!
 }

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) {
   query: Query
 }
 
@@ -36,8 +36,8 @@ enum link__Purpose {
 scalar link__Import
 
 enum join__Graph {
-  WITH_CONNECTORS_V0_3_ @join__graph(name: "with-connectors-v0_3", url: "http://with-connectors-v0_3")
   WITH_CONNECTORS_V0_1_ @join__graph(name: "with-connectors-v0_1", url: "http://with-connectors-v0_1")
+  WITH_CONNECTORS_V0_3_ @join__graph(name: "with-connectors-v0_3", url: "http://with-connectors-v0_3")
 }
 
 scalar join__FieldSet
@@ -53,17 +53,17 @@ input join__ContextArgument {
   selection: join__FieldValue!
 }
 
-type Query @join__type(graph: WITH_CONNECTORS_V0_3_) @join__type(graph: WITH_CONNECTORS_V0_1_) {
-  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+type Query @join__type(graph: WITH_CONNECTORS_V0_1_) @join__type(graph: WITH_CONNECTORS_V0_3_) {
   widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_1_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_1_], args: {source: "v1", http: {GET: "/widgets"}, selection: ""})
+  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
 }
 
-type Resource @join__type(graph: WITH_CONNECTORS_V0_3_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {id: "conn_id", source: "v1", http: {GET: "/resources", path: "", queryParams: ""}, batch: {maxSize: 5}, errors: {message: "", extensions: ""}, isSuccess: "", selection: ""}) {
+type Widget @join__type(graph: WITH_CONNECTORS_V0_1_, key: "id") {
   id: ID!
   name: String!
 }
 
-type Widget @join__type(graph: WITH_CONNECTORS_V0_1_, key: "id") {
+type Resource @join__type(graph: WITH_CONNECTORS_V0_3_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {id: "conn_id", source: "v1", http: {GET: "/resources", path: "", queryParams: ""}, batch: {maxSize: 5}, errors: {message: "", extensions: ""}, isSuccess: "", selection: ""}) {
   id: ID!
   name: String!
 }


### PR DESCRIPTION
JavaScript had implicit subgraph ordering by using a `Subgraphs` wrapper class that stored subgraphs in `OrderedMap` (by name). Updated our composition logic to sort the vec of subgraphs before doing any composition logic.

Reverted changes from https://github.com/apollographql/router/pull/8946 that attempted to fix merged description mismatches between JS and RS.

<!-- FED-983 -->