### PR TITLE
composition: fix `origin_to_use()` to prefer definition over extension

### DIFF
--- a/apollo-federation/src/connectors/spec/type_and_directive_specifications.rs
+++ b/apollo-federation/src/connectors/spec/type_and_directive_specifications.rs
@@ -573,11 +573,11 @@ mod tests {
             .expand_links()
             .expect("expanded successfully");
         assert_snapshot!(subgraph.schema_string(), @r#"
-        schema {
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
           query: Query
         }
 
-        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.10") @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"])
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.10") @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"])
 
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
@@ -707,11 +707,11 @@ mod tests {
             .expand_links()
             .expect("expanded successfully");
         assert_snapshot!(subgraph.schema_string(), @r#"
-        schema {
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
           query: Query
         }
 
-        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@source"])
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@source"])
 
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
@@ -950,11 +950,11 @@ mod tests {
             .expand_links()
             .expect("expanded successfully");
         assert_snapshot!(subgraph.schema_string(), @r#"
-        schema {
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
           query: Query
         }
 
-        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2", import: [{name: "@source", as: "@api"}, {name: "JSONSelection", as: "Mapping"}, {name: "ConnectorErrors", as: "ErrorMappings"}, "ConnectHTTP"])
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2", import: [{name: "@source", as: "@api"}, {name: "JSONSelection", as: "Mapping"}, {name: "ConnectorErrors", as: "ErrorMappings"}, "ConnectHTTP"])
 
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
@@ -1091,11 +1091,11 @@ mod tests {
             .expand_links()
             .expect("expanded successfully");
         assert_snapshot!(subgraph.schema_string(), @r#"
-        schema {
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
           query: Query
         }
 
-        extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2")
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.11") @link(url: "https://specs.apollo.dev/connect/v0.2")
 
         directive @connect(source: String, http: connect__ConnectHTTP!, selection: connect__JSONSelection!) repeatable on FIELD_DEFINITION
 

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -1423,18 +1423,15 @@ pub(crate) trait SchemaElement {
     }
 
     fn origin_to_use(&self) -> ComponentOrigin {
-        let extensions = self.extensions();
-        // Find an arbitrary extension origin if the schema definition has any extension elements.
-        // Note: No defined ordering between origins.
-        let first_extension = extensions.first();
-        if let Some(first_extension) = first_extension {
-            // If there is an extension, use the first extension.
-            ComponentOrigin::Extension((*first_extension).clone())
-        } else {
-            // Use the existing definition if exists, or maybe a new definition if no definition
-            // nor extensions exist.
-            ComponentOrigin::Definition
+        let (has_definition, extensions) = self.definition_and_extensions();
+        // Use extension origin only when extensions exist but no definition does
+        // (i.e., only extension elements are populated). Otherwise, use definition.
+        // For more details, see the comments in the `add_to_schema` method.
+        // Note: Use an arbitrary extension origin, since no defined ordering between origins.
+        if !has_definition && let Some(first_extension) = extensions.first() {
+            return ComponentOrigin::Extension((*first_extension).clone());
         }
+        ComponentOrigin::Definition
     }
 }
 

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -1996,4 +1996,50 @@ mod tests {
         );
         assert!(subgraph.schema().schema().get_scalar("Mutation").is_some());
     }
+
+    /// When a schema has both an explicit `schema { ... }` definition and an
+    /// `extend schema @link(...) { ... }` extension, the link-to-link `@link` directive
+    /// should be added to the definition (not the extension), because a definition exists.
+    /// This tests the `origin_to_use()` fix.
+    #[test]
+    fn link_to_link_goes_on_definition_when_both_definition_and_extension_exist() {
+        let subgraph = build_and_validate(
+            r#"
+            schema {
+                mutation: Mutation
+            }
+
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.12") {
+                subscription: Subscription
+            }
+
+            type Mutation {
+                update(id: ID!, value: String!): String
+            }
+
+            type Subscription {
+                news: String!
+            }
+            "#,
+        );
+
+        // Take only the first few lines (schema definition + extension blocks)
+        // to verify the @link placement without snapshotting all the directives.
+        let schema_str = subgraph.schema_string();
+        let first_lines: String = schema_str.lines().take(9).collect::<Vec<_>>().join("\n");
+        // The link-to-link @link should be on the schema definition (first block),
+        // NOT on the extension block. Before the fix, origin_to_use() would return
+        // Extension whenever any extensions existed, causing the @link to end up on
+        // the extend schema block instead of the definition.
+        insta::assert_snapshot!(first_lines, @r#"
+        schema @link(url: "https://specs.apollo.dev/link/v1.0") {
+          query: Query
+          mutation: Mutation
+        }
+
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.12") {
+          subscription: Subscription
+        }
+        "#);
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `origin_to_use()` in `SchemaElement` trait to only return an extension origin when no definition exists. Previously, it always returned an extension origin whenever *any* extensions were present — even when a definition also existed — causing directives like the link-to-link `@link` to be incorrectly placed on `extend schema` instead of the `schema` definition.
- Add a regression test verifying that `@link(url: ".../link/v1.0")` is placed on the `schema` definition (not the extension) when both exist.
- Update 4 connector snapshot tests whose output changed as a result of the fix.

## Details

`origin_to_use()` determines where new directives (e.g., the link-to-link `@link`) get added when constructing a schema. The old logic was:

```rust
if let Some(first_extension) = extensions.first() {
    ComponentOrigin::Extension(...)  // always picked extension if any existed
} else {
    ComponentOrigin::Definition
}
```

The fix aligns with the intent described in `add_to_schema()` comments — use an extension origin only when the schema has *no* definition and only extension elements are populated:

```rust
if !has_definition && let Some(first_extension) = extensions.first() {
    return ComponentOrigin::Extension(...);
}
ComponentOrigin::Definition
```

## Test plan

- [x] New test `link_to_link_goes_on_definition_when_both_definition_and_extension_exist` passes
- [x] Updated connector snapshot tests pass (`expands_connect_v01`, `expands_connect_v0_2`, `test_v0_2_compatible_defs`, `test_v0_2_renames`)

<!-- start metadata -->

<!-- [FED-985] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary


[FED-985]: https://apollographql.atlassian.net/browse/FED-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ