### PR TITLE
docs: expand HTTP proxy documentation

### DIFF
--- a/.changesets/docs_abernix_otlp_http_proxy_support.md
+++ b/.changesets/docs_abernix_otlp_http_proxy_support.md
@@ -1,0 +1,7 @@
+### Document HTTP proxy support for GraphOS OTLP exporters ([PR #9055](https://github.com/apollographql/router/pull/9055))
+
+Documents that the router's GraphOS OTLP exporters respect the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables when using the HTTP transport. Includes a note that TLS-inspecting proxies also require the proxy's root certificate to be added to the router's trust store.
+
+Also corrects the minimum version badge for `experimental_otlp_tracing_protocol` / `experimental_otlp_metrics_protocol` to Router v1.49.0, which is when HTTP transport support was first introduced.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/9152

--- a/docs/source/_sidebar.yaml
+++ b/docs/source/_sidebar.yaml
@@ -279,7 +279,7 @@ items:
         children:
           - label: "Google Cloud Run"
             href: "./self-hosted/containerization/gcp"
-      - label: "Proxy Certificates"
+      - label: "HTTP Proxy"
         href: "./self-hosted/containerization/proxy-certificates"
       - label: "Managed Hosting"
         children:

--- a/docs/source/routing/observability/graphos/graphos-reporting.mdx
+++ b/docs/source/routing/observability/graphos/graphos-reporting.mdx
@@ -73,7 +73,7 @@ telemetry:
 
 #### Configuring the transport protocol
 
-<MinVersionBadge version="Router v2.14.0" />
+<MinVersionBadge version="Router v2.13.0" />
 
 By default, the router sends GraphOS OTLP data over gRPC. To switch to HTTP protobuf, set `experimental_otlp_tracing_protocol` and `experimental_otlp_metrics_protocol`:
 
@@ -460,14 +460,7 @@ telemetry:
 
 <MinVersionBadge version="Router v2.14.0" />
 
-The router's GraphOS OTLP exporters respect the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. Set them before starting your router to route OTLP traffic through a proxy:
-
-```bash
-export HTTPS_PROXY=https://your-proxy.example.com:3128
-export NO_PROXY=localhost,127.0.0.1
-```
-
-The router reads these variables at startup — restart your router for changes to take effect.
+The router's GraphOS OTLP exporters respect the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. For full setup instructions, including TLS certificate configuration for inspecting proxies, see [HTTP proxy configuration](/graphos/routing/self-hosted/containerization/proxy-certificates).
 
 <Note>
 

--- a/docs/source/routing/self-hosted/containerization/proxy-certificates.mdx
+++ b/docs/source/routing/self-hosted/containerization/proxy-certificates.mdx
@@ -1,29 +1,72 @@
 ---
-title: Add Proxy Certificates to Router Containers
-subtitle: Configure trust for your proxy's root certificate
-description: Add your corporate proxy's root certificate to Apollo Router containers to enable TLS inspection in enterprise environments.
+title: HTTP proxy configuration
+subtitle: Route router traffic through a corporate HTTP proxy
+description: Configure HTTP_PROXY, HTTPS_PROXY, and NO_PROXY to route Apollo Router's outbound connections through a proxy, and add the proxy's certificate to the router's trust store for TLS inspection environments.
 ---
 
 import ElasticNotice from '../../../../shared/elastic-notice.mdx';
 
-If your organization uses a corporate proxy that performs TLS inspection (SSL inspection or HTTPS interception), add the proxy's root certificate to your router container. Without this certificate, Apollo Router can't establish secure connections to GraphOS or your subgraphs.
+Corporate network environments often require outbound HTTP traffic to pass through a proxy. Apollo Router supports standard proxy environment variables for its control-plane and telemetry connections, and can be configured to trust a proxy's TLS certificate when the proxy performs traffic inspection.
 
 <ElasticNotice />
 
-## Understanding proxy certificate requirements
+## Affected connections
 
-Corporate proxies often intercept HTTPS traffic for security monitoring. They decrypt and re-encrypt traffic using their own certificate. Apollo Router must have the proxy's root certificate authority (CA) certificate installed in its trust store to trust these connections.
+Apollo Router respects `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` for connections that use its internal reqwest-based HTTP client. This includes:
 
-A missing proxy certificate causes these common symptoms:
+- **Apollo Uplink** — fetches the supergraph schema, license, and persisted query manifests
+- **GraphOS telemetry** — reports traces and metrics to GraphOS (Apollo Usage Reporting protocol and OTLP HTTP)
+- **Third-party telemetry exporters** — Datadog traces and other exporters using the HTTP transport
+- **JWKS endpoints** — fetches JSON Web Key Sets for JWT authentication
+
+**Subgraph connections are not affected.** The router uses a separate high-performance HTTP client built directly on `hyper` for subgraph traffic. That client doesn't read proxy environment variables. To proxy subgraph traffic, configure your network layer (for example, a service mesh or sidecar) instead.
+
+## Configure proxy routing
+
+Set `HTTPS_PROXY` and `NO_PROXY` before starting the router. The router reads these variables at startup — restart the router for changes to take effect.
+
+```bash
+export HTTPS_PROXY=https://your-proxy.example.com:3128
+export NO_PROXY=localhost,127.0.0.1
+```
+
+If your proxy performs TLS inspection, also add the proxy's root certificate to the router's trust store. See [Add the proxy certificate](#add-the-proxy-certificate) below.
+
+<Note>
+
+Proxy routing for GraphOS OTLP exporters also requires the HTTP transport. Set `experimental_otlp_tracing_protocol` and `experimental_otlp_metrics_protocol` to `http` in your router config. See [GraphOS reporting](/graphos/routing/observability/graphos/graphos-reporting#configuring-the-transport-protocol) for details. <MinVersionBadge version="Router v2.14.0" />
+
+</Note>
+
+## Add the proxy certificate
+
+If your proxy performs TLS inspection (SSL inspection or HTTPS interception), it decrypts and re-encrypts HTTPS traffic using its own certificate. Apollo Router must have the proxy's root CA certificate installed in its trust store to trust those connections. Without it, you'll see errors like:
+
 - Connection failures to Apollo Uplink
 - TLS handshake errors when fetching the supergraph schema
-- Certificate verification failures when connecting to subgraphs
+- Certificate verification failures in telemetry exporters
 
-## Adding certificates to Docker containers
+Apollo Router container images are based on Debian and use the system CA certificate store at `/etc/ssl/certs/`. You can add your proxy's certificate by either updating the container's CA store or by pointing the `SSL_CERT_FILE` environment variable at a certificate bundle.
 
-Apollo Router container images are based on Debian and use the system CA certificate store at `/etc/ssl/certs/`.
+### Use SSL_CERT_FILE
 
-### Mounting the certificate at runtime
+Set `SSL_CERT_FILE` to the path of a PEM bundle that contains both your proxy's root CA certificate and the standard system CA certificates. Apollo Router reads this variable at startup for all TLS connections.
+
+<Note>
+
+If `SSL_CERT_FILE` is set, Apollo Router loads certificates from that file instead of the system CA store. The bundle must include your proxy's root CA certificate alongside the system CA certificates you want to trust — not the proxy certificate alone.
+
+</Note>
+
+```bash
+# Combine your proxy CA with the system CA bundle
+cat /etc/ssl/certs/ca-certificates.crt /path/to/proxy-ca.crt > /path/to/combined-ca-bundle.pem
+export SSL_CERT_FILE=/path/to/combined-ca-bundle.pem
+```
+
+### Add certificates to Docker containers
+
+#### Mount the certificate at runtime
 
 Mount your proxy's root certificate and update the CA store when you start the container.
 
@@ -38,7 +81,7 @@ docker run -p 4000:4000 \
   -c "update-ca-certificates && su -s /bin/bash router -c '/dist/router_wrapper.sh'"
 ```
 
-### Building a custom image
+#### Build a custom image
 
 For production deployments, build a custom image that includes your proxy's root certificate.
 
@@ -61,11 +104,9 @@ docker run -p 4000:4000 \
   router-with-proxy-cert
 ```
 
-## Adding certificates in Kubernetes
+### Add certificates in Kubernetes
 
-When deploying with Kubernetes, use a ConfigMap or Secret to provide the certificate and an init container to install it.
-
-### Using an init container
+Use a ConfigMap and an init container to install the certificate.
 
 1. Create a ConfigMap with your proxy certificate.
 
@@ -106,9 +147,7 @@ When deploying with Kubernetes, use a ConfigMap or Secret to provide the certifi
             mountPath: /ca-certs
     ```
 
-### Building a custom image for Kubernetes
-
-Build a custom Docker image with the certificate as described in [Building a custom image](#building-a-custom-image) and reference it in your Helm values.
+To use a custom Docker image with Kubernetes instead, follow [Build a custom image](#build-a-custom-image) and reference it in your Helm values.
 
 ```yaml title="values.yaml"
 image:
@@ -116,28 +155,35 @@ image:
   tag: <your-tag>
 ```
 
-## Adding certificates for cloud deployments
+### Add certificates for cloud deployments
 
-For cloud deployments (AWS ECS, Azure Container Apps, GCP Cloud Run), build a custom Docker image that includes your proxy's root certificate, then push that image to your cloud provider's container registry.
+For cloud deployments (AWS ECS, Azure Container Apps, GCP Cloud Run), build a custom Docker image that includes your proxy's root certificate, then push it to your cloud provider's container registry.
 
-Follow the [custom image instructions](#building-a-custom-image), then push the image to your registry before you deploy.
+Follow the [custom image instructions](#build-a-custom-image), then push the image to your registry before deploying.
 
-## Verifying the certificate installation
+## Verify the configuration
 
-Check the container's CA store:
+If you're using `SSL_CERT_FILE`, confirm the variable is set and the bundle is readable before starting the router:
+
+```bash
+echo $SSL_CERT_FILE
+openssl verify -CAfile "$SSL_CERT_FILE" "$SSL_CERT_FILE"
+```
+
+If you're using the container CA store approach, check that the certificate is present:
 
 ```bash
 docker run --entrypoint /bin/bash -it router-with-proxy-cert -c "ls /etc/ssl/certs | grep proxy"
 ```
 
-Test connectivity to a service through the proxy:
+Test connectivity to Apollo Uplink through the proxy:
 
 ```bash
 docker run --entrypoint /bin/bash -it router-with-proxy-cert -c "curl -v https://uplink.api.apollographql.com/"
 ```
 
-## Related Topics
+## Related topics
 
-- [TLS configuration](/graphos/routing/security/tls): Configure TLS settings for Apollo Router
-- [Docker deployment](/graphos/routing/self-hosted/containerization/docker): Deploy Apollo Runtime using Docker
-- [Kubernetes deployment](/graphos/routing/self-hosted/containerization/kubernetes/quickstart): Deploy Apollo Router using Helm
+- [TLS configuration](/graphos/routing/security/tls)
+- [Docker deployment](/graphos/routing/self-hosted/containerization/docker)
+- [Kubernetes deployment](/graphos/routing/self-hosted/containerization/kubernetes/quickstart)


### PR DESCRIPTION
## Context

Follow-up to #9152 (which landed test + docs for OTLP HTTP proxy support from #9055).

While reviewing the docs post-merge, it felt like `proxy-certificates.mdx` page and the new `graphos-reporting.mdx` section were covering the same topic from different angles without telling a complete story — and neither explained the full scope of what the proxy env vars actually affect.

## What changed

### `proxy-certificates.mdx` — expanded into a full HTTP proxy page

The page was focused solely on adding TLS certificates to containers. It's now a complete "HTTP proxy configuration" guide covering the full setup in one place:

- **Which connections respect proxy env vars** — Uplink, GraphOS telemetry, OTLP exporters, Datadog, JWKS auth. Importantly, subgraph connections don't: the router uses `hyper` directly for subgraph traffic, which doesn't read proxy env vars.
- **`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` setup** — with a note that OTLP specifically requires the HTTP transport (v2.14.0+).
- **Two cert approaches** — `SSL_CERT_FILE` (simpler, env-var-only) and the existing container CA store update (Docker mount / custom image / Kubernetes init container). `SSL_CERT_FILE` works because the router uses `rustls-native-certs` v0.8 for both its `reqwest` clients and the `hyper` subgraph client, and that crate reads `SSL_CERT_FILE` on Linux at startup.
- Sidebar label updated from "Proxy Certificates" → "HTTP Proxy".

### `graphos-reporting.mdx` — trimmed to a pointer

The "HTTP proxy support" subsection now contains a single sentence pointing to the full page, plus the existing `<Note>` about HTTP transport. The env var example and inline cert instructions are removed — they belong on the dedicated page.

### Changeset

Added some sort of changeset entry for #9152

## Checklist

- [x] Documentation updated
- [x] Changeset added