### PR TITLE
Use `BoxCloneService` instead of `BoxService` in router pipeline services

### DIFF
--- a/apollo-router/examples/planner.rs
+++ b/apollo-router/examples/planner.rs
@@ -10,7 +10,6 @@ use apollo_router::services::execution;
 use apollo_router::services::supergraph;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 #[derive(Debug)]
 struct DoNotExecute {
@@ -28,7 +27,10 @@ impl Plugin for DoNotExecute {
         })
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         ServiceBuilder::new()
             .map_request(|mut req: supergraph::Request| {
                 let body = req.supergraph_request.body_mut();
@@ -39,7 +41,7 @@ impl Plugin for DoNotExecute {
                 req
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn execution_service(

--- a/apollo-router/examples/planner.rs
+++ b/apollo-router/examples/planner.rs
@@ -2,6 +2,7 @@ use std::ops::ControlFlow;
 
 use anyhow::Result;
 use apollo_router::layers::ServiceBuilderExt;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -41,7 +42,10 @@ impl Plugin for DoNotExecute {
             .boxed()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         ServiceBuilder::new()
             .checkpoint(|req: execution::Request| {
                 Ok(ControlFlow::Break(
@@ -52,7 +56,7 @@ impl Plugin for DoNotExecute {
                 ))
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/examples/planner.rs
+++ b/apollo-router/examples/planner.rs
@@ -2,7 +2,6 @@ use std::ops::ControlFlow;
 
 use anyhow::Result;
 use apollo_router::layers::ServiceBuilderExt;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -10,6 +9,7 @@ use apollo_router::services::execution;
 use apollo_router::services::supergraph;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 #[derive(Debug)]
 struct DoNotExecute {
@@ -29,8 +29,8 @@ impl Plugin for DoNotExecute {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         ServiceBuilder::new()
             .map_request(|mut req: supergraph::Request| {
                 let body = req.supergraph_request.body_mut();
@@ -41,13 +41,10 @@ impl Plugin for DoNotExecute {
                 req
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         ServiceBuilder::new()
             .checkpoint(|req: execution::Request| {
                 Ok(ControlFlow::Break(
@@ -58,7 +55,7 @@ impl Plugin for DoNotExecute {
                 ))
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -561,13 +561,13 @@ mod tests {
     use std::sync::Arc;
 
     use axum::BoxError;
+    use tower::ServiceExt;
     use tower::service_fn;
 
     use super::*;
     use crate::axum_factory::tests::init_with_config;
     use crate::configuration::Sandbox;
     use crate::configuration::Supergraph;
-    use crate::layers::ServiceExt;
     use crate::services::router;
     use crate::services::router::body;
 
@@ -609,7 +609,7 @@ mod tests {
                     .unwrap(),
             )
         })
-        .boxed_clone_sync();
+        .boxed_clone();
 
         let mut web_endpoints = MultiMap::new();
         web_endpoints.insert(
@@ -650,7 +650,7 @@ mod tests {
                 .context(req.context)
                 .build()
         })
-        .boxed_clone_sync();
+        .boxed_clone();
 
         let mut mm = MultiMap::new();
         mm.insert(

--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -561,13 +561,13 @@ mod tests {
     use std::sync::Arc;
 
     use axum::BoxError;
-    use tower::ServiceExt;
     use tower::service_fn;
 
     use super::*;
     use crate::axum_factory::tests::init_with_config;
     use crate::configuration::Sandbox;
     use crate::configuration::Supergraph;
+    use crate::layers::ServiceExt;
     use crate::services::router;
     use crate::services::router::body;
 
@@ -609,7 +609,7 @@ mod tests {
                     .unwrap(),
             )
         })
-        .boxed();
+        .boxed_clone_sync();
 
         let mut web_endpoints = MultiMap::new();
         web_endpoints.insert(
@@ -650,7 +650,7 @@ mod tests {
                 .context(req.context)
                 .build()
         })
-        .boxed();
+        .boxed_clone_sync();
 
         let mut mm = MultiMap::new();
         mm.insert(

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -74,7 +74,6 @@ use crate::graphql;
 use crate::http_server_factory::HttpServerFactory;
 use crate::http_server_factory::HttpServerHandle;
 use crate::json_ext::Path;
-use crate::layers::ServiceExt as _;
 use crate::plugins::healthcheck::Config as HealthCheck;
 use crate::router_factory::Endpoint;
 use crate::router_factory::RouterFactory;
@@ -1498,21 +1497,15 @@ async fn it_answers_to_custom_endpoint() -> Result<(), ApolloRouterError> {
                 .into(),
         )
     })
-    .boxed_clone_sync();
+    .boxed_clone();
     let mut web_endpoints = MultiMap::new();
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service(
-            "/a-custom-path".to_string(),
-            endpoint.clone().boxed_clone_sync(),
-        ),
+        Endpoint::from_router_service("/a-custom-path".to_string(), endpoint.clone().boxed_clone()),
     );
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service(
-            "/an-other-custom-path".to_string(),
-            endpoint.boxed_clone_sync(),
-        ),
+        Endpoint::from_router_service("/an-other-custom-path".to_string(), endpoint.boxed_clone()),
     );
 
     let conf = Configuration::fake_builder().build().unwrap();
@@ -1611,19 +1604,16 @@ async fn it_refuses_to_bind_two_extra_endpoints_on_the_same_path() {
                 .into(),
         )
     })
-    .boxed_clone_sync();
+    .boxed_clone();
 
     let mut web_endpoints = MultiMap::new();
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service(
-            "/a-custom-path".to_string(),
-            endpoint.clone().boxed_clone_sync(),
-        ),
+        Endpoint::from_router_service("/a-custom-path".to_string(), endpoint.clone().boxed_clone()),
     );
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service("/a-custom-path".to_string(), endpoint.boxed_clone_sync()),
+        Endpoint::from_router_service("/a-custom-path".to_string(), endpoint.boxed_clone()),
     );
 
     let conf = Configuration::fake_builder().build().unwrap();
@@ -2141,7 +2131,7 @@ async fn http_compressed_service() -> impl Service<
                         graphql_response
                     })
                 })
-                .boxed_clone_sync()
+                .boxed_clone()
         })
         .build_http_service()
         .await
@@ -2191,7 +2181,7 @@ async fn http_deferred_service() -> impl Service<
                         graphql_response
                     })
                 })
-                .boxed_clone_sync()
+                .boxed_clone()
         })
         .build_http_service()
         .await
@@ -2525,11 +2515,11 @@ async fn test_sneaky_supergraph_and_health_check_configuration() {
                 .into(),
         )
     })
-    .boxed_clone_sync();
+    .boxed_clone();
     let mut web_endpoints = MultiMap::new();
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service("/health".to_string(), endpoint.boxed_clone_sync()),
+        Endpoint::from_router_service("/health".to_string(), endpoint.boxed_clone()),
     );
 
     let error = init_with_config(

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -74,6 +74,7 @@ use crate::graphql;
 use crate::http_server_factory::HttpServerFactory;
 use crate::http_server_factory::HttpServerHandle;
 use crate::json_ext::Path;
+use crate::layers::ServiceExt as _;
 use crate::plugins::healthcheck::Config as HealthCheck;
 use crate::router_factory::Endpoint;
 use crate::router_factory::RouterFactory;
@@ -2131,7 +2132,7 @@ async fn http_compressed_service() -> impl Service<
                         graphql_response
                     })
                 })
-                .boxed()
+                .boxed_clone_sync()
         })
         .build_http_service()
         .await
@@ -2181,7 +2182,7 @@ async fn http_deferred_service() -> impl Service<
                         graphql_response
                     })
                 })
-                .boxed()
+                .boxed_clone_sync()
         })
         .build_http_service()
         .await

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1498,15 +1498,21 @@ async fn it_answers_to_custom_endpoint() -> Result<(), ApolloRouterError> {
                 .into(),
         )
     })
-    .boxed_clone();
+    .boxed_clone_sync();
     let mut web_endpoints = MultiMap::new();
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service("/a-custom-path".to_string(), endpoint.clone().boxed()),
+        Endpoint::from_router_service(
+            "/a-custom-path".to_string(),
+            endpoint.clone().boxed_clone_sync(),
+        ),
     );
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service("/an-other-custom-path".to_string(), endpoint.boxed()),
+        Endpoint::from_router_service(
+            "/an-other-custom-path".to_string(),
+            endpoint.boxed_clone_sync(),
+        ),
     );
 
     let conf = Configuration::fake_builder().build().unwrap();
@@ -1605,16 +1611,19 @@ async fn it_refuses_to_bind_two_extra_endpoints_on_the_same_path() {
                 .into(),
         )
     })
-    .boxed_clone();
+    .boxed_clone_sync();
 
     let mut web_endpoints = MultiMap::new();
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service("/a-custom-path".to_string(), endpoint.clone().boxed()),
+        Endpoint::from_router_service(
+            "/a-custom-path".to_string(),
+            endpoint.clone().boxed_clone_sync(),
+        ),
     );
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service("/a-custom-path".to_string(), endpoint.boxed()),
+        Endpoint::from_router_service("/a-custom-path".to_string(), endpoint.boxed_clone_sync()),
     );
 
     let conf = Configuration::fake_builder().build().unwrap();
@@ -2516,11 +2525,11 @@ async fn test_sneaky_supergraph_and_health_check_configuration() {
                 .into(),
         )
     })
-    .boxed_clone();
+    .boxed_clone_sync();
     let mut web_endpoints = MultiMap::new();
     web_endpoints.insert(
         ListenAddr::SocketAddr("127.0.0.1:0".parse().unwrap()),
-        Endpoint::from_router_service("/health".to_string(), endpoint.boxed()),
+        Endpoint::from_router_service("/health".to_string(), endpoint.boxed_clone_sync()),
     );
 
     let error = init_with_config(

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -846,7 +846,7 @@ mod tests {
                             r
                         },
                     )
-                    .boxed()
+                    .boxed_clone_sync()
             })
             .with_subgraph_network_requests()
             .build_router()

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -846,7 +846,7 @@ mod tests {
                             r
                         },
                     )
-                    .boxed_clone_sync()
+                    .boxed_clone()
             })
             .with_subgraph_network_requests()
             .build_router()

--- a/apollo-router/src/layers/async_checkpoint.rs
+++ b/apollo-router/src/layers/async_checkpoint.rs
@@ -80,6 +80,22 @@ where
     checkpoint_fn: Arc<Pin<Box<dyn Fn(Request) -> Fut + Send + Sync + 'static>>>,
 }
 
+impl<S, Fut, Request> Clone for AsyncCheckpointService<S, Fut, Request>
+where
+    Request: Send + 'static,
+    S: Service<Request, Error = BoxError> + Clone + Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Future: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            service: self.service.clone(),
+            checkpoint_fn: Arc::clone(&self.checkpoint_fn),
+        }
+    }
+}
+
 impl<S, Fut, Request> AsyncCheckpointService<S, Fut, Request>
 where
     Request: Send + 'static,

--- a/apollo-router/src/layers/instrument.rs
+++ b/apollo-router/src/layers/instrument.rs
@@ -30,7 +30,7 @@ where
     F: Fn(&Request) -> tracing::Span,
 {
     span_fn: F,
-    phantom: PhantomData<Request>,
+    phantom: PhantomData<fn(Request)>,
 }
 
 impl<F, Request> InstrumentLayer<F, Request>
@@ -70,7 +70,21 @@ where
 {
     inner: S,
     span_fn: F,
-    phantom: PhantomData<Request>,
+    phantom: PhantomData<fn(Request)>,
+}
+
+impl<F, S, Request> Clone for InstrumentService<F, S, Request>
+where
+    S: Service<Request> + Clone,
+    F: Fn(&Request) -> tracing::Span + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            span_fn: self.span_fn.clone(),
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<F, S, Request> Service<Request> for InstrumentService<F, S, Request>

--- a/apollo-router/src/layers/map_first_graphql_response.rs
+++ b/apollo-router/src/layers/map_first_graphql_response.rs
@@ -22,6 +22,8 @@ pub struct MapFirstGraphqlResponseLayer<Callback> {
 }
 
 /// [`Service`] for mapping first graphql responses. See [`ServiceBuilderExt::map_first_graphql_response()`](crate::layers::ServiceBuilderExt::map_first_graphql_response()).
+
+#[derive(Clone)]
 pub struct MapFirstGraphqlResponseService<InnerService, Callback> {
     inner: InnerService,
     callback: Callback,
@@ -106,7 +108,7 @@ mod tests {
                             );
                             (http_parts, graphql_response)
                         })
-                        .boxed()
+                        .boxed_clone_sync()
                 })
                 .build_supergraph()
                 .await

--- a/apollo-router/src/layers/map_first_graphql_response.rs
+++ b/apollo-router/src/layers/map_first_graphql_response.rs
@@ -108,7 +108,7 @@ mod tests {
                             );
                             (http_parts, graphql_response)
                         })
-                        .boxed_clone_sync()
+                        .boxed_clone()
                 })
                 .build_supergraph()
                 .await

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -6,6 +6,7 @@ use std::ops::ControlFlow;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::layer::util::Stack;
+use tower::util::BoxCloneSyncService;
 use tower_service::Service;
 use tracing::Span;
 
@@ -457,6 +458,17 @@ pub trait ServiceExt<Request>: Service<Request> {
         MF: Clone,
     {
         MapFutureWithRequestDataService::new(self, req_fn, map_fn)
+    }
+
+    /// See [`tower::util::boxed_clone`] for details.
+    /// This variant returns a [`BoxCloneSyncService`] instead of a [`BoxService`].
+    fn boxed_clone_sync(self) -> BoxCloneSyncService<Request, Self::Response, Self::Error>
+    where
+        Self: Sized + Send + 'static,
+        Self::Future: Send + 'static,
+        Self: Clone + Sync,
+    {
+        BoxCloneSyncService::new(self)
     }
 }
 impl<T: ?Sized, Request> ServiceExt<Request> for T where T: Service<Request> {}

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -460,8 +460,9 @@ pub trait ServiceExt<Request>: Service<Request> {
         MapFutureWithRequestDataService::new(self, req_fn, map_fn)
     }
 
-    /// See [`tower::util::boxed_clone`] for details.
-    /// This variant returns a [`BoxCloneSyncService`] instead of a [`BoxService`].
+    /// See [`tower::util::ServiceExt::boxed_clone`] for details.
+    /// This variant returns a [`tower::util::BoxCloneSyncService`] instead
+    /// of a [`tower::util::BoxCloneService`].
     fn boxed_clone_sync(self) -> BoxCloneSyncService<Request, Self::Response, Self::Error>
     where
         Self: Sized + Send + 'static,

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -64,7 +64,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tracing::info_span;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxService) {
+    /// # fn test(service: supergraph::BoxCloneSyncService) {
     /// let _ = ServiceBuilder::new()
     ///     .checkpoint(|req: supergraph::Request|{
     ///         if req.supergraph_request.method() == Method::GET {
@@ -124,7 +124,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tracing::info_span;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxService) {
+    /// # fn test(service: supergraph::BoxCloneSyncService) {
     /// let _ = ServiceBuilder::new()
     ///     .checkpoint_async(|req: supergraph::Request|
     ///         async {
@@ -169,7 +169,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tracing::info_span;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxService) {
+    /// # fn test(service: supergraph::BoxCloneSyncService) {
     /// let _ = ServiceBuilder::new()
     ///             .buffered()
     ///             .service(service);
@@ -198,7 +198,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tracing::info_span;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxService) {
+    /// # fn test(service: supergraph::BoxCloneSyncService) {
     /// let instrumented = ServiceBuilder::new()
     ///             .instrument(|_request| info_span!("query_planning"))
     ///             .service(service);
@@ -250,7 +250,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     ///     #     Ok(Self)
     ///     # }
     ///     // …
-    ///     fn supergraph_service(&self, inner: supergraph::BoxService) -> supergraph::BoxService {
+    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService {
     ///         tower::ServiceBuilder::new()
     ///             .map_first_graphql_response(|context, mut http_parts, mut graphql_response| {
     ///                 // Something interesting here
@@ -299,8 +299,8 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use apollo_router::Context;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxService) {
-    /// let _ : supergraph::BoxService = ServiceBuilder::new()
+    /// # fn test(service: supergraph::BoxCloneSyncService) {
+    /// let _ : supergraph::BoxCloneSyncService = ServiceBuilder::new()
     ///     .map_future_with_request_data(
     ///         |req: &supergraph::Request| req.context.clone(),
     ///         |ctx : Context, fut| async { fut.await })
@@ -385,7 +385,7 @@ pub trait ServiceExt<Request>: Service<Request> {
     ///     #     Ok(Self)
     ///     # }
     ///     // …
-    ///     fn supergraph_service(&self, inner: supergraph::BoxService) -> supergraph::BoxService {
+    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService {
     ///         inner
     ///             .map_first_graphql_response(|context, mut http_parts, mut graphql_response| {
     ///                 // Something interesting here
@@ -438,8 +438,8 @@ pub trait ServiceExt<Request>: Service<Request> {
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
     /// # use apollo_router::layers::ServiceExt as ApolloServiceExt;
-    /// # fn test(service: supergraph::BoxService) {
-    /// let _ : supergraph::BoxService = service
+    /// # fn test(service: supergraph::BoxCloneSyncService) {
+    /// let _ : supergraph::BoxCloneSyncService = service
     ///     .map_future_with_request_data(
     ///         |req: &supergraph::Request| req.context.clone(),
     ///         |ctx : Context, fut| async { fut.await }

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -6,7 +6,6 @@ use std::ops::ControlFlow;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::layer::util::Stack;
-use tower::util::BoxCloneSyncService;
 use tower_service::Service;
 use tracing::Span;
 
@@ -64,7 +63,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tracing::info_span;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxCloneSyncService) {
+    /// # fn test(service: supergraph::BoxCloneService) {
     /// let _ = ServiceBuilder::new()
     ///     .checkpoint(|req: supergraph::Request|{
     ///         if req.supergraph_request.method() == Method::GET {
@@ -124,7 +123,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tracing::info_span;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxCloneSyncService) {
+    /// # fn test(service: supergraph::BoxCloneService) {
     /// let _ = ServiceBuilder::new()
     ///     .checkpoint_async(|req: supergraph::Request|
     ///         async {
@@ -169,7 +168,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tracing::info_span;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxCloneSyncService) {
+    /// # fn test(service: supergraph::BoxCloneService) {
     /// let _ = ServiceBuilder::new()
     ///             .buffered()
     ///             .service(service);
@@ -198,7 +197,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tracing::info_span;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxCloneSyncService) {
+    /// # fn test(service: supergraph::BoxCloneService) {
     /// let instrumented = ServiceBuilder::new()
     ///             .instrument(|_request| info_span!("query_planning"))
     ///             .service(service);
@@ -250,7 +249,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     ///     #     Ok(Self)
     ///     # }
     ///     // …
-    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService {
+    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneService) -> supergraph::BoxCloneService {
     ///         tower::ServiceBuilder::new()
     ///             .map_first_graphql_response(|context, mut http_parts, mut graphql_response| {
     ///                 // Something interesting here
@@ -299,8 +298,8 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use apollo_router::Context;
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test(service: supergraph::BoxCloneSyncService) {
-    /// let _ : supergraph::BoxCloneSyncService = ServiceBuilder::new()
+    /// # fn test(service: supergraph::BoxCloneService) {
+    /// let _ : supergraph::BoxCloneService = ServiceBuilder::new()
     ///     .map_future_with_request_data(
     ///         |req: &supergraph::Request| req.context.clone(),
     ///         |ctx : Context, fut| async { fut.await })
@@ -385,7 +384,7 @@ pub trait ServiceExt<Request>: Service<Request> {
     ///     #     Ok(Self)
     ///     # }
     ///     // …
-    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService {
+    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneService) -> supergraph::BoxCloneService {
     ///         inner
     ///             .map_first_graphql_response(|context, mut http_parts, mut graphql_response| {
     ///                 // Something interesting here
@@ -438,8 +437,8 @@ pub trait ServiceExt<Request>: Service<Request> {
     /// # use apollo_router::services::supergraph;
     /// # use apollo_router::layers::ServiceBuilderExt;
     /// # use apollo_router::layers::ServiceExt as ApolloServiceExt;
-    /// # fn test(service: supergraph::BoxCloneSyncService) {
-    /// let _ : supergraph::BoxCloneSyncService = service
+    /// # fn test(service: supergraph::BoxCloneService) {
+    /// let _ : supergraph::BoxCloneService = service
     ///     .map_future_with_request_data(
     ///         |req: &supergraph::Request| req.context.clone(),
     ///         |ctx : Context, fut| async { fut.await }
@@ -458,18 +457,6 @@ pub trait ServiceExt<Request>: Service<Request> {
         MF: Clone,
     {
         MapFutureWithRequestDataService::new(self, req_fn, map_fn)
-    }
-
-    /// See [`tower::util::ServiceExt::boxed_clone`] for details.
-    /// This variant returns a [`tower::util::BoxCloneSyncService`] instead
-    /// of a [`tower::util::BoxCloneService`].
-    fn boxed_clone_sync(self) -> BoxCloneSyncService<Request, Self::Response, Self::Error>
-    where
-        Self: Sized + Send + 'static,
-        Self::Future: Send + 'static,
-        Self: Clone + Sync,
-    {
-        BoxCloneSyncService::new(self)
     }
 }
 impl<T: ?Sized, Request> ServiceExt<Request> for T where T: Service<Request> {}

--- a/apollo-router/src/layers/sync_checkpoint.rs
+++ b/apollo-router/src/layers/sync_checkpoint.rs
@@ -84,7 +84,6 @@ where
 }
 
 /// [`Service`] for Synchronous Checkpoints. See [`ServiceBuilderExt::checkpoint()`](crate::layers::ServiceBuilderExt::checkpoint()).
-#[derive(Clone)]
 #[allow(clippy::type_complexity)]
 pub struct CheckpointService<S, Request>
 where
@@ -162,6 +161,23 @@ where
             Ok(ControlFlow::Break(response)) => Box::pin(async move { Ok(response) }),
             Ok(ControlFlow::Continue(request)) => Box::pin(self.inner.call(request)),
             Err(error) => Box::pin(async move { Err(error) }),
+        }
+    }
+}
+
+impl<S, Request> Clone for CheckpointService<S, Request>
+where
+    S: Service<Request>,
+    S: Send + Clone + 'static,
+    S::Future: Send,
+    S::Response: Send + 'static,
+    S::Error: Into<BoxError> + Send + 'static,
+    Request: Send + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            checkpoint_fn: Arc::clone(&self.checkpoint_fn),
+            inner: self.inner.clone(),
         }
     }
 }

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -379,7 +379,7 @@ pub trait Plugin: Send + Sync + 'static {
     /// It's the entrypoint of every requests and also the last hook before sending the response.
     /// Define `router_service` if your customization needs to interact at the earliest or latest point possible.
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         service
     }
 
@@ -388,17 +388,14 @@ pub trait Plugin: Send + Sync + 'static {
     /// Define `supergraph_service` if your customization needs to interact at the earliest or latest point possible, yet operates on GraphQL payloads.
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         service
     }
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         service
     }
 
@@ -408,8 +405,8 @@ pub trait Plugin: Send + Sync + 'static {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         service
     }
 
@@ -459,7 +456,7 @@ pub trait PluginUnstable: Send + Sync + 'static {
     /// It's the entrypoint of every requests and also the last hook before sending the response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible.
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         service
     }
 
@@ -468,17 +465,14 @@ pub trait PluginUnstable: Send + Sync + 'static {
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible, yet operates on GraphQL payloads.
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         service
     }
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         service
     }
 
@@ -488,8 +482,8 @@ pub trait PluginUnstable: Send + Sync + 'static {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         service
     }
 
@@ -526,29 +520,26 @@ where
         Plugin::new(init).await
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         Plugin::router_service(self, service)
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         Plugin::supergraph_service(self, service)
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         Plugin::execution_service(self, service)
     }
 
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         Plugin::subgraph_service(self, subgraph_name, service)
     }
 
@@ -602,7 +593,7 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     /// It's the entrypoint of every requests and also the last hook before sending the response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible.
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         service
     }
 
@@ -611,17 +602,14 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible, yet operates on GraphQL payloads.
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         service
     }
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         service
     }
 
@@ -631,8 +619,8 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         service
     }
 
@@ -640,17 +628,17 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     fn http_client_service(
         &self,
         _subgraph_name: &str,
-        service: crate::services::http::BoxCloneSyncService,
-    ) -> crate::services::http::BoxCloneSyncService {
+        service: crate::services::http::BoxCloneService,
+    ) -> crate::services::http::BoxCloneService {
         service
     }
 
     /// This service handles individual requests to Apollo Connectors
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxCloneSyncService,
+        service: crate::services::connector::request_service::BoxCloneService,
         _source_name: String,
-    ) -> crate::services::connector::request_service::BoxCloneSyncService {
+    ) -> crate::services::connector::request_service::BoxCloneService {
         service
     }
 
@@ -687,29 +675,26 @@ where
         PluginUnstable::new(init).await
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         PluginUnstable::router_service(self, service)
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         PluginUnstable::supergraph_service(self, service)
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         PluginUnstable::execution_service(self, service)
     }
 
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         PluginUnstable::subgraph_service(self, subgraph_name, service)
     }
 
@@ -743,22 +728,19 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
     /// It's the entrypoint of every requests and also the last hook before sending the response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible.
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService;
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService;
 
     /// This service runs after the HTTP request payload has been deserialized into a GraphQL request,
     /// and before the GraphQL response payload is serialized into a raw HTTP response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible, yet operates on GraphQL payloads.
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService;
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService;
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService;
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService;
 
     /// This service handles communication between the Apollo Router and your subgraphs.
     /// Define `subgraph_service` to configure this communication (for example, to dynamically add headers to pass to a subgraph).
@@ -766,22 +748,22 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService;
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService;
 
     /// This service handles HTTP communication
     fn http_client_service(
         &self,
         _subgraph_name: &str,
-        service: crate::services::http::BoxCloneSyncService,
-    ) -> crate::services::http::BoxCloneSyncService;
+        service: crate::services::http::BoxCloneService,
+    ) -> crate::services::http::BoxCloneService;
 
     /// This service handles individual requests to Apollo Connectors
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxCloneSyncService,
+        service: crate::services::connector::request_service::BoxCloneService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxCloneSyncService;
+    ) -> crate::services::connector::request_service::BoxCloneService;
 
     /// Return the name of the plugin.
     fn name(&self) -> &'static str;
@@ -807,29 +789,26 @@ where
     T: PluginPrivate,
     for<'de> <T as PluginPrivate>::Config: Deserialize<'de>,
 {
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         self.router_service(service)
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         self.supergraph_service(service)
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         self.execution_service(service)
     }
 
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         self.subgraph_service(name, service)
     }
 
@@ -837,16 +816,16 @@ where
     fn http_client_service(
         &self,
         name: &str,
-        service: crate::services::http::BoxCloneSyncService,
-    ) -> crate::services::http::BoxCloneSyncService {
+        service: crate::services::http::BoxCloneService,
+    ) -> crate::services::http::BoxCloneService {
         self.http_client_service(name, service)
     }
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxCloneSyncService,
+        service: crate::services::connector::request_service::BoxCloneService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxCloneSyncService {
+    ) -> crate::services::connector::request_service::BoxCloneService {
         self.connector_request_service(service, source_name)
     }
 
@@ -958,12 +937,12 @@ macro_rules! register_private_plugin {
 pub(crate) struct Handler {
     service: UnconstrainedBuffer<
         router::Request,
-        <router::BoxCloneSyncService as Service<router::Request>>::Future,
+        <router::BoxCloneService as Service<router::Request>>::Future,
     >,
 }
 
 impl Handler {
-    pub(crate) fn new(service: router::BoxCloneSyncService) -> Self {
+    pub(crate) fn new(service: router::BoxCloneService) -> Self {
         Self {
             service: ServiceBuilder::new().buffered().service(service),
         }
@@ -984,8 +963,8 @@ impl Service<router::Request> for Handler {
     }
 }
 
-impl From<router::BoxCloneSyncService> for Handler {
-    fn from(original: router::BoxCloneSyncService) -> Self {
+impl From<router::BoxCloneService> for Handler {
+    fn from(original: router::BoxCloneService) -> Self {
         Self::new(original)
     }
 }

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -402,8 +402,8 @@ pub trait Plugin: Send + Sync + 'static {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         service
     }
 
@@ -476,8 +476,8 @@ pub trait PluginUnstable: Send + Sync + 'static {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         service
     }
 
@@ -529,8 +529,8 @@ where
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         Plugin::subgraph_service(self, subgraph_name, service)
     }
 
@@ -607,8 +607,8 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         service
     }
 
@@ -678,8 +678,8 @@ where
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         PluginUnstable::subgraph_service(self, subgraph_name, service)
     }
 
@@ -730,8 +730,8 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService;
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService;
 
     /// This service handles HTTP communication
     fn http_client_service(
@@ -783,7 +783,11 @@ where
         self.execution_service(service)
     }
 
-    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         self.subgraph_service(name, service)
     }
 

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -386,7 +386,10 @@ pub trait Plugin: Send + Sync + 'static {
     /// This service runs after the HTTP request payload has been deserialized into a GraphQL request,
     /// and before the GraphQL response payload is serialized into a raw HTTP response.
     /// Define `supergraph_service` if your customization needs to interact at the earliest or latest point possible, yet operates on GraphQL payloads.
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         service
     }
 
@@ -463,7 +466,10 @@ pub trait PluginUnstable: Send + Sync + 'static {
     /// This service runs after the HTTP request payload has been deserialized into a GraphQL request,
     /// and before the GraphQL response payload is serialized into a raw HTTP response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible, yet operates on GraphQL payloads.
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         service
     }
 
@@ -524,7 +530,10 @@ where
         Plugin::router_service(self, service)
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         Plugin::supergraph_service(self, service)
     }
 
@@ -600,7 +609,10 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     /// This service runs after the HTTP request payload has been deserialized into a GraphQL request,
     /// and before the GraphQL response payload is serialized into a raw HTTP response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible, yet operates on GraphQL payloads.
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         service
     }
 
@@ -679,7 +691,10 @@ where
         PluginUnstable::router_service(self, service)
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         PluginUnstable::supergraph_service(self, service)
     }
 
@@ -733,7 +748,10 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
     /// This service runs after the HTTP request payload has been deserialized into a GraphQL request,
     /// and before the GraphQL response payload is serialized into a raw HTTP response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible, yet operates on GraphQL payloads.
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService;
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService;
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
@@ -793,7 +811,10 @@ where
         self.router_service(service)
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         self.supergraph_service(service)
     }
 

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -616,8 +616,8 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     fn http_client_service(
         &self,
         _subgraph_name: &str,
-        service: crate::services::http::BoxService,
-    ) -> crate::services::http::BoxService {
+        service: crate::services::http::BoxCloneSyncService,
+    ) -> crate::services::http::BoxCloneSyncService {
         service
     }
 
@@ -737,8 +737,8 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
     fn http_client_service(
         &self,
         _subgraph_name: &str,
-        service: crate::services::http::BoxService,
-    ) -> crate::services::http::BoxService;
+        service: crate::services::http::BoxCloneSyncService,
+    ) -> crate::services::http::BoxCloneSyncService;
 
     /// This service handles individual requests to Apollo Connectors
     fn connector_request_service(
@@ -791,8 +791,8 @@ where
     fn http_client_service(
         &self,
         name: &str,
-        service: crate::services::http::BoxService,
-    ) -> crate::services::http::BoxService {
+        service: crate::services::http::BoxCloneSyncService,
+    ) -> crate::services::http::BoxCloneSyncService {
         self.http_client_service(name, service)
     }
 

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -648,9 +648,9 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     /// This service handles individual requests to Apollo Connectors
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
+        service: crate::services::connector::request_service::BoxCloneSyncService,
         _source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
+    ) -> crate::services::connector::request_service::BoxCloneSyncService {
         service
     }
 
@@ -779,9 +779,9 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
     /// This service handles individual requests to Apollo Connectors
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
+        service: crate::services::connector::request_service::BoxCloneSyncService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxService;
+    ) -> crate::services::connector::request_service::BoxCloneSyncService;
 
     /// Return the name of the plugin.
     fn name(&self) -> &'static str;
@@ -844,9 +844,9 @@ where
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
+        service: crate::services::connector::request_service::BoxCloneSyncService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
+    ) -> crate::services::connector::request_service::BoxCloneSyncService {
         self.connector_request_service(service, source_name)
     }
 

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -392,7 +392,10 @@ pub trait Plugin: Send + Sync + 'static {
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         service
     }
 
@@ -466,7 +469,10 @@ pub trait PluginUnstable: Send + Sync + 'static {
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         service
     }
 
@@ -522,7 +528,10 @@ where
         Plugin::supergraph_service(self, service)
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         Plugin::execution_service(self, service)
     }
 
@@ -597,7 +606,10 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         service
     }
 
@@ -671,7 +683,10 @@ where
         PluginUnstable::supergraph_service(self, service)
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         PluginUnstable::execution_service(self, service)
     }
 
@@ -722,7 +737,10 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService;
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService;
 
     /// This service handles communication between the Apollo Router and your subgraphs.
     /// Define `subgraph_service` to configure this communication (for example, to dynamically add headers to pass to a subgraph).
@@ -779,7 +797,10 @@ where
         self.supergraph_service(service)
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         self.execution_service(service)
     }
 

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -379,7 +379,7 @@ pub trait Plugin: Send + Sync + 'static {
     /// It's the entrypoint of every requests and also the last hook before sending the response.
     /// Define `router_service` if your customization needs to interact at the earliest or latest point possible.
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         service
     }
 
@@ -459,7 +459,7 @@ pub trait PluginUnstable: Send + Sync + 'static {
     /// It's the entrypoint of every requests and also the last hook before sending the response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible.
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         service
     }
 
@@ -526,7 +526,7 @@ where
         Plugin::new(init).await
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         Plugin::router_service(self, service)
     }
 
@@ -602,7 +602,7 @@ pub(crate) trait PluginPrivate: Send + Sync + 'static {
     /// It's the entrypoint of every requests and also the last hook before sending the response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible.
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         service
     }
 
@@ -687,7 +687,7 @@ where
         PluginUnstable::new(init).await
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         PluginUnstable::router_service(self, service)
     }
 
@@ -743,7 +743,7 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
     /// It's the entrypoint of every requests and also the last hook before sending the response.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible.
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
-    fn router_service(&self, service: router::BoxService) -> router::BoxService;
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService;
 
     /// This service runs after the HTTP request payload has been deserialized into a GraphQL request,
     /// and before the GraphQL response payload is serialized into a raw HTTP response.
@@ -807,7 +807,7 @@ where
     T: PluginPrivate,
     for<'de> <T as PluginPrivate>::Config: Deserialize<'de>,
 {
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         self.router_service(service)
     }
 
@@ -958,12 +958,12 @@ macro_rules! register_private_plugin {
 pub(crate) struct Handler {
     service: UnconstrainedBuffer<
         router::Request,
-        <router::BoxService as Service<router::Request>>::Future,
+        <router::BoxCloneSyncService as Service<router::Request>>::Future,
     >,
 }
 
 impl Handler {
-    pub(crate) fn new(service: router::BoxService) -> Self {
+    pub(crate) fn new(service: router::BoxCloneSyncService) -> Self {
         Self {
             service: ServiceBuilder::new().buffered().service(service),
         }
@@ -984,8 +984,8 @@ impl Service<router::Request> for Handler {
     }
 }
 
-impl From<router::BoxService> for Handler {
-    fn from(original: router::BoxService) -> Self {
+impl From<router::BoxCloneSyncService> for Handler {
+    fn from(original: router::BoxCloneSyncService) -> Self {
         Self::new(original)
     }
 }

--- a/apollo-router/src/plugins/authentication/connector.rs
+++ b/apollo-router/src/plugins/authentication/connector.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use super::subgraph::AuthConfig;
+use crate::layers::ServiceExt as _;
 use crate::plugins::authentication::subgraph::SigningParamsConfig;
 use crate::services::connector;
 use crate::services::connector_service::ConnectorSourceRef;
@@ -18,8 +18,8 @@ pub(super) struct ConnectorAuth {
 impl ConnectorAuth {
     pub(super) fn connector_request_service(
         &self,
-        service: connector::request_service::BoxService,
-    ) -> connector::request_service::BoxService {
+        service: connector::request_service::BoxCloneSyncService,
+    ) -> connector::request_service::BoxCloneSyncService {
         let signing_params = self.signing_params.clone();
         ServiceBuilder::new()
             .map_request(move |req: connector::request_service::Request| {
@@ -38,7 +38,7 @@ impl ConnectorAuth {
                 req
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/authentication/connector.rs
+++ b/apollo-router/src/plugins/authentication/connector.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use super::subgraph::AuthConfig;
-use crate::layers::ServiceExt as _;
 use crate::plugins::authentication::subgraph::SigningParamsConfig;
 use crate::services::connector;
 use crate::services::connector_service::ConnectorSourceRef;
@@ -18,8 +18,8 @@ pub(super) struct ConnectorAuth {
 impl ConnectorAuth {
     pub(super) fn connector_request_service(
         &self,
-        service: connector::request_service::BoxCloneSyncService,
-    ) -> connector::request_service::BoxCloneSyncService {
+        service: connector::request_service::BoxCloneService,
+    ) -> connector::request_service::BoxCloneService {
         let signing_params = self.signing_params.clone();
         ServiceBuilder::new()
             .map_request(move |req: connector::request_service::Request| {
@@ -38,7 +38,7 @@ impl ConnectorAuth {
                 req
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -22,6 +22,7 @@ use serde::Serialize;
 use serde_json::Value;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use url::Url;
 
 use self::jwks::JwksManager;
@@ -30,7 +31,6 @@ use self::subgraph::SigningParamsConfig;
 use self::subgraph::SubgraphAuth;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugin::serde::deserialize_header_name;
@@ -237,7 +237,7 @@ impl PluginPrivate for AuthenticationPlugin {
         })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         // Return without layering if no router config was defined
         let Some(router_config) = &self.router else {
             return service;
@@ -262,14 +262,14 @@ impl PluginPrivate for AuthenticationPlugin {
                 Ok(authenticate(&configuration, &jwks_manager, request))
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         name: &str,
-        service: crate::services::subgraph::BoxCloneSyncService,
-    ) -> crate::services::subgraph::BoxCloneSyncService {
+        service: crate::services::subgraph::BoxCloneService,
+    ) -> crate::services::subgraph::BoxCloneService {
         // Return without layering if no subgraph config was defined
         let Some(subgraph) = &self.subgraph else {
             return service;
@@ -280,9 +280,9 @@ impl PluginPrivate for AuthenticationPlugin {
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxCloneSyncService,
+        service: crate::services::connector::request_service::BoxCloneService,
         _: String,
-    ) -> crate::services::connector::request_service::BoxCloneSyncService {
+    ) -> crate::services::connector::request_service::BoxCloneService {
         // Return without layering if no connector config was defined
         let Some(connector_auth) = &self.connector else {
             return service;

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -280,9 +280,9 @@ impl PluginPrivate for AuthenticationPlugin {
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
+        service: crate::services::connector::request_service::BoxCloneSyncService,
         _: String,
-    ) -> crate::services::connector::request_service::BoxService {
+    ) -> crate::services::connector::request_service::BoxCloneSyncService {
         // Return without layering if no connector config was defined
         let Some(connector_auth) = &self.connector else {
             return service;

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -268,8 +268,8 @@ impl PluginPrivate for AuthenticationPlugin {
     fn subgraph_service(
         &self,
         name: &str,
-        service: crate::services::subgraph::BoxService,
-    ) -> crate::services::subgraph::BoxService {
+        service: crate::services::subgraph::BoxCloneSyncService,
+    ) -> crate::services::subgraph::BoxCloneSyncService {
         // Return without layering if no subgraph config was defined
         let Some(subgraph) = &self.subgraph else {
             return service;

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -22,7 +22,6 @@ use serde::Serialize;
 use serde_json::Value;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use url::Url;
 
 use self::jwks::JwksManager;
@@ -31,6 +30,7 @@ use self::subgraph::SigningParamsConfig;
 use self::subgraph::SubgraphAuth;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugin::serde::deserialize_header_name;
@@ -237,7 +237,7 @@ impl PluginPrivate for AuthenticationPlugin {
         })
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         // Return without layering if no router config was defined
         let Some(router_config) = &self.router else {
             return service;
@@ -262,7 +262,7 @@ impl PluginPrivate for AuthenticationPlugin {
                 Ok(authenticate(&configuration, &jwks_manager, request))
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/apollo-router/src/plugins/authentication/subgraph.rs
+++ b/apollo-router/src/plugins/authentication/subgraph.rs
@@ -31,8 +31,8 @@ use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
-use crate::layers::ServiceExt as _;
 use crate::services::SubgraphRequest;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
@@ -493,8 +493,8 @@ impl SubgraphAuth {
     pub(super) fn subgraph_service(
         &self,
         name: &str,
-        service: crate::services::subgraph::BoxCloneSyncService,
-    ) -> crate::services::subgraph::BoxCloneSyncService {
+        service: crate::services::subgraph::BoxCloneService,
+    ) -> crate::services::subgraph::BoxCloneService {
         if let Some(signing_params) = self.params_for_service(name) {
             ServiceBuilder::new()
                 .map_request(move |req: SubgraphRequest| {
@@ -505,7 +505,7 @@ impl SubgraphAuth {
                     req
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         } else {
             service
         }
@@ -676,7 +676,7 @@ mod test {
                 subgraphs: Default::default(),
             }),
         }
-        .subgraph_service("test_subgraph", mock.boxed_clone_sync());
+        .subgraph_service("test_subgraph", mock.boxed_clone());
 
         service.ready().await?.call(subgraph_request).await?;
         Ok(())
@@ -729,7 +729,7 @@ mod test {
                 subgraphs: Default::default(),
             }),
         }
-        .subgraph_service("test_subgraph", mock.boxed_clone_sync());
+        .subgraph_service("test_subgraph", mock.boxed_clone());
 
         service.ready().await?.call(subgraph_request).await?;
         Ok(())

--- a/apollo-router/src/plugins/authentication/subgraph.rs
+++ b/apollo-router/src/plugins/authentication/subgraph.rs
@@ -31,8 +31,8 @@ use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
+use crate::layers::ServiceExt as _;
 use crate::services::SubgraphRequest;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
@@ -493,8 +493,8 @@ impl SubgraphAuth {
     pub(super) fn subgraph_service(
         &self,
         name: &str,
-        service: crate::services::subgraph::BoxService,
-    ) -> crate::services::subgraph::BoxService {
+        service: crate::services::subgraph::BoxCloneSyncService,
+    ) -> crate::services::subgraph::BoxCloneSyncService {
         if let Some(signing_params) = self.params_for_service(name) {
             ServiceBuilder::new()
                 .map_request(move |req: SubgraphRequest| {
@@ -505,7 +505,7 @@ impl SubgraphAuth {
                     req
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         } else {
             service
         }
@@ -533,6 +533,7 @@ mod test {
     use http::header::HOST;
     use regex::Regex;
     use tower::Service;
+    use tower::ServiceExt as _;
 
     use super::*;
     use crate::Context;
@@ -675,7 +676,7 @@ mod test {
                 subgraphs: Default::default(),
             }),
         }
-        .subgraph_service("test_subgraph", mock.boxed());
+        .subgraph_service("test_subgraph", mock.boxed_clone_sync());
 
         service.ready().await?.call(subgraph_request).await?;
         Ok(())
@@ -728,7 +729,7 @@ mod test {
                 subgraphs: Default::default(),
             }),
         }
-        .subgraph_service("test_subgraph", mock.boxed());
+        .subgraph_service("test_subgraph", mock.boxed_clone_sync());
 
         service.ready().await?.call(subgraph_request).await?;
         Ok(())

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -53,6 +53,7 @@ use crate::assert_errors_eq_ignoring_id;
 use crate::assert_response_eq_ignoring_error_id;
 use crate::assert_snapshot_subscriber;
 use crate::graphql;
+use crate::layers::ServiceExt as _;
 use crate::plugin::test;
 use crate::plugins::authentication::Issuers;
 use crate::plugins::authentication::jwks::Audiences;
@@ -164,7 +165,7 @@ async fn build_a_test_harness(
     match crate::TestHarness::builder()
         .configuration_json(config)
         .unwrap()
-        .supergraph_hook(move |_| mock_service.clone().boxed())
+        .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
         .build_router()
         .await
     {
@@ -209,7 +210,7 @@ async fn it_rejects_when_there_is_no_auth_header() {
     let test_harness = crate::TestHarness::builder()
         .configuration_json(config)
         .unwrap()
-        .supergraph_hook(move |_| mock_service.clone().boxed())
+        .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
         .build_router()
         .await
         .unwrap();
@@ -922,7 +923,7 @@ async fn it_extracts_the_token_from_cookies() {
     let test_harness = crate::TestHarness::builder()
         .configuration_json(config)
         .unwrap()
-        .supergraph_hook(move |_| mock_service.clone().boxed())
+        .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
         .build_router()
         .await
         .unwrap();
@@ -1018,7 +1019,7 @@ async fn it_supports_multiple_sources() {
     let test_harness = crate::TestHarness::builder()
         .configuration_json(config)
         .unwrap()
-        .supergraph_hook(move |_| mock_service.clone().boxed())
+        .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
         .build_router()
         .await
         .unwrap();

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -53,7 +53,6 @@ use crate::assert_errors_eq_ignoring_id;
 use crate::assert_response_eq_ignoring_error_id;
 use crate::assert_snapshot_subscriber;
 use crate::graphql;
-use crate::layers::ServiceExt as _;
 use crate::plugin::test;
 use crate::plugins::authentication::Issuers;
 use crate::plugins::authentication::jwks::Audiences;
@@ -165,7 +164,7 @@ async fn build_a_test_harness(
     match crate::TestHarness::builder()
         .configuration_json(config)
         .unwrap()
-        .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+        .supergraph_hook(move |_| mock_service.clone().boxed_clone())
         .build_router()
         .await
     {
@@ -210,7 +209,7 @@ async fn it_rejects_when_there_is_no_auth_header() {
     let test_harness = crate::TestHarness::builder()
         .configuration_json(config)
         .unwrap()
-        .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+        .supergraph_hook(move |_| mock_service.clone().boxed_clone())
         .build_router()
         .await
         .unwrap();
@@ -923,7 +922,7 @@ async fn it_extracts_the_token_from_cookies() {
     let test_harness = crate::TestHarness::builder()
         .configuration_json(config)
         .unwrap()
-        .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+        .supergraph_hook(move |_| mock_service.clone().boxed_clone())
         .build_router()
         .await
         .unwrap();
@@ -1019,7 +1018,7 @@ async fn it_supports_multiple_sources() {
     let test_harness = crate::TestHarness::builder()
         .configuration_json(config)
         .unwrap()
-        .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+        .supergraph_hook(move |_| mock_service.clone().boxed_clone())
         .build_router()
         .await
         .unwrap();

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 use serde_json_bytes::Value;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use self::authenticated::AUTHENTICATED_SPEC_VERSION_RANGE;
 use self::authenticated::AuthenticatedCheckVisitor;
@@ -31,7 +32,6 @@ use crate::error::ServiceBuildError;
 use crate::graphql;
 use crate::json_ext::Path;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
@@ -588,8 +588,8 @@ impl Plugin for AuthorizationPlugin {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         if self.require_authentication {
             ServiceBuilder::new()
                 .checkpoint(move |request: supergraph::Request| {
@@ -616,16 +616,13 @@ impl Plugin for AuthorizationPlugin {
                     }
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         } else {
             service
         }
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         ServiceBuilder::new()
             .map_request(|request: execution::Request| {
                 let filtered = !request.query_plan.query.unauthorized.paths.is_empty();
@@ -646,7 +643,7 @@ impl Plugin for AuthorizationPlugin {
                 request
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -14,7 +14,6 @@ use serde::Serialize;
 use serde_json_bytes::Value;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use self::authenticated::AUTHENTICATED_SPEC_VERSION_RANGE;
 use self::authenticated::AuthenticatedCheckVisitor;
@@ -587,7 +586,10 @@ impl Plugin for AuthorizationPlugin {
         })
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         if self.require_authentication {
             ServiceBuilder::new()
                 .checkpoint(move |request: supergraph::Request| {
@@ -614,7 +616,7 @@ impl Plugin for AuthorizationPlugin {
                     }
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         } else {
             service
         }

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -32,6 +32,7 @@ use crate::error::ServiceBuildError;
 use crate::graphql;
 use crate::json_ext::Path;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
@@ -619,7 +620,10 @@ impl Plugin for AuthorizationPlugin {
         }
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         ServiceBuilder::new()
             .map_request(|request: execution::Request| {
                 let filtered = !request.query_plan.query.unauthorized.paths.is_empty();
@@ -640,7 +644,7 @@ impl Plugin for AuthorizationPlugin {
                 request
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/authorization/tests.rs
+++ b/apollo-router/src/plugins/authorization/tests.rs
@@ -9,7 +9,6 @@ use crate::Context;
 use crate::MockedSubgraphs;
 use crate::TestHarness;
 use crate::graphql;
-use crate::layers::ServiceExt as _;
 use crate::plugin::test::MockSubgraph;
 use crate::plugin::test::MockSubgraphService;
 use crate::plugins::authorization::APOLLO_AUTHENTICATION_JWT_CLAIMS;
@@ -1129,7 +1128,7 @@ async fn cache_key_metadata() {
                         .build())
                 },
             );
-            mock_subgraph_service.boxed_clone_sync()
+            mock_subgraph_service.boxed_clone()
         })
         .build_router()
         .await

--- a/apollo-router/src/plugins/authorization/tests.rs
+++ b/apollo-router/src/plugins/authorization/tests.rs
@@ -9,6 +9,7 @@ use crate::Context;
 use crate::MockedSubgraphs;
 use crate::TestHarness;
 use crate::graphql;
+use crate::layers::ServiceExt as _;
 use crate::plugin::test::MockSubgraph;
 use crate::plugin::test::MockSubgraphService;
 use crate::plugins::authorization::APOLLO_AUTHENTICATION_JWT_CLAIMS;
@@ -1128,7 +1129,7 @@ async fn cache_key_metadata() {
                         .build())
                 },
             );
-            mock_subgraph_service.boxed()
+            mock_subgraph_service.boxed_clone_sync()
         })
         .build_router()
         .await

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -52,6 +52,7 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugins::authorization::CacheKeyMetadata;
@@ -354,8 +355,8 @@ impl PluginPrivate for EntityCache {
     fn subgraph_service(
         &self,
         name: &str,
-        mut service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        mut service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         let storage = match self.storage.get(name) {
             Some(storage) => storage.clone(),
             None => {
@@ -371,7 +372,7 @@ impl PluginPrivate for EntityCache {
                         response
                     })
                     .service(service)
-                    .boxed();
+                    .boxed_clone_sync();
             }
         };
 
@@ -407,7 +408,7 @@ impl PluginPrivate for EntityCache {
                     service: ServiceBuilder::new()
                         .buffered()
                         .service(service)
-                        .boxed_clone(),
+                        .boxed_clone_sync(),
                     entity_type: self.entity_type.clone(),
                     name: name.to_string(),
                     storage,
@@ -419,7 +420,7 @@ impl PluginPrivate for EntityCache {
                     supergraph_schema: self.supergraph_schema.clone(),
                     subgraph_enums: self.subgraph_enums.clone(),
                 });
-            tower::util::BoxService::new(inner)
+            tower::util::BoxCloneSyncService::new(inner)
         } else {
             ServiceBuilder::new()
                 .map_response(move |response: subgraph::Response| {
@@ -433,7 +434,7 @@ impl PluginPrivate for EntityCache {
                     response
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         }
     }
 
@@ -584,7 +585,7 @@ fn get_subgraph_enums(supergraph_schema: &Valid<Schema>) -> HashMap<String, Stri
 
 #[derive(Clone)]
 struct CacheService {
-    service: subgraph::BoxCloneService,
+    service: subgraph::BoxCloneSyncService,
     name: String,
     entity_type: Option<String>,
     storage: RedisCacheStorage,
@@ -600,7 +601,7 @@ struct CacheService {
 impl Service<subgraph::Request> for CacheService {
     type Response = subgraph::Response;
     type Error = BoxError;
-    type Future = <subgraph::BoxService as Service<subgraph::Request>>::Future;
+    type Future = <subgraph::BoxCloneSyncService as Service<subgraph::Request>>::Future;
 
     fn poll_ready(
         &mut self,

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -22,6 +22,7 @@ use sha2::Sha256;
 use tokio::sync::RwLock;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower_service::Service;
 use tracing::Instrument;
 use tracing::Level;
@@ -51,7 +52,6 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugins::authorization::CacheKeyMetadata;
@@ -336,8 +336,8 @@ impl PluginPrivate for EntityCache {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         ServiceBuilder::new()
             .map_response(|mut response: supergraph::Response| {
                 if let Some(cache_control) = response
@@ -351,14 +351,14 @@ impl PluginPrivate for EntityCache {
                 response
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         name: &str,
-        mut service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        mut service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         let storage = match self.storage.get(name) {
             Some(storage) => storage.clone(),
             None => {
@@ -374,7 +374,7 @@ impl PluginPrivate for EntityCache {
                         response
                     })
                     .service(service)
-                    .boxed_clone_sync();
+                    .boxed_clone();
             }
         };
 
@@ -410,7 +410,7 @@ impl PluginPrivate for EntityCache {
                     service: ServiceBuilder::new()
                         .buffered()
                         .service(service)
-                        .boxed_clone_sync(),
+                        .boxed_clone(),
                     entity_type: self.entity_type.clone(),
                     name: name.to_string(),
                     storage,
@@ -422,7 +422,7 @@ impl PluginPrivate for EntityCache {
                     supergraph_schema: self.supergraph_schema.clone(),
                     subgraph_enums: self.subgraph_enums.clone(),
                 });
-            tower::util::BoxCloneSyncService::new(inner)
+            tower::util::BoxCloneService::new(inner)
         } else {
             ServiceBuilder::new()
                 .map_response(move |response: subgraph::Response| {
@@ -436,7 +436,7 @@ impl PluginPrivate for EntityCache {
                     response
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         }
     }
 
@@ -456,7 +456,7 @@ impl PluginPrivate for EntityCache {
                     let endpoint = Endpoint::from_router_service(
                         endpoint_config.path.clone(),
                         InvalidationService::new(self.subgraphs.clone(), self.invalidation.clone())
-                            .boxed_clone_sync(),
+                            .boxed_clone(),
                     );
                     tracing::info!(
                         "Entity caching invalidation endpoint listening on: {}{}",
@@ -587,7 +587,7 @@ fn get_subgraph_enums(supergraph_schema: &Valid<Schema>) -> HashMap<String, Stri
 
 #[derive(Clone)]
 struct CacheService {
-    service: subgraph::BoxCloneSyncService,
+    service: subgraph::BoxCloneService,
     name: String,
     entity_type: Option<String>,
     storage: RedisCacheStorage,
@@ -603,7 +603,7 @@ struct CacheService {
 impl Service<subgraph::Request> for CacheService {
     type Response = subgraph::Response;
     type Error = BoxError;
-    type Future = <subgraph::BoxCloneSyncService as Service<subgraph::Request>>::Future;
+    type Future = <subgraph::BoxCloneService as Service<subgraph::Request>>::Future;
 
     fn poll_ready(
         &mut self,

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -335,7 +335,10 @@ impl PluginPrivate for EntityCache {
         })
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         ServiceBuilder::new()
             .map_response(|mut response: supergraph::Response| {
                 if let Some(cache_control) = response
@@ -349,7 +352,7 @@ impl PluginPrivate for EntityCache {
                 response
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -22,7 +22,6 @@ use sha2::Sha256;
 use tokio::sync::RwLock;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use tower_service::Service;
 use tracing::Instrument;
 use tracing::Level;
@@ -457,7 +456,7 @@ impl PluginPrivate for EntityCache {
                     let endpoint = Endpoint::from_router_service(
                         endpoint_config.path.clone(),
                         InvalidationService::new(self.subgraphs.clone(), self.invalidation.clone())
-                            .boxed(),
+                            .boxed_clone_sync(),
                     );
                     tracing::info!(
                         "Entity caching invalidation endpoint listening on: {}{}",

--- a/apollo-router/src/plugins/cache/metrics.rs
+++ b/apollo-router/src/plugins/cache/metrics.rs
@@ -18,7 +18,6 @@ use super::entity::Ttl;
 use super::entity::hash_query;
 use super::entity::hash_vary_headers;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::services::subgraph;
 use crate::spec::TYPENAME;
 
@@ -28,15 +27,15 @@ pub(crate) const CACHE_INFO_SUBGRAPH_CONTEXT_KEY: &str =
 impl CacheMetricsService {
     pub(crate) fn create(
         name: String,
-        service: subgraph::BoxCloneSyncService,
+        service: subgraph::BoxCloneService,
         ttl: Option<&Ttl>,
         separate_per_type: bool,
-    ) -> subgraph::BoxCloneSyncService {
-        tower::util::BoxCloneSyncService::new(CacheMetricsService {
+    ) -> subgraph::BoxCloneService {
+        tower::util::BoxCloneService::new(CacheMetricsService {
             service: ServiceBuilder::new()
                 .buffered()
                 .service(service)
-                .boxed_clone_sync(),
+                .boxed_clone(),
             name: Arc::new(name),
             counter: Some(Arc::new(Mutex::new(CacheCounter::new(
                 ttl.map(|t| t.0).unwrap_or_else(|| Duration::from_secs(60)),
@@ -48,7 +47,7 @@ impl CacheMetricsService {
 
 #[derive(Clone)]
 pub(crate) struct CacheMetricsService {
-    service: subgraph::BoxCloneSyncService,
+    service: subgraph::BoxCloneService,
     name: Arc<String>,
     counter: Option<Arc<Mutex<CacheCounter>>>,
 }
@@ -56,7 +55,7 @@ pub(crate) struct CacheMetricsService {
 impl Service<subgraph::Request> for CacheMetricsService {
     type Response = subgraph::Response;
     type Error = BoxError;
-    type Future = <subgraph::BoxCloneSyncService as Service<subgraph::Request>>::Future;
+    type Future = <subgraph::BoxCloneService as Service<subgraph::Request>>::Future;
 
     fn poll_ready(
         &mut self,

--- a/apollo-router/src/plugins/cache/metrics.rs
+++ b/apollo-router/src/plugins/cache/metrics.rs
@@ -18,6 +18,7 @@ use super::entity::Ttl;
 use super::entity::hash_query;
 use super::entity::hash_vary_headers;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::services::subgraph;
 use crate::spec::TYPENAME;
 
@@ -27,15 +28,15 @@ pub(crate) const CACHE_INFO_SUBGRAPH_CONTEXT_KEY: &str =
 impl CacheMetricsService {
     pub(crate) fn create(
         name: String,
-        service: subgraph::BoxService,
+        service: subgraph::BoxCloneSyncService,
         ttl: Option<&Ttl>,
         separate_per_type: bool,
-    ) -> subgraph::BoxService {
-        tower::util::BoxService::new(CacheMetricsService {
+    ) -> subgraph::BoxCloneSyncService {
+        tower::util::BoxCloneSyncService::new(CacheMetricsService {
             service: ServiceBuilder::new()
                 .buffered()
                 .service(service)
-                .boxed_clone(),
+                .boxed_clone_sync(),
             name: Arc::new(name),
             counter: Some(Arc::new(Mutex::new(CacheCounter::new(
                 ttl.map(|t| t.0).unwrap_or_else(|| Duration::from_secs(60)),
@@ -47,7 +48,7 @@ impl CacheMetricsService {
 
 #[derive(Clone)]
 pub(crate) struct CacheMetricsService {
-    service: subgraph::BoxCloneService,
+    service: subgraph::BoxCloneSyncService,
     name: Arc<String>,
     counter: Option<Arc<Mutex<CacheCounter>>>,
 }
@@ -55,7 +56,7 @@ pub(crate) struct CacheMetricsService {
 impl Service<subgraph::Request> for CacheMetricsService {
     type Response = subgraph::Response;
     type Error = BoxError;
-    type Future = <subgraph::BoxService as Service<subgraph::Request>>::Future;
+    type Future = <subgraph::BoxCloneSyncService as Service<subgraph::Request>>::Future;
 
     fn poll_ready(
         &mut self,

--- a/apollo-router/src/plugins/cache/tests.rs
+++ b/apollo-router/src/plugins/cache/tests.rs
@@ -20,6 +20,7 @@ use crate::Context;
 use crate::MockedSubgraphs;
 use crate::TestHarness;
 use crate::cache::redis::RedisCacheStorage;
+use crate::layers::ServiceExt as _;
 use crate::plugin::test::MockSubgraph;
 use crate::plugin::test::MockSubgraphService;
 use crate::plugins::cache::entity::CONTEXT_CACHE_KEYS;
@@ -969,7 +970,7 @@ async fn no_data() {
                     .expect_call()
                     .times(1)
                     .returning(move |_req: subgraph::Request| Err("orga not found".into()));
-                subgraph.boxed()
+                subgraph.boxed_clone_sync()
             } else {
                 service
             }

--- a/apollo-router/src/plugins/cache/tests.rs
+++ b/apollo-router/src/plugins/cache/tests.rs
@@ -20,7 +20,6 @@ use crate::Context;
 use crate::MockedSubgraphs;
 use crate::TestHarness;
 use crate::cache::redis::RedisCacheStorage;
-use crate::layers::ServiceExt as _;
 use crate::plugin::test::MockSubgraph;
 use crate::plugin::test::MockSubgraphService;
 use crate::plugins::cache::entity::CONTEXT_CACHE_KEYS;
@@ -970,7 +969,7 @@ async fn no_data() {
                     .expect_call()
                     .times(1)
                     .returning(move |_req: subgraph::Request| Err("orga not found".into()));
-                subgraph.boxed_clone_sync()
+                subgraph.boxed_clone()
             } else {
                 service
             }

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -139,7 +139,10 @@ impl Plugin for Connectors {
             .boxed()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         if !self.expose_sources_in_context {
             return service;
         }
@@ -171,7 +174,7 @@ impl Plugin for Connectors {
                 req
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -10,7 +10,6 @@ use parking_lot::Mutex;
 use serde_json_bytes::json;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt as TowerServiceExt;
 
 use super::query_plans::get_connectors;
 use crate::layers::ServiceExt;
@@ -73,7 +72,10 @@ impl Plugin for Connectors {
         })
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         let conf_enabled = self.debug_extensions;
         let max_requests = self.max_requests;
         service
@@ -136,7 +138,7 @@ impl Plugin for Connectors {
                     res
                 },
             )
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn execution_service(

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -10,9 +10,10 @@ use parking_lot::Mutex;
 use serde_json_bytes::json;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use super::query_plans::get_connectors;
-use crate::layers::ServiceExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::connectors::configuration::ConnectorsConfig;
@@ -74,8 +75,8 @@ impl Plugin for Connectors {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         let conf_enabled = self.debug_extensions;
         let max_requests = self.max_requests;
         service
@@ -138,13 +139,10 @@ impl Plugin for Connectors {
                     res
                 },
             )
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         if !self.expose_sources_in_context {
             return service;
         }
@@ -176,7 +174,7 @@ impl Plugin for Connectors {
                 req
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/coprocessor/connector.rs
+++ b/apollo-router/src/plugins/coprocessor/connector.rs
@@ -15,7 +15,6 @@ use serde_json_bytes::ByteString;
 use tower::BoxError;
 use tower::Service;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use super::COPROCESSOR_ERROR_EXTENSION;
 use super::ContextConf;
@@ -30,6 +29,7 @@ use crate::Context;
 use crate::context::context_key_from_deprecated;
 use crate::json_ext::Value;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::layers::async_checkpoint::AsyncCheckpointLayer;
 use crate::layers::map_future_with_request_data::MapFutureWithRequestDataLayer;
 use crate::plugins::telemetry::config_new::conditions::Condition;
@@ -108,10 +108,10 @@ impl ConnectorStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: request_service::BoxService,
+        service: request_service::BoxCloneSyncService,
         default_url: String,
         service_name: String,
-    ) -> request_service::BoxService
+    ) -> request_service::BoxCloneSyncService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -217,7 +217,7 @@ impl ConnectorStage {
             .option_layer(response_layer)
             .buffered()
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/coprocessor/connector.rs
+++ b/apollo-router/src/plugins/coprocessor/connector.rs
@@ -15,6 +15,7 @@ use serde_json_bytes::ByteString;
 use tower::BoxError;
 use tower::Service;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use super::COPROCESSOR_ERROR_EXTENSION;
 use super::ContextConf;
@@ -29,7 +30,6 @@ use crate::Context;
 use crate::context::context_key_from_deprecated;
 use crate::json_ext::Value;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::layers::async_checkpoint::AsyncCheckpointLayer;
 use crate::layers::map_future_with_request_data::MapFutureWithRequestDataLayer;
 use crate::plugins::telemetry::config_new::conditions::Condition;
@@ -108,10 +108,10 @@ impl ConnectorStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: request_service::BoxCloneSyncService,
+        service: request_service::BoxCloneService,
         default_url: String,
         service_name: String,
-    ) -> request_service::BoxCloneSyncService
+    ) -> request_service::BoxCloneService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -217,7 +217,7 @@ impl ConnectorStage {
             .option_layer(response_layer)
             .buffered()
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -69,11 +69,11 @@ impl ExecutionStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: execution::BoxCloneSyncService,
+        service: execution::BoxCloneService,
         default_url: String,
         sdl: Arc<String>,
         response_validation: bool,
-    ) -> execution::BoxCloneSyncService
+    ) -> execution::BoxCloneService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -174,7 +174,7 @@ impl ExecutionStage {
             .option_layer(response_layer)
             .buffered() // XXX: Added during backpressure fixing
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -738,7 +738,7 @@ mod tests {
 
         let service = execution_stage.as_service(
             mock_http_client,
-            mock_execution_service.boxed_clone_sync(),
+            mock_execution_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -809,7 +809,7 @@ mod tests {
 
         let service = execution_stage.as_service(
             mock_http_client,
-            mock_execution_service.boxed_clone_sync(),
+            mock_execution_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -940,7 +940,7 @@ mod tests {
 
         let service = execution_stage.as_service(
             mock_http_client,
-            mock_execution_service.boxed_clone_sync(),
+            mock_execution_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1055,7 +1055,7 @@ mod tests {
 
         let service = execution_stage.as_service(
             mock_http_client,
-            mock_execution_service.boxed_clone_sync(),
+            mock_execution_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1269,7 +1269,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_disabled_invalid() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_invalid_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1288,7 +1288,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_disabled_empty() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_empty_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1310,7 +1310,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_enabled_valid() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_valid_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1329,7 +1329,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_enabled_empty() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_empty_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1353,7 +1353,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_enabled_invalid() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_invalid_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1377,7 +1377,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_disabled_valid() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_valid_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1396,7 +1396,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_disabled_empty() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_empty_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1417,7 +1417,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_disabled_invalid() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_invalid_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1439,7 +1439,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_enabled_valid() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_execution_response_valid_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1457,7 +1457,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_enabled_empty() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_empty_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1474,7 +1474,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_enabled_invalid() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_invalid_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1491,7 +1491,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_disabled_valid() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_execution_response_valid_response(),
-            create_mock_execution_service().boxed_clone_sync(),
+            create_mock_execution_service().boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -69,11 +69,11 @@ impl ExecutionStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: execution::BoxService,
+        service: execution::BoxCloneSyncService,
         default_url: String,
         sdl: Arc<String>,
         response_validation: bool,
-    ) -> execution::BoxService
+    ) -> execution::BoxCloneSyncService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -174,7 +174,7 @@ impl ExecutionStage {
             .option_layer(response_layer)
             .buffered() // XXX: Added during backpressure fixing
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -738,7 +738,7 @@ mod tests {
 
         let service = execution_stage.as_service(
             mock_http_client,
-            mock_execution_service.boxed(),
+            mock_execution_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -809,7 +809,7 @@ mod tests {
 
         let service = execution_stage.as_service(
             mock_http_client,
-            mock_execution_service.boxed(),
+            mock_execution_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -940,7 +940,7 @@ mod tests {
 
         let service = execution_stage.as_service(
             mock_http_client,
-            mock_execution_service.boxed(),
+            mock_execution_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1055,7 +1055,7 @@ mod tests {
 
         let service = execution_stage.as_service(
             mock_http_client,
-            mock_execution_service.boxed(),
+            mock_execution_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1269,7 +1269,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_disabled_invalid() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_invalid_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1288,7 +1288,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_disabled_empty() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_empty_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1310,7 +1310,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_enabled_valid() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_valid_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1329,7 +1329,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_enabled_empty() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_empty_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1353,7 +1353,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_enabled_invalid() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_invalid_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1377,7 +1377,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_disabled_valid() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_valid_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1396,7 +1396,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_disabled_empty() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_empty_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1417,7 +1417,7 @@ mod tests {
     async fn external_plugin_execution_request_validation_disabled_invalid() {
         let service = create_execution_stage_for_request_validation_test().as_service(
             create_mock_http_client_execution_request_invalid_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled
@@ -1439,7 +1439,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_enabled_valid() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_execution_response_valid_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1457,7 +1457,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_enabled_empty() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_empty_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1474,7 +1474,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_enabled_invalid() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_invalid_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true, // Validation enabled
@@ -1491,7 +1491,7 @@ mod tests {
     async fn external_plugin_execution_response_validation_disabled_valid() {
         let service = create_execution_stage_for_response_validation_test().as_service(
             create_mock_http_client_execution_response_valid_response(),
-            create_mock_execution_service().boxed(),
+            create_mock_execution_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             false, // Validation disabled

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -213,8 +213,8 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
 
     fn execution_service(
         &self,
-        service: services::execution::BoxService,
-    ) -> services::execution::BoxService {
+        service: services::execution::BoxCloneSyncService,
+    ) -> services::execution::BoxCloneSyncService {
         self.execution_service(service)
     }
 
@@ -309,8 +309,8 @@ where
 
     fn execution_service(
         &self,
-        service: services::execution::BoxService,
-    ) -> services::execution::BoxService {
+        service: services::execution::BoxCloneSyncService,
+    ) -> services::execution::BoxCloneSyncService {
         self.configuration.execution.as_service(
             self.http_client.clone(),
             service,

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -24,7 +24,6 @@ use tower::BoxError;
 use tower::Layer;
 use tower::Service;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use tower::timeout::TimeoutLayer;
 use tower::util::MapFutureLayer;
 
@@ -200,7 +199,7 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
         CoprocessorPlugin::new(client, init.config, init.supergraph_sdl)
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         self.router_service(service)
     }
 
@@ -284,7 +283,7 @@ where
         })
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         self.configuration.router.as_service(
             self.http_client.clone(),
             service,
@@ -689,11 +688,11 @@ impl RouterStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: router::BoxService,
+        service: router::BoxCloneSyncService,
         default_url: String,
         sdl: Arc<String>,
         response_validation: bool,
-    ) -> router::BoxService
+    ) -> router::BoxCloneSyncService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -792,7 +791,7 @@ impl RouterStage {
             .option_layer(response_layer)
             .buffered() // XXX: Added during backpressure fixing
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -36,6 +36,7 @@ use crate::error::Error;
 use crate::graphql;
 use crate::json_ext::Value;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::layers::async_checkpoint::AsyncCheckpointLayer;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
@@ -217,7 +218,11 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
         self.execution_service(service)
     }
 
-    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         self.subgraph_service(name, service)
     }
 
@@ -315,7 +320,11 @@ where
         )
     }
 
-    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         self.configuration.subgraph.all.as_service(
             self.http_client.clone(),
             service,
@@ -811,11 +820,11 @@ impl SubgraphStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: subgraph::BoxService,
+        service: subgraph::BoxCloneSyncService,
         default_url: String,
         service_name: String,
         response_validation: bool,
-    ) -> subgraph::BoxService
+    ) -> subgraph::BoxCloneSyncService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -915,7 +924,7 @@ impl SubgraphStage {
             .option_layer(response_layer)
             .buffered() // XXX: Added during backpressure fixing
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -206,8 +206,8 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
 
     fn supergraph_service(
         &self,
-        service: services::supergraph::BoxService,
-    ) -> services::supergraph::BoxService {
+        service: services::supergraph::BoxCloneSyncService,
+    ) -> services::supergraph::BoxCloneSyncService {
         self.supergraph_service(service)
     }
 
@@ -296,8 +296,8 @@ where
 
     fn supergraph_service(
         &self,
-        service: services::supergraph::BoxService,
-    ) -> services::supergraph::BoxService {
+        service: services::supergraph::BoxCloneSyncService,
+    ) -> services::supergraph::BoxCloneSyncService {
         self.configuration.supergraph.as_service(
             self.http_client.clone(),
             service,

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -24,6 +24,7 @@ use tower::BoxError;
 use tower::Layer;
 use tower::Service;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower::timeout::TimeoutLayer;
 use tower::util::MapFutureLayer;
 
@@ -35,7 +36,6 @@ use crate::error::Error;
 use crate::graphql;
 use crate::json_ext::Value;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::layers::async_checkpoint::AsyncCheckpointLayer;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
@@ -199,37 +199,37 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
         CoprocessorPlugin::new(client, init.config, init.supergraph_sdl)
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         self.router_service(service)
     }
 
     fn supergraph_service(
         &self,
-        service: services::supergraph::BoxCloneSyncService,
-    ) -> services::supergraph::BoxCloneSyncService {
+        service: services::supergraph::BoxCloneService,
+    ) -> services::supergraph::BoxCloneService {
         self.supergraph_service(service)
     }
 
     fn execution_service(
         &self,
-        service: services::execution::BoxCloneSyncService,
-    ) -> services::execution::BoxCloneSyncService {
+        service: services::execution::BoxCloneService,
+    ) -> services::execution::BoxCloneService {
         self.execution_service(service)
     }
 
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         self.subgraph_service(name, service)
     }
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxCloneSyncService,
+        service: crate::services::connector::request_service::BoxCloneService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxCloneSyncService {
+    ) -> crate::services::connector::request_service::BoxCloneService {
         self.connector_request_service(&source_name, service)
     }
 }
@@ -283,7 +283,7 @@ where
         })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         self.configuration.router.as_service(
             self.http_client.clone(),
             service,
@@ -295,8 +295,8 @@ where
 
     fn supergraph_service(
         &self,
-        service: services::supergraph::BoxCloneSyncService,
-    ) -> services::supergraph::BoxCloneSyncService {
+        service: services::supergraph::BoxCloneService,
+    ) -> services::supergraph::BoxCloneService {
         self.configuration.supergraph.as_service(
             self.http_client.clone(),
             service,
@@ -308,8 +308,8 @@ where
 
     fn execution_service(
         &self,
-        service: services::execution::BoxCloneSyncService,
-    ) -> services::execution::BoxCloneSyncService {
+        service: services::execution::BoxCloneService,
+    ) -> services::execution::BoxCloneService {
         self.configuration.execution.as_service(
             self.http_client.clone(),
             service,
@@ -322,8 +322,8 @@ where
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         self.configuration.subgraph.all.as_service(
             self.http_client.clone(),
             service,
@@ -336,8 +336,8 @@ where
     fn connector_request_service(
         &self,
         source_name: &str,
-        service: crate::services::connector::request_service::BoxCloneSyncService,
-    ) -> crate::services::connector::request_service::BoxCloneSyncService {
+        service: crate::services::connector::request_service::BoxCloneService,
+    ) -> crate::services::connector::request_service::BoxCloneService {
         self.configuration.connector.all.as_service(
             self.http_client.clone(),
             service,
@@ -688,11 +688,11 @@ impl RouterStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: router::BoxCloneSyncService,
+        service: router::BoxCloneService,
         default_url: String,
         sdl: Arc<String>,
         response_validation: bool,
-    ) -> router::BoxCloneSyncService
+    ) -> router::BoxCloneService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -791,7 +791,7 @@ impl RouterStage {
             .option_layer(response_layer)
             .buffered() // XXX: Added during backpressure fixing
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -819,11 +819,11 @@ impl SubgraphStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: subgraph::BoxCloneSyncService,
+        service: subgraph::BoxCloneService,
         default_url: String,
         service_name: String,
         response_validation: bool,
-    ) -> subgraph::BoxCloneSyncService
+    ) -> subgraph::BoxCloneService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -923,7 +923,7 @@ impl SubgraphStage {
             .option_layer(response_layer)
             .buffered() // XXX: Added during backpressure fixing
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -228,9 +228,9 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
+        service: crate::services::connector::request_service::BoxCloneSyncService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
+    ) -> crate::services::connector::request_service::BoxCloneSyncService {
         self.connector_request_service(&source_name, service)
     }
 }
@@ -337,8 +337,8 @@ where
     fn connector_request_service(
         &self,
         source_name: &str,
-        service: crate::services::connector::request_service::BoxService,
-    ) -> crate::services::connector::request_service::BoxService {
+        service: crate::services::connector::request_service::BoxCloneSyncService,
+    ) -> crate::services::connector::request_service::BoxCloneSyncService {
         self.configuration.connector.all.as_service(
             self.http_client.clone(),
             service,

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -72,11 +72,11 @@ impl SupergraphStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: supergraph::BoxCloneSyncService,
+        service: supergraph::BoxCloneService,
         default_url: String,
         sdl: Arc<String>,
         response_validation: bool,
-    ) -> supergraph::BoxCloneSyncService
+    ) -> supergraph::BoxCloneService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -177,7 +177,7 @@ impl SupergraphStage {
             .option_layer(response_layer)
             .buffered() // XXX: Added during backpressure fixing
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -752,7 +752,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -831,7 +831,7 @@ mod tests {
 
         let service = supergraph_stage.clone().as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -909,7 +909,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1025,7 +1025,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1141,7 +1141,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1259,7 +1259,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1475,7 +1475,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_disabled_invalid() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_invalid_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1494,7 +1494,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_disabled_empty() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_empty_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1516,7 +1516,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_enabled_valid() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_valid_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1535,7 +1535,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_enabled_empty() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_empty_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1559,7 +1559,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_enabled_invalid() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_invalid_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1583,7 +1583,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_disabled_valid() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_valid_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1602,7 +1602,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_disabled_empty() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_empty_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1623,7 +1623,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_disabled_invalid() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_invalid_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1645,7 +1645,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_enabled_valid() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_supergraph_response_valid_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1663,7 +1663,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_enabled_empty() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_empty_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1680,7 +1680,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_enabled_invalid() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_invalid_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1697,7 +1697,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_disabled_valid() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_supergraph_response_valid_response(),
-            create_mock_supergraph_service().boxed_clone_sync(),
+            create_mock_supergraph_service().boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -72,11 +72,11 @@ impl SupergraphStage {
     pub(crate) fn as_service<C>(
         &self,
         http_client: C,
-        service: supergraph::BoxService,
+        service: supergraph::BoxCloneSyncService,
         default_url: String,
         sdl: Arc<String>,
         response_validation: bool,
-    ) -> supergraph::BoxService
+    ) -> supergraph::BoxCloneSyncService
     where
         C: Service<HttpRequest, Response = HttpResponse, Error = BoxError>
             + Clone
@@ -177,7 +177,7 @@ impl SupergraphStage {
             .option_layer(response_layer)
             .buffered() // XXX: Added during backpressure fixing
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -752,7 +752,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -831,7 +831,7 @@ mod tests {
 
         let service = supergraph_stage.clone().as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -909,7 +909,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1025,7 +1025,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1141,7 +1141,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1259,7 +1259,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -1475,7 +1475,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_disabled_invalid() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_invalid_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1494,7 +1494,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_disabled_empty() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_empty_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1516,7 +1516,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_enabled_valid() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_valid_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1535,7 +1535,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_enabled_empty() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_empty_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1559,7 +1559,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_enabled_invalid() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_invalid_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1583,7 +1583,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_disabled_valid() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_valid_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1602,7 +1602,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_disabled_empty() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_empty_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1623,7 +1623,7 @@ mod tests {
     async fn external_plugin_supergraph_request_validation_disabled_invalid() {
         let service = create_supergraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_supergraph_request_invalid_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled
@@ -1645,7 +1645,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_enabled_valid() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_supergraph_response_valid_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1663,7 +1663,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_enabled_empty() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_empty_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1680,7 +1680,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_enabled_invalid() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_invalid_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true, // Validation enabled
@@ -1697,7 +1697,7 @@ mod tests {
     async fn external_plugin_supergraph_response_validation_disabled_valid() {
         let service = create_supergraph_stage_for_response_validation_test().as_service(
             create_mock_http_client_supergraph_response_valid_response(),
-            create_mock_supergraph_service().boxed(),
+            create_mock_supergraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             false, // Validation disabled

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -477,7 +477,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -620,7 +620,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -773,7 +773,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -940,7 +940,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1024,7 +1024,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1088,7 +1088,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1145,7 +1145,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1263,7 +1263,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1379,7 +1379,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1507,7 +1507,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1656,7 +1656,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1793,7 +1793,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -3855,7 +3855,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_disabled_invalid() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_invalid_subgraph_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -3878,7 +3878,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_enabled_valid() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_valid_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -3899,7 +3899,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_enabled_empty() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_empty_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -3922,7 +3922,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_enabled_invalid() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_invalid_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -3945,7 +3945,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_disabled_valid() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_valid_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -3966,7 +3966,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_disabled_empty() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_empty_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -3986,7 +3986,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_disabled_invalid() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_invalid_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -4007,7 +4007,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_enabled_valid() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_subgraph_response_valid_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -4027,7 +4027,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_enabled_empty() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_subgraph_response_empty_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -4044,7 +4044,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_enabled_invalid() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_invalid_subgraph_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -4061,7 +4061,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_disabled_valid() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_subgraph_response_valid_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -4081,7 +4081,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_disabled_empty() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_subgraph_response_empty_response(),
-            create_mock_subgraph_service().boxed(),
+            create_mock_subgraph_service().boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -4165,7 +4165,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -4251,7 +4251,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -4323,7 +4323,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -4408,7 +4408,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -4500,7 +4500,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed(),
+            mock_subgraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Disable response validation since coprocessor returns only extensions
@@ -5258,7 +5258,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_request_valid_response(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5287,7 +5287,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_response_valid_response(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5316,7 +5316,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_request_valid_response(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5342,7 +5342,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_response_valid_response(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5368,7 +5368,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_request_valid_response(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5384,7 +5384,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_response_valid_response(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5412,7 +5412,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_hard_error(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     true, // Validation enabled
@@ -5441,7 +5441,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_hard_error(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     true, // Validation enabled
@@ -5470,7 +5470,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_hard_error(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     true, // Validation enabled
@@ -5486,7 +5486,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_hard_error(),
-                    create_mock_subgraph_service().boxed(),
+                    create_mock_subgraph_service().boxed_clone_sync(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     true, // Validation enabled

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -218,7 +218,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://127.0.0.1:8081".to_string(), // global URL - should NOT be used
             Arc::new("".to_string()),
             true,
@@ -294,7 +294,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -358,7 +358,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -421,7 +421,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2212,7 +2212,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2360,7 +2360,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2494,7 +2494,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2625,7 +2625,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2701,7 +2701,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2787,7 +2787,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2922,7 +2922,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed(),
+            mock_router_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -3003,7 +3003,7 @@ mod tests {
         let service_stack = router_stage
             .as_service(
                 mock_http_client,
-                mock_router_service.boxed(),
+                mock_router_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 Arc::new("".to_string()),
                 false, // response_validation - doesn't matter for router stage
@@ -3221,7 +3221,7 @@ mod tests {
         }
     }
 
-    async fn create_mock_router_service_for_validation_test() -> router::BoxService {
+    async fn create_mock_router_service_for_validation_test() -> router::BoxCloneSyncService {
         router::service::from_supergraph_mock_callback(move |req| {
             Ok(supergraph::Response::builder()
                 .data(json!({"test": 42}))
@@ -3230,7 +3230,7 @@ mod tests {
                 .unwrap())
         })
         .await
-        .boxed()
+        .boxed_clone_sync()
     }
 
     // Helper function to create working router service mock
@@ -5518,7 +5518,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5547,7 +5547,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5577,7 +5577,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5607,7 +5607,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5637,7 +5637,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5657,7 +5657,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5689,7 +5689,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false,
@@ -5718,7 +5718,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5751,7 +5751,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5771,7 +5771,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed(),
+                        mock_router_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -218,7 +218,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://127.0.0.1:8081".to_string(), // global URL - should NOT be used
             Arc::new("".to_string()),
             true,
@@ -294,7 +294,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -358,7 +358,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -421,7 +421,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -477,7 +477,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -620,7 +620,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -773,7 +773,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -940,7 +940,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1024,7 +1024,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1088,7 +1088,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1145,7 +1145,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1263,7 +1263,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1379,7 +1379,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1507,7 +1507,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1656,7 +1656,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1793,7 +1793,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -1872,7 +1872,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true,
@@ -1963,7 +1963,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true,
@@ -2062,7 +2062,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed_clone_sync(),
+            mock_supergraph_service.boxed_clone(),
             "http://test".to_string(),
             Arc::default(),
             true,
@@ -2212,7 +2212,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2360,7 +2360,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2494,7 +2494,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2625,7 +2625,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2701,7 +2701,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2787,7 +2787,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -2922,7 +2922,7 @@ mod tests {
 
         let service = router_stage.as_service(
             mock_http_client,
-            mock_router_service.boxed_clone_sync(),
+            mock_router_service.boxed_clone(),
             "http://test".to_string(),
             Arc::new("".to_string()),
             true,
@@ -3003,7 +3003,7 @@ mod tests {
         let service_stack = router_stage
             .as_service(
                 mock_http_client,
-                mock_router_service.boxed_clone_sync(),
+                mock_router_service.boxed_clone(),
                 "http://test".to_string(),
                 Arc::new("".to_string()),
                 false, // response_validation - doesn't matter for router stage
@@ -3221,7 +3221,7 @@ mod tests {
         }
     }
 
-    async fn create_mock_router_service_for_validation_test() -> router::BoxCloneSyncService {
+    async fn create_mock_router_service_for_validation_test() -> router::BoxCloneService {
         router::service::from_supergraph_mock_callback(move |req| {
             Ok(supergraph::Response::builder()
                 .data(json!({"test": 42}))
@@ -3230,7 +3230,7 @@ mod tests {
                 .unwrap())
         })
         .await
-        .boxed_clone_sync()
+        .boxed_clone()
     }
 
     // Helper function to create working router service mock
@@ -3855,7 +3855,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_disabled_invalid() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_invalid_subgraph_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -3878,7 +3878,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_enabled_valid() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_valid_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -3899,7 +3899,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_enabled_empty() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_empty_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -3922,7 +3922,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_enabled_invalid() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_invalid_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -3945,7 +3945,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_disabled_valid() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_valid_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -3966,7 +3966,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_disabled_empty() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_empty_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -3986,7 +3986,7 @@ mod tests {
     async fn external_plugin_subgraph_request_validation_disabled_invalid() {
         let service = create_subgraph_stage_for_request_validation_test().as_service(
             create_mock_http_client_subgraph_request_invalid_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -4007,7 +4007,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_enabled_valid() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_subgraph_response_valid_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -4027,7 +4027,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_enabled_empty() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_subgraph_response_empty_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -4044,7 +4044,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_enabled_invalid() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_invalid_subgraph_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true, // Validation enabled
@@ -4061,7 +4061,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_disabled_valid() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_subgraph_response_valid_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -4081,7 +4081,7 @@ mod tests {
     async fn external_plugin_subgraph_response_validation_disabled_empty() {
         let service = create_subgraph_stage_for_validation_test().as_service(
             create_mock_http_client_subgraph_response_empty_response(),
-            create_mock_subgraph_service().boxed_clone_sync(),
+            create_mock_subgraph_service().boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Validation disabled
@@ -4165,7 +4165,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -4251,7 +4251,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -4323,7 +4323,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -4408,7 +4408,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             true,
@@ -4500,7 +4500,7 @@ mod tests {
 
         let service = subgraph_stage.as_service(
             mock_http_client,
-            mock_subgraph_service.boxed_clone_sync(),
+            mock_subgraph_service.boxed_clone(),
             "http://test".to_string(),
             "my_subgraph_service_name".to_string(),
             false, // Disable response validation since coprocessor returns only extensions
@@ -5258,7 +5258,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_request_valid_response(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5287,7 +5287,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_response_valid_response(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5316,7 +5316,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_request_valid_response(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5342,7 +5342,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_response_valid_response(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5368,7 +5368,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_request_valid_response(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5384,7 +5384,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_subgraph_response_valid_response(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     false, // Validation disabled
@@ -5412,7 +5412,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_hard_error(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     true, // Validation enabled
@@ -5441,7 +5441,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_hard_error(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     true, // Validation enabled
@@ -5470,7 +5470,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_hard_error(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     true, // Validation enabled
@@ -5486,7 +5486,7 @@ mod tests {
 
                 let _service = _stage.as_service(
                     create_mock_http_client_hard_error(),
-                    create_mock_subgraph_service().boxed_clone_sync(),
+                    create_mock_subgraph_service().boxed_clone(),
                     "http://test".to_string(),
                     "my_service".to_string(),
                     true, // Validation enabled
@@ -5518,7 +5518,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5547,7 +5547,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5577,7 +5577,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5607,7 +5607,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5637,7 +5637,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5657,7 +5657,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5689,7 +5689,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false,
@@ -5718,7 +5718,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5751,7 +5751,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -5771,7 +5771,7 @@ mod tests {
                 let service_stack = router_stage
                     .as_service(
                         mock_http_client,
-                        mock_router_service.boxed_clone_sync(),
+                        mock_router_service.boxed_clone(),
                         "http://test".to_string(),
                         Arc::new("".to_string()),
                         false, // response_validation - doesn't matter for router stage
@@ -6256,7 +6256,6 @@ mod tests {
         use tower::BoxError;
         use tower::ServiceExt;
 
-        use crate::layers::ServiceExt as _;
         use crate::metrics::FutureMetricsExt;
         use crate::plugin::test::MockInternalHttpClientService;
         use crate::plugins::coprocessor::ContextConf;
@@ -6406,7 +6405,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6457,7 +6456,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6508,7 +6507,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6572,7 +6571,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6645,7 +6644,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                inner_service.boxed_clone_sync(),
+                inner_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6701,7 +6700,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6749,7 +6748,7 @@ mod tests {
 
                     let service = connector_stage.as_service(
                         mock_http_client,
-                        mock_connector_service.boxed_clone_sync(),
+                        mock_connector_service.boxed_clone(),
                         "http://test".to_string(),
                         "my_connector_source".to_string(),
                     );
@@ -6802,7 +6801,7 @@ mod tests {
 
                     let service = connector_stage.as_service(
                         mock_http_client,
-                        mock_connector_service.boxed_clone_sync(),
+                        mock_connector_service.boxed_clone(),
                         "http://test".to_string(),
                         "my_connector_source".to_string(),
                     );
@@ -6849,7 +6848,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6892,7 +6891,7 @@ mod tests {
 
                     let service = connector_stage.as_service(
                         mock_http_client,
-                        mock_connector_service.boxed_clone_sync(),
+                        mock_connector_service.boxed_clone(),
                         "http://test".to_string(),
                         "my_connector_source".to_string(),
                     );
@@ -6950,7 +6949,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6998,7 +6997,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7056,7 +7055,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7117,7 +7116,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7163,7 +7162,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7208,7 +7207,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed_clone_sync(),
+                mock_connector_service.boxed_clone(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7224,7 +7223,7 @@ mod tests {
             }
         }
 
-        fn create_error_connector_service() -> tower::util::BoxCloneSyncService<
+        fn create_error_connector_service() -> tower::util::BoxCloneService<
             request_service::Request,
             request_service::Response,
             BoxError,
@@ -7247,7 +7246,7 @@ mod tests {
                     },
                 })
             })
-            .boxed_clone_sync()
+            .boxed_clone()
         }
 
         #[tokio::test]

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -6256,6 +6256,7 @@ mod tests {
         use tower::BoxError;
         use tower::ServiceExt;
 
+        use crate::layers::ServiceExt as _;
         use crate::metrics::FutureMetricsExt;
         use crate::plugin::test::MockInternalHttpClientService;
         use crate::plugins::coprocessor::ContextConf;
@@ -6405,7 +6406,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6456,7 +6457,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6507,7 +6508,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6571,7 +6572,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6644,7 +6645,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                inner_service.boxed(),
+                inner_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6700,7 +6701,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6748,7 +6749,7 @@ mod tests {
 
                     let service = connector_stage.as_service(
                         mock_http_client,
-                        mock_connector_service.boxed(),
+                        mock_connector_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         "my_connector_source".to_string(),
                     );
@@ -6801,7 +6802,7 @@ mod tests {
 
                     let service = connector_stage.as_service(
                         mock_http_client,
-                        mock_connector_service.boxed(),
+                        mock_connector_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         "my_connector_source".to_string(),
                     );
@@ -6848,7 +6849,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6891,7 +6892,7 @@ mod tests {
 
                     let service = connector_stage.as_service(
                         mock_http_client,
-                        mock_connector_service.boxed(),
+                        mock_connector_service.boxed_clone_sync(),
                         "http://test".to_string(),
                         "my_connector_source".to_string(),
                     );
@@ -6949,7 +6950,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -6997,7 +6998,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7055,7 +7056,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7116,7 +7117,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7162,7 +7163,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7207,7 +7208,7 @@ mod tests {
 
             let service = connector_stage.as_service(
                 mock_http_client,
-                mock_connector_service.boxed(),
+                mock_connector_service.boxed_clone_sync(),
                 "http://test".to_string(),
                 "my_connector_source".to_string(),
             );
@@ -7223,9 +7224,11 @@ mod tests {
             }
         }
 
-        fn create_error_connector_service()
-        -> tower::util::BoxService<request_service::Request, request_service::Response, BoxError>
-        {
+        fn create_error_connector_service() -> tower::util::BoxCloneSyncService<
+            request_service::Request,
+            request_service::Response,
+            BoxError,
+        > {
             tower::service_fn(|req: request_service::Request| async {
                 Ok(request_service::Response {
                     context: req.context,
@@ -7244,7 +7247,7 @@ mod tests {
                     },
                 })
             })
-            .boxed()
+            .boxed_clone_sync()
         }
 
         #[tokio::test]

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -1872,7 +1872,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true,
@@ -1963,7 +1963,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true,
@@ -2062,7 +2062,7 @@ mod tests {
 
         let service = supergraph_stage.as_service(
             mock_http_client,
-            mock_supergraph_service.boxed(),
+            mock_supergraph_service.boxed_clone_sync(),
             "http://test".to_string(),
             Arc::default(),
             true,

--- a/apollo-router/src/plugins/csrf/mod.rs
+++ b/apollo-router/src/plugins/csrf/mod.rs
@@ -9,9 +9,9 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::router;
@@ -100,7 +100,7 @@ impl Plugin for Csrf {
         })
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         if !self.config.unsafe_disabled {
             let required_headers = self.config.required_headers.clone();
             ServiceBuilder::new()
@@ -129,7 +129,7 @@ impl Plugin for Csrf {
                     }
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         } else {
             service
         }

--- a/apollo-router/src/plugins/csrf/mod.rs
+++ b/apollo-router/src/plugins/csrf/mod.rs
@@ -9,9 +9,9 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::router;
@@ -100,7 +100,7 @@ impl Plugin for Csrf {
         })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         if !self.config.unsafe_disabled {
             let required_headers = self.config.required_headers.clone();
             ServiceBuilder::new()
@@ -129,7 +129,7 @@ impl Plugin for Csrf {
                     }
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         } else {
             service
         }

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -26,6 +26,7 @@ use serde_json_bytes::Value;
 use thiserror::Error;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use crate::Context;
 use crate::configuration::subgraph::SubgraphConfiguration;
@@ -34,7 +35,6 @@ use crate::graphql;
 use crate::graphql::IntoGraphQLErrors;
 use crate::json_ext::Object;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::demand_control::cost_calculator::CostBySubgraph;
@@ -551,10 +551,7 @@ impl Plugin for DemandControl {
         })
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         if !self.config.enabled {
             service
         } else {
@@ -649,15 +646,15 @@ impl Plugin for DemandControl {
                     resp
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         }
     }
 
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         if !self.config.enabled {
             service
         } else {
@@ -713,7 +710,7 @@ impl Plugin for DemandControl {
                     },
                 )
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         }
     }
 }

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -35,6 +35,7 @@ use crate::graphql;
 use crate::graphql::IntoGraphQLErrors;
 use crate::json_ext::Object;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::demand_control::cost_calculator::CostBySubgraph;
@@ -654,8 +655,8 @@ impl Plugin for DemandControl {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         if !self.config.enabled {
             service
         } else {
@@ -711,7 +712,7 @@ impl Plugin for DemandControl {
                     },
                 )
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         }
     }
 }

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -26,7 +26,6 @@ use serde_json_bytes::Value;
 use thiserror::Error;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use crate::Context;
 use crate::configuration::subgraph::SubgraphConfiguration;
@@ -44,7 +43,6 @@ use crate::plugins::demand_control::strategy::Strategy;
 use crate::plugins::demand_control::strategy::StrategyFactory;
 use crate::plugins::telemetry::tracing::apollo_telemetry::emit_error_event;
 use crate::services::execution;
-use crate::services::execution::BoxService;
 use crate::services::subgraph;
 
 pub(crate) mod cost_calculator;
@@ -553,7 +551,10 @@ impl Plugin for DemandControl {
         })
     }
 
-    fn execution_service(&self, service: BoxService) -> BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         if !self.config.enabled {
             service
         } else {
@@ -648,7 +649,7 @@ impl Plugin for DemandControl {
                     resp
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         }
     }
 

--- a/apollo-router/src/plugins/enhanced_client_awareness/mod.rs
+++ b/apollo-router/src/plugins/enhanced_client_awareness/mod.rs
@@ -5,9 +5,9 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::telemetry::CLIENT_LIBRARY_NAME;
@@ -37,8 +37,8 @@ impl Plugin for EnhancedClientAwareness {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         ServiceBuilder::new()
             .checkpoint(|request: supergraph::Request| {
                 if let Some(client_library_metadata) = request
@@ -91,7 +91,7 @@ impl Plugin for EnhancedClientAwareness {
                 Ok(ControlFlow::Continue(request))
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/enhanced_client_awareness/mod.rs
+++ b/apollo-router/src/plugins/enhanced_client_awareness/mod.rs
@@ -5,9 +5,9 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::telemetry::CLIENT_LIBRARY_NAME;
@@ -35,7 +35,10 @@ impl Plugin for EnhancedClientAwareness {
         Ok(EnhancedClientAwareness {})
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         ServiceBuilder::new()
             .checkpoint(|request: supergraph::Request| {
                 if let Some(client_library_metadata) = request
@@ -88,7 +91,7 @@ impl Plugin for EnhancedClientAwareness {
                 Ok(ControlFlow::Continue(request))
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/enhanced_client_awareness/tests.rs
+++ b/apollo-router/src/plugins/enhanced_client_awareness/tests.rs
@@ -3,7 +3,6 @@ use tower::ServiceExt;
 
 use super::EnhancedClientAwareness;
 use crate::Context;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugin::test::MockSupergraphService;
@@ -51,7 +50,7 @@ async fn given_client_library_metadata_adds_values_to_context() {
         EnhancedClientAwareness::new(PluginInit::fake_new(Config {}, Default::default()))
             .await
             .unwrap()
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
     // given
     let mut clients_map = serde_json_bytes::map::Map::new();
@@ -90,7 +89,7 @@ async fn without_client_library_metadata_does_not_add_values_to_context() {
         EnhancedClientAwareness::new(PluginInit::fake_new(Config {}, Default::default()))
             .await
             .unwrap()
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
     // when
     let request = supergraph::Request::fake_builder()
@@ -110,7 +109,7 @@ async fn invalid_library_name_returns_bad_request() {
         EnhancedClientAwareness::new(PluginInit::fake_new(Config {}, Default::default()))
             .await
             .unwrap()
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
     let mut clients_map = serde_json_bytes::map::Map::new();
     clients_map.insert(CLIENT_LIBRARY_NAME_KEY, r#"invalid";||"#.into());
@@ -136,7 +135,7 @@ async fn invalid_library_version_returns_bad_request() {
         EnhancedClientAwareness::new(PluginInit::fake_new(Config {}, Default::default()))
             .await
             .unwrap()
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
     let mut clients_map = serde_json_bytes::map::Map::new();
     clients_map.insert(CLIENT_LIBRARY_VERSION_KEY, r#"invalid";||"#.into());

--- a/apollo-router/src/plugins/enhanced_client_awareness/tests.rs
+++ b/apollo-router/src/plugins/enhanced_client_awareness/tests.rs
@@ -3,6 +3,7 @@ use tower::ServiceExt;
 
 use super::EnhancedClientAwareness;
 use crate::Context;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugin::test::MockSupergraphService;
@@ -50,7 +51,7 @@ async fn given_client_library_metadata_adds_values_to_context() {
         EnhancedClientAwareness::new(PluginInit::fake_new(Config {}, Default::default()))
             .await
             .unwrap()
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
     // given
     let mut clients_map = serde_json_bytes::map::Map::new();
@@ -89,7 +90,7 @@ async fn without_client_library_metadata_does_not_add_values_to_context() {
         EnhancedClientAwareness::new(PluginInit::fake_new(Config {}, Default::default()))
             .await
             .unwrap()
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
     // when
     let request = supergraph::Request::fake_builder()
@@ -109,7 +110,7 @@ async fn invalid_library_name_returns_bad_request() {
         EnhancedClientAwareness::new(PluginInit::fake_new(Config {}, Default::default()))
             .await
             .unwrap()
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
     let mut clients_map = serde_json_bytes::map::Map::new();
     clients_map.insert(CLIENT_LIBRARY_NAME_KEY, r#"invalid";||"#.into());
@@ -135,7 +136,7 @@ async fn invalid_library_version_returns_bad_request() {
         EnhancedClientAwareness::new(PluginInit::fake_new(Config {}, Default::default()))
             .await
             .unwrap()
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
     let mut clients_map = serde_json_bytes::map::Map::new();
     clients_map.insert(CLIENT_LIBRARY_VERSION_KEY, r#"invalid";||"#.into());

--- a/apollo-router/src/plugins/expose_query_plan.rs
+++ b/apollo-router/src/plugins/expose_query_plan.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 use serde_json_bytes::json;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use super::connectors::query_plans::replace_connector_service_names;
 use super::connectors::query_plans::replace_connector_service_names_text;
@@ -58,10 +59,7 @@ impl Plugin for ExposeQueryPlan {
         })
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         ServiceBuilder::new()
             .checkpoint(|req: execution::Request| {
                 let setting = req
@@ -96,13 +94,13 @@ impl Plugin for ExposeQueryPlan {
                 }
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         let conf_enabled = self.enabled;
         service
             .map_future_with_request_data(move |req: &supergraph::Request| {
@@ -154,7 +152,7 @@ impl Plugin for ExposeQueryPlan {
 
                 res
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -175,7 +173,7 @@ mod tests {
 
     static VALID_QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
 
-    async fn build_mock_supergraph(config: serde_json::Value) -> supergraph::BoxCloneSyncService {
+    async fn build_mock_supergraph(config: serde_json::Value) -> supergraph::BoxCloneService {
         let mut extensions = Object::new();
         extensions.insert("test", Value::String(ByteString::from("value")));
 
@@ -232,7 +230,7 @@ mod tests {
 
     async fn execute_supergraph_test(
         query: &str,
-        mut supergraph_service: supergraph::BoxCloneSyncService,
+        mut supergraph_service: supergraph::BoxCloneService,
     ) -> Response {
         let request = supergraph::Request::fake_builder()
             .query(query.to_string())
@@ -255,7 +253,7 @@ mod tests {
 
     async fn execute_supergraph_test_dry_run(
         query: &str,
-        mut supergraph_service: supergraph::BoxCloneSyncService,
+        mut supergraph_service: supergraph::BoxCloneService,
     ) -> Response {
         let request = supergraph::Request::fake_builder()
             .query(query.to_string())

--- a/apollo-router/src/plugins/expose_query_plan.rs
+++ b/apollo-router/src/plugins/expose_query_plan.rs
@@ -59,7 +59,10 @@ impl Plugin for ExposeQueryPlan {
         })
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         ServiceBuilder::new()
             .checkpoint(|req: execution::Request| {
                 let setting = req
@@ -94,7 +97,7 @@ impl Plugin for ExposeQueryPlan {
                 }
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {

--- a/apollo-router/src/plugins/expose_query_plan.rs
+++ b/apollo-router/src/plugins/expose_query_plan.rs
@@ -10,12 +10,11 @@ use serde::Serialize;
 use serde_json_bytes::json;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt as TowerServiceExt;
 
 use super::connectors::query_plans::replace_connector_service_names;
 use super::connectors::query_plans::replace_connector_service_names_text;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::execution;
@@ -100,7 +99,10 @@ impl Plugin for ExposeQueryPlan {
             .boxed_clone_sync()
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         let conf_enabled = self.enabled;
         service
             .map_future_with_request_data(move |req: &supergraph::Request| {
@@ -152,7 +154,7 @@ impl Plugin for ExposeQueryPlan {
 
                 res
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -163,6 +165,7 @@ mod tests {
     use serde_json_bytes::ByteString;
     use serde_json_bytes::Value;
     use tower::Service;
+    use tower::ServiceExt as _;
 
     use super::*;
     use crate::MockedSubgraphs;
@@ -172,7 +175,7 @@ mod tests {
 
     static VALID_QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
 
-    async fn build_mock_supergraph(config: serde_json::Value) -> supergraph::BoxCloneService {
+    async fn build_mock_supergraph(config: serde_json::Value) -> supergraph::BoxCloneSyncService {
         let mut extensions = Object::new();
         extensions.insert("test", Value::String(ByteString::from("value")));
 
@@ -229,7 +232,7 @@ mod tests {
 
     async fn execute_supergraph_test(
         query: &str,
-        mut supergraph_service: supergraph::BoxCloneService,
+        mut supergraph_service: supergraph::BoxCloneSyncService,
     ) -> Response {
         let request = supergraph::Request::fake_builder()
             .query(query.to_string())
@@ -252,7 +255,7 @@ mod tests {
 
     async fn execute_supergraph_test_dry_run(
         query: &str,
-        mut supergraph_service: supergraph::BoxCloneService,
+        mut supergraph_service: supergraph::BoxCloneSyncService,
     ) -> Response {
         let request = supergraph::Request::fake_builder()
             .query(query.to_string())

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -86,7 +86,10 @@ impl PluginPrivate for FileUploadsPlugin {
             .boxed()
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         if !self.enabled {
             return service;
         }
@@ -108,7 +111,7 @@ impl PluginPrivate for FileUploadsPlugin {
             })
             .buffered()
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn execution_service(

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -24,6 +24,7 @@ use self::multipart_request::MultipartRequest;
 use self::rearrange_query_plan::rearrange_query_plan;
 use crate::json_ext;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::services::execution;
@@ -134,8 +135,8 @@ impl PluginPrivate for FileUploadsPlugin {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         if !self.enabled {
             return service;
         }
@@ -148,7 +149,7 @@ impl PluginPrivate for FileUploadsPlugin {
             })
             .buffered()
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -13,6 +13,7 @@ use mediatype::names::FORM_DATA;
 use mediatype::names::MULTIPART;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use self::config::FileUploadsConfig;
 use self::config::MultipartRequestLimits;
@@ -23,7 +24,6 @@ use self::multipart_request::MultipartRequest;
 use self::rearrange_query_plan::rearrange_query_plan;
 use crate::json_ext;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::services::execution;
@@ -59,7 +59,7 @@ impl PluginPrivate for FileUploadsPlugin {
         Ok(Self { enabled, limits })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         if !self.enabled {
             return service;
         }
@@ -82,13 +82,13 @@ impl PluginPrivate for FileUploadsPlugin {
             })
             .buffered()
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         if !self.enabled {
             return service;
         }
@@ -110,13 +110,10 @@ impl PluginPrivate for FileUploadsPlugin {
             })
             .buffered()
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         if !self.enabled {
             return service;
         }
@@ -134,14 +131,14 @@ impl PluginPrivate for FileUploadsPlugin {
                 })
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         if !self.enabled {
             return service;
         }
@@ -154,7 +151,7 @@ impl PluginPrivate for FileUploadsPlugin {
             })
             .buffered()
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -111,7 +111,10 @@ impl PluginPrivate for FileUploadsPlugin {
             .boxed()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         if !self.enabled {
             return service;
         }
@@ -129,7 +132,7 @@ impl PluginPrivate for FileUploadsPlugin {
                 })
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -13,7 +13,6 @@ use mediatype::names::FORM_DATA;
 use mediatype::names::MULTIPART;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use self::config::FileUploadsConfig;
 use self::config::MultipartRequestLimits;
@@ -60,7 +59,7 @@ impl PluginPrivate for FileUploadsPlugin {
         Ok(Self { enabled, limits })
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         if !self.enabled {
             return service;
         }
@@ -83,7 +82,7 @@ impl PluginPrivate for FileUploadsPlugin {
             })
             .buffered()
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn supergraph_service(

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -15,11 +15,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use sysinfo::System;
 use tower::BoxError;
-use tower::ServiceExt as _;
-use tower::util::BoxCloneSyncService;
+use tower::ServiceExt;
+use tower::util::BoxCloneService;
 use tracing::debug;
 
-use crate::layers::ServiceExt as _;
 use crate::metrics::meter_provider;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
@@ -260,7 +259,7 @@ impl PluginPrivate for FleetDetector {
         }
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         service
             // Count the number of request bytes from clients to the router
             .map_request(move |req: router::Request| router::Request {
@@ -329,14 +328,14 @@ impl PluginPrivate for FleetDetector {
                     .build()
                     .unwrap()
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn http_client_service(
         &self,
         subgraph_name: &str,
-        service: BoxCloneSyncService<HttpRequest, HttpResponse, BoxError>,
-    ) -> BoxCloneSyncService<HttpRequest, HttpResponse, BoxError> {
+        service: BoxCloneService<HttpRequest, HttpResponse, BoxError>,
+    ) -> BoxCloneService<HttpRequest, HttpResponse, BoxError> {
         let sn_req = Arc::new(subgraph_name.to_string());
         let sn_res = sn_req.clone();
         service
@@ -427,7 +426,7 @@ impl PluginPrivate for FleetDetector {
                     }
                 }
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -619,7 +618,7 @@ mod tests {
                         .build()
                 });
             let mut bad_request_router_service =
-                plugin.router_service(mock_bad_request_service.boxed_clone_sync());
+                plugin.router_service(mock_bad_request_service.boxed_clone());
             let router_req = router::Request::fake_builder()
                 .body(router::body::from_bytes("request"))
                 .build()
@@ -671,7 +670,7 @@ mod tests {
                         http_response: res,
                         context: Default::default(),
                     })
-                    .boxed_clone_sync(),
+                    .boxed_clone(),
             );
             let http_client_req = HttpRequest {
                 http_request: http::Request::builder()
@@ -748,7 +747,7 @@ mod tests {
                         http_response: res.map(Body::from),
                         context: Default::default(),
                     })
-                    .boxed_clone_sync(),
+                    .boxed_clone(),
             );
             let http_client_req = HttpRequest {
                 http_request: http::Request::builder()
@@ -918,7 +917,7 @@ nodev   cgroup
                         .build()
                 });
 
-            let mut router_service = plugin.router_service(mock_service.boxed_clone_sync());
+            let mut router_service = plugin.router_service(mock_service.boxed_clone());
             let router_req = router::Request::fake_builder()
                 .body(router::body::from_bytes("test request"))
                 .build()
@@ -975,7 +974,7 @@ nodev   cgroup
                         .build()
                 });
 
-            let mut router_service = plugin.router_service(mock_service.boxed_clone_sync());
+            let mut router_service = plugin.router_service(mock_service.boxed_clone());
             let router_req = router::Request::fake_builder()
                 .body(router::body::from_result_stream(futures::stream::once(
                     async { Ok::<_, Infallible>(bytes::Bytes::from("streaming request")) },

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -260,7 +260,7 @@ impl PluginPrivate for FleetDetector {
         }
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         service
             // Count the number of request bytes from clients to the router
             .map_request(move |req: router::Request| router::Request {
@@ -329,7 +329,7 @@ impl PluginPrivate for FleetDetector {
                     .build()
                     .unwrap()
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn http_client_service(
@@ -619,7 +619,7 @@ mod tests {
                         .build()
                 });
             let mut bad_request_router_service =
-                plugin.router_service(mock_bad_request_service.boxed());
+                plugin.router_service(mock_bad_request_service.boxed_clone_sync());
             let router_req = router::Request::fake_builder()
                 .body(router::body::from_bytes("request"))
                 .build()
@@ -918,7 +918,7 @@ nodev   cgroup
                         .build()
                 });
 
-            let mut router_service = plugin.router_service(mock_service.boxed());
+            let mut router_service = plugin.router_service(mock_service.boxed_clone_sync());
             let router_req = router::Request::fake_builder()
                 .body(router::body::from_bytes("test request"))
                 .build()
@@ -975,7 +975,7 @@ nodev   cgroup
                         .build()
                 });
 
-            let mut router_service = plugin.router_service(mock_service.boxed());
+            let mut router_service = plugin.router_service(mock_service.boxed_clone_sync());
             let router_req = router::Request::fake_builder()
                 .body(router::body::from_result_stream(futures::stream::once(
                     async { Ok::<_, Infallible>(bytes::Bytes::from("streaming request")) },

--- a/apollo-router/src/plugins/fleet_detector.rs
+++ b/apollo-router/src/plugins/fleet_detector.rs
@@ -16,9 +16,10 @@ use serde::Deserialize;
 use sysinfo::System;
 use tower::BoxError;
 use tower::ServiceExt as _;
-use tower::util::BoxService;
+use tower::util::BoxCloneSyncService;
 use tracing::debug;
 
+use crate::layers::ServiceExt as _;
 use crate::metrics::meter_provider;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
@@ -334,8 +335,8 @@ impl PluginPrivate for FleetDetector {
     fn http_client_service(
         &self,
         subgraph_name: &str,
-        service: BoxService<HttpRequest, HttpResponse, BoxError>,
-    ) -> BoxService<HttpRequest, HttpResponse, BoxError> {
+        service: BoxCloneSyncService<HttpRequest, HttpResponse, BoxError>,
+    ) -> BoxCloneSyncService<HttpRequest, HttpResponse, BoxError> {
         let sn_req = Arc::new(subgraph_name.to_string());
         let sn_res = sn_req.clone();
         service
@@ -426,7 +427,7 @@ impl PluginPrivate for FleetDetector {
                     }
                 }
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -670,7 +671,7 @@ mod tests {
                         http_response: res,
                         context: Default::default(),
                     })
-                    .boxed(),
+                    .boxed_clone_sync(),
             );
             let http_client_req = HttpRequest {
                 http_request: http::Request::builder()
@@ -747,7 +748,7 @@ mod tests {
                         http_response: res.map(Body::from),
                         context: Default::default(),
                     })
-                    .boxed(),
+                    .boxed_clone_sync(),
             );
             let http_client_req = HttpRequest {
                 http_request: http::Request::builder()

--- a/apollo-router/src/plugins/forbid_mutations.rs
+++ b/apollo-router/src/plugins/forbid_mutations.rs
@@ -6,10 +6,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use crate::error::Error;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::ExecutionRequest;
@@ -39,7 +39,10 @@ impl Plugin for ForbidMutations {
         })
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         if self.forbid {
             ServiceBuilder::new()
                 .checkpoint(|req: ExecutionRequest| {
@@ -59,7 +62,7 @@ impl Plugin for ForbidMutations {
                     }
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         } else {
             service
         }
@@ -98,7 +101,7 @@ mod forbid_http_get_mutations_tests {
         ))
         .await
         .expect("couldn't create forbid_mutations plugin")
-        .execution_service(mock_service.boxed());
+        .execution_service(mock_service.boxed_clone_sync());
 
         let request = create_request(Method::GET, OperationKind::Query);
 
@@ -125,7 +128,7 @@ mod forbid_http_get_mutations_tests {
         ))
         .await
         .expect("couldn't create forbid_mutations plugin")
-        .execution_service(MockExecutionService::new().boxed());
+        .execution_service(MockExecutionService::new().boxed_clone_sync());
         let request = create_request(Method::GET, OperationKind::Mutation);
 
         let mut response = service_stack.oneshot(request).await.unwrap();
@@ -150,7 +153,7 @@ mod forbid_http_get_mutations_tests {
         ))
         .await
         .expect("couldn't create forbid_mutations plugin")
-        .execution_service(mock_service.boxed());
+        .execution_service(mock_service.boxed_clone_sync());
 
         let request = create_request(Method::GET, OperationKind::Mutation);
 

--- a/apollo-router/src/plugins/forbid_mutations.rs
+++ b/apollo-router/src/plugins/forbid_mutations.rs
@@ -6,10 +6,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use crate::error::Error;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::ExecutionRequest;
@@ -39,10 +39,7 @@ impl Plugin for ForbidMutations {
         })
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         if self.forbid {
             ServiceBuilder::new()
                 .checkpoint(|req: ExecutionRequest| {
@@ -62,7 +59,7 @@ impl Plugin for ForbidMutations {
                     }
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         } else {
             service
         }
@@ -101,7 +98,7 @@ mod forbid_http_get_mutations_tests {
         ))
         .await
         .expect("couldn't create forbid_mutations plugin")
-        .execution_service(mock_service.boxed_clone_sync());
+        .execution_service(mock_service.boxed_clone());
 
         let request = create_request(Method::GET, OperationKind::Query);
 
@@ -128,7 +125,7 @@ mod forbid_http_get_mutations_tests {
         ))
         .await
         .expect("couldn't create forbid_mutations plugin")
-        .execution_service(MockExecutionService::new().boxed_clone_sync());
+        .execution_service(MockExecutionService::new().boxed_clone());
         let request = create_request(Method::GET, OperationKind::Mutation);
 
         let mut response = service_stack.oneshot(request).await.unwrap();
@@ -153,7 +150,7 @@ mod forbid_http_get_mutations_tests {
         ))
         .await
         .expect("couldn't create forbid_mutations plugin")
-        .execution_service(mock_service.boxed_clone_sync());
+        .execution_service(mock_service.boxed_clone());
 
         let request = create_request(Method::GET, OperationKind::Mutation);
 

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -30,9 +30,9 @@ use serde_json_bytes::path::JsonPathInst;
 use tower::BoxError;
 use tower::Layer;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower_service::Service;
 
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugin::serde::deserialize_header_name;
@@ -266,8 +266,8 @@ impl PluginPrivate for Headers {
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         ServiceBuilder::new()
             .layer(HeadersLayer::new(
                 self.subgraph_operations
@@ -276,14 +276,14 @@ impl PluginPrivate for Headers {
                     .unwrap_or_else(|| self.all_operations.clone()),
             ))
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxCloneSyncService,
+        service: crate::services::connector::request_service::BoxCloneService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxCloneSyncService {
+    ) -> crate::services::connector::request_service::BoxCloneService {
         ServiceBuilder::new()
             .layer(HeadersLayer::new(
                 self.connector_source_operations
@@ -292,7 +292,7 @@ impl PluginPrivate for Headers {
                     .unwrap_or_else(|| self.all_connector_operations.clone()),
             ))
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -33,6 +33,7 @@ use tower::ServiceBuilder;
 use tower::ServiceExt;
 use tower_service::Service;
 
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugin::serde::deserialize_header_name;
@@ -263,7 +264,11 @@ impl PluginPrivate for Headers {
         })
     }
 
-    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         ServiceBuilder::new()
             .layer(HeadersLayer::new(
                 self.subgraph_operations
@@ -272,7 +277,7 @@ impl PluginPrivate for Headers {
                     .unwrap_or_else(|| self.all_operations.clone()),
             ))
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn connector_request_service(
@@ -312,6 +317,7 @@ impl<S> Layer<S> for HeadersLayer {
         }
     }
 }
+#[derive(Clone)]
 struct HeadersService<S> {
     inner: S,
     operations: Arc<Vec<Operation>>,

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -30,7 +30,6 @@ use serde_json_bytes::path::JsonPathInst;
 use tower::BoxError;
 use tower::Layer;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use tower_service::Service;
 
 use crate::layers::ServiceExt as _;
@@ -282,9 +281,9 @@ impl PluginPrivate for Headers {
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
+        service: crate::services::connector::request_service::BoxCloneSyncService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
+    ) -> crate::services::connector::request_service::BoxCloneSyncService {
         ServiceBuilder::new()
             .layer(HeadersLayer::new(
                 self.connector_source_operations
@@ -293,7 +292,7 @@ impl PluginPrivate for Headers {
                     .unwrap_or_else(|| self.all_connector_operations.clone()),
             ))
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -629,6 +628,7 @@ mod test {
     use serde_json_bytes::json;
     use subgraph::SubgraphRequestId;
     use tower::BoxError;
+    use tower::ServiceExt as _;
 
     use super::*;
     use crate::Context;

--- a/apollo-router/src/plugins/healthcheck/mod.rs
+++ b/apollo-router/src/plugins/healthcheck/mod.rs
@@ -21,11 +21,11 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use tower::service_fn;
 
 use crate::Endpoint;
 use crate::configuration::ListenAddr;
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::services::router;
@@ -225,7 +225,7 @@ impl PluginPrivate for HealthCheck {
 
     // Track rejected requests due to traffic shaping.
     // We always do this; even if the health check is disabled.
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         let my_rejected = self.rejected.clone();
 
         ServiceBuilder::new()
@@ -238,7 +238,7 @@ impl PluginPrivate for HealthCheck {
                 res
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     // Support the health-check endpoint for the router, incorporating both live and ready.
@@ -300,7 +300,7 @@ impl PluginPrivate for HealthCheck {
                             .build()
                     }
                 })
-                .boxed(),
+                .boxed_clone_sync(),
             );
 
             map.insert(self.config.listen.clone(), endpoint);
@@ -344,7 +344,7 @@ mod test {
         response_status_code: StatusCode,
     ) -> (
         Option<Endpoint>,
-        Option<ServiceHandle<router::Request, router::BoxService>>,
+        Option<ServiceHandle<router::Request, router::BoxCloneSyncService>>,
         PluginTestHarness<HealthCheck>,
     ) {
         let test_harness: PluginTestHarness<HealthCheck> = PluginTestHarness::builder()

--- a/apollo-router/src/plugins/healthcheck/mod.rs
+++ b/apollo-router/src/plugins/healthcheck/mod.rs
@@ -21,11 +21,11 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower::service_fn;
 
 use crate::Endpoint;
 use crate::configuration::ListenAddr;
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::services::router;
@@ -225,7 +225,7 @@ impl PluginPrivate for HealthCheck {
 
     // Track rejected requests due to traffic shaping.
     // We always do this; even if the health check is disabled.
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         let my_rejected = self.rejected.clone();
 
         ServiceBuilder::new()
@@ -238,7 +238,7 @@ impl PluginPrivate for HealthCheck {
                 res
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     // Support the health-check endpoint for the router, incorporating both live and ready.
@@ -300,7 +300,7 @@ impl PluginPrivate for HealthCheck {
                             .build()
                     }
                 })
-                .boxed_clone_sync(),
+                .boxed_clone(),
             );
 
             map.insert(self.config.listen.clone(), endpoint);
@@ -344,7 +344,7 @@ mod test {
         response_status_code: StatusCode,
     ) -> (
         Option<Endpoint>,
-        Option<ServiceHandle<router::Request, router::BoxCloneSyncService>>,
+        Option<ServiceHandle<router::Request, router::BoxCloneService>>,
         PluginTestHarness<HealthCheck>,
     ) {
         let test_harness: PluginTestHarness<HealthCheck> = PluginTestHarness::builder()

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -23,7 +23,7 @@ use crate::plugin::PluginInit;
 use crate::services::SupergraphResponse;
 use crate::services::fetch::AddSubgraphNameExt;
 use crate::services::fetch::SubgraphNameExt;
-use crate::services::supergraph::BoxService;
+use crate::services::supergraph::BoxCloneSyncService;
 
 static REDACTED_ERROR_MESSAGE: &str = "Subgraph errors redacted";
 
@@ -57,7 +57,7 @@ impl Plugin for IncludeSubgraphErrors {
         Ok(IncludeSubgraphErrors { config })
     }
 
-    fn supergraph_service(&self, service: BoxService) -> BoxService {
+    fn supergraph_service(&self, service: BoxCloneSyncService) -> BoxCloneSyncService {
         let config = Arc::clone(&self.config);
 
         service
@@ -75,7 +75,7 @@ impl Plugin for IncludeSubgraphErrors {
                     graphql_response
                 })
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -17,13 +17,12 @@ use tower::ServiceExt;
 use crate::error::Error;
 use crate::graphql;
 use crate::json_ext::Object;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::SupergraphResponse;
 use crate::services::fetch::AddSubgraphNameExt;
 use crate::services::fetch::SubgraphNameExt;
-use crate::services::supergraph::BoxCloneSyncService;
+use crate::services::supergraph::BoxCloneService;
 
 static REDACTED_ERROR_MESSAGE: &str = "Subgraph errors redacted";
 
@@ -57,7 +56,7 @@ impl Plugin for IncludeSubgraphErrors {
         Ok(IncludeSubgraphErrors { config })
     }
 
-    fn supergraph_service(&self, service: BoxCloneSyncService) -> BoxCloneSyncService {
+    fn supergraph_service(&self, service: BoxCloneService) -> BoxCloneService {
         let config = Arc::clone(&self.config);
 
         service
@@ -75,14 +74,14 @@ impl Plugin for IncludeSubgraphErrors {
                     graphql_response
                 })
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: crate::services::subgraph::BoxCloneSyncService,
-    ) -> crate::services::subgraph::BoxCloneSyncService {
+        service: crate::services::subgraph::BoxCloneService,
+    ) -> crate::services::subgraph::BoxCloneService {
         // We need to attach the subgraph name to each error so that we can do the filtering in the supergraph service.
         // The reason filtering is not done here is that other types of request may also generate errors that need filtering.
         // Pushing the error filtering to supergraph will ensure that everything gets filtered.
@@ -95,7 +94,7 @@ impl Plugin for IncludeSubgraphErrors {
                 }
                 r
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -17,6 +17,7 @@ use tower::ServiceExt;
 use crate::error::Error;
 use crate::graphql;
 use crate::json_ext::Object;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::SupergraphResponse;
@@ -80,8 +81,8 @@ impl Plugin for IncludeSubgraphErrors {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: crate::services::subgraph::BoxService,
-    ) -> crate::services::subgraph::BoxService {
+        service: crate::services::subgraph::BoxCloneSyncService,
+    ) -> crate::services::subgraph::BoxCloneSyncService {
         // We need to attach the subgraph name to each error so that we can do the filtering in the supergraph service.
         // The reason filtering is not done here is that other types of request may also generate errors that need filtering.
         // Pushing the error filtering to supergraph will ensure that everything gets filtered.
@@ -94,7 +95,7 @@ impl Plugin for IncludeSubgraphErrors {
                 }
                 r
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/license_enforcement/mod.rs
+++ b/apollo-router/src/plugins/license_enforcement/mod.rs
@@ -12,12 +12,12 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use tower::limit::RateLimitLayer;
 use tower::load_shed::error::Overloaded;
 
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::services::RouterResponse;
@@ -64,8 +64,9 @@ impl PluginPrivate for LicenseEnforcement {
         Ok(Self { tps })
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         ServiceBuilder::new()
+            .buffered()
             .map_future_with_request_data(
                 |req: &router::Request| req.context.clone(),
                 move |ctx, future| async {
@@ -95,7 +96,7 @@ impl PluginPrivate for LicenseEnforcement {
                     .map(|config| RateLimitLayer::new(config.capacity.into(), config.interval)),
             )
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/license_enforcement/mod.rs
+++ b/apollo-router/src/plugins/license_enforcement/mod.rs
@@ -12,12 +12,12 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower::limit::RateLimitLayer;
 use tower::load_shed::error::Overloaded;
 
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::services::RouterResponse;
@@ -64,7 +64,7 @@ impl PluginPrivate for LicenseEnforcement {
         Ok(Self { tps })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         ServiceBuilder::new()
             .buffered()
             .map_future_with_request_data(
@@ -96,7 +96,7 @@ impl PluginPrivate for LicenseEnforcement {
                     .map(|config| RateLimitLayer::new(config.capacity.into(), config.interval)),
             )
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/limits/layer.rs
+++ b/apollo-router/src/plugins/limits/layer.rs
@@ -105,6 +105,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct RequestBodyLimit<Body, S> {
     _phantom: std::marker::PhantomData<Body>,
     inner: S,

--- a/apollo-router/src/plugins/limits/mod.rs
+++ b/apollo-router/src/plugins/limits/mod.rs
@@ -11,11 +11,11 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use crate::Context;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::limits::layer::BodyLimitError;
@@ -171,7 +171,7 @@ impl Plugin for LimitsPlugin {
         })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         ServiceBuilder::new()
             .buffered()
             .map_future_with_request_data(
@@ -187,7 +187,7 @@ impl Plugin for LimitsPlugin {
             .map_request(Into::into)
             .map_response(Into::into)
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/limits/mod.rs
+++ b/apollo-router/src/plugins/limits/mod.rs
@@ -11,17 +11,16 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use crate::Context;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::limits::layer::BodyLimitError;
 use crate::plugins::limits::layer::RequestBodyLimitLayer;
 use crate::services::router;
-use crate::services::router::BoxService;
 
 /// Configuration for operation limits, parser limits, HTTP limits, etc.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -172,8 +171,9 @@ impl Plugin for LimitsPlugin {
         })
     }
 
-    fn router_service(&self, service: BoxService) -> BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         ServiceBuilder::new()
+            .buffered()
             .map_future_with_request_data(
                 |r: &router::Request| r.context.clone(),
                 |ctx, f| async { Self::map_error_to_graphql(f.await, ctx) },
@@ -187,7 +187,7 @@ impl Plugin for LimitsPlugin {
             .map_request(Into::into)
             .map_response(Into::into)
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/mock_subgraphs/mod.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/mod.rs
@@ -16,9 +16,9 @@ use apollo_compiler::response::JsonMap;
 use apollo_compiler::response::JsonValue;
 use apollo_compiler::validation::Valid;
 use tower::BoxError;
-use tower::ServiceExt;
 
 use crate::graphql;
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugins::response_cache::plugin::GRAPHQL_RESPONSE_EXTENSION_ENTITY_CACHE_TAGS;
@@ -115,7 +115,11 @@ impl PluginPrivate for MockSubgraphsPlugin {
         })
     }
 
-    fn subgraph_service(&self, name: &str, _: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        _: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         let config = self.per_subgraph_config.get(name).cloned();
         let subgraph_schema = self.subgraph_schemas[name].clone();
         tower::service_fn(move |request: subgraph::Request| {
@@ -159,7 +163,7 @@ impl PluginPrivate for MockSubgraphsPlugin {
                 ))
             }
         })
-        .boxed()
+        .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/mock_subgraphs/mod.rs
+++ b/apollo-router/src/plugins/mock_subgraphs/mod.rs
@@ -16,9 +16,9 @@ use apollo_compiler::response::JsonMap;
 use apollo_compiler::response::JsonValue;
 use apollo_compiler::validation::Valid;
 use tower::BoxError;
+use tower::ServiceExt;
 
 use crate::graphql;
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugins::response_cache::plugin::GRAPHQL_RESPONSE_EXTENSION_ENTITY_CACHE_TAGS;
@@ -118,8 +118,8 @@ impl PluginPrivate for MockSubgraphsPlugin {
     fn subgraph_service(
         &self,
         name: &str,
-        _: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        _: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         let config = self.per_subgraph_config.get(name).cloned();
         let subgraph_schema = self.subgraph_schemas[name].clone();
         tower::service_fn(move |request: subgraph::Request| {
@@ -163,7 +163,7 @@ impl PluginPrivate for MockSubgraphsPlugin {
                 ))
             }
         })
-        .boxed_clone_sync()
+        .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/override_url.rs
+++ b/apollo-router/src/plugins/override_url.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceExt;
 
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::SubgraphRequest;
@@ -74,8 +75,8 @@ impl Plugin for OverrideSubgraphUrl {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         let new_url = self.urls.get(subgraph_name).cloned();
         service
             .map_request(move |mut req: SubgraphRequest| {
@@ -85,7 +86,7 @@ impl Plugin for OverrideSubgraphUrl {
 
                 req
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -99,7 +100,7 @@ mod tests {
     use serde_json::Value;
     use tower::Service;
     use tower::ServiceExt;
-    use tower::util::BoxService;
+    use tower::util::BoxCloneSyncService;
 
     use crate::Context;
     use crate::plugin::DynPlugin;
@@ -137,7 +138,7 @@ mod tests {
             .await
             .unwrap();
         let mut subgraph_service =
-            dyn_plugin.subgraph_service("test_one", BoxService::new(mock_service));
+            dyn_plugin.subgraph_service("test_one", BoxCloneSyncService::new(mock_service));
         let context = Context::new();
         context.insert("test".to_string(), 5i64).unwrap();
         let subgraph_req = SubgraphRequest::fake_builder().context(context);
@@ -190,7 +191,7 @@ mod tests {
             .unwrap();
 
         let mut subgraph_service =
-            dyn_plugin.subgraph_service("test_one", BoxService::new(mock_service));
+            dyn_plugin.subgraph_service("test_one", BoxCloneSyncService::new(mock_service));
         let subgraph_req = SubgraphRequest::fake_builder().context(Context::new());
 
         let _subgraph_resp = subgraph_service

--- a/apollo-router/src/plugins/override_url.rs
+++ b/apollo-router/src/plugins/override_url.rs
@@ -10,7 +10,6 @@ use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceExt;
 
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::SubgraphRequest;
@@ -75,8 +74,8 @@ impl Plugin for OverrideSubgraphUrl {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         let new_url = self.urls.get(subgraph_name).cloned();
         service
             .map_request(move |mut req: SubgraphRequest| {
@@ -86,7 +85,7 @@ impl Plugin for OverrideSubgraphUrl {
 
                 req
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -100,7 +99,7 @@ mod tests {
     use serde_json::Value;
     use tower::Service;
     use tower::ServiceExt;
-    use tower::util::BoxCloneSyncService;
+    use tower::util::BoxCloneService;
 
     use crate::Context;
     use crate::plugin::DynPlugin;
@@ -138,7 +137,7 @@ mod tests {
             .await
             .unwrap();
         let mut subgraph_service =
-            dyn_plugin.subgraph_service("test_one", BoxCloneSyncService::new(mock_service));
+            dyn_plugin.subgraph_service("test_one", BoxCloneService::new(mock_service));
         let context = Context::new();
         context.insert("test".to_string(), 5i64).unwrap();
         let subgraph_req = SubgraphRequest::fake_builder().context(context);
@@ -191,7 +190,7 @@ mod tests {
             .unwrap();
 
         let mut subgraph_service =
-            dyn_plugin.subgraph_service("test_one", BoxCloneSyncService::new(mock_service));
+            dyn_plugin.subgraph_service("test_one", BoxCloneService::new(mock_service));
         let subgraph_req = SubgraphRequest::fake_builder().context(Context::new());
 
         let _subgraph_resp = subgraph_service

--- a/apollo-router/src/plugins/progressive_override/mod.rs
+++ b/apollo-router/src/plugins/progressive_override/mod.rs
@@ -15,7 +15,6 @@ use sha2::Digest;
 use sha2::Sha256;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 use self::layers::query_analysis::ParsedDocument;
 use self::visitor::OverrideLabelVisitor;
@@ -142,7 +141,7 @@ impl Plugin for ProgressiveOverridePlugin {
 
     // Add all arbitrary labels (non-percentage-based labels) from the schema to
     // the context so coprocessors can resolve their values
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         if !self.enabled {
             service
         } else {
@@ -155,7 +154,7 @@ impl Plugin for ProgressiveOverridePlugin {
                     request
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         }
     }
 

--- a/apollo-router/src/plugins/progressive_override/mod.rs
+++ b/apollo-router/src/plugins/progressive_override/mod.rs
@@ -19,6 +19,7 @@ use tower::ServiceExt;
 
 use self::layers::query_analysis::ParsedDocument;
 use self::visitor::OverrideLabelVisitor;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::*;
@@ -166,7 +167,10 @@ impl Plugin for ProgressiveOverridePlugin {
     //    operation
     // 4. Add the filtered, sorted set of labels to the context for use by the
     //    query planner
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         if !self.enabled {
             service
         } else {
@@ -255,7 +259,7 @@ impl Plugin for ProgressiveOverridePlugin {
                 request
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
         }
     }
 }

--- a/apollo-router/src/plugins/progressive_override/mod.rs
+++ b/apollo-router/src/plugins/progressive_override/mod.rs
@@ -15,10 +15,10 @@ use sha2::Digest;
 use sha2::Sha256;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use self::layers::query_analysis::ParsedDocument;
 use self::visitor::OverrideLabelVisitor;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::*;
@@ -141,7 +141,7 @@ impl Plugin for ProgressiveOverridePlugin {
 
     // Add all arbitrary labels (non-percentage-based labels) from the schema to
     // the context so coprocessors can resolve their values
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         if !self.enabled {
             service
         } else {
@@ -154,7 +154,7 @@ impl Plugin for ProgressiveOverridePlugin {
                     request
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         }
     }
 
@@ -168,8 +168,8 @@ impl Plugin for ProgressiveOverridePlugin {
     //    query planner
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         if !self.enabled {
             service
         } else {
@@ -258,7 +258,7 @@ impl Plugin for ProgressiveOverridePlugin {
                 request
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
         }
     }
 }

--- a/apollo-router/src/plugins/progressive_override/tests.rs
+++ b/apollo-router/src/plugins/progressive_override/tests.rs
@@ -6,7 +6,6 @@ use tower::ServiceExt;
 
 use crate::Context;
 use crate::TestHarness;
-use crate::layers::ServiceExt as _;
 use crate::metrics::FutureMetricsExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
@@ -151,7 +150,7 @@ async fn plugin_router_service_adds_all_arbitrary_labels_to_context() {
     ))
     .await
     .unwrap()
-    .router_service(mock_service.boxed_clone_sync());
+    .router_service(mock_service.boxed_clone());
 
     let _ = service_stack
         .oneshot(router::Request::fake_builder().build().unwrap())
@@ -206,7 +205,7 @@ async fn assert_expected_and_absent_labels_for_supergraph_service(
     ))
     .await
     .unwrap()
-    .supergraph_service(mock_service.boxed_clone_sync());
+    .supergraph_service(mock_service.boxed_clone());
 
     let schema = crate::spec::Schema::parse(
         include_str!("./testdata/supergraph.graphql"),
@@ -355,7 +354,7 @@ async fn query_with_labels(query: &str, labels_from_coprocessors: Vec<&str>) {
     ))
     .await
     .unwrap()
-    .supergraph_service(mock_service.boxed_clone_sync());
+    .supergraph_service(mock_service.boxed_clone());
 
     let schema = crate::spec::Schema::parse(
         include_str!("./testdata/supergraph.graphql"),

--- a/apollo-router/src/plugins/progressive_override/tests.rs
+++ b/apollo-router/src/plugins/progressive_override/tests.rs
@@ -6,6 +6,7 @@ use tower::ServiceExt;
 
 use crate::Context;
 use crate::TestHarness;
+use crate::layers::ServiceExt as _;
 use crate::metrics::FutureMetricsExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
@@ -205,7 +206,7 @@ async fn assert_expected_and_absent_labels_for_supergraph_service(
     ))
     .await
     .unwrap()
-    .supergraph_service(mock_service.boxed());
+    .supergraph_service(mock_service.boxed_clone_sync());
 
     let schema = crate::spec::Schema::parse(
         include_str!("./testdata/supergraph.graphql"),
@@ -354,7 +355,7 @@ async fn query_with_labels(query: &str, labels_from_coprocessors: Vec<&str>) {
     ))
     .await
     .unwrap()
-    .supergraph_service(mock_service.boxed());
+    .supergraph_service(mock_service.boxed_clone_sync());
 
     let schema = crate::spec::Schema::parse(
         include_str!("./testdata/supergraph.graphql"),

--- a/apollo-router/src/plugins/progressive_override/tests.rs
+++ b/apollo-router/src/plugins/progressive_override/tests.rs
@@ -151,7 +151,7 @@ async fn plugin_router_service_adds_all_arbitrary_labels_to_context() {
     ))
     .await
     .unwrap()
-    .router_service(mock_service.boxed());
+    .router_service(mock_service.boxed_clone_sync());
 
     let _ = service_stack
         .oneshot(router::Request::fake_builder().build().unwrap())

--- a/apollo-router/src/plugins/record_replay/record.rs
+++ b/apollo-router/src/plugins/record_replay/record.rs
@@ -11,7 +11,6 @@ use http_body_util::BodyExt;
 use tokio::fs;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt as TowerServiceExt;
 
 use super::recording::Recording;
 use super::recording::RequestDetails;
@@ -80,7 +79,7 @@ impl Plugin for Record {
         Ok(plugin)
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         if !self.enabled {
             return service;
         }
@@ -141,7 +140,7 @@ impl Plugin for Record {
                 }
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn supergraph_service(

--- a/apollo-router/src/plugins/record_replay/record.rs
+++ b/apollo-router/src/plugins/record_replay/record.rs
@@ -144,7 +144,10 @@ impl Plugin for Record {
             .boxed()
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         if !self.enabled {
             return service;
         }
@@ -210,7 +213,7 @@ impl Plugin for Record {
                 })
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn execution_service(

--- a/apollo-router/src/plugins/record_replay/record.rs
+++ b/apollo-router/src/plugins/record_replay/record.rs
@@ -11,13 +11,13 @@ use http_body_util::BodyExt;
 use tokio::fs;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use super::recording::Recording;
 use super::recording::RequestDetails;
 use super::recording::ResponseDetails;
 use super::recording::Subgraph;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::execution;
@@ -79,7 +79,7 @@ impl Plugin for Record {
         Ok(plugin)
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         if !self.enabled {
             return service;
         }
@@ -140,13 +140,13 @@ impl Plugin for Record {
                 }
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         if !self.enabled {
             return service;
         }
@@ -212,13 +212,10 @@ impl Plugin for Record {
                 })
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         ServiceBuilder::new()
             .map_request(|req: execution::Request| {
                 req.context.extensions().with_lock(|lock| {
@@ -230,14 +227,14 @@ impl Plugin for Record {
                 req
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         if !self.enabled {
             return service;
         }
@@ -299,7 +296,7 @@ impl Plugin for Record {
                 },
             )
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/record_replay/record.rs
+++ b/apollo-router/src/plugins/record_replay/record.rs
@@ -213,7 +213,10 @@ impl Plugin for Record {
             .boxed()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         ServiceBuilder::new()
             .map_request(|req: execution::Request| {
                 req.context.extensions().with_lock(|lock| {
@@ -225,7 +228,7 @@ impl Plugin for Record {
                 req
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/apollo-router/src/plugins/record_replay/record.rs
+++ b/apollo-router/src/plugins/record_replay/record.rs
@@ -18,6 +18,7 @@ use super::recording::RequestDetails;
 use super::recording::ResponseDetails;
 use super::recording::Subgraph;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::execution;
@@ -230,8 +231,8 @@ impl Plugin for Record {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         if !self.enabled {
             return service;
         }
@@ -293,7 +294,7 @@ impl Plugin for Record {
                 },
             )
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/record_replay/replay.rs
+++ b/apollo-router/src/plugins/record_replay/replay.rs
@@ -20,6 +20,7 @@ use tower::ServiceExt as TowerServiceExt;
 use super::recording::Recording;
 use crate::context::Context;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::TryIntoHeaderName;
@@ -191,8 +192,8 @@ impl Plugin for Replay {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         let subgraph_name = String::from(subgraph_name);
 
         let report = self.report.clone();
@@ -243,7 +244,7 @@ impl Plugin for Replay {
                 }
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/plugins/record_replay/replay.rs
+++ b/apollo-router/src/plugins/record_replay/replay.rs
@@ -15,7 +15,6 @@ use serde_json_bytes::Value;
 use tokio::fs;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt as TowerServiceExt;
 
 use super::recording::Recording;
 use crate::context::Context;
@@ -93,7 +92,7 @@ impl Plugin for Replay {
         unreachable!()
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         let report = self.report.clone();
         let recorded_headers = self.recording.client_response.headers.clone();
 
@@ -128,7 +127,7 @@ impl Plugin for Replay {
                 res
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn supergraph_service(

--- a/apollo-router/src/plugins/record_replay/replay.rs
+++ b/apollo-router/src/plugins/record_replay/replay.rs
@@ -15,11 +15,11 @@ use serde_json_bytes::Value;
 use tokio::fs;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use super::recording::Recording;
 use crate::context::Context;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::services::TryIntoHeaderName;
@@ -92,7 +92,7 @@ impl Plugin for Replay {
         unreachable!()
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         let report = self.report.clone();
         let recorded_headers = self.recording.client_response.headers.clone();
 
@@ -127,13 +127,13 @@ impl Plugin for Replay {
                 res
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         let report = self.report.clone();
         let recorded_chunks = self.recording.client_response.chunks.clone();
 
@@ -163,13 +163,10 @@ impl Plugin for Replay {
                 })
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         let recorded = self.recording.formatted_query_plan.clone();
         let report = self.report.clone();
         ServiceBuilder::new()
@@ -191,14 +188,14 @@ impl Plugin for Replay {
                 req
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         let subgraph_name = String::from(subgraph_name);
 
         let report = self.report.clone();
@@ -249,7 +246,7 @@ impl Plugin for Replay {
                 }
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/record_replay/replay.rs
+++ b/apollo-router/src/plugins/record_replay/replay.rs
@@ -164,7 +164,10 @@ impl Plugin for Replay {
             .boxed()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         let recorded = self.recording.formatted_query_plan.clone();
         let report = self.report.clone();
         ServiceBuilder::new()
@@ -186,7 +189,7 @@ impl Plugin for Replay {
                 req
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/apollo-router/src/plugins/record_replay/replay.rs
+++ b/apollo-router/src/plugins/record_replay/replay.rs
@@ -131,7 +131,10 @@ impl Plugin for Replay {
             .boxed()
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         let report = self.report.clone();
         let recorded_chunks = self.recording.client_response.chunks.clone();
 
@@ -161,7 +164,7 @@ impl Plugin for Replay {
                 })
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn execution_service(

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -526,7 +526,7 @@ impl PluginPrivate for ResponseCache {
                     let endpoint = Endpoint::from_router_service(
                         endpoint_config.path.clone(),
                         InvalidationService::new(self.subgraphs.clone(), self.invalidation.clone())
-                            .boxed(),
+                            .boxed_clone_sync(),
                     );
                     tracing::info!(
                         "Response cache invalidation endpoint listening on: {}{}",

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -59,7 +59,6 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugins::authorization::CacheKeyMetadata;
@@ -382,8 +381,8 @@ impl PluginPrivate for ResponseCache {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         let debug = self.debug;
         ServiceBuilder::new()
             .map_response(move |mut response: supergraph::Response| {
@@ -425,14 +424,14 @@ impl PluginPrivate for ResponseCache {
                 response
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         let subgraph_ttl = self
             .subgraph_ttl(name)
             .unwrap_or_else(|| Duration::from_secs(60 * 60 * 24)); // The unwrap should not happen because it's checked when creating the plugin (except for tests)
@@ -458,7 +457,7 @@ impl PluginPrivate for ResponseCache {
                     service: ServiceBuilder::new()
                         .buffered()
                         .service(service)
-                        .boxed_clone_sync(),
+                        .boxed_clone(),
                     entity_type: self.entity_type.clone(),
                     name: name.to_string(),
                     storage: self.storage.clone(),
@@ -470,7 +469,7 @@ impl PluginPrivate for ResponseCache {
                     subgraph_enums: self.subgraph_enums.clone(),
                     lru_size_instrument: self.lru_size_instrument.clone(),
                 });
-            tower::util::BoxCloneSyncService::new(inner)
+            tower::util::BoxCloneService::new(inner)
         } else {
             ServiceBuilder::new()
                 .map_response(move |response: subgraph::Response| {
@@ -484,7 +483,7 @@ impl PluginPrivate for ResponseCache {
                     response
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         }
     }
 
@@ -526,7 +525,7 @@ impl PluginPrivate for ResponseCache {
                     let endpoint = Endpoint::from_router_service(
                         endpoint_config.path.clone(),
                         InvalidationService::new(self.subgraphs.clone(), self.invalidation.clone())
-                            .boxed_clone_sync(),
+                            .boxed_clone(),
                     );
                     tracing::info!(
                         "Response cache invalidation endpoint listening on: {}{}",
@@ -718,7 +717,7 @@ fn get_subgraph_enums(supergraph_schema: &Valid<Schema>) -> HashMap<String, Stri
 
 #[derive(Clone)]
 struct CacheService {
-    service: subgraph::BoxCloneSyncService,
+    service: subgraph::BoxCloneService,
     name: String,
     entity_type: Option<String>,
     storage: Arc<StorageInterface>,
@@ -734,7 +733,7 @@ struct CacheService {
 impl Service<subgraph::Request> for CacheService {
     type Response = subgraph::Response;
     type Error = BoxError;
-    type Future = <subgraph::BoxCloneSyncService as Service<subgraph::Request>>::Future;
+    type Future = <subgraph::BoxCloneService as Service<subgraph::Request>>::Future;
 
     fn poll_ready(
         &mut self,

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -380,7 +380,10 @@ impl PluginPrivate for ResponseCache {
         self.storage.activate();
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         let debug = self.debug;
         ServiceBuilder::new()
             .map_response(move |mut response: supergraph::Response| {
@@ -422,7 +425,7 @@ impl PluginPrivate for ResponseCache {
                 response
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -59,6 +59,7 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::plugins::authorization::CacheKeyMetadata;
@@ -424,7 +425,11 @@ impl PluginPrivate for ResponseCache {
             .boxed()
     }
 
-    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         let subgraph_ttl = self
             .subgraph_ttl(name)
             .unwrap_or_else(|| Duration::from_secs(60 * 60 * 24)); // The unwrap should not happen because it's checked when creating the plugin (except for tests)
@@ -450,7 +455,7 @@ impl PluginPrivate for ResponseCache {
                     service: ServiceBuilder::new()
                         .buffered()
                         .service(service)
-                        .boxed_clone(),
+                        .boxed_clone_sync(),
                     entity_type: self.entity_type.clone(),
                     name: name.to_string(),
                     storage: self.storage.clone(),
@@ -462,7 +467,7 @@ impl PluginPrivate for ResponseCache {
                     subgraph_enums: self.subgraph_enums.clone(),
                     lru_size_instrument: self.lru_size_instrument.clone(),
                 });
-            tower::util::BoxService::new(inner)
+            tower::util::BoxCloneSyncService::new(inner)
         } else {
             ServiceBuilder::new()
                 .map_response(move |response: subgraph::Response| {
@@ -476,7 +481,7 @@ impl PluginPrivate for ResponseCache {
                     response
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         }
     }
 
@@ -710,7 +715,7 @@ fn get_subgraph_enums(supergraph_schema: &Valid<Schema>) -> HashMap<String, Stri
 
 #[derive(Clone)]
 struct CacheService {
-    service: subgraph::BoxCloneService,
+    service: subgraph::BoxCloneSyncService,
     name: String,
     entity_type: Option<String>,
     storage: Arc<StorageInterface>,
@@ -726,7 +731,7 @@ struct CacheService {
 impl Service<subgraph::Request> for CacheService {
     type Response = subgraph::Response;
     type Error = BoxError;
-    type Future = <subgraph::BoxService as Service<subgraph::Request>>::Future;
+    type Future = <subgraph::BoxCloneSyncService as Service<subgraph::Request>>::Future;
 
     fn poll_ready(
         &mut self,

--- a/apollo-router/src/plugins/response_cache/tests.rs
+++ b/apollo-router/src/plugins/response_cache/tests.rs
@@ -19,7 +19,6 @@ use crate::MockedSubgraphs;
 use crate::TestHarness;
 use crate::configuration::subgraph::SubgraphConfiguration;
 use crate::graphql;
-use crate::layers::ServiceExt as _;
 use crate::metrics::FutureMetricsExt;
 use crate::plugin::test::MockSubgraph;
 use crate::plugin::test::MockSubgraphService;
@@ -2628,7 +2627,7 @@ async fn no_data() {
                     .expect_call()
                     .times(1)
                     .returning(move |_req: subgraph::Request| Err("orga not found".into()));
-                subgraph.boxed_clone_sync()
+                subgraph.boxed_clone()
             } else {
                 service
             }
@@ -3919,7 +3918,7 @@ async fn no_store_on_subgraph_timeout() {
                     // Unreachable in practice — the traffic shaping timeout fires first.
                     Err::<subgraph::Response, tower::BoxError>("orga sleep exceeded".into())
                 })
-                .boxed_clone_sync()
+                .boxed_clone()
             } else {
                 service
             }

--- a/apollo-router/src/plugins/response_cache/tests.rs
+++ b/apollo-router/src/plugins/response_cache/tests.rs
@@ -19,6 +19,7 @@ use crate::MockedSubgraphs;
 use crate::TestHarness;
 use crate::configuration::subgraph::SubgraphConfiguration;
 use crate::graphql;
+use crate::layers::ServiceExt as _;
 use crate::metrics::FutureMetricsExt;
 use crate::plugin::test::MockSubgraph;
 use crate::plugin::test::MockSubgraphService;
@@ -2627,7 +2628,7 @@ async fn no_data() {
                     .expect_call()
                     .times(1)
                     .returning(move |_req: subgraph::Request| Err("orga not found".into()));
-                subgraph.boxed()
+                subgraph.boxed_clone_sync()
             } else {
                 service
             }
@@ -3918,7 +3919,7 @@ async fn no_store_on_subgraph_timeout() {
                     // Unreachable in practice — the traffic shaping timeout fires first.
                     Err::<subgraph::Response, tower::BoxError>("orga sleep exceeded".into())
                 })
-                .boxed()
+                .boxed_clone_sync()
             } else {
                 service
             }

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -25,7 +25,6 @@ use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
 use tower::util::BoxCloneSyncService;
-use tower::util::BoxService;
 
 use self::engine::RhaiService;
 use self::engine::SharedMut;
@@ -108,7 +107,7 @@ impl Plugin for Rhai {
         })
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         const FUNCTION_NAME_SERVICE: &str = "router_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -206,7 +205,7 @@ impl Plugin for Rhai {
 
 #[derive(Clone, Debug)]
 pub(crate) enum ServiceStep {
-    Router(SharedMut<router::BoxService>),
+    Router(SharedMut<router::BoxCloneSyncService>),
     Supergraph(SharedMut<supergraph::BoxCloneSyncService>),
     Execution(SharedMut<execution::BoxCloneSyncService>),
     Subgraph(SharedMut<subgraph::BoxCloneSyncService>),
@@ -357,7 +356,7 @@ macro_rules! gen_map_router_deferred_request {
                     */
                 })
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         })
     };
 }
@@ -400,7 +399,7 @@ macro_rules! gen_map_response {
 macro_rules! gen_map_router_deferred_response {
     ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
         $borrow.replace(|service| {
-            BoxService::new(service.and_then(
+            BoxCloneSyncService::new(service.and_then(
                 |mapped_response: $base::Response| async move {
                     // we split the response stream into headers+first response, then a stream of deferred responses
                     // for which we will implement mapping later

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -24,6 +24,7 @@ use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
+use tower::util::BoxCloneSyncService;
 use tower::util::BoxService;
 
 use self::engine::RhaiService;
@@ -149,7 +150,10 @@ impl Plugin for Rhai {
         shared_service.take_unwrap()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         const FUNCTION_NAME_SERVICE: &str = "execution_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -201,7 +205,7 @@ impl Plugin for Rhai {
 pub(crate) enum ServiceStep {
     Router(SharedMut<router::BoxService>),
     Supergraph(SharedMut<supergraph::BoxService>),
-    Execution(SharedMut<execution::BoxService>),
+    Execution(SharedMut<execution::BoxCloneSyncService>),
     Subgraph(SharedMut<subgraph::BoxCloneSyncService>),
 }
 
@@ -497,9 +501,9 @@ macro_rules! gen_map_router_deferred_response {
 }
 
 macro_rules! gen_map_deferred_response {
-    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
+    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident, $service: ident) => {
         $borrow.replace(|service| {
-            BoxService::new(service.and_then(
+            $service::new(service.and_then(
                 |mapped_response: $base::Response| async move {
                     // we split the response stream into headers+first response, then a stream of deferred responses
                     // for which we will implement mapping later
@@ -617,7 +621,7 @@ impl ServiceStep {
                 gen_map_request!(supergraph, service, rhai_service, callback, boxed);
             }
             ServiceStep::Execution(service) => {
-                gen_map_request!(execution, service, rhai_service, callback, boxed);
+                gen_map_request!(execution, service, rhai_service, callback, boxed_clone_sync);
             }
             ServiceStep::Subgraph(service) => {
                 gen_map_request!(subgraph, service, rhai_service, callback, boxed_clone_sync);
@@ -631,10 +635,16 @@ impl ServiceStep {
                 gen_map_router_deferred_response!(router, service, rhai_service, callback);
             }
             ServiceStep::Supergraph(service) => {
-                gen_map_deferred_response!(supergraph, service, rhai_service, callback);
+                gen_map_deferred_response!(supergraph, service, rhai_service, callback, BoxService);
             }
             ServiceStep::Execution(service) => {
-                gen_map_deferred_response!(execution, service, rhai_service, callback);
+                gen_map_deferred_response!(
+                    execution,
+                    service,
+                    rhai_service,
+                    callback,
+                    BoxCloneSyncService
+                );
             }
             ServiceStep::Subgraph(service) => {
                 gen_map_response!(subgraph, service, rhai_service, callback, boxed_clone_sync);

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -30,6 +30,7 @@ use self::engine::RhaiService;
 use self::engine::SharedMut;
 use crate::error::Error;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::rhai::engine::OptionDance;
@@ -169,7 +170,11 @@ impl Plugin for Rhai {
         shared_service.take_unwrap()
     }
 
-    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         const FUNCTION_NAME_SERVICE: &str = "subgraph_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -197,12 +202,12 @@ pub(crate) enum ServiceStep {
     Router(SharedMut<router::BoxService>),
     Supergraph(SharedMut<supergraph::BoxService>),
     Execution(SharedMut<execution::BoxService>),
-    Subgraph(SharedMut<subgraph::BoxService>),
+    Subgraph(SharedMut<subgraph::BoxCloneSyncService>),
 }
 
 // Actually use the checkpoint function so that we can shortcut requests which fail
 macro_rules! gen_map_request {
-    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
+    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident, $cloner: ident) => {
         $borrow.replace(|service| {
             fn rhai_service_span() -> impl Fn(&$base::Request) -> tracing::Span + Clone {
                 move |_request: &$base::Request| {
@@ -234,7 +239,7 @@ macro_rules! gen_map_request {
                     Ok(ControlFlow::Continue(request_opt.unwrap()))
                 })
                 .service(service)
-                .boxed()
+                .$cloner()
         })
     };
 }
@@ -351,7 +356,7 @@ macro_rules! gen_map_router_deferred_request {
 }
 
 macro_rules! gen_map_response {
-    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
+    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident, $cloner: ident) => {
         $borrow.replace(|service| {
             service
                 .map_response(move |response: $base::Response| {
@@ -375,7 +380,7 @@ macro_rules! gen_map_response {
                     let response_opt = guard.take();
                     response_opt.unwrap()
                 })
-                .boxed()
+                .$cloner()
         })
     };
 }
@@ -609,13 +614,13 @@ impl ServiceStep {
                 gen_map_router_deferred_request!(router, service, rhai_service, callback);
             }
             ServiceStep::Supergraph(service) => {
-                gen_map_request!(supergraph, service, rhai_service, callback);
+                gen_map_request!(supergraph, service, rhai_service, callback, boxed);
             }
             ServiceStep::Execution(service) => {
-                gen_map_request!(execution, service, rhai_service, callback);
+                gen_map_request!(execution, service, rhai_service, callback, boxed);
             }
             ServiceStep::Subgraph(service) => {
-                gen_map_request!(subgraph, service, rhai_service, callback);
+                gen_map_request!(subgraph, service, rhai_service, callback, boxed_clone_sync);
             }
         }
     }
@@ -632,7 +637,7 @@ impl ServiceStep {
                 gen_map_deferred_response!(execution, service, rhai_service, callback);
             }
             ServiceStep::Subgraph(service) => {
-                gen_map_response!(subgraph, service, rhai_service, callback);
+                gen_map_response!(subgraph, service, rhai_service, callback, boxed_clone_sync);
             }
         }
     }

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -24,13 +24,12 @@ use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
-use tower::util::BoxCloneSyncService;
+use tower::util::BoxCloneService;
 
 use self::engine::RhaiService;
 use self::engine::SharedMut;
 use crate::error::Error;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::plugins::rhai::engine::OptionDance;
@@ -107,7 +106,7 @@ impl Plugin for Rhai {
         })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         const FUNCTION_NAME_SERVICE: &str = "router_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -130,8 +129,8 @@ impl Plugin for Rhai {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         const FUNCTION_NAME_SERVICE: &str = "supergraph_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -152,10 +151,7 @@ impl Plugin for Rhai {
         shared_service.take_unwrap()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         const FUNCTION_NAME_SERVICE: &str = "execution_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -179,8 +175,8 @@ impl Plugin for Rhai {
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         const FUNCTION_NAME_SERVICE: &str = "subgraph_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -205,10 +201,10 @@ impl Plugin for Rhai {
 
 #[derive(Clone, Debug)]
 pub(crate) enum ServiceStep {
-    Router(SharedMut<router::BoxCloneSyncService>),
-    Supergraph(SharedMut<supergraph::BoxCloneSyncService>),
-    Execution(SharedMut<execution::BoxCloneSyncService>),
-    Subgraph(SharedMut<subgraph::BoxCloneSyncService>),
+    Router(SharedMut<router::BoxCloneService>),
+    Supergraph(SharedMut<supergraph::BoxCloneService>),
+    Execution(SharedMut<execution::BoxCloneService>),
+    Subgraph(SharedMut<subgraph::BoxCloneService>),
 }
 
 // Actually use the checkpoint function so that we can shortcut requests which fail
@@ -245,7 +241,7 @@ macro_rules! gen_map_request {
                     Ok(ControlFlow::Continue(request_opt.unwrap()))
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         })
     };
 }
@@ -356,7 +352,7 @@ macro_rules! gen_map_router_deferred_request {
                     */
                 })
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         })
     };
 }
@@ -386,7 +382,7 @@ macro_rules! gen_map_response {
                     let response_opt = guard.take();
                     response_opt.unwrap()
                 })
-                .boxed_clone_sync()
+                .boxed_clone()
         })
     };
 }
@@ -399,7 +395,7 @@ macro_rules! gen_map_response {
 macro_rules! gen_map_router_deferred_response {
     ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
         $borrow.replace(|service| {
-            BoxCloneSyncService::new(service.and_then(
+            BoxCloneService::new(service.and_then(
                 |mapped_response: $base::Response| async move {
                     // we split the response stream into headers+first response, then a stream of deferred responses
                     // for which we will implement mapping later
@@ -505,7 +501,7 @@ macro_rules! gen_map_router_deferred_response {
 macro_rules! gen_map_deferred_response {
     ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
         $borrow.replace(|service| {
-            BoxCloneSyncService::new(service.and_then(
+            BoxCloneService::new(service.and_then(
                 |mapped_response: $base::Response| async move {
                     // we split the response stream into headers+first response, then a stream of deferred responses
                     // for which we will implement mapping later

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -129,7 +129,10 @@ impl Plugin for Rhai {
         shared_service.take_unwrap()
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         const FUNCTION_NAME_SERVICE: &str = "supergraph_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -204,14 +207,14 @@ impl Plugin for Rhai {
 #[derive(Clone, Debug)]
 pub(crate) enum ServiceStep {
     Router(SharedMut<router::BoxService>),
-    Supergraph(SharedMut<supergraph::BoxService>),
+    Supergraph(SharedMut<supergraph::BoxCloneSyncService>),
     Execution(SharedMut<execution::BoxCloneSyncService>),
     Subgraph(SharedMut<subgraph::BoxCloneSyncService>),
 }
 
 // Actually use the checkpoint function so that we can shortcut requests which fail
 macro_rules! gen_map_request {
-    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident, $cloner: ident) => {
+    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
         $borrow.replace(|service| {
             fn rhai_service_span() -> impl Fn(&$base::Request) -> tracing::Span + Clone {
                 move |_request: &$base::Request| {
@@ -243,7 +246,7 @@ macro_rules! gen_map_request {
                     Ok(ControlFlow::Continue(request_opt.unwrap()))
                 })
                 .service(service)
-                .$cloner()
+                .boxed_clone_sync()
         })
     };
 }
@@ -360,7 +363,7 @@ macro_rules! gen_map_router_deferred_request {
 }
 
 macro_rules! gen_map_response {
-    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident, $cloner: ident) => {
+    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
         $borrow.replace(|service| {
             service
                 .map_response(move |response: $base::Response| {
@@ -384,7 +387,7 @@ macro_rules! gen_map_response {
                     let response_opt = guard.take();
                     response_opt.unwrap()
                 })
-                .$cloner()
+                .boxed_clone_sync()
         })
     };
 }
@@ -501,9 +504,9 @@ macro_rules! gen_map_router_deferred_response {
 }
 
 macro_rules! gen_map_deferred_response {
-    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident, $service: ident) => {
+    ($base: ident, $borrow: ident, $rhai_service: ident, $callback: ident) => {
         $borrow.replace(|service| {
-            $service::new(service.and_then(
+            BoxCloneSyncService::new(service.and_then(
                 |mapped_response: $base::Response| async move {
                     // we split the response stream into headers+first response, then a stream of deferred responses
                     // for which we will implement mapping later
@@ -618,13 +621,13 @@ impl ServiceStep {
                 gen_map_router_deferred_request!(router, service, rhai_service, callback);
             }
             ServiceStep::Supergraph(service) => {
-                gen_map_request!(supergraph, service, rhai_service, callback, boxed);
+                gen_map_request!(supergraph, service, rhai_service, callback);
             }
             ServiceStep::Execution(service) => {
-                gen_map_request!(execution, service, rhai_service, callback, boxed_clone_sync);
+                gen_map_request!(execution, service, rhai_service, callback);
             }
             ServiceStep::Subgraph(service) => {
-                gen_map_request!(subgraph, service, rhai_service, callback, boxed_clone_sync);
+                gen_map_request!(subgraph, service, rhai_service, callback);
             }
         }
     }
@@ -635,19 +638,13 @@ impl ServiceStep {
                 gen_map_router_deferred_response!(router, service, rhai_service, callback);
             }
             ServiceStep::Supergraph(service) => {
-                gen_map_deferred_response!(supergraph, service, rhai_service, callback, BoxService);
+                gen_map_deferred_response!(supergraph, service, rhai_service, callback);
             }
             ServiceStep::Execution(service) => {
-                gen_map_deferred_response!(
-                    execution,
-                    service,
-                    rhai_service,
-                    callback,
-                    BoxCloneSyncService
-                );
+                gen_map_deferred_response!(execution, service, rhai_service, callback);
             }
             ServiceStep::Subgraph(service) => {
-                gen_map_response!(subgraph, service, rhai_service, callback, boxed_clone_sync);
+                gen_map_response!(subgraph, service, rhai_service, callback);
             }
         }
     }

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -16,6 +16,7 @@ use sha2::Digest;
 use tower::BoxError;
 use tower::Service;
 use tower::ServiceExt;
+use tower::util::BoxCloneSyncService;
 use tower::util::BoxService;
 use tracing_futures::WithSubscriber;
 use uuid::Uuid;
@@ -997,7 +998,8 @@ async fn test_subgraph_error_logging(script_name: &str) -> Result<(), BoxError> 
 
     let dyn_plugin = create_plugin(script_name).await?;
 
-    let mut service = dyn_plugin.subgraph_service("test_subgraph", BoxService::new(mock_service));
+    let mut service =
+        dyn_plugin.subgraph_service("test_subgraph", BoxCloneSyncService::new(mock_service));
     let req = SubgraphRequest::fake_builder()
         .context(Context::new())
         .build();

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -197,7 +197,8 @@ async fn rhai_plugin_execution_service_error() -> Result<(), BoxError> {
             )
             .await
             .unwrap();
-        let mut router_service = dyn_plugin.execution_service(BoxService::new(mock_service));
+        let mut router_service =
+            dyn_plugin.execution_service(BoxCloneSyncService::new(mock_service));
         let fake_req = http_ext::Request::fake_builder()
             .header("x-custom-header", "CUSTOM_VALUE")
             .body(Request::builder().query(String::new()).build())
@@ -964,7 +965,7 @@ async fn test_execution_error_logging(script_name: &str) -> Result<(), BoxError>
         mock_service
     });
     let dyn_plugin = create_plugin(script_name).await?;
-    let mut service = dyn_plugin.execution_service(BoxService::new(mock_service));
+    let mut service = dyn_plugin.execution_service(BoxCloneSyncService::new(mock_service));
     let fake_req = http_ext::Request::fake_builder()
         .body(Request::builder().query(String::new()).build())
         .build()?;

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -142,7 +142,8 @@ async fn rhai_plugin_supergraph_service() -> Result<(), BoxError> {
             )
             .await
             .unwrap();
-        let mut router_service = dyn_plugin.supergraph_service(BoxService::new(mock_service));
+        let mut router_service =
+            dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
         let context = Context::new();
         context.insert("test", 5i64).unwrap();
         let supergraph_req = SupergraphRequest::fake_builder().context(context).build()?;
@@ -780,7 +781,7 @@ async fn test_router_service_adds_timestamp_header() -> Result<(), BoxError> {
         .await
         .unwrap();
 
-    let mut router_service = dyn_plugin.supergraph_service(BoxService::new(mock_service));
+    let mut router_service = dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
     let context = Context::new();
     context.insert("test", 5i64).unwrap();
     let supergraph_req = SupergraphRequest::fake_builder()
@@ -820,7 +821,7 @@ async fn it_can_access_demand_control_context() -> Result<(), BoxError> {
         .await
         .unwrap();
 
-    let mut router_service = dyn_plugin.supergraph_service(BoxService::new(mock_service));
+    let mut router_service = dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
     let context = Context::new();
     context.insert_estimated_cost(50.0).unwrap();
     context.insert_actual_cost(35.0).unwrap();
@@ -898,7 +899,7 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
         .await
         .unwrap();
 
-    let mut router_service = dyn_plugin.supergraph_service(BoxService::new(mock_service));
+    let mut router_service = dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
     let context = Context::new();
     let supergraph_req = SupergraphRequest::fake_builder().context(context).build()?;
 
@@ -935,7 +936,7 @@ async fn test_supergraph_error_logging(script_name: &str) -> Result<(), BoxError
 
     let dyn_plugin = create_plugin(script_name).await?;
 
-    let mut service = dyn_plugin.supergraph_service(BoxService::new(mock_service));
+    let mut service = dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
     let req = SupergraphRequest::fake_builder()
         .context(Context::new())
         .build()?;

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -17,7 +17,6 @@ use tower::BoxError;
 use tower::Service;
 use tower::ServiceExt;
 use tower::util::BoxCloneSyncService;
-use tower::util::BoxService;
 use tracing_futures::WithSubscriber;
 use uuid::Uuid;
 
@@ -985,7 +984,7 @@ async fn test_router_error_logging(script_name: &str) -> Result<(), BoxError> {
 
     let dyn_plugin = create_plugin(script_name).await?;
 
-    let mut service = dyn_plugin.router_service(BoxService::new(mock_service));
+    let mut service = dyn_plugin.router_service(BoxCloneSyncService::new(mock_service));
     let req = crate::services::RouterRequest::fake_builder()
         .context(Context::new())
         .build()?;

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -16,7 +16,7 @@ use sha2::Digest;
 use tower::BoxError;
 use tower::Service;
 use tower::ServiceExt;
-use tower::util::BoxCloneSyncService;
+use tower::util::BoxCloneService;
 use tracing_futures::WithSubscriber;
 use uuid::Uuid;
 
@@ -141,8 +141,7 @@ async fn rhai_plugin_supergraph_service() -> Result<(), BoxError> {
             )
             .await
             .unwrap();
-        let mut router_service =
-            dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
+        let mut router_service = dyn_plugin.supergraph_service(BoxCloneService::new(mock_service));
         let context = Context::new();
         context.insert("test", 5i64).unwrap();
         let supergraph_req = SupergraphRequest::fake_builder().context(context).build()?;
@@ -197,8 +196,7 @@ async fn rhai_plugin_execution_service_error() -> Result<(), BoxError> {
             )
             .await
             .unwrap();
-        let mut router_service =
-            dyn_plugin.execution_service(BoxCloneSyncService::new(mock_service));
+        let mut router_service = dyn_plugin.execution_service(BoxCloneService::new(mock_service));
         let fake_req = http_ext::Request::fake_builder()
             .header("x-custom-header", "CUSTOM_VALUE")
             .body(Request::builder().query(String::new()).build())
@@ -780,7 +778,7 @@ async fn test_router_service_adds_timestamp_header() -> Result<(), BoxError> {
         .await
         .unwrap();
 
-    let mut router_service = dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
+    let mut router_service = dyn_plugin.supergraph_service(BoxCloneService::new(mock_service));
     let context = Context::new();
     context.insert("test", 5i64).unwrap();
     let supergraph_req = SupergraphRequest::fake_builder()
@@ -820,7 +818,7 @@ async fn it_can_access_demand_control_context() -> Result<(), BoxError> {
         .await
         .unwrap();
 
-    let mut router_service = dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
+    let mut router_service = dyn_plugin.supergraph_service(BoxCloneService::new(mock_service));
     let context = Context::new();
     context.insert_estimated_cost(50.0).unwrap();
     context.insert_actual_cost(35.0).unwrap();
@@ -898,7 +896,7 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
         .await
         .unwrap();
 
-    let mut router_service = dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
+    let mut router_service = dyn_plugin.supergraph_service(BoxCloneService::new(mock_service));
     let context = Context::new();
     let supergraph_req = SupergraphRequest::fake_builder().context(context).build()?;
 
@@ -935,7 +933,7 @@ async fn test_supergraph_error_logging(script_name: &str) -> Result<(), BoxError
 
     let dyn_plugin = create_plugin(script_name).await?;
 
-    let mut service = dyn_plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
+    let mut service = dyn_plugin.supergraph_service(BoxCloneService::new(mock_service));
     let req = SupergraphRequest::fake_builder()
         .context(Context::new())
         .build()?;
@@ -965,7 +963,7 @@ async fn test_execution_error_logging(script_name: &str) -> Result<(), BoxError>
         mock_service
     });
     let dyn_plugin = create_plugin(script_name).await?;
-    let mut service = dyn_plugin.execution_service(BoxCloneSyncService::new(mock_service));
+    let mut service = dyn_plugin.execution_service(BoxCloneService::new(mock_service));
     let fake_req = http_ext::Request::fake_builder()
         .body(Request::builder().query(String::new()).build())
         .build()?;
@@ -984,7 +982,7 @@ async fn test_router_error_logging(script_name: &str) -> Result<(), BoxError> {
 
     let dyn_plugin = create_plugin(script_name).await?;
 
-    let mut service = dyn_plugin.router_service(BoxCloneSyncService::new(mock_service));
+    let mut service = dyn_plugin.router_service(BoxCloneService::new(mock_service));
     let req = crate::services::RouterRequest::fake_builder()
         .context(Context::new())
         .build()?;
@@ -1000,7 +998,7 @@ async fn test_subgraph_error_logging(script_name: &str) -> Result<(), BoxError> 
     let dyn_plugin = create_plugin(script_name).await?;
 
     let mut service =
-        dyn_plugin.subgraph_service("test_subgraph", BoxCloneSyncService::new(mock_service));
+        dyn_plugin.subgraph_service("test_subgraph", BoxCloneService::new(mock_service));
     let req = SubgraphRequest::fake_builder()
         .context(Context::new())
         .build();

--- a/apollo-router/src/plugins/subscription/mod.rs
+++ b/apollo-router/src/plugins/subscription/mod.rs
@@ -19,6 +19,7 @@ use crate::ListenAddr;
 use crate::graphql;
 use crate::json_ext::Object;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::protocols::websocket::WebSocketProtocol;
@@ -276,8 +277,8 @@ impl Plugin for Subscription {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: crate::services::subgraph::BoxService,
-    ) -> crate::services::subgraph::BoxService {
+        service: crate::services::subgraph::BoxCloneSyncService,
+    ) -> crate::services::subgraph::BoxCloneSyncService {
         let enabled = self.config.enabled
             && (self.config.mode.callback.is_some() || self.config.mode.passthrough.is_some());
         ServiceBuilder::new()
@@ -301,7 +302,7 @@ impl Plugin for Subscription {
                 }
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint> {
@@ -337,7 +338,7 @@ mod tests {
     use serde_json::Value;
     use tower::Service;
     use tower::ServiceExt;
-    use tower::util::BoxService;
+    use tower::util::BoxCloneSyncService;
 
     use super::*;
     use crate::Notify;
@@ -780,8 +781,10 @@ mod tests {
                     .build())
             });
 
-        let mut subgraph_service =
-            dyn_plugin.subgraph_service("my_subgraph_name", BoxService::new(mock_subgraph_service));
+        let mut subgraph_service = dyn_plugin.subgraph_service(
+            "my_subgraph_name",
+            BoxCloneSyncService::new(mock_subgraph_service),
+        );
         let subgraph_req = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http_ext::Request::fake_builder()

--- a/apollo-router/src/plugins/subscription/mod.rs
+++ b/apollo-router/src/plugins/subscription/mod.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use uuid::Uuid;
 
 use self::callback::CallbackService;
@@ -18,7 +19,6 @@ use crate::ListenAddr;
 use crate::graphql;
 use crate::json_ext::Object;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::protocols::websocket::WebSocketProtocol;
@@ -276,8 +276,8 @@ impl Plugin for Subscription {
     fn subgraph_service(
         &self,
         _subgraph_name: &str,
-        service: crate::services::subgraph::BoxCloneSyncService,
-    ) -> crate::services::subgraph::BoxCloneSyncService {
+        service: crate::services::subgraph::BoxCloneService,
+    ) -> crate::services::subgraph::BoxCloneService {
         let enabled = self.config.enabled
             && (self.config.mode.callback.is_some() || self.config.mode.passthrough.is_some());
         ServiceBuilder::new()
@@ -301,7 +301,7 @@ impl Plugin for Subscription {
                 }
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint> {
@@ -317,7 +317,7 @@ impl Plugin for Subscription {
             let endpoint = Endpoint::from_router_service(
                 format!("{path}/{{callback}}"),
                 CallbackService::new(self.notify.clone(), path.to_string(), callback_hmac_key)
-                    .boxed_clone_sync(),
+                    .boxed_clone(),
             );
             map.insert(listen.clone().unwrap_or_else(default_listen_addr), endpoint);
         }
@@ -337,7 +337,7 @@ mod tests {
     use serde_json::Value;
     use tower::Service;
     use tower::ServiceExt;
-    use tower::util::BoxCloneSyncService;
+    use tower::util::BoxCloneService;
 
     use super::*;
     use crate::Notify;
@@ -782,7 +782,7 @@ mod tests {
 
         let mut subgraph_service = dyn_plugin.subgraph_service(
             "my_subgraph_name",
-            BoxCloneSyncService::new(mock_subgraph_service),
+            BoxCloneService::new(mock_subgraph_service),
         );
         let subgraph_req = SubgraphRequest::fake_builder()
             .subgraph_request(

--- a/apollo-router/src/plugins/subscription/mod.rs
+++ b/apollo-router/src/plugins/subscription/mod.rs
@@ -9,7 +9,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use uuid::Uuid;
 
 use self::callback::CallbackService;
@@ -318,7 +317,7 @@ impl Plugin for Subscription {
             let endpoint = Endpoint::from_router_service(
                 format!("{path}/{{callback}}"),
                 CallbackService::new(self.notify.clone(), path.to_string(), callback_hmac_key)
-                    .boxed(),
+                    .boxed_clone_sync(),
             );
             map.insert(listen.clone().unwrap_or_else(default_listen_addr), endpoint);
         }

--- a/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
@@ -91,6 +91,7 @@ impl MetricsConfigurator for Config {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct PrometheusService {
     pub(crate) registry: Registry,
 }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -549,7 +549,7 @@ impl PluginPrivate for Telemetry {
                         request.context.clone(),
                     )
                 },
-                move |(mut custom_attributes, custom_instruments, mut custom_events, ctx): (
+                move |(custom_attributes, custom_instruments, mut custom_events, ctx): (
                     Vec<KeyValue>,
                     RouterInstruments,
                     RouterEvents,
@@ -566,34 +566,6 @@ impl PluginPrivate for Telemetry {
                     Self::plugin_metrics(&config);
 
                     async move {
-                        // NB: client name and version must be picked up here, rather than in the
-                        //  `req_fn` of this `map_future_with_request_data` call, to allow plugins
-                        //  at the router service to modify the name and version.
-                        let get_from_context =
-                            |ctx: &Context, key| ctx.get::<&str, String>(key).ok().flatten();
-                        let client_name = get_from_context(&ctx, CLIENT_NAME).or_else(|| {
-                            get_from_context(
-                                &ctx,
-                                crate::context::deprecated::DEPRECATED_CLIENT_NAME,
-                            )
-                        });
-                        let client_version = get_from_context(&ctx, CLIENT_VERSION).or_else(|| {
-                            get_from_context(
-                                &ctx,
-                                crate::context::deprecated::DEPRECATED_CLIENT_VERSION,
-                            )
-                        });
-
-                        if let Some(key) = client_name_key {
-                            custom_attributes
-                                .push(KeyValue::new(key, client_name.unwrap_or_default()));
-                        }
-
-                        if let Some(key) = client_version_key {
-                            custom_attributes
-                                .push(KeyValue::new(key, client_version.unwrap_or_default()));
-                        }
-
                         if let Some(http_server_response_body_size) =
                             &custom_instruments.http_server_response_body_size
                         {
@@ -617,6 +589,44 @@ impl PluginPrivate for Telemetry {
                         let span = Span::current();
                         span.set_span_dyn_attributes(custom_attributes);
                         let response: Result<router::Response, BoxError> = fut.await;
+
+                        // Client name and version must be picked up after awaiting
+                        // the inner service future, because router service plugins
+                        // (e.g. rhai) may modify these values in the shared context
+                        // during request processing. With buffered service layers,
+                        // that processing is deferred until the future is polled.
+                        let get_from_context =
+                            |ctx: &Context, key| ctx.get::<&str, String>(key).ok().flatten();
+                        let client_name = get_from_context(&ctx, CLIENT_NAME).or_else(|| {
+                            get_from_context(
+                                &ctx,
+                                crate::context::deprecated::DEPRECATED_CLIENT_NAME,
+                            )
+                        });
+                        let client_version = get_from_context(&ctx, CLIENT_VERSION).or_else(|| {
+                            get_from_context(
+                                &ctx,
+                                crate::context::deprecated::DEPRECATED_CLIENT_VERSION,
+                            )
+                        });
+
+                        if let Some(key) = client_name_key {
+                            span.set_span_dyn_attribute(
+                                key,
+                                opentelemetry::Value::String(
+                                    client_name.unwrap_or_default().into(),
+                                ),
+                            );
+                        }
+
+                        if let Some(key) = client_version_key {
+                            span.set_span_dyn_attribute(
+                                key,
+                                opentelemetry::Value::String(
+                                    client_version.unwrap_or_default().into(),
+                                ),
+                            );
+                        }
 
                         span.record(
                             APOLLO_PRIVATE_DURATION_NS,

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -942,7 +942,11 @@ impl PluginPrivate for Telemetry {
             .boxed()
     }
 
-    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         let config = self.config.clone();
         let span_mode = self.config.instrumentation.spans.mode;
         let conf = self.config.clone();
@@ -1074,7 +1078,7 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn connector_request_service(
@@ -2106,6 +2110,7 @@ mod tests {
     use serde_json_bytes::json;
     use tower::Service;
     use tower::ServiceExt;
+    use tower::util::BoxCloneSyncService;
     use tower::util::BoxService;
 
     use super::CustomTraceIdPropagator;
@@ -2743,7 +2748,7 @@ mod tests {
                 },
             );
             let mut bad_request_subgraph_service =
-                plugin.subgraph_service("test", BoxService::new(mock_bad_request_service));
+                plugin.subgraph_service("test", BoxCloneSyncService::new(mock_bad_request_service));
             let sub_req = http::Request::builder()
                 .method("POST")
                 .uri("http://test")
@@ -2845,7 +2850,7 @@ mod tests {
                 },
             );
             let mut bad_request_subgraph_service =
-                plugin.subgraph_service("test", BoxService::new(mock_bad_request_service));
+                plugin.subgraph_service("test", BoxCloneSyncService::new(mock_bad_request_service));
             let sub_req = http::Request::builder()
                 .method("POST")
                 .uri("http://test")
@@ -3007,8 +3012,10 @@ mod tests {
                         .build())
                 });
 
-            let mut subgraph_service =
-                plugin.subgraph_service("my_subgraph_name", BoxService::new(mock_subgraph_service));
+            let mut subgraph_service = plugin.subgraph_service(
+                "my_subgraph_name",
+                BoxCloneSyncService::new(mock_subgraph_service),
+            );
             let subgraph_req = SubgraphRequest::fake_builder()
                 .subgraph_request(
                     http_ext::Request::fake_builder()
@@ -3067,7 +3074,7 @@ mod tests {
 
             let mut subgraph_service = plugin.subgraph_service(
                 "my_subgraph_name_error",
-                BoxService::new(mock_subgraph_service_in_error),
+                BoxCloneSyncService::new(mock_subgraph_service_in_error),
             );
 
             let subgraph_req = SubgraphRequest::fake_builder()

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1089,9 +1089,9 @@ impl PluginPrivate for Telemetry {
 
     fn connector_request_service(
         &self,
-        service: connector::request_service::BoxService,
+        service: connector::request_service::BoxCloneSyncService,
         source_name: String,
-    ) -> connector::request_service::BoxService {
+    ) -> connector::request_service::BoxCloneSyncService {
         let req_fn_config = self.config.clone();
         let res_fn_config = self.config.clone();
         let span_mode = self.config.instrumentation.spans.mode;
@@ -1197,7 +1197,7 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn http_client_service(

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -87,6 +87,7 @@ use crate::context::OPERATION_KIND;
 use crate::context::OPERATION_NAME;
 use crate::graphql::ResponseVisitor;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::layers::instrument::InstrumentLayer;
 use crate::metrics::meter_provider;
 use crate::plugin::PluginInit;
@@ -1192,8 +1193,8 @@ impl PluginPrivate for Telemetry {
     fn http_client_service(
         &self,
         _subgraph_name: &str,
-        service: crate::services::http::BoxService,
-    ) -> crate::services::http::BoxService {
+        service: crate::services::http::BoxCloneSyncService,
+    ) -> crate::services::http::BoxCloneSyncService {
         let req_fn_config = self.config.clone();
         let res_fn_config = self.config.clone();
 
@@ -1270,7 +1271,7 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint> {

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -717,7 +717,10 @@ impl PluginPrivate for Telemetry {
             .boxed()
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         let metrics_sender = self.apollo_metrics_sender.clone();
         let span_mode = self.config.instrumentation.spans.mode;
         let config = self.config.clone();
@@ -905,7 +908,7 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn execution_service(
@@ -2224,7 +2227,8 @@ mod tests {
                     .unwrap())
             });
 
-        let mut supergraph_service = plugin.supergraph_service(BoxService::new(mock_service));
+        let mut supergraph_service =
+            plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
         let router_req = SupergraphRequest::fake_builder().header("test", "my_value_set");
         let _router_response = supergraph_service
             .ready()
@@ -2425,7 +2429,7 @@ mod tests {
                 },
             );
             let mut bad_request_supergraph_service =
-                plugin.supergraph_service(BoxService::new(mock_bad_request_service));
+                plugin.supergraph_service(BoxCloneSyncService::new(mock_bad_request_service));
             let router_req = SupergraphRequest::fake_builder().header("test", "my_value_set");
             let _router_response = bad_request_supergraph_service
                 .ready()
@@ -2636,7 +2640,7 @@ mod tests {
                 },
             );
             let mut bad_request_supergraph_service =
-                plugin.supergraph_service(BoxService::new(mock_bad_request_service));
+                plugin.supergraph_service(BoxCloneSyncService::new(mock_bad_request_service));
             let supergraph_req = SupergraphRequest::fake_builder()
                 .header("x-custom", "TEST")
                 .header("conditional-custom", "X")
@@ -2954,7 +2958,7 @@ mod tests {
                     .unwrap())
             });
         let mut request_supergraph_service =
-            plugin.supergraph_service(BoxService::new(mock_request_service));
+            plugin.supergraph_service(BoxCloneSyncService::new(mock_request_service));
 
         for _ in 0..10 {
             let supergraph_req = SupergraphRequest::fake_builder()
@@ -3383,7 +3387,7 @@ mod tests {
                     .build()
             });
 
-        let mut service = plugin.supergraph_service(BoxService::new(mock_service));
+        let mut service = plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
         let router_req = SupergraphRequest::fake_builder().build().unwrap();
         let _router_response = service
             .ready()

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -56,7 +56,6 @@ use serde_json_bytes::Value;
 use serde_json_bytes::json;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use uuid::Uuid;
 
 use self::apollo::ForwardValues;
@@ -362,7 +361,7 @@ impl PluginPrivate for Telemetry {
         })
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         let config = self.config.clone();
         let supergraph_schema_id = self.supergraph_schema_id.clone();
         let config_later = self.config.clone();
@@ -714,7 +713,7 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn supergraph_service(
@@ -2117,7 +2116,6 @@ mod tests {
     use tower::Service;
     use tower::ServiceExt;
     use tower::util::BoxCloneSyncService;
-    use tower::util::BoxService;
 
     use super::CustomTraceIdPropagator;
     use super::EnabledFeatures;
@@ -2476,7 +2474,7 @@ mod tests {
                         .unwrap())
                 });
             let mut bad_request_router_service =
-                plugin.router_service(BoxService::new(mock_bad_request_service));
+                plugin.router_service(BoxCloneSyncService::new(mock_bad_request_service));
             let router_req = RouterRequest::fake_builder()
                 .header("x-custom", "TEST")
                 .header("conditional-custom", "X")
@@ -2553,7 +2551,7 @@ mod tests {
                         .unwrap())
                 });
             let mut bad_request_router_service =
-                plugin.router_service(BoxService::new(mock_bad_request_service));
+                plugin.router_service(BoxCloneSyncService::new(mock_bad_request_service));
             let router_req = RouterRequest::fake_builder()
                 .header("x-custom", "TEST")
                 .header("conditional-custom", "X")

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -56,6 +56,7 @@ use serde_json_bytes::Value;
 use serde_json_bytes::json;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use uuid::Uuid;
 
 use self::apollo::ForwardValues;
@@ -86,7 +87,6 @@ use crate::context::OPERATION_KIND;
 use crate::context::OPERATION_NAME;
 use crate::graphql::ResponseVisitor;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::layers::instrument::InstrumentLayer;
 use crate::metrics::meter_provider;
 use crate::plugin::PluginInit;
@@ -361,7 +361,7 @@ impl PluginPrivate for Telemetry {
         })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         let config = self.config.clone();
         let supergraph_schema_id = self.supergraph_schema_id.clone();
         let config_later = self.config.clone();
@@ -723,13 +723,13 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         let metrics_sender = self.apollo_metrics_sender.clone();
         let span_mode = self.config.instrumentation.spans.mode;
         let config = self.config.clone();
@@ -917,13 +917,10 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         let config = self.config.clone();
         let config_map_res_first = config.clone();
 
@@ -954,14 +951,14 @@ impl PluginPrivate for Telemetry {
                 }
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         let config = self.config.clone();
         let span_mode = self.config.instrumentation.spans.mode;
         let conf = self.config.clone();
@@ -1093,14 +1090,14 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn connector_request_service(
         &self,
-        service: connector::request_service::BoxCloneSyncService,
+        service: connector::request_service::BoxCloneService,
         source_name: String,
-    ) -> connector::request_service::BoxCloneSyncService {
+    ) -> connector::request_service::BoxCloneService {
         let req_fn_config = self.config.clone();
         let res_fn_config = self.config.clone();
         let span_mode = self.config.instrumentation.spans.mode;
@@ -1206,14 +1203,14 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn http_client_service(
         &self,
         _subgraph_name: &str,
-        service: crate::services::http::BoxCloneSyncService,
-    ) -> crate::services::http::BoxCloneSyncService {
+        service: crate::services::http::BoxCloneService,
+    ) -> crate::services::http::BoxCloneService {
         let req_fn_config = self.config.clone();
         let res_fn_config = self.config.clone();
 
@@ -1290,7 +1287,7 @@ impl PluginPrivate for Telemetry {
                 },
             )
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint> {
@@ -2125,7 +2122,7 @@ mod tests {
     use serde_json_bytes::json;
     use tower::Service;
     use tower::ServiceExt;
-    use tower::util::BoxCloneSyncService;
+    use tower::util::BoxCloneService;
 
     use super::CustomTraceIdPropagator;
     use super::EnabledFeatures;
@@ -2235,8 +2232,7 @@ mod tests {
                     .unwrap())
             });
 
-        let mut supergraph_service =
-            plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
+        let mut supergraph_service = plugin.supergraph_service(BoxCloneService::new(mock_service));
         let router_req = SupergraphRequest::fake_builder().header("test", "my_value_set");
         let _router_response = supergraph_service
             .ready()
@@ -2437,7 +2433,7 @@ mod tests {
                 },
             );
             let mut bad_request_supergraph_service =
-                plugin.supergraph_service(BoxCloneSyncService::new(mock_bad_request_service));
+                plugin.supergraph_service(BoxCloneService::new(mock_bad_request_service));
             let router_req = SupergraphRequest::fake_builder().header("test", "my_value_set");
             let _router_response = bad_request_supergraph_service
                 .ready()
@@ -2484,7 +2480,7 @@ mod tests {
                         .unwrap())
                 });
             let mut bad_request_router_service =
-                plugin.router_service(BoxCloneSyncService::new(mock_bad_request_service));
+                plugin.router_service(BoxCloneService::new(mock_bad_request_service));
             let router_req = RouterRequest::fake_builder()
                 .header("x-custom", "TEST")
                 .header("conditional-custom", "X")
@@ -2561,7 +2557,7 @@ mod tests {
                         .unwrap())
                 });
             let mut bad_request_router_service =
-                plugin.router_service(BoxCloneSyncService::new(mock_bad_request_service));
+                plugin.router_service(BoxCloneService::new(mock_bad_request_service));
             let router_req = RouterRequest::fake_builder()
                 .header("x-custom", "TEST")
                 .header("conditional-custom", "X")
@@ -2648,7 +2644,7 @@ mod tests {
                 },
             );
             let mut bad_request_supergraph_service =
-                plugin.supergraph_service(BoxCloneSyncService::new(mock_bad_request_service));
+                plugin.supergraph_service(BoxCloneService::new(mock_bad_request_service));
             let supergraph_req = SupergraphRequest::fake_builder()
                 .header("x-custom", "TEST")
                 .header("conditional-custom", "X")
@@ -2763,7 +2759,7 @@ mod tests {
                 },
             );
             let mut bad_request_subgraph_service =
-                plugin.subgraph_service("test", BoxCloneSyncService::new(mock_bad_request_service));
+                plugin.subgraph_service("test", BoxCloneService::new(mock_bad_request_service));
             let sub_req = http::Request::builder()
                 .method("POST")
                 .uri("http://test")
@@ -2865,7 +2861,7 @@ mod tests {
                 },
             );
             let mut bad_request_subgraph_service =
-                plugin.subgraph_service("test", BoxCloneSyncService::new(mock_bad_request_service));
+                plugin.subgraph_service("test", BoxCloneService::new(mock_bad_request_service));
             let sub_req = http::Request::builder()
                 .method("POST")
                 .uri("http://test")
@@ -2966,7 +2962,7 @@ mod tests {
                     .unwrap())
             });
         let mut request_supergraph_service =
-            plugin.supergraph_service(BoxCloneSyncService::new(mock_request_service));
+            plugin.supergraph_service(BoxCloneService::new(mock_request_service));
 
         for _ in 0..10 {
             let supergraph_req = SupergraphRequest::fake_builder()
@@ -3029,7 +3025,7 @@ mod tests {
 
             let mut subgraph_service = plugin.subgraph_service(
                 "my_subgraph_name",
-                BoxCloneSyncService::new(mock_subgraph_service),
+                BoxCloneService::new(mock_subgraph_service),
             );
             let subgraph_req = SubgraphRequest::fake_builder()
                 .subgraph_request(
@@ -3089,7 +3085,7 @@ mod tests {
 
             let mut subgraph_service = plugin.subgraph_service(
                 "my_subgraph_name_error",
-                BoxCloneSyncService::new(mock_subgraph_service_in_error),
+                BoxCloneService::new(mock_subgraph_service_in_error),
             );
 
             let subgraph_req = SubgraphRequest::fake_builder()
@@ -3395,7 +3391,7 @@ mod tests {
                     .build()
             });
 
-        let mut service = plugin.supergraph_service(BoxCloneSyncService::new(mock_service));
+        let mut service = plugin.supergraph_service(BoxCloneService::new(mock_service));
         let router_req = SupergraphRequest::fake_builder().build().unwrap();
         let _router_response = service
             .ready()

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -908,7 +908,10 @@ impl PluginPrivate for Telemetry {
             .boxed()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         let config = self.config.clone();
         let config_map_res_first = config.clone();
 
@@ -939,7 +942,7 @@ impl PluginPrivate for Telemetry {
                 }
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/apollo-router/src/plugins/telemetry/reload/builder.rs
+++ b/apollo-router/src/plugins/telemetry/reload/builder.rs
@@ -28,10 +28,10 @@ use std::sync::atomic::Ordering;
 use multimap::MultiMap;
 use tokio::task::block_in_place;
 use tower::BoxError;
+use tower::ServiceExt;
 
 use crate::Endpoint;
 use crate::ListenAddr;
-use crate::layers::ServiceExt as _;
 use crate::metrics::aggregation::MeterProviderType;
 use crate::plugins::telemetry::apollo;
 use crate::plugins::telemetry::apollo_exporter::Sender;
@@ -125,7 +125,7 @@ impl<'a> Builder<'a> {
                     PrometheusService {
                         registry: prometheus_registry.clone(),
                     }
-                    .boxed_clone_sync(),
+                    .boxed_clone(),
                 ),
             );
         }

--- a/apollo-router/src/plugins/telemetry/reload/builder.rs
+++ b/apollo-router/src/plugins/telemetry/reload/builder.rs
@@ -28,10 +28,10 @@ use std::sync::atomic::Ordering;
 use multimap::MultiMap;
 use tokio::task::block_in_place;
 use tower::BoxError;
-use tower::ServiceExt;
 
 use crate::Endpoint;
 use crate::ListenAddr;
+use crate::layers::ServiceExt as _;
 use crate::metrics::aggregation::MeterProviderType;
 use crate::plugins::telemetry::apollo;
 use crate::plugins::telemetry::apollo_exporter::Sender;
@@ -125,7 +125,7 @@ impl<'a> Builder<'a> {
                     PrometheusService {
                         registry: prometheus_registry.clone(),
                     }
-                    .boxed(),
+                    .boxed_clone_sync(),
                 ),
             );
         }

--- a/apollo-router/src/plugins/test/mod.rs
+++ b/apollo-router/src/plugins/test/mod.rs
@@ -199,11 +199,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     pub(crate) fn execution_service<F>(
         &self,
         response_fn: impl Fn(execution::Request) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<execution::Request, execution::BoxService>
+    ) -> ServiceHandle<execution::Request, execution::BoxCloneSyncService>
     where
         F: Future<Output = Result<execution::Response, BoxError>> + Send + 'static,
     {
-        let service: execution::BoxService = execution::BoxService::new(
+        let service: execution::BoxCloneSyncService = execution::BoxCloneSyncService::new(
             ServiceBuilder::new().service_fn(move |req: execution::Request| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }

--- a/apollo-router/src/plugins/test/mod.rs
+++ b/apollo-router/src/plugins/test/mod.rs
@@ -236,11 +236,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
         &self,
         subgraph: &str,
         response_fn: impl Fn(http::HttpRequest) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<http::HttpRequest, http::BoxService>
+    ) -> ServiceHandle<http::HttpRequest, http::BoxCloneSyncService>
     where
         F: Future<Output = Result<http::HttpResponse, BoxError>> + Send + 'static,
     {
-        let service: http::BoxService = http::BoxService::new(ServiceBuilder::new().service_fn(
+        let service: http::BoxCloneSyncService = http::BoxCloneSyncService::new(ServiceBuilder::new().service_fn(
             move |req: http::HttpRequest| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }

--- a/apollo-router/src/plugins/test/mod.rs
+++ b/apollo-router/src/plugins/test/mod.rs
@@ -24,7 +24,6 @@ use tower_service::Service;
 
 use crate::Configuration;
 use crate::Notify;
-use crate::layers::ServiceExt as _;
 use crate::plugin;
 use crate::plugin::DynPlugin;
 use crate::plugin::PluginInit;
@@ -165,11 +164,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     pub(crate) fn router_service<F>(
         &self,
         response_fn: impl Fn(router::Request) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<router::Request, router::BoxCloneSyncService>
+    ) -> ServiceHandle<router::Request, router::BoxCloneService>
     where
         F: Future<Output = Result<router::Response, BoxError>> + Send + 'static,
     {
-        let service: router::BoxCloneSyncService = router::BoxCloneSyncService::new(
+        let service: router::BoxCloneService = router::BoxCloneService::new(
             ServiceBuilder::new().service_fn(move |req: router::Request| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
@@ -182,11 +181,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     pub(crate) fn supergraph_service<F>(
         &self,
         response_fn: impl Fn(supergraph::Request) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<supergraph::Request, supergraph::BoxCloneSyncService>
+    ) -> ServiceHandle<supergraph::Request, supergraph::BoxCloneService>
     where
         F: Future<Output = Result<supergraph::Response, BoxError>> + Send + 'static,
     {
-        let service: supergraph::BoxCloneSyncService = supergraph::BoxCloneSyncService::new(
+        let service: supergraph::BoxCloneService = supergraph::BoxCloneService::new(
             ServiceBuilder::new().service_fn(move |req: supergraph::Request| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
@@ -200,11 +199,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     pub(crate) fn execution_service<F>(
         &self,
         response_fn: impl Fn(execution::Request) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<execution::Request, execution::BoxCloneSyncService>
+    ) -> ServiceHandle<execution::Request, execution::BoxCloneService>
     where
         F: Future<Output = Result<execution::Response, BoxError>> + Send + 'static,
     {
-        let service: execution::BoxCloneSyncService = execution::BoxCloneSyncService::new(
+        let service: execution::BoxCloneService = execution::BoxCloneService::new(
             ServiceBuilder::new().service_fn(move |req: execution::Request| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
@@ -219,11 +218,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
         &self,
         subgraph: &str,
         response_fn: impl Fn(subgraph::Request) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<subgraph::Request, subgraph::BoxCloneSyncService>
+    ) -> ServiceHandle<subgraph::Request, subgraph::BoxCloneService>
     where
         F: Future<Output = Result<subgraph::Response, BoxError>> + Send + 'static,
     {
-        let service: subgraph::BoxCloneSyncService = subgraph::BoxCloneSyncService::new(
+        let service: subgraph::BoxCloneService = subgraph::BoxCloneService::new(
             ServiceBuilder::new().service_fn(move |req: subgraph::Request| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
@@ -237,11 +236,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
         &self,
         subgraph: &str,
         response_fn: impl Fn(http::HttpRequest) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<http::HttpRequest, http::BoxCloneSyncService>
+    ) -> ServiceHandle<http::HttpRequest, http::BoxCloneService>
     where
         F: Future<Output = Result<http::HttpResponse, BoxError>> + Send + 'static,
     {
-        let service: http::BoxCloneSyncService = http::BoxCloneSyncService::new(
+        let service: http::BoxCloneService = http::BoxCloneService::new(
             ServiceBuilder::new().service_fn(move |req: http::HttpRequest| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
@@ -263,8 +262,8 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
         + Clone
         + 'static,
     ) -> Result<connector::request_service::Response, BoxError> {
-        let service: connector::request_service::BoxCloneSyncService =
-            connector::request_service::BoxCloneSyncService::new(ServiceBuilder::new().service_fn(
+        let service: connector::request_service::BoxCloneService =
+            connector::request_service::BoxCloneService::new(ServiceBuilder::new().service_fn(
                 move |req: connector::request_service::Request| {
                     let response_fn = response_fn.clone();
                     async move { Ok((response_fn)(req)) }
@@ -300,7 +299,7 @@ where
     service: Arc<tokio::sync::Mutex<S>>,
 }
 
-impl Clone for ServiceHandle<router::Request, router::BoxCloneSyncService> {
+impl Clone for ServiceHandle<router::Request, router::BoxCloneService> {
     fn clone(&self) -> Self {
         Self {
             _phantom: Default::default(),
@@ -463,7 +462,7 @@ mod test_for_harness {
     use crate::metrics::FutureMetricsExt;
     use crate::plugin::Plugin;
     use crate::services::router;
-    use crate::services::router::BoxCloneSyncService;
+    use crate::services::router::BoxCloneService;
     use crate::services::router::body;
 
     /// Config for the test plugin
@@ -482,23 +481,23 @@ mod test_for_harness {
             Ok(Self {})
         }
 
-        fn router_service(&self, service: BoxCloneSyncService) -> BoxCloneSyncService {
+        fn router_service(&self, service: BoxCloneService) -> BoxCloneService {
             ServiceBuilder::new()
                 .load_shed()
                 .concurrency_limit(1)
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         }
 
         fn supergraph_service(
             &self,
-            service: supergraph::BoxCloneSyncService,
-        ) -> supergraph::BoxCloneSyncService {
+            service: supergraph::BoxCloneService,
+        ) -> supergraph::BoxCloneService {
             // This purposely does not use load_shed to allow us to test readiness.
             ServiceBuilder::new()
                 .concurrency_limit(1)
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         }
     }
     register_plugin!("apollo_testing", "my_test_plugin", MyTestPlugin);

--- a/apollo-router/src/plugins/test/mod.rs
+++ b/apollo-router/src/plugins/test/mod.rs
@@ -263,8 +263,8 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
         + Clone
         + 'static,
     ) -> Result<connector::request_service::Response, BoxError> {
-        let service: connector::request_service::BoxService =
-            connector::request_service::BoxService::new(ServiceBuilder::new().service_fn(
+        let service: connector::request_service::BoxCloneSyncService =
+            connector::request_service::BoxCloneSyncService::new(ServiceBuilder::new().service_fn(
                 move |req: connector::request_service::Request| {
                     let response_fn = response_fn.clone();
                     async move { Ok((response_fn)(req)) }

--- a/apollo-router/src/plugins/test/mod.rs
+++ b/apollo-router/src/plugins/test/mod.rs
@@ -165,11 +165,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     pub(crate) fn router_service<F>(
         &self,
         response_fn: impl Fn(router::Request) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<router::Request, router::BoxService>
+    ) -> ServiceHandle<router::Request, router::BoxCloneSyncService>
     where
         F: Future<Output = Result<router::Response, BoxError>> + Send + 'static,
     {
-        let service: router::BoxService = router::BoxService::new(
+        let service: router::BoxCloneSyncService = router::BoxCloneSyncService::new(
             ServiceBuilder::new().service_fn(move |req: router::Request| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
@@ -300,7 +300,7 @@ where
     service: Arc<tokio::sync::Mutex<S>>,
 }
 
-impl Clone for ServiceHandle<router::Request, router::BoxService> {
+impl Clone for ServiceHandle<router::Request, router::BoxCloneSyncService> {
     fn clone(&self) -> Self {
         Self {
             _phantom: Default::default(),
@@ -463,7 +463,7 @@ mod test_for_harness {
     use crate::metrics::FutureMetricsExt;
     use crate::plugin::Plugin;
     use crate::services::router;
-    use crate::services::router::BoxService;
+    use crate::services::router::BoxCloneSyncService;
     use crate::services::router::body;
 
     /// Config for the test plugin
@@ -482,12 +482,12 @@ mod test_for_harness {
             Ok(Self {})
         }
 
-        fn router_service(&self, service: BoxService) -> BoxService {
+        fn router_service(&self, service: BoxCloneSyncService) -> BoxCloneSyncService {
             ServiceBuilder::new()
                 .load_shed()
                 .concurrency_limit(1)
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         }
 
         fn supergraph_service(

--- a/apollo-router/src/plugins/test/mod.rs
+++ b/apollo-router/src/plugins/test/mod.rs
@@ -218,11 +218,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
         &self,
         subgraph: &str,
         response_fn: impl Fn(subgraph::Request) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<subgraph::Request, subgraph::BoxService>
+    ) -> ServiceHandle<subgraph::Request, subgraph::BoxCloneSyncService>
     where
         F: Future<Output = Result<subgraph::Response, BoxError>> + Send + 'static,
     {
-        let service: subgraph::BoxService = subgraph::BoxService::new(
+        let service: subgraph::BoxCloneSyncService = subgraph::BoxCloneSyncService::new(
             ServiceBuilder::new().service_fn(move |req: subgraph::Request| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
@@ -240,12 +240,12 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     where
         F: Future<Output = Result<http::HttpResponse, BoxError>> + Send + 'static,
     {
-        let service: http::BoxCloneSyncService = http::BoxCloneSyncService::new(ServiceBuilder::new().service_fn(
-            move |req: http::HttpRequest| {
+        let service: http::BoxCloneSyncService = http::BoxCloneSyncService::new(
+            ServiceBuilder::new().service_fn(move |req: http::HttpRequest| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
-            },
-        ));
+            }),
+        );
 
         ServiceHandle::new(self.plugin.http_client_service(subgraph, service))
     }

--- a/apollo-router/src/plugins/test/mod.rs
+++ b/apollo-router/src/plugins/test/mod.rs
@@ -24,6 +24,7 @@ use tower_service::Service;
 
 use crate::Configuration;
 use crate::Notify;
+use crate::layers::ServiceExt as _;
 use crate::plugin;
 use crate::plugin::DynPlugin;
 use crate::plugin::PluginInit;
@@ -181,11 +182,11 @@ impl<T: Into<Box<dyn DynPlugin + 'static>> + 'static> PluginTestHarness<T> {
     pub(crate) fn supergraph_service<F>(
         &self,
         response_fn: impl Fn(supergraph::Request) -> F + Send + Sync + Clone + 'static,
-    ) -> ServiceHandle<supergraph::Request, supergraph::BoxService>
+    ) -> ServiceHandle<supergraph::Request, supergraph::BoxCloneSyncService>
     where
         F: Future<Output = Result<supergraph::Response, BoxError>> + Send + 'static,
     {
-        let service: supergraph::BoxService = supergraph::BoxService::new(
+        let service: supergraph::BoxCloneSyncService = supergraph::BoxCloneSyncService::new(
             ServiceBuilder::new().service_fn(move |req: supergraph::Request| {
                 let response_fn = response_fn.clone();
                 async move { (response_fn)(req).await }
@@ -489,12 +490,15 @@ mod test_for_harness {
                 .boxed()
         }
 
-        fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+        fn supergraph_service(
+            &self,
+            service: supergraph::BoxCloneSyncService,
+        ) -> supergraph::BoxCloneSyncService {
             // This purposely does not use load_shed to allow us to test readiness.
             ServiceBuilder::new()
                 .concurrency_limit(1)
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         }
     }
     register_plugin!("apollo_testing", "my_test_plugin", MyTestPlugin);

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -22,7 +22,6 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use tower::limit::ConcurrencyLimitLayer;
 use tower::limit::RateLimitLayer;
 use tower::load_shed::error::Overloaded;
@@ -327,10 +326,11 @@ impl PluginPrivate for TrafficShaping {
         })
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         // NB: consider each triplet (map_future_with_request_data, load_shed, layer) as a unit of
         //  behavior
         ServiceBuilder::new()
+            .buffered()
             .map_future_with_request_data(
                 |req: &router::Request| req.context.clone(),
                 move |ctx, future| async {
@@ -402,7 +402,7 @@ impl PluginPrivate for TrafficShaping {
                     .map(|limit| RateLimitLayer::new(limit.capacity.into(), limit.interval))
             }))
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(
@@ -663,6 +663,7 @@ mod test {
     use tokio::task::JoinSet;
     use tokio::time::sleep;
     use tower::Service;
+    use tower::ServiceExt as _;
 
     use super::*;
     use crate::Configuration;
@@ -695,7 +696,7 @@ mod test {
     async fn execute_router_test(
         query: &str,
         body: &Bytes,
-        mut router_service: router::BoxService,
+        mut router_service: router::BoxCloneSyncService,
     ) {
         let request = SupergraphRequest::fake_builder()
             .query(query.to_string())
@@ -722,7 +723,7 @@ mod test {
 
     async fn build_mock_router_with_variable_dedup_optimization(
         plugin: Box<dyn DynPlugin>,
-    ) -> router::BoxService {
+    ) -> router::BoxCloneSyncService {
         let mut extensions = Object::new();
         extensions.insert("test", Value::String(ByteString::from("value")));
 
@@ -817,7 +818,7 @@ mod test {
         .await
         .unwrap()
         .make()
-        .boxed()
+        .boxed_clone_sync()
     }
 
     async fn get_traffic_shaping_plugin(config: &serde_json::Value) -> Box<dyn DynPlugin> {
@@ -1259,7 +1260,7 @@ mod test {
             .returning(MockRouterService::new);
 
         // let mut svc = plugin.router_service(mock_service.clone().boxed());
-        let mut svc = plugin.router_service(mock_service.boxed());
+        let mut svc = plugin.router_service(mock_service.boxed_clone_sync());
 
         let response: RouterResponse = svc
             .ready()
@@ -1320,7 +1321,7 @@ mod test {
                     .data(json!({ "test": 1234_u32 }))
                     .build()
             })
-            .boxed();
+            .boxed_clone_sync();
 
         let mut rs = plugin.router_service(svc);
 
@@ -1611,7 +1612,7 @@ mod test {
                 sleep(Duration::from_millis(500)).await;
                 RouterResponse::fake_builder().build()
             })
-            .boxed();
+            .boxed_clone_sync();
 
         let mut router_service = plugin.router_service(svc);
 

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -22,6 +22,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower::limit::ConcurrencyLimitLayer;
 use tower::limit::RateLimitLayer;
 use tower::load_shed::error::Overloaded;
@@ -33,7 +34,6 @@ use crate::configuration::shared::DnsResolutionStrategy;
 use crate::configuration::shared::default_pool_idle_timeout;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::services::RouterResponse;
@@ -326,7 +326,7 @@ impl PluginPrivate for TrafficShaping {
         })
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         // NB: consider each triplet (map_future_with_request_data, load_shed, layer) as a unit of
         //  behavior
         ServiceBuilder::new()
@@ -402,14 +402,14 @@ impl PluginPrivate for TrafficShaping {
                     .map(|limit| RateLimitLayer::new(limit.capacity.into(), limit.interval))
             }))
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         // Either we have the subgraph config and we merge it with the all config, or we just have the all config or we have nothing.
         let all_config = self.config.all.as_ref();
         let subgraph_config = self.config.subgraphs.get(name);
@@ -485,7 +485,7 @@ impl PluginPrivate for TrafficShaping {
                 })
                 .buffered()
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         } else {
             service
         }
@@ -493,9 +493,9 @@ impl PluginPrivate for TrafficShaping {
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxCloneSyncService,
+        service: crate::services::connector::request_service::BoxCloneService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxCloneSyncService {
+    ) -> crate::services::connector::request_service::BoxCloneService {
         let all_config = self.config.connector.all.as_ref();
         let source_config = self.config.connector.sources.get(&source_name).cloned();
         let final_config = Self::merge_config(all_config, source_config.as_ref());
@@ -561,7 +561,7 @@ impl PluginPrivate for TrafficShaping {
                 })
                 .buffered()
                 .service(service)
-                .boxed_clone_sync()
+                .boxed_clone()
         } else {
             service
         }
@@ -696,7 +696,7 @@ mod test {
     async fn execute_router_test(
         query: &str,
         body: &Bytes,
-        mut router_service: router::BoxCloneSyncService,
+        mut router_service: router::BoxCloneService,
     ) {
         let request = SupergraphRequest::fake_builder()
             .query(query.to_string())
@@ -723,7 +723,7 @@ mod test {
 
     async fn build_mock_router_with_variable_dedup_optimization(
         plugin: Box<dyn DynPlugin>,
-    ) -> router::BoxCloneSyncService {
+    ) -> router::BoxCloneService {
         let mut extensions = Object::new();
         extensions.insert("test", Value::String(ByteString::from("value")));
 
@@ -818,7 +818,7 @@ mod test {
         .await
         .unwrap()
         .make()
-        .boxed_clone_sync()
+        .boxed_clone()
     }
 
     async fn get_traffic_shaping_plugin(config: &serde_json::Value) -> Box<dyn DynPlugin> {
@@ -936,7 +936,7 @@ mod test {
         });
 
         let _response = plugin
-            .subgraph_service("test", test_service.boxed_clone_sync())
+            .subgraph_service("test", test_service.boxed_clone())
             .oneshot(request)
             .await
             .unwrap();
@@ -971,7 +971,7 @@ mod test {
 
         let _response = plugin
             .connector_request_service(
-                test_service.boxed_clone_sync(),
+                test_service.boxed_clone(),
                 "test_subgraph.test_sourcename".to_string(),
             )
             .oneshot(request)
@@ -1125,7 +1125,7 @@ mod test {
             graphql::Request::default() => graphql::Response::default()
         });
 
-        let mut svc = plugin.subgraph_service("test", test_service.boxed_clone_sync());
+        let mut svc = plugin.subgraph_service("test", test_service.boxed_clone());
 
         assert!(
             svc.ready()
@@ -1188,7 +1188,7 @@ mod test {
         });
 
         let mut svc = plugin.connector_request_service(
-            test_service.boxed_clone_sync(),
+            test_service.boxed_clone(),
             "test_subgraph.test_sourcename".to_string(),
         );
 
@@ -1260,7 +1260,7 @@ mod test {
             .returning(MockRouterService::new);
 
         // let mut svc = plugin.router_service(mock_service.clone().boxed());
-        let mut svc = plugin.router_service(mock_service.boxed_clone_sync());
+        let mut svc = plugin.router_service(mock_service.boxed_clone());
 
         let response: RouterResponse = svc
             .ready()
@@ -1321,7 +1321,7 @@ mod test {
                     .data(json!({ "test": 1234_u32 }))
                     .build()
             })
-            .boxed_clone_sync();
+            .boxed_clone();
 
         let mut rs = plugin.router_service(svc);
 
@@ -1612,7 +1612,7 @@ mod test {
                 sleep(Duration::from_millis(500)).await;
                 RouterResponse::fake_builder().build()
             })
-            .boxed_clone_sync();
+            .boxed_clone();
 
         let mut router_service = plugin.router_service(svc);
 

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -34,6 +34,7 @@ use crate::configuration::shared::DnsResolutionStrategy;
 use crate::configuration::shared::default_pool_idle_timeout;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
 use crate::services::RouterResponse;
@@ -404,7 +405,11 @@ impl PluginPrivate for TrafficShaping {
             .boxed()
     }
 
-    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         // Either we have the subgraph config and we merge it with the all config, or we just have the all config or we have nothing.
         let all_config = self.config.all.as_ref();
         let subgraph_config = self.config.subgraphs.get(name);
@@ -429,6 +434,7 @@ impl PluginPrivate for TrafficShaping {
                 });
 
             ServiceBuilder::new()
+                .buffered()
                 .map_future_with_request_data(
                     |req: &subgraph::Request| (req.context.clone(), req.subgraph_name.clone()),
                     move |(ctx, subgraph_name), future| {
@@ -479,7 +485,7 @@ impl PluginPrivate for TrafficShaping {
                 })
                 .buffered()
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         } else {
             service
         }
@@ -928,7 +934,7 @@ mod test {
         });
 
         let _response = plugin
-            .subgraph_service("test", test_service.boxed())
+            .subgraph_service("test", test_service.boxed_clone_sync())
             .oneshot(request)
             .await
             .unwrap();
@@ -1117,7 +1123,7 @@ mod test {
             graphql::Request::default() => graphql::Response::default()
         });
 
-        let mut svc = plugin.subgraph_service("test", test_service.boxed());
+        let mut svc = plugin.subgraph_service("test", test_service.boxed_clone_sync());
 
         assert!(
             svc.ready()

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -493,9 +493,9 @@ impl PluginPrivate for TrafficShaping {
 
     fn connector_request_service(
         &self,
-        service: crate::services::connector::request_service::BoxService,
+        service: crate::services::connector::request_service::BoxCloneSyncService,
         source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
+    ) -> crate::services::connector::request_service::BoxCloneSyncService {
         let all_config = self.config.connector.all.as_ref();
         let source_config = self.config.connector.sources.get(&source_name).cloned();
         let final_config = Self::merge_config(all_config, source_config.as_ref());
@@ -515,6 +515,7 @@ impl PluginPrivate for TrafficShaping {
             });
 
             ServiceBuilder::new()
+                .buffered()
                 .map_future_with_request_data(
                     |req: &Request| (req.context.clone(), req.key.clone()),
                     move |(context, response_key), future| {
@@ -560,7 +561,7 @@ impl PluginPrivate for TrafficShaping {
                 })
                 .buffered()
                 .service(service)
-                .boxed()
+                .boxed_clone_sync()
         } else {
             service
         }
@@ -969,7 +970,7 @@ mod test {
 
         let _response = plugin
             .connector_request_service(
-                test_service.boxed(),
+                test_service.boxed_clone_sync(),
                 "test_subgraph.test_sourcename".to_string(),
             )
             .oneshot(request)
@@ -1186,7 +1187,7 @@ mod test {
         });
 
         let mut svc = plugin.connector_request_service(
-            test_service.boxed(),
+            test_service.boxed_clone_sync(),
             "test_subgraph.test_sourcename".to_string(),
         );
 

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -35,6 +35,7 @@ use crate::configuration::cooperative_cancellation::CooperativeCancellation;
 use crate::configuration::mode::Mode;
 use crate::error::CacheResolverError;
 use crate::error::QueryPlannerError;
+use crate::layers::ServiceExt as _;
 use crate::plugins::authorization::AuthorizationPlugin;
 use crate::plugins::authorization::CacheKeyMetadata;
 use crate::plugins::limits;
@@ -143,7 +144,7 @@ fn init_query_plan_from_redis(
     Ok(())
 }
 
-impl<T: Clone + 'static> CachingQueryPlanner<T>
+impl<T: Clone + Sync + 'static> CachingQueryPlanner<T>
 where
     T: tower::Service<
             QueryPlannerRequest,
@@ -218,7 +219,7 @@ where
             self.plugins
                 .iter()
                 .rev()
-                .fold(self.delegate.clone().boxed(), |acc, (_, e)| {
+                .fold(self.delegate.clone().boxed_clone_sync(), |acc, (_, e)| {
                     e.query_planner_service(acc)
                 }),
         );

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -35,7 +35,6 @@ use crate::configuration::cooperative_cancellation::CooperativeCancellation;
 use crate::configuration::mode::Mode;
 use crate::error::CacheResolverError;
 use crate::error::QueryPlannerError;
-use crate::layers::ServiceExt as _;
 use crate::plugins::authorization::AuthorizationPlugin;
 use crate::plugins::authorization::CacheKeyMetadata;
 use crate::plugins::limits;
@@ -219,7 +218,7 @@ where
             self.plugins
                 .iter()
                 .rev()
-                .fold(self.delegate.clone().boxed_clone_sync(), |acc, (_, e)| {
+                .fold(self.delegate.clone().boxed_clone(), |acc, (_, e)| {
                     e.query_planner_service(acc)
                 }),
         );

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -35,7 +35,7 @@ use crate::plugins::authorization::AuthorizationPlugin;
 use crate::plugins::authorization::CacheKeyMetadata;
 use crate::services::SubgraphRequest;
 use crate::services::fetch::ErrorMapping;
-use crate::services::subgraph::BoxCloneSyncService;
+use crate::services::subgraph::BoxCloneService;
 use crate::spec::QueryHash;
 use crate::spec::Schema;
 use crate::spec::SchemaHash;
@@ -267,7 +267,7 @@ impl FetchNode {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn subgraph_fetch(
         &self,
-        service: BoxCloneSyncService,
+        service: BoxCloneService,
         subgraph_request: SubgraphRequest,
         current_dir: &Path,
         schema: &Schema,

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -35,7 +35,7 @@ use crate::plugins::authorization::AuthorizationPlugin;
 use crate::plugins::authorization::CacheKeyMetadata;
 use crate::services::SubgraphRequest;
 use crate::services::fetch::ErrorMapping;
-use crate::services::subgraph::BoxService;
+use crate::services::subgraph::BoxCloneSyncService;
 use crate::spec::QueryHash;
 use crate::spec::Schema;
 use crate::spec::SchemaHash;
@@ -267,7 +267,7 @@ impl FetchNode {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn subgraph_fetch(
         &self,
-        service: BoxService,
+        service: BoxCloneSyncService,
         subgraph_request: SubgraphRequest,
         current_dir: &Path,
         schema: &Schema,

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -656,7 +656,6 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
-    use crate::layers::ServiceExt as _;
     use crate::metrics::FutureMetricsExt as _;
     use crate::services::subgraph;
     use crate::services::supergraph;
@@ -1201,7 +1200,7 @@ mod tests {
                             .build())
                     }
                 })
-                .boxed_clone_sync()
+                .boxed_clone()
             })
             .build_supergraph()
             .await

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -656,6 +656,7 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
+    use crate::layers::ServiceExt as _;
     use crate::metrics::FutureMetricsExt as _;
     use crate::services::subgraph;
     use crate::services::supergraph;
@@ -1200,7 +1201,7 @@ mod tests {
                             .build())
                     }
                 })
-                .boxed()
+                .boxed_clone_sync()
             })
             .build_supergraph()
             .await

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -79,7 +79,7 @@ impl std::fmt::Debug for Endpoint {
 
 impl Endpoint {
     /// Creates an Endpoint given a path and a Boxed Service
-    pub fn from_router_service(path: String, handler: router::BoxCloneSyncService) -> Self {
+    pub fn from_router_service(path: String, handler: router::BoxCloneService) -> Self {
         Self {
             path,
             handler: EndpointHandler::Service(Handler::new(handler)),

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -79,7 +79,7 @@ impl std::fmt::Debug for Endpoint {
 
 impl Endpoint {
     /// Creates an Endpoint given a path and a Boxed Service
-    pub fn from_router_service(path: String, handler: router::BoxService) -> Self {
+    pub fn from_router_service(path: String, handler: router::BoxCloneSyncService) -> Self {
         Self {
             path,
             handler: EndpointHandler::Service(Handler::new(handler)),

--- a/apollo-router/src/services/connect.rs
+++ b/apollo-router/src/services/connect.rs
@@ -14,7 +14,7 @@ use crate::graphql;
 use crate::graphql::Request as GraphQLRequest;
 use crate::query_planner::fetch::Variables;
 
-pub(crate) type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
+pub(crate) type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
 
 #[non_exhaustive]
 pub(crate) struct Request {

--- a/apollo-router/src/services/connect.rs
+++ b/apollo-router/src/services/connect.rs
@@ -14,7 +14,7 @@ use crate::graphql;
 use crate::graphql::Request as GraphQLRequest;
 use crate::query_planner::fetch::Variables;
 
-pub(crate) type BoxService = tower::util::BoxService<Request, Response, BoxError>;
+pub(crate) type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 
 #[non_exhaustive]
 pub(crate) struct Request {

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -31,6 +31,7 @@ use crate::Context;
 use crate::error::FetchError;
 use crate::graphql;
 use crate::layers::DEFAULT_BUFFER_SIZE;
+use crate::layers::ServiceExt as _;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugins::connectors::handle_responses::process_response;
 use crate::plugins::connectors::request_limit::RequestLimits;
@@ -47,6 +48,7 @@ use crate::services::http::HttpClientServiceFactory;
 use crate::services::router;
 
 pub(crate) type BoxService = tower::util::BoxService<Request, Response, BoxError>;
+pub(crate) type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub(crate) type ServiceResult = Result<Response, BoxError>;
 
 assert_impl_all!(Request: Send);
@@ -170,10 +172,10 @@ impl ConnectorRequestServiceFactory {
                         ConnectorRequestService {
                             http_client_service_factory: http_client_service_factory.clone(),
                         }
-                        .boxed(),
+                        .boxed_clone_sync(),
                         |acc, (_, e)| e.connector_request_service(acc, source.clone()),
                     )
-                    .boxed(),
+                    .boxed_clone_sync(),
                 DEFAULT_BUFFER_SIZE,
             );
             map.insert(source.clone(), service);

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -31,7 +31,6 @@ use crate::Context;
 use crate::error::FetchError;
 use crate::graphql;
 use crate::layers::DEFAULT_BUFFER_SIZE;
-use crate::layers::ServiceExt as _;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugins::connectors::handle_responses::process_response;
 use crate::plugins::connectors::request_limit::RequestLimits;
@@ -48,7 +47,7 @@ use crate::services::http::HttpClientServiceFactory;
 use crate::services::router;
 
 pub(crate) type BoxService = tower::util::BoxService<Request, Response, BoxError>;
-pub(crate) type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
+pub(crate) type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
 pub(crate) type ServiceResult = Result<Response, BoxError>;
 
 assert_impl_all!(Request: Send);
@@ -172,10 +171,10 @@ impl ConnectorRequestServiceFactory {
                         ConnectorRequestService {
                             http_client_service_factory: http_client_service_factory.clone(),
                         }
-                        .boxed_clone_sync(),
+                        .boxed_clone(),
                         |acc, (_, e)| e.connector_request_service(acc, source.clone()),
                     )
-                    .boxed_clone_sync(),
+                    .boxed_clone(),
                 DEFAULT_BUFFER_SIZE,
             );
             map.insert(source.clone(), service);

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -19,9 +19,8 @@ use tower::BoxError;
 use tower::ServiceExt;
 use tracing_futures::Instrument;
 
-use super::connect::BoxCloneSyncService;
+use super::connect::BoxCloneService;
 use super::new_service::ServiceFactory;
-use crate::layers::ServiceExt as _;
 use crate::plugins::connectors::handle_responses::aggregate_responses;
 use crate::plugins::connectors::make_requests::make_requests;
 use crate::plugins::connectors::tracing::CONNECTOR_TYPE_HTTP;
@@ -276,7 +275,7 @@ impl ConnectorServiceFactory {
 }
 
 impl ServiceFactory<ConnectRequest> for ConnectorServiceFactory {
-    type Service = BoxCloneSyncService;
+    type Service = BoxCloneService;
 
     fn create(&self) -> Self::Service {
         ConnectorService {
@@ -286,6 +285,6 @@ impl ServiceFactory<ConnectRequest> for ConnectorServiceFactory {
             connectors_by_service_name: self.connectors_by_service_name.clone(),
             connector_request_service_factory: self.connector_request_service_factory.clone(),
         }
-        .boxed_clone_sync()
+        .boxed_clone()
     }
 }

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -19,8 +19,9 @@ use tower::BoxError;
 use tower::ServiceExt;
 use tracing_futures::Instrument;
 
-use super::connect::BoxService;
+use super::connect::BoxCloneSyncService;
 use super::new_service::ServiceFactory;
+use crate::layers::ServiceExt as _;
 use crate::plugins::connectors::handle_responses::aggregate_responses;
 use crate::plugins::connectors::make_requests::make_requests;
 use crate::plugins::connectors::tracing::CONNECTOR_TYPE_HTTP;
@@ -275,7 +276,7 @@ impl ConnectorServiceFactory {
 }
 
 impl ServiceFactory<ConnectRequest> for ConnectorServiceFactory {
-    type Service = BoxService;
+    type Service = BoxCloneSyncService;
 
     fn create(&self) -> Self::Service {
         ConnectorService {
@@ -285,6 +286,6 @@ impl ServiceFactory<ConnectRequest> for ConnectorServiceFactory {
             connectors_by_service_name: self.connectors_by_service_name.clone(),
             connector_request_service_factory: self.connector_request_service_factory.clone(),
         }
-        .boxed()
+        .boxed_clone_sync()
     }
 }

--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -14,6 +14,7 @@ pub(crate) mod service;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
+pub type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
 
 // Reachable from Request

--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -14,7 +14,6 @@ pub(crate) mod service;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
-pub type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
 
 // Reachable from Request

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -22,6 +22,7 @@ use tokio::sync::mpsc::error::TryRecvError;
 use tokio_stream::wrappers::ReceiverStream;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower_service::Service;
 use tracing::Instrument;
 use tracing::Span;
@@ -36,7 +37,6 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::json_ext::ValueExt;
-use crate::layers::ServiceExt as _;
 use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
 use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN;
 use crate::plugins::subscription::Subscription;
@@ -631,7 +631,7 @@ pub(crate) struct ExecutionServiceFactory {
 }
 
 impl ServiceFactory<ExecutionRequest> for ExecutionServiceFactory {
-    type Service = execution::BoxCloneSyncService;
+    type Service = execution::BoxCloneService;
 
     fn create(&self) -> Self::Service {
         let subscription_plugin_conf = self
@@ -658,11 +658,11 @@ impl ServiceFactory<ExecutionRequest> for ExecutionServiceFactory {
                         apollo_telemetry_config: apollo_telemetry_conf,
                         configuration: Arc::clone(&self.configuration),
                     }
-                    .boxed_clone_sync(),
+                    .boxed_clone(),
                     |acc, (_, e)| e.execution_service(acc),
                 ),
             )
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -22,7 +22,6 @@ use tokio::sync::mpsc::error::TryRecvError;
 use tokio_stream::wrappers::ReceiverStream;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt as _;
 use tower_service::Service;
 use tracing::Instrument;
 use tracing::Span;
@@ -37,6 +36,7 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::json_ext::ValueExt;
+use crate::layers::ServiceExt as _;
 use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
 use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN;
 use crate::plugins::subscription::Subscription;
@@ -631,7 +631,7 @@ pub(crate) struct ExecutionServiceFactory {
 }
 
 impl ServiceFactory<ExecutionRequest> for ExecutionServiceFactory {
-    type Service = execution::BoxService;
+    type Service = execution::BoxCloneSyncService;
 
     fn create(&self) -> Self::Service {
         let subscription_plugin_conf = self
@@ -658,11 +658,11 @@ impl ServiceFactory<ExecutionRequest> for ExecutionServiceFactory {
                         apollo_telemetry_config: apollo_telemetry_conf,
                         configuration: Arc::clone(&self.configuration),
                     }
-                    .boxed(),
+                    .boxed_clone_sync(),
                     |acc, (_, e)| e.execution_service(acc),
                 ),
             )
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/services/fetch.rs
+++ b/apollo-router/src/services/fetch.rs
@@ -22,7 +22,7 @@ use crate::query_planner::subscription::SubscriptionNode;
 /// its existence.
 const SUBGRAPH_NAME_EXTENSION_KEY: &str = "apollo.private.subgraph.name";
 
-pub(crate) type BoxService = tower::util::BoxService<Request, Response, BoxError>;
+pub(crate) type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 
 // XXX(@goto-bus-stop): The `SubscriptionRequest` should not be an enum branch here in the future.
 // The information it represents must be isolated to the subscription plugin.

--- a/apollo-router/src/services/fetch.rs
+++ b/apollo-router/src/services/fetch.rs
@@ -22,7 +22,7 @@ use crate::query_planner::subscription::SubscriptionNode;
 /// its existence.
 const SUBGRAPH_NAME_EXTENSION_KEY: &str = "apollo.private.subgraph.name";
 
-pub(crate) type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
+pub(crate) type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
 
 // XXX(@goto-bus-stop): The `SubscriptionRequest` should not be an enum branch here in the future.
 // The information it represents must be isolated to the subscription plugin.

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -15,12 +15,13 @@ use super::FetchRequest;
 use super::SubgraphRequest;
 use super::connector_service::ConnectorServiceFactory;
 use super::fetch::AddSubgraphNameExt;
-use super::fetch::BoxService;
+use super::fetch::BoxCloneSyncService;
 use super::new_service::ServiceFactory;
 use crate::configuration::HoistOrphanErrors;
 use crate::configuration::subgraph::SubgraphConfiguration;
 use crate::graphql::Request as GraphQLRequest;
 use crate::http_ext;
+use crate::layers::ServiceExt as _;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::plugins::subscription::fetch_service_handle_subscription;
 use crate::query_planner::FETCH_SPAN_NAME;
@@ -312,7 +313,7 @@ impl FetchServiceFactory {
 }
 
 impl ServiceFactory<Request> for FetchServiceFactory {
-    type Service = BoxService;
+    type Service = BoxCloneSyncService;
 
     fn create(&self) -> Self::Service {
         FetchService {
@@ -323,6 +324,6 @@ impl ServiceFactory<Request> for FetchServiceFactory {
             connector_service_factory: self.connector_service_factory.clone(),
             hoist_orphan_errors: self.hoist_orphan_errors.clone(),
         }
-        .boxed()
+        .boxed_clone_sync()
     }
 }

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -15,13 +15,12 @@ use super::FetchRequest;
 use super::SubgraphRequest;
 use super::connector_service::ConnectorServiceFactory;
 use super::fetch::AddSubgraphNameExt;
-use super::fetch::BoxCloneSyncService;
+use super::fetch::BoxCloneService;
 use super::new_service::ServiceFactory;
 use crate::configuration::HoistOrphanErrors;
 use crate::configuration::subgraph::SubgraphConfiguration;
 use crate::graphql::Request as GraphQLRequest;
 use crate::http_ext;
-use crate::layers::ServiceExt as _;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::plugins::subscription::fetch_service_handle_subscription;
 use crate::query_planner::FETCH_SPAN_NAME;
@@ -313,7 +312,7 @@ impl FetchServiceFactory {
 }
 
 impl ServiceFactory<Request> for FetchServiceFactory {
-    type Service = BoxCloneSyncService;
+    type Service = BoxCloneService;
 
     fn create(&self) -> Self::Service {
         FetchService {
@@ -324,6 +323,6 @@ impl ServiceFactory<Request> for FetchServiceFactory {
             connector_service_factory: self.connector_service_factory.clone(),
             hoist_orphan_errors: self.hoist_orphan_errors.clone(),
         }
-        .boxed_clone_sync()
+        .boxed_clone()
     }
 }

--- a/apollo-router/src/services/http.rs
+++ b/apollo-router/src/services/http.rs
@@ -2,12 +2,12 @@
 use std::sync::Arc;
 
 use tower::BoxError;
-use tower::ServiceExt;
 use tower_service::Service;
 
 use super::Plugins;
 use super::router::body::RouterBody;
 use crate::Context;
+use crate::layers::ServiceExt as _;
 
 pub(crate) mod service;
 #[cfg(test)]
@@ -17,6 +17,8 @@ pub(crate) use service::HttpClientService;
 
 pub(crate) type BoxService = tower::util::BoxService<HttpRequest, HttpResponse, BoxError>;
 pub(crate) type BoxCloneService = tower::util::BoxCloneService<HttpRequest, HttpResponse, BoxError>;
+pub(crate) type BoxCloneSyncService =
+    tower::util::BoxCloneSyncService<HttpRequest, HttpResponse, BoxError>;
 pub(crate) type ServiceResult = Result<HttpResponse, BoxError>;
 
 #[non_exhaustive]
@@ -64,19 +66,19 @@ impl HttpClientServiceFactory {
         }
     }
 
-    pub(crate) fn create(&self, name: &str) -> BoxService {
+    pub(crate) fn create(&self, name: &str) -> BoxCloneSyncService {
         let service = self.service.clone();
         self.plugins
             .iter()
             .rev()
-            .fold(service.boxed(), |acc, (_, e)| {
+            .fold(service.boxed_clone_sync(), |acc, (_, e)| {
                 e.http_client_service(name, acc)
             })
     }
 }
 
 pub(crate) trait MakeHttpService: Send + Sync + 'static {
-    fn make(&self) -> BoxService;
+    fn make(&self) -> BoxCloneSyncService;
 }
 
 impl<S> MakeHttpService for S
@@ -88,7 +90,7 @@ where
         + 'static,
     <S as Service<HttpRequest>>::Future: Send,
 {
-    fn make(&self) -> BoxService {
-        self.clone().boxed()
+    fn make(&self) -> BoxCloneSyncService {
+        self.clone().boxed_clone_sync()
     }
 }

--- a/apollo-router/src/services/http.rs
+++ b/apollo-router/src/services/http.rs
@@ -2,12 +2,12 @@
 use std::sync::Arc;
 
 use tower::BoxError;
+use tower::ServiceExt;
 use tower_service::Service;
 
 use super::Plugins;
 use super::router::body::RouterBody;
 use crate::Context;
-use crate::layers::ServiceExt as _;
 
 pub(crate) mod service;
 #[cfg(test)]
@@ -17,8 +17,6 @@ pub(crate) use service::HttpClientService;
 
 pub(crate) type BoxService = tower::util::BoxService<HttpRequest, HttpResponse, BoxError>;
 pub(crate) type BoxCloneService = tower::util::BoxCloneService<HttpRequest, HttpResponse, BoxError>;
-pub(crate) type BoxCloneSyncService =
-    tower::util::BoxCloneSyncService<HttpRequest, HttpResponse, BoxError>;
 pub(crate) type ServiceResult = Result<HttpResponse, BoxError>;
 
 #[non_exhaustive]
@@ -66,19 +64,19 @@ impl HttpClientServiceFactory {
         }
     }
 
-    pub(crate) fn create(&self, name: &str) -> BoxCloneSyncService {
+    pub(crate) fn create(&self, name: &str) -> BoxCloneService {
         let service = self.service.clone();
         self.plugins
             .iter()
             .rev()
-            .fold(service.boxed_clone_sync(), |acc, (_, e)| {
+            .fold(service.boxed_clone(), |acc, (_, e)| {
                 e.http_client_service(name, acc)
             })
     }
 }
 
 pub(crate) trait MakeHttpService: Send + Sync + 'static {
-    fn make(&self) -> BoxCloneSyncService;
+    fn make(&self) -> BoxCloneService;
 }
 
 impl<S> MakeHttpService for S
@@ -90,7 +88,7 @@ where
         + 'static,
     <S as Service<HttpRequest>>::Future: Send,
 {
-    fn make(&self) -> BoxCloneSyncService {
-        self.clone().boxed_clone_sync()
+    fn make(&self) -> BoxCloneService {
+        self.clone().boxed_clone()
     }
 }

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -639,7 +639,7 @@ mod tests {
     use crate::plugins::telemetry::dynamic_attribute::DynAttributeLayer;
     use crate::plugins::telemetry::otel;
     use crate::plugins::telemetry::otel::OtelData;
-    use crate::services::http::BoxService;
+    use crate::services::http::BoxCloneSyncService;
     use crate::services::http::HttpClientService;
     use crate::services::http::HttpRequest;
     use crate::services::http::service::WireByteCount;
@@ -715,7 +715,7 @@ mod tests {
         (guard, recording_layer)
     }
 
-    async fn make_telemetry_http_client(service_name: &str) -> BoxService {
+    async fn make_telemetry_http_client(service_name: &str) -> BoxCloneSyncService {
         let full_config = serde_json::json!({
             "telemetry": {}
         });
@@ -747,7 +747,7 @@ mod tests {
         )
         .expect("can create a HttpClientService");
 
-        plugin.http_client_service(service_name, BoxService::new(http_client_service))
+        plugin.http_client_service(service_name, BoxCloneSyncService::new(http_client_service))
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -898,7 +898,7 @@ mod tests {
 
         // Wrap with telemetry plugin
         let mut telemetry_wrapped_service =
-            plugin.http_client_service("test", BoxService::new(http_client_service));
+            plugin.http_client_service("test", BoxCloneSyncService::new(http_client_service));
 
         let (_guard, recording_layer) = setup_tracing();
 

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -639,7 +639,7 @@ mod tests {
     use crate::plugins::telemetry::dynamic_attribute::DynAttributeLayer;
     use crate::plugins::telemetry::otel;
     use crate::plugins::telemetry::otel::OtelData;
-    use crate::services::http::BoxCloneSyncService;
+    use crate::services::http::BoxCloneService;
     use crate::services::http::HttpClientService;
     use crate::services::http::HttpRequest;
     use crate::services::http::service::WireByteCount;
@@ -715,7 +715,7 @@ mod tests {
         (guard, recording_layer)
     }
 
-    async fn make_telemetry_http_client(service_name: &str) -> BoxCloneSyncService {
+    async fn make_telemetry_http_client(service_name: &str) -> BoxCloneService {
         let full_config = serde_json::json!({
             "telemetry": {}
         });
@@ -747,7 +747,7 @@ mod tests {
         )
         .expect("can create a HttpClientService");
 
-        plugin.http_client_service(service_name, BoxCloneSyncService::new(http_client_service))
+        plugin.http_client_service(service_name, BoxCloneService::new(http_client_service))
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -898,7 +898,7 @@ mod tests {
 
         // Wrap with telemetry plugin
         let mut telemetry_wrapped_service =
-            plugin.http_client_service("test", BoxCloneSyncService::new(http_client_service));
+            plugin.http_client_service("test", BoxCloneService::new(http_client_service));
 
         let (_guard, recording_layer) = setup_tracing();
 

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -943,8 +943,8 @@ mod plugin_loading {
         fn http_client_service(
             &self,
             _subgraph_name: &str,
-            service: crate::services::http::BoxService,
-        ) -> crate::services::http::BoxService {
+            service: crate::services::http::BoxCloneSyncService,
+        ) -> crate::services::http::BoxCloneSyncService {
             self.started.store(true, Ordering::Release);
             service
         }

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -943,8 +943,8 @@ mod plugin_loading {
         fn http_client_service(
             &self,
             _subgraph_name: &str,
-            service: crate::services::http::BoxCloneSyncService,
-        ) -> crate::services::http::BoxCloneSyncService {
+            service: crate::services::http::BoxCloneService,
+        ) -> crate::services::http::BoxCloneService {
             self.started.store(true, Ordering::Release);
             service
         }

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -20,7 +20,6 @@ use mime::APPLICATION_JSON;
 use tower::BoxError;
 use tower::Layer;
 use tower::Service;
-use tower::ServiceExt;
 
 use crate::graphql;
 use crate::layers::ServiceExt as _;
@@ -164,10 +163,12 @@ impl<S> Layer<S> for SupergraphLayer
 where
     S: Service<supergraph::Request, Response = supergraph::Response, Error = BoxError>
         + Send
+        + Clone
+        + Sync
         + 'static,
     <S as Service<supergraph::Request>>::Future: Send + 'static,
 {
-    type Service = supergraph::BoxService;
+    type Service = supergraph::BoxCloneSyncService;
 
     fn layer(&self, service: S) -> Self::Service {
         service
@@ -200,7 +201,7 @@ where
                 }
                 (parts, res)
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -20,6 +20,7 @@ use mime::APPLICATION_JSON;
 use tower::BoxError;
 use tower::Layer;
 use tower::Service;
+use tower::ServiceExt;
 
 use crate::graphql;
 use crate::layers::ServiceExt as _;
@@ -164,11 +165,10 @@ where
     S: Service<supergraph::Request, Response = supergraph::Response, Error = BoxError>
         + Send
         + Clone
-        + Sync
         + 'static,
     <S as Service<supergraph::Request>>::Future: Send + 'static,
 {
-    type Service = supergraph::BoxCloneSyncService;
+    type Service = supergraph::BoxCloneService;
 
     fn layer(&self, service: S) -> Self::Service {
         service
@@ -201,7 +201,7 @@ where
                 }
                 (parts, res)
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -134,8 +134,7 @@ impl Response {
 }
 
 pub(crate) type ServiceError = MaybeBackPressureError<QueryPlannerError>;
-pub(crate) type BoxCloneSyncService =
-    tower::util::BoxCloneSyncService<Request, Response, ServiceError>;
+pub(crate) type BoxCloneService = tower::util::BoxCloneService<Request, Response, ServiceError>;
 #[allow(dead_code)]
 pub(crate) type ServiceResult = Result<Response, ServiceError>;
 
@@ -143,5 +142,5 @@ pub(crate) type ServiceResult = Result<Response, ServiceError>;
 pub(crate) trait QueryPlannerPlugin: Send + Sync + 'static {
     /// This service runs right after the query planner cache, which means that it will be called once per unique
     /// query, unless the cache entry was evicted
-    fn query_planner_service(&self, service: BoxCloneSyncService) -> BoxCloneSyncService;
+    fn query_planner_service(&self, service: BoxCloneService) -> BoxCloneService;
 }

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -134,9 +134,8 @@ impl Response {
 }
 
 pub(crate) type ServiceError = MaybeBackPressureError<QueryPlannerError>;
-pub(crate) type BoxService = tower::util::BoxService<Request, Response, ServiceError>;
-#[allow(dead_code)]
-pub(crate) type BoxCloneService = tower::util::BoxCloneService<Request, Response, ServiceError>;
+pub(crate) type BoxCloneSyncService =
+    tower::util::BoxCloneSyncService<Request, Response, ServiceError>;
 #[allow(dead_code)]
 pub(crate) type ServiceResult = Result<Response, ServiceError>;
 
@@ -144,5 +143,5 @@ pub(crate) type ServiceResult = Result<Response, ServiceError>;
 pub(crate) trait QueryPlannerPlugin: Send + Sync + 'static {
     /// This service runs right after the query planner cache, which means that it will be called once per unique
     /// query, unless the cache entry was evicted
-    fn query_planner_service(&self, service: BoxService) -> BoxService;
+    fn query_planner_service(&self, service: BoxCloneSyncService) -> BoxCloneSyncService;
 }

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -41,7 +41,6 @@ use crate::services::TryIntoHeaderValue;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
-pub type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
 
 pub type Body = RouterBody;

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -41,6 +41,7 @@ use crate::services::TryIntoHeaderValue;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
+pub type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
 
 pub type Body = RouterBody;

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -48,6 +48,7 @@ use crate::graphql;
 use crate::http_ext;
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 #[cfg(test)]
 use crate::plugin::test::MockSupergraphService;
@@ -103,19 +104,21 @@ pub(crate) struct RouterService {
     // Cannot be under Arc. Batching state must be preserved for each RouterService
     // instance
     batching: Batching,
-    supergraph_service: supergraph::BoxCloneService,
+    supergraph_service: supergraph::BoxCloneSyncService,
 }
 
 impl RouterService {
     fn new(
-        sgb: supergraph::BoxService,
+        sgb: supergraph::BoxCloneSyncService,
         apq_layer: APQLayer,
         persisted_query_layer: Arc<PersistedQueryLayer>,
         query_analysis_layer: QueryAnalysisLayer,
         batching: Batching,
     ) -> Self {
-        let supergraph_service: supergraph::BoxCloneService =
-            ServiceBuilder::new().buffered().service(sgb).boxed_clone();
+        let supergraph_service: supergraph::BoxCloneSyncService = ServiceBuilder::new()
+            .buffered()
+            .service(sgb)
+            .boxed_clone_sync();
 
         RouterService {
             apq_layer: Arc::new(apq_layer),
@@ -152,7 +155,7 @@ pub(crate) async fn from_supergraph_mock_callback_and_configuration(
 
     let (_, _, supergraph_creator) = crate::TestHarness::builder()
         .configuration(configuration.clone())
-        .supergraph_hook(move |_| supergraph_service.clone().boxed())
+        .supergraph_hook(move |_| supergraph_service.clone().boxed_clone_sync())
         .build_common()
         .await
         .unwrap();
@@ -202,7 +205,7 @@ pub(crate) async fn empty() -> impl Service<
 
     let (_, _, supergraph_creator) = crate::TestHarness::builder()
         .configuration(Default::default())
-        .supergraph_hook(move |_| supergraph_service.clone().boxed())
+        .supergraph_hook(move |_| supergraph_service.clone().boxed_clone_sync())
         .build_common()
         .await
         .unwrap();

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -48,7 +48,6 @@ use crate::graphql;
 use crate::http_ext;
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 #[cfg(test)]
 use crate::plugin::test::MockSupergraphService;
@@ -104,21 +103,19 @@ pub(crate) struct RouterService {
     // Cannot be under Arc. Batching state must be preserved for each RouterService
     // instance
     batching: Batching,
-    supergraph_service: supergraph::BoxCloneSyncService,
+    supergraph_service: supergraph::BoxCloneService,
 }
 
 impl RouterService {
     fn new(
-        sgb: supergraph::BoxCloneSyncService,
+        sgb: supergraph::BoxCloneService,
         apq_layer: APQLayer,
         persisted_query_layer: Arc<PersistedQueryLayer>,
         query_analysis_layer: QueryAnalysisLayer,
         batching: Batching,
     ) -> Self {
-        let supergraph_service: supergraph::BoxCloneSyncService = ServiceBuilder::new()
-            .buffered()
-            .service(sgb)
-            .boxed_clone_sync();
+        let supergraph_service: supergraph::BoxCloneService =
+            ServiceBuilder::new().buffered().service(sgb).boxed_clone();
 
         RouterService {
             apq_layer: Arc::new(apq_layer),
@@ -144,7 +141,6 @@ pub(crate) async fn from_supergraph_mock_callback_and_configuration(
     Error = BoxError,
     Future = BoxFuture<'static, router::ServiceResult>,
 > + Send
-+ Sync
 + Clone {
     let mut supergraph_service = MockSupergraphService::new();
 
@@ -157,7 +153,7 @@ pub(crate) async fn from_supergraph_mock_callback_and_configuration(
 
     let (_, _, supergraph_creator) = crate::TestHarness::builder()
         .configuration(configuration.clone())
-        .supergraph_hook(move |_| supergraph_service.clone().boxed_clone_sync())
+        .supergraph_hook(move |_| supergraph_service.clone().boxed_clone())
         .build_common()
         .await
         .unwrap();
@@ -186,7 +182,6 @@ pub(crate) async fn from_supergraph_mock_callback(
     Error = BoxError,
     Future = BoxFuture<'static, router::ServiceResult>,
 > + Send
-+ Sync
 + Clone {
     from_supergraph_mock_callback_and_configuration(
         supergraph_callback,
@@ -209,7 +204,7 @@ pub(crate) async fn empty() -> impl Service<
 
     let (_, _, supergraph_creator) = crate::TestHarness::builder()
         .configuration(Default::default())
-        .supergraph_hook(move |_| supergraph_service.clone().boxed_clone_sync())
+        .supergraph_hook(move |_| supergraph_service.clone().boxed_clone())
         .build_common()
         .await
         .unwrap();
@@ -833,14 +828,14 @@ pub(crate) struct RouterCreator {
 }
 
 impl ServiceFactory<router::Request> for RouterCreator {
-    type Service = router::BoxCloneSyncService;
+    type Service = router::BoxCloneService;
     fn create(&self) -> Self::Service {
-        self.make().boxed_clone_sync()
+        self.make().boxed_clone()
     }
 }
 
 impl RouterFactory for RouterCreator {
-    type RouterService = router::BoxCloneSyncService;
+    type RouterService = router::BoxCloneService;
 
     type Future = <<RouterCreator as ServiceFactory<router::Request>>::Service as Service<
         router::Request,
@@ -913,11 +908,11 @@ impl RouterCreator {
                         .plugins()
                         .iter()
                         .rev()
-                        .fold(router_service.boxed_clone_sync(), |acc, (_, e)| {
+                        .fold(router_service.boxed_clone(), |acc, (_, e)| {
                             e.router_service(acc)
                         }),
                 )
-                .boxed_clone_sync(),
+                .boxed_clone(),
             DEFAULT_BUFFER_SIZE,
         );
 
@@ -929,8 +924,8 @@ impl RouterCreator {
         })
     }
 
-    pub(crate) fn make(&self) -> router::BoxCloneSyncService {
-        self.sb.clone().boxed_clone_sync()
+    pub(crate) fn make(&self) -> router::BoxCloneService {
+        self.sb.clone().boxed_clone()
     }
 }
 

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -143,7 +143,9 @@ pub(crate) async fn from_supergraph_mock_callback_and_configuration(
     Response = router::Response,
     Error = BoxError,
     Future = BoxFuture<'static, router::ServiceResult>,
-> + Send {
+> + Send
++ Sync
++ Clone {
     let mut supergraph_service = MockSupergraphService::new();
 
     supergraph_service.expect_clone().returning(move || {
@@ -183,7 +185,9 @@ pub(crate) async fn from_supergraph_mock_callback(
     Response = router::Response,
     Error = BoxError,
     Future = BoxFuture<'static, router::ServiceResult>,
-> + Send {
+> + Send
++ Sync
++ Clone {
     from_supergraph_mock_callback_and_configuration(
         supergraph_callback,
         Arc::new(Configuration::default()),
@@ -829,14 +833,14 @@ pub(crate) struct RouterCreator {
 }
 
 impl ServiceFactory<router::Request> for RouterCreator {
-    type Service = router::BoxService;
+    type Service = router::BoxCloneSyncService;
     fn create(&self) -> Self::Service {
-        self.make().boxed()
+        self.make().boxed_clone_sync()
     }
 }
 
 impl RouterFactory for RouterCreator {
-    type RouterService = router::BoxService;
+    type RouterService = router::BoxCloneSyncService;
 
     type Future = <<RouterCreator as ServiceFactory<router::Request>>::Service as Service<
         router::Request,
@@ -909,9 +913,11 @@ impl RouterCreator {
                         .plugins()
                         .iter()
                         .rev()
-                        .fold(router_service.boxed(), |acc, (_, e)| e.router_service(acc)),
+                        .fold(router_service.boxed_clone_sync(), |acc, (_, e)| {
+                            e.router_service(acc)
+                        }),
                 )
-                .boxed(),
+                .boxed_clone_sync(),
             DEFAULT_BUFFER_SIZE,
         );
 
@@ -923,17 +929,8 @@ impl RouterCreator {
         })
     }
 
-    pub(crate) fn make(
-        &self,
-    ) -> impl Service<
-        router::Request,
-        Response = router::Response,
-        Error = BoxError,
-        Future = BoxFuture<'static, router::ServiceResult>,
-    > + Send
-    + use<> {
-        // Note: We have to box our cloned service to erase the type of the Buffer.
-        self.sb.clone().boxed()
+    pub(crate) fn make(&self) -> router::BoxCloneSyncService {
+        self.sb.clone().boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -16,6 +16,7 @@ use tower_service::Service;
 
 use crate::Context;
 use crate::graphql;
+use crate::layers::ServiceExt as _;
 use crate::metrics::FutureMetricsExt;
 use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::services::SupergraphRequest;
@@ -573,7 +574,7 @@ async fn escaped_quotes_in_string_literal() {
                     }
                     response
                 })
-                .boxed()
+                .boxed_clone_sync()
         })
         .build_supergraph()
         .await

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -16,7 +16,6 @@ use tower_service::Service;
 
 use crate::Context;
 use crate::graphql;
-use crate::layers::ServiceExt as _;
 use crate::metrics::FutureMetricsExt;
 use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::services::SupergraphRequest;
@@ -574,7 +573,7 @@ async fn escaped_quotes_in_string_literal() {
                     }
                     response
                 })
-                .boxed_clone_sync()
+                .boxed_clone()
         })
         .build_supergraph()
         .await

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -41,6 +41,7 @@ use crate::spec::QueryHash;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
+pub type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
 pub(crate) type BoxGqlStream = Pin<Box<dyn Stream<Item = graphql::Response> + Send + Sync>>;
 /// unique id for a subgraph request and the related response

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -41,7 +41,6 @@ use crate::spec::QueryHash;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
-pub type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
 pub(crate) type BoxGqlStream = Pin<Box<dyn Stream<Item = graphql::Response> + Send + Sync>>;
 /// unique id for a subgraph request and the related response

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -32,6 +32,7 @@ use tokio::sync::oneshot;
 use tower::BoxError;
 use tower::Service;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tracing::Instrument;
 use tracing::instrument;
 
@@ -55,7 +56,6 @@ use crate::error::SubgraphBatchingError;
 use crate::graphql;
 use crate::json_ext::Object;
 use crate::layers::DEFAULT_BUFFER_SIZE;
-use crate::layers::ServiceExt as _;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::layers::unconstrained_buffer::UnconstrainedBufferLayer;
 use crate::plugins::file_uploads;
@@ -800,7 +800,7 @@ pub(crate) async fn call_single_http(
     request: SubgraphRequest,
     body: graphql::Request,
     context: Context,
-    client: crate::services::http::BoxCloneSyncService,
+    client: crate::services::http::BoxCloneService,
     service_name: &str,
 ) -> Result<SubgraphResponse, BoxError> {
     let subgraph_request_event = context
@@ -1053,7 +1053,7 @@ fn get_graphql_content_type(service_name: &str, parts: &Parts) -> Result<Content
 }
 
 async fn do_fetch(
-    mut client: crate::services::http::BoxCloneSyncService,
+    mut client: crate::services::http::BoxCloneService,
     context: &Context,
     service_name: &str,
     request: Request<RouterBody>,
@@ -1155,7 +1155,7 @@ impl SubgraphServiceFactory {
                     Arc::from(name.clone()),
                 ))
                 .service(maker.make())
-                .boxed_clone_sync();
+                .boxed_clone();
             let service = ServiceBuilder::new()
                 .layer(UnconstrainedBufferLayer::new(DEFAULT_BUFFER_SIZE))
                 .service(
@@ -1172,11 +1172,9 @@ impl SubgraphServiceFactory {
         }
     }
 
-    pub(crate) fn create(&self, name: &str) -> Option<subgraph::BoxCloneSyncService> {
+    pub(crate) fn create(&self, name: &str) -> Option<subgraph::BoxCloneService> {
         // Note: We have to box our cloned service to erase the type of the Buffer.
-        self.services
-            .get(name)
-            .map(|svc| svc.clone().boxed_clone_sync())
+        self.services.get(name).map(|svc| svc.clone().boxed_clone())
     }
 }
 
@@ -1184,7 +1182,7 @@ impl SubgraphServiceFactory {
 ///
 /// there can be multiple instances of that service executing at any given time
 pub(crate) trait MakeSubgraphService: Send + Sync + 'static {
-    fn make(&self) -> subgraph::BoxCloneSyncService;
+    fn make(&self) -> subgraph::BoxCloneService;
 }
 
 impl<S> MakeSubgraphService for S
@@ -1196,8 +1194,8 @@ where
         + 'static,
     <S as Service<SubgraphRequest>>::Future: Send,
 {
-    fn make(&self) -> subgraph::BoxCloneSyncService {
-        self.clone().boxed_clone_sync()
+    fn make(&self) -> subgraph::BoxCloneService {
+        self.clone().boxed_clone()
     }
 }
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -32,7 +32,6 @@ use tokio::sync::oneshot;
 use tower::BoxError;
 use tower::Service;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 use tracing::Instrument;
 use tracing::instrument;
 
@@ -56,6 +55,7 @@ use crate::error::SubgraphBatchingError;
 use crate::graphql;
 use crate::json_ext::Object;
 use crate::layers::DEFAULT_BUFFER_SIZE;
+use crate::layers::ServiceExt as _;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::layers::unconstrained_buffer::UnconstrainedBufferLayer;
 use crate::plugins::file_uploads;
@@ -1155,7 +1155,7 @@ impl SubgraphServiceFactory {
                     Arc::from(name.clone()),
                 ))
                 .service(maker.make())
-                .boxed();
+                .boxed_clone_sync();
             let service = ServiceBuilder::new()
                 .layer(UnconstrainedBufferLayer::new(DEFAULT_BUFFER_SIZE))
                 .service(
@@ -1172,9 +1172,11 @@ impl SubgraphServiceFactory {
         }
     }
 
-    pub(crate) fn create(&self, name: &str) -> Option<subgraph::BoxService> {
+    pub(crate) fn create(&self, name: &str) -> Option<subgraph::BoxCloneSyncService> {
         // Note: We have to box our cloned service to erase the type of the Buffer.
-        self.services.get(name).map(|svc| svc.clone().boxed())
+        self.services
+            .get(name)
+            .map(|svc| svc.clone().boxed_clone_sync())
     }
 }
 
@@ -1182,7 +1184,7 @@ impl SubgraphServiceFactory {
 ///
 /// there can be multiple instances of that service executing at any given time
 pub(crate) trait MakeSubgraphService: Send + Sync + 'static {
-    fn make(&self) -> subgraph::BoxCloneService;
+    fn make(&self) -> subgraph::BoxCloneSyncService;
 }
 
 impl<S> MakeSubgraphService for S
@@ -1194,8 +1196,8 @@ where
         + 'static,
     <S as Service<SubgraphRequest>>::Future: Send,
 {
-    fn make(&self) -> subgraph::BoxCloneService {
-        self.clone().boxed_clone()
+    fn make(&self) -> subgraph::BoxCloneSyncService {
+        self.clone().boxed_clone_sync()
     }
 }
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -800,7 +800,7 @@ pub(crate) async fn call_single_http(
     request: SubgraphRequest,
     body: graphql::Request,
     context: Context,
-    client: crate::services::http::BoxService,
+    client: crate::services::http::BoxCloneSyncService,
     service_name: &str,
 ) -> Result<SubgraphResponse, BoxError> {
     let subgraph_request_event = context
@@ -1053,7 +1053,7 @@ fn get_graphql_content_type(service_name: &str, parts: &Parts) -> Result<Content
 }
 
 async fn do_fetch(
-    mut client: crate::services::http::BoxService,
+    mut client: crate::services::http::BoxCloneSyncService,
     context: &Context,
     service_name: &str,
     request: Request<RouterBody>,

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -31,6 +31,7 @@ mod tests;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
+pub type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
 
 assert_impl_all!(Request: Send);
@@ -415,7 +416,7 @@ impl Response {
     ///     #     Ok(Self)
     ///     # }
     ///     // …
-    ///     fn supergraph_service(&self, inner: supergraph::BoxService) -> supergraph::BoxService {
+    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService {
     ///         inner
     ///             .map_response(|supergraph_response| {
     ///                 supergraph_response.map_stream(|graphql_response| {

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -31,7 +31,6 @@ mod tests;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
-pub type BoxCloneSyncService = tower::util::BoxCloneSyncService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
 
 assert_impl_all!(Request: Send);
@@ -416,7 +415,7 @@ impl Response {
     ///     #     Ok(Self)
     ///     # }
     ///     // …
-    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService {
+    ///     fn supergraph_service(&self, inner: supergraph::BoxCloneService) -> supergraph::BoxCloneService {
     ///         inner
     ///             .map_response(|supergraph_response| {
     ///                 supergraph_response.map_stream(|graphql_response| {

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -31,6 +31,7 @@ use crate::graphql::IntoGraphQLErrors;
 use crate::json_ext::Object;
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::layers::ServiceBuilderExt;
+use crate::layers::ServiceExt as _;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugin::DynPlugin;
 use crate::plugins::connectors::query_plans::store_connectors;
@@ -78,7 +79,7 @@ pub(crate) type Plugins = IndexMap<String, Box<dyn DynPlugin>>;
 #[derive(Clone)]
 pub(crate) struct SupergraphService {
     query_planner_service: CachingQueryPlanner<QueryPlannerService>,
-    execution_service: execution::BoxCloneService,
+    execution_service: execution::BoxCloneSyncService,
     schema: Arc<Schema>,
     strict_variable_validation: Mode,
 }
@@ -88,7 +89,7 @@ impl SupergraphService {
     #[builder]
     pub(crate) fn new(
         query_planner_service: CachingQueryPlanner<QueryPlannerService>,
-        execution_service: execution::BoxCloneService,
+        execution_service: execution::BoxCloneSyncService,
         schema: Arc<Schema>,
         strict_variable_validation: Mode,
     ) -> Self {
@@ -154,7 +155,7 @@ impl Service<SupergraphRequest> for SupergraphService {
 
 async fn service_call(
     planning: CachingQueryPlanner<QueryPlannerService>,
-    execution_service: execution::BoxCloneService,
+    execution_service: execution::BoxCloneSyncService,
     schema: Arc<Schema>,
     req: SupergraphRequest,
     strict_variable_validation: Mode,
@@ -448,7 +449,7 @@ async fn plan_query(
 ///
 /// This is at the heart of the delegation of responsibility model for the router. A schema,
 /// collection of plugins, collection of subgraph services are assembled to generate a
-/// [`tower::util::BoxCloneService`] capable of processing a router request
+/// [`tower::util::BoxCloneSyncService`] capable of processing a router request
 /// through the entire stack to return a response.
 pub(crate) struct PluggableSupergraphServiceBuilder {
     plugins: Arc<Plugins>,
@@ -583,7 +584,7 @@ impl PluggableSupergraphServiceBuilder {
             configuration: Arc::clone(&configuration),
         };
 
-        let execution_service: execution::BoxCloneService = ServiceBuilder::new()
+        let execution_service: execution::BoxCloneSyncService = ServiceBuilder::new()
             // We attach the subscription execution-side layer here instead of inside
             // the `ExecutionServiceFactory` because the subscription layer requires the
             // inner service is cloneable, and ESF does not produce a cloneable service.
@@ -592,7 +593,7 @@ impl PluggableSupergraphServiceBuilder {
             ))
             .buffered()
             .service(execution_service_factory.create())
-            .boxed_clone();
+            .boxed_clone_sync();
 
         let supergraph_service = SupergraphService::builder()
             .query_planner_service(query_planner_service.clone())
@@ -611,7 +612,7 @@ impl PluggableSupergraphServiceBuilder {
                     self.plugins
                         .iter()
                         .rev()
-                        .fold(supergraph_service.boxed(), |acc, (_, e)| {
+                        .fold(supergraph_service.boxed_clone_sync(), |acc, (_, e)| {
                             e.supergraph_service(acc)
                         }),
                 )
@@ -658,24 +659,15 @@ impl HasSchema for SupergraphCreator {
 }
 
 impl ServiceFactory<supergraph::Request> for SupergraphCreator {
-    type Service = supergraph::BoxService;
+    type Service = supergraph::BoxCloneSyncService;
     fn create(&self) -> Self::Service {
-        self.make().boxed()
+        self.make()
     }
 }
 
 impl SupergraphCreator {
-    pub(crate) fn make(
-        &self,
-    ) -> impl Service<
-        supergraph::Request,
-        Response = supergraph::Response,
-        Error = BoxError,
-        Future = BoxFuture<'static, supergraph::ServiceResult>,
-    > + Send
-    + use<> {
-        // Note: We have to box our cloned service to erase the type of the Buffer.
-        self.sb.clone().boxed()
+    pub(crate) fn make(&self) -> supergraph::BoxCloneSyncService {
+        self.sb.clone().boxed_clone_sync()
     }
 
     pub(crate) fn previous_cache(&self) -> InMemoryCachePlanner {

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -31,7 +31,6 @@ use crate::graphql::IntoGraphQLErrors;
 use crate::json_ext::Object;
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::layers::ServiceBuilderExt;
-use crate::layers::ServiceExt as _;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugin::DynPlugin;
 use crate::plugins::connectors::query_plans::store_connectors;
@@ -79,7 +78,7 @@ pub(crate) type Plugins = IndexMap<String, Box<dyn DynPlugin>>;
 #[derive(Clone)]
 pub(crate) struct SupergraphService {
     query_planner_service: CachingQueryPlanner<QueryPlannerService>,
-    execution_service: execution::BoxCloneSyncService,
+    execution_service: execution::BoxCloneService,
     schema: Arc<Schema>,
     strict_variable_validation: Mode,
 }
@@ -89,7 +88,7 @@ impl SupergraphService {
     #[builder]
     pub(crate) fn new(
         query_planner_service: CachingQueryPlanner<QueryPlannerService>,
-        execution_service: execution::BoxCloneSyncService,
+        execution_service: execution::BoxCloneService,
         schema: Arc<Schema>,
         strict_variable_validation: Mode,
     ) -> Self {
@@ -155,7 +154,7 @@ impl Service<SupergraphRequest> for SupergraphService {
 
 async fn service_call(
     planning: CachingQueryPlanner<QueryPlannerService>,
-    execution_service: execution::BoxCloneSyncService,
+    execution_service: execution::BoxCloneService,
     schema: Arc<Schema>,
     req: SupergraphRequest,
     strict_variable_validation: Mode,
@@ -449,7 +448,7 @@ async fn plan_query(
 ///
 /// This is at the heart of the delegation of responsibility model for the router. A schema,
 /// collection of plugins, collection of subgraph services are assembled to generate a
-/// [`tower::util::BoxCloneSyncService`] capable of processing a router request
+/// [`tower::util::BoxCloneService`] capable of processing a router request
 /// through the entire stack to return a response.
 pub(crate) struct PluggableSupergraphServiceBuilder {
     plugins: Arc<Plugins>,
@@ -584,7 +583,7 @@ impl PluggableSupergraphServiceBuilder {
             configuration: Arc::clone(&configuration),
         };
 
-        let execution_service: execution::BoxCloneSyncService = ServiceBuilder::new()
+        let execution_service: execution::BoxCloneService = ServiceBuilder::new()
             // We attach the subscription execution-side layer here instead of inside
             // the `ExecutionServiceFactory` because the subscription layer requires the
             // inner service is cloneable, and ESF does not produce a cloneable service.
@@ -593,7 +592,7 @@ impl PluggableSupergraphServiceBuilder {
             ))
             .buffered()
             .service(execution_service_factory.create())
-            .boxed_clone_sync();
+            .boxed_clone();
 
         let supergraph_service = SupergraphService::builder()
             .query_planner_service(query_planner_service.clone())
@@ -612,11 +611,11 @@ impl PluggableSupergraphServiceBuilder {
                     self.plugins
                         .iter()
                         .rev()
-                        .fold(supergraph_service.boxed_clone_sync(), |acc, (_, e)| {
+                        .fold(supergraph_service.boxed_clone(), |acc, (_, e)| {
                             e.supergraph_service(acc)
                         }),
                 )
-                .boxed(),
+                .boxed_clone(),
             DEFAULT_BUFFER_SIZE,
         );
 
@@ -659,15 +658,15 @@ impl HasSchema for SupergraphCreator {
 }
 
 impl ServiceFactory<supergraph::Request> for SupergraphCreator {
-    type Service = supergraph::BoxCloneSyncService;
+    type Service = supergraph::BoxCloneService;
     fn create(&self) -> Self::Service {
         self.make()
     }
 }
 
 impl SupergraphCreator {
-    pub(crate) fn make(&self) -> supergraph::BoxCloneSyncService {
-        self.sb.clone().boxed_clone_sync()
+    pub(crate) fn make(&self) -> supergraph::BoxCloneService {
+        self.sb.clone().boxed_clone()
     }
 
     pub(crate) fn previous_cache(&self) -> InMemoryCachePlanner {

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -11,6 +11,7 @@ use crate::Context;
 use crate::Notify;
 use crate::TestHarness;
 use crate::graphql;
+use crate::layers::ServiceExt as _;
 use crate::plugin::test::MockSubgraph;
 use crate::services::router::ClientRequestAccepts;
 use crate::services::subgraph;
@@ -3216,7 +3217,7 @@ async fn id_scalar_can_overflow_i32() {
                 let id = &request.subgraph_request.body().variables["id"];
                 Err(format!("$id = {id}").into())
             })
-            .boxed()
+            .boxed_clone_sync()
         })
         .build_supergraph()
         .await

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -11,7 +11,6 @@ use crate::Context;
 use crate::Notify;
 use crate::TestHarness;
 use crate::graphql;
-use crate::layers::ServiceExt as _;
 use crate::plugin::test::MockSubgraph;
 use crate::services::router::ClientRequestAccepts;
 use crate::services::subgraph;
@@ -3217,7 +3216,7 @@ async fn id_scalar_can_overflow_i32() {
                 let id = &request.subgraph_request.body().variables["id"];
                 Err(format!("$id = {id}").into())
             })
-            .boxed_clone_sync()
+            .boxed_clone()
         })
         .build_supergraph()
         .await

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -2024,14 +2024,14 @@ mod tests {
         MyRouterFactory {}
 
         impl RouterFactory for MyRouterFactory {
-            type RouterService = router::BoxCloneSyncService;
+            type RouterService = router::BoxCloneService;
             type Future = <Self::RouterService as Service<RouterRequest>>::Future;
             fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint>;
             fn pipeline_ref(&self) -> Arc<PipelineRef>;
         }
         impl ServiceFactory<RouterRequest> for MyRouterFactory {
-            type Service = router::BoxCloneSyncService;
-            fn create(&self) -> router::BoxCloneSyncService;
+            type Service = router::BoxCloneService;
+            fn create(&self) -> router::BoxCloneService;
         }
 
         impl Clone for MyRouterFactory {

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -2024,14 +2024,14 @@ mod tests {
         MyRouterFactory {}
 
         impl RouterFactory for MyRouterFactory {
-            type RouterService = router::BoxService;
+            type RouterService = router::BoxCloneSyncService;
             type Future = <Self::RouterService as Service<RouterRequest>>::Future;
             fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint>;
             fn pipeline_ref(&self) -> Arc<PipelineRef>;
         }
         impl ServiceFactory<RouterRequest> for MyRouterFactory {
-            type Service = router::BoxService;
-            fn create(&self) -> router::BoxService;
+            type Service = router::BoxCloneSyncService;
+            fn create(&self) -> router::BoxCloneSyncService;
         }
 
         impl Clone for MyRouterFactory {

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -271,7 +271,10 @@ impl<'a> TestHarness<'a> {
     /// Adds a callback-based hook similar to [`Plugin::execution_service`]
     pub fn execution_hook(
         self,
-        callback: impl Fn(execution::BoxService) -> execution::BoxService + Send + Sync + 'static,
+        callback: impl Fn(execution::BoxCloneSyncService) -> execution::BoxCloneSyncService
+        + Send
+        + Sync
+        + 'static,
     ) -> Self {
         self.extra_plugin(ExecutionServicePlugin(callback))
     }
@@ -478,7 +481,7 @@ where
 #[async_trait::async_trait]
 impl<F> Plugin for ExecutionServicePlugin<F>
 where
-    F: 'static + Send + Sync + Fn(execution::BoxService) -> execution::BoxService,
+    F: 'static + Send + Sync + Fn(execution::BoxCloneSyncService) -> execution::BoxCloneSyncService,
 {
     type Config = ();
 
@@ -486,7 +489,10 @@ where
         unreachable!()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         (self.0)(service)
     }
 }

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -20,7 +20,6 @@ use crate::axum_factory::utils::PropagatingMakeSpan;
 use crate::configuration::Configuration;
 use crate::configuration::ConfigurationError;
 use crate::graphql;
-use crate::layers::ServiceExt as _;
 use crate::plugin::DynPlugin;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
@@ -255,10 +254,7 @@ impl<'a> TestHarness<'a> {
     /// Adds a callback-based hook similar to [`Plugin::router_service`]
     pub fn router_hook(
         self,
-        callback: impl Fn(router::BoxCloneSyncService) -> router::BoxCloneSyncService
-        + Send
-        + Sync
-        + 'static,
+        callback: impl Fn(router::BoxCloneService) -> router::BoxCloneService + Send + Sync + 'static,
     ) -> Self {
         self.extra_plugin(RouterServicePlugin(callback))
     }
@@ -266,7 +262,7 @@ impl<'a> TestHarness<'a> {
     /// Adds a callback-based hook similar to [`Plugin::supergraph_service`]
     pub fn supergraph_hook(
         self,
-        callback: impl Fn(supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService
+        callback: impl Fn(supergraph::BoxCloneService) -> supergraph::BoxCloneService
         + Send
         + Sync
         + 'static,
@@ -277,7 +273,7 @@ impl<'a> TestHarness<'a> {
     /// Adds a callback-based hook similar to [`Plugin::execution_service`]
     pub fn execution_hook(
         self,
-        callback: impl Fn(execution::BoxCloneSyncService) -> execution::BoxCloneSyncService
+        callback: impl Fn(execution::BoxCloneService) -> execution::BoxCloneService
         + Send
         + Sync
         + 'static,
@@ -288,7 +284,7 @@ impl<'a> TestHarness<'a> {
     /// Adds a callback-based hook similar to [`Plugin::subgraph_service`]
     pub fn subgraph_hook(
         self,
-        callback: impl Fn(&str, subgraph::BoxCloneSyncService) -> subgraph::BoxCloneSyncService
+        callback: impl Fn(&str, subgraph::BoxCloneService) -> subgraph::BoxCloneService
         + Send
         + Sync
         + 'static,
@@ -350,7 +346,7 @@ impl<'a> TestHarness<'a> {
     }
 
     /// Builds the supergraph service
-    pub async fn build_supergraph(self) -> Result<supergraph::BoxCloneSyncService, BoxError> {
+    pub async fn build_supergraph(self) -> Result<supergraph::BoxCloneService, BoxError> {
         let (config, schema, supergraph_creator) = self.build_common().await?;
 
         Ok(tower::service_fn(move |request: supergraph::Request| {
@@ -383,7 +379,7 @@ impl<'a> TestHarness<'a> {
 
             async move { router.oneshot(request).await }
         })
-        .boxed_clone_sync())
+        .boxed_clone())
     }
 
     /// Builds the router service
@@ -455,7 +451,7 @@ struct SubgraphServicePlugin<F>(F);
 #[async_trait::async_trait]
 impl<F> Plugin for RouterServicePlugin<F>
 where
-    F: 'static + Send + Sync + Fn(router::BoxCloneSyncService) -> router::BoxCloneSyncService,
+    F: 'static + Send + Sync + Fn(router::BoxCloneService) -> router::BoxCloneService,
 {
     type Config = ();
 
@@ -463,7 +459,7 @@ where
         unreachable!()
     }
 
-    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
+    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
         (self.0)(service)
     }
 }
@@ -471,10 +467,7 @@ where
 #[async_trait::async_trait]
 impl<F> Plugin for SupergraphServicePlugin<F>
 where
-    F: 'static
-        + Send
-        + Sync
-        + Fn(supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService,
+    F: 'static + Send + Sync + Fn(supergraph::BoxCloneService) -> supergraph::BoxCloneService,
 {
     type Config = ();
 
@@ -484,8 +477,8 @@ where
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         (self.0)(service)
     }
 }
@@ -493,7 +486,7 @@ where
 #[async_trait::async_trait]
 impl<F> Plugin for ExecutionServicePlugin<F>
 where
-    F: 'static + Send + Sync + Fn(execution::BoxCloneSyncService) -> execution::BoxCloneSyncService,
+    F: 'static + Send + Sync + Fn(execution::BoxCloneService) -> execution::BoxCloneService,
 {
     type Config = ();
 
@@ -501,10 +494,7 @@ where
         unreachable!()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         (self.0)(service)
     }
 }
@@ -512,10 +502,7 @@ where
 #[async_trait::async_trait]
 impl<F> Plugin for SubgraphServicePlugin<F>
 where
-    F: 'static
-        + Send
-        + Sync
-        + Fn(&str, subgraph::BoxCloneSyncService) -> subgraph::BoxCloneSyncService,
+    F: 'static + Send + Sync + Fn(&str, subgraph::BoxCloneService) -> subgraph::BoxCloneService,
 {
     type Config = ();
 
@@ -526,8 +513,8 @@ where
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         (self.0)(subgraph_name, service)
     }
 }
@@ -554,11 +541,11 @@ impl Plugin for MockedSubgraphs {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        default: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        default: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         self.0
             .get(subgraph_name)
-            .map(|service| service.clone().boxed_clone_sync())
+            .map(|service| service.clone().boxed_clone())
             .unwrap_or(default)
     }
 }

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -255,7 +255,10 @@ impl<'a> TestHarness<'a> {
     /// Adds a callback-based hook similar to [`Plugin::router_service`]
     pub fn router_hook(
         self,
-        callback: impl Fn(router::BoxService) -> router::BoxService + Send + Sync + 'static,
+        callback: impl Fn(router::BoxCloneSyncService) -> router::BoxCloneSyncService
+        + Send
+        + Sync
+        + 'static,
     ) -> Self {
         self.extra_plugin(RouterServicePlugin(callback))
     }
@@ -452,7 +455,7 @@ struct SubgraphServicePlugin<F>(F);
 #[async_trait::async_trait]
 impl<F> Plugin for RouterServicePlugin<F>
 where
-    F: 'static + Send + Sync + Fn(router::BoxService) -> router::BoxService,
+    F: 'static + Send + Sync + Fn(router::BoxCloneSyncService) -> router::BoxCloneSyncService,
 {
     type Config = ();
 
@@ -460,7 +463,7 @@ where
         unreachable!()
     }
 
-    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+    fn router_service(&self, service: router::BoxCloneSyncService) -> router::BoxCloneSyncService {
         (self.0)(service)
     }
 }

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -20,6 +20,7 @@ use crate::axum_factory::utils::PropagatingMakeSpan;
 use crate::configuration::Configuration;
 use crate::configuration::ConfigurationError;
 use crate::graphql;
+use crate::layers::ServiceExt as _;
 use crate::plugin::DynPlugin;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
@@ -278,7 +279,10 @@ impl<'a> TestHarness<'a> {
     /// Adds a callback-based hook similar to [`Plugin::subgraph_service`]
     pub fn subgraph_hook(
         self,
-        callback: impl Fn(&str, subgraph::BoxService) -> subgraph::BoxService + Send + Sync + 'static,
+        callback: impl Fn(&str, subgraph::BoxCloneSyncService) -> subgraph::BoxCloneSyncService
+        + Send
+        + Sync
+        + 'static,
     ) -> Self {
         self.extra_plugin(SubgraphServicePlugin(callback))
     }
@@ -490,7 +494,10 @@ where
 #[async_trait::async_trait]
 impl<F> Plugin for SubgraphServicePlugin<F>
 where
-    F: 'static + Send + Sync + Fn(&str, subgraph::BoxService) -> subgraph::BoxService,
+    F: 'static
+        + Send
+        + Sync
+        + Fn(&str, subgraph::BoxCloneSyncService) -> subgraph::BoxCloneSyncService,
 {
     type Config = ();
 
@@ -501,8 +508,8 @@ where
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         (self.0)(subgraph_name, service)
     }
 }
@@ -529,11 +536,11 @@ impl Plugin for MockedSubgraphs {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        default: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        default: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         self.0
             .get(subgraph_name)
-            .map(|service| service.clone().boxed())
+            .map(|service| service.clone().boxed_clone_sync())
             .unwrap_or(default)
     }
 }

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -263,7 +263,10 @@ impl<'a> TestHarness<'a> {
     /// Adds a callback-based hook similar to [`Plugin::supergraph_service`]
     pub fn supergraph_hook(
         self,
-        callback: impl Fn(supergraph::BoxService) -> supergraph::BoxService + Send + Sync + 'static,
+        callback: impl Fn(supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService
+        + Send
+        + Sync
+        + 'static,
     ) -> Self {
         self.extra_plugin(SupergraphServicePlugin(callback))
     }
@@ -344,7 +347,7 @@ impl<'a> TestHarness<'a> {
     }
 
     /// Builds the supergraph service
-    pub async fn build_supergraph(self) -> Result<supergraph::BoxCloneService, BoxError> {
+    pub async fn build_supergraph(self) -> Result<supergraph::BoxCloneSyncService, BoxError> {
         let (config, schema, supergraph_creator) = self.build_common().await?;
 
         Ok(tower::service_fn(move |request: supergraph::Request| {
@@ -377,7 +380,7 @@ impl<'a> TestHarness<'a> {
 
             async move { router.oneshot(request).await }
         })
-        .boxed_clone())
+        .boxed_clone_sync())
     }
 
     /// Builds the router service
@@ -465,7 +468,10 @@ where
 #[async_trait::async_trait]
 impl<F> Plugin for SupergraphServicePlugin<F>
 where
-    F: 'static + Send + Sync + Fn(supergraph::BoxService) -> supergraph::BoxService,
+    F: 'static
+        + Send
+        + Sync
+        + Fn(supergraph::BoxCloneSyncService) -> supergraph::BoxCloneSyncService,
 {
     type Config = ();
 
@@ -473,7 +479,10 @@ where
         unreachable!()
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         (self.0)(service)
     }
 }

--- a/apollo-router/tests/integration/entity_cache.rs
+++ b/apollo-router/tests/integration/entity_cache.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
 use apollo_router::graphql;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::services;
 use apollo_router::test_harness::HttpService;
 use http::HeaderMap;
@@ -96,7 +97,7 @@ async fn harness(
                         counter.fetch_add(1, Ordering::Relaxed);
                         req
                     })
-                    .boxed()
+                    .boxed_clone_sync()
             } else {
                 service
             }

--- a/apollo-router/tests/integration/entity_cache.rs
+++ b/apollo-router/tests/integration/entity_cache.rs
@@ -3,7 +3,6 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
 use apollo_router::graphql;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::services;
 use apollo_router::test_harness::HttpService;
 use http::HeaderMap;
@@ -97,7 +96,7 @@ async fn harness(
                         counter.fetch_add(1, Ordering::Relaxed);
                         req
                     })
-                    .boxed_clone_sync()
+                    .boxed_clone()
             } else {
                 service
             }

--- a/apollo-router/tests/integration/introspection.rs
+++ b/apollo-router/tests/integration/introspection.rs
@@ -1,3 +1,4 @@
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::test::MockSubgraph;
 use apollo_router::services::supergraph::Request;
 use serde_json::json;
@@ -355,7 +356,7 @@ async fn make_request_with_extra_config(
                     json!({"data": {"me": {"id": 1}}}),
                 )
                 .build()
-                .boxed(),
+                .boxed_clone_sync(),
             _ => default,
         })
         .build_supergraph()

--- a/apollo-router/tests/integration/introspection.rs
+++ b/apollo-router/tests/integration/introspection.rs
@@ -1,4 +1,3 @@
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::test::MockSubgraph;
 use apollo_router::services::supergraph::Request;
 use serde_json::json;
@@ -356,7 +355,7 @@ async fn make_request_with_extra_config(
                     json!({"data": {"me": {"id": 1}}}),
                 )
                 .build()
-                .boxed_clone_sync(),
+                .boxed_clone(),
             _ => default,
         })
         .build_supergraph()

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -408,7 +408,10 @@ macro_rules! make_plugin {
                     Ok(Self)
                 }
 
-                fn router_service(&self, service: router::BoxService) -> router::BoxService {
+                fn router_service(
+                    &self,
+                    service: router::BoxCloneSyncService,
+                ) -> router::BoxCloneSyncService {
                     ServiceBuilder::new()
                         .map_request(|request: router::Request| {
                             test_plugin_ordering_push_trace(
@@ -425,7 +428,7 @@ macro_rules! make_plugin {
                             response
                         })
                         .service(service)
-                        .boxed()
+                        .boxed_clone_sync()
                 }
 
                 fn supergraph_service(

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -385,7 +385,7 @@ async fn test_plugin_ordering() {
 macro_rules! make_plugin {
     ($mod_name: ident, $str_name: expr) => {
         mod $mod_name {
-            use apollo_router::layers::ServiceExt as _;
+            use tower::ServiceExt;
 
             use super::*;
 
@@ -410,8 +410,8 @@ macro_rules! make_plugin {
 
                 fn router_service(
                     &self,
-                    service: router::BoxCloneSyncService,
-                ) -> router::BoxCloneSyncService {
+                    service: router::BoxCloneService,
+                ) -> router::BoxCloneService {
                     ServiceBuilder::new()
                         .map_request(|request: router::Request| {
                             test_plugin_ordering_push_trace(
@@ -428,13 +428,13 @@ macro_rules! make_plugin {
                             response
                         })
                         .service(service)
-                        .boxed_clone_sync()
+                        .boxed_clone()
                 }
 
                 fn supergraph_service(
                     &self,
-                    service: supergraph::BoxCloneSyncService,
-                ) -> supergraph::BoxCloneSyncService {
+                    service: supergraph::BoxCloneService,
+                ) -> supergraph::BoxCloneService {
                     ServiceBuilder::new()
                         .map_request(|request: supergraph::Request| {
                             test_plugin_ordering_push_trace(
@@ -451,7 +451,7 @@ macro_rules! make_plugin {
                             response
                         })
                         .service(service)
-                        .boxed_clone_sync()
+                        .boxed_clone()
                 }
             }
         }

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -385,6 +385,8 @@ async fn test_plugin_ordering() {
 macro_rules! make_plugin {
     ($mod_name: ident, $str_name: expr) => {
         mod $mod_name {
+            use apollo_router::layers::ServiceExt as _;
+
             use super::*;
 
             #[derive(Deserialize, JsonSchema)]
@@ -428,8 +430,8 @@ macro_rules! make_plugin {
 
                 fn supergraph_service(
                     &self,
-                    service: supergraph::BoxService,
-                ) -> supergraph::BoxService {
+                    service: supergraph::BoxCloneSyncService,
+                ) -> supergraph::BoxCloneSyncService {
                     ServiceBuilder::new()
                         .map_request(|request: supergraph::Request| {
                             test_plugin_ordering_push_trace(
@@ -446,7 +448,7 @@ macro_rules! make_plugin {
                             response
                         })
                         .service(service)
-                        .boxed()
+                        .boxed_clone_sync()
                 }
             }
         }

--- a/apollo-router/tests/integration/operation_limits.rs
+++ b/apollo-router/tests/integration/operation_limits.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::Ordering;
 use apollo_compiler::parser::Parser;
 use apollo_router::TestHarness;
 use apollo_router::graphql;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::services::execution;
 use apollo_router::services::supergraph;
 use serde_json::json;
@@ -367,7 +368,7 @@ async fn build_test_harness(
                         .unwrap())
                 }
             })
-            .boxed()
+            .boxed_clone_sync()
         })
         .build_supergraph()
         .await

--- a/apollo-router/tests/integration/operation_limits.rs
+++ b/apollo-router/tests/integration/operation_limits.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::Ordering;
 use apollo_compiler::parser::Parser;
 use apollo_router::TestHarness;
 use apollo_router::graphql;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::services::execution;
 use apollo_router::services::supergraph;
 use serde_json::json;
@@ -341,7 +340,7 @@ limits:
 
 async fn build_test_harness(
     limits_config: serde_json::Value,
-) -> (supergraph::BoxCloneSyncService, impl Fn() -> u32) {
+) -> (supergraph::BoxCloneService, impl Fn() -> u32) {
     let execution_count = Arc::new(AtomicU32::new(0));
     let execution_count_2 = execution_count.clone();
     let get_execution_count = move || execution_count_2.load(Ordering::Acquire);
@@ -368,7 +367,7 @@ async fn build_test_harness(
                         .unwrap())
                 }
             })
-            .boxed_clone_sync()
+            .boxed_clone()
         })
         .build_supergraph()
         .await
@@ -376,10 +375,7 @@ async fn build_test_harness(
     (service, get_execution_count)
 }
 
-async fn run_request(
-    service: &mut supergraph::BoxCloneSyncService,
-    query: &str,
-) -> graphql::Response {
+async fn run_request(service: &mut supergraph::BoxCloneService, query: &str) -> graphql::Response {
     let request = supergraph::Request::fake_builder()
         .query(query)
         .build()

--- a/apollo-router/tests/integration/operation_limits.rs
+++ b/apollo-router/tests/integration/operation_limits.rs
@@ -341,7 +341,7 @@ limits:
 
 async fn build_test_harness(
     limits_config: serde_json::Value,
-) -> (supergraph::BoxCloneService, impl Fn() -> u32) {
+) -> (supergraph::BoxCloneSyncService, impl Fn() -> u32) {
     let execution_count = Arc::new(AtomicU32::new(0));
     let execution_count_2 = execution_count.clone();
     let get_execution_count = move || execution_count_2.load(Ordering::Acquire);
@@ -376,7 +376,10 @@ async fn build_test_harness(
     (service, get_execution_count)
 }
 
-async fn run_request(service: &mut supergraph::BoxCloneService, query: &str) -> graphql::Response {
+async fn run_request(
+    service: &mut supergraph::BoxCloneSyncService,
+    query: &str,
+) -> graphql::Response {
     let request = supergraph::Request::fake_builder()
         .query(query)
         .build()

--- a/apollo-router/tests/integration/operation_name.rs
+++ b/apollo-router/tests/integration/operation_name.rs
@@ -1,5 +1,4 @@
 use apollo_router::graphql::Request;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::test::MockSubgraph;
 use serde_json::json;
 use tower::ServiceExt;
@@ -185,7 +184,7 @@ async fn make_request(request: Request) -> apollo_router::graphql::Response {
                     json!({"data": {"me": {"id": 1}}}),
                 )
                 .build()
-                .boxed_clone_sync(),
+                .boxed_clone(),
             _ => default,
         })
         .build_router()

--- a/apollo-router/tests/integration/operation_name.rs
+++ b/apollo-router/tests/integration/operation_name.rs
@@ -1,4 +1,5 @@
 use apollo_router::graphql::Request;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::test::MockSubgraph;
 use serde_json::json;
 use tower::ServiceExt;
@@ -184,7 +185,7 @@ async fn make_request(request: Request) -> apollo_router::graphql::Response {
                     json!({"data": {"me": {"id": 1}}}),
                 )
                 .build()
-                .boxed(),
+                .boxed_clone_sync(),
             _ => default,
         })
         .build_router()

--- a/apollo-router/tests/integration/response_cache.rs
+++ b/apollo-router/tests/integration/response_cache.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use apollo_router::graphql;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::services::router;
 use apollo_router::services::router::body::RouterBody;
 use apollo_router::services::supergraph;
@@ -286,7 +287,7 @@ async fn harness(
                         counter.fetch_add(1, Ordering::Relaxed);
                         req
                     })
-                    .boxed()
+                    .boxed_clone_sync()
             } else {
                 service
             }

--- a/apollo-router/tests/integration/response_cache.rs
+++ b/apollo-router/tests/integration/response_cache.rs
@@ -4,7 +4,6 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use apollo_router::graphql;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::services::router;
 use apollo_router::services::router::body::RouterBody;
 use apollo_router::services::supergraph;
@@ -287,7 +286,7 @@ async fn harness(
                         counter.fetch_add(1, Ordering::Relaxed);
                         req
                     })
-                    .boxed_clone_sync()
+                    .boxed_clone()
             } else {
                 service
             }

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -12,6 +12,7 @@ use apollo_router::Configuration;
 use apollo_router::Context;
 use apollo_router::graphql;
 use apollo_router::graphql::Error;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::services::router;
@@ -1396,8 +1397,8 @@ impl Plugin for CountingServiceRegistry {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         let name = subgraph_name.to_owned();
         let counters = self.clone();
         service
@@ -1405,7 +1406,7 @@ impl Plugin for CountingServiceRegistry {
                 counters.increment(&name);
                 request
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -12,7 +12,6 @@ use apollo_router::Configuration;
 use apollo_router::Context;
 use apollo_router::graphql;
 use apollo_router::graphql::Error;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::services::router;
@@ -1397,8 +1396,8 @@ impl Plugin for CountingServiceRegistry {
     fn subgraph_service(
         &self,
         subgraph_name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         let name = subgraph_name.to_owned();
         let counters = self.clone();
         service
@@ -1406,7 +1405,7 @@ impl Plugin for CountingServiceRegistry {
                 counters.increment(&name);
                 request
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/apollo-router/tests/tracing_common/mod.rs
+++ b/apollo-router/tests/tracing_common/mod.rs
@@ -1,3 +1,4 @@
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::test::MockSubgraph;
 use apollo_router::services::subgraph;
 use base64::Engine as _;
@@ -9,7 +10,6 @@ use proto::reports::trace::Node;
 use proto::reports::trace::node::Id::Index;
 use proto::reports::trace::node::Id::ResponseName;
 use serde_json::json;
-use tower::ServiceExt;
 
 #[allow(unreachable_pub)]
 pub(crate) mod proto {
@@ -23,7 +23,7 @@ pub(crate) fn encode_ftv1(trace: Trace) -> String {
     BASE64_STANDARD.encode(trace.encode_to_vec())
 }
 
-pub(crate) fn subgraph_mocks(subgraph: &str) -> subgraph::BoxService {
+pub(crate) fn subgraph_mocks(subgraph: &str) -> subgraph::BoxCloneSyncService {
     let builder = MockSubgraph::builder();
     // base64 FTV1 blobs were manually captured from un-mocked responses
     if subgraph == "products" {
@@ -553,5 +553,5 @@ pub(crate) fn subgraph_mocks(subgraph: &str) -> subgraph::BoxService {
       builder
   }
   .build()
-  .boxed()
+  .boxed_clone_sync()
 }

--- a/apollo-router/tests/tracing_common/mod.rs
+++ b/apollo-router/tests/tracing_common/mod.rs
@@ -1,4 +1,3 @@
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::test::MockSubgraph;
 use apollo_router::services::subgraph;
 use base64::Engine as _;
@@ -10,6 +9,7 @@ use proto::reports::trace::Node;
 use proto::reports::trace::node::Id::Index;
 use proto::reports::trace::node::Id::ResponseName;
 use serde_json::json;
+use tower::ServiceExt;
 
 #[allow(unreachable_pub)]
 pub(crate) mod proto {
@@ -23,7 +23,7 @@ pub(crate) fn encode_ftv1(trace: Trace) -> String {
     BASE64_STANDARD.encode(trace.encode_to_vec())
 }
 
-pub(crate) fn subgraph_mocks(subgraph: &str) -> subgraph::BoxCloneSyncService {
+pub(crate) fn subgraph_mocks(subgraph: &str) -> subgraph::BoxCloneService {
     let builder = MockSubgraph::builder();
     // base64 FTV1 blobs were manually captured from un-mocked responses
     if subgraph == "products" {
@@ -553,5 +553,5 @@ pub(crate) fn subgraph_mocks(subgraph: &str) -> subgraph::BoxCloneSyncService {
       builder
   }
   .build()
-  .boxed_clone_sync()
+  .boxed_clone()
 }

--- a/docs/source/routing/customization/native-plugins.mdx
+++ b/docs/source/routing/customization/native-plugins.mdx
@@ -94,22 +94,22 @@ impl Plugin for HelloWorld {
     // implementation returns its associated service with no changes.
     fn router_service(
         &self,
-        service: router::BoxCloneSyncService,
-    ) -> router::BoxCloneSyncService {
+        service: router::BoxCloneService,
+    ) -> router::BoxCloneService {
         service
     }
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         service
     }
 
     fn execution_service(
         &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+        service: execution::BoxCloneService,
+    ) -> execution::BoxCloneService {
         service
     }
 
@@ -119,8 +119,8 @@ impl Plugin for HelloWorld {
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         service
     }
 }
@@ -139,8 +139,8 @@ use apollo_router::ServiceBuilderExt as ApolloServiceBuilderExt;
 
 fn supergraph_service(
     &self,
-    service: router::BoxCloneSyncService,
-) -> router::BoxCloneSyncService {
+    service: router::BoxCloneService,
+) -> router::BoxCloneService {
     // Always use service builder to compose your plugins.
     // It provides off-the-shelf building blocks for your plugin.
     ServiceBuilder::new()
@@ -151,7 +151,7 @@ fn supergraph_service(
         // .checkpoint()
         // .timeout()
         .service(service)
-        .boxed_clone_sync()
+        .boxed_clone()
 }
 ```
 

--- a/docs/source/routing/customization/native-plugins.mdx
+++ b/docs/source/routing/customization/native-plugins.mdx
@@ -101,8 +101,8 @@ impl Plugin for HelloWorld {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxService,
-    ) -> supergraph::BoxService {
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         service
     }
 

--- a/docs/source/routing/customization/native-plugins.mdx
+++ b/docs/source/routing/customization/native-plugins.mdx
@@ -94,8 +94,8 @@ impl Plugin for HelloWorld {
     // implementation returns its associated service with no changes.
     fn router_service(
         &self,
-        service: router::BoxService,
-    ) -> router::BoxService {
+        service: router::BoxCloneSyncService,
+    ) -> router::BoxCloneSyncService {
         service
     }
 
@@ -139,8 +139,8 @@ use apollo_router::ServiceBuilderExt as ApolloServiceBuilderExt;
 
 fn supergraph_service(
     &self,
-    service: router::BoxService,
-) -> router::BoxService {
+    service: router::BoxCloneSyncService,
+) -> router::BoxCloneSyncService {
     // Always use service builder to compose your plugins.
     // It provides off-the-shelf building blocks for your plugin.
     ServiceBuilder::new()
@@ -151,7 +151,7 @@ fn supergraph_service(
         // .checkpoint()
         // .timeout()
         .service(service)
-        .boxed()
+        .boxed_clone_sync()
 }
 ```
 

--- a/docs/source/routing/customization/native-plugins.mdx
+++ b/docs/source/routing/customization/native-plugins.mdx
@@ -119,8 +119,8 @@ impl Plugin for HelloWorld {
     fn subgraph_service(
         &self,
         name: &str,
-        service: subgraph::BoxService,
-    ) -> subgraph::BoxService {
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         service
     }
 }

--- a/docs/source/routing/customization/native-plugins.mdx
+++ b/docs/source/routing/customization/native-plugins.mdx
@@ -108,8 +108,8 @@ impl Plugin for HelloWorld {
 
     fn execution_service(
         &self,
-        service: execution::BoxService,
-    ) -> execution::BoxService {
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         service
     }
 

--- a/examples/add-timestamp-header/rhai/src/main.rs
+++ b/examples/add-timestamp-header/rhai/src/main.rs
@@ -13,7 +13,6 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::supergraph;
     use http::StatusCode;
@@ -53,7 +52,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone())
             .build_router()
             .await
             .unwrap();

--- a/examples/add-timestamp-header/rhai/src/main.rs
+++ b/examples/add-timestamp-header/rhai/src/main.rs
@@ -13,6 +13,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::supergraph;
     use http::StatusCode;
@@ -52,7 +53,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
             .build_router()
             .await
             .unwrap();

--- a/examples/async-auth/rust/README.md
+++ b/examples/async-auth/rust/README.md
@@ -18,13 +18,13 @@ authentication server.
 ```rust
     fn supergraph_service(
         &mut self,
-        service: router::BoxService,
-    ) -> router::BoxService {
+        service: router::BoxCloneSyncService,
+    ) -> router::BoxCloneSyncService {
         ServiceBuilder::new()
             .checkpoint_async(...) // Authentication happens here
             .buffer(20_000) // Required, see note below
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 ```
 

--- a/examples/async-auth/rust/README.md
+++ b/examples/async-auth/rust/README.md
@@ -18,13 +18,13 @@ authentication server.
 ```rust
     fn supergraph_service(
         &mut self,
-        service: router::BoxCloneSyncService,
-    ) -> router::BoxCloneSyncService {
+        service: router::BoxCloneService,
+    ) -> router::BoxCloneService {
         ServiceBuilder::new()
             .checkpoint_async(...) // Authentication happens here
             .buffer(20_000) // Required, see note below
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 ```
 

--- a/examples/async-auth/rust/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/rust/src/allow_client_id_from_file.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -14,6 +13,7 @@ use serde::Deserialize;
 use serde_json_bytes::Value;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 // This structure is the one we'll deserialize the yml configuration into
 #[derive(Deserialize, JsonSchema)]
@@ -48,8 +48,8 @@ impl Plugin for AllowClientIdFromFile {
     // switching the async file read with an async http request
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         let header_key = self.header.clone();
         // async_checkpoint is an async function.
         // this means it will run whenever the service `await`s it
@@ -155,7 +155,7 @@ impl Plugin for AllowClientIdFromFile {
             .checkpoint_async(handler)
             .buffered()
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -177,7 +177,6 @@ register_plugin!(
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::plugin::PluginInit;
@@ -230,7 +229,7 @@ mod tests {
         let service_stack = AllowClientIdFromFile::new(init)
             .await
             .expect("couldn't create AllowClientIdFromFile")
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
         // Let's create a request without a client id...
         let request_without_client_id = supergraph::Request::fake_builder()
@@ -273,7 +272,7 @@ mod tests {
         let service_stack = AllowClientIdFromFile::new(init)
             .await
             .expect("couldn't create AllowClientIdFromFile")
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
         // Let's create a request with a not allowed client id...
         let request_with_unauthorized_client_id = supergraph::Request::fake_builder()
@@ -342,7 +341,7 @@ mod tests {
         let service_stack = AllowClientIdFromFile::new(init)
             .await
             .expect("couldn't create AllowClientIdFromFile")
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
         // Let's create a request with an valid client id...
         let request_with_valid_client_id = supergraph::Request::fake_builder()

--- a/examples/async-auth/rust/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/rust/src/allow_client_id_from_file.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -13,7 +14,6 @@ use serde::Deserialize;
 use serde_json_bytes::Value;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 // This structure is the one we'll deserialize the yml configuration into
 #[derive(Deserialize, JsonSchema)]
@@ -46,7 +46,10 @@ impl Plugin for AllowClientIdFromFile {
     // While this is not the most performant and efficient usecase,
     // We could easily change the place where the file list is stored,
     // switching the async file read with an async http request
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         let header_key = self.header.clone();
         // async_checkpoint is an async function.
         // this means it will run whenever the service `await`s it
@@ -152,7 +155,7 @@ impl Plugin for AllowClientIdFromFile {
             .checkpoint_async(handler)
             .buffered()
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -174,6 +177,7 @@ register_plugin!(
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::plugin::PluginInit;
@@ -226,7 +230,7 @@ mod tests {
         let service_stack = AllowClientIdFromFile::new(init)
             .await
             .expect("couldn't create AllowClientIdFromFile")
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
         // Let's create a request without a client id...
         let request_without_client_id = supergraph::Request::fake_builder()
@@ -269,7 +273,7 @@ mod tests {
         let service_stack = AllowClientIdFromFile::new(init)
             .await
             .expect("couldn't create AllowClientIdFromFile")
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
         // Let's create a request with a not allowed client id...
         let request_with_unauthorized_client_id = supergraph::Request::fake_builder()
@@ -338,7 +342,7 @@ mod tests {
         let service_stack = AllowClientIdFromFile::new(init)
             .await
             .expect("couldn't create AllowClientIdFromFile")
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
         // Let's create a request with an valid client id...
         let request_with_valid_client_id = supergraph::Request::fake_builder()

--- a/examples/cache-control/rhai/src/main.rs
+++ b/examples/cache-control/rhai/src/main.rs
@@ -8,7 +8,6 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::subgraph;
     use apollo_router::services::supergraph;
@@ -74,8 +73,8 @@ mod tests {
             .configuration_json(config)
             .unwrap()
             .subgraph_hook(move |name, _| match name {
-                "accounts" => mock_service1.clone().boxed_clone_sync(),
-                _ => mock_service2.clone().boxed_clone_sync(),
+                "accounts" => mock_service1.clone().boxed_clone(),
+                _ => mock_service2.clone().boxed_clone(),
             })
             // .log_level("DEBUG")
             .build_router()

--- a/examples/cache-control/rhai/src/main.rs
+++ b/examples/cache-control/rhai/src/main.rs
@@ -8,6 +8,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::subgraph;
     use apollo_router::services::supergraph;
@@ -73,8 +74,8 @@ mod tests {
             .configuration_json(config)
             .unwrap()
             .subgraph_hook(move |name, _| match name {
-                "accounts" => mock_service1.clone().boxed(),
-                _ => mock_service2.clone().boxed(),
+                "accounts" => mock_service1.clone().boxed_clone_sync(),
+                _ => mock_service2.clone().boxed_clone_sync(),
             })
             // .log_level("DEBUG")
             .build_router()

--- a/examples/context/rust/src/context_data.rs
+++ b/examples/context/rust/src/context_data.rs
@@ -42,7 +42,10 @@ impl Plugin for ContextData {
         Ok(Self::default())
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         // `ServiceBuilder` provides us with `map_request` and `map_response` methods.
         //
         // These allow basic interception and transformation of request and response messages.
@@ -66,7 +69,7 @@ impl Plugin for ContextData {
                 }
                 response
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn subgraph_service(

--- a/examples/context/rust/src/context_data.rs
+++ b/examples/context/rust/src/context_data.rs
@@ -1,4 +1,3 @@
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -44,8 +43,8 @@ impl Plugin for ContextData {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         // `ServiceBuilder` provides us with `map_request` and `map_response` methods.
         //
         // These allow basic interception and transformation of request and response messages.
@@ -69,14 +68,14 @@ impl Plugin for ContextData {
                 }
                 response
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     fn subgraph_service(
         &self,
         _name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         ServiceBuilder::new()
             .map_request(|req: subgraph::Request| {
                 // Pick up a value from the context that was populated earlier.
@@ -100,7 +99,7 @@ impl Plugin for ContextData {
                 }
                 resp
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/examples/context/rust/src/context_data.rs
+++ b/examples/context/rust/src/context_data.rs
@@ -1,3 +1,4 @@
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -68,7 +69,11 @@ impl Plugin for ContextData {
             .boxed()
     }
 
-    fn subgraph_service(&self, _name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        _name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         ServiceBuilder::new()
             .map_request(|req: subgraph::Request| {
                 // Pick up a value from the context that was populated earlier.
@@ -92,7 +97,7 @@ impl Plugin for ContextData {
                 }
                 resp
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/examples/cookies-to-headers/rhai/src/main.rs
+++ b/examples/cookies-to-headers/rhai/src/main.rs
@@ -33,11 +33,12 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::subgraph;
     use apollo_router::services::supergraph;
     use http::StatusCode;
-    use tower::util::ServiceExt;
+    use tower::util::ServiceExt as _;
 
     #[tokio::test]
     async fn test_subgraph_processes_cookies() {
@@ -87,7 +88,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .subgraph_hook(move |_, _| mock_service.clone().boxed())
+            .subgraph_hook(move |_, _| mock_service.clone().boxed_clone_sync())
             .supergraph_hook(|service| {
                 service
                     .map_response(|response| {

--- a/examples/cookies-to-headers/rhai/src/main.rs
+++ b/examples/cookies-to-headers/rhai/src/main.rs
@@ -33,7 +33,6 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::subgraph;
     use apollo_router::services::supergraph;
@@ -88,7 +87,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .subgraph_hook(move |_, _| mock_service.clone().boxed_clone_sync())
+            .subgraph_hook(move |_, _| mock_service.clone().boxed_clone())
             .supergraph_hook(|service| {
                 service
                     .map_response(|response| {
@@ -98,7 +97,7 @@ mod tests {
                             stream_item
                         })
                     })
-                    .boxed_clone_sync()
+                    .boxed_clone()
             })
             .build_router()
             .await

--- a/examples/cookies-to-headers/rhai/src/main.rs
+++ b/examples/cookies-to-headers/rhai/src/main.rs
@@ -98,7 +98,7 @@ mod tests {
                             stream_item
                         })
                     })
-                    .boxed()
+                    .boxed_clone_sync()
             })
             .build_router()
             .await

--- a/examples/coprocessor-subgraph/rust/src/echo_co_processor.rs
+++ b/examples/coprocessor-subgraph/rust/src/echo_co_processor.rs
@@ -1,6 +1,5 @@
 use std::net::SocketAddr;
 
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -18,6 +17,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tower::BoxError;
 use tower::Service;
+use tower::ServiceExt;
 
 #[derive(Debug)]
 struct EchoCoProcessor {
@@ -48,7 +48,7 @@ impl Plugin for EchoCoProcessor {
     // written in a language you're comfortable with.
     fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint> {
         let web_endpoint =
-            Endpoint::from_router_service("/".to_string(), SimpleEndpoint {}.boxed_clone_sync());
+            Endpoint::from_router_service("/".to_string(), SimpleEndpoint {}.boxed_clone());
 
         let mut endpoints = MultiMap::new();
         let socket_addr: SocketAddr = format!("127.0.0.1:{}", self.configuration.port)

--- a/examples/coprocessor-subgraph/rust/src/echo_co_processor.rs
+++ b/examples/coprocessor-subgraph/rust/src/echo_co_processor.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -17,7 +18,6 @@ use serde::Deserialize;
 use serde_json::json;
 use tower::BoxError;
 use tower::Service;
-use tower::ServiceExt;
 
 #[derive(Debug)]
 struct EchoCoProcessor {
@@ -48,7 +48,7 @@ impl Plugin for EchoCoProcessor {
     // written in a language you're comfortable with.
     fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint> {
         let web_endpoint =
-            Endpoint::from_router_service("/".to_string(), SimpleEndpoint {}.boxed());
+            Endpoint::from_router_service("/".to_string(), SimpleEndpoint {}.boxed_clone_sync());
 
         let mut endpoints = MultiMap::new();
         let socket_addr: SocketAddr = format!("127.0.0.1:{}", self.configuration.port)
@@ -62,6 +62,7 @@ impl Plugin for EchoCoProcessor {
 
 // This is a simple server, that will do a couple of transforms to payloads and return it.
 // In real life you will implement this outside the router, in your favorite language.
+#[derive(Clone)]
 struct SimpleEndpoint {}
 
 impl Service<router::Request> for SimpleEndpoint {

--- a/examples/forbid-anonymous-operations/rhai/src/main.rs
+++ b/examples/forbid-anonymous-operations/rhai/src/main.rs
@@ -12,7 +12,6 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::supergraph;
     use http::StatusCode;
@@ -36,7 +35,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone())
             .build_router()
             .await
             .unwrap();

--- a/examples/forbid-anonymous-operations/rhai/src/main.rs
+++ b/examples/forbid-anonymous-operations/rhai/src/main.rs
@@ -12,6 +12,7 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::supergraph;
     use http::StatusCode;
@@ -35,7 +36,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
             .build_router()
             .await
             .unwrap();

--- a/examples/forbid-anonymous-operations/rust/README.md
+++ b/examples/forbid-anonymous-operations/rust/README.md
@@ -15,11 +15,11 @@ cargo run -- -s ../../graphql/supergraph.graphql -c ./router.yaml
 ```rust
     fn supergraph_service(
         &mut self,
-        service: router::BoxCloneSyncService,
-    ) -> router::BoxCloneSyncService {
+        service: router::BoxCloneService,
+    ) -> router::BoxCloneService {
         ServiceBuilder::new()
             .checkpoint(...) // Validation happens here
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 ```

--- a/examples/forbid-anonymous-operations/rust/README.md
+++ b/examples/forbid-anonymous-operations/rust/README.md
@@ -15,11 +15,11 @@ cargo run -- -s ../../graphql/supergraph.graphql -c ./router.yaml
 ```rust
     fn supergraph_service(
         &mut self,
-        service: router::BoxService,
-    ) -> router::BoxService {
+        service: router::BoxCloneSyncService,
+    ) -> router::BoxCloneSyncService {
         ServiceBuilder::new()
             .checkpoint(...) // Validation happens here
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 ```

--- a/examples/forbid-anonymous-operations/rust/src/forbid_anonymous_operations.rs
+++ b/examples/forbid-anonymous-operations/rust/src/forbid_anonymous_operations.rs
@@ -2,6 +2,7 @@ use std::ops::ControlFlow;
 
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -9,7 +10,6 @@ use apollo_router::services::supergraph;
 use http::StatusCode;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 #[derive(Default)]
 // Global state for our plugin would live here.
@@ -31,7 +31,10 @@ impl Plugin for ForbidAnonymousOperations {
 
     // Forbidding anonymous operations can happen at the very beginning of our GraphQL request lifecycle.
     // We will thus put the logic it in the `supergraph_service` section of our plugin.
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         // `ServiceBuilder` provides us with a `checkpoint` method.
         //
         // This method allows us to return ControlFlow::Continue(request) if we want to let the request through,
@@ -72,7 +75,7 @@ impl Plugin for ForbidAnonymousOperations {
                 }
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -94,6 +97,7 @@ register_plugin!(
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::services::supergraph;
@@ -131,8 +135,8 @@ mod tests {
         let mock_service = test::MockSupergraphService::new();
 
         // In this service_stack, ForbidAnonymousOperations is `decorating` or `wrapping` our mock_service.
-        let service_stack =
-            ForbidAnonymousOperations::default().supergraph_service(mock_service.boxed());
+        let service_stack = ForbidAnonymousOperations::default()
+            .supergraph_service(mock_service.boxed_clone_sync());
 
         // Let's create a request without an operation name...
         let request_without_any_operation_name = supergraph::Request::fake_builder()
@@ -166,8 +170,8 @@ mod tests {
         let mock_service = test::MockSupergraphService::new();
 
         // In this service_stack, ForbidAnonymousOperations is `decorating` or `wrapping` our mock_service.
-        let service_stack =
-            ForbidAnonymousOperations::default().supergraph_service(mock_service.boxed());
+        let service_stack = ForbidAnonymousOperations::default()
+            .supergraph_service(mock_service.boxed_clone_sync());
 
         // Let's create a request with an empty operation name...
         let request_with_empty_operation_name = supergraph::Request::fake_builder()
@@ -226,8 +230,8 @@ mod tests {
             });
 
         // In this service_stack, ForbidAnonymousOperations is `decorating` or `wrapping` our mock_service.
-        let service_stack =
-            ForbidAnonymousOperations::default().supergraph_service(mock_service.boxed());
+        let service_stack = ForbidAnonymousOperations::default()
+            .supergraph_service(mock_service.boxed_clone_sync());
 
         // Let's create a request with an valid operation name...
         let request_with_operation_name = supergraph::Request::fake_builder()

--- a/examples/forbid-anonymous-operations/rust/src/forbid_anonymous_operations.rs
+++ b/examples/forbid-anonymous-operations/rust/src/forbid_anonymous_operations.rs
@@ -2,7 +2,6 @@ use std::ops::ControlFlow;
 
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -10,6 +9,7 @@ use apollo_router::services::supergraph;
 use http::StatusCode;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 #[derive(Default)]
 // Global state for our plugin would live here.
@@ -33,8 +33,8 @@ impl Plugin for ForbidAnonymousOperations {
     // We will thus put the logic it in the `supergraph_service` section of our plugin.
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         // `ServiceBuilder` provides us with a `checkpoint` method.
         //
         // This method allows us to return ControlFlow::Continue(request) if we want to let the request through,
@@ -75,7 +75,7 @@ impl Plugin for ForbidAnonymousOperations {
                 }
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -97,7 +97,6 @@ register_plugin!(
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::services::supergraph;
@@ -135,8 +134,8 @@ mod tests {
         let mock_service = test::MockSupergraphService::new();
 
         // In this service_stack, ForbidAnonymousOperations is `decorating` or `wrapping` our mock_service.
-        let service_stack = ForbidAnonymousOperations::default()
-            .supergraph_service(mock_service.boxed_clone_sync());
+        let service_stack =
+            ForbidAnonymousOperations::default().supergraph_service(mock_service.boxed_clone());
 
         // Let's create a request without an operation name...
         let request_without_any_operation_name = supergraph::Request::fake_builder()
@@ -170,8 +169,8 @@ mod tests {
         let mock_service = test::MockSupergraphService::new();
 
         // In this service_stack, ForbidAnonymousOperations is `decorating` or `wrapping` our mock_service.
-        let service_stack = ForbidAnonymousOperations::default()
-            .supergraph_service(mock_service.boxed_clone_sync());
+        let service_stack =
+            ForbidAnonymousOperations::default().supergraph_service(mock_service.boxed_clone());
 
         // Let's create a request with an empty operation name...
         let request_with_empty_operation_name = supergraph::Request::fake_builder()
@@ -230,8 +229,8 @@ mod tests {
             });
 
         // In this service_stack, ForbidAnonymousOperations is `decorating` or `wrapping` our mock_service.
-        let service_stack = ForbidAnonymousOperations::default()
-            .supergraph_service(mock_service.boxed_clone_sync());
+        let service_stack =
+            ForbidAnonymousOperations::default().supergraph_service(mock_service.boxed_clone());
 
         // Let's create a request with an valid operation name...
         let request_with_operation_name = supergraph::Request::fake_builder()

--- a/examples/hello-world/rust/src/hello_world.rs
+++ b/examples/hello-world/rust/src/hello_world.rs
@@ -1,3 +1,4 @@
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -59,7 +60,11 @@ impl Plugin for HelloWorld {
     }
 
     // Called for each subgraph
-    fn subgraph_service(&self, _name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        _name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         // Always use service builder to compose your plugins.
         // It provides off the shelf building blocks for your plugin.
         ServiceBuilder::new()
@@ -69,7 +74,7 @@ impl Plugin for HelloWorld {
             // .checkpoint()
             // .timeout()
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/examples/hello-world/rust/src/hello_world.rs
+++ b/examples/hello-world/rust/src/hello_world.rs
@@ -9,7 +9,6 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 #[derive(Debug)]
 struct HelloWorld {
@@ -34,7 +33,10 @@ impl Plugin for HelloWorld {
         })
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         // Say hello when our service is added to the router_service
         // stage of the router plugin pipeline.
         #[cfg(test)]
@@ -50,7 +52,7 @@ impl Plugin for HelloWorld {
             // .checkpoint()
             // .timeout()
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn execution_service(

--- a/examples/hello-world/rust/src/hello_world.rs
+++ b/examples/hello-world/rust/src/hello_world.rs
@@ -53,7 +53,10 @@ impl Plugin for HelloWorld {
             .boxed()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         //This is the default implementation and does not modify the default service.
         // The trait also has this implementation, and we just provide it here for illustration.
         service

--- a/examples/hello-world/rust/src/hello_world.rs
+++ b/examples/hello-world/rust/src/hello_world.rs
@@ -1,4 +1,3 @@
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -9,6 +8,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 #[derive(Debug)]
 struct HelloWorld {
@@ -35,8 +35,8 @@ impl Plugin for HelloWorld {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         // Say hello when our service is added to the router_service
         // stage of the router plugin pipeline.
         #[cfg(test)]
@@ -52,13 +52,10 @@ impl Plugin for HelloWorld {
             // .checkpoint()
             // .timeout()
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         //This is the default implementation and does not modify the default service.
         // The trait also has this implementation, and we just provide it here for illustration.
         service
@@ -68,8 +65,8 @@ impl Plugin for HelloWorld {
     fn subgraph_service(
         &self,
         _name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         // Always use service builder to compose your plugins.
         // It provides off the shelf building blocks for your plugin.
         ServiceBuilder::new()
@@ -79,7 +76,7 @@ impl Plugin for HelloWorld {
             // .checkpoint()
             // .timeout()
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/examples/jwt-claims/rhai/src/main.rs
+++ b/examples/jwt-claims/rhai/src/main.rs
@@ -34,7 +34,6 @@ fn main() -> Result<()> {
 mod tests {
 
     use apollo_router::graphql;
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::router;
     use apollo_router::services::supergraph;
@@ -103,7 +102,7 @@ mod tests {
         apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone())
             .build_router()
             .await
             .unwrap()

--- a/examples/jwt-claims/rhai/src/main.rs
+++ b/examples/jwt-claims/rhai/src/main.rs
@@ -34,6 +34,7 @@ fn main() -> Result<()> {
 mod tests {
 
     use apollo_router::graphql;
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::router;
     use apollo_router::services::supergraph;
@@ -102,7 +103,7 @@ mod tests {
         apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
             .build_router()
             .await
             .unwrap()

--- a/examples/logging/rhai/src/main.rs
+++ b/examples/logging/rhai/src/main.rs
@@ -14,7 +14,6 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::supergraph;
     use http::StatusCode;
@@ -53,7 +52,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone())
             .build_router()
             .await
             .unwrap();

--- a/examples/logging/rhai/src/main.rs
+++ b/examples/logging/rhai/src/main.rs
@@ -14,6 +14,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::supergraph;
     use http::StatusCode;
@@ -52,7 +53,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
             .build_router()
             .await
             .unwrap();

--- a/examples/op-name-to-header/rhai/src/main.rs
+++ b/examples/op-name-to-header/rhai/src/main.rs
@@ -13,6 +13,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::supergraph;
     use http::StatusCode;
@@ -59,7 +60,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
             .build_router()
             .await
             .unwrap();

--- a/examples/op-name-to-header/rhai/src/main.rs
+++ b/examples/op-name-to-header/rhai/src/main.rs
@@ -13,7 +13,6 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use apollo_router::graphql;
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::services::supergraph;
     use http::StatusCode;
@@ -60,7 +59,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .supergraph_hook(move |_| mock_service.clone().boxed_clone_sync())
+            .supergraph_hook(move |_| mock_service.clone().boxed_clone())
             .build_router()
             .await
             .unwrap();

--- a/examples/status-code-propagation/rust/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/rust/src/propagate_status_code.rs
@@ -1,4 +1,3 @@
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -37,8 +36,8 @@ impl Plugin for PropagateStatusCode {
     fn subgraph_service(
         &self,
         _name: &str,
-        service: subgraph::BoxCloneSyncService,
-    ) -> subgraph::BoxCloneSyncService {
+        service: subgraph::BoxCloneService,
+    ) -> subgraph::BoxCloneService {
         let all_status_codes = self.status_codes.clone();
         service
             .map_response(move |res| {
@@ -62,14 +61,14 @@ impl Plugin for PropagateStatusCode {
                 }
                 res
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
     // At this point, all subgraph_services will have pushed their status codes if they match the `watch list`.
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         service
             .map_response(move |mut res| {
                 if let Some(code) = res
@@ -82,7 +81,7 @@ impl Plugin for PropagateStatusCode {
                 }
                 res
             })
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 
@@ -96,7 +95,6 @@ register_plugin!("example", "propagate_status_code", PropagateStatusCode);
 // and test your plugins in isolation:
 #[cfg(test)]
 mod tests {
-    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::plugin::PluginInit;
@@ -156,7 +154,7 @@ mod tests {
         let service_stack = PropagateStatusCode::new(init)
             .await
             .expect("couldn't create plugin")
-            .subgraph_service("accounts", mock_service.boxed_clone_sync());
+            .subgraph_service("accounts", mock_service.boxed_clone());
 
         let subgraph_request = subgraph::Request::fake_builder().build();
 
@@ -192,7 +190,7 @@ mod tests {
         let service_stack = PropagateStatusCode::new(init)
             .await
             .expect("couldn't create plugin")
-            .subgraph_service("accounts", mock_service.boxed_clone_sync());
+            .subgraph_service("accounts", mock_service.boxed_clone());
 
         let subgraph_request = subgraph::Request::fake_builder().build();
 
@@ -238,7 +236,7 @@ mod tests {
         let service_stack = PropagateStatusCode::new(init)
             .await
             .expect("couldn't create plugin")
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
         let router_request = supergraph::Request::fake_builder()
             .build()
@@ -278,7 +276,7 @@ mod tests {
         let service_stack = PropagateStatusCode::new(init)
             .await
             .expect("couldn't create plugin")
-            .supergraph_service(mock_service.boxed_clone_sync());
+            .supergraph_service(mock_service.boxed_clone());
 
         let router_request = supergraph::Request::fake_builder()
             .build()

--- a/examples/status-code-propagation/rust/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/rust/src/propagate_status_code.rs
@@ -66,7 +66,10 @@ impl Plugin for PropagateStatusCode {
     }
 
     // At this point, all subgraph_services will have pushed their status codes if they match the `watch list`.
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         service
             .map_response(move |mut res| {
                 if let Some(code) = res
@@ -79,7 +82,7 @@ impl Plugin for PropagateStatusCode {
                 }
                 res
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 
@@ -235,7 +238,7 @@ mod tests {
         let service_stack = PropagateStatusCode::new(init)
             .await
             .expect("couldn't create plugin")
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
         let router_request = supergraph::Request::fake_builder()
             .build()
@@ -275,7 +278,7 @@ mod tests {
         let service_stack = PropagateStatusCode::new(init)
             .await
             .expect("couldn't create plugin")
-            .supergraph_service(mock_service.boxed());
+            .supergraph_service(mock_service.boxed_clone_sync());
 
         let router_request = supergraph::Request::fake_builder()
             .build()

--- a/examples/status-code-propagation/rust/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/rust/src/propagate_status_code.rs
@@ -1,3 +1,4 @@
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -33,7 +34,11 @@ impl Plugin for PropagateStatusCode {
         })
     }
 
-    fn subgraph_service(&self, _name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+    fn subgraph_service(
+        &self,
+        _name: &str,
+        service: subgraph::BoxCloneSyncService,
+    ) -> subgraph::BoxCloneSyncService {
         let all_status_codes = self.status_codes.clone();
         service
             .map_response(move |res| {
@@ -57,7 +62,7 @@ impl Plugin for PropagateStatusCode {
                 }
                 res
             })
-            .boxed()
+            .boxed_clone_sync()
     }
 
     // At this point, all subgraph_services will have pushed their status codes if they match the `watch list`.
@@ -88,6 +93,7 @@ register_plugin!("example", "propagate_status_code", PropagateStatusCode);
 // and test your plugins in isolation:
 #[cfg(test)]
 mod tests {
+    use apollo_router::layers::ServiceExt as _;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::plugin::PluginInit;
@@ -147,7 +153,7 @@ mod tests {
         let service_stack = PropagateStatusCode::new(init)
             .await
             .expect("couldn't create plugin")
-            .subgraph_service("accounts", mock_service.boxed());
+            .subgraph_service("accounts", mock_service.boxed_clone_sync());
 
         let subgraph_request = subgraph::Request::fake_builder().build();
 
@@ -183,7 +189,7 @@ mod tests {
         let service_stack = PropagateStatusCode::new(init)
             .await
             .expect("couldn't create plugin")
-            .subgraph_service("accounts", mock_service.boxed());
+            .subgraph_service("accounts", mock_service.boxed_clone_sync());
 
         let subgraph_request = subgraph::Request::fake_builder().build();
 

--- a/examples/supergraph-sdl/rust/src/supergraph_sdl.rs
+++ b/examples/supergraph-sdl/rust/src/supergraph_sdl.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Schema;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
 use apollo_router::services::supergraph;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 // Global state for our plugin would live here.
 // We keep our parsed supergraph schema in a reference-counted pointer
@@ -33,8 +33,8 @@ impl Plugin for SupergraphSDL {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         // Clone our parsed schema for use in map_request
         let schema = self.schema.clone();
         // `ServiceBuilder` provides us with `map_request` and `map_response` methods.
@@ -60,7 +60,7 @@ impl Plugin for SupergraphSDL {
                 req
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/examples/supergraph-sdl/rust/src/supergraph_sdl.rs
+++ b/examples/supergraph-sdl/rust/src/supergraph_sdl.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Schema;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
 use apollo_router::services::supergraph;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 // Global state for our plugin would live here.
 // We keep our parsed supergraph schema in a reference-counted pointer
@@ -31,7 +31,10 @@ impl Plugin for SupergraphSDL {
         })
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         // Clone our parsed schema for use in map_request
         let schema = self.schema.clone();
         // `ServiceBuilder` provides us with `map_request` and `map_response` methods.
@@ -57,7 +60,7 @@ impl Plugin for SupergraphSDL {
                 req
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/fuzz/examples/usage_reporting_router.rs
+++ b/fuzz/examples/usage_reporting_router.rs
@@ -3,7 +3,6 @@ use std::ops::ControlFlow;
 use anyhow::Result;
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
-use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -11,6 +10,7 @@ use apollo_router::services::execution;
 use apollo_router::services::supergraph;
 use tower::BoxError;
 use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 #[derive(Debug)]
 struct ExposeReferencedFieldsByType {
@@ -30,8 +30,8 @@ impl Plugin for ExposeReferencedFieldsByType {
 
     fn supergraph_service(
         &self,
-        service: supergraph::BoxCloneSyncService,
-    ) -> supergraph::BoxCloneSyncService {
+        service: supergraph::BoxCloneService,
+    ) -> supergraph::BoxCloneService {
         ServiceBuilder::new()
             .map_first_graphql_response(
                 |context, http_parts, mut graphql_response: graphql::Response| {
@@ -43,13 +43,10 @@ impl Plugin for ExposeReferencedFieldsByType {
                 },
             )
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 
-    fn execution_service(
-        &self,
-        service: execution::BoxCloneSyncService,
-    ) -> execution::BoxCloneSyncService {
+    fn execution_service(&self, service: execution::BoxCloneService) -> execution::BoxCloneService {
         ServiceBuilder::new()
             .checkpoint(|req: execution::Request| {
                 let as_json: serde_json_bytes::Value =
@@ -68,7 +65,7 @@ impl Plugin for ExposeReferencedFieldsByType {
                 ))
             })
             .service(service)
-            .boxed_clone_sync()
+            .boxed_clone()
     }
 }
 

--- a/fuzz/examples/usage_reporting_router.rs
+++ b/fuzz/examples/usage_reporting_router.rs
@@ -3,6 +3,7 @@ use std::ops::ControlFlow;
 use anyhow::Result;
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
+use apollo_router::layers::ServiceExt as _;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
@@ -43,7 +44,10 @@ impl Plugin for ExposeReferencedFieldsByType {
             .boxed()
     }
 
-    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+    fn execution_service(
+        &self,
+        service: execution::BoxCloneSyncService,
+    ) -> execution::BoxCloneSyncService {
         ServiceBuilder::new()
             .checkpoint(|req: execution::Request| {
                 let as_json: serde_json_bytes::Value =
@@ -62,7 +66,7 @@ impl Plugin for ExposeReferencedFieldsByType {
                 ))
             })
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 }
 

--- a/fuzz/examples/usage_reporting_router.rs
+++ b/fuzz/examples/usage_reporting_router.rs
@@ -11,7 +11,6 @@ use apollo_router::services::execution;
 use apollo_router::services::supergraph;
 use tower::BoxError;
 use tower::ServiceBuilder;
-use tower::ServiceExt;
 
 #[derive(Debug)]
 struct ExposeReferencedFieldsByType {
@@ -29,7 +28,10 @@ impl Plugin for ExposeReferencedFieldsByType {
         })
     }
 
-    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+    fn supergraph_service(
+        &self,
+        service: supergraph::BoxCloneSyncService,
+    ) -> supergraph::BoxCloneSyncService {
         ServiceBuilder::new()
             .map_first_graphql_response(
                 |context, http_parts, mut graphql_response: graphql::Response| {
@@ -41,7 +43,7 @@ impl Plugin for ExposeReferencedFieldsByType {
                 },
             )
             .service(service)
-            .boxed()
+            .boxed_clone_sync()
     }
 
     fn execution_service(


### PR DESCRIPTION
Originally opened https://github.com/apollographql/router/pull/9145, but after discussing we think the `Sync` version is not needed 

<!-- start metadata -->

<!-- [ROUTER-1681] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1681]: https://apollographql.atlassian.net/browse/ROUTER-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ