### PR TITLE
fix(demand-control): improve cost estimation for @skip/@include and type conditions

### DIFF
--- a/.changesets/fix_duckki_fed_1000.md
+++ b/.changesets/fix_duckki_fed_1000.md
@@ -1,0 +1,16 @@
+### Improved demand control cost estimation by considering Boolean conditions and type conditions ([PR #9209](https://github.com/apollographql/router/pull/9209))
+
+The static cost calculator now evaluates `@skip` / `@include` conditions against request variables, picks the correct branch of `PlanNode::Condition` based on its condition variable, and avoids summing costs from mutually-exclusive fragment spreads.
+
+- `@skip(if: $var)` and `@include(if: $var)` directives are now resolved against the supplied variables for fields, fragment spreads, and inline fragments. Previously only boolean literals were handled, so variable-driven inclusion always treated the selection as present.
+- `PlanNode::Condition` (the node the query planner emits for `@defer(if: $var)` and similar conditionals) now picks the branch that will actually run at request time instead of taking the maximum cost of both branches.
+
+
+Selection set cost estimator now group selections by their statically known narrowest type. Selections that apply to abstract types form a shared "abstract" bucket whose cost is always added. Each observed concrete object type condition gets its own bucket, and because only one concrete type can apply at runtime the estimator takes the MAX across concrete buckets rather than summing them.
+
+- Nested spreads carry the outer narrowing through, so `... on Cat { ... on Pet { x } }` still contributes `x` to the `Cat` bucket.
+- Within each bucket, occurrences sharing a response key collapse via MAX per key to honor GraphQL field merging. This prevents spreads across many implementation types (e.g. `... on A { a } ... on B { b } ... on C { c }`) from inflating the estimate by summing every mutually-exclusive branch.
+
+As a result, estimated costs now more closely track the real shape of the request and no longer over-count fields that will be skipped by the runtime, merged by field merging, or ruled out by the runtime type.
+
+By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/9209

--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -14,7 +14,6 @@ use apollo_compiler::validation::Valid;
 use apollo_federation::link::cost_spec_definition::ListSizeDirective as ParsedListSizeDirective;
 use indexmap::IndexSet;
 use serde_json_bytes::Value as JsonValue;
-use tower::BoxError;
 
 use crate::json_ext::Object;
 use crate::json_ext::ValueExt;
@@ -120,23 +119,34 @@ fn collect_slicing_sizes<'a>(
         .collect()
 }
 
-pub(in crate::plugins::demand_control) struct IncludeDirective {
-    pub(in crate::plugins::demand_control) is_included: bool,
+// Resolves a boolean AST value, following variable references into the provided variables map.
+// Returns `None` for null, missing, or unsupported value types.
+fn resolve_bool_argument(value: &AstValue, variables: &Object) -> Option<bool> {
+    match value {
+        AstValue::Boolean(b) => Some(*b),
+        AstValue::Variable(var_name) => variables.get(var_name.as_str()).and_then(|v| v.as_bool()),
+        _ => None,
+    }
 }
 
-impl IncludeDirective {
-    pub(in crate::plugins::demand_control) fn from_field(
-        field: &Field,
-    ) -> Result<Option<Self>, BoxError> {
-        let directive = field
-            .directives
-            .get("include")
-            .and_then(|skip| skip.specified_argument_by_name("if"))
-            .and_then(|arg| arg.to_bool())
-            .map(|cond| Self { is_included: cond });
-
-        Ok(directive)
-    }
+// Returns whether a selection is excluded by `@skip(if: ...)` or `@include(if: ...)`
+// directives, resolving variable references against the provided variables map.
+//
+// - `@skip(if: true)` excludes the selection.
+// - `@include(if: false)` excludes the selection.
+// - Any directive whose `if` argument cannot be resolved to a boolean is ignored,
+//   matching the runtime behavior where the selection is kept.
+pub(in crate::plugins::demand_control) fn is_skipped_by_directives(
+    directives: &apollo_compiler::ast::DirectiveList,
+    variables: &Object,
+) -> bool {
+    let resolved_if = |name: &str| {
+        directives
+            .get(name)
+            .and_then(|d| d.specified_argument_by_name("if"))
+            .and_then(|arg| resolve_bool_argument(arg, variables))
+    };
+    matches!(resolved_if("skip"), Some(true)) || matches!(resolved_if("include"), Some(false))
 }
 
 #[derive(Clone, Debug)]
@@ -380,25 +390,6 @@ impl RequiresDirective {
         } else {
             Ok(None)
         }
-    }
-}
-
-pub(in crate::plugins::demand_control) struct SkipDirective {
-    pub(in crate::plugins::demand_control) is_skipped: bool,
-}
-
-impl SkipDirective {
-    pub(in crate::plugins::demand_control) fn from_field(
-        field: &Field,
-    ) -> Result<Option<Self>, BoxError> {
-        let directive = field
-            .directives
-            .get("skip")
-            .and_then(|skip| skip.specified_argument_by_name("if"))
-            .and_then(|arg| arg.to_bool())
-            .map(|cond| Self { is_skipped: cond });
-
-        Ok(directive)
     }
 }
 

--- a/apollo-router/src/plugins/demand_control/cost_calculator/mod.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/mod.rs
@@ -29,30 +29,6 @@ impl CostBySubgraph {
     pub(crate) fn total(&self) -> f64 {
         self.0.values().sum()
     }
-
-    /// Creates a new `CostBySubgraph` where each value in the map is the maximum of its value
-    /// in the two input `CostBySubgraph`s.
-    ///
-    /// ```rust
-    /// let cost1 = CostBySubgraph::new("hello", 1.0);
-    /// let mut cost2 = CostBySubgraph::new("hello", 2.0);
-    /// cost2.add_or_insert("world", 1.0);
-    ///
-    /// let max = CostBySubgraph::maximum(cost1, cost2);
-    /// assert_eq!(max.0.get("hello"), Some(2.0));
-    /// assert_eq!(max.0.get("world"), Some(1.0));
-    /// ```
-    pub(crate) fn maximum(mut cost1: Self, cost2: Self) -> Self {
-        for (subgraph, value) in cost2.0.into_iter() {
-            if let Some(subgraph_cost) = cost1.0.get_mut(&subgraph) {
-                *subgraph_cost = subgraph_cost.max(value);
-            } else {
-                cost1.0.insert(subgraph, value);
-            }
-        }
-
-        cost1
-    }
 }
 
 impl AddAssign for CostBySubgraph {

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -16,8 +16,7 @@ use serde_json_bytes::Value;
 
 use super::CostBySubgraph;
 use super::DemandControlError;
-use super::directives::IncludeDirective;
-use super::directives::SkipDirective;
+use super::directives::is_skipped_by_directives;
 use super::schema::DemandControlledSchema;
 use super::schema::InputDefinition;
 use crate::configuration::subgraph::SubgraphConfiguration;
@@ -197,10 +196,6 @@ impl StaticCostCalculator {
         if field.name == TYPENAME {
             return Ok(0.0);
         }
-        if StaticCostCalculator::skipped_by_directives(field) {
-            return Ok(0.0);
-        }
-
         let definition = ctx
             .schema
             .output_field_definition(parent_type, &field.name)
@@ -394,6 +389,18 @@ impl StaticCostCalculator {
         inherited_list_sizes: &[ListSizeDirective],
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
+        // `@skip(if: ...)` and `@include(if: ...)` apply to fields, fragment spreads, and
+        // inline fragments alike. Short-circuit excluded selections before scoring so the
+        // estimate reflects only what will actually execute.
+        let selection_directives = match selection {
+            Selection::Field(f) => &f.directives,
+            Selection::FragmentSpread(s) => &s.directives,
+            Selection::InlineFragment(i) => &i.directives,
+        };
+        if is_skipped_by_directives(selection_directives, ctx.variables) {
+            return Ok(0.0);
+        }
+
         match selection {
             Selection::Field(f) => {
                 // We need two things for scoring this field: (1) the list size to use for
@@ -455,6 +462,8 @@ impl StaticCostCalculator {
     ) -> Result<f64, DemandControlError> {
         let mut cost = 0.0;
         for selection in selection_set.selections.iter() {
+            // TODO: Spreads with mutually exclusive type conditions should not be added together.
+            //       Current estimate may exaggerate cost of spreads across many implementation types.
             cost += self.score_selection(
                 ctx,
                 selection,
@@ -467,20 +476,6 @@ impl StaticCostCalculator {
         Ok(cost)
     }
 
-    fn skipped_by_directives(field: &Field) -> bool {
-        let include_directive = IncludeDirective::from_field(field);
-        if let Ok(Some(IncludeDirective { is_included: false })) = include_directive {
-            return true;
-        }
-
-        let skip_directive = SkipDirective::from_field(field);
-        if let Ok(Some(SkipDirective { is_skipped: true })) = skip_directive {
-            return true;
-        }
-
-        false
-    }
-
     fn score_plan_node(
         &self,
         plan_node: &PlanNode,
@@ -491,10 +486,10 @@ impl StaticCostCalculator {
             PlanNode::Parallel { nodes } => self.summed_score_of_nodes(nodes, variables),
             PlanNode::Flatten(flatten_node) => self.score_plan_node(&flatten_node.node, variables),
             PlanNode::Condition {
-                condition: _,
+                condition,
                 if_clause,
                 else_clause,
-            } => self.max_score_of_nodes(if_clause, else_clause, variables),
+            } => self.score_conditional_nodes(condition, if_clause, else_clause, variables),
             PlanNode::Defer { primary, deferred } => {
                 self.summed_score_of_deferred_nodes(primary, deferred, variables)
             }
@@ -532,21 +527,23 @@ impl StaticCostCalculator {
         Ok(CostBySubgraph::new(subgraph, cost))
     }
 
-    fn max_score_of_nodes(
+    fn score_conditional_nodes(
         &self,
-        left: &Option<Box<PlanNode>>,
-        right: &Option<Box<PlanNode>>,
+        condition: &str,
+        if_clause: &Option<Box<PlanNode>>,
+        else_clause: &Option<Box<PlanNode>>,
         variables: &Object,
     ) -> Result<CostBySubgraph, DemandControlError> {
-        match (left, right) {
-            (None, None) => Ok(CostBySubgraph::default()),
-            (None, Some(right)) => self.score_plan_node(right, variables),
-            (Some(left), None) => self.score_plan_node(left, variables),
-            (Some(left), Some(right)) => {
-                let left_score = self.score_plan_node(left, variables)?;
-                let right_score = self.score_plan_node(right, variables)?;
-                Ok(CostBySubgraph::maximum(left_score, right_score))
-            }
+        // Evaluate the condition variable. If the variable is missing, default to `true`
+        // to match the runtime behavior in `PlanNode::is_deferred`.
+        let branch = variables
+            .get(condition)
+            .map(|v| v.as_bool().unwrap_or(false))
+            .unwrap_or(true);
+        let selected = if branch { if_clause } else { else_clause };
+        match selected {
+            Some(node) => self.score_plan_node(node, variables),
+            None => Ok(CostBySubgraph::default()),
         }
     }
 
@@ -1095,6 +1092,73 @@ mod tests {
         let variables = "{}";
 
         assert_eq!(basic_estimated_cost(schema, query, variables), 0.0)
+    }
+
+    #[test]
+    fn skip_directive_resolves_variables() {
+        let schema = include_str!("./fixtures/basic_schema.graphql");
+        let query = "query Test($shouldSkip: Boolean!) {
+            someObjects @skip(if: $shouldSkip) { field1 }
+        }";
+        let baseline = "{ someObjects { field1 } }";
+
+        assert_eq!(
+            basic_estimated_cost(schema, query, r#"{"shouldSkip": true}"#),
+            0.0
+        );
+        let expected = basic_estimated_cost(schema, baseline, r#"{"shouldSkip": false}"#);
+        assert!(expected > 0.0);
+        assert_eq!(
+            basic_estimated_cost(schema, query, r#"{"shouldSkip": false}"#),
+            expected
+        );
+    }
+
+    #[test]
+    fn skip_directive_on_inline_fragment_excludes_cost() {
+        let schema = include_str!("./fixtures/basic_schema.graphql");
+        let query = "{ ... @skip(if: true) { someObjects { field1 } } }";
+
+        assert_eq!(basic_estimated_cost(schema, query, "{}"), 0.0);
+    }
+
+    #[test]
+    fn skip_directive_on_fragment_spread_resolves_variables() {
+        let schema = include_str!("./fixtures/basic_schema.graphql");
+        let query = "fragment ObjectFields on Query { someObjects { field1 } }
+            query Test($shouldSkip: Boolean!) { ...ObjectFields @skip(if: $shouldSkip) }";
+        let baseline = "{ someObjects { field1 } }";
+
+        assert_eq!(
+            basic_estimated_cost(schema, query, r#"{"shouldSkip": true}"#),
+            0.0
+        );
+        let expected = basic_estimated_cost(schema, baseline, r#"{"shouldSkip": false}"#);
+        assert!(expected > 0.0);
+        assert_eq!(
+            basic_estimated_cost(schema, query, r#"{"shouldSkip": false}"#),
+            expected
+        );
+    }
+
+    #[test]
+    fn include_directive_resolves_variables() {
+        let schema = include_str!("./fixtures/basic_schema.graphql");
+        let query = "query Test($shouldInclude: Boolean!) {
+            someObjects @include(if: $shouldInclude) { field1 }
+        }";
+        let baseline = "{ someObjects { field1 } }";
+
+        assert_eq!(
+            basic_estimated_cost(schema, query, r#"{"shouldInclude": false}"#),
+            0.0
+        );
+        let expected = basic_estimated_cost(schema, baseline, r#"{"shouldInclude": true}"#);
+        assert!(expected > 0.0);
+        assert_eq!(
+            basic_estimated_cost(schema, query, r#"{"shouldInclude": true}"#),
+            expected
+        );
     }
 
     #[test(tokio::test)]

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -5,8 +5,6 @@ use apollo_compiler::ast;
 use apollo_compiler::ast::NamedType;
 use apollo_compiler::executable::ExecutableDocument;
 use apollo_compiler::executable::Field;
-use apollo_compiler::executable::FragmentSpread;
-use apollo_compiler::executable::InlineFragment;
 use apollo_compiler::executable::Operation;
 use apollo_compiler::executable::Selection;
 use apollo_compiler::executable::SelectionSet;
@@ -307,52 +305,6 @@ impl StaticCostCalculator {
         Ok(cost)
     }
 
-    fn score_fragment_spread(
-        &self,
-        ctx: &ScoringContext,
-        fragment_spread: &FragmentSpread,
-        list_size_directives: &[ListSizeDirective],
-        inherited_list_sizes: &[ListSizeDirective],
-        subgraph: &str,
-    ) -> Result<f64, DemandControlError> {
-        let fragment = fragment_spread.fragment_def(ctx.query).ok_or_else(|| {
-            DemandControlError::QueryParseFailure(format!(
-                "Parsed operation did not have a definition for fragment {}",
-                fragment_spread.fragment_name
-            ))
-        })?;
-        self.score_selection_set(
-            ctx,
-            &fragment.selection_set,
-            fragment.type_condition(),
-            list_size_directives,
-            inherited_list_sizes,
-            subgraph,
-        )
-    }
-
-    fn score_inline_fragment(
-        &self,
-        ctx: &ScoringContext,
-        inline_fragment: &InlineFragment,
-        parent_type: &NamedType,
-        list_size_directives: &[ListSizeDirective],
-        inherited_list_sizes: &[ListSizeDirective],
-        subgraph: &str,
-    ) -> Result<f64, DemandControlError> {
-        self.score_selection_set(
-            ctx,
-            &inline_fragment.selection_set,
-            inline_fragment
-                .type_condition
-                .as_ref()
-                .unwrap_or(parent_type),
-            list_size_directives,
-            inherited_list_sizes,
-            subgraph,
-        )
-    }
-
     fn score_operation(
         &self,
         operation: &Operation,
@@ -380,77 +332,6 @@ impl StaticCostCalculator {
         Ok(cost)
     }
 
-    fn score_selection(
-        &self,
-        ctx: &ScoringContext,
-        selection: &Selection,
-        parent_type: &NamedType,
-        list_size_directives: &[ListSizeDirective],
-        inherited_list_sizes: &[ListSizeDirective],
-        subgraph: &str,
-    ) -> Result<f64, DemandControlError> {
-        // `@skip(if: ...)` and `@include(if: ...)` apply to fields, fragment spreads, and
-        // inline fragments alike. Short-circuit excluded selections before scoring so the
-        // estimate reflects only what will actually execute.
-        let selection_directives = match selection {
-            Selection::Field(f) => &f.directives,
-            Selection::FragmentSpread(s) => &s.directives,
-            Selection::InlineFragment(i) => &i.directives,
-        };
-        if is_skipped_by_directives(selection_directives, ctx.variables) {
-            return Ok(0.0);
-        }
-
-        match selection {
-            Selection::Field(f) => {
-                // We need two things for scoring this field: (1) the list size to use for
-                // instance_count if this field is a list (list_size_from_upstream), and (2) the
-                // directive(s) to pass to this field's selection set so nested lists (e.g. "page"
-                // under "results") get the right sizing (descended). With repeatable @listSize,
-                // multiple directives can descend to the same field, so we collect all of them.
-                let size_from_parent = list_size_directives
-                    .iter()
-                    .filter_map(|dir| dir.size_of(f))
-                    .max();
-                let size_from_inherited = inherited_list_sizes
-                    .iter()
-                    .filter_map(|dir| dir.size_of(f))
-                    .max();
-                let list_size_from_upstream = size_from_parent.or(size_from_inherited);
-
-                let descended: Vec<ListSizeDirective> = list_size_directives
-                    .iter()
-                    .chain(inherited_list_sizes.iter())
-                    .filter_map(|dir| dir.descend(f.name.as_str()))
-                    .collect();
-
-                self.score_field(
-                    ctx,
-                    f,
-                    parent_type,
-                    list_size_from_upstream,
-                    &descended,
-                    subgraph,
-                )
-            }
-            Selection::FragmentSpread(s) => self.score_fragment_spread(
-                ctx,
-                s,
-                list_size_directives,
-                inherited_list_sizes,
-                subgraph,
-            ),
-            Selection::InlineFragment(i) => self.score_inline_fragment(
-                ctx,
-                i,
-                parent_type,
-                list_size_directives,
-                inherited_list_sizes,
-                subgraph,
-            ),
-        }
-    }
-
     fn score_selection_set(
         &self,
         ctx: &ScoringContext,
@@ -460,18 +341,79 @@ impl StaticCostCalculator {
         inherited_list_sizes: &[ListSizeDirective],
         subgraph: &str,
     ) -> Result<f64, DemandControlError> {
-        let mut cost = 0.0;
-        for selection in selection_set.selections.iter() {
-            // TODO: Spreads with mutually exclusive type conditions should not be added together.
-            //       Current estimate may exaggerate cost of spreads across many implementation types.
-            cost += self.score_selection(
+        // Expand fragment spreads / inline fragments and partition field occurrences into buckets:
+        // one "abstract" bucket for selections under any abstract type conditions, plus one bucket
+        // per concrete object type condition observed. The abstract bucket's cost is always
+        // incurred; among the concrete buckets only one applies at runtime, so we take their MAX.
+        // Within each bucket we take MAX per response key to honor field merging.
+        let mut buckets: HashMap<selection::BucketKey, selection::Bucket> = HashMap::default();
+        // Note: selection_set.ty is expected to be the same as parent_type_name.
+        assert_eq!(selection_set.ty, *parent_type_name);
+        selection::collect_occurrences(ctx, selection_set, parent_type_name, &mut buckets)?;
+
+        let mut abstract_cost = 0.0;
+        let mut concrete_max: f64 = 0.0;
+        for (bucket_key, bucket) in &buckets {
+            let bucket_cost = self.score_bucket(
                 ctx,
-                selection,
-                parent_type_name,
+                bucket,
                 list_size_directives,
                 inherited_list_sizes,
                 subgraph,
             )?;
+            if bucket_key.is_none() {
+                abstract_cost = bucket_cost;
+            } else {
+                concrete_max = concrete_max.max(bucket_cost);
+            }
+        }
+        Ok(abstract_cost + concrete_max)
+    }
+
+    fn score_bucket(
+        &self,
+        ctx: &ScoringContext,
+        bucket: &selection::Bucket,
+        list_size_directives: &[ListSizeDirective],
+        inherited_list_sizes: &[ListSizeDirective],
+        subgraph: &str,
+    ) -> Result<f64, DemandControlError> {
+        let mut cost = 0.0;
+        for occurrences in bucket.values() {
+            let mut max_cost: f64 = 0.0;
+            for occ in occurrences {
+                // We need two things for scoring this field: (1) the list size to use for
+                // instance_count if this field is a list (list_size_from_upstream), and (2) the
+                // directive(s) to pass to this field's selection set so nested lists (e.g. "page"
+                // under "results") get the right sizing (descended). With repeatable @listSize,
+                // multiple directives can descend to the same field, so we collect all of them.
+                let size_from_parent = list_size_directives
+                    .iter()
+                    .filter_map(|dir| dir.size_of(occ.field))
+                    .max();
+                let size_from_inherited = inherited_list_sizes
+                    .iter()
+                    .filter_map(|dir| dir.size_of(occ.field))
+                    .max();
+                let list_size_from_upstream = size_from_parent.or(size_from_inherited);
+
+                let descended: Vec<ListSizeDirective> = list_size_directives
+                    .iter()
+                    .chain(inherited_list_sizes.iter())
+                    .filter_map(|dir| dir.descend(occ.field.name.as_str()))
+                    .collect();
+
+                let occ_cost = self.score_field(
+                    ctx,
+                    occ.field,
+                    occ.parent_type,
+                    list_size_from_upstream,
+                    &descended,
+                    subgraph,
+                )?;
+                max_cost = max_cost.max(occ_cost);
+            }
+            cost += max_cost;
         }
         Ok(cost)
     }
@@ -620,6 +562,103 @@ impl StaticCostCalculator {
         let mut visitor = ResponseCostCalculator::new(&self.supergraph_schema);
         visitor.visit(request, response, variables);
         Ok(visitor.cost)
+    }
+}
+
+mod selection {
+    use super::*;
+
+    /// A single field occurrence produced by expanding a selection set's fragment spreads and
+    /// inline fragments. `parent_type` is the type condition that was in effect where the field was
+    /// written, which may differ across occurrences with the same response key (e.g. `...on A { f }`
+    /// vs `...on B { f }`).
+    pub(super) struct Occurrence<'a> {
+        pub(super) field: &'a Field,
+        pub(super) parent_type: &'a NamedType,
+    }
+
+    /// Bucket grouping field occurrences by response key. Within a bucket we take the MAX cost per
+    /// response key (GraphQL field-merging collapses selections that share a response key).
+    pub(super) type Bucket<'a> = HashMap<&'a str, Vec<Occurrence<'a>>>;
+
+    /// Which runtime type the bucket is conditional on. `None` means the selections apply to every
+    /// runtime type (no enclosing object type condition); `Some(name)` means they only apply when
+    /// the runtime type is exactly `name` (an object type).
+    pub(super) type BucketKey<'a> = Option<&'a str>;
+
+    /// Narrow `current` by the nested `candidate` type. `narrowed_parent_type` is an
+    /// over-approximation of the runtime type for the current selection position: once we've
+    /// entered a concrete object type condition, inner spreads can only be compatible with that
+    /// same concrete type (by GraphQL validation), so we hold it. Otherwise we take the candidate,
+    /// which is at least as specific as the current abstract type.
+    fn narrow<'a>(
+        schema: &'a DemandControlledSchema,
+        current: &'a NamedType,
+        candidate: &'a NamedType,
+    ) -> &'a NamedType {
+        if matches!(schema.types.get(current), Some(ExtendedType::Object(_))) {
+            current
+        } else {
+            candidate
+        }
+    }
+
+    pub(super) fn collect_occurrences<'a>(
+        ctx: &'a ScoringContext,
+        selection_set: &'a SelectionSet,
+        narrowed_parent_type: &'a NamedType,
+        buckets: &mut HashMap<BucketKey<'a>, Bucket<'a>>,
+    ) -> Result<(), DemandControlError> {
+        // Selections here are gated on runtime type ⊆ narrowed_parent_type. When that's an object
+        // type, all selections only apply to that specific runtime type — they go into the
+        // per-object concrete bucket. Otherwise the runtime type is any implementation of an
+        // abstract type, and the selections go into the shared "abstract" bucket.
+        let bucket_key: BucketKey = match ctx.schema.types.get(narrowed_parent_type) {
+            Some(ExtendedType::Object(_)) => Some(narrowed_parent_type.as_str()),
+            _ => None,
+        };
+
+        for selection in selection_set.selections.iter() {
+            // `@skip(if: ...)` and `@include(if: ...)` apply to fields, fragment spreads, and
+            // inline fragments alike. Short-circuit excluded selections so the estimate reflects
+            // only what will actually execute.
+            let directives = match selection {
+                Selection::Field(f) => &f.directives,
+                Selection::FragmentSpread(s) => &s.directives,
+                Selection::InlineFragment(i) => &i.directives,
+            };
+            if is_skipped_by_directives(directives, ctx.variables) {
+                continue;
+            }
+            match selection {
+                Selection::Field(f) => {
+                    buckets
+                        .entry(bucket_key)
+                        .or_default()
+                        .entry(f.response_key().as_str())
+                        .or_default()
+                        .push(Occurrence {
+                            field: f,
+                            parent_type: narrowed_parent_type,
+                        });
+                }
+                Selection::FragmentSpread(spread) => {
+                    let fragment = spread.fragment_def(ctx.query).ok_or_else(|| {
+                        DemandControlError::QueryParseFailure(format!(
+                            "Parsed operation did not have a definition for fragment {}",
+                            spread.fragment_name
+                        ))
+                    })?;
+                    let next = narrow(ctx.schema, narrowed_parent_type, &fragment.selection_set.ty);
+                    collect_occurrences(ctx, &fragment.selection_set, next, buckets)?;
+                }
+                Selection::InlineFragment(inline) => {
+                    let next = narrow(ctx.schema, narrowed_parent_type, &inline.selection_set.ty);
+                    collect_occurrences(ctx, &inline.selection_set, next, buckets)?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1159,6 +1198,66 @@ mod tests {
             basic_estimated_cost(schema, query, r#"{"shouldInclude": true}"#),
             expected
         );
+    }
+
+    #[test]
+    fn mutually_exclusive_fragments_dedupe_by_response_key() {
+        // `pet` is `Pet` (an interface), and fragments on `Cat` / `Dog` both select a field named
+        // `buddies`. At runtime only one branch applies, and GraphQL field merging means the
+        // field is fetched once. The estimator should take the MAX cost per response key rather
+        // than summing both occurrences.
+        let schema = r#"
+            type Query { pet: Pet }
+            interface Pet { id: ID }
+            type Cat implements Pet { id: ID, buddies: [Pet] }
+            type Dog implements Pet { id: ID, buddies: [Pet] }
+        "#;
+        let query = r#"
+            {
+                pet {
+                    ... on Cat { buddies { id } }
+                    ... on Dog { buddies { id } }
+                }
+            }
+        "#;
+        // pet (interface object) = 1, buddies = MAX(100 * 1, 100 * 1) = 100.
+        // Before the dedup fix, this would have been 1 + 100 + 100 = 201.
+        assert_eq!(basic_estimated_cost(schema, query, "{}"), 101.0);
+    }
+
+    #[test]
+    fn mutually_exclusive_fragments_with_distinct_selections_take_max_across_types() {
+        // The estimator partitions selections into an "abstract" bucket (selections that apply
+        // to every runtime type) and one bucket per observed concrete object type condition.
+        // The abstract bucket's cost is added unconditionally; among the concrete buckets, only
+        // one applies at runtime, so we take their MAX. This keeps distinct mutually-exclusive
+        // spreads from inflating the estimate, even when they pick different response keys.
+        //
+        // The `... on Pet` spread overlaps with both object types — fields selected through the
+        // interface apply regardless of the runtime type, so they stay in the abstract bucket
+        // and correctly add into the total.
+        let schema = r#"
+            type Query { pet: Pet }
+            interface Pet { id: ID, owner: Person }
+            type Person { id: ID }
+            type Cat implements Pet { id: ID, owner: Person, kittens: [Cat] }
+            type Dog implements Pet { id: ID, owner: Person, puppies: [Dog] }
+        "#;
+        let query = r#"
+            {
+                pet {
+                    ... on Pet { owner { id } }
+                    ... on Cat { kittens { id } }
+                    ... on Dog { puppies { id } }
+                }
+            }
+        "#;
+        // pet (interface object) = 1,
+        // abstract bucket: owner = 1,
+        // Cat bucket: kittens = 100 * 1 = 100,
+        // Dog bucket: puppies = 100 * 1 = 100,
+        // total = 1 + 1 + MAX(100, 100) = 102.
+        assert_eq!(basic_estimated_cost(schema, query, "{}"), 102.0);
     }
 
     #[test(tokio::test)]


### PR DESCRIPTION
## Summary

- Resolve `@skip(if:)` / `@include(if:)` directives against runtime variables (and apply them uniformly to fields, fragment spreads, and inline fragments) instead of only checking boolean literals.
- Pick the branch of `PlanNode::Condition` that will actually run by evaluating its condition variable, rather than taking the max cost of both branches.
- Group selections by the narrowest statically-known type condition and take MAX cost across mutually-exclusive concrete type conditions, so spreads like `... on A { ... } ... on B { ... } ... on C { ... }` no longer inflate the estimate.
- Collapse multiple occurrences of the same response key via MAX per key within each bucket, matching GraphQL field-merging semantics.

## Details

### Boolean conditions

`StaticCostCalculator::skipped_by_directives` previously only recognised boolean-literal `@skip` / `@include` arguments, so variable-driven conditions were always treated as present. The new `is_skipped_by_directives` helper in `directives.rs` resolves variables and is called once, uniformly, at the top of `collect_occurrences` for fields, fragment spreads, and inline fragments alike.

`PlanNode::Condition` (emitted by the query planner for `@defer(if: $var)` and friends) previously returned `max(score(if), score(else))`. It now reads the condition variable and scores only the selected branch.

### Type condition bucketing

`score_selection_set` now expands fragment spreads and inline fragments into field occurrences partitioned by the narrowest statically-known type condition at each position:

- Selections under abstract type conditions form a shared **abstract** bucket whose cost is always added.
- Each observed concrete object type condition gets its **own** bucket. Because only one concrete type can apply at runtime, the estimator takes the MAX across concrete buckets instead of summing them.
- A `narrow(schema, current, candidate)` helper threads the narrowing through nested spreads: once inside an object type condition, it stays there, so `... on Cat { ... on Pet { x } }` correctly contributes `x` to the `Cat` bucket.
- Within each bucket, occurrences sharing a response key collapse via MAX per key to honor GraphQL field merging.

Three helper methods (`score_selection`, `score_fragment_spread`, `score_inline_fragment`) collapse into a single `collect_occurrences` walker plus `score_bucket`.

## Test plan

- [x] Added `skip_directive_resolves_variables`, `include_directive_resolves_variables`, `skip_directive_on_inline_fragment_excludes_cost`, `skip_directive_on_fragment_spread_resolves_variables` covering variable-driven `@skip` / `@include` on each selection kind.
- [x] Added `mutually_exclusive_fragments_dedupe_by_response_key` (same response key across `... on Cat` / `... on Dog` → MAX, not SUM).
- [x] Added `mutually_exclusive_fragments_with_distinct_selections_take_max_across_types` exercising the per-object-type bucket split with an overlapping `... on Pet` interface spread.
- [x] All 120 `plugins::demand_control` unit tests pass; fmt + clippy clean.

<!-- start metadata -->

<!-- [FED-1000] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary


[FED-1000]: https://apollographql.atlassian.net/browse/FED-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ