### PR TITLE
fix(composition): enable ignored tests

### DIFF
--- a/apollo-federation/src/schema/validators/from_context.rs
+++ b/apollo-federation/src/schema/validators/from_context.rs
@@ -3093,8 +3093,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: Fix this if we decide we care, but probably not worth the effort
-    // Port note: Ported from JS test "contextual argument on a directive definition argument"
     fn test_fromcontext_on_directive_definition() {
         let schema_str = r#"
             extend schema

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -156,8 +156,9 @@ fn misc_existing_authenticated_directive_with_fed1() {
           id: ID!
           name: String! @authenticated(scope: ["read:foo"])
         }
-        "#
-    ).expect("valid subgraph");
+        "#,
+    )
+    .expect("valid subgraph");
 
     let subgraph_b = Subgraph::parse(
         "subgraphB",
@@ -170,13 +171,20 @@ fn misc_existing_authenticated_directive_with_fed1() {
         type Foo @key(fields: "id") {
           id: ID!
         }
-        "#
-    ).expect("valid subgraph");
+        "#,
+    )
+    .expect("valid subgraph");
 
     let result = compose(vec![subgraph_a, subgraph_b])
         .expect("Expected composition to succeed with existing @authenticated directive");
 
-    assert!(!result.schema().schema().directive_definitions.contains_key("@authenticated"));
+    assert!(
+        !result
+            .schema()
+            .schema()
+            .directive_definitions
+            .contains_key("@authenticated")
+    );
 }
 
 #[test]

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -11,7 +11,6 @@ use super::print_sdl;
 // =============================================================================
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn misc_works_with_normal_graphql_type_extension_when_definition_is_empty() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",
@@ -36,7 +35,6 @@ fn misc_works_with_normal_graphql_type_extension_when_definition_is_empty() {
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn misc_handles_fragments_in_requires_using_inaccessible_types() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",
@@ -147,23 +145,24 @@ fn misc_handles_fragments_in_requires_using_inaccessible_types() {
 }
 
 #[test]
-#[ignore = "until merge implementation completed"]
 fn misc_existing_authenticated_directive_with_fed1() {
-    let subgraph_a = ServiceDefinition {
-        name: "subgraphA",
-        type_defs: r#"
+    let subgraph_a = Subgraph::parse(
+        "subgraphA",
+        "http://subgraphA",
+        r#"
         directive @authenticated(scope: [String!]) repeatable on FIELD_DEFINITION
 
         extend type Foo @key(fields: "id") {
           id: ID!
           name: String! @authenticated(scope: ["read:foo"])
         }
-        "#,
-    };
+        "#
+    ).expect("valid subgraph");
 
-    let subgraph_b = ServiceDefinition {
-        name: "subgraphB",
-        type_defs: r#"
+    let subgraph_b = Subgraph::parse(
+        "subgraphB",
+        "http://subgraphB",
+        r#"
         type Query {
           foo: Foo
         }
@@ -171,18 +170,13 @@ fn misc_existing_authenticated_directive_with_fed1() {
         type Foo @key(fields: "id") {
           id: ID!
         }
-        "#,
-    };
+        "#
+    ).expect("valid subgraph");
 
-    // NOTE: This test uses composeServices() in JS (Fed1), not composeAsFed2Subgraphs()
-    // The test validates that existing @authenticated directives in Fed1 are handled properly
-    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
-    let supergraph =
-        result.expect("Expected composition to succeed with existing @authenticated directive");
+    let result = compose(vec![subgraph_a, subgraph_b])
+        .expect("Expected composition to succeed with existing @authenticated directive");
 
-    // NOTE: The JS test validates that the custom @authenticated directive is NOT present in the final schema
-    // (it should be filtered out). For now, we just verify composition succeeds.
-    let _schema = supergraph.schema();
+    assert!(!result.schema().schema().directive_definitions.contains_key("@authenticated"));
 }
 
 #[test]

--- a/apollo-federation/tests/composition/validation_errors.rs
+++ b/apollo-federation/tests/composition/validation_errors.rs
@@ -176,7 +176,6 @@ mod non_resolvable_keys_tests {
 mod interface_object_tests {
     use super::*;
 
-    #[ignore = "Error message is missing message part about interface object usage"]
     #[test]
     fn fails_on_interface_object_usage_with_missing_key_on_interface() {
         let subgraph_a = ServiceDefinition {


### PR DESCRIPTION
Enable previously ignored tests. With composition mostly done, those tests are now succeeding.
