### PR TITLE
fix(composition): fix cache tag supergaph spec and join__directive logic

### DIFF
--- a/apollo-federation/src/link/cache_tag_spec_definition.rs
+++ b/apollo-federation/src/link/cache_tag_spec_definition.rs
@@ -5,20 +5,12 @@
 // PORT_NOTE: Ported from internals-js/src/specs/cacheTagSpec.ts (federation PR #3274).
 use std::sync::LazyLock;
 
-use apollo_compiler::schema::DirectiveLocation;
-
-use super::federation_spec_definition::FEDERATION_CACHE_TAG_DIRECTIVE_NAME_IN_SPEC;
-use super::federation_spec_definition::FEDERATION_FORMAT_ARGUMENT_NAME;
 use crate::link::Purpose;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
 use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::link::spec_definition::SpecDefinitions;
-use crate::schema::type_and_directive_specification::ArgumentSpecification;
-use crate::schema::type_and_directive_specification::DirectiveArgumentSpecification;
-use crate::schema::type_and_directive_specification::DirectiveCompositionOptions;
-use crate::schema::type_and_directive_specification::DirectiveSpecification;
 use crate::schema::type_and_directive_specification::TypeAndDirectiveSpecification;
 
 pub(crate) struct CacheTagSpecDefinition {
@@ -36,36 +28,6 @@ impl CacheTagSpecDefinition {
             minimum_federation_version,
         }
     }
-
-    fn directive_locations(&self) -> Vec<DirectiveLocation> {
-        vec![
-            DirectiveLocation::FieldDefinition,
-            DirectiveLocation::Object,
-        ]
-    }
-
-    fn directive_specification(&self) -> Box<dyn TypeAndDirectiveSpecification> {
-        Box::new(DirectiveSpecification::new(
-            FEDERATION_CACHE_TAG_DIRECTIVE_NAME_IN_SPEC,
-            &[DirectiveArgumentSpecification {
-                base_spec: ArgumentSpecification {
-                    name: FEDERATION_FORMAT_ARGUMENT_NAME,
-                    get_type: |_, _| Ok(apollo_compiler::ty!(String!)),
-                    default_value: None,
-                },
-                composition_strategy: None,
-            }],
-            true, // repeatable
-            &self.directive_locations(),
-            Some(DirectiveCompositionOptions {
-                supergraph_specification: &|v| {
-                    CACHE_TAG_VERSIONS.get_dyn_minimum_required_version(v)
-                },
-                static_argument_transform: None,
-                use_join_directive: true,
-            }),
-        ))
-    }
 }
 
 impl SpecDefinition for CacheTagSpecDefinition {
@@ -74,7 +36,7 @@ impl SpecDefinition for CacheTagSpecDefinition {
     }
 
     fn directive_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
-        vec![self.directive_specification()]
+        vec![]
     }
 
     fn type_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
@@ -86,7 +48,7 @@ impl SpecDefinition for CacheTagSpecDefinition {
     }
 
     fn purpose(&self) -> Option<Purpose> {
-        None
+        Some(Purpose::EXECUTION)
     }
 }
 

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -2325,9 +2325,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                 // schema. For Connectors (see `should_use_join_directive_for_url`), this is an import name (the
                 // same name imported in the supergraph and the extracted subgraphs). For others, this is
                 // the fully qualified directive name in the subgraph schema (re-assigned below).
-                let mut directive_name_for_join_directive = None;
-
-                if source_link
+                let directive_name_for_join_directive = if source_link
                     .as_ref()
                     .is_some_and(|e| e.link.url.identity == Identity::link_identity())
                 {
@@ -2339,31 +2337,37 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                         if SPEC_REGISTRY.get_definition(&link.url).is_some() {
                             links_to_persist.push((link.url.clone(), directive.as_ref().clone()));
                         }
-                        directive_name_for_join_directive = Some(directive.name.clone());
+                        Some(directive.name.clone())
+                    } else {
+                        None
                     }
                 // See if directives from this feature URL should use the @join__directive.
-                } else if !source_link
+                } else if source_link
                     .as_ref()
                     .is_some_and(|e| self.should_use_join_directive_for_url(&e.link.url))
-                    && self
-                        .directives_using_join_directive
-                        .contains(&directive.name)
+                {
+                    Some(directive.name.clone())
+                // See if this directive is one of the directives that should use the @join__directive.
+                } else if self
+                    .directives_using_join_directive
+                    .contains(&directive.name)
                 {
                     if let Some(source_link) = source_link {
                         // Compute the fully qualified directive name in the subgraph schema without using
                         // `import`, so it can be referenced in the extracted subgraph schema via
                         // `@join__directive`.
-                        directive_name_for_join_directive =
-                            Some(Link::directive_name_in_schema_for_core_arguments(
-                                &source_link.link.url,
-                                &source_link.link.url.identity.name,
-                                &[],
-                                &source_link.name_in_spec,
-                            ));
+                        Some(Link::directive_name_in_schema_for_core_arguments(
+                            &source_link.link.url,
+                            &source_link.link.url.identity.name,
+                            &[],
+                            &source_link.name_in_spec,
+                        ))
                     } else {
-                        directive_name_for_join_directive = Some(directive.name.clone());
+                        Some(directive.name.clone())
                     }
-                }
+                } else {
+                    None
+                };
 
                 if let Some(directive_name_for_join_directive) = directive_name_for_join_directive {
                     let existing_joins = joins_by_directive_name

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -849,7 +849,10 @@ impl Merger {
             return true;
         }
 
-        if self.directives_using_join_directive.contains(&directive.name) {
+        if self
+            .directives_using_join_directive
+            .contains(&directive.name)
+        {
             // This directive will be added as `@join__directive` by the `add_join_directive_directives`
             // method. So, we skip the normal merging logic.
             return false;
@@ -2316,52 +2319,53 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
 
             let source: DirectiveTargetPosition = source.clone().try_into()?;
             for directive in source.get_all_applied_directives(schema).iter() {
-                let source_link = link_import_identity_url_map.source_link_of_directive(&directive.name);
-                let mut should_include_as_join_directive = false;
-                // `directiveNameForJoinDirective`: The directive name to use in the extracted subgraph
-                // schema. For Connectors (see `shouldUseJoinDirectiveForURL`), this is an import name (the
+                let source_link =
+                    link_import_identity_url_map.source_link_of_directive(&directive.name);
+                // `directive_name_for_join_directive`: The directive name to use in the extracted subgraph
+                // schema. For Connectors (see `should_use_join_directive_for_url`), this is an import name (the
                 // same name imported in the supergraph and the extracted subgraphs). For others, this is
                 // the fully qualified directive name in the subgraph schema (re-assigned below).
-                let mut directive_name_for_join_directive = directive.name.clone();
-                
-                if source_link.as_ref().is_some_and(|e| e.link.url.identity == Identity::link_identity()) {
-                    if let Ok(link) = Link::from_directive_application(directive, schema.schema()) {
-                        should_include_as_join_directive =
-                            self.should_use_join_directive_for_url(&link.url);
+                let mut directive_name_for_join_directive = None;
 
+                if source_link
+                    .as_ref()
+                    .is_some_and(|e| e.link.url.identity == Identity::link_identity())
+                {
+                    if let Ok(link) = Link::from_directive_application(directive, schema.schema())
+                        && self.should_use_join_directive_for_url(&link.url)
+                    {
                         // Persist link when the spec uses @join__directive and the feature
                         // identity is one of the known join-directive feature definitions.
-                        if should_include_as_join_directive
-                            && SPEC_REGISTRY.get_definition(&link.url).is_some()
-                        {
+                        if SPEC_REGISTRY.get_definition(&link.url).is_some() {
                             links_to_persist.push((link.url.clone(), directive.as_ref().clone()));
                         }
+                        directive_name_for_join_directive = Some(directive.name.clone());
                     }
-                } else {
-                    // See if directives from this feature URL should use the @join__directive.
-                    should_include_as_join_directive = source_link.as_ref()
-                        .is_some_and(|e| self.should_use_join_directive_for_url(&e.link.url));
-                    if !should_include_as_join_directive
-                        && self
-                            .directives_using_join_directive
-                            .contains(&directive.name)
-                    {
-                        should_include_as_join_directive = true;
-                        if let Some(source_link) = source_link {
-                            // Compute the fully qualified directive name in the subgraph schema without using
-                            // `import`, so it can be referenced in the extracted subgraph schema via
-                            // `@join__directive`.
-                            directive_name_for_join_directive = Link::directive_name_in_schema_for_core_arguments(
+                // See if directives from this feature URL should use the @join__directive.
+                } else if !source_link
+                    .as_ref()
+                    .is_some_and(|e| self.should_use_join_directive_for_url(&e.link.url))
+                    && self
+                        .directives_using_join_directive
+                        .contains(&directive.name)
+                {
+                    if let Some(source_link) = source_link {
+                        // Compute the fully qualified directive name in the subgraph schema without using
+                        // `import`, so it can be referenced in the extracted subgraph schema via
+                        // `@join__directive`.
+                        directive_name_for_join_directive =
+                            Some(Link::directive_name_in_schema_for_core_arguments(
                                 &source_link.link.url,
                                 &source_link.link.url.identity.name,
-                                &vec![],
+                                &[],
                                 &source_link.name_in_spec,
-                            );
-                        }
+                            ));
+                    } else {
+                        directive_name_for_join_directive = Some(directive.name.clone());
                     }
                 }
 
-                if should_include_as_join_directive {
+                if let Some(directive_name_for_join_directive) = directive_name_for_join_directive {
                     let existing_joins = joins_by_directive_name
                         .entry(directive_name_for_join_directive)
                         .or_default();

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -849,6 +849,12 @@ impl Merger {
             return true;
         }
 
+        if self.directives_using_join_directive.contains(&directive.name) {
+            // This directive will be added as `@join__directive` by the `add_join_directive_directives`
+            // method. So, we skip the normal merging logic.
+            return false;
+        }
+
         self.merged_federation_directive_names
             .contains(directive.name.as_str())
             || BUILT_IN_DIRECTIVES.contains(&directive.name.as_str())
@@ -2307,18 +2313,18 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
             let Some(link_import_identity_url_map) = schema.metadata() else {
                 continue;
             };
-            let Ok(Some(link_directive_name)) = self
-                .link_spec_definition
-                .directive_name_in_schema(schema, &DEFAULT_LINK_NAME)
-            else {
-                continue;
-            };
 
             let source: DirectiveTargetPosition = source.clone().try_into()?;
             for directive in source.get_all_applied_directives(schema).iter() {
+                let source_link = link_import_identity_url_map.source_link_of_directive(&directive.name);
                 let mut should_include_as_join_directive = false;
-
-                if directive.name == link_directive_name {
+                // `directiveNameForJoinDirective`: The directive name to use in the extracted subgraph
+                // schema. For Connectors (see `shouldUseJoinDirectiveForURL`), this is an import name (the
+                // same name imported in the supergraph and the extracted subgraphs). For others, this is
+                // the fully qualified directive name in the subgraph schema (re-assigned below).
+                let mut directive_name_for_join_directive = directive.name.clone();
+                
+                if source_link.as_ref().is_some_and(|e| e.link.url.identity == Identity::link_identity()) {
                     if let Ok(link) = Link::from_directive_application(directive, schema.schema()) {
                         should_include_as_join_directive =
                             self.should_use_join_directive_for_url(&link.url);
@@ -2331,23 +2337,33 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                             links_to_persist.push((link.url.clone(), directive.as_ref().clone()));
                         }
                     }
-                } else if let Some(url_for_directive) =
-                    link_import_identity_url_map.source_link_of_directive(&directive.name)
-                {
-                    should_include_as_join_directive =
-                        self.should_use_join_directive_for_url(&url_for_directive.link.url);
+                } else {
+                    // See if directives from this feature URL should use the @join__directive.
+                    should_include_as_join_directive = source_link.as_ref()
+                        .is_some_and(|e| self.should_use_join_directive_for_url(&e.link.url));
                     if !should_include_as_join_directive
                         && self
                             .directives_using_join_directive
                             .contains(&directive.name)
                     {
                         should_include_as_join_directive = true;
+                        if let Some(source_link) = source_link {
+                            // Compute the fully qualified directive name in the subgraph schema without using
+                            // `import`, so it can be referenced in the extracted subgraph schema via
+                            // `@join__directive`.
+                            directive_name_for_join_directive = Link::directive_name_in_schema_for_core_arguments(
+                                &source_link.link.url,
+                                &source_link.link.url.identity.name,
+                                &vec![],
+                                &source_link.name_in_spec,
+                            );
+                        }
                     }
                 }
 
                 if should_include_as_join_directive {
                     let existing_joins = joins_by_directive_name
-                        .entry(directive.name.clone())
+                        .entry(directive_name_for_join_directive)
                         .or_default();
                     let existing_graphs_with_these_arguments = existing_joins
                         .entry(directive.arguments.clone())

--- a/apollo-federation/tests/composition/compose_cache_tag.rs
+++ b/apollo-federation/tests/composition/compose_cache_tag.rs
@@ -51,8 +51,7 @@ fn composes_with_multiple_subgraphs() {
           }
         "#,
     };
-    let result =
-        compose_as_fed2_subgraphs(&[products, reviews]).expect("composed successfully");
+    let result = compose_as_fed2_subgraphs(&[products, reviews]).expect("composed successfully");
     assert_snapshot!(result.schema().schema());
 }
 

--- a/apollo-federation/tests/composition/compose_cache_tag.rs
+++ b/apollo-federation/tests/composition/compose_cache_tag.rs
@@ -1,0 +1,78 @@
+use insta::assert_snapshot;
+use apollo_federation::composition::compose;
+use apollo_federation::subgraph::typestate::Subgraph;
+use test_log::test;
+use crate::composition::{compose_as_fed2_subgraphs, ServiceDefinition};
+
+#[test]
+fn composes_single_subgraph() {
+    let products = ServiceDefinition {
+        name: "products",
+        type_defs: r#"
+            type Query {
+                product(id: ID!): Product @cacheTag(format: "product-{$args.id}")
+                products: [Product!]! @cacheTag(format: "products")
+            }
+
+            type Product @key(fields: "id") @cacheTag(format: "product-{$key.id}") {
+                id: ID!
+                name: String!
+            }
+        "#
+    };
+    let result = compose_as_fed2_subgraphs(&vec![products])
+        .expect("composed successfully");
+    assert_snapshot!(result.schema().schema());
+}
+
+#[test]
+fn composes_with_multiple_subgraphs() {
+    let products = ServiceDefinition {
+        name: "products",
+        type_defs: r#"
+            type Query {
+                product(id: ID!): Product @cacheTag(format: "product-{$args.id}")
+                products: [Product!]! @cacheTag(format: "products")
+            }
+
+            type Product @key(fields: "id") @cacheTag(format: "product-{$key.id}") {
+                id: ID!
+                name: String!
+            }
+        "#
+    };
+    let reviews = ServiceDefinition {
+        name: "reviews",
+        type_defs: r#"
+          type Product @key(fields: "id") @cacheTag(format: "product-{$key.id}") {
+            id: ID!
+            reviews: [String!]!
+          }
+        "#
+    };
+    let result = compose_as_fed2_subgraphs(&vec![products, reviews])
+        .expect("composed successfully");
+    assert_snapshot!(result.schema().schema());
+}
+
+#[test]
+fn cache_tag_can_be_renamed() {
+    let sdl = r#"
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key", {name: "@cacheTag" as: "@myCacheTag"}])
+
+        type Query {
+            product(id: ID!): Product @myCacheTag(format: "product-{$args.id}")
+        }
+
+        type Product @key(fields: "id") @myCacheTag(format: "product-{$key.id}") {
+            id: ID!
+            name: String!
+        }
+    "#;
+    let products = Subgraph::parse("products", "http://products/graphql", sdl)
+        .expect("parsed subgraph");
+    let result = compose(vec![products])
+        .expect("composed successfully");
+    assert_snapshot!(result.schema().schema());
+}
+

--- a/apollo-federation/tests/composition/compose_cache_tag.rs
+++ b/apollo-federation/tests/composition/compose_cache_tag.rs
@@ -1,8 +1,10 @@
-use insta::assert_snapshot;
 use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
+use insta::assert_snapshot;
 use test_log::test;
-use crate::composition::{compose_as_fed2_subgraphs, ServiceDefinition};
+
+use crate::composition::ServiceDefinition;
+use crate::composition::compose_as_fed2_subgraphs;
 
 #[test]
 fn composes_single_subgraph() {
@@ -18,10 +20,9 @@ fn composes_single_subgraph() {
                 id: ID!
                 name: String!
             }
-        "#
+        "#,
     };
-    let result = compose_as_fed2_subgraphs(&vec![products])
-        .expect("composed successfully");
+    let result = compose_as_fed2_subgraphs(&[products]).expect("composed successfully");
     assert_snapshot!(result.schema().schema());
 }
 
@@ -39,7 +40,7 @@ fn composes_with_multiple_subgraphs() {
                 id: ID!
                 name: String!
             }
-        "#
+        "#,
     };
     let reviews = ServiceDefinition {
         name: "reviews",
@@ -48,10 +49,10 @@ fn composes_with_multiple_subgraphs() {
             id: ID!
             reviews: [String!]!
           }
-        "#
+        "#,
     };
-    let result = compose_as_fed2_subgraphs(&vec![products, reviews])
-        .expect("composed successfully");
+    let result =
+        compose_as_fed2_subgraphs(&[products, reviews]).expect("composed successfully");
     assert_snapshot!(result.schema().schema());
 }
 
@@ -69,10 +70,8 @@ fn cache_tag_can_be_renamed() {
             name: String!
         }
     "#;
-    let products = Subgraph::parse("products", "http://products/graphql", sdl)
-        .expect("parsed subgraph");
-    let result = compose(vec![products])
-        .expect("composed successfully");
+    let products =
+        Subgraph::parse("products", "http://products/graphql", sdl).expect("parsed subgraph");
+    let result = compose(vec![products]).expect("composed successfully");
     assert_snapshot!(result.schema().schema());
 }
-

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -22,6 +22,7 @@ mod override_directive;
 mod subscription;
 mod supergraph_reversibility;
 mod validation_errors;
+mod compose_cache_tag;
 
 pub(crate) mod test_helpers {
     use std::iter::zip;

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -1,5 +1,6 @@
 mod compose_auth;
 mod compose_basic;
+mod compose_cache_tag;
 mod compose_directive;
 mod compose_directive_sharing;
 mod compose_fed1_subgraphs;
@@ -22,7 +23,6 @@ mod override_directive;
 mod subscription;
 mod supergraph_reversibility;
 mod validation_errors;
-mod compose_cache_tag;
 
 pub(crate) mod test_helpers {
     use std::iter::zip;

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_cache_tag__cache_tag_can_be_renamed.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_cache_tag__cache_tag_can_be_renamed.snap
@@ -1,0 +1,62 @@
+---
+source: apollo-federation/tests/composition/compose_cache_tag.rs
+expression: result.schema().schema()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/cacheTag/v0.1", for: EXECUTION) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  PRODUCTS @join__graph(name: "products", url: "http://products/graphql")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+type Query @join__type(graph: PRODUCTS) {
+  product(id: ID!): Product @join__directive(name: "federation__cacheTag", graphs: [PRODUCTS], args: {format: "product-{$args.id}"})
+}
+
+type Product @join__type(graph: PRODUCTS, key: "id") @join__directive(name: "federation__cacheTag", graphs: [PRODUCTS], args: {format: "product-{$key.id}"}) {
+  id: ID!
+  name: String!
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_cache_tag__composes_single_subgraph.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_cache_tag__composes_single_subgraph.snap
@@ -1,0 +1,63 @@
+---
+source: apollo-federation/tests/composition/compose_cache_tag.rs
+expression: result.schema().schema()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/cacheTag/v0.1", for: EXECUTION) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  PRODUCTS @join__graph(name: "products", url: "http://products")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+type Query @join__type(graph: PRODUCTS) {
+  product(id: ID!): Product @join__directive(name: "federation__cacheTag", graphs: [PRODUCTS], args: {format: "product-{$args.id}"})
+  products: [Product!]! @join__directive(name: "federation__cacheTag", graphs: [PRODUCTS], args: {format: "products"})
+}
+
+type Product @join__type(graph: PRODUCTS, key: "id") @join__directive(name: "federation__cacheTag", graphs: [PRODUCTS], args: {format: "product-{$key.id}"}) {
+  id: ID!
+  name: String!
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_cache_tag__composes_with_multiple_subgraphs.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_cache_tag__composes_with_multiple_subgraphs.snap
@@ -1,0 +1,65 @@
+---
+source: apollo-federation/tests/composition/compose_cache_tag.rs
+expression: result.schema().schema()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/cacheTag/v0.1", for: EXECUTION) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  PRODUCTS @join__graph(name: "products", url: "http://products")
+  REVIEWS @join__graph(name: "reviews", url: "http://reviews")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+type Query @join__type(graph: PRODUCTS) @join__type(graph: REVIEWS) {
+  product(id: ID!): Product @join__field(graph: PRODUCTS) @join__directive(name: "federation__cacheTag", graphs: [PRODUCTS], args: {format: "product-{$args.id}"})
+  products: [Product!]! @join__field(graph: PRODUCTS) @join__directive(name: "federation__cacheTag", graphs: [PRODUCTS], args: {format: "products"})
+}
+
+type Product @join__type(graph: PRODUCTS, key: "id") @join__type(graph: REVIEWS, key: "id") @join__directive(name: "federation__cacheTag", graphs: [PRODUCTS, REVIEWS], args: {format: "product-{$key.id}"}) {
+  id: ID!
+  name: String! @join__field(graph: PRODUCTS)
+  reviews: [String!]! @join__field(graph: REVIEWS)
+}


### PR DESCRIPTION
Fixed `@cacheTag` supergraph spec
- directives from federation spec were incorrectly included in supergraph spec
- added missing tests

Fixed `@join__directive` merge logic
- add missing check in `is_merged_directive`
- fixed `add_join_directive_directives` logic to use correct name

<!-- FED-995 -->