### PR TITLE
fix(composition): link specs should be imported in deterministic order

### DIFF
--- a/apollo-federation/src/merger/merge_links.rs
+++ b/apollo-federation/src/merger/merge_links.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
@@ -54,10 +53,10 @@ impl Merger {
         trace!("Collecting core directives used in subgraphs");
         // Groups directives by their feature and major version (we use negative numbers for
         // pre-1.0 version numbers on the minor, since all minors are incompatible).
-        let mut directives_per_feature_and_version: HashMap<
+        let mut directives_per_feature_and_version: IndexMap<
             String,
-            HashMap<i32, CoreDirectiveInSubgraphs>,
-        > = HashMap::new();
+            IndexMap<i32, CoreDirectiveInSubgraphs>,
+        > = IndexMap::default();
 
         for subgraph in &self.subgraphs {
             let Some(features) = subgraph.schema().metadata() else {
@@ -149,8 +148,8 @@ impl Merger {
         &mut self,
         directives_merge_info: &[CoreDirectiveInSubgraphs],
     ) -> Result<(), FederationError> {
-        let mut supergraph_info_by_identity: HashMap<Identity, Vec<CoreDirectiveInSupergraph>> =
-            HashMap::new();
+        let mut supergraph_info_by_identity: IndexMap<Identity, Vec<CoreDirectiveInSupergraph>> =
+            IndexMap::default();
 
         trace!("Determining supergraph names for directives used in subgraphs");
         for subgraph_core_directive in directives_merge_info {

--- a/apollo-federation/tests/composition/compose_auth.rs
+++ b/apollo-federation/tests/composition/compose_auth.rs
@@ -1,6 +1,7 @@
 use apollo_compiler::coord;
 use insta::assert_snapshot;
-
+use apollo_federation::composition::compose;
+use apollo_federation::subgraph::typestate::Subgraph;
 use super::ServiceDefinition;
 use super::assert_composition_errors;
 use super::compose_as_fed2_subgraphs;
@@ -480,6 +481,47 @@ fn policy_comprehensive_locations() {
         let has_policy = target.directives.iter().any(|d| d.name == "policy");
         assert!(has_policy, "No policy directive found in {}", target.node);
     }
+}
+
+
+#[test]
+fn specs_compose_in_consistent_order() {
+    let users_sdl = r#"
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@authenticated", "@key", "@policy", "@requiresScopes"])
+
+        type Query {
+          users: [User!]! @requiresScopes(scopes: [["admin"]])
+          user(id: ID!): User @authenticated
+        }
+
+        type User @key(fields: "id") @requiresScopes(scopes: [["user_1"]]) {
+          id: ID!
+          name: String!
+          dob: String! @policy(policies: [["user"]])
+        }
+    "#;
+    let users = Subgraph::parse("users", "http://users/graphql", users_sdl)
+        .expect("valid users subgraph");
+
+    let address_sdl = r#"
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key", "@requiresScopes"])
+
+        type User @key(fields: "id") @requiresScopes(scopes: [["user_2"]]) {
+          id: ID!
+          address: String
+        }
+    "#;
+    let address = Subgraph::parse("address", "http://address/graphql", address_sdl)
+        .expect("valid address subgraph");
+
+    let result = compose(vec![users.clone(), address.clone()])
+        .expect("composes successfully");
+    let supergraph_schema = result.schema().schema();
+    assert_snapshot!(supergraph_schema);
+
+    let result = compose(vec![address, users])
+        .expect("composes successfully");
+    assert_eq!(result.schema().schema(), supergraph_schema);
 }
 
 mod transitive_auth {

--- a/apollo-federation/tests/composition/compose_auth.rs
+++ b/apollo-federation/tests/composition/compose_auth.rs
@@ -1,7 +1,8 @@
 use apollo_compiler::coord;
-use insta::assert_snapshot;
 use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
+use insta::assert_snapshot;
+
 use super::ServiceDefinition;
 use super::assert_composition_errors;
 use super::compose_as_fed2_subgraphs;
@@ -483,7 +484,6 @@ fn policy_comprehensive_locations() {
     }
 }
 
-
 #[test]
 fn specs_compose_in_consistent_order() {
     let users_sdl = r#"
@@ -500,8 +500,8 @@ fn specs_compose_in_consistent_order() {
           dob: String! @policy(policies: [["user"]])
         }
     "#;
-    let users = Subgraph::parse("users", "http://users/graphql", users_sdl)
-        .expect("valid users subgraph");
+    let users =
+        Subgraph::parse("users", "http://users/graphql", users_sdl).expect("valid users subgraph");
 
     let address_sdl = r#"
         extend schema @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key", "@requiresScopes"])
@@ -514,13 +514,11 @@ fn specs_compose_in_consistent_order() {
     let address = Subgraph::parse("address", "http://address/graphql", address_sdl)
         .expect("valid address subgraph");
 
-    let result = compose(vec![users.clone(), address.clone()])
-        .expect("composes successfully");
+    let result = compose(vec![users.clone(), address.clone()]).expect("composes successfully");
     let supergraph_schema = result.schema().schema();
     assert_snapshot!(supergraph_schema);
 
-    let result = compose(vec![address, users])
-        .expect("composes successfully");
+    let result = compose(vec![address, users]).expect("composes successfully");
     assert_eq!(result.schema().schema(), supergraph_schema);
 }
 

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_auth__specs_compose_in_consistent_order.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_auth__specs_compose_in_consistent_order.snap
@@ -1,0 +1,76 @@
+---
+source: apollo-federation/tests/composition/compose_auth.rs
+expression: supergraph_schema
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/requiresScopes/v0.1", for: SECURITY) @link(url: "https://specs.apollo.dev/authenticated/v0.1", for: SECURITY) @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @requiresScopes(scopes: [[requiresScopes__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @policy(policies: [[policy__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  ADDRESS @join__graph(name: "address", url: "http://address/graphql")
+  USERS @join__graph(name: "users", url: "http://users/graphql")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar requiresScopes__Scope
+
+scalar policy__Policy
+
+type User @join__type(graph: ADDRESS, key: "id") @join__type(graph: USERS, key: "id") @requiresScopes(scopes: [["user_1", "user_2"]]) {
+  id: ID!
+  address: String @join__field(graph: ADDRESS)
+  name: String! @join__field(graph: USERS)
+  dob: String! @join__field(graph: USERS) @policy(policies: [["user"]])
+}
+
+type Query @join__type(graph: ADDRESS) @join__type(graph: USERS) {
+  users: [User!]! @join__field(graph: USERS) @requiresScopes(scopes: [["admin"]])
+  user(id: ID!): User @join__field(graph: USERS) @authenticated
+}


### PR DESCRIPTION
When merging link we were using HashMaps instead of preserving the iteration order.