### PR TITLE
fix(composition): Fix port of `@composeDirective`

### DIFF
--- a/apollo-federation/src/link/argument.rs
+++ b/apollo-federation/src/link/argument.rs
@@ -71,6 +71,8 @@ pub(crate) fn directive_required_string_argument<'doc>(
 ) -> Result<&'doc str, FederationError> {
     directive_optional_string_argument(application, name)?.ok_or_else(|| {
         SingleFederationError::Internal {
+            // Note that part of compose_directive_manager.rs unfortunately string-matches this
+            // error message.
             message: format!(
                 "Required argument \"{}\" of directive \"@{}\" was not present.",
                 name, application.name

--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -99,14 +99,13 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
     let mut by_name_in_schema = IndexMap::default();
     let mut types_by_imported_name = IndexMap::default();
     let mut directives_by_imported_name = IndexMap::default();
-    let mut directives_by_original_name = IndexMap::default();
     let link_applications = schema
         .schema_definition
         .directives
         .iter()
         .filter(|d| d.name == *link_name_in_schema);
     for application in link_applications {
-        let mut link = Link::from_directive_application(application)?;
+        let mut link = Link::from_directive_application(application, schema)?;
         if link.url.identity == Identity::federation_identity() && link.url.version.major == 1 {
             // add fake imports for the fed1 federation link.
             if !link.imports.is_empty() {
@@ -180,11 +179,6 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
                     import.imported_display_name()
                 )));
             }
-
-            if import.is_directive {
-                directives_by_original_name
-                    .insert(import.element.clone(), (link.clone(), import.clone()));
-            }
         }
     }
 
@@ -194,7 +188,6 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
         by_name_in_schema,
         types_by_imported_name,
         directives_by_imported_name,
-        directives_by_original_name,
     }))
 }
 

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -261,6 +261,7 @@ impl LinkSpecDefinition {
             spec_alias: alias,
             imports,
             purpose: None,
+            line_column_range: None,
         });
         Ok(())
             .and_try(

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::ops::Range;
 use std::str;
 use std::sync::Arc;
 
@@ -11,6 +12,7 @@ use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::name;
+use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::Component;
 use thiserror::Error;
 
@@ -297,6 +299,7 @@ pub struct Link {
     pub spec_alias: Option<Name>,
     pub imports: Vec<Arc<Import>>,
     pub purpose: Option<Purpose>,
+    pub line_column_range: Option<Range<LineColumn>>,
 }
 
 impl Link {
@@ -348,7 +351,10 @@ impl Link {
         }
     }
 
-    pub fn from_directive_application(directive: &Node<Directive>) -> Result<Link, LinkError> {
+    pub fn from_directive_application(
+        directive: &Node<Directive>,
+        schema: &Schema,
+    ) -> Result<Link, LinkError> {
         let (url, is_link) = if let Some(value) = directive.specified_argument_by_name("url") {
             (value, true)
         } else if let Some(value) = directive.specified_argument_by_name("feature") {
@@ -399,11 +405,14 @@ impl Link {
             Default::default()
         };
 
+        let line_column_range = directive.line_column_range(&schema.sources);
+
         Ok(Link {
             url,
             spec_alias,
             imports,
             purpose,
+            line_column_range,
         })
     }
 
@@ -416,7 +425,7 @@ impl Link {
             .directives
             .iter()
             .find_map(|directive| {
-                let link = Link::from_directive_application(directive).ok()?;
+                let link = Link::from_directive_application(directive, schema).ok()?;
                 if link.url.identity == *identity {
                     Some((link, directive))
                 } else {
@@ -464,16 +473,17 @@ impl fmt::Display for Link {
 pub struct LinkedElement {
     pub link: Arc<Link>,
     pub import: Option<Arc<Import>>,
+    pub name: Name,
+    pub name_in_spec: Name,
 }
 
-#[derive(Clone, Default, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct LinksMetadata {
     pub(crate) links: Vec<Arc<Link>>,
     pub(crate) by_identity: IndexMap<Identity, Arc<Link>>,
     pub(crate) by_name_in_schema: IndexMap<Name, Arc<Link>>,
     pub(crate) types_by_imported_name: IndexMap<Name, (Arc<Link>, Arc<Import>)>,
     pub(crate) directives_by_imported_name: IndexMap<Name, (Arc<Link>, Arc<Import>)>,
-    pub(crate) directives_by_original_name: IndexMap<Name, (Arc<Link>, Arc<Import>)>,
 }
 
 impl LinksMetadata {
@@ -511,54 +521,74 @@ impl LinksMetadata {
         self.by_identity.get(identity).cloned()
     }
 
-    pub fn source_link_of_type(&self, type_name: &Name) -> Option<LinkedElement> {
-        // For types, it's either an imported name or it must be fully qualified
-
-        if let Some((link, import)) = self.types_by_imported_name.get(type_name) {
-            Some(LinkedElement {
-                link: Arc::clone(link),
-                import: Some(Arc::clone(import)),
-            })
-        } else {
-            type_name.split_once("__").and_then(|(spec_name, _)| {
-                self.by_name_in_schema
-                    .get(spec_name)
-                    .map(|link| LinkedElement {
-                        link: Arc::clone(link),
-                        import: None,
-                    })
-            })
-        }
-    }
-
-    pub fn source_link_of_directive(&self, directive_name: &Name) -> Option<LinkedElement> {
-        // For directives, it can be either:
-        //   1. be an imported name,
-        //   2. be the "imported" name of a linked spec (special case of a directive named like the
-        //      spec),
-        //   3. or it must be fully qualified.
-        if let Some((link, import)) = self.directives_by_imported_name.get(directive_name) {
-            return Some(LinkedElement {
-                link: Arc::clone(link),
-                import: Some(Arc::clone(import)),
-            });
-        }
-
-        if let Some(link) = self.by_name_in_schema.get(directive_name) {
-            return Some(LinkedElement {
-                link: Arc::clone(link),
-                import: None,
-            });
-        }
-
-        directive_name.split_once("__").and_then(|(spec_name, _)| {
-            self.by_name_in_schema
+    pub fn source_link_of_type<'e>(&'e self, type_name: &'e Name) -> Option<LinkedElement> {
+        // For types, it's either fully qualified or it must be an imported name.
+        if let Some((spec_name, name_in_spec)) = type_name.split_once("__") {
+            let Ok(name_in_spec) = Name::new(name_in_spec) else {
+                return None;
+            };
+            return self
+                .by_name_in_schema
                 .get(spec_name)
                 .map(|link| LinkedElement {
                     link: Arc::clone(link),
                     import: None,
-                })
-        })
+                    name: type_name.clone(),
+                    name_in_spec,
+                });
+        }
+
+        self.types_by_imported_name
+            .get(type_name)
+            .map(|(link, import)| LinkedElement {
+                link: Arc::clone(link),
+                import: Some(Arc::clone(import)),
+                name: type_name.clone(),
+                name_in_spec: import.element.clone(),
+            })
+    }
+
+    pub fn source_link_of_directive<'e>(
+        &'e self,
+        directive_name: &'e Name,
+    ) -> Option<LinkedElement> {
+        // For directives, it can be either:
+        //   1. be fully qualified,
+        //   2. be an imported name,
+        //   2. or it must be the "imported" name of a linked spec (special case of a directive
+        //      named like the spec).
+        if let Some((spec_name, name_in_spec)) = directive_name.split_once("__") {
+            let Ok(name_in_spec) = Name::new(name_in_spec) else {
+                return None;
+            };
+            return self
+                .by_name_in_schema
+                .get(spec_name)
+                .map(|link| LinkedElement {
+                    link: Arc::clone(link),
+                    import: None,
+                    name: directive_name.clone(),
+                    name_in_spec,
+                });
+        }
+
+        if let Some((link, import)) = self.directives_by_imported_name.get(directive_name) {
+            return Some(LinkedElement {
+                link: Arc::clone(link),
+                import: Some(Arc::clone(import)),
+                name: directive_name.clone(),
+                name_in_spec: import.element.clone(),
+            });
+        }
+
+        self.by_name_in_schema
+            .get(directive_name)
+            .map(|link| LinkedElement {
+                link: Arc::clone(link),
+                import: None,
+                name: directive_name.clone(),
+                name_in_spec: link.url.identity.name.clone(),
+            })
     }
 
     pub(crate) fn import_to_feature_url_map(&self) -> HashMap<String, Url> {

--- a/apollo-federation/src/merger/compose_directive_manager.rs
+++ b/apollo-federation/src/merger/compose_directive_manager.rs
@@ -1,14 +1,16 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
-use apollo_compiler::Node;
 use apollo_compiler::ast::DirectiveDefinition;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 
+use crate::bail;
 use crate::error::CompositionError;
 use crate::error::FederationError;
 use crate::error::HasLocations;
+use crate::error::Locations;
 use crate::error::SingleFederationError;
 use crate::error::SubgraphLocation;
 use crate::error::suggestion::did_you_mean;
@@ -25,10 +27,12 @@ use crate::link::spec::APOLLO_SPEC_DOMAIN;
 use crate::link::spec::Identity;
 use crate::merger::error_reporter::ErrorReporter;
 use crate::merger::hints::HintCode;
+use crate::schema::position::DirectiveDefinitionPosition;
 use crate::subgraph::typestate::HasMetadata;
 use crate::subgraph::typestate::Subgraph;
 use crate::supergraph::CompositionHint;
 use crate::utils::MultiIndexMap as MultiMap;
+use crate::utils::human_readable::human_readable_subgraph_names;
 
 const DEFAULT_COMPOSED_DIRECTIVES: [Name; 6] = [
     FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC,
@@ -40,15 +44,21 @@ const DEFAULT_COMPOSED_DIRECTIVES: [Name; 6] = [
 ];
 
 pub(crate) struct ComposeDirectiveManager {
-    /// Map of subgraphs to directives being composed
+    /// Map of subgraphs to directives that should be composed in that subgraph; note this will not
+    /// include directives for
     merge_directive_map: IndexMap<String, IndexSet<Name>>,
-    /// Map of (original) directive name to the latest definition found across subgraphs
-    latest_directive_definition_map: IndexMap<Name, DirectiveDefinition>,
-    /// Map of identities to the `Link` with latest version and the subgraph where it is applied
-    latest_feature_map: IndexMap<Identity, (Arc<Link>, String)>,
-    /// Map of identities to the list of directives imported from that identity across all
-    /// subgraphs. The directive names are recorded in a map of original name to aliased name.
-    directives_for_feature_map: IndexMap<Identity, IndexMap<Name, Name>>,
+    /// Map of identities to the `Link` with latest version and all subgraph names at that version.
+    latest_feature_map: IndexMap<Identity, (Arc<Link>, IndexSet<String>)>,
+    /// Map from directives that should be composed to their spec's identity and their name in the
+    /// spec (a.k.a. the original name). Note that when validation fails, this map may still contain
+    /// entries for @composeDirective directives that have errored. This has the effect of ensuring
+    /// directive definition merging, when there's a non-composed directive definition with the same
+    /// name, will still attempt to use a definition from the appropriate spec in the face of these
+    /// errors.
+    directive_identity_map: IndexMap<Name, (Identity, Name)>,
+    /// Inverse of the [directive_identity_map] above, mapping merged identities to another map from
+    /// the directive's name in schema to its name in spec (a.k.a. the original name).
+    identity_directive_map: IndexMap<Identity, IndexMap<Name, Name>>,
 }
 
 #[derive(Clone)]
@@ -56,33 +66,14 @@ pub(crate) struct MergeDirectiveItem {
     subgraph_name: String,
     pub(crate) definition: DirectiveDefinition,
     link: LinkedElement,
-    original_name: Name,
 }
 
 impl MergeDirectiveItem {
     fn new(subgraph_name: String, definition: DirectiveDefinition, link: LinkedElement) -> Self {
-        let original_name = if let Some(import) = &link.import {
-            import.element.clone()
-        } else {
-            let spec_name = link.link.spec_name_in_schema();
-            let directive_name = &definition.name;
-
-            if let Some(suffix) = directive_name
-                .as_str()
-                .strip_prefix(spec_name.as_str())
-                .and_then(|s| s.strip_prefix("__"))
-            {
-                Name::new(suffix).unwrap_or_else(|_| directive_name.clone())
-            } else {
-                directive_name.clone()
-            }
-        };
-
         Self {
             subgraph_name,
             definition,
             link,
-            original_name,
         }
     }
 
@@ -90,38 +81,61 @@ impl MergeDirectiveItem {
         &self.link.link.url.identity
     }
 
-    fn original_directive_name(&self) -> &Name {
-        &self.original_name
+    fn directive_name_in_spec(&self) -> &Name {
+        &self.link.name_in_spec
     }
 
-    fn aliased_directive_name(&self) -> &Name {
-        self.link
-            .import
-            .as_ref()
-            .map(|i| i.imported_name())
-            .or_else(|| self.link.link.spec_alias.as_ref())
-            .unwrap_or(&self.definition.name)
+    fn directive_name(&self) -> &Name {
+        &self.link.name
+    }
+
+    fn directive_has_different_name_in_subgraph<T: HasMetadata>(
+        &self,
+        subgraph: &Subgraph<T>,
+    ) -> bool {
+        let Some(metadata) = subgraph.schema().metadata() else {
+            return false;
+        };
+        let Some(link) = metadata.for_identity(&self.link.link.url.identity) else {
+            return false;
+        };
+        let Some(imp) = link
+            .imports
+            .iter()
+            .find(|i| i.is_directive && &i.element == self.directive_name_in_spec())
+        else {
+            return false;
+        };
+        let name_in_subgraph = imp.alias.as_ref().unwrap_or(&imp.element);
+        name_in_subgraph != self.directive_name()
     }
 }
 
 impl std::fmt::Display for MergeDirectiveItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.aliased_directive_name())
+        write!(f, "{}", self.directive_name())
     }
 }
+
+type DirectiveImportSpecNamesByAlias<'a> = Cow<'a, IndexMap<Name, Name>>;
 
 #[allow(dead_code)]
 impl ComposeDirectiveManager {
     pub(crate) fn new() -> Self {
         Self {
             merge_directive_map: Default::default(),
-            latest_directive_definition_map: Default::default(),
             latest_feature_map: Default::default(),
-            directives_for_feature_map: Default::default(),
+            directive_identity_map: Default::default(),
+            identity_directive_map: Default::default(),
         }
     }
 
-    pub(crate) fn all_composed_core_features(&self) -> Vec<(Arc<Link>, IndexMap<Name, Name>)> {
+    /// Returns all non-Apollo links/features that should be composed via @composeDirective,
+    /// specifically an example of a subgraph link with the correct identity/version paired with a
+    /// map of directive names in supergraph schema to their names in spec (a.k.a. original name).
+    pub(crate) fn all_composed_core_features(
+        &self,
+    ) -> Vec<(Arc<Link>, DirectiveImportSpecNamesByAlias<'_>)> {
         self.latest_feature_map
             .iter()
             .filter_map(|(identity, (link, _))| {
@@ -130,9 +144,9 @@ impl ComposeDirectiveManager {
                 } else {
                     Some((
                         link.clone(),
-                        self.directives_for_feature_map
+                        self.identity_directive_map
                             .get(identity)
-                            .cloned()
+                            .map(Cow::Borrowed)
                             .unwrap_or_default(),
                     ))
                 }
@@ -141,29 +155,72 @@ impl ComposeDirectiveManager {
     }
 
     pub(crate) fn directive_exists_in_supergraph(&self, directive_name: &Name) -> bool {
-        self.latest_directive_definition_map
-            .contains_key(directive_name)
+        self.directive_identity_map.contains_key(directive_name)
     }
 
-    pub(crate) fn has_latest_directive_definition(&self, directive_name: &Name) -> bool {
-        self.latest_directive_definition_map
-            .contains_key(directive_name)
-    }
-
-    pub(crate) fn composed_directive_names(&self) -> impl Iterator<Item = &Name> {
-        self.latest_directive_definition_map.keys()
-    }
-
-    /// Returns the latest definition found across subgraphs for the given directive name. It
-    /// expects the name to be the aliased name of the directive as it appears in the schema.
-    pub(crate) fn get_latest_directive_definition(
+    /// If the given directive name uses @composeDirective in some subgraph, this returns the name
+    /// of the subgraph containing the definition for the version of the spec that will be embedded
+    /// in the supergraph schema (this will be the latest spec version among subgraphs that use
+    /// @composeDirective for the spec). Note this potentially may be from a subgraph that doesn't
+    /// use @composeDirective for the spec (the subgraph just needs to have the right spec version
+    /// and the definition present). Also note the name of this directive may be different from the
+    /// one given due to aliasing, and accordingly we also return the position in the subgraph.
+    pub(crate) fn get_latest_directive_definition<T: HasMetadata>(
         &self,
         directive_name: &Name,
-    ) -> Result<Option<Node<DirectiveDefinition>>, FederationError> {
-        Ok(self
-            .latest_directive_definition_map
-            .get(directive_name)
-            .map(|d| Node::new(d.clone())))
+        subgraphs: &[Subgraph<T>],
+        error_reporter: &mut ErrorReporter,
+    ) -> Result<Option<(String, DirectiveDefinitionPosition)>, FederationError> {
+        let Some((identity, name_in_spec)) = self.directive_identity_map.get(directive_name) else {
+            return Ok(None);
+        };
+        let Some((link, subgraph_names)) = self.latest_feature_map.get(identity) else {
+            bail!("link feature identity must exist in map");
+        };
+        let mut latest_subgraphs: Vec<Option<&Subgraph<T>>> = std::iter::repeat_with(|| None)
+            .take(subgraph_names.len())
+            .collect();
+        for subgraph in subgraphs {
+            let Some(index) = subgraph_names.get_index_of(&subgraph.name) else {
+                continue;
+            };
+            let Some(entry) = latest_subgraphs.get_mut(index) else {
+                bail!("subgraph index unexpectedly not in same-size vector");
+            };
+            *entry = Some(subgraph);
+        }
+        for subgraph in latest_subgraphs {
+            let Some(subgraph) = subgraph else {
+                bail!("subgraph name unexpectedly not in list of subgraphs");
+            };
+            // We need to convert from the name that is used in the schema(s) that export the
+            // directive via @composeDirective to the name used in the schema that contains the
+            // definition for the latest version (which may or may not export). See the test
+            // "exported directive not imported everywhere. imported with different name".
+            let Some(metadata) = subgraph.schema().metadata() else {
+                continue;
+            };
+            let Some(link) = metadata.for_identity(identity) else {
+                continue;
+            };
+            let name_in_schema = link.directive_name_in_schema(name_in_spec);
+            let Some(def) = subgraph.schema().get_directive_definition(&name_in_schema) else {
+                continue;
+            };
+            return Ok(Some((subgraph.name.clone(), def)));
+        }
+        let plural = subgraph_names.len() != 1;
+        error_reporter.add_error(CompositionError::DirectiveCompositionError {
+            message: format!(
+                "Core feature \"{}/v{}\" in {} {} not have a directive definition for \"@{}\"",
+                identity,
+                link.url.version,
+                human_readable_subgraph_names(subgraph_names.iter()),
+                if plural { "do" } else { "does" },
+                directive_name,
+            ),
+        });
+        Ok(None)
     }
 
     pub(crate) fn should_compose_directive(
@@ -184,9 +241,9 @@ impl ComposeDirectiveManager {
         let mut wont_merge_features: IndexSet<_> = Default::default();
         let mut wont_merge_directive_names: IndexSet<_> = Default::default();
         let mut items_by_subgraph: MultiMap<String, MergeDirectiveItem> = MultiMap::new();
-        let mut items_by_identity: MultiMap<Identity, MergeDirectiveItem> = MultiMap::new();
         let mut items_by_directive_name: MultiMap<Name, MergeDirectiveItem> = MultiMap::new();
-        let mut items_by_orig_directive_name: MultiMap<Name, MergeDirectiveItem> = MultiMap::new();
+        let mut items_by_directive_name_in_spec: MultiMap<Name, MergeDirectiveItem> =
+            MultiMap::new();
 
         let tag_names_in_subgraphs: MultiMap<Name, String> = subgraphs
             .iter()
@@ -268,13 +325,8 @@ impl ComposeDirectiveManager {
                         // Note that we check for conflicts across subgraphs to make sure that we
                         // don't compose a custom `@tag` directive with the federation one, if it
                         // hasn't been properly renamed in another subgraph.
-                        let original_directive_name = feature
-                            .import
-                            .as_ref()
-                            .map(|import| &import.element)
-                            .unwrap_or(&directive.name);
                         if feature.link.url.identity.domain == APOLLO_SPEC_DOMAIN
-                            && DEFAULT_COMPOSED_DIRECTIVES.contains(original_directive_name)
+                            && DEFAULT_COMPOSED_DIRECTIVES.contains(&feature.name_in_spec)
                         {
                             error_reporter
                                 .add_compose_directive_hint_for_default_composed_directive(
@@ -287,17 +339,17 @@ impl ComposeDirectiveManager {
                                 subgraph.name.as_str(),
                             );
                         } else if let Some(subgraphs_with_conflict) =
-                            inaccessible_names_in_subgraphs.get_vec(&directive.name)
+                            tag_names_in_subgraphs.get_vec(&directive.name)
                         {
-                            error_reporter.add_compose_directive_error_for_inaccessible_conflict(
+                            error_reporter.add_compose_directive_error_for_tag_conflict(
                                 compose_directive.arguments.name,
                                 subgraph.name.as_str(),
                                 subgraphs_with_conflict,
                             );
                         } else if let Some(subgraphs_with_conflict) =
-                            tag_names_in_subgraphs.get_vec(&directive.name)
+                            inaccessible_names_in_subgraphs.get_vec(&directive.name)
                         {
-                            error_reporter.add_compose_directive_error_for_tag_conflict(
+                            error_reporter.add_compose_directive_error_for_inaccessible_conflict(
                                 compose_directive.arguments.name,
                                 subgraph.name.as_str(),
                                 subgraphs_with_conflict,
@@ -306,14 +358,12 @@ impl ComposeDirectiveManager {
                             let item = MergeDirectiveItem::new(
                                 subgraph.name.clone(),
                                 directive.as_ref().clone(),
-                                feature.clone(),
+                                feature,
                             );
                             items_by_subgraph.insert(subgraph.name.clone(), item.clone());
-                            items_by_identity
-                                .insert(feature.link.url.identity.clone(), item.clone());
                             items_by_directive_name.insert(directive.name.clone(), item.clone());
-                            items_by_orig_directive_name
-                                .insert(item.original_directive_name().clone(), item);
+                            items_by_directive_name_in_spec
+                                .insert(item.directive_name_in_spec().to_owned(), item);
                         }
                     }
                     Err(FederationError::SingleFederationError(
@@ -333,96 +383,49 @@ impl ComposeDirectiveManager {
             }
         }
 
-        // Build a map of all core features used across subgraphs (even non-composed ones)
-        let mut all_features_by_identity: MultiMap<Identity, (Arc<Link>, String)> = MultiMap::new();
-        for subgraph in subgraphs {
-            if let Some(links) = subgraph.schema().metadata() {
-                for link in &links.links {
-                    all_features_by_identity.insert(
-                        link.url.identity.clone(),
-                        (link.clone(), subgraph.name.clone()),
-                    );
-                }
-            }
-        }
+        // Build a set of all identities across subgraphs. Note that in order to ensure that we
+        // properly hint or error when there is a major version incompatibility, it's important that
+        // we examine all core features, even if the directives within them will not be composed via
+        // @composeDirective.
+        let all_identities: IndexSet<&Identity> = subgraphs
+            .iter()
+            .filter_map(|subgraph| {
+                Some(
+                    subgraph
+                        .schema()
+                        .metadata()?
+                        .links
+                        .iter()
+                        .map(|link| &link.url.identity),
+                )
+            })
+            .flatten()
+            .collect();
 
-        // Check for major version mismatches in ALL features (composed and non-composed)
-        // For non-composed features with mismatches, emit a hint
-        for (identity, features) in all_features_by_identity.iter_all() {
-            if identity.domain == APOLLO_SPEC_DOMAIN {
-                continue;
-            }
-
-            let mut major_versions: IndexSet<_> = Default::default();
-            for (link, _) in features {
-                major_versions.insert(link.url.version.major);
-            }
-
-            if major_versions.len() > 1 {
-                // Check if this feature is being composed
-                let is_composed = items_by_identity.contains_key(identity);
-
-                if is_composed {
-                    error_reporter.add_error(CompositionError::DirectiveCompositionError {
-                        message: format!(
-                            "Core feature \"{}\" requested to be merged has major version mismatch across subgraphs",
-                            identity
-                        )
-                    });
-                    wont_merge_features.insert(identity.clone());
-                } else {
-                    error_reporter.add_hint(CompositionHint {
-                        code: HintCode::DirectiveCompositionInfo.code().to_string(),
-                        message: format!("Non-composed core feature \"{}\" has major version mismatch across subgraphs", identity),
-                        locations: vec![],
-                    });
-                }
-            }
-        }
-
-        // Find the latest version for each imported feature that is being composed
-        for (identity, linked_elements) in items_by_identity.iter_all() {
-            if wont_merge_features.contains(identity) {
-                continue;
-            }
-
-            for linked_element in linked_elements {
-                let latest = self.latest_feature_map.entry(identity.clone()).or_insert((
-                    linked_element.link.link.clone(),
-                    linked_element.subgraph_name.clone(),
-                ));
-
-                if linked_element
-                    .link
-                    .link
-                    .url
-                    .version
-                    .satisfies(&latest.0.url.version)
-                {
-                    *latest = (
-                        linked_element.link.link.clone(),
-                        linked_element.subgraph_name.clone(),
-                    );
-                    self.latest_directive_definition_map.insert(
-                        linked_element.aliased_directive_name().clone(),
-                        linked_element.definition.clone(),
-                    );
-                    self.directives_for_feature_map
-                        .entry(identity.clone())
-                        .or_default()
-                        .insert(
-                            linked_element.original_directive_name().clone(),
-                            linked_element.aliased_directive_name().clone(),
-                        );
-                } else {
-                    wont_merge_features.insert(identity.clone());
-                }
+        for identity in all_identities {
+            let subgraphs_used = subgraphs
+                .iter()
+                .filter_map(|subgraph| {
+                    let items = items_by_subgraph.get(&subgraph.name)?;
+                    if items.iter().any(|item| item.identity() == identity) {
+                        Some(subgraph.name.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if let Some(latest) =
+                Self::get_latest_if_compatible(identity, subgraphs, &subgraphs_used, error_reporter)
+            {
+                self.latest_feature_map.insert(identity.clone(), latest);
+            } else {
+                wont_merge_features.insert(identity);
             }
         }
 
         // Ensure the composed directives refer to the same directive from the same spec in every subgraph
         for (name, items) in items_by_directive_name.iter_all() {
-            if !Self::all_elements_equal(items, |item| item.original_directive_name()) {
+            if !Self::all_elements_equal(items, |item| item.directive_name_in_spec()) {
                 wont_merge_directive_names.insert(name.clone());
                 error_reporter.add_error(CompositionError::DirectiveCompositionError {
                     message: format!("Composed directive \"@{name}\" does not refer to the same directive in every subgraph"),
@@ -437,40 +440,37 @@ impl ComposeDirectiveManager {
         }
 
         // Ensure each composed directive is exported with the same name in every subgraph
-        for (name, items) in items_by_orig_directive_name.iter_all() {
-            if !Self::all_elements_equal(items, |item| item.aliased_directive_name()) {
+        for (name, items) in items_by_directive_name_in_spec.iter_all() {
+            if !Self::all_elements_equal(items, |item| item.directive_name()) {
                 for item in items {
-                    wont_merge_directive_names.insert(item.original_directive_name().clone());
+                    wont_merge_directive_names.insert(item.directive_name().clone());
                 }
                 error_reporter
                     .add_compose_directive_error_for_inconsistent_imports(items, subgraphs);
-            } else {
-                let subgraphs_exporting_this_directive = items
-                    .iter()
-                    .map(|i| i.subgraph_name.clone())
-                    .collect::<IndexSet<_>>();
-                for subgraph in subgraphs {
+            }
+            // Also check that subgraphs that don't export the directive don't have inconsistent naming.
+            let Some(item) = items.first() else {
+                continue;
+            };
+            let subgraphs_exporting_this_directive = items
+                .iter()
+                .map(|i| i.subgraph_name.clone())
+                .collect::<IndexSet<_>>();
+            let subgraphs_with_different_naming: Vec<_> = subgraphs
+                .iter()
+                .filter(|subgraph| {
                     if subgraphs_exporting_this_directive.contains(&subgraph.name) {
-                        continue;
+                        return false;
                     }
-                    let Some(links) = subgraph.schema().metadata() else {
-                        continue;
-                    };
-                    if links
-                        .directives_by_original_name
-                        .get(name)
-                        .is_some_and(|(_, import)| {
-                            import.imported_name() != items[0].aliased_directive_name()
-                        })
-                    {
-                        error_reporter.add_hint(CompositionHint {
-                            code: HintCode::DirectiveCompositionWarn.code().to_string(),
-                            message: format!("Composed directive \"@{name}\" is named differently in a subgraph that doesn't export it. Consistent naming will be required to export it."),
-                            locations: vec![],
-                        });
-                        break;
-                    }
-                }
+                    item.directive_has_different_name_in_subgraph(subgraph)
+                })
+                .collect();
+            if !subgraphs_with_different_naming.is_empty() {
+                error_reporter.add_hint(CompositionHint {
+                    code: HintCode::DirectiveCompositionWarn.code().to_string(),
+                    message: format!("Composed directive \"@{name}\" is named differently in a subgraph that doesn't export it. Consistent naming will be required to export it."),
+                    locations: Self::locations_for_identity(item.identity(), subgraphs_with_different_naming),
+                });
             }
         }
 
@@ -479,16 +479,136 @@ impl ComposeDirectiveManager {
             let mut directives_for_subgraph = IndexSet::with_capacity(items.len());
             for item in items {
                 if !wont_merge_features.contains(item.identity())
-                    && !wont_merge_directive_names.contains(item.aliased_directive_name())
+                    && !wont_merge_directive_names.contains(item.directive_name())
                 {
-                    directives_for_subgraph.insert(item.aliased_directive_name().clone());
+                    directives_for_subgraph.insert(item.directive_name().clone());
                 }
+                // We specifically insert into `directive_identity_map` (and its inverse map
+                // `identity_directive_map`) even when there's failures because we want directive
+                // definition merging to use a definition from a spec we've found, in the event
+                // merging finds non-composed directive definitions that happen to have the same
+                // name.
+                self.directive_identity_map.insert(
+                    item.directive_name().clone(),
+                    (
+                        item.identity().clone(),
+                        item.directive_name_in_spec().to_owned(),
+                    ),
+                );
+                self.identity_directive_map
+                    .entry(item.identity().clone())
+                    .or_default()
+                    // Note that normally we would just always insert (meaning last-write-wins), but
+                    // we use first-write-wins here to maintain backwards compatibility.
+                    .entry(item.directive_name().clone())
+                    .or_insert(item.directive_name_in_spec().clone());
             }
             self.merge_directive_map
                 .insert(subgraph.clone(), directives_for_subgraph);
         }
 
         Ok(())
+    }
+
+    /// If the subgraph's features/links are compatible for the given identity, then return the
+    /// link with the latest spec version for those subgraphs that are actually used (a.k.a. the
+    /// subgraphs with @composeDirective with a directive from that spec), along with the subgraph
+    /// names of all subgraphs with that specific spec version (regardless of whether they use
+    /// @composeDirective).
+    fn get_latest_if_compatible<T: HasMetadata>(
+        identity: &Identity,
+        subgraphs: &[Subgraph<T>],
+        subgraphs_used: &IndexSet<String>,
+        error_reporter: &mut ErrorReporter,
+    ) -> Option<(Arc<Link>, IndexSet<String>)> {
+        let mut links_and_subgraphs: Vec<(Arc<Link>, &String)> = Vec::new();
+        // Keep track of the latest link among subgraphs with @composeDirective for the identity, or
+        // among all subgraphs if none of them have @composeDirective for the identity.
+        let mut latest_link: Option<Arc<Link>> = None;
+        // Whether any subgraphs have @composeDirective for the identity.
+        let mut any_composed = false;
+        // Whether a hint has been raised around major version mismatch yet.
+        let mut major_mismatch_hint_raised = false;
+        for subgraph in subgraphs {
+            let Some(link) = subgraph.schema().metadata()?.for_identity(identity) else {
+                continue;
+            };
+            links_and_subgraphs.push((link.clone(), &subgraph.name));
+            let composed = subgraphs_used.contains(&subgraph.name);
+            let Some(previous_latest_link) = &mut latest_link else {
+                // If this is the first link seen with the identity, then track it, along with
+                // whether it uses @composeDirective.
+                latest_link = Some(link);
+                any_composed = composed;
+                continue;
+            };
+            if previous_latest_link.url.version.major != link.url.version.major {
+                // If both subgraphs use @composeDirective with differing major versions, we can't
+                // reconcile the incompatible directive semantics so we immediately error and unset
+                // the latest link.
+                if any_composed && composed {
+                    latest_link = None;
+                    any_composed = false;
+                    error_reporter.add_error(CompositionError::DirectiveCompositionError {
+                        message: format!("Core feature \"{identity}\" requested to be merged has major version mismatch across subgraphs")
+                    });
+                    break;
+                }
+                // If only one (or none) of the subgraphs use @composeDirective, we can just ignore
+                // the non-composing subgraph(s). But we don't really know whether it's permissible
+                // for these non-composing subgraphs to have differing major versions, as it's
+                // dependent on the user-defined spec semantics. So we raise a hint here, and let
+                // the user determine whether it's an issue.
+                if !major_mismatch_hint_raised {
+                    error_reporter.add_hint(CompositionHint {
+                        code: HintCode::DirectiveCompositionInfo.code().to_string(),
+                        message: format!("Non-composed core feature \"{identity}\" has major version mismatch across subgraphs"),
+                        locations: Self::locations_for_identity(identity, subgraphs),
+                    });
+                    major_mismatch_hint_raised = true;
+                }
+                // The previous latest link is incomparable to the current link, so track the
+                // current one unless some previous latest link was composed (which means the
+                // current one isn't composed, otherwise we would have errored above).
+                if !any_composed {
+                    *previous_latest_link = link;
+                    any_composed = composed;
+                }
+                continue;
+            }
+            // If the previous latest link has used @composeDirective while the current link has,
+            // then we ignore the current link completely.
+            if any_composed && !composed {
+                continue;
+            }
+            // If no previous latest link has used @composeDirective while the current link has,
+            // then we start tracking the current link, regardless of minor versions.
+            if !any_composed && composed {
+                *previous_latest_link = link;
+                any_composed = true;
+                continue;
+            }
+            // At this point, we know `any_composed` is equal to `composed`, so we just track the
+            // current link provided its minor version isn't earlier than that of the previous
+            // latest link.
+            if previous_latest_link.url.version.minor <= link.url.version.minor {
+                *previous_latest_link = link;
+            }
+        }
+        let latest_link = latest_link?;
+        if !any_composed {
+            return None;
+        }
+        let subgraph_names_with_latest_link = links_and_subgraphs
+            .into_iter()
+            .filter(|(link, _)| link.url.version == latest_link.url.version)
+            .map(|(_, subgraph_name)| subgraph_name.clone())
+            // The rev() here is necessary to maintain backwards compatibility with previous
+            // behavior (specifically, the search order of subgraphs when multiple of them have the
+            // right version).
+            .rev()
+            .collect();
+        Some((latest_link, subgraph_names_with_latest_link))
     }
 
     fn all_elements_equal<'a, T: PartialEq>(
@@ -507,6 +627,24 @@ impl ComposeDirectiveManager {
             }
         }
         true
+    }
+
+    fn locations_for_identity<'a, T: HasMetadata + 'a>(
+        identity: &Identity,
+        subgraphs: impl IntoIterator<Item = &'a Subgraph<T>>,
+    ) -> Locations {
+        subgraphs
+            .into_iter()
+            .flat_map(|subgraph| {
+                let Some(metadata) = subgraph.schema().metadata() else {
+                    return Locations::new();
+                };
+                let Some(link) = metadata.for_identity(identity) else {
+                    return Locations::new();
+                };
+                link.locations(subgraph)
+            })
+            .collect()
     }
 }
 
@@ -599,7 +737,7 @@ impl ErrorReporter {
         );
         self.add_error(CompositionError::DirectiveCompositionError {
             message: format!(
-                "Could not find matching directive definition for argument to @composeDirective \"{name}\" in subgraph \"{}\".{}",
+                "Could not find matching directive definition for argument to @composeDirective \"{name}\" in subgraph \"{}\". {}",
                 subgraph.name,
                 did_you_mean(words),
             ),
@@ -628,7 +766,7 @@ impl ErrorReporter {
             },
             &sources,
             subgraphs,
-            |elt, _| Some(format!("\"@{}\"", elt.aliased_directive_name())),
+            |elt, _| Some(format!("\"@{}\"", elt.directive_name())),
         );
     }
 }

--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -26,6 +26,7 @@ use crate::merger::merge::map_sources;
 use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::DirectiveTargetPosition;
 use crate::schema::position::HasAppliedDirectives;
+use crate::schema::position::HasDescription;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::type_and_directive_specification::StaticArgumentsTransform;
 use crate::subgraph::typestate::Subgraph;
@@ -445,9 +446,18 @@ impl Merger {
         &mut self,
         name: &Name,
     ) -> Result<(), FederationError> {
-        let Some(def) = self
+        // Note that the source here may have a different name than the destination.
+        let Some((subgraph_name, source)) = self
             .compose_directive_manager
-            .get_latest_directive_definition(name)?
+            .get_latest_directive_definition(name, &self.subgraphs, &mut self.error_reporter)?
+        else {
+            return Ok(());
+        };
+        let Some((source_idx, subgraph)) = self
+            .subgraphs
+            .iter()
+            .enumerate()
+            .find(|(_, subgraph)| subgraph.name == subgraph_name)
         else {
             return Ok(());
         };
@@ -455,26 +465,21 @@ impl Merger {
         let dest = DirectiveDefinitionPosition {
             directive_name: name.clone(),
         };
+        let subgraph_def = source.get(subgraph.schema().schema())?;
+        dest.set_repeatable(&mut self.merged, subgraph_def.repeatable)?;
+        dest.set_locations(&mut self.merged, subgraph_def.locations.clone())?;
+        dest.set_description(&mut self.merged, subgraph_def.description.clone())?;
 
-        if self.merged.get_directive_definition(name).is_none() {
-            dest.pre_insert(&mut self.merged)?;
-            dest.insert(&mut self.merged, def.clone())?;
-        }
-
-        let sources = self
-            .subgraphs
-            .iter()
-            .enumerate()
-            .map(|(idx, subgraph)| (idx, subgraph.schema().get_directive_definition(name)))
-            .collect();
+        let sources: Sources<DirectiveDefinitionPosition> =
+            std::iter::once((source_idx, Some(source.clone()))).collect();
         let arg_names = self.add_arguments_shallow(&sources, &dest)?;
 
         for arg_name in arg_names {
-            let sources = map_sources(&sources, |source| {
+            let sources_arg = map_sources(&sources, |source| {
                 source.as_ref().map(|s| s.argument(arg_name.clone()))
             });
             let dest_arg = dest.argument(arg_name);
-            self.merge_argument(&sources, &dest_arg)?;
+            self.merge_argument(&sources_arg, &dest_arg)?;
         }
         Ok(())
     }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -622,7 +622,7 @@ impl Merger {
         {
             let imports = directives
                 .iter()
-                .map(|(original, alias)| {
+                .map(|(alias, original)| {
                     if *alias == *original {
                         Import {
                             alias: None,
@@ -825,9 +825,6 @@ impl Merger {
             for (name, definition) in subgraph.schema().schema().directive_definitions.iter() {
                 if self.merged.get_directive_definition(name).is_none()
                     && self.is_merged_directive_definition(&subgraph.name, definition)
-                    && !self
-                        .compose_directive_manager
-                        .has_latest_directive_definition(name)
                 {
                     let pos = DirectiveDefinitionPosition {
                         directive_name: name.clone(),
@@ -1687,17 +1684,13 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
         // We should skip the supergraph specific directives, that is the @core and @join directives.
 
         // Collect all directive names from both the merged schema and the compose directive manager
-        let mut directive_names: IndexSet<Name> = self
+        let directive_names: IndexSet<Name> = self
             .merged
             .schema()
             .directive_definitions
             .keys()
             .cloned()
             .collect();
-
-        for name in self.compose_directive_manager.composed_directive_names() {
-            directive_names.insert(name.clone());
-        }
 
         for directive_name in directive_names {
             if self
@@ -2326,7 +2319,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                 let mut should_include_as_join_directive = false;
 
                 if directive.name == link_directive_name {
-                    if let Ok(link) = Link::from_directive_application(directive) {
+                    if let Ok(link) = Link::from_directive_application(directive, schema.schema()) {
                         should_include_as_join_directive =
                             self.should_use_join_directive_for_url(&link.url);
 

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1681,7 +1681,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
     }
 
     fn merge_directive_definitions(&mut self) -> Result<(), FederationError> {
-        // We should skip the supergraph specific directives, that is the @core and @join directives.
+        // We should skip the supergraph specific directives, that is the @link and @join directives.
 
         // Collect all directive names from both the merged schema and the compose directive manager
         let directive_names: IndexSet<Name> = self

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -313,6 +313,7 @@ impl FederationBlueprint {
             imports: fed1_link_imports(),
             spec_alias: None,
             purpose: None,
+            line_column_range: None,
         });
         for type_spec in &FED_1.type_specs() {
             if let Err(err) = type_spec.check_or_add(schema, Some(&fed_1_link)) {

--- a/apollo-federation/src/schema/locations.rs
+++ b/apollo-federation/src/schema/locations.rs
@@ -5,6 +5,7 @@ use apollo_compiler::schema::ExtendedType;
 use crate::error::HasLocations;
 use crate::error::Locations;
 use crate::error::SubgraphLocation;
+use crate::link::Link;
 use crate::merger::compose_directive_manager::MergeDirectiveItem;
 use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::CompositeTypeDefinitionPosition;
@@ -50,6 +51,19 @@ impl HasLocations for DirectiveDefinition {
 impl HasLocations for MergeDirectiveItem {
     fn locations<T: HasMetadata>(&self, subgraph: &Subgraph<T>) -> Locations {
         self.definition.locations(subgraph)
+    }
+}
+
+impl HasLocations for Link {
+    fn locations<T: HasMetadata>(&self, subgraph: &Subgraph<T>) -> Locations {
+        self.line_column_range
+            .clone()
+            .into_iter()
+            .map(|range| SubgraphLocation {
+                subgraph: subgraph.name.to_string(),
+                range,
+            })
+            .collect()
     }
 }
 

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -74,7 +74,7 @@ impl Subgraph {
             .get_all(&default_link_name);
 
         for directive in link_directives {
-            let link_directive = Link::from_directive_application(directive)?;
+            let link_directive = Link::from_directive_application(directive, &schema)?;
             if link_directive.url.identity == Identity::federation_identity() {
                 if imported_federation_definitions.is_some() {
                     let msg = "invalid graphql schema - multiple @link imports for the federation specification are not supported";

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -273,6 +273,7 @@ impl FederationSpecDefinitions {
                 .collect::<Vec<Arc<Import>>>(),
             purpose: None,
             spec_alias: None,
+            line_column_range: None,
         })
     }
 
@@ -796,6 +797,7 @@ impl Default for LinkSpecDefinitions {
             })],
             purpose: None,
             spec_alias: None,
+            line_column_range: None,
         };
         Self::new(link)
     }
@@ -829,6 +831,7 @@ mod tests {
             spec_alias: None,
             imports: vec![],
             purpose: None,
+            line_column_range: None,
         })
         .expect_err("federation version 99 is not yet supported");
     }

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -436,25 +436,16 @@ mod inconsistent_feature_versions {
 mod inconsistent_imports {
     use super::*;
 
-    #[rstest]
-    #[case(
-        r#"
-        directive @foo(name: String!) on FIELD_DEFINITION
-        directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
-    "#
-    )]
-    #[case(
-        r#"
-        directive @foo(name: String!) on FIELD_DEFINITION
-        directive @foo_bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
-    "#
-    )]
-    fn composes_mismatched_imports_with_unqualified_name(#[case] directive_text: &str) {
+    #[test]
+    fn composes_exported_directive_with_default_definition_in_later_spec_subgraph() {
         let subgraph_a = generate_subgraph(
             "subgraphA",
             r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo"])"#,
             r#"@composeDirective(name: "@foo")"#,
-            directive_text,
+            r#"
+            directive @foo(name: String!) on FIELD_DEFINITION
+            directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
+            "#,
             r#"@foo(name: "a")"#,
         );
         let subgraph_b = generate_subgraph(
@@ -479,6 +470,70 @@ mod inconsistent_imports {
         );
 
         let schema = result.schema().schema();
+        assert!(
+            schema.to_string().contains(
+                r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo", "@bar"])"#
+            ),
+            "Schema does not contain expected @link directive"
+        );
+
+        let subgraph_a_field = coord!(User.subgraphA).lookup_field(schema).unwrap();
+        let foo_directive = subgraph_a_field
+            .directives
+            .iter()
+            .find(|d| d.name == "foo")
+            .expect("Expected @foo directive to be present on User.subgraphA");
+        assert_eq!(foo_directive.to_string(), r#"@foo(name: "a")"#);
+
+        let subgraph_b_field = coord!(User.subgraphB).lookup_field(schema).unwrap();
+        let bar_directive = subgraph_b_field
+            .directives
+            .iter()
+            .find(|d| d.name == "bar")
+            .expect("Expected @bar directive to be present on User.subgraphB");
+        assert_eq!(bar_directive.to_string(), r#"@bar(name: "b")"#);
+    }
+
+    #[test]
+    fn composes_exported_directive_with_unqualified_definition_in_later_spec_subgraph() {
+        let subgraph_a = generate_subgraph(
+            "subgraphA",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo"])"#,
+            r#"@composeDirective(name: "@foo")"#,
+            r#"
+            directive @foo(name: String!) on FIELD_DEFINITION
+            directive @foo__bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
+            "#,
+            r#"@foo(name: "a")"#,
+        );
+        let subgraph_b = generate_subgraph(
+            "subgraphB",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@bar"])"#,
+            r#"@composeDirective(name: "@bar")"#,
+            r#"
+            directive @foo(name: String!) on FIELD_DEFINITION
+            directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
+            "#,
+            r#"@bar(name: "b")"#,
+        );
+
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap();
+        assert_has_directive_definition(
+            &result,
+            "directive @foo(name: String!) on FIELD_DEFINITION",
+        );
+        assert_has_directive_definition(
+            &result,
+            "directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT",
+        );
+
+        let schema = result.schema().schema();
+        assert!(
+            schema.to_string().contains(
+                r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo", "@bar"])"#
+            ),
+            "Schema does not contain expected @link directive"
+        );
 
         let subgraph_a_field = coord!(User.subgraphA).lookup_field(schema).unwrap();
         let foo_directive = subgraph_a_field
@@ -501,7 +556,7 @@ mod inconsistent_imports {
     fn hints_when_imported_with_mismatched_name_but_not_exported() {
         let subgraph_a = generate_subgraph(
             "subgraphA",
-            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo", { name: "@bar", as: "@baz" }])"#,
+            r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo", { name: "@bar", as: "@baz" }])"#,
             r#"@composeDirective(name: "@foo")"#,
             r#"
             directive @foo(name: String!) on FIELD_DEFINITION
@@ -511,7 +566,7 @@ mod inconsistent_imports {
         );
         let subgraph_b = generate_subgraph(
             "subgraphB",
-            r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@bar"])"#,
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@bar"])"#,
             r#"@composeDirective(name: "@bar")"#,
             r#"
             directive @foo(name: String!) on FIELD_DEFINITION
@@ -540,6 +595,12 @@ mod inconsistent_imports {
         );
 
         let schema = result.schema().schema();
+        assert!(
+            schema.to_string().contains(
+                r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo", "@bar"])"#
+            ),
+            "Schema does not contain expected @link directive"
+        );
 
         let subgraph_a_field = coord!(User.subgraphA).lookup_field(schema).unwrap();
         let foo_directive = subgraph_a_field
@@ -558,12 +619,151 @@ mod inconsistent_imports {
         assert_eq!(bar_directive.to_string(), r#"@bar(name: "b")"#);
     }
 
-    // PORT NOTE: This is an improvement in behavior over the JS version, which errors in this
-    // case. There isn't a strong reason to force all subgraphs to define a directive if they do
-    // not use it. This was effectively forcing customers to define a new spec for every custom
-    // directive they wanted to compose, even if only one subgraph used it.
     #[test]
-    fn allows_importing_different_directives_from_the_same_spec_in_different_subgraphs() {
+    fn errors_when_exported_directive_missing_definition_in_later_spec_subgraph() {
+        let subgraph_a = generate_subgraph(
+            "subgraphA",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo"])"#,
+            r#"@composeDirective(name: "@foo")"#,
+            "directive @foo(name: String!) on FIELD_DEFINITION",
+            r#"@foo(name: "a")"#,
+        );
+        let subgraph_b = generate_subgraph(
+            "subgraphB",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@bar"])"#,
+            r#"@composeDirective(name: "@bar")"#,
+            r#"
+            directive @foo(name: String!) on FIELD_DEFINITION
+            directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
+            "#,
+            r#"@bar(name: "b")"#,
+        );
+
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        assert_eq!(result.len(), 1);
+        let error = result.first().unwrap();
+        assert_eq!(
+            error.code().definition().code().to_string(),
+            "DIRECTIVE_COMPOSITION_ERROR"
+        );
+        assert_eq!(
+            error.to_string(),
+            r#"Core feature "https://specs.custom.dev/foo/v1.1" in subgraph "subgraphA" does not have a directive definition for "@bar""#
+        );
+    }
+
+    #[test]
+    fn composes_exported_directive_with_imported_definition_in_later_spec_subgraph() {
+        let subgraph_a = generate_subgraph(
+            "subgraphA",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo", "@bar"])"#,
+            r#"@composeDirective(name: "@foo")"#,
+            r#"
+            directive @foo(name: String!) on FIELD_DEFINITION
+            directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
+            "#,
+            r#"@foo(name: "a")"#,
+        );
+        let subgraph_b = generate_subgraph(
+            "subgraphB",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@bar"])"#,
+            r#"@composeDirective(name: "@bar")"#,
+            "directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT",
+            r#"@bar(name: "b")"#,
+        );
+
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap();
+        assert_has_directive_definition(
+            &result,
+            "directive @foo(name: String!) on FIELD_DEFINITION",
+        );
+        assert_has_directive_definition(
+            &result,
+            "directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT",
+        );
+
+        let schema = result.schema().schema();
+        assert!(
+            schema.to_string().contains(
+                r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo", "@bar"])"#
+            ),
+            "Schema does not contain expected @link directive"
+        );
+
+        let subgraph_a_field = coord!(User.subgraphA).lookup_field(schema).unwrap();
+        let foo_directive = subgraph_a_field
+            .directives
+            .iter()
+            .find(|d| d.name == "foo")
+            .expect("Expected @foo directive to be present on User.subgraphA");
+        assert_eq!(foo_directive.to_string(), r#"@foo(name: "a")"#);
+
+        let subgraph_b_field = coord!(User.subgraphB).lookup_field(schema).unwrap();
+        let bar_directive = subgraph_b_field
+            .directives
+            .iter()
+            .find(|d| d.name == "bar")
+            .expect("Expected @bar directive to be present on User.subgraphB");
+        assert_eq!(bar_directive.to_string(), r#"@bar(name: "b")"#);
+    }
+
+    #[test]
+    fn composes_exported_directive_with_missing_definition_in_one_subgraph() {
+        let subgraph_a = generate_subgraph(
+            "subgraphA",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@bar"])"#,
+            r#"@composeDirective(name: "@bar")"#,
+            r#"
+            directive @foo(name: String!) on FIELD_DEFINITION
+            directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
+            "#,
+            r#"@bar(name: "a")"#,
+        );
+        let subgraph_b = generate_subgraph(
+            "subgraphB",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo"])"#,
+            r#"@composeDirective(name: "@foo")"#,
+            "directive @foo(name: String!) on FIELD_DEFINITION",
+            r#"@foo(name: "b")"#,
+        );
+
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap();
+        assert_has_directive_definition(
+            &result,
+            "directive @foo(name: String!) on FIELD_DEFINITION",
+        );
+        assert_has_directive_definition(
+            &result,
+            "directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT",
+        );
+
+        let schema = result.schema().schema();
+        assert!(
+            schema.to_string().contains(
+                r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@bar", "@foo"])"#
+            ),
+            "Schema does not contain expected @link directive"
+        );
+
+        let subgraph_a_field = coord!(User.subgraphA).lookup_field(schema).unwrap();
+        let foo_directive = subgraph_a_field
+            .directives
+            .iter()
+            .find(|d| d.name == "bar")
+            .expect("Expected @bar directive to be present on User.subgraphA");
+        assert_eq!(foo_directive.to_string(), r#"@bar(name: "a")"#);
+
+        let subgraph_b_field = coord!(User.subgraphB).lookup_field(schema).unwrap();
+        let bar_directive = subgraph_b_field
+            .directives
+            .iter()
+            .find(|d| d.name == "foo")
+            .expect("Expected @foo directive to be present on User.subgraphB");
+        assert_eq!(bar_directive.to_string(), r#"@foo(name: "b")"#);
+    }
+
+    #[test]
+    fn composes_exported_directive_with_split_definitions_across_subgraphs() {
         let subgraph_a = generate_subgraph(
             "subgraphA",
             r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo"])"#,
@@ -573,22 +773,99 @@ mod inconsistent_imports {
         );
         let subgraph_b = generate_subgraph(
             "subgraphB",
-            r#"@link(url: "https://specs.custom.dev/foo/v1.1", import: ["@bar"])"#,
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@bar"])"#,
             r#"@composeDirective(name: "@bar")"#,
-            r#"
-            directive @foo(name: String!) on FIELD_DEFINITION
-            directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT
-           "#,
+            "directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT",
             r#"@bar(name: "b")"#,
         );
 
-        let result = compose(vec![subgraph_a, subgraph_b]).expect("Composition should succeed");
-        assert_eq!(result.hints().len(), 0);
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap();
+        assert_has_directive_definition(
+            &result,
+            "directive @foo(name: String!) on FIELD_DEFINITION",
+        );
+        assert_has_directive_definition(
+            &result,
+            "directive @bar(name: String!, address: String) on FIELD_DEFINITION | OBJECT",
+        );
 
-        // We're primarily looking for the combined link for the custom spec to combine both
-        // directives with the latest version. It should look like:
-        // @link(url: "https://specs.custom.dev/foo/v1.1", import: ["@foo", "@bar"])
-        insta::assert_snapshot!(result.schema().schema());
+        let schema = result.schema().schema();
+        assert!(
+            schema.to_string().contains(
+                r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo", "@bar"])"#
+            ),
+            "Schema does not contain expected @link directive"
+        );
+
+        let subgraph_a_field = coord!(User.subgraphA).lookup_field(schema).unwrap();
+        let foo_directive = subgraph_a_field
+            .directives
+            .iter()
+            .find(|d| d.name == "foo")
+            .expect("Expected @foo directive to be present on User.subgraphA");
+        assert_eq!(foo_directive.to_string(), r#"@foo(name: "a")"#);
+
+        let subgraph_b_field = coord!(User.subgraphB).lookup_field(schema).unwrap();
+        let bar_directive = subgraph_b_field
+            .directives
+            .iter()
+            .find(|d| d.name == "bar")
+            .expect("Expected @bar directive to be present on User.subgraphB");
+        assert_eq!(bar_directive.to_string(), r#"@bar(name: "b")"#);
+    }
+
+    // This isn't something that users should be allowed to do, and can sometimes result in an
+    // error. But we don't explicitly validate against it today, and it may sometimes succeed. So we
+    // test the current behavior, which is to pick the last definition.
+    #[test]
+    fn composes_exported_directive_with_different_definitions_across_subgraphs() {
+        let subgraph_a = generate_subgraph(
+            "subgraphA",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo"])"#,
+            r#"@composeDirective(name: "@foo")"#,
+            "directive @foo(name: String!) on FIELD_DEFINITION",
+            r#"@foo(name: "a")"#,
+        );
+        let subgraph_b = generate_subgraph(
+            "subgraphB",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo"])"#,
+            r#"@composeDirective(name: "@foo")"#,
+            "directive @foo(name: String!, address: String) on FIELD_DEFINITION",
+            r#"@foo(name: "b", address: "c")"#,
+        );
+
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap();
+        assert_has_directive_definition(
+            &result,
+            "directive @foo(name: String!, address: String) on FIELD_DEFINITION",
+        );
+
+        let schema = result.schema().schema();
+        assert!(
+            schema
+                .to_string()
+                .contains(r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo"])"#),
+            "Schema does not contain expected @link directive"
+        );
+
+        let subgraph_a_field = coord!(User.subgraphA).lookup_field(schema).unwrap();
+        let foo_directive = subgraph_a_field
+            .directives
+            .iter()
+            .find(|d| d.name == "foo")
+            .expect("Expected @foo directive to be present on User.subgraphA");
+        assert_eq!(foo_directive.to_string(), r#"@foo(name: "a")"#);
+
+        let subgraph_b_field = coord!(User.subgraphB).lookup_field(schema).unwrap();
+        let bar_directive = subgraph_b_field
+            .directives
+            .iter()
+            .find(|d| d.name == "foo")
+            .expect("Expected @foo directive to be present on User.subgraphB");
+        assert_eq!(
+            bar_directive.to_string(),
+            r#"@foo(name: "b", address: "c")"#
+        );
     }
 
     #[test]
@@ -639,15 +916,9 @@ mod inconsistent_imports {
             error.code().definition().code().to_string(),
             "DIRECTIVE_COMPOSITION_ERROR"
         );
-
-        // There's some non-determinism in the serialization order here. We'll need to figure that
-        // out, but for now we just check both orders.
-        assert!(
-            &[
-                r#"Composed directive is not named consistently in all subgraphs but "@foo" in subgraph "subgraphA" and "@bar" in subgraph "subgraphB""#.to_string(),
-                r#"Composed directive is not named consistently in all subgraphs but "@bar" in subgraph "subgraphB" and "@foo" in subgraph "subgraphA""#.to_string(),
-            ].contains(&error.to_string()),
-            "Unexpected error message: {error}",
+        assert_eq!(
+            error.to_string(),
+            r#"Composed directive is not named consistently in all subgraphs but "@foo" in subgraph "subgraphA" and "@bar" in subgraph "subgraphB""#,
         );
     }
 
@@ -756,12 +1027,6 @@ mod inconsistent_imports {
         );
     }
 
-    /*
-    * We need to understand why this test was set up this way in the original source. It explicitly
-    * adds a definition for the `@join__x` directive that it's defining (as an alias for `@foo`).
-    * So, the error saying it isn't part of a core feature, when it's clearly linked, seems wrong.
-    * Maybe JS silently ignores definitions starting with `@join__`?
-    *
     #[rstest]
     #[case("@join__field")]
     #[case("@join__graph")]
@@ -793,7 +1058,6 @@ mod inconsistent_imports {
             )
         );
     }
-    */
 }
 
 mod validation {
@@ -824,7 +1088,7 @@ mod validation {
     fn errors_when_name_argument_is_missing_at_symbol() {
         let subgraph_a = generate_subgraph(
             "subgraphA",
-            "",
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo"])"#,
             r#"@composeDirective(name: "foo")"#,
             "directive @foo(name: String!) on FIELD_DEFINITION",
             r#"@foo(name: "a")"#,
@@ -847,33 +1111,17 @@ mod validation {
     #[rstest]
     #[case(
         r#""@foo""#,
-        "@foo",
         "@fooz",
-        r#"[subgraphA] Error: cannot find directive `@fooz` in this document
-    ╭─[ subgraphA:14:31 ]
-    │
- 14 │             subgraphA: String @fooz(name: "a")
-    │                               ────────┬───────  
-    │                                       ╰───────── directive not defined
-────╯
-Did you mean "@foo"?
-"#
+        "@foo",
+        r#"Could not find matching directive definition for argument to @composeDirective "@fooz" in subgraph "subgraphA". Did you mean "@foo" or "@cost"?"#
     )]
     #[case(
         r#"{ name: "@foo", as: "@bar" }"#,
-        "@bar",
         "@barz",
-        r#"[subgraphA] Error: cannot find directive `@barz` in this document
-    ╭─[ subgraphA:14:31 ]
-    │
- 14 │             subgraphA: String @barz(name: "a")
-    │                               ────────┬───────  
-    │                                       ╰───────── directive not defined
-────╯
-Did you mean "@bar"?
-"#
+        "@bar",
+        r#"Could not find matching directive definition for argument to @composeDirective "@barz" in subgraph "subgraphA". Did you mean "@bar" or "@tag"?"#
     )]
-    fn errors_when_directive_does_not_exist(
+    fn errors_when_compose_directive_target_does_not_exist(
         #[case] import: &str,
         #[case] name: &str,
         #[case] usage: &str,
@@ -884,7 +1132,7 @@ Did you mean "@bar"?
             &r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: [<IMPORT>])"#
                 .replace("<IMPORT>", import),
             &r#"@composeDirective(name: "<NAME>")"#.replace("<NAME>", name),
-            &r#"directive <NAME>(name: String!) on FIELD_DEFINITION"#.replace("<NAME>", name),
+            &r#"directive <NAME>(name: String!) on FIELD_DEFINITION"#.replace("<NAME>", usage),
             &r#"<NAME>(name: "a")"#.replace("<NAME>", usage),
         );
         let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
@@ -894,7 +1142,7 @@ Did you mean "@bar"?
         let error = result.first().unwrap();
         assert_eq!(
             error.code().definition().code().to_string(),
-            "INVALID_GRAPHQL"
+            "DIRECTIVE_COMPOSITION_ERROR"
         );
         assert_eq!(error.to_string(), expected_message);
     }
@@ -1034,6 +1282,11 @@ mod composition {
             schema
                 .to_string()
                 .contains(r#"@link(url: "https://custom.dev/myspec/v1.0", import: ["@tag"])"#)
+        );
+        assert!(
+            schema
+                .to_string()
+                .contains(r#"@link(url: "https://specs.apollo.dev/tag/v0.3", import: [{name: "@tag", as: "@mytag"}])"#)
         );
     }
 

--- a/apollo-federation/tests/dhat_profiling/supergraph.rs
+++ b/apollo-federation/tests/dhat_profiling/supergraph.rs
@@ -11,12 +11,12 @@ fn valid_supergraph_schema() {
     const SCHEMA: &str = "../examples/graphql/supergraph.graphql";
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 136_317.
-    const MAX_BYTES_SUPERGRAPH: usize = 143_132; // ~143 KiB. actual number: 136317
+    // Actual number: 143_768.
+    const MAX_BYTES_SUPERGRAPH: usize = 150_956; // ~151 KiB. actual number: 143768
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 4952.
-    const MAX_ALLOCATIONS_SUPERGRAPH: u64 = 5_200; // number of allocations.
+    // Actual number: 4959.
+    const MAX_ALLOCATIONS_SUPERGRAPH: u64 = 5_207; // number of allocations.
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
     // Actual number: 195_884.


### PR DESCRIPTION
While reviewing #8936, I noticed some issues in the PR, but there were also more issues in the surrounding code for `@composeDirective`. This PR brings the Rust port more inline with the JS code (including the changes that #8936 were trying to port over). There were also a fair amount of issues with the tests, and I've similarly fixed those.

<!-- FED-849 -->
<!-- FED-996 -->