### PR TITLE
chore: faster cicd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,15 @@ commands:
           name: Fetch dependencies
           command: cargo fetch --locked
 
+  xtask_fmt_check:
+    steps:
+      - run:
+          name: Check formatting
+          command: |
+            RUSTFMT_CONFIG="imports_granularity=Item,group_imports=StdExternalCrate"
+            cargo fmt --all -- --config "${RUSTFMT_CONFIG}" --check
+            cd xtask && cargo fmt --all -- --config "${RUSTFMT_CONFIG}" --check
+
   xtask_lint:
     steps:
       - restore_cache:
@@ -418,6 +427,19 @@ commands:
           path: ./codecov_report.json
 
 jobs:
+  fmt_check:
+    environment:
+      <<: *common_job_environment
+    parameters:
+      platform:
+        type: executor
+    executor: << parameters.platform >>
+    steps:
+      - checkout
+      - setup_environment:
+          platform: << parameters.platform >>
+      - xtask_fmt_check
+
   lint:
     environment:
       <<: *common_job_environment
@@ -965,6 +987,10 @@ workflows:
           - << pipeline.parameters.quick_nightly >>
           - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
+      - fmt_check:
+          matrix:
+            parameters:
+              platform: [amd_linux_helm]
       - lint:
           matrix:
             parameters:
@@ -982,9 +1008,7 @@ workflows:
           # this should be changed back to true on dev after release
           fuzz: false
           requires:
-            - lint
-            - check_helm
-            - check_compliance
+            - fmt_check
           matrix:
             parameters:
               platform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,10 +282,7 @@ commands:
     steps:
       - run:
           name: Check formatting
-          command: |
-            RUSTFMT_CONFIG="imports_granularity=Item,group_imports=StdExternalCrate"
-            cargo fmt --all -- --config "${RUSTFMT_CONFIG}" --check
-            cd xtask && cargo fmt --all -- --config "${RUSTFMT_CONFIG}" --check
+          command: cargo fmt --all -- --config imports_granularity=Item,group_imports=StdExternalCrate --check
 
   xtask_lint:
     steps:


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-####] -->
---

shuffles some stuff around for circle so that we aren't waiting for linting, helm checks, and compliance checks just to start tests (when they have nothing to do with tests); adding a lighter-weight `cargo fmt --check` to bail early if we have formatting issues to save on credits, otherwise tests begin right away

without much data (because of few runs), it looks like this saves us about **12 minutes** from the [p95 of dev](https://app.circleci.com/insights/gh/apollographql/router?reporting-window=last-90-days) (last 90 days, 30 mins, 40s; this branch's cicd completes in about 18 mins)


**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
