### PR TITLE
fix(QP-execution): Report errors when entity fetches are skipped due to missing non-nullable required fields

### DIFF
--- a/.changesets/fix_duckki_rh_1335.md
+++ b/.changesets/fix_duckki_rh_1335.md
@@ -1,0 +1,9 @@
+### Report errors when entity fetches are skipped due to missing non-nullable required fields ([PR #9191](https://github.com/apollographql/router/pull/9191))
+
+This fixes two bugs related to `@key`/`@requires` fields validation:
+
+1. **Silent skipping of entity fetches**: When a non-nullable field required by `@key`/`@requires` was missing from the entity representation, the router silently skipped the downstream entity fetch, producing null fields with no errors in the response. Clients had no way to know why fields were null. The router now detects unsatisfied requires conditions per entity and generates `UNSATISFIED_FETCH_CONDITION` errors for each field that could not be fetched. This works correctly with entity batching — entities with satisfied requirements are still fetched, while only the failed entities produce errors.
+
+2. **Incorrect fetch with unsatisfied nested required fields**: When a non-nullable field was missing inside a nested required selection (e.g., `@requires(fields: "data { a b }")` where `b` is missing), the entity representation was still sent to the subgraph with incomplete data. The router now correctly detects missing nested non-nullable fields and skips the entity fetch.
+
+By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/9191

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use apollo_compiler::Name;
+use apollo_compiler::executable;
 use futures::StreamExt;
 use futures::future::join_all;
 use futures::prelude::*;
-use indexmap::IndexSet;
+use indexmap::IndexMap;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::BroadcastStream;
@@ -50,6 +52,7 @@ use crate::services::fetch_service::FetchServiceFactory;
 use crate::services::new_service::ServiceFactory;
 use crate::spec::Fragment;
 use crate::spec::Fragments;
+use crate::spec::IncludeSkip;
 use crate::spec::Query;
 use crate::spec::Schema;
 use crate::spec::Selection;
@@ -303,11 +306,12 @@ impl PlanNode {
                             &fetch_node.context_rewrites,
                         );
 
-                        // Generate errors for any entities whose required fields were missing.
-                        let mut skipped_errors = Vec::new();
+                        // Generate errors for skipped entities due to missing requirements.
+                        let mut skipped_entity_errors = Vec::new();
                         for unsatisfied_path in &unsatisfied_paths {
-                            skipped_errors.extend(errors_for_skipped_fetch(
+                            skipped_entity_errors.extend(errors_for_skipped_entity::generate(
                                 parameters,
+                                fetch_node,
                                 unsatisfied_path,
                                 parent_value,
                             ));
@@ -360,7 +364,7 @@ impl PlanNode {
 
                                     errors.push(err);
                                 }
-                                errors.extend(skipped_errors);
+                                errors.extend(skipped_entity_errors);
 
                                 FetchNode::deferred_fetches(
                                     current_dir,
@@ -372,7 +376,7 @@ impl PlanNode {
                             }
                             None => {
                                 value = Value::Object(Object::default());
-                                errors = skipped_errors;
+                                errors = skipped_entity_errors;
                             }
                         };
                     }
@@ -680,329 +684,583 @@ impl DeferredNode {
     }
 }
 
-/// Generate errors for fields that could not be fetched because the entity
-/// fetch was skipped (a non-nullable `@requires` input field was missing).
-///
-/// Uses the supergraph query's selection set to find which fields are expected
-/// at `current_dir`, then checks which of those are absent from `parent_value`.
-/// Each missing field gets an error with its path.
-/// Navigate a JSON value by following key segments in a path, returning
-/// the nested value (or `Value::Null` if any segment is missing or
-/// non-object).
-fn errors_for_skipped_fetch(
-    parameters: &ExecutionParameters<'_>,
-    current_dir: &Path,
-    parent_value: &Value,
-) -> Vec<Error> {
-    // Navigate parent_value to the object at current_dir
-    let entity_data = get_value_at_path(parent_value, current_dir);
+mod errors_for_skipped_entity {
+    use super::*;
 
-    let variables = &parameters.supergraph_request.body().variables;
-    let expected_fields = collect_field_names_at_path(
-        &parameters.query.operation.selection_set,
-        &current_dir.0,
-        parent_value,
-        parameters.schema,
-        variables,
-        &parameters.query.fragments,
-    );
+    /// Generate errors for all leaf selections from the given entity fetch because the entity was
+    /// skipped (for example, a non-nullable `@requires` input field was missing).
+    ///
+    /// Reports leaf-path errors for fields that are both (a) fetched by the subgraph query and (b)
+    /// selected in the original input query at `current_dir`.
+    /// Note: Reporting at leaves (rather than top-level response keys) matters for `@shareable`
+    /// composite fields: if a parallel subgraph also resolves the shared parent, only the leaves
+    /// the skipped fetch alone would have supplied should be flagged.
+    pub(super) fn generate(
+        parameters: &ExecutionParameters<'_>,
+        fetch_node: &FetchNode,
+        current_dir: &Path,
+        parent_value: &Value,
+    ) -> Vec<Error> {
+        let entity_data = get_value_at_path(parent_value, current_dir);
+        let entity_type = typename_of(entity_data);
+        let ctx = FilterContext {
+            schema: parameters.schema,
+            variables: &parameters.supergraph_request.body().variables,
+            fragments: &parameters.query.fragments,
+        };
 
-    expected_fields
-        .into_iter()
-        .filter(|field_name| {
-            // Only generate errors for fields NOT already present in parent_value
-            match entity_data {
-                Value::Object(obj) => !obj.contains_key(*field_name),
-                _ => true,
-            }
-        })
-        .map(|field_name| {
-            let mut path = current_dir.clone();
-            path.push(PathElement::Key(field_name.to_string(), None));
-            Error::builder()
-                .message("Could not fetch field")
-                .path(path)
-                .extension_code("UNSATISFIED_FETCH_CONDITION")
-                .build()
-        })
-        .collect()
-}
+        // Step 1: build a tree of response keys the skipped fetch would have
+        // produced for this entity. Recursing into composite fields preserves
+        // depth so we can report at the leaf level.
+        let Some(fetched_tree) =
+            entity_response_key_tree(fetch_node, entity_type, ctx.schema, ctx.variables)
+        else {
+            return Vec::new();
+        };
 
-fn get_value_at_path<'a>(value: &'a Value, path: &Path) -> &'a Value {
-    let mut current = value;
-    for segment in &path.0 {
-        match segment {
-            PathElement::Key(k, _) => match current {
-                Value::Object(obj) => {
-                    current = match obj.get(k.as_str()) {
-                        Some(v) => v,
-                        None => &Value::Null,
-                    };
-                }
-                _ => {
-                    return &Value::Null;
-                }
-            },
-            PathElement::Index(i) => match current {
-                Value::Array(arr) => {
-                    current = match arr.get(*i) {
-                        Some(v) => v,
-                        None => &Value::Null,
-                    };
-                }
-                _ => {
-                    return &Value::Null;
-                }
-            },
-            _ => {
-                return &Value::Null;
-            }
-        }
-    }
-    current
-}
-
-/// Extract `__typename` from a JSON value, returning `None` if not present.
-fn typename_of(value: &Value) -> Option<&str> {
-    match value {
-        Value::Object(obj) => obj.get(TYPENAME).and_then(|v| v.as_str()),
-        _ => None,
-    }
-}
-
-/// Collect field names from a query selection set at the given path, handling inline fragments,
-/// named fragment spreads, and @skip/@include conditions.
-///
-/// When `remaining_dir` is non-empty, navigates through selections (including fragments) to reach
-/// the target depth. Once there, collects unique field names (excluding `__typename`), recursing
-/// into fragments whose `type_condition` matches the runtime type at each level (read from
-/// `current_value`'s `__typename`).
-fn collect_field_names_at_path<'sel>(
-    selection_set: &'sel [Selection],
-    remaining_dir: &[PathElement],
-    current_value: &Value,
-    schema: &Schema,
-    variables: &Object,
-    fragments: &'sel Fragments,
-) -> IndexSet<&'sel str> {
-    let current_type = typename_of(current_value);
-    if let Some((segment, rest)) = remaining_dir.split_first() {
-        match segment {
-            PathElement::Key(k, _) => {
-                let key = k.as_str();
-                // Look up the child value for the next navigation level
-                let child_value = match current_value {
-                    Value::Object(obj) => obj.get(key).unwrap_or(&Value::Null),
-                    _ => &Value::Null,
-                };
-                let mut field_names = IndexSet::new();
-                collect_field_names_at_path_inner(
-                    selection_set,
-                    key,
-                    rest,
-                    child_value,
-                    current_type,
-                    schema,
-                    variables,
-                    fragments,
-                    &mut field_names,
-                );
-                field_names
-            }
-            PathElement::Index(i) => {
-                // Array index doesn't correspond to a selection set field — navigate
-                // into the array element value and continue with the same selection set.
-                let child_value = match current_value {
-                    Value::Array(arr) => arr.get(*i).unwrap_or(&Value::Null),
-                    _ => &Value::Null,
-                };
-                collect_field_names_at_path(
-                    selection_set,
-                    rest,
-                    child_value,
-                    schema,
-                    variables,
-                    fragments,
-                )
-            }
-            _ => IndexSet::default(),
-        }
-    } else {
-        let mut field_names = IndexSet::new();
-        collect_fields_from_selections(
-            selection_set,
-            current_type,
-            schema,
-            variables,
-            fragments,
-            &mut field_names,
+        // Step 2: intersect that tree with the input query at `current_dir`,
+        // preserving structure so composite branches survive only when both
+        // sides have matching sub-selections.
+        let filtered_tree = filter_response_key_tree_at_path(
+            &ctx,
+            &fetched_tree,
+            &parameters.query.operation.selection_set,
+            &current_dir.0,
+            parent_value,
         );
-        field_names
-    }
-}
 
-/// Navigate into a selection set looking for fields matching `key`, digging into inline fragments
-/// and named fragment spreads. `child_value` is the JSON value at the child level. `current_type`
-/// is the runtime type at this level for fragment type-condition checks. Collects field names
-/// from all matching fields across all matching fragments (does not short-circuit on the first
-/// match, since multiple fragments may contain the same key and contribute different sub-fields).
-#[allow(clippy::too_many_arguments)]
-fn collect_field_names_at_path_inner<'sel>(
-    selection_set: &'sel [Selection],
-    key: &str,
-    remaining_dir: &[PathElement],
-    child_value: &Value,
-    current_type: Option<&str>,
-    schema: &Schema,
-    variables: &Object,
-    fragments: &'sel Fragments,
-    field_names: &mut IndexSet<&'sel str>,
-) {
-    for sel in selection_set {
-        match sel {
-            Selection::Field {
-                name,
-                alias,
-                selection_set: Some(inner),
-                include_skip,
-                ..
-            } => {
-                if include_skip.should_skip(variables) {
-                    continue;
+        // Step 3: walk the intersected tree alongside `entity_data`, emitting an
+        // error for each leaf whose value isn't already populated on the entity.
+        enumerate_leaf_paths(&filtered_tree, entity_data)
+            .into_iter()
+            .map(|segments| {
+                let mut path = current_dir.clone();
+                for segment in segments {
+                    path.push(PathElement::Key(segment, None));
                 }
-                let field_name = alias.as_ref().unwrap_or(name);
-                if field_name.as_str() == key {
-                    field_names.extend(collect_field_names_at_path(
-                        inner,
-                        remaining_dir,
-                        child_value,
-                        schema,
-                        variables,
-                        fragments,
-                    ));
-                }
-            }
-            Selection::InlineFragment {
-                type_condition,
-                selection_set,
-                include_skip,
-                ..
-            } => {
-                if include_skip.should_skip(variables) {
-                    continue;
-                }
-                if type_condition_matches(schema, current_type, type_condition) {
-                    collect_field_names_at_path_inner(
-                        selection_set,
-                        key,
-                        remaining_dir,
-                        child_value,
-                        current_type,
-                        schema,
-                        variables,
-                        fragments,
-                        field_names,
-                    );
-                }
-            }
-            Selection::FragmentSpread {
-                name, include_skip, ..
-            } => {
-                if include_skip.should_skip(variables) {
-                    continue;
-                }
-                if let Some(Fragment {
-                    type_condition,
-                    selection_set,
-                }) = fragments.get(name)
-                    && type_condition_matches(schema, current_type, type_condition)
-                {
-                    collect_field_names_at_path_inner(
-                        selection_set,
-                        key,
-                        remaining_dir,
-                        child_value,
-                        current_type,
-                        schema,
-                        variables,
-                        fragments,
-                        field_names,
-                    );
-                }
-            }
-            _ => {}
+                Error::builder()
+                    .message("Could not fetch field")
+                    .path(path)
+                    .extension_code("UNSATISFIED_FETCH_CONDITION")
+                    .build()
+            })
+            .collect()
+    }
+
+    /// Context shared by the helpers that walk the input query to intersect it
+    /// with a fetched-response-key tree.
+    struct FilterContext<'a> {
+        schema: &'a Schema,
+        variables: &'a Object,
+        fragments: &'a Fragments,
+    }
+
+    /// Tree of response keys produced by a subgraph fetch. An entry with an
+    /// empty `children` map is a leaf (scalar/enum field, or a composite pruned
+    /// to empty during intersection); a non-empty map is a composite branch.
+    /// `is_list_stop` marks leaves where we stopped descent because the field is
+    /// a list — such leaves must emit an error even if another fetch has
+    /// populated the array, since we can't report per-item.
+    #[derive(Default, Debug)]
+    struct ResponseKeyTree {
+        is_list_stop: bool,
+        children: IndexMap<Name, ResponseKeyTree>,
+    }
+
+    impl ResponseKeyTree {
+        fn is_empty(&self) -> bool {
+            self.children.is_empty() && !self.is_list_stop
         }
     }
-}
 
-/// Recursively collect field names from a selection set, expanding inline fragments and named
-/// fragment spreads whose type_condition matches `entity_type`.
-fn collect_fields_from_selections<'sel>(
-    selection_set: &'sel [Selection],
-    entity_type: Option<&str>,
-    schema: &Schema,
-    variables: &Object,
-    fragments: &'sel Fragments,
-    field_names: &mut IndexSet<&'sel str>,
-) {
-    for sel in selection_set {
-        match sel {
-            Selection::Field {
-                name,
-                alias,
-                include_skip,
-                ..
-            } => {
-                if include_skip.should_skip(variables) {
-                    continue;
-                }
-                if name.as_str() == TYPENAME {
-                    continue;
-                }
-                field_names.insert(alias.as_ref().unwrap_or(name).as_str());
+    /// Build a tree of response keys for a subgraph `_entities` fetch, filtered
+    /// to fragments matching `entity_type` and not excluded by `@skip`/`@include`.
+    ///
+    /// Returns `None` when the operation isn't an `_entities` fetch or yields no
+    /// matching fields — callers treat that as "nothing to report".
+    fn entity_response_key_tree(
+        fetch_node: &FetchNode,
+        entity_type: Option<&str>,
+        schema: &Schema,
+        variables: &Object,
+    ) -> Option<ResponseKeyTree> {
+        let parsed = fetch_node.operation.as_parsed().ok()?;
+        let operation = parsed
+            .operations
+            .anonymous
+            .as_ref()
+            .or_else(|| parsed.operations.named.values().next())?;
+
+        let mut tree = ResponseKeyTree::default();
+        for sel in &operation.selection_set.selections {
+            if let executable::Selection::Field(f) = sel
+                && f.name.as_str() == "_entities"
+            {
+                collect_response_key_tree(
+                    &f.selection_set,
+                    parsed,
+                    entity_type,
+                    schema,
+                    variables,
+                    &mut tree,
+                );
             }
-            Selection::InlineFragment {
-                type_condition,
-                selection_set,
-                include_skip,
-                ..
-            } => {
-                if include_skip.should_skip(variables) {
-                    continue;
+        }
+        if tree.is_empty() { None } else { Some(tree) }
+    }
+
+    /// Recursively populate `tree` from a subgraph selection set. Descends through
+    /// inline fragments and resolves named fragment spreads from `document`,
+    /// filtering by `entity_type` against each fragment's type condition. When
+    /// recursing into a composite field, `entity_type` resets to `None` since we
+    /// don't track field return types here — any fragment nested below that point
+    /// with an explicit type condition is then rejected. Skips `__typename`.
+    fn collect_response_key_tree(
+        selection_set: &executable::SelectionSet,
+        document: &executable::ExecutableDocument,
+        entity_type: Option<&str>,
+        schema: &Schema,
+        variables: &Object,
+        tree: &mut ResponseKeyTree,
+    ) {
+        for sel in &selection_set.selections {
+            match sel {
+                executable::Selection::Field(f) => {
+                    if IncludeSkip::parse(&f.directives).should_skip(variables) {
+                        continue;
+                    }
+                    let key = f.response_key();
+                    if key.as_str() == TYPENAME {
+                        continue;
+                    }
+                    let entry = tree.children.entry(key.clone()).or_default();
+                    // Stop at list-typed fields: the tree has no array
+                    // indices, so we can't address per-item leaves and must
+                    // report at the list field itself. Mark the leaf so
+                    // Step 3 emits unconditionally.
+                    if f.ty().is_list() {
+                        entry.is_list_stop = true;
+                    } else if !f.selection_set.selections.is_empty() {
+                        collect_response_key_tree(
+                            &f.selection_set,
+                            document,
+                            None,
+                            schema,
+                            variables,
+                            entry,
+                        );
+                    }
                 }
-                if type_condition_matches(schema, entity_type, type_condition) {
-                    collect_fields_from_selections(
+                executable::Selection::InlineFragment(frag) => {
+                    if IncludeSkip::parse(&frag.directives).should_skip(variables) {
+                        continue;
+                    }
+                    // Inline fragment without a type condition inherits the
+                    // parent type — always accept.
+                    let matches = match &frag.type_condition {
+                        None => true,
+                        Some(cond) => type_condition_matches(schema, entity_type, cond.as_str()),
+                    };
+                    if matches {
+                        collect_response_key_tree(
+                            &frag.selection_set,
+                            document,
+                            entity_type,
+                            schema,
+                            variables,
+                            tree,
+                        );
+                    }
+                }
+                executable::Selection::FragmentSpread(spread) => {
+                    if IncludeSkip::parse(&spread.directives).should_skip(variables) {
+                        continue;
+                    }
+                    if let Some(fragment) = document.fragments.get(&spread.fragment_name)
+                        && type_condition_matches(
+                            schema,
+                            entity_type,
+                            fragment.type_condition().as_str(),
+                        )
+                    {
+                        collect_response_key_tree(
+                            &fragment.selection_set,
+                            document,
+                            entity_type,
+                            schema,
+                            variables,
+                            tree,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn get_value_at_path<'a>(value: &'a Value, path: &Path) -> &'a Value {
+        let mut current = value;
+        for segment in &path.0 {
+            match segment {
+                PathElement::Key(k, _) => match current {
+                    Value::Object(obj) => {
+                        current = match obj.get(k.as_str()) {
+                            Some(v) => v,
+                            None => &Value::Null,
+                        };
+                    }
+                    _ => {
+                        return &Value::Null;
+                    }
+                },
+                PathElement::Index(i) => match current {
+                    Value::Array(arr) => {
+                        current = match arr.get(*i) {
+                            Some(v) => v,
+                            None => &Value::Null,
+                        };
+                    }
+                    _ => {
+                        return &Value::Null;
+                    }
+                },
+                _ => {
+                    return &Value::Null;
+                }
+            }
+        }
+        current
+    }
+
+    /// Extract `__typename` from a JSON value, returning `None` if not present.
+    fn typename_of(value: &Value) -> Option<&str> {
+        match value {
+            Value::Object(obj) => obj.get(TYPENAME).and_then(|v| v.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Walk the input query once and return the subtree of `fetched_tree` whose
+    /// fields are also selected in the input query at `remaining_dir`. The result
+    /// preserves `fetched_tree`'s shape, pruned to the intersection. Handles path
+    /// navigation, inline fragments, named fragment spreads, and
+    /// `@skip`/`@include`.
+    fn filter_response_key_tree_at_path(
+        ctx: &FilterContext<'_>,
+        fetched_tree: &ResponseKeyTree,
+        selection_set: &[Selection],
+        remaining_dir: &[PathElement],
+        current_value: &Value,
+    ) -> ResponseKeyTree {
+        let mut result = ResponseKeyTree::default();
+        if fetched_tree.is_empty() {
+            return result;
+        }
+        descend_tree_to_selection_set(
+            ctx,
+            fetched_tree,
+            selection_set,
+            remaining_dir,
+            current_value,
+            &mut result,
+        );
+        result
+    }
+
+    /// Navigate `remaining_dir` through the input query to reach the selection set
+    /// at the target path, then intersect fetched_tree against selections at that
+    /// level.
+    fn descend_tree_to_selection_set(
+        ctx: &FilterContext<'_>,
+        fetched_tree: &ResponseKeyTree,
+        selection_set: &[Selection],
+        remaining_dir: &[PathElement],
+        current_value: &Value,
+        result: &mut ResponseKeyTree,
+    ) {
+        let current_type = typename_of(current_value);
+        if let Some((segment, rest)) = remaining_dir.split_first() {
+            match segment {
+                PathElement::Key(k, _) => {
+                    let key = k.as_str();
+                    let child_value = match current_value {
+                        Value::Object(obj) => obj.get(key).unwrap_or(&Value::Null),
+                        _ => &Value::Null,
+                    };
+                    descend_tree_into_key(
+                        ctx,
+                        fetched_tree,
                         selection_set,
-                        entity_type,
-                        schema,
-                        variables,
-                        fragments,
-                        field_names,
+                        key,
+                        rest,
+                        child_value,
+                        current_type,
+                        result,
                     );
                 }
-            }
-            Selection::FragmentSpread {
-                name, include_skip, ..
-            } => {
-                if include_skip.should_skip(variables) {
-                    continue;
+                PathElement::Index(i) => {
+                    // Array index doesn't correspond to a selection set field —
+                    // navigate into the array element and keep the selection set.
+                    let child_value = match current_value {
+                        Value::Array(arr) => arr.get(*i).unwrap_or(&Value::Null),
+                        _ => &Value::Null,
+                    };
+                    descend_tree_to_selection_set(
+                        ctx,
+                        fetched_tree,
+                        selection_set,
+                        rest,
+                        child_value,
+                        result,
+                    );
                 }
-                if let Some(Fragment {
+                _ => {}
+            }
+        } else {
+            intersect_tree_with_selections(ctx, fetched_tree, selection_set, current_type, result);
+        }
+    }
+
+    /// Recurse into `selection_set` to find a field whose response key is `key`,
+    /// then continue navigating `remaining_dir` inside its sub-selection. Descends
+    /// through inline fragments and named fragment spreads whose type condition
+    /// matches `current_type`.
+    #[allow(clippy::too_many_arguments)]
+    fn descend_tree_into_key(
+        ctx: &FilterContext<'_>,
+        fetched_tree: &ResponseKeyTree,
+        selection_set: &[Selection],
+        key: &str,
+        remaining_dir: &[PathElement],
+        child_value: &Value,
+        current_type: Option<&str>,
+        result: &mut ResponseKeyTree,
+    ) {
+        for sel in selection_set {
+            match sel {
+                Selection::Field {
+                    name,
+                    alias,
+                    selection_set: Some(inner),
+                    include_skip,
+                    ..
+                } => {
+                    if include_skip.should_skip(ctx.variables) {
+                        continue;
+                    }
+                    let field_name = alias.as_ref().unwrap_or(name);
+                    if field_name.as_str() == key {
+                        descend_tree_to_selection_set(
+                            ctx,
+                            fetched_tree,
+                            inner,
+                            remaining_dir,
+                            child_value,
+                            result,
+                        );
+                    }
+                }
+                Selection::InlineFragment {
                     type_condition,
                     selection_set,
-                }) = fragments.get(name)
-                    && type_condition_matches(schema, entity_type, type_condition)
-                {
-                    collect_fields_from_selections(
+                    include_skip,
+                    ..
+                } => {
+                    if include_skip.should_skip(ctx.variables) {
+                        continue;
+                    }
+                    if type_condition_matches(ctx.schema, current_type, type_condition) {
+                        descend_tree_into_key(
+                            ctx,
+                            fetched_tree,
+                            selection_set,
+                            key,
+                            remaining_dir,
+                            child_value,
+                            current_type,
+                            result,
+                        );
+                    }
+                }
+                Selection::FragmentSpread {
+                    name, include_skip, ..
+                } => {
+                    if include_skip.should_skip(ctx.variables) {
+                        continue;
+                    }
+                    if let Some(Fragment {
+                        type_condition,
                         selection_set,
-                        entity_type,
-                        schema,
-                        variables,
-                        fragments,
-                        field_names,
-                    );
+                    }) = ctx.fragments.get(name)
+                        && type_condition_matches(ctx.schema, current_type, type_condition)
+                    {
+                        descend_tree_into_key(
+                            ctx,
+                            fetched_tree,
+                            selection_set,
+                            key,
+                            remaining_dir,
+                            child_value,
+                            current_type,
+                            result,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Walk `selection_set` and build `result` as the intersection against
+    /// `fetched_tree`. For each field whose response key is in `fetched_tree`:
+    /// if fetched is a leaf, add a leaf; if fetched is composite and the input
+    /// has a sub-selection, recurse and attach the non-empty subtree. Descends
+    /// through inline fragments and named fragment spreads whose type condition
+    /// matches `entity_type`; when recursing into a composite field, `entity_type`
+    /// resets to `None` since we don't track field return types here.
+    fn intersect_tree_with_selections(
+        ctx: &FilterContext<'_>,
+        fetched_tree: &ResponseKeyTree,
+        selection_set: &[Selection],
+        entity_type: Option<&str>,
+        result: &mut ResponseKeyTree,
+    ) {
+        for sel in selection_set {
+            match sel {
+                Selection::Field {
+                    name,
+                    alias,
+                    selection_set: sub,
+                    include_skip,
+                    ..
+                } => {
+                    if include_skip.should_skip(ctx.variables) {
+                        continue;
+                    }
+                    if name.as_str() == TYPENAME {
+                        continue;
+                    }
+                    let response_key = Name::new_unchecked(alias.as_ref().unwrap_or(name).as_str());
+                    let Some(fetched_sub) = fetched_tree.children.get(&response_key) else {
+                        continue;
+                    };
+                    if fetched_sub.children.is_empty() {
+                        // Leaf on the fetched side → leaf in result. Carry
+                        // `is_list_stop` over so unconditional emission is
+                        // preserved.
+                        let entry = result.children.entry(response_key).or_default();
+                        if fetched_sub.is_list_stop {
+                            entry.is_list_stop = true;
+                        }
+                    } else if let Some(input_sub) = sub {
+                        // Composite on both sides → recurse; only keep non-empty.
+                        let mut subresult = ResponseKeyTree::default();
+                        intersect_tree_with_selections(
+                            ctx,
+                            fetched_sub,
+                            input_sub,
+                            None,
+                            &mut subresult,
+                        );
+                        if !subresult.is_empty() {
+                            result.children.insert(response_key, subresult);
+                        }
+                    }
+                }
+                Selection::InlineFragment {
+                    type_condition,
+                    selection_set,
+                    include_skip,
+                    ..
+                } => {
+                    if include_skip.should_skip(ctx.variables) {
+                        continue;
+                    }
+                    if type_condition_matches(ctx.schema, entity_type, type_condition) {
+                        intersect_tree_with_selections(
+                            ctx,
+                            fetched_tree,
+                            selection_set,
+                            entity_type,
+                            result,
+                        );
+                    }
+                }
+                Selection::FragmentSpread {
+                    name, include_skip, ..
+                } => {
+                    if include_skip.should_skip(ctx.variables) {
+                        continue;
+                    }
+                    if let Some(Fragment {
+                        type_condition,
+                        selection_set,
+                    }) = ctx.fragments.get(name)
+                        && type_condition_matches(ctx.schema, entity_type, type_condition)
+                    {
+                        intersect_tree_with_selections(
+                            ctx,
+                            fetched_tree,
+                            selection_set,
+                            entity_type,
+                            result,
+                        );
+                    }
                 }
             }
+        }
+    }
+
+    /// Enumerate root-to-leaf paths in `tree`, traversing `entity_data` in step
+    /// so a leaf is emitted only when its value isn't already populated on the
+    /// entity. A leaf is considered populated when its key is present on the
+    /// corresponding object (including when the value is null) — that key has
+    /// been written by some other (successful) fetch. List-stop leaves are the
+    /// exception: they emit unconditionally, since another fetch may have
+    /// written the array but can't have filled in the per-item fields this
+    /// fetch would have contributed.
+    fn enumerate_leaf_paths(tree: &ResponseKeyTree, entity_data: &Value) -> Vec<Vec<String>> {
+        let mut paths = Vec::new();
+        let mut current = Vec::new();
+        collect_leaf_paths(tree, entity_data, &mut current, &mut paths);
+        paths
+    }
+
+    fn collect_leaf_paths(
+        tree: &ResponseKeyTree,
+        data: &Value,
+        current: &mut Vec<String>,
+        paths: &mut Vec<Vec<String>>,
+    ) {
+        for (key, subtree) in &tree.children {
+            current.push(key.as_str().to_owned());
+            if subtree.children.is_empty() {
+                // List-stop leaves emit unconditionally: another fetch may
+                // have populated the array, but we can't address per-item
+                // leaves, so the miss must be reported at the list field.
+                // This only arises with shareable list fields that are
+                // partially fetched across subgraphs — a rare case where we
+                // can't pinpoint per-item paths, so we report at the list
+                // field itself as a best effort.
+                let should_emit = if subtree.is_list_stop {
+                    true
+                } else {
+                    let populated = match data {
+                        Value::Object(obj) => obj.contains_key(key.as_str()),
+                        _ => false,
+                    };
+                    !populated
+                };
+                if should_emit {
+                    paths.push(current.clone());
+                }
+            } else {
+                let child_data = match data {
+                    Value::Object(obj) => obj.get(key.as_str()).unwrap_or(&Value::Null),
+                    _ => &Value::Null,
+                };
+                collect_leaf_paths(subtree, child_data, current, paths);
+            }
+            current.pop();
         }
     }
 }

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use futures::StreamExt;
 use futures::future::join_all;
 use futures::prelude::*;
+use indexmap::IndexSet;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::BroadcastStream;
@@ -14,6 +15,7 @@ use super::DeferredNode;
 use super::PlanNode;
 use super::QueryPlan;
 use super::log;
+use super::selection::type_condition_matches;
 use super::subscription::SubscriptionHandle;
 use crate::Context;
 use crate::axum_factory::CanceledRequest;
@@ -46,8 +48,12 @@ use crate::services::fetch::ErrorMapping;
 use crate::services::fetch::SubscriptionRequest;
 use crate::services::fetch_service::FetchServiceFactory;
 use crate::services::new_service::ServiceFactory;
+use crate::spec::Fragment;
+use crate::spec::Fragments;
 use crate::spec::Query;
 use crate::spec::Schema;
+use crate::spec::Selection;
+use crate::spec::TYPENAME;
 
 impl QueryPlan {
     #[allow(clippy::too_many_arguments)]
@@ -228,7 +234,9 @@ impl PlanNode {
                                 .build(),
                         ];
                     } else {
-                        match Variables::new(
+                        // Note: subscriptions currently pass empty requires (&[]), so
+                        // _unsatisfied_paths will always be empty.
+                        let (opt_variables, _unsatisfied_paths) = Variables::new(
                             &[],
                             &subscription_node.variable_usages,
                             parent_value,
@@ -237,7 +245,8 @@ impl PlanNode {
                             parameters.schema,
                             &subscription_node.input_rewrites,
                             &None,
-                        ) {
+                        );
+                        match opt_variables {
                             Some(variables) => {
                                 let service = parameters.service_factory.create();
                                 let request = fetch::Request::Subscription(
@@ -283,7 +292,7 @@ impl PlanNode {
                         value = Value::Object(Object::default());
                         errors = Vec::new();
                     } else {
-                        match Variables::new(
+                        let (opt_variables, unsatisfied_paths) = Variables::new(
                             &fetch_node.requires,
                             &fetch_node.variable_usages,
                             parent_value,
@@ -292,7 +301,19 @@ impl PlanNode {
                             parameters.schema.as_ref(),
                             &fetch_node.input_rewrites,
                             &fetch_node.context_rewrites,
-                        ) {
+                        );
+
+                        // Generate errors for any entities whose required fields were missing.
+                        let mut skipped_errors = Vec::new();
+                        for unsatisfied_path in &unsatisfied_paths {
+                            skipped_errors.extend(errors_for_skipped_fetch(
+                                parameters,
+                                unsatisfied_path,
+                                parent_value,
+                            ));
+                        }
+
+                        match opt_variables {
                             Some(variables) => {
                                 let paths = variables.inverted_paths.clone();
                                 let service = parameters.service_factory.create();
@@ -339,6 +360,7 @@ impl PlanNode {
 
                                     errors.push(err);
                                 }
+                                errors.extend(skipped_errors);
 
                                 FetchNode::deferred_fetches(
                                     current_dir,
@@ -350,7 +372,7 @@ impl PlanNode {
                             }
                             None => {
                                 value = Value::Object(Object::default());
-                                errors = Vec::new();
+                                errors = skipped_errors;
                             }
                         };
                     }
@@ -654,6 +676,333 @@ impl DeferredNode {
                 }
                 drop(tx);
             };
+        }
+    }
+}
+
+/// Generate errors for fields that could not be fetched because the entity
+/// fetch was skipped (a non-nullable `@requires` input field was missing).
+///
+/// Uses the supergraph query's selection set to find which fields are expected
+/// at `current_dir`, then checks which of those are absent from `parent_value`.
+/// Each missing field gets an error with its path.
+/// Navigate a JSON value by following key segments in a path, returning
+/// the nested value (or `Value::Null` if any segment is missing or
+/// non-object).
+fn errors_for_skipped_fetch(
+    parameters: &ExecutionParameters<'_>,
+    current_dir: &Path,
+    parent_value: &Value,
+) -> Vec<Error> {
+    // Navigate parent_value to the object at current_dir
+    let entity_data = get_value_at_path(parent_value, current_dir);
+
+    let variables = &parameters.supergraph_request.body().variables;
+    let expected_fields = collect_field_names_at_path(
+        &parameters.query.operation.selection_set,
+        &current_dir.0,
+        parent_value,
+        parameters.schema,
+        variables,
+        &parameters.query.fragments,
+    );
+
+    expected_fields
+        .into_iter()
+        .filter(|field_name| {
+            // Only generate errors for fields NOT already present in parent_value
+            match entity_data {
+                Value::Object(obj) => !obj.contains_key(*field_name),
+                _ => true,
+            }
+        })
+        .map(|field_name| {
+            let mut path = current_dir.clone();
+            path.push(PathElement::Key(field_name.to_string(), None));
+            Error::builder()
+                .message("Could not fetch field")
+                .path(path)
+                .extension_code("UNSATISFIED_FETCH_CONDITION")
+                .build()
+        })
+        .collect()
+}
+
+fn get_value_at_path<'a>(value: &'a Value, path: &Path) -> &'a Value {
+    let mut current = value;
+    for segment in &path.0 {
+        match segment {
+            PathElement::Key(k, _) => match current {
+                Value::Object(obj) => {
+                    current = match obj.get(k.as_str()) {
+                        Some(v) => v,
+                        None => &Value::Null,
+                    };
+                }
+                _ => {
+                    return &Value::Null;
+                }
+            },
+            PathElement::Index(i) => match current {
+                Value::Array(arr) => {
+                    current = match arr.get(*i) {
+                        Some(v) => v,
+                        None => &Value::Null,
+                    };
+                }
+                _ => {
+                    return &Value::Null;
+                }
+            },
+            _ => {
+                return &Value::Null;
+            }
+        }
+    }
+    current
+}
+
+/// Extract `__typename` from a JSON value, returning `None` if not present.
+fn typename_of(value: &Value) -> Option<&str> {
+    match value {
+        Value::Object(obj) => obj.get(TYPENAME).and_then(|v| v.as_str()),
+        _ => None,
+    }
+}
+
+/// Collect field names from a query selection set at the given path, handling inline fragments,
+/// named fragment spreads, and @skip/@include conditions.
+///
+/// When `remaining_dir` is non-empty, navigates through selections (including fragments) to reach
+/// the target depth. Once there, collects unique field names (excluding `__typename`), recursing
+/// into fragments whose `type_condition` matches the runtime type at each level (read from
+/// `current_value`'s `__typename`).
+fn collect_field_names_at_path<'sel>(
+    selection_set: &'sel [Selection],
+    remaining_dir: &[PathElement],
+    current_value: &Value,
+    schema: &Schema,
+    variables: &Object,
+    fragments: &'sel Fragments,
+) -> IndexSet<&'sel str> {
+    let current_type = typename_of(current_value);
+    if let Some((segment, rest)) = remaining_dir.split_first() {
+        match segment {
+            PathElement::Key(k, _) => {
+                let key = k.as_str();
+                // Look up the child value for the next navigation level
+                let child_value = match current_value {
+                    Value::Object(obj) => obj.get(key).unwrap_or(&Value::Null),
+                    _ => &Value::Null,
+                };
+                let mut field_names = IndexSet::new();
+                collect_field_names_at_path_inner(
+                    selection_set,
+                    key,
+                    rest,
+                    child_value,
+                    current_type,
+                    schema,
+                    variables,
+                    fragments,
+                    &mut field_names,
+                );
+                field_names
+            }
+            PathElement::Index(i) => {
+                // Array index doesn't correspond to a selection set field — navigate
+                // into the array element value and continue with the same selection set.
+                let child_value = match current_value {
+                    Value::Array(arr) => arr.get(*i).unwrap_or(&Value::Null),
+                    _ => &Value::Null,
+                };
+                collect_field_names_at_path(
+                    selection_set,
+                    rest,
+                    child_value,
+                    schema,
+                    variables,
+                    fragments,
+                )
+            }
+            _ => IndexSet::default(),
+        }
+    } else {
+        let mut field_names = IndexSet::new();
+        collect_fields_from_selections(
+            selection_set,
+            current_type,
+            schema,
+            variables,
+            fragments,
+            &mut field_names,
+        );
+        field_names
+    }
+}
+
+/// Navigate into a selection set looking for fields matching `key`, digging into inline fragments
+/// and named fragment spreads. `child_value` is the JSON value at the child level. `current_type`
+/// is the runtime type at this level for fragment type-condition checks. Collects field names
+/// from all matching fields across all matching fragments (does not short-circuit on the first
+/// match, since multiple fragments may contain the same key and contribute different sub-fields).
+#[allow(clippy::too_many_arguments)]
+fn collect_field_names_at_path_inner<'sel>(
+    selection_set: &'sel [Selection],
+    key: &str,
+    remaining_dir: &[PathElement],
+    child_value: &Value,
+    current_type: Option<&str>,
+    schema: &Schema,
+    variables: &Object,
+    fragments: &'sel Fragments,
+    field_names: &mut IndexSet<&'sel str>,
+) {
+    for sel in selection_set {
+        match sel {
+            Selection::Field {
+                name,
+                alias,
+                selection_set: Some(inner),
+                include_skip,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                let field_name = alias.as_ref().unwrap_or(name);
+                if field_name.as_str() == key {
+                    field_names.extend(collect_field_names_at_path(
+                        inner,
+                        remaining_dir,
+                        child_value,
+                        schema,
+                        variables,
+                        fragments,
+                    ));
+                }
+            }
+            Selection::InlineFragment {
+                type_condition,
+                selection_set,
+                include_skip,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                if type_condition_matches(schema, current_type, type_condition) {
+                    collect_field_names_at_path_inner(
+                        selection_set,
+                        key,
+                        remaining_dir,
+                        child_value,
+                        current_type,
+                        schema,
+                        variables,
+                        fragments,
+                        field_names,
+                    );
+                }
+            }
+            Selection::FragmentSpread {
+                name, include_skip, ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                if let Some(Fragment {
+                    type_condition,
+                    selection_set,
+                }) = fragments.get(name)
+                    && type_condition_matches(schema, current_type, type_condition)
+                {
+                    collect_field_names_at_path_inner(
+                        selection_set,
+                        key,
+                        remaining_dir,
+                        child_value,
+                        current_type,
+                        schema,
+                        variables,
+                        fragments,
+                        field_names,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Recursively collect field names from a selection set, expanding inline fragments and named
+/// fragment spreads whose type_condition matches `entity_type`.
+fn collect_fields_from_selections<'sel>(
+    selection_set: &'sel [Selection],
+    entity_type: Option<&str>,
+    schema: &Schema,
+    variables: &Object,
+    fragments: &'sel Fragments,
+    field_names: &mut IndexSet<&'sel str>,
+) {
+    for sel in selection_set {
+        match sel {
+            Selection::Field {
+                name,
+                alias,
+                include_skip,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                if name.as_str() == TYPENAME {
+                    continue;
+                }
+                field_names.insert(alias.as_ref().unwrap_or(name).as_str());
+            }
+            Selection::InlineFragment {
+                type_condition,
+                selection_set,
+                include_skip,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                if type_condition_matches(schema, entity_type, type_condition) {
+                    collect_fields_from_selections(
+                        selection_set,
+                        entity_type,
+                        schema,
+                        variables,
+                        fragments,
+                        field_names,
+                    );
+                }
+            }
+            Selection::FragmentSpread {
+                name, include_skip, ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                if let Some(Fragment {
+                    type_condition,
+                    selection_set,
+                }) = fragments.get(name)
+                    && type_condition_matches(schema, entity_type, type_condition)
+                {
+                    collect_fields_from_selections(
+                        selection_set,
+                        entity_type,
+                        schema,
+                        variables,
+                        fragments,
+                        field_names,
+                    );
+                }
+            }
         }
     }
 }

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -249,6 +249,10 @@ impl PlanNode {
                             &subscription_node.input_rewrites,
                             &None,
                         );
+                        debug_assert!(
+                            _unsatisfied_paths.is_empty(),
+                            "subscriptions pass empty `requires` — unsatisfied_paths should always be empty",
+                        );
                         match opt_variables {
                             Some(variables) => {
                                 let service = parameters.service_factory.create();
@@ -857,10 +861,9 @@ mod errors_for_skipped_entity {
                     }
                     // Inline fragment without a type condition inherits the
                     // parent type — always accept.
-                    let matches = match &frag.type_condition {
-                        None => true,
-                        Some(cond) => type_condition_matches(schema, entity_type, cond.as_str()),
-                    };
+                    let matches = frag.type_condition.as_ref().is_none_or(|cond| {
+                        type_condition_matches(schema, entity_type, cond.as_str())
+                    });
                     if matches {
                         collect_response_key_tree(
                             &frag.selection_set,
@@ -898,37 +901,15 @@ mod errors_for_skipped_entity {
     }
 
     fn get_value_at_path<'a>(value: &'a Value, path: &Path) -> &'a Value {
-        let mut current = value;
-        for segment in &path.0 {
-            match segment {
-                PathElement::Key(k, _) => match current {
-                    Value::Object(obj) => {
-                        current = match obj.get(k.as_str()) {
-                            Some(v) => v,
-                            None => &Value::Null,
-                        };
-                    }
-                    _ => {
-                        return &Value::Null;
-                    }
-                },
-                PathElement::Index(i) => match current {
-                    Value::Array(arr) => {
-                        current = match arr.get(*i) {
-                            Some(v) => v,
-                            None => &Value::Null,
-                        };
-                    }
-                    _ => {
-                        return &Value::Null;
-                    }
-                },
-                _ => {
-                    return &Value::Null;
+        path.0
+            .iter()
+            .fold(value, |current, segment| match (segment, current) {
+                (PathElement::Key(k, _), Value::Object(obj)) => {
+                    obj.get(k.as_str()).unwrap_or(&Value::Null)
                 }
-            }
-        }
-        current
+                (PathElement::Index(i), Value::Array(arr)) => arr.get(*i).unwrap_or(&Value::Null),
+                _ => &Value::Null,
+            })
     }
 
     /// Extract `__typename` from a JSON value, returning `None` if not present.
@@ -1241,23 +1222,18 @@ mod errors_for_skipped_entity {
                 // partially fetched across subgraphs — a rare case where we
                 // can't pinpoint per-item paths, so we report at the list
                 // field itself as a best effort.
-                let should_emit = if subtree.is_list_stop {
-                    true
-                } else {
-                    let populated = match data {
-                        Value::Object(obj) => obj.contains_key(key.as_str()),
-                        _ => false,
-                    };
-                    !populated
-                };
+                let should_emit = subtree.is_list_stop
+                    || data
+                        .as_object()
+                        .is_none_or(|obj| !obj.contains_key(key.as_str()));
                 if should_emit {
                     paths.push(current.clone());
                 }
             } else {
-                let child_data = match data {
-                    Value::Object(obj) => obj.get(key.as_str()).unwrap_or(&Value::Null),
-                    _ => &Value::Null,
-                };
+                let child_data = data
+                    .as_object()
+                    .and_then(|obj| obj.get(key.as_str()))
+                    .unwrap_or(&Value::Null);
                 collect_leaf_paths(subtree, child_data, current, paths);
             }
             current.pop();

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -169,6 +169,14 @@ pub(crate) struct Variables {
 }
 
 impl Variables {
+    /// Build variables for a subgraph fetch from the current response data.
+    ///
+    /// Returns a pair of `(Option<Variables>, Vec<Path>)`:
+    /// - The first element is `Some(variables)` when entity representations were successfully
+    ///   built, or `None` when there are no entities to fetch (either no matching data or all
+    ///   entities were skipped).
+    /// - The second element is a list of paths for entities whose required fields were
+    ///   unsatisfied (and thus skipped). The caller should generate errors for these paths.
     #[instrument(skip_all, level = "debug", name = "make_variables")]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -180,7 +188,7 @@ impl Variables {
         schema: &Schema,
         input_rewrites: &Option<Vec<rewrites::DataRewrite>>,
         context_rewrites: &Option<Vec<rewrites::DataRewrite>>,
-    ) -> Option<Variables> {
+    ) -> (Option<Variables>, Vec<Path>) {
         let body = request.body();
         let mut subgraph_context = SubgraphContext::new(data, schema, context_rewrites);
         if !requires.is_empty() {
@@ -192,6 +200,7 @@ impl Variables {
                     .map(|(variable_key, value)| (variable_key.clone(), value.clone()))
             }));
 
+            let mut unsatisfied_paths: Vec<Path> = Vec::new();
             let mut inverted_paths: Vec<Vec<Path>> = Vec::new();
             let mut values: IndexSet<Value> = IndexSet::default();
             data.select_values_and_paths(schema, current_dir, |path, value| {
@@ -200,24 +209,30 @@ impl Variables {
                     context.execute_on_path(path);
                 }
 
-                let mut value = execute_selection_set(value, requires, schema, None);
-                if value.as_object().map(|o| !o.is_empty()).unwrap_or(false) {
-                    rewrites::apply_rewrites(schema, &mut value, input_rewrites);
-                    match values.get_index_of(&value) {
-                        Some(index) => {
-                            inverted_paths[index].push(path.clone());
-                        }
-                        None => {
-                            inverted_paths.push(vec![path.clone()]);
-                            values.insert(value);
-                            debug_assert!(inverted_paths.len() == values.len());
+                let (mut value, had_errors) = execute_selection_set(value, requires, schema, None);
+                if had_errors {
+                    // Execution error means an unsatisfied condition => skip the entity and record the path.
+                    unsatisfied_paths.push(path.clone());
+                } else {
+                    let value_ok = value.as_object().map(|o| !o.is_empty()).unwrap_or(false);
+                    if value_ok {
+                        rewrites::apply_rewrites(schema, &mut value, input_rewrites);
+                        match values.get_index_of(&value) {
+                            Some(index) => {
+                                inverted_paths[index].push(path.clone());
+                            }
+                            None => {
+                                inverted_paths.push(vec![path.clone()]);
+                                values.insert(value);
+                                debug_assert!(inverted_paths.len() == values.len());
+                            }
                         }
                     }
                 }
             });
 
             if values.is_empty() {
-                return None;
+                return (None, unsatisfied_paths);
             }
 
             let representations = Value::Array(Vec::from_iter(values));
@@ -227,11 +242,14 @@ impl Variables {
             };
 
             variables.insert("representations", representations);
-            Some(Variables {
-                variables,
-                inverted_paths,
-                contextual_arguments,
-            })
+            (
+                Some(Variables {
+                    variables,
+                    inverted_paths,
+                    contextual_arguments,
+                }),
+                unsatisfied_paths,
+            )
         } else {
             // with nested operations (Query or Mutation has an operation returning a Query or Mutation),
             // when the first fetch fails, the query plan will still execute up until the second fetch,
@@ -244,21 +262,24 @@ impl Variables {
                     .map(|value| value.is_null())
                     .unwrap_or(true)
             {
-                return None;
+                return (None, Vec::new());
             }
 
-            Some(Variables {
-                variables: variable_usages
-                    .iter()
-                    .filter_map(|key| {
-                        body.variables
-                            .get_key_value(key.as_ref())
-                            .map(|(variable_key, value)| (variable_key.clone(), value.clone()))
-                    })
-                    .collect::<Object>(),
-                inverted_paths: Vec::new(),
-                contextual_arguments: None,
-            })
+            (
+                Some(Variables {
+                    variables: variable_usages
+                        .iter()
+                        .filter_map(|key| {
+                            body.variables
+                                .get_key_value(key.as_ref())
+                                .map(|(variable_key, value)| (variable_key.clone(), value.clone()))
+                        })
+                        .collect::<Object>(),
+                    inverted_paths: Vec::new(),
+                    contextual_arguments: None,
+                }),
+                Vec::new(),
+            )
         }
     }
 }

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -914,6 +914,56 @@ mod tests {
         );
     }
 
+    /// When a nullable required field is completely absent from the entity data (not present
+    /// at all, as opposed to present with a null value), `execute_selection_set` should fill
+    /// it in as null and proceed without errors.
+    #[test]
+    fn test_missing_nullable_required_field_proceeds_with_null() {
+        let schema = with_supergraph_boilerplate(
+            "type Query @join__type(graph: TEST) { me: String @join__field(graph: TEST) }
+            type Entity { code: String name: String }",
+        );
+        let schema = Schema::parse(&schema, &Default::default()).unwrap();
+
+        // `name` is completely absent from the response
+        let response = bjson!({
+            "__typename": "Entity",
+            "code": "ABC"
+        });
+
+        let requires = json!([
+            {
+                "kind": "InlineFragment",
+                "typeCondition": "Entity",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": "__typename",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "code",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "name",
+                    }
+                ],
+            },
+        ]);
+        let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
+
+        let (value, had_errors) = execute_selection_set(&response, &selection, &schema, None);
+
+        // Nullable field `name` is absent — should be filled as null without errors.
+        assert!(!had_errors, "Expected no errors for missing nullable field");
+        assert_eq!(
+            value,
+            bjson!({"__typename": "Entity", "code": "ABC", "name": null}),
+            "Missing nullable field should be filled as null in the representation"
+        );
+    }
+
     fn with_supergraph_boilerplate(content: &str) -> String {
         format!(
             "{}\n{}",

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -11,11 +11,35 @@ use crate::json_ext::ValueExt;
 use crate::spec::Schema;
 use crate::spec::TYPENAME;
 
+/// Executes a selection set against the input data, extracting fields specified by the selections.
+/// Returns `(value, had_errors)` where `had_errors` is true if a non-nullable field was missing
+/// and an error null was evaluated for it.
+/// Note: Unlike the GraphQL spec execution, this function does not bubble up error nulls to the
+///       nearest nullable parent, but instead it indicates the presence of such errors via the
+///       `had_errors` flag.
 pub(crate) fn execute_selection_set<'a>(
     input_content: &'a Value,
     selections: &[Selection],
     schema: &Schema,
+    current_type: Option<&'a str>,
+) -> (Value, bool) {
+    let mut had_errors = false;
+    let value = execute_selection_set_inner(
+        input_content,
+        selections,
+        schema,
+        current_type,
+        &mut had_errors,
+    );
+    (value, had_errors)
+}
+
+fn execute_selection_set_inner<'a>(
+    input_content: &'a Value,
+    selections: &[Selection],
+    schema: &Schema,
     mut current_type: Option<&'a str>,
+    had_errors: &mut bool,
 ) -> Value {
     let content = match input_content.as_object() {
         Some(o) => o,
@@ -76,6 +100,7 @@ pub(crate) fn execute_selection_set<'a>(
                         {
                             output.insert(ByteString::from(selection_name.to_owned()), Value::Null);
                         } else {
+                            *had_errors = true;
                             return Value::Null;
                         }
                     }
@@ -85,13 +110,14 @@ pub(crate) fn execute_selection_set<'a>(
                                 .iter()
                                 .map(|element| {
                                     if !selections.is_empty() {
-                                        execute_selection_set(
+                                        execute_selection_set_inner(
                                             element,
                                             selections,
                                             schema,
                                             field_type
                                                 .as_ref()
                                                 .map(|ty| ty.inner_named_type().as_str()),
+                                            had_errors,
                                         )
                                     } else {
                                         element.clone()
@@ -102,11 +128,12 @@ pub(crate) fn execute_selection_set<'a>(
                         } else if !selections.is_empty() {
                             output.insert(
                                 key.clone(),
-                                execute_selection_set(
+                                execute_selection_set_inner(
                                     value,
                                     selections,
                                     schema,
                                     field_type.as_ref().map(|ty| ty.inner_named_type().as_str()),
+                                    had_errors,
                                 ),
                             );
                         } else {
@@ -121,17 +148,23 @@ pub(crate) fn execute_selection_set<'a>(
             }) => match type_condition {
                 None => continue,
                 Some(condition) => {
-                    if type_condition_matches(schema, current_type, condition)
-                        && let Value::Object(selected) =
-                            execute_selection_set(input_content, selections, schema, current_type)
-                    {
-                        for (key, value) in selected.into_iter() {
-                            match output.entry(key) {
-                                Entry::Vacant(e) => {
-                                    e.insert(value);
-                                }
-                                Entry::Occupied(e) => {
-                                    e.into_mut().type_aware_deep_merge(value, schema);
+                    if type_condition_matches(schema, current_type, condition) {
+                        let inner = execute_selection_set_inner(
+                            input_content,
+                            selections,
+                            schema,
+                            current_type,
+                            had_errors,
+                        );
+                        if let Value::Object(selected) = inner {
+                            for (key, value) in selected.into_iter() {
+                                match output.entry(key) {
+                                    Entry::Vacant(e) => {
+                                        e.insert(value);
+                                    }
+                                    Entry::Occupied(e) => {
+                                        e.into_mut().type_aware_deep_merge(value, schema);
+                                    }
                                 }
                             }
                         }
@@ -152,7 +185,7 @@ pub(crate) fn execute_selection_set<'a>(
 /// <https://spec.graphql.org/October2021/#DoesFragmentTypeApply()>
 /// <https://spec.graphql.org/October2021/#CompleteValue()>
 /// <https://spec.graphql.org/October2021/#ResolveAbstractType()>
-fn type_condition_matches(
+pub(crate) fn type_condition_matches(
     schema: &Schema,
     current_type: Option<&str>,
     type_condition: &str,
@@ -240,7 +273,7 @@ mod tests {
         Ok(Value::Array(
             values
                 .into_iter()
-                .map(|value| execute_selection_set(value, selections, schema, None))
+                .map(|value| execute_selection_set(value, selections, schema, None).0)
                 .collect::<Vec<_>>(),
         ))
     }
@@ -388,7 +421,7 @@ mod tests {
         ]);
         let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
 
-        let value = execute_selection_set(&response, &selection, &schema, None);
+        let (value, _had_errors) = execute_selection_set(&response, &selection, &schema, None);
         println!(
             "response\n{}\nand selection\n{:?}\n returns:\n{}",
             serde_json::to_string_pretty(&response).unwrap(),
@@ -653,7 +686,7 @@ mod tests {
 
         let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
 
-        let value = execute_selection_set(&response, &selection, &schema, None);
+        let (value, _had_errors) = execute_selection_set(&response, &selection, &schema, None);
 
         assert_eq!(
             value,
@@ -678,6 +711,205 @@ mod tests {
                   "id": 1780384,
                 },
                 "id": 1780384,
+            })
+        );
+    }
+
+    /// Test for the nested non-null field missing bug.
+    ///
+    /// When `@requires(fields: "data { a b }")` and `b` is non-null but missing,
+    /// `execute_selection_set` should return `Value::Null` so the entity is skipped.
+    /// Currently it returns `{ "data": null }` (a non-empty object), which causes the
+    /// entity to NOT be skipped in `Variables::new` (fetch.rs), leading to an invalid
+    /// representation being sent to the subgraph.
+    #[test]
+    fn test_nested_non_null_missing_field_should_nullify_parent() {
+        let schema = with_supergraph_boilerplate(
+            "type Query @join__type(graph: TEST) { me: String @join__field(graph: TEST) }
+            type Entity { data: NestedData! }
+            type NestedData { a: String! b: String! }",
+        );
+        let schema = Schema::parse(&schema, &Default::default()).unwrap();
+
+        // Simulates @requires(fields: "data { a b }") where `b` is missing
+        let response = bjson!({
+            "__typename": "Entity",
+            "data": {
+                "a": "value_a"
+                // "b" is missing — it's non-null (String!), so this should fail
+            }
+        });
+
+        // Selection: ... on Entity { __typename data { a b } }
+        let requires = json!([
+            {
+                "kind": "InlineFragment",
+                "typeCondition": "Entity",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": "__typename",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "data",
+                        "selections": [
+                            {
+                                "kind": "Field",
+                                "name": "a",
+                            },
+                            {
+                                "kind": "Field",
+                                "name": "b",
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]);
+        let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
+
+        let (value, had_errors) = execute_selection_set(&response, &selection, &schema, None);
+
+        // `execute_selection_set` returns `{ "__typename": "Entity", "data": null }` because
+        // null-bubbling stops at the `data` field level. The `had_errors` flag is what
+        // fetch.rs uses to skip this entity from the downstream fetch.
+        assert!(
+            had_errors,
+            "Expected had_errors=true for missing non-null field"
+        );
+        assert_eq!(
+            value,
+            bjson!({"__typename": "Entity", "data": null}),
+            "Expected data to be nullified due to missing non-null field `b`"
+        );
+    }
+
+    /// Same as above but with a nullable parent field.
+    /// Even when the parent field (`data`) is nullable, if a nested non-null field is
+    /// missing, the representation is incomplete and should not be sent.
+    #[test]
+    fn test_nested_non_null_missing_field_nullable_parent_should_nullify() {
+        let schema = with_supergraph_boilerplate(
+            "type Query @join__type(graph: TEST) { me: String @join__field(graph: TEST) }
+            type Entity { data: NestedData }
+            type NestedData { a: String! b: String! }",
+        );
+        let schema = Schema::parse(&schema, &Default::default()).unwrap();
+
+        // `data` is present (non-null object), but inner field `b` is missing
+        let response = bjson!({
+            "__typename": "Entity",
+            "data": {
+                "a": "value_a"
+            }
+        });
+
+        let requires = json!([
+            {
+                "kind": "InlineFragment",
+                "typeCondition": "Entity",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": "__typename",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "data",
+                        "selections": [
+                            {
+                                "kind": "Field",
+                                "name": "a",
+                            },
+                            {
+                                "kind": "Field",
+                                "name": "b",
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]);
+        let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
+
+        let (value, had_errors) = execute_selection_set(&response, &selection, &schema, None);
+
+        // `execute_selection_set` returns `{ "__typename": "Entity", "data": null }` because
+        // null-bubbling nullifies the `data` field. The `had_errors` flag is what fetch.rs
+        // uses to skip this entity from the downstream fetch.
+        assert!(
+            had_errors,
+            "Expected had_errors=true for missing non-null field"
+        );
+        assert_eq!(
+            value,
+            bjson!({"__typename": "Entity", "data": null}),
+            "Expected data to be nullified due to missing non-null field `b`"
+        );
+    }
+
+    /// Verify that when all nested fields are present, the selection works correctly.
+    #[test]
+    fn test_nested_fields_all_present() {
+        let schema = with_supergraph_boilerplate(
+            "type Query @join__type(graph: TEST) { me: String @join__field(graph: TEST) }
+            type Entity { data: NestedData! }
+            type NestedData { a: String! b: String! }",
+        );
+        let schema = Schema::parse(&schema, &Default::default()).unwrap();
+
+        let response = bjson!({
+            "__typename": "Entity",
+            "data": {
+                "a": "value_a",
+                "b": "value_b"
+            }
+        });
+
+        let requires = json!([
+            {
+                "kind": "InlineFragment",
+                "typeCondition": "Entity",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": "__typename",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "data",
+                        "selections": [
+                            {
+                                "kind": "Field",
+                                "name": "a",
+                            },
+                            {
+                                "kind": "Field",
+                                "name": "b",
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]);
+        let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
+
+        let (value, had_errors) = execute_selection_set(&response, &selection, &schema, None);
+
+        // All fields present — should return the full selection
+        assert!(
+            !had_errors,
+            "Expected no errors when all fields are present"
+        );
+        assert_eq!(
+            value,
+            bjson!({
+                "__typename": "Entity",
+                "data": {
+                    "a": "value_a",
+                    "b": "value_b"
+                }
             })
         );
     }

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__typename_propagation2.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__typename_propagation2.snap
@@ -4,12 +4,28 @@ expression: "serde_json::to_value(&response).unwrap()"
 ---
 {
   "data": {
-    "book": {
-      "__typename": "Book",
-      "id": "1",
-      "author": {
-        "__typename": "Author"
+    "book": null
+  },
+  "errors": [
+    {
+      "message": "Could not fetch field",
+      "path": [
+        "book",
+        "id"
+      ],
+      "extensions": {
+        "code": "UNSATISFIED_FETCH_CONDITION"
       }
     }
+  ],
+  "extensions": {
+    "valueCompletion": [
+      {
+        "message": "Null value found for non-nullable type ID",
+        "path": [
+          "book"
+        ]
+      }
+    ]
   }
 }

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -2347,6 +2347,297 @@ async fn missing_nonnull_field_in_requires_returns_error() {
     }
 }
 
+// Variant of `missing_nonnull_field_in_requires_returns_error` where `computed` is a non-nullable
+// field. When the skipped fetch's field is non-nullable, `apply_selection_set` propagates null up
+// to the parent (entity), per the GraphQL spec. The UNSATISFIED_FETCH_CONDITION error is still
+// emitted at the leaf that caused the skip.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error_nonnull_leaf() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID!
+    name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    computed: String! @join__field(graph: SUB2, requires: "code")
+    nickname: String @join__field(graph: SUB2, requires: "name")
+  }"#;
+
+    let query = "query {
+        entity {
+          id
+          computed
+          nickname
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // sub1 returns WITHOUT code — sub2 (which requires code) is skipped.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    // `computed: String!` is non-nullable — the missing value bubbles up and nullifies
+    // `data.entity` per GraphQL null-propagation rules.
+    assert_eq!(value["data"]["entity"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Exactly two UNSATISFIED_FETCH_CONDITION errors — one per field sub2 would have supplied.
+    // No separate null-propagation error is emitted when `computed: String!` bubbles up.
+    assert_eq!(
+        errors.len(),
+        2,
+        "expected only UNSATISFIED_FETCH_CONDITION errors, got: {:?}",
+        errors
+    );
+    let paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "computed"])),
+        "should have error for entity.computed, got: {:?}",
+        paths
+    );
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "nickname"])),
+        "should have error for entity.nickname, got: {:?}",
+        paths
+    );
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+    }
+}
+
+// Variant of `missing_nonnull_field_in_requires_returns_error` where the root `Query.entity`
+// field is non-nullable. With `computed: String!` also non-nullable, the missing value at the
+// leaf bubbles up: `computed` → `entity` (becomes null) → `data` (becomes null, since
+// `Query.entity` is non-null). This tests how null-propagation behaves when there's no
+// nullable ancestor to stop at.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error_nonnull_entity() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    entity: Entity! @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID!
+    name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    computed: String! @join__field(graph: SUB2, requires: "code")
+    nickname: String @join__field(graph: SUB2, requires: "name")
+  }"#;
+
+    let query = "query {
+        entity {
+          id
+          computed
+          nickname
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // sub1 returns WITHOUT code — sub2 (which requires code) is skipped.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    // `computed: String!` missing → nullifies `entity` → `Query.entity: Entity!` is non-null →
+    // the null bubbles up to `data` itself.
+    assert_eq!(value["data"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Still exactly the two UNSATISFIED_FETCH_CONDITION errors — one per field sub2 would have
+    // supplied. No extra error is emitted for the null-propagation to `data`.
+    assert_eq!(
+        errors.len(),
+        2,
+        "expected only UNSATISFIED_FETCH_CONDITION errors, got: {:?}",
+        errors
+    );
+    let paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "computed"])),
+        "should have error for entity.computed, got: {:?}",
+        paths
+    );
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "nickname"])),
+        "should have error for entity.nickname, got: {:?}",
+        paths
+    );
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+    }
+}
+
 // Regression test: when a list of entities is fetched and only some entities have missing
 // non-nullable @requires fields, the router should still fetch the successful entities
 // and generate errors only for the failed ones.
@@ -2691,6 +2982,177 @@ async fn run_parallel_sibling_skipped_fetch(generate_query_fragments: bool) {
         errors[0]["extensions"]["code"].as_str(),
         Some("UNSATISFIED_FETCH_CONDITION"),
     );
+}
+
+// Regression test: a chained @requires failure. Fetch A misses a field that
+// fetch B requires; fetch B would have produced an input that fetch C
+// requires, but that input isn't in the user's operation. When B is skipped,
+// C is also skipped — but errors should only be emitted for fields the user
+// asked for. The planner-internal intermediate field should NOT appear in
+// error paths.
+//
+// Scenario:
+//   query { entity { final other } }
+//   sub1: _entities -> { id, code }           (code missing)
+//   sub2: _entities { aux other } requires "code"   (skipped, would have supplied `aux` and `other`)
+//   sub3: _entities { final } requires "aux"        (skipped transitively — `aux` never fetched)
+//
+// Expected errors:
+//   [entity, other] — sub2's skip, user-visible field
+//   [entity, final] — sub3's skip, user-visible field
+// NOT [entity, aux] — planner-internal, not in the user's operation.
+#[tokio::test]
+async fn chained_requires_skipped_fetch_hides_internal_fields() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/sub1")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/sub2")
+    SUB3 @join__graph(name: "sub3", url: "http://localhost:4002/sub3")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+    @join__type(graph: SUB3)
+  {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+    @join__type(graph: SUB3, key: "id", extension: true)
+  {
+    id: ID!
+    code: String!
+      @join__field(graph: SUB1)
+      @join__field(graph: SUB2, external: true)
+    aux: String!
+      @join__field(graph: SUB2, requires: "code")
+      @join__field(graph: SUB3, external: true)
+    other: String @join__field(graph: SUB2, requires: "code")
+    final: String @join__field(graph: SUB3, requires: "aux")
+  }"#;
+
+    let query = "query {
+        entity {
+          final
+          other
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id code}}"}},
+                        // code missing — sub2 (which requires code) is skipped; sub3 follows.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                                "__typename": "Entity",
+                                "id": "1"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // sub2 and sub3 should never be called.
+            ("sub2", MockSubgraph::builder().build()),
+            ("sub3", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Exactly two errors — one per user-visible field that went unfetched.
+    // `aux` is planner-internal (not in the user's operation) and must NOT
+    // appear in any error path.
+    let paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert_eq!(
+        errors.len(),
+        2,
+        "expected exactly 2 UNSATISFIED_FETCH_CONDITION errors, got: {:?}",
+        errors
+    );
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "other"])),
+        "should have error for entity.other, got: {:?}",
+        paths
+    );
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "final"])),
+        "should have error for entity.final, got: {:?}",
+        paths
+    );
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+        // `aux` is planner-internal — it must NOT leak into user-visible errors.
+        assert_ne!(
+            err["path"],
+            serde_json::json!(["entity", "aux"]),
+            "planner-internal `aux` leaked into errors: {:?}",
+            err
+        );
+    }
 }
 
 // Regression test: when two subgraph fetches share a composite field via

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -2176,3 +2176,667 @@ async fn batched_entity_partial_requires_failure() {
         );
     }
 }
+
+// Regression test: when two @requires fetches execute in parallel at the same
+// entity path, skipping one must not produce errors for the sibling fetch's
+// fields. Before the fix, `errors_for_skipped_fetch` reported every input-query
+// field absent from `parent_value` — which swept in fields the other parallel
+// fetch was about to provide.
+#[tokio::test]
+async fn parallel_sibling_skipped_fetch_does_not_over_report() {
+    run_parallel_sibling_skipped_fetch(false).await;
+}
+
+// Same scenario, but with `generate_query_fragments: true`. The skipped fetch's
+// operation may contain named fragment spreads; verifying the fix still intersects
+// correctly against the fetch's response shape when fragments are present.
+#[tokio::test]
+async fn parallel_sibling_skipped_fetch_does_not_over_report_generate_fragments() {
+    run_parallel_sibling_skipped_fetch(true).await;
+}
+
+async fn run_parallel_sibling_skipped_fetch(generate_query_fragments: bool) {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/sub1")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/sub2")
+    SUB3 @join__graph(name: "sub3", url: "http://localhost:4002/sub3")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+    @join__type(graph: SUB3)
+  {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+    @join__type(graph: SUB3, key: "id", extension: true)
+  {
+    id: ID!
+    code1: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    code2: String! @join__field(graph: SUB1) @join__field(graph: SUB3, external: true)
+    a: String @join__field(graph: SUB1)
+    b: String @join__field(graph: SUB2, requires: "code1")
+    c: String @join__field(graph: SUB3, requires: "code2")
+  }"#;
+
+    let query = "query {
+        entity {
+          a
+          b
+          c
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id a code1 code2}}"}},
+                        // code1 is missing — sub2 (which requires code1) will be skipped.
+                        // code2 is present — sub3 (which requires code2) will succeed.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                                "__typename": "Entity",
+                                "id": "1",
+                                "a": "a-value",
+                                "code2": "c2"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+            (
+                "sub3",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{
+                            "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Entity{c}}}",
+                            "variables": {
+                                "representations": [
+                                    {"__typename": "Entity", "id": "1", "code2": "c2"}
+                                ]
+                            }
+                        }},
+                        serde_json::json! {{"data": {
+                            "_entities": [
+                                {"c": "c-value"}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+            "supergraph": {
+                "generate_query_fragments": generate_query_fragments,
+            }
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let entity = &value["data"]["entity"];
+    // sub1 and sub3 succeeded — `a` and `c` should be populated, `b` is null.
+    assert_eq!(entity["a"], serde_json::json!("a-value"));
+    assert_eq!(entity["c"], serde_json::json!("c-value"));
+    assert_eq!(entity["b"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Only `entity.b` should be reported — NOT `entity.c`, even though `c`
+    // was absent from parent_value at the time sub2 was skipped.
+    assert_eq!(
+        errors.len(),
+        1,
+        "should only report the skipped sibling's field, got: {:?}",
+        errors
+    );
+    assert_eq!(errors[0]["path"], serde_json::json!(["entity", "b"]));
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("UNSATISFIED_FETCH_CONDITION"),
+    );
+}
+
+// Regression test: when two subgraph fetches share a composite field via
+// @shareable, and one is skipped by a missing @requires input, the sibling
+// fetch still provides its subfields. Error reporting should cover the fields
+// that only the skipped fetch would have supplied, not the shared parent.
+//
+// Scenario:
+//   query { me { profile { firstName address } } }
+//   subA: me -> User { id, fullName }   (fullName missing from response)
+//   subB: User.profile @requires(fullName) -> { firstName }   (skipped)
+//   subC: User.profile -> { address }                         (succeeds)
+#[tokio::test]
+async fn skipped_fetch_with_overlapping_shareable_composite_field() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+    SUBC @join__graph(name: "subc", url: "http://localhost:4003/subc")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+    @join__type(graph: SUBC)
+  {
+    me: User @join__field(graph: SUBA)
+  }
+
+  type User
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+    @join__type(graph: SUBC, key: "id", extension: true)
+  {
+    id: ID!
+    fullName: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    profile: Profile
+      @join__field(graph: SUBB, requires: "fullName")
+      @join__field(graph: SUBC)
+  }
+
+  type Profile
+    @join__type(graph: SUBB)
+    @join__type(graph: SUBC)
+  {
+    firstName: String @join__field(graph: SUBB)
+    address: String @join__field(graph: SUBC)
+  }"#;
+
+    let query = "query {
+        me {
+          profile {
+            firstName
+            address
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{me{__typename id fullName}}"}},
+                        // fullName missing — subB (which requires fullName) will be skipped.
+                        serde_json::json! {{"data": {
+                            "me": {
+                                "__typename": "User",
+                                "id": "1"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // subB is skipped — it should never be called.
+            ("subb", MockSubgraph::builder().build()),
+            (
+                "subc",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{
+                            "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{profile{address}}}}",
+                            "variables": {
+                                "representations": [
+                                    {"__typename": "User", "id": "1"}
+                                ]
+                            }
+                        }},
+                        serde_json::json! {{"data": {
+                            "_entities": [
+                                {"profile": {"address": "123 Main St"}}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    // subC succeeded — address should be present; firstName was not fetched.
+    let profile = &value["data"]["me"]["profile"];
+    assert_eq!(profile["address"], serde_json::json!("123 Main St"));
+    assert_eq!(profile["firstName"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Only firstName (uniquely provided by the skipped subB) should be reported.
+    // `profile` itself should NOT be flagged — subC successfully provided it.
+    assert_eq!(
+        errors.len(),
+        1,
+        "should only report the field uniquely provided by the skipped fetch, got: {:?}",
+        errors
+    );
+    assert_eq!(
+        errors[0]["path"],
+        serde_json::json!(["me", "profile", "firstName"])
+    );
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("UNSATISFIED_FETCH_CONDITION"),
+    );
+}
+
+// When the skipped fetch would have populated a list-typed field with per-item
+// sub-selections, the error must stop at the list field itself. The
+// response-key tree has no array indices, so we can't enumerate per-item
+// leaves like `[..., addresses, 0, street]`.
+//
+// Scenario:
+//   query { me { addresses { street city } } }
+//   subA: me -> User { id, fullName }   (fullName missing from response)
+//   subB: User.addresses @requires(fullName) -> [Address { street, city }] (skipped)
+#[tokio::test]
+async fn skipped_fetch_with_list_field_reports_at_list_level() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    me: User @join__field(graph: SUBA)
+  }
+
+  type User
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    fullName: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    addresses: [Address]
+      @join__field(graph: SUBB, requires: "fullName")
+  }
+
+  type Address
+    @join__type(graph: SUBB)
+  {
+    street: String @join__field(graph: SUBB)
+    city: String @join__field(graph: SUBB)
+  }"#;
+
+    let query = "query {
+        me {
+          addresses {
+            street
+            city
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{me{__typename id fullName}}"}},
+                        // fullName missing — subB (which requires fullName) will be skipped.
+                        serde_json::json! {{"data": {
+                            "me": {
+                                "__typename": "User",
+                                "id": "1"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // subB is skipped — it should never be called.
+            ("subb", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Exactly one error, at the list field itself — not descending with fake
+    // indices or enumerating per-item leaves under `addresses`.
+    assert_eq!(
+        errors.len(),
+        1,
+        "should emit one error at the list field, got: {:?}",
+        errors
+    );
+    assert_eq!(errors[0]["path"], serde_json::json!(["me", "addresses"]));
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("UNSATISFIED_FETCH_CONDITION"),
+    );
+}
+
+// When a shareable list-typed field is partially fetched — one subgraph
+// populates the array while another's fetch is skipped for @requires — we
+// still emit an error at the list field. The tree has no array indices, so we
+// can't enumerate per-item leaves for the skipped subgraph's contributions,
+// and the list-level emission must not be suppressed just because another
+// fetch already wrote a value at that path.
+//
+// Scenario:
+//   query { person { friends { name hobby job } } }
+//   subA: person -> Person { id, friends: [Friend{name, hobby}] }   (fullName missing)
+//   subB: Person.friends @requires(fullName) -> [Friend{job}]       (skipped)
+#[tokio::test]
+async fn skipped_fetch_with_shareable_list_field_reports_error_and_value() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    person: Person @join__field(graph: SUBA)
+  }
+
+  type Person
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    fullName: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    friends: [Friend]
+      @join__field(graph: SUBA)
+      @join__field(graph: SUBB, requires: "fullName")
+  }
+
+  type Friend
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    name: String @join__field(graph: SUBA) @join__field(graph: SUBB)
+    hobby: String @join__field(graph: SUBA)
+    job: String @join__field(graph: SUBB)
+  }"#;
+
+    let query = "query {
+        person {
+          friends {
+            name
+            hobby
+            job
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{person{__typename id friends{name hobby} fullName}}"}},
+                        // fullName missing — subB (which requires fullName) is skipped.
+                        serde_json::json! {{"data": {
+                            "person": {
+                                "__typename": "Person",
+                                "id": "1",
+                                "friends": [
+                                    { "name": "Alice", "hobby": "chess" }
+                                ]
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // subB is skipped — it should never be called.
+            ("subb", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // One UNSATISFIED_FETCH_CONDITION error at the list field itself — even
+    // though subA populated `friends` with a value.
+    let unsatisfied: Vec<_> = errors
+        .iter()
+        .filter(|e| e["extensions"]["code"].as_str() == Some("UNSATISFIED_FETCH_CONDITION"))
+        .collect();
+    assert_eq!(
+        unsatisfied.len(),
+        1,
+        "should emit exactly one UNSATISFIED_FETCH_CONDITION at the list field, got: {:?}",
+        errors
+    );
+    assert_eq!(
+        unsatisfied[0]["path"],
+        serde_json::json!(["person", "friends"])
+    );
+
+    // The response still carries the array populated by subA.
+    let friends = &value["data"]["person"]["friends"];
+    assert!(
+        friends.is_array(),
+        "friends should be populated by subA, got: {:?}",
+        value["data"]
+    );
+    assert_eq!(friends[0]["name"].as_str(), Some("Alice"));
+    assert_eq!(friends[0]["hobby"].as_str(), Some("chess"));
+}

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -1646,6 +1646,10 @@ async fn typename_propagation() {
 }
 
 #[tokio::test]
+// Tests that when a subgraph returns __typename: null for a nested object,
+// the entity representation cannot be built (the non-nullable `fullName`
+// in the composite key `bookId author { fullName }` is unresolvable),
+// so the downstream entity fetch is properly skipped with errors.
 async fn typename_propagation2() {
     let subgraphs = MockedSubgraphs(
         [
@@ -1655,6 +1659,8 @@ async fn typename_propagation2() {
                     "query": "query QueryBook__book_subgraph__0{book{__typename bookId author{__typename authorId}}}",
                     "operationName": "QueryBook__book_subgraph__0"
                 }},
+                // author.__typename is null — the Author entity cannot be resolved,
+                // so fullName (needed for the Book key) is unresolvable.
                 serde_json::json! {{"data": {
                     "book": {
                       "__typename": "Book",
@@ -1666,45 +1672,9 @@ async fn typename_propagation2() {
                     }
                 } }},
             ).build()),
-            ("node_relay_subgraph", MockSubgraph::builder().with_json(
-                serde_json::json! {{
-                    "query": "query QueryBook__node_relay_subgraph__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename id}}}",
-                    "operationName": "QueryBook__node_relay_subgraph__2",
-                    "variables": {
-                        "representations": [{
-                            "__typename": "Book",
-                            "bookId": "book1",
-                            "author": null
-                        }]
-                    }
-                }},
-                serde_json::json! {{"data": {
-                    "_entities": [{
-                        "__typename": "Book",
-                        "id": "1"
-                    }]
-                } }},
-            ).with_json(
-                serde_json::json! {{
-                    "query": "query QueryBook__node_relay_subgraph__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename id}}}",
-                    "operationName": "QueryBook__node_relay_subgraph__2",
-                    "variables": {
-                        "representations": [{
-                            "__typename": "Book",
-                            "bookId": "book1",
-                            "author": {
-                                "fullName": null
-                            }
-                        }]
-                    }
-                }},
-                serde_json::json! {{"data": {
-                    "_entities": [{
-                        "__typename": "Book",
-                        "id": "1"
-                    }]
-                } }},
-            ).build()),
+            // node_relay_subgraph is never called because the Book entity
+            // representation cannot be built.
+            ("node_relay_subgraph", MockSubgraph::builder().build()),
         ]
         .into_iter()
         .collect(),
@@ -1891,4 +1861,318 @@ fn broken_plan_does_not_panic() {
         result.unwrap_err().to_string(),
         r#"[1:3] Cannot query field "invalid" on type "Query"."#
     );
+}
+
+// When a non-nullable field in a @requires selection is missing from the upstream subgraph
+// response (e.g. stripped by a coprocessor), the entire downstream entity fetch shouldn't be
+// silently skipped with no error. We ensure that errors are propagated to the client response
+// explaining why the entity fields were nullified.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID!
+    name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    computed: String @join__field(graph: SUB2, requires: "code")
+    nickname: String @join__field(graph: SUB2, requires: "name")
+  }"#;
+
+    let query = "query {
+        entity {
+          id
+          computed
+          nickname
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        // Router queries sub1 for entity fields including code and name (needed for @requires)
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // Sub1 returns WITHOUT code (simulating coprocessor stripping the field from the request,
+                        // so the subgraph never received it and doesn't return it)
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let data = &value["data"]["entity"];
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Both fields are null because the entity was nullified (non-nullable @requires field missing).
+    // Per GraphQL spec, null bubbles up from the missing non-nullable field to the entity.
+    assert_eq!(data["computed"], serde_json::Value::Null);
+    assert_eq!(data["nickname"], serde_json::Value::Null);
+
+    // The response now includes errors for each unfetched field.
+    // Previously (bug), errors was empty — the fetch was silently skipped.
+    assert_eq!(errors.len(), 2, "should have one error per unfetched field");
+
+    let error_paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert!(
+        error_paths.contains(&&serde_json::json!(["entity", "computed"])),
+        "should have error for entity.computed, got: {:?}",
+        error_paths
+    );
+    assert!(
+        error_paths.contains(&&serde_json::json!(["entity", "nickname"])),
+        "should have error for entity.nickname, got: {:?}",
+        error_paths
+    );
+
+    // Error messages are abstract — they don't expose internal @requires details.
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+    }
+}
+
+// Regression test: when a list of entities is fetched and only some entities have missing
+// non-nullable @requires fields, the router should still fetch the successful entities
+// and generate errors only for the failed ones.
+#[tokio::test]
+async fn batched_entity_partial_requires_failure() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    entities: [Entity] @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID!
+    code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    computed: String @join__field(graph: SUB2, requires: "code")
+  }"#;
+
+    let query = "query {
+        entities {
+          id
+          computed
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entities{__typename id code}}"}},
+                        // Entity 0 and 2 have code, entity 1 and 3 do NOT (missing required field)
+                        serde_json::json! {{"data": {
+                            "entities": [
+                              {"__typename": "Entity", "id": "1", "code": "ABC"},
+                              {"__typename": "Entity", "id": "2"},
+                              {"__typename": "Entity", "id": "3", "code": "XYZ"},
+                              {"__typename": "Entity", "id": "4"}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+            (
+                "sub2",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{
+                            "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Entity{computed}}}",
+                            "variables": {
+                                "representations": [
+                                    {"__typename": "Entity", "id": "1", "code": "ABC"},
+                                    {"__typename": "Entity", "id": "3", "code": "XYZ"}
+                                ]
+                            }
+                        }},
+                        serde_json::json! {{"data": {
+                            "_entities": [
+                                {"computed": "computed-1"},
+                                {"computed": "computed-3"}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let entities = value["data"]["entities"]
+        .as_array()
+        .expect("entities should be an array");
+
+    // Entities 0 and 2 succeeded — they have computed values
+    assert_eq!(entities[0]["computed"], serde_json::json!("computed-1"));
+    assert_eq!(entities[2]["computed"], serde_json::json!("computed-3"));
+
+    // Entities 1 and 3 failed — computed is null because code was missing
+    assert_eq!(entities[1]["computed"], serde_json::Value::Null);
+    assert_eq!(entities[3]["computed"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Should have errors for the 2 failed entities
+    assert_eq!(errors.len(), 2, "should have one error per failed entity");
+
+    let error_paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert!(
+        error_paths.contains(&&serde_json::json!(["entities", 1, "computed"])),
+        "should have error for entities[1].computed, got: {:?}",
+        error_paths
+    );
+    assert!(
+        error_paths.contains(&&serde_json::json!(["entities", 3, "computed"])),
+        "should have error for entities[3].computed, got: {:?}",
+        error_paths
+    );
+
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+    }
 }

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_one_subgraph_cost_are_accepted@federated_ships_required.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_one_subgraph_cost_are_accepted@federated_ships_required.snap
@@ -3,9 +3,9 @@ source: apollo-router/tests/integration/demand_control.rs
 expression: parse_result_for_snapshot(response).await
 ---
 {
-  "apollo::demand_control::actual_cost": 9.0,
+  "apollo::demand_control::actual_cost": 6.0,
   "apollo::demand_control::actual_cost_by_subgraph": {
-    "vehicles": 9.0
+    "vehicles": 6.0
   },
   "apollo::demand_control::estimated_cost": 140.0,
   "apollo::demand_control::estimated_cost_by_subgraph": {
@@ -19,7 +19,7 @@ expression: parse_result_for_snapshot(response).await
   },
   "apollo::demand_control::strategy": "static_estimated",
   "apollo::experimental_mock_subgraphs::subgraph_call_count": {
-    "vehicles": 2
+    "vehicles": 1
   },
   "body": {
     "data": {
@@ -79,6 +79,39 @@ expression: parse_result_for_snapshot(response).await
         "path": [
           "ships",
           2
+        ]
+      },
+      {
+        "extensions": {
+          "code": "UNSATISFIED_FETCH_CONDITION"
+        },
+        "message": "Could not fetch field",
+        "path": [
+          "ships",
+          0,
+          "registrationFee"
+        ]
+      },
+      {
+        "extensions": {
+          "code": "UNSATISFIED_FETCH_CONDITION"
+        },
+        "message": "Could not fetch field",
+        "path": [
+          "ships",
+          1,
+          "registrationFee"
+        ]
+      },
+      {
+        "extensions": {
+          "code": "UNSATISFIED_FETCH_CONDITION"
+        },
+        "message": "Could not fetch field",
+        "path": [
+          "ships",
+          2,
+          "registrationFee"
         ]
       }
     ]


### PR DESCRIPTION
### Summary

The issue was that Router silently skips downstream entity fetches when a non-nullable `@key`/`@requires` field is missing, skipping a fetch for that entity without errors.

Previously, when `execute_selection_set` detected a missing non-nullable field during entity representation building, the entity was silently dropped — no fetch was made and no errors were reported. This violated the GraphQL spec expectation that clients should receive errors explaining why fields are null.

Also, there was another bug where `execute_selection_set` had no way to signal a missing non-nullable field under a nested field. In this case, such unsatisfied entities would be added to representations variable anyways, instead of skipping them.

#### Key changes

**`selection.rs` — `execute_selection_set` `had_errors` flag**
- The function now returns `(Value, bool)` where the bool indicates whether any required field was missing.

**`fetch.rs` — `Variables::new` return type change**
- Changed return type from `Result<Option<Variables>, ()>` to `(Option<Variables>, Vec<Path>)`.
- The second element collects the paths of entities skipped due to unsatisfied required fields.
- When `execute_selection_set` returns `had_errors=true`, the entity is added to `unsatisfied_paths` and excluded from the fetch batch.
- This supports partial batch success: some entities in a batch can succeed while others fail.

**`execution.rs` — Error generation for skipped fetches**
- Added `errors_for_skipped_fetch()` that inspects the supergraph query's selection set to discover which fields would have been returned by the skipped fetch.
- Generates abstract `UNSATISFIED_FETCH_CONDITION` errors (without exposing `@requires` internals).
- Handles inline fragments, named fragment spreads, `@skip`/`@include` directives, and `PathElement::Index` for array entity batches.
- Errors are appended regardless of whether `Variables::new` returns `Some` or `None` (partial vs. full batch failure).

### Test plan

- `missing_nonnull_field_in_requires_returns_error` — single entity, missing required field, expects `UNSATISFIED_FETCH_CONDITION` error
- `batched_entity_partial_requires_failure` — 4 entities in a batch, 2 succeed and 2 fail, verifies partial success with errors only for failed entities
- `typename_propagation2` — updated snapshot to expect error behavior when `__typename` is null
- `test_nested_non_null_missing_field_should_nullify_parent` — nested non-null field missing with non-null parent
- `test_nested_non_null_missing_field_nullable_parent_should_nullify` — nested non-null field missing with nullable parent
- `test_nested_fields_all_present` — all fields present, no errors

<!-- start metadata -->

<!-- [RH-1335] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary




[RH-1335]: https://apollographql.atlassian.net/browse/RH-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ