### PR TITLE
fix(composition): fix connect auto upgrade logic

### DIFF
--- a/apollo-federation/src/connectors/spec/mod.rs
+++ b/apollo-federation/src/connectors/spec/mod.rs
@@ -265,7 +265,7 @@ pub(crate) static CONNECT_VERSIONS: LazyLock<SpecDefinitions<ConnectSpecDefiniti
                 minor: 12,
             },
         ));
-        definitions.add(ConnectSpecDefinition::new(
+        definitions.add_preview(ConnectSpecDefinition::new(
             Version { major: 0, minor: 4 },
             Version {
                 major: 2,

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -7,8 +7,10 @@ use std::sync::LazyLock;
 
 use apollo_compiler::Name;
 use apollo_compiler::Node;
+use apollo_compiler::collections::HashSet;
 use apollo_compiler::schema::DirectiveDefinition;
 use apollo_compiler::schema::ExtendedType;
+use itertools::Itertools;
 
 use crate::AUTHENTICATED_VERSIONS;
 use crate::CACHE_TAG_VERSIONS;
@@ -202,6 +204,7 @@ pub(crate) trait SpecDefinition {
 pub(crate) struct SpecDefinitions<T: SpecDefinition> {
     identity: Identity,
     definitions: BTreeMap<Version, T>,
+    preview_versions: HashSet<Version>,
 }
 
 impl<T: SpecDefinition> SpecDefinitions<T> {
@@ -209,6 +212,7 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
         Self {
             identity,
             definitions: BTreeMap::new(),
+            preview_versions: Default::default(),
         }
     }
 
@@ -227,6 +231,12 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
             .insert(definition.version().clone(), definition);
     }
 
+    pub(crate) fn add_preview(&mut self, definition: T) {
+        let preview_version = definition.version().clone();
+        self.add(definition);
+        self.preview_versions.insert(preview_version);
+    }
+
     pub(crate) fn find(&self, requested: &Version) -> Option<&T> {
         self.definitions.get(requested)
     }
@@ -239,6 +249,20 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
         self.definitions
             .last_key_value()
             .expect("There should always be at least one version defined")
+            .1
+    }
+
+    /// Like [`SpecDefinitions::latest`], but skips versions marked as preview. Used by
+    /// [`Merger::add_join_directive_directives`] in the composition merger to avoid
+    /// stamping a preview spec version (e.g. connect/v0.4) into the
+    /// supergraph `@link` when no subgraph explicitly uses it. Falls back
+    /// to latest if all versions are preview.
+    pub(crate) fn latest_non_preview(&self) -> &T {
+        self.definitions
+            .iter()
+            .rev()
+            .find_or_first(|(v, _)| !self.preview_versions.contains(v))
+            .expect("There should always be at least one non-preview version defined")
             .1
     }
 
@@ -280,17 +304,14 @@ pub(crate) struct SpecRegistry {
 }
 
 impl SpecRegistry {
-    pub(crate) fn new() -> Self {
+    fn new() -> Self {
         Self {
             definitions_by_url: HashMap::new(),
             available_versions_by_identity: HashMap::new(),
         }
     }
 
-    pub(crate) fn extend<T: SpecDefinition + Sync>(
-        &mut self,
-        definitions: &'static SpecDefinitions<T>,
-    ) {
+    fn extend<T: SpecDefinition + Sync>(&mut self, definitions: &'static SpecDefinitions<T>) {
         for (v, spec) in definitions.iter() {
             self.definitions_by_url.insert(spec.url().clone(), spec);
             self.available_versions_by_identity

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -16,6 +16,7 @@ use apollo_compiler::ast::NamedType;
 use apollo_compiler::ast::Type;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
+use apollo_compiler::name;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ComponentName;
 use apollo_compiler::schema::ComponentOrigin;
@@ -29,6 +30,7 @@ use tracing::trace;
 use crate::LinkSpecDefinition;
 use crate::api_schema;
 use crate::bail;
+use crate::connectors::spec::CONNECT_VERSIONS;
 use crate::error::CompositionError;
 use crate::error::FederationError;
 use crate::error::HasLocations;
@@ -2305,7 +2307,8 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
             Name,
             IndexMap<Vec<Node<Argument>>, IndexSet<Name>>,
         > = IndexMap::default();
-        let mut links_to_persist: Vec<(Url, Directive)> = Vec::new();
+        // JS PORT NOTE: This was a Set in JS. We are using Vec instead of IndexSet as Hash trait is not dyn compatible
+        let mut links_to_persist: Vec<&dyn SpecDefinition> = Default::default();
 
         for (idx, source) in sources.iter() {
             let Some(source) = source else {
@@ -2334,8 +2337,8 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                     {
                         // Persist link when the spec uses @join__directive and the feature
                         // identity is one of the known join-directive feature definitions.
-                        if SPEC_REGISTRY.get_definition(&link.url).is_some() {
-                            links_to_persist.push((link.url.clone(), directive.as_ref().clone()));
+                        if let Some(definition) = SPEC_REGISTRY.get_definition(&link.url) {
+                            links_to_persist.push(*definition);
                         }
                         Some(directive.name.clone())
                     } else {
@@ -2397,31 +2400,57 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
         // change the output supergraph schema. Here, when we encounter a link directive, we
         // preserve the version the subgraph used in a `@join__directive` so the query planner can
         // extract the subgraph schemas with correct links.
-        let mut latest_or_highest_link_by_identity: HashMap<Identity, (Url, Directive)> =
-            HashMap::new();
-        for (url, link_directive) in links_to_persist {
-            if let Some((existing_url, existing_directive)) =
-                latest_or_highest_link_by_identity.get_mut(&url.identity)
-            {
-                if url.version > existing_url.version {
-                    *existing_url = url;
-                    *existing_directive = link_directive;
-                }
-            } else {
-                latest_or_highest_link_by_identity
-                    .insert(url.identity.clone(), (url, link_directive));
-            }
-        }
+        let latest_or_highest_link_by_identity: IndexMap<Identity, &dyn SpecDefinition> =
+            links_to_persist
+                .iter()
+                .fold(IndexMap::default(), |mut acc, spec_definition| {
+                    // auto upgrade connectors spec to latest non_preview
+                    //
+                    // PORT NOTE: JavaScript logic auto upgrade logic was generic allowing any spec to be auto upgraded,
+                    //   keeping it simple for now as auto-upgrade logic is connectors only
+                    let latest_spec: &dyn SpecDefinition = if *spec_definition.identity()
+                        == Identity::connect_identity()
+                        && CONNECT_VERSIONS.latest_non_preview().version()
+                            > spec_definition.version()
+                    {
+                        CONNECT_VERSIONS.latest_non_preview()
+                    } else {
+                        *spec_definition
+                    };
+
+                    acc.entry(latest_spec.identity().clone())
+                        .and_modify(|existing| {
+                            if existing.version() < latest_spec.version() {
+                                *existing = latest_spec
+                            }
+                        })
+                        .or_insert(latest_spec);
+                    acc
+                });
 
         let dest: DirectiveTargetPosition = dest.clone().try_into()?;
-        for (_, directive) in latest_or_highest_link_by_identity.into_values() {
-            // We insert the directive as it was in the subgraph, but with the name of `@link` in
-            // the supergraph, in case it was renamed in the subgraph.
+        for spec in latest_or_highest_link_by_identity.into_values() {
+            // we need to manually apply `@link` for the target spec
+            // we cannot use `apply_feature_to_schema` as @connect spec defines subgraph specification
+            // we use the same link import in the supergraph but we don't bring in any of the types
+            let mut arguments = vec![];
+            arguments.push(Node::new(Argument {
+                name: name!("url"),
+                value: Node::new(Value::String(spec.to_string())),
+            }));
+            if let Some(purpose) = spec.purpose() {
+                arguments.push(Node::new(Argument {
+                    name: name!("for"),
+                    value: Node::new(Value::Enum(Name::new_unchecked(
+                        purpose.to_string().as_str(),
+                    ))),
+                }));
+            }
             dest.insert_directive(
                 &mut self.merged,
                 Directive {
                     name: link_directive_name.clone(),
-                    arguments: directive.arguments,
+                    arguments,
                 },
             )?;
         }

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_2.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_2_], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_2_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_2_], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_2_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}}) {
   query: Query
 }
 

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) {
   query: Query
 }
 

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_4_], args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_4_], args: {name: "v4", http: {baseURL: "http://v4"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_4_], args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_4_], args: {name: "v4", http: {baseURL: "http://v4"}}) {
   query: Query
 }
 

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_with_renames.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_with_renames.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.1", as: "http", import: [{name: "@connect", as: "@http"}, {name: "@source", as: "@api"}]) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", as: "http", import: [{name: "@connect", as: "@http"}, {name: "@source", as: "@api"}]}) @join__directive(name: "api", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", as: "http", import: [{name: "@connect", as: "@http"}, {name: "@source", as: "@api"}]}) @join__directive(name: "api", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
   query: Query
 }
 

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__connect_spec_and_join_directive_composes.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__connect_spec_and_join_directive_composes.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
   query: Query
 }
 

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__does_not_require_importing_connect.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__does_not_require_importing_connect.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
   query: Query
 }
 

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__using_as_alias.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__using_as_alias.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.1", as: "http", import: ["@source"]) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", as: "http", import: ["@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", as: "http", import: ["@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
   query: Query
 }
 


### PR DESCRIPTION
Fixed `add_join_directive_directives` logic to auto upgrade `@connect` spec to the latest non preview version.