### PR TITLE
docs: document list-type argument support for slicingArguments

### DIFF
--- a/.changesets/docs_demand_control_list_slicing_args.md
+++ b/.changesets/docs_demand_control_list_slicing_args.md
@@ -1,0 +1,5 @@
+### Document list-type argument support for `slicingArguments` in demand control ([PR #9196](https://github.com/apollographql/router/pull/9196))
+
+The router supports using the length of list-type arguments as the cost multiplier in `@listSize(slicingArguments: [...])`, but this was not documented. Adds a new "List-type arguments in `slicingArguments`" subsection to the demand control docs with schema examples, query examples (both inline arrays and variables), and cost calculation breakdowns.
+
+By [@shanemyrick](https://github.com/shanemyrick) in https://github.com/apollographql/router/pull/9196

--- a/docs/source/routing/security/demand-control.mdx
+++ b/docs/source/routing/security/demand-control.mdx
@@ -248,7 +248,7 @@ query BooksByIds {
 
 </ExpansionPanel>
 
-This also works when the list is passed via a query variable. For example, the following query with `{"ids": ["abc", "def", "ghi", "jkl", "mno"]}` would have a cost of ten:
+This also works when the list is passed using query variables.
 
 ```graphql
 query BooksByIds($ids: [ID!]!) {
@@ -260,6 +260,20 @@ query BooksByIds($ids: [ID!]!) {
   }
 }
 ```
+
+```json title="Query variables"
+{
+  "ids": ["abc", "def", "ghi", "jkl", "mno"]
+}
+```
+
+<ExpansionPanel title="Cost of booksByIds query">
+
+```text disableCopy=true showLineNumbers=false
+1 Query (0) + 5 book objects (5 * (1 book object (1) + 1 author object (1))) = 10 total cost
+```
+
+</ExpansionPanel>
 
 #### Nested paths in `slicingArguments`
 

--- a/docs/source/routing/security/demand-control.mdx
+++ b/docs/source/routing/security/demand-control.mdx
@@ -210,6 +210,57 @@ When requesting 7 books:
 1 Query (0) + 7 book objects (7 * (1 book object (1) + 1 author object (1) + 1 publisher object (1) + 1 address object (5))) = 56 total cost
 ```
 
+#### List-type arguments in `slicingArguments`
+
+When a `slicingArguments` entry references a list-type argument, the router uses the **length** of that list as the list size. This is useful when a field resolves one result per input ID or tag, rather than using a numeric paging argument.
+
+```graphql
+type Query {
+  book(id: ID): Book
+  bestsellers: [Book] @listSize(assumedSize: 5)
+  newestAdditions(after: ID, limit: Int!): [Book]
+    @listSize(slicingArguments: ["limit"])
+  #highlight-start
+  booksByIds(ids: [ID!]!): [Book]
+    @listSize(slicingArguments: ["ids"])
+  #highlight-end
+}
+```
+
+With this schema, the router uses the length of the `ids` argument as the list size:
+
+```graphql
+query BooksByIds {
+  booksByIds(ids: ["abc", "def", "ghi"]) {
+    title
+    author {
+      name
+    }
+  }
+}
+```
+
+<ExpansionPanel title="Cost of booksByIds query">
+
+```text disableCopy=true showLineNumbers=false
+1 Query (0) + 3 book objects (3 * (1 book object (1) + 1 author object (1))) = 6 total cost
+```
+
+</ExpansionPanel>
+
+This also works when the list is passed via a query variable. For example, the following query with `{"ids": ["abc", "def", "ghi", "jkl", "mno"]}` would have a cost of 10:
+
+```graphql
+query BooksByIds($ids: [ID!]!) {
+  booksByIds(ids: $ids) {
+    title
+    author {
+      name
+    }
+  }
+}
+```
+
 #### Nested paths in `slicingArguments`
 
 <MinVersionBadge version="Router v2.12.0" />

--- a/docs/source/routing/security/demand-control.mdx
+++ b/docs/source/routing/security/demand-control.mdx
@@ -212,7 +212,7 @@ When requesting 7 books:
 
 #### List-type arguments in `slicingArguments`
 
-When a `slicingArguments` entry references a list-type argument, the router uses the **length** of that list as the list size. This is useful when a field resolves one result per input ID or tag, rather than using a numeric paging argument.
+When a `slicingArguments` entry references a list-type argument, the router uses the length of that list as the list size. This is useful when your resolver returns one result per input ID or tag, instead of using a numeric paging argument.
 
 ```graphql
 type Query {
@@ -227,7 +227,7 @@ type Query {
 }
 ```
 
-With this schema, the router uses the length of the `ids` argument as the list size:
+With your schema, the router uses the length of the `ids` argument as the list size:
 
 ```graphql
 query BooksByIds {
@@ -248,7 +248,7 @@ query BooksByIds {
 
 </ExpansionPanel>
 
-This also works when the list is passed via a query variable. For example, the following query with `{"ids": ["abc", "def", "ghi", "jkl", "mno"]}` would have a cost of 10:
+This also works when the list is passed via a query variable. For example, the following query with `{"ids": ["abc", "def", "ghi", "jkl", "mno"]}` would have a cost of ten:
 
 ```graphql
 query BooksByIds($ids: [ID!]!) {


### PR DESCRIPTION
## Summary
- The router already supports using the **length of list-type arguments** as the cost multiplier in `@listSize(slicingArguments: [...])`, but this was not documented
- Adds a new "List-type arguments in `slicingArguments`" subsection to the demand control docs with schema examples, inline query examples, variable examples, and cost calculation breakdowns
- Follows existing doc patterns (Book domain, `<ExpansionPanel>` for cost math, `#highlight` annotations)

## How we know this is supported

The implementation in [`directives.rs`](https://github.com/apollographql/router/blob/dev/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs) explicitly handles list-type arguments:

```rust
fn infer_size_from_argument(value: Option<&AstValue>, variables: &Object) -> Option<i32> {
    match value? {
        AstValue::Int(n) => n.try_to_i32().ok(),        // scalar int → use the value
        AstValue::List(items) => Some(items.len() as i32), // list → use the LENGTH
        AstValue::Variable(var_name) => infer_size_from_variable(variables.get(var_name.as_str())),
        _ => None,
    }
}
```

And the same for variables passed at runtime:

```rust
fn infer_size_from_variable(value: Option<&JsonValue>) -> Option<i32> {
    match value? {
        JsonValue::Array(items) => Some(items.len() as i32),
        other => other.as_i32(),
    }
}
```

There are also dedicated tests in [`static_cost.rs`](https://github.com/apollographql/router/blob/dev/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs) under `array_slicing_argument_tests` that validate:
- **Inline arrays**: `itemsByIds(ids: ["a", "b"])` → cost multiplier of 2
- **Variable arrays**: `$ids = ["a", "b", "c", "d", "e"]` → cost multiplier of 5
- **Empty arrays**: `ids: []` → cost multiplier of 0


🤖 Generated with [Claude Code](https://claude.com/claude-code)