### PR TITLE
[DXM-100] Add Redis TLS config shared component

### DIFF
--- a/docs/shared/redis-tls.mdx
+++ b/docs/shared/redis-tls.mdx
@@ -1,16 +1,15 @@
-For Redis TLS connections, you can set up a client certificate or override the root certificate authority by configuring `tls` in your router's [YAML config file](https://www.apollographql.com/docs/router/overview/#yaml-config-file). For example:
+For Redis TLS connections, you can set up a client certificate or override the root certificate authority by configuring `tls` in your router's [YAML config file](/graphos/routing/configuration/overview#yaml-config-file). Nest the `tls` configuration under the `redis` section for your feature. For example:
 
 ```yaml
-apq:
-  router:
-    cache:
-      redis:
-        urls: [ "rediss://redis.example.com:6379" ]
-        #highlight-start
-        tls:
-          certificate_authorities: ${file./path/to/ca.crt}
-          client_authentication:
-            certificate_chain: ${file./path/to/certificate_chain.pem}
-            key: ${file./path/to/key.pem}
-        #highlight-end
+redis:
+  urls: ["rediss://redis.example.com:6379"]
+  #highlight-start
+  tls:
+    certificate_authorities: ${file./path/to/ca.crt}
+    client_authentication:
+      certificate_chain: ${file./path/to/certificate_chain.pem}
+      key: ${file./path/to/key.pem}
+  #highlight-end
 ```
+
+For comprehensive TLS configuration details, including client-side and subgraph TLS, see [TLS configuration](/router/configuration/tls).

--- a/docs/shared/redis-tls.mdx
+++ b/docs/shared/redis-tls.mdx
@@ -1,4 +1,4 @@
-For Redis TLS connections, you can set up a client certificate or override the root certificate authority by configuring `tls` in your router's [YAML config file](/graphos/routing/configuration/overview#yaml-config-file). Nest the `tls` configuration under the `redis` section for your feature. For example:
+For Redis TLS connections, you can set up a client certificate or override the root certificate authority by configuring `tls` in your router's [YAML config file](/graphos/routing/configuration/overview#yaml-config-file).
 
 ```yaml
 redis:

--- a/docs/source/routing/operations/apq.mdx
+++ b/docs/source/routing/operations/apq.mdx
@@ -4,6 +4,8 @@ subtitle: Configure caching for automatic persisted queries
 description: Configure automatic persisted queries (APQ) in GraphOS Router to reduce network usage by sending query hashes instead of full query strings.
 ---
 
+import RedisTls from '../../../shared/redis-tls.mdx';
+
 [Automatic Persisted Queries (**APQ**)](/apollo-server/performance/apq) enable GraphQL clients to send a server the _hash_ of their query string, _instead of_ sending the query string itself. When query strings are very large, this can significantly reduce network usage.
 
 The router supports using APQ in its communications with both clients _and_ subgraphs:
@@ -198,20 +200,7 @@ When using the same Redis instance for multiple purposes, the `namespace` option
 
 #### TLS
 
-For Redis TLS connections, you can set up a client certificate or override the root certificate authority by configuring `tls` in your router's [YAML config file](/graphos/routing/configuration/overview#yaml-config-file). For example:
-
-```yaml
-apq:
-  router:
-    cache:
-      redis:
-        urls: ["rediss://redis.example.com:6379"]
-        tls:
-          certificate_authorities: ${file./path/to/ca.crt}
-          client_authentication:
-            certificate_chain: ${file./path/to/certificate_chain.pem}
-            key: ${file./path/to/key.pem}
-```
+<RedisTls />
 
 #### Required to start
 

--- a/docs/source/routing/operations/apq.mdx
+++ b/docs/source/routing/operations/apq.mdx
@@ -202,6 +202,12 @@ When using the same Redis instance for multiple purposes, the `namespace` option
 
 <RedisTls />
 
+<Note>
+
+Nest this `tls` configuration under `apq.router.cache`.
+
+</Note>
+
 #### Required to start
 
 When active, the `required_to_start` option will prevent the router from starting if it cannot connect to Redis. By default, the router will still start without a connection to Redis, which would result in only using the in-memory cache for APQ.

--- a/docs/source/routing/performance/caching/response-caching/customization.mdx
+++ b/docs/source/routing/performance/caching/response-caching/customization.mdx
@@ -5,6 +5,8 @@ description: Configure per-user caching with private data, create custom cache k
 minVersion: Router v2.10.0
 ---
 
+import RedisTls from '../../../../../shared/redis-tls.mdx';
+
 Beyond basic response caching, the router supports customization for caching private data, modifying cache keys, and advanced Redis configuration.
 
 ## When to customize
@@ -254,28 +256,7 @@ or, if configured with multiple URLs:
 
 ### TLS and authentication
 
-For Redis TLS connections, you can set up a client certificate or override the root certificate authority by configuring `tls` in your router's [YAML config file](https://www.apollographql.com/docs/router/overview/#yaml-config-file). For example:
-
-```yaml title="router.yaml"
-# Enable response caching globally
-response_cache:
-  enabled: true
-  subgraph:
-    all:
-      enabled: true
-      # Configure Redis globally
-      redis:
-        urls: [ "rediss://redis.example.com:6379" ]
-        #highlight-start
-        username: root
-        password: ${env.REDIS_PASSWORD}
-        tls:
-          certificate_authorities: ${file./path/to/ca.crt}
-          client_authentication:
-            certificate_chain: ${file./path/to/certificate_chain.pem}
-            key: ${file./path/to/key.pem}
-        #highlight-end
-```
+<RedisTls />
 
 ### Timeout configuration
 

--- a/docs/source/routing/performance/caching/response-caching/customization.mdx
+++ b/docs/source/routing/performance/caching/response-caching/customization.mdx
@@ -258,6 +258,12 @@ or, if configured with multiple URLs:
 
 <RedisTls />
 
+<Note>
+
+Nest this `tls` configuration under `response_cache.subgraph.all`.
+
+</Note>
+
 ### Timeout configuration
 
 Redis connections and commands have default timeouts that you can override. The timeouts are tailored to specific caching operations: fetch, insert, invalidate, and maintenance. Set a lower fetch timeout and a higher insert timeout for a good balance of reliability and client responsiveness:

--- a/docs/source/routing/query-planning/caching.mdx
+++ b/docs/source/routing/query-planning/caching.mdx
@@ -4,6 +4,8 @@ subtitle: Configure in-memory and distributed caching for query plans
 description: Configure query plan caching to improve router performance by storing generated query plans in memory or Redis.
 ---
 
+import RedisTls from '../../../shared/redis-tls.mdx';
+
 Whenever your router receives an incoming GraphQL operation, it generates a [query plan](/graphos/resources/federation/query-plans) to determine which subgraphs it needs to query to resolve that operation.
 
 By caching previously generated query plans, your router can skip generating them again if a client later sends the exact same operation—improving your router's responsiveness.
@@ -243,20 +245,7 @@ When using the same Redis instance for multiple purposes, the `namespace` option
 
 #### TLS
 
-For Redis TLS connections, you can set up a client certificate or override the root certificate authority by configuring `tls` in your router's [YAML config file](/graphos/routing/configuration/overview#yaml-config-file). For example:
-
-```yaml
-supergraph:
-  query_planning:
-    cache:
-      redis:
-        urls: ["rediss://redis.example.com:6379"]
-        tls:
-          certificate_authorities: ${file./path/to/ca.crt}
-          client_authentication:
-            certificate_chain: ${file./path/to/certificate_chain.pem}
-            key: ${file./path/to/key.pem}
-```
+<RedisTls />
 
 #### Required to start
 

--- a/docs/source/routing/query-planning/caching.mdx
+++ b/docs/source/routing/query-planning/caching.mdx
@@ -247,6 +247,12 @@ When using the same Redis instance for multiple purposes, the `namespace` option
 
 <RedisTls />
 
+<Note>
+
+Nest this `tls` configuration under `supergraph.query_planning.cache`.
+
+</Note>
+
 #### Required to start
 
 When active, the `required_to_start` option will prevent the router from starting if it cannot connect to Redis. By default, the router will still start without a connection to Redis, which would result in only using the in-memory cache for query planning.

--- a/docs/source/routing/security/tls.mdx
+++ b/docs/source/routing/security/tls.mdx
@@ -5,6 +5,8 @@ redirectFrom:
   - /router/configuration/overview/#tls
 ---
 
+import RedisTls from '../../../shared/redis-tls.mdx';
+
 The GraphOS Router supports TLS to authenticate and encrypt communications, both on the client side and the subgraph side. It works automatically on the subgraph side if the subgraph URL starts with `https://`.
 
 ```yaml title="Example TLS configuration"
@@ -128,19 +130,4 @@ tls:
 
 ## Redis TLS configuration
 
-For Redis TLS connections, you can set up a client certificate or override the root certificate authority by configuring `tls` in your router's [YAML config file](https://www.apollographql.com/docs/router/overview/#yaml-config-file). For example:
-
-```yaml
-apq:
-  router:
-    cache:
-      redis:
-        urls: [ "rediss://redis.example.com:6379" ]
-        #highlight-start
-        tls:
-          certificate_authorities: ${file./path/to/ca.crt}
-          client_authentication:
-            certificate_chain: ${file./path/to/certificate_chain.pem}
-            key: ${file./path/to/key.pem}
-        #highlight-end
-```
+<RedisTls />

--- a/docs/source/routing/security/tls.mdx
+++ b/docs/source/routing/security/tls.mdx
@@ -131,3 +131,9 @@ tls:
 ## Redis TLS configuration
 
 <RedisTls />
+
+<Note>
+
+Nest this `tls` configuration under the `redis` key for your feature, for example, under `apq.router.cache` for APQ caching.
+
+</Note>


### PR DESCRIPTION
## Summary

Resolves [DXM-100](https://apollographql.atlassian.net/browse/DXM-100).

The docs mention that any Redis connection supports a TLS config, but this information only lived in a single spot ([TLS configuration overview](https://www.apollographql.com/docs/router/configuration/overview#redis-tls-configuration)) that users were unlikely to discover when reading a feature page directly (APQ, Entity Cache, response caching, etc.).

This PR:
- Updates the existing shared component `docs/shared/redis-tls.mdx` with generic, feature-agnostic content and a clean YAML example showing just the `redis.tls` block structure
- Imports and renders that shared component on every feature page that exposes a Redis configuration section:
  - `docs/source/routing/operations/apq.mdx` (APQ distributed caching)
  - `docs/source/routing/query-planning/caching.mdx` (query plan distributed caching)
  - `docs/source/routing/performance/caching/response-caching/customization.mdx` (response cache advanced Redis config)
  - `docs/source/routing/security/tls.mdx` (TLS overview — Redis section)
- Removes duplicate inline TLS content from each of those pages (55 lines of duplication eliminated)

## Acceptance criteria

- [x] Redis TLS config info is now visible contextually on each feature page that configures Redis
- [x] A single shared component (`docs/shared/redis-tls.mdx`) is the single source of truth for the Redis TLS blurb
- [x] The shared component links back to the full TLS configuration page for comprehensive details

## Jeff's direction

> You'll need to work from the repo apollographql/router. From the project root, look for docs/source/routing/configuration/overview.mdx. Search for other Redis TLS config references per the ticket, you'll need to look over everything in the /docs/ directory (including nested directories) to find all the areas where we could include this shared context.

Ticket: https://apollographql.atlassian.net/browse/DXM-100

[DXM-100]: https://apollographql.atlassian.net/browse/DXM-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ