### PR TITLE
fix(tests): drop hyper client before graceful_shutdown in h2 header limit tests

### DIFF
--- a/apollo-router/tests/integration/http_server.rs
+++ b/apollo-router/tests/integration/http_server.rs
@@ -180,6 +180,10 @@ async fn test_http2_max_header_list_size_exceeded() -> Result<(), BoxError> {
         "Expected 431 Request Header Fields Too Large when header list exceeds 20MiB limit"
     );
 
+    // Drop response and client before shutdown so the h2 connection is closed and the router can
+    // drain its connections cleanly — otherwise graceful_shutdown hangs waiting for the open conn.
+    drop(response);
+    drop(client);
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -234,6 +238,8 @@ async fn test_http2_max_header_list_size_within_limit() -> Result<(), BoxError> 
         "Expected HTTP/2 to be negotiated"
     );
 
+    drop(response);
+    drop(client);
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -285,6 +291,8 @@ async fn test_tcp_max_header_list_size_exceeded() -> Result<(), BoxError> {
         "Expected 431 Request Header Fields Too Large when header list exceeds 20MiB limit for TCP"
     );
 
+    drop(response);
+    drop(client);
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -340,6 +348,8 @@ async fn test_tcp_max_header_list_size_within_limit() -> Result<(), BoxError> {
         "Expected HTTP/2 to be negotiated for TCP"
     );
 
+    drop(response);
+    drop(client);
     router.graceful_shutdown().await;
     Ok(())
 }


### PR DESCRIPTION
<!-- start metadata -->

<!-- no ROUTER ticket — this is a test reliability fix found via CI flakiness investigation -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

Test-only change — no changeset, no documentation, no metrics, no performance impact.  The tests themselves are what's being fixed.

---

## What's going on

Four integration tests in `http_server.rs` have been showing up as flaky in CI — specifically, they hit the "unable to shutdown router, this probably means a hang" panic in `assert_shutdown`.  The tests themselves pass (the right status codes come back), but the router hangs when the test tries to shut it down afterward.

The tests are:
- `test_http2_max_header_list_size_exceeded`
- `test_http2_max_header_list_size_within_limit`
- `test_tcp_max_header_list_size_exceeded`
- `test_tcp_max_header_list_size_within_limit`

## Why I think it hangs

HTTP/2 connections are persistent by design — one connection, many requests multiplexed on it.  The hyper client in each of these tests opens a connection, sends one request, gets a response, and then just... sits there, holding the connection open, ready for more!

When we call `router.graceful_shutdown().await`, the router does the right thing: it stops accepting new connections and waits for all existing ones to drain before exiting.  The problem is that the test's `client` variable is still alive at that point — Rust won't drop it until the function returns, but the function can't return because it's suspended awaiting graceful_shutdown, which can't complete because the client is still holding the connection.  Classic deadlock.

The fix is — hopefully — just `drop(response); drop(client)` before `graceful_shutdown()`.  Explicitly dropping the client causes hyper to send a GOAWAY frame, the router sees the connection close, drains cleanly, and shuts down.

## Why it's *flaky* rather than *always* broken

Working theory: Occasionally the OS or the scheduler happens to clean things up fast enough in the background that the router drains before the shutdown timeout fires.  On a loaded CI machine it's much more likely to lose that race — hence intermittent.

## Asking for a second set of eyes

I'm medium confident this is the root cause — the CI panic message points directly at `graceful_shutdown`.  But I'd appreciate someone to look at whether the `drop(client)` approach is actually sufficient, or whether there's a more correct way to signal connection close here, or if it's just worth a shot.

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
