### PR TITLE
[Draft] demand-control: generate cost breakdown enabling end-user diagnosis of cost limit errors

### DIFF
--- a/.changesets/fix_duckki_fed_951.md
+++ b/.changesets/fix_duckki_fed_951.md
@@ -1,0 +1,7 @@
+### Fix demand control `_entities` cardinality estimation ([PR #9192](https://github.com/apollographql/router/pull/9192))
+
+The demand control plugin's static cost estimator now derives the `_entities` instance count from the `FlattenNode` path in the query plan, rather than falling back to the global `list_size` default. For nested-list federated queries (e.g. `companies { employees { salary } }` where both fields are lists), this produces a much more accurate upper-bound estimate by multiplying list sizes along the path. Previously, the estimate used the flat `list_size` default regardless of nesting depth, which could both overcount (e.g. `list_size=100` when `_entities` has one item for a single-object parent) and undercount (e.g. `list_size=100` when nested lists produce 10,000 entities).
+
+The `@listSize(assumedSize: N)` directive on supergraph fields is respected when computing path cardinality.
+
+By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/9192

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_nested_list_query.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_nested_list_query.graphql
@@ -1,0 +1,8 @@
+{
+  companies {
+    name
+    employees {
+      salary
+    }
+  }
+}

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_nested_list_schema.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_nested_list_schema.graphql
@@ -1,0 +1,51 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  COMPANIES @join__graph(name: "companies", url: "http://localhost:4001")
+  EMPLOYEES @join__graph(name: "employees", url: "http://localhost:4002")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: COMPANIES)
+  @join__type(graph: EMPLOYEES)
+{
+  companies: [Company!]! @join__field(graph: COMPANIES)
+}
+
+type Company
+  @join__type(graph: COMPANIES, key: "id")
+{
+  id: ID!
+  name: String!
+  employees: [Employee!]! @join__field(graph: COMPANIES)
+}
+
+type Employee
+  @join__type(graph: COMPANIES, key: "id", resolvable: false)
+  @join__type(graph: EMPLOYEES, key: "id")
+{
+  id: ID!
+  salary: Float @join__field(graph: EMPLOYEES)
+}

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_ships_listsize_schema.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_ships_listsize_schema.graphql
@@ -1,0 +1,47 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@cost", "@listSize"])
+{
+  query: Query
+}
+
+directive @cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+directive @listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean) on FIELD_DEFINITION
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  USERS @join__graph(name: "users", url: "http://localhost:4001")
+  VEHICLES @join__graph(name: "vehicles", url: "http://localhost:4002")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: USERS)
+  @join__type(graph: VEHICLES)
+{
+  ships: [Ship!]! @join__field(graph: VEHICLES) @listSize(assumedSize: 5)
+}
+
+type Ship
+  @join__type(graph: VEHICLES, key: "id")
+  @join__type(graph: USERS, key: "id")
+{
+  id: ID!
+  name: String! @join__field(graph: VEHICLES)
+  registrationFee: Float @join__field(graph: USERS)
+}

--- a/apollo-router/src/plugins/demand_control/cost_calculator/mod.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/mod.rs
@@ -7,13 +7,37 @@ use std::ops::AddAssign;
 
 use crate::plugins::demand_control::DemandControlError;
 
+/// Cost of a single fetch operation in the query plan.
+#[derive(Clone, Debug)]
+pub(crate) struct FetchCostEntry<'a> {
+    pub(crate) subgraph: &'a str,
+    pub(crate) cost: f64,
+}
+
+/// Result of costing a query plan: the raw per-fetch entries.
+/// Aggregations (e.g. per-subgraph totals) are computed on demand.
+pub(crate) struct PlanCostResult<'a> {
+    pub(crate) entries: Vec<FetchCostEntry<'a>>,
+}
+
+impl<'a> PlanCostResult<'a> {
+    pub(crate) fn new(entries: Vec<FetchCostEntry<'a>>) -> Self {
+        Self { entries }
+    }
+
+    /// Aggregate per-fetch costs by subgraph.
+    pub(crate) fn by_subgraph(&self) -> CostBySubgraph {
+        let mut by_subgraph = CostBySubgraph::default();
+        for entry in &self.entries {
+            by_subgraph.add_or_insert(entry.subgraph, entry.cost);
+        }
+        by_subgraph
+    }
+}
+
 #[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct CostBySubgraph(HashMap<String, f64>);
 impl CostBySubgraph {
-    pub(crate) fn new(subgraph: &str, value: f64) -> Self {
-        Self(HashMap::from([(subgraph.to_string(), value)]))
-    }
-
     pub(crate) fn add_or_insert(&mut self, subgraph: &str, value: f64) {
         if let Some(subgraph_cost) = self.0.get_mut(subgraph) {
             *subgraph_cost += value;
@@ -28,30 +52,6 @@ impl CostBySubgraph {
 
     pub(crate) fn total(&self) -> f64 {
         self.0.values().sum()
-    }
-
-    /// Creates a new `CostBySubgraph` where each value in the map is the maximum of its value
-    /// in the two input `CostBySubgraph`s.
-    ///
-    /// ```rust
-    /// let cost1 = CostBySubgraph::new("hello", 1.0);
-    /// let mut cost2 = CostBySubgraph::new("hello", 2.0);
-    /// cost2.add_or_insert("world", 1.0);
-    ///
-    /// let max = CostBySubgraph::maximum(cost1, cost2);
-    /// assert_eq!(max.0.get("hello"), Some(2.0));
-    /// assert_eq!(max.0.get("world"), Some(1.0));
-    /// ```
-    pub(crate) fn maximum(mut cost1: Self, cost2: Self) -> Self {
-        for (subgraph, value) in cost2.0.into_iter() {
-            if let Some(subgraph_cost) = cost1.0.get_mut(&subgraph) {
-                *subgraph_cost = subgraph_cost.max(value);
-            } else {
-                cost1.0.insert(subgraph, value);
-            }
-        }
-
-        cost1
     }
 }
 

--- a/apollo-router/src/plugins/demand_control/cost_calculator/mod.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/mod.rs
@@ -2,8 +2,12 @@ mod directives;
 pub(in crate::plugins::demand_control) mod schema;
 pub(crate) mod static_cost;
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::ops::AddAssign;
+
+use apollo_federation::query_plan::serializable_document::SerializableDocument;
+use serde::ser::SerializeMap;
 
 use crate::plugins::demand_control::DemandControlError;
 
@@ -12,6 +16,76 @@ use crate::plugins::demand_control::DemandControlError;
 pub(crate) struct FetchCostEntry<'a> {
     pub(crate) subgraph: &'a str,
     pub(crate) cost: f64,
+    /// The response path leading to this fetch (empty for root fetches).
+    pub(crate) response_path: Vec<String>,
+    /// The subgraph operation document (for breakdown building).
+    pub(crate) operation: &'a SerializableDocument,
+}
+
+/// A tree node representing per-field cost breakdown.
+///
+/// Each node has an `own_cost` (the cost directly attributable to this field)
+/// and children representing nested fields. The subtotal is own_cost plus the
+/// sum of all children's subtotals.
+#[derive(Clone, Default, Debug)]
+pub(crate) struct CostBreakdownNode {
+    pub(crate) own_cost: f64,
+    pub(crate) children: BTreeMap<String, CostBreakdownNode>,
+}
+
+impl CostBreakdownNode {
+    /// Additively merge another breakdown node into this one.
+    pub(crate) fn merge(&mut self, other: CostBreakdownNode) {
+        self.own_cost += other.own_cost;
+        for (key, child) in other.children {
+            self.children.entry(key).or_default().merge(child);
+        }
+    }
+
+    /// Navigate to the given path and merge the node there.
+    pub(crate) fn merge_at_path(&mut self, path: &[String], other: CostBreakdownNode) {
+        if path.is_empty() {
+            self.merge(other);
+        } else {
+            self.children
+                .entry(path[0].clone())
+                .or_default()
+                .merge_at_path(&path[1..], other);
+        }
+    }
+
+    /// Returns true if this node and all descendants have zero cost.
+    fn is_empty(&self) -> bool {
+        self.own_cost == 0.0 && self.children.values().all(|c| c.is_empty())
+    }
+}
+
+#[cfg(test)]
+impl CostBreakdownNode {
+    /// Total cost of this node: own cost plus all descendants.
+    pub(crate) fn subtotal(&self) -> f64 {
+        self.own_cost + self.children.values().map(|c| c.subtotal()).sum::<f64>()
+    }
+}
+
+impl serde::Serialize for CostBreakdownNode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Count non-empty children + 1 for __cost
+        let non_empty_children: Vec<_> = self
+            .children
+            .iter()
+            .filter(|(_, c)| !c.is_empty())
+            .collect();
+        let mut map = serializer.serialize_map(Some(non_empty_children.len() + 1))?;
+        map.serialize_entry("__cost", &self.own_cost)?;
+        for (key, child) in non_empty_children {
+            map.serialize_entry(key, child)?;
+        }
+        map.end()
+    }
 }
 
 /// Result of costing a query plan: the raw per-fetch entries.

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -15,8 +15,9 @@ use apollo_federation::query_plan::serializable_document::SerializableDocument;
 use apollo_federation::subgraph::spec::ENTITIES_QUERY;
 use serde_json_bytes::Value;
 
-use super::CostBySubgraph;
 use super::DemandControlError;
+use super::FetchCostEntry;
+use super::PlanCostResult;
 use super::directives::IncludeDirective;
 use super::directives::SkipDirective;
 use super::schema::DemandControlledSchema;
@@ -26,9 +27,7 @@ use crate::graphql::Response;
 use crate::graphql::ResponseVisitor;
 use crate::json_ext::Object;
 use crate::plugins::demand_control::cost_calculator::directives::ListSizeDirective;
-use crate::query_planner::DeferredNode;
 use crate::query_planner::PlanNode;
-use crate::query_planner::Primary;
 use crate::query_planner::QueryPlan;
 use crate::spec::TYPENAME;
 
@@ -501,14 +500,18 @@ impl StaticCostCalculator {
         false
     }
 
-    fn score_plan_node(
+    fn collect_plan_costs<'a>(
         &self,
-        plan_node: &PlanNode,
+        plan_node: &'a PlanNode,
         variables: &Object,
-    ) -> Result<CostBySubgraph, DemandControlError> {
+        entries: &mut Vec<FetchCostEntry<'a>>,
+    ) -> Result<(), DemandControlError> {
         match plan_node {
-            PlanNode::Sequence { nodes } => self.summed_score_of_nodes(nodes, variables),
-            PlanNode::Parallel { nodes } => self.summed_score_of_nodes(nodes, variables),
+            PlanNode::Sequence { nodes } | PlanNode::Parallel { nodes } => {
+                for node in nodes {
+                    self.collect_plan_costs(node, variables, entries)?;
+                }
+            }
             PlanNode::Flatten(flatten_node) => {
                 // Check if the inner node is directly an entity fetch (non-empty requires).
                 // If so, supply the cardinality derived from the flatten path so that
@@ -517,46 +520,87 @@ impl StaticCostCalculator {
                     && !fetch_node.requires.is_empty()
                 {
                     let cardinality = self.estimated_path_cardinality(&flatten_node.path);
-                    return self.estimated_cost_of_operation(
+                    let cost = self.compute_fetch_cost(
                         &fetch_node.service_name,
                         &fetch_node.operation,
                         variables,
                         Some(cardinality),
-                    );
+                    )?;
+                    entries.push(FetchCostEntry {
+                        subgraph: &fetch_node.service_name,
+                        cost,
+                    });
+                } else {
+                    self.collect_plan_costs(&flatten_node.node, variables, entries)?;
                 }
-                // Non-entity flatten or nested structure: recurse normally.
-                self.score_plan_node(&flatten_node.node, variables)
             }
             PlanNode::Condition {
-                condition: _,
                 if_clause,
                 else_clause,
-            } => self.max_score_of_nodes(if_clause, else_clause, variables),
-            PlanNode::Defer { primary, deferred } => {
-                self.summed_score_of_deferred_nodes(primary, deferred, variables)
+                ..
+            } => {
+                // Collect both branches, keep the one with higher total cost.
+                let mut if_entries = Vec::new();
+                if let Some(node) = if_clause {
+                    self.collect_plan_costs(node, variables, &mut if_entries)?;
+                }
+                let mut else_entries = Vec::new();
+                if let Some(node) = else_clause {
+                    self.collect_plan_costs(node, variables, &mut else_entries)?;
+                }
+                let if_total: f64 = if_entries.iter().map(|e| e.cost).sum();
+                let else_total: f64 = else_entries.iter().map(|e| e.cost).sum();
+                if if_total >= else_total {
+                    entries.extend(if_entries);
+                } else {
+                    entries.extend(else_entries);
+                }
             }
-            PlanNode::Fetch(fetch_node) => self.estimated_cost_of_operation(
-                &fetch_node.service_name,
-                &fetch_node.operation,
-                variables,
-                None,
-            ),
-            PlanNode::Subscription { primary, rest: _ } => self.estimated_cost_of_operation(
-                &primary.service_name,
-                &primary.operation,
-                variables,
-                None,
-            ),
+            PlanNode::Defer { primary, deferred } => {
+                if let Some(node) = &primary.node {
+                    self.collect_plan_costs(node, variables, entries)?;
+                }
+                for d in deferred {
+                    if let Some(node) = &d.node {
+                        self.collect_plan_costs(node, variables, entries)?;
+                    }
+                }
+            }
+            PlanNode::Fetch(fetch_node) => {
+                let cost = self.compute_fetch_cost(
+                    &fetch_node.service_name,
+                    &fetch_node.operation,
+                    variables,
+                    None,
+                )?;
+                entries.push(FetchCostEntry {
+                    subgraph: &fetch_node.service_name,
+                    cost,
+                });
+            }
+            PlanNode::Subscription { primary, rest: _ } => {
+                let cost = self.compute_fetch_cost(
+                    &primary.service_name,
+                    &primary.operation,
+                    variables,
+                    None,
+                )?;
+                entries.push(FetchCostEntry {
+                    subgraph: &primary.service_name,
+                    cost,
+                });
+            }
         }
+        Ok(())
     }
 
-    fn estimated_cost_of_operation(
+    fn compute_fetch_cost(
         &self,
         subgraph: &str,
         operation: &SerializableDocument,
         variables: &Object,
         entity_count_hint: Option<i32>,
-    ) -> Result<CostBySubgraph, DemandControlError> {
+    ) -> Result<f64, DemandControlError> {
         tracing::debug!("On subgraph {}, scoring operation: {}", subgraph, operation);
 
         let schema = self.subgraph_schemas.get(subgraph).ok_or_else(|| {
@@ -568,63 +612,14 @@ impl StaticCostCalculator {
         let operation = operation
             .as_parsed()
             .map_err(DemandControlError::SubgraphOperationNotInitialized)?;
-        let cost = self.estimated(
+        self.estimated(
             operation,
             schema,
             variables,
             false,
             subgraph,
             entity_count_hint,
-        )?;
-        Ok(CostBySubgraph::new(subgraph, cost))
-    }
-
-    fn max_score_of_nodes(
-        &self,
-        left: &Option<Box<PlanNode>>,
-        right: &Option<Box<PlanNode>>,
-        variables: &Object,
-    ) -> Result<CostBySubgraph, DemandControlError> {
-        match (left, right) {
-            (None, None) => Ok(CostBySubgraph::default()),
-            (None, Some(right)) => self.score_plan_node(right, variables),
-            (Some(left), None) => self.score_plan_node(left, variables),
-            (Some(left), Some(right)) => {
-                let left_score = self.score_plan_node(left, variables)?;
-                let right_score = self.score_plan_node(right, variables)?;
-                Ok(CostBySubgraph::maximum(left_score, right_score))
-            }
-        }
-    }
-
-    fn summed_score_of_deferred_nodes(
-        &self,
-        primary: &Primary,
-        deferred: &Vec<DeferredNode>,
-        variables: &Object,
-    ) -> Result<CostBySubgraph, DemandControlError> {
-        let mut score = CostBySubgraph::default();
-        if let Some(node) = &primary.node {
-            score += self.score_plan_node(node, variables)?;
-        }
-        for d in deferred {
-            if let Some(node) = &d.node {
-                score += self.score_plan_node(node, variables)?;
-            }
-        }
-        Ok(score)
-    }
-
-    fn summed_score_of_nodes(
-        &self,
-        nodes: &Vec<PlanNode>,
-        variables: &Object,
-    ) -> Result<CostBySubgraph, DemandControlError> {
-        let mut sum = CostBySubgraph::default();
-        for node in nodes {
-            sum += self.score_plan_node(node, variables)?;
-        }
-        Ok(sum)
+        )
     }
 
     /// Determine cost for a single-subgraph operation.
@@ -655,12 +650,14 @@ impl StaticCostCalculator {
     }
 
     /// Determine cost for an operation which may span multiple subgraphs.
-    pub(crate) fn planned(
+    pub(crate) fn planned<'a>(
         &self,
-        query_plan: &QueryPlan,
+        query_plan: &'a QueryPlan,
         variables: &Object,
-    ) -> Result<CostBySubgraph, DemandControlError> {
-        self.score_plan_node(&query_plan.root, variables)
+    ) -> Result<PlanCostResult<'a>, DemandControlError> {
+        let mut entries = Vec::new();
+        self.collect_plan_costs(&query_plan.root, variables, &mut entries)?;
+        Ok(PlanCostResult::new(entries))
     }
 
     /// Estimate the total number of entities in an entity fetch by walking the
@@ -880,7 +877,10 @@ mod tests {
             variables: &Object,
         ) -> Result<f64, DemandControlError> {
             let js_planner_node: PlanNode = query_plan.node.as_ref().unwrap().into();
-            Ok(self.score_plan_node(&js_planner_node, variables)?.total())
+            let mut entries = Vec::new();
+            self.collect_plan_costs(&js_planner_node, variables, &mut entries)?;
+            let result = PlanCostResult::new(entries);
+            Ok(result.by_subgraph().total())
         }
     }
 
@@ -1016,7 +1016,11 @@ mod tests {
             100,
         );
 
-        calculator.planned(&query_plan, &variables).unwrap().total()
+        calculator
+            .planned(&query_plan, &variables)
+            .unwrap()
+            .by_subgraph()
+            .total()
     }
 
     fn planned_cost_rust(schema_str: &str, query_str: &str, variables_str: &str) -> f64 {

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -15,6 +15,7 @@ use apollo_federation::query_plan::serializable_document::SerializableDocument;
 use apollo_federation::subgraph::spec::ENTITIES_QUERY;
 use serde_json_bytes::Value;
 
+use super::CostBreakdownNode;
 use super::DemandControlError;
 use super::FetchCostEntry;
 use super::PlanCostResult;
@@ -504,15 +505,22 @@ impl StaticCostCalculator {
         &self,
         plan_node: &'a PlanNode,
         variables: &Object,
+        response_path: Vec<String>,
         entries: &mut Vec<FetchCostEntry<'a>>,
     ) -> Result<(), DemandControlError> {
         match plan_node {
             PlanNode::Sequence { nodes } | PlanNode::Parallel { nodes } => {
                 for node in nodes {
-                    self.collect_plan_costs(node, variables, entries)?;
+                    self.collect_plan_costs(node, variables, response_path.clone(), entries)?;
                 }
             }
             PlanNode::Flatten(flatten_node) => {
+                let mut response_path = Vec::new();
+                for elem in &flatten_node.path.0 {
+                    if let crate::json_ext::PathElement::Key(name, _) = elem {
+                        response_path.push(name.to_string());
+                    }
+                }
                 // Check if the inner node is directly an entity fetch (non-empty requires).
                 // If so, supply the cardinality derived from the flatten path so that
                 // _entities is scored with the correct instance count.
@@ -529,9 +537,11 @@ impl StaticCostCalculator {
                     entries.push(FetchCostEntry {
                         subgraph: &fetch_node.service_name,
                         cost,
+                        response_path,
+                        operation: &fetch_node.operation,
                     });
                 } else {
-                    self.collect_plan_costs(&flatten_node.node, variables, entries)?;
+                    self.collect_plan_costs(&flatten_node.node, variables, response_path, entries)?;
                 }
             }
             PlanNode::Condition {
@@ -542,11 +552,16 @@ impl StaticCostCalculator {
                 // Collect both branches, keep the one with higher total cost.
                 let mut if_entries = Vec::new();
                 if let Some(node) = if_clause {
-                    self.collect_plan_costs(node, variables, &mut if_entries)?;
+                    self.collect_plan_costs(
+                        node,
+                        variables,
+                        response_path.clone(),
+                        &mut if_entries,
+                    )?;
                 }
                 let mut else_entries = Vec::new();
                 if let Some(node) = else_clause {
-                    self.collect_plan_costs(node, variables, &mut else_entries)?;
+                    self.collect_plan_costs(node, variables, response_path, &mut else_entries)?;
                 }
                 let if_total: f64 = if_entries.iter().map(|e| e.cost).sum();
                 let else_total: f64 = else_entries.iter().map(|e| e.cost).sum();
@@ -558,11 +573,11 @@ impl StaticCostCalculator {
             }
             PlanNode::Defer { primary, deferred } => {
                 if let Some(node) = &primary.node {
-                    self.collect_plan_costs(node, variables, entries)?;
+                    self.collect_plan_costs(node, variables, response_path.clone(), entries)?;
                 }
                 for d in deferred {
                     if let Some(node) = &d.node {
-                        self.collect_plan_costs(node, variables, entries)?;
+                        self.collect_plan_costs(node, variables, response_path.clone(), entries)?;
                     }
                 }
             }
@@ -576,6 +591,8 @@ impl StaticCostCalculator {
                 entries.push(FetchCostEntry {
                     subgraph: &fetch_node.service_name,
                     cost,
+                    response_path,
+                    operation: &fetch_node.operation,
                 });
             }
             PlanNode::Subscription { primary, rest: _ } => {
@@ -588,6 +605,8 @@ impl StaticCostCalculator {
                 entries.push(FetchCostEntry {
                     subgraph: &primary.service_name,
                     cost,
+                    response_path,
+                    operation: &primary.operation,
                 });
             }
         }
@@ -656,7 +675,7 @@ impl StaticCostCalculator {
         variables: &Object,
     ) -> Result<PlanCostResult<'a>, DemandControlError> {
         let mut entries = Vec::new();
-        self.collect_plan_costs(&query_plan.root, variables, &mut entries)?;
+        self.collect_plan_costs(&query_plan.root, variables, vec![], &mut entries)?;
         Ok(PlanCostResult::new(entries))
     }
 
@@ -729,6 +748,374 @@ impl StaticCostCalculator {
         }
 
         cardinality
+    }
+
+    /// Build a cost breakdown tree from collected fetch entries.
+    pub(crate) fn build_breakdown(
+        &self,
+        entries: &[FetchCostEntry],
+        variables: &Object,
+    ) -> Result<CostBreakdownNode, DemandControlError> {
+        let mut root = CostBreakdownNode::default();
+        for entry in entries {
+            let fetch_breakdown = self.build_fetch_breakdown(entry, variables)?;
+            root.merge_at_path(&entry.response_path, fetch_breakdown);
+        }
+        Ok(root)
+    }
+
+    /// Build a breakdown tree for a single fetch operation.
+    fn build_fetch_breakdown(
+        &self,
+        entry: &FetchCostEntry,
+        variables: &Object,
+    ) -> Result<CostBreakdownNode, DemandControlError> {
+        let schema = self.subgraph_schemas.get(entry.subgraph).ok_or_else(|| {
+            DemandControlError::QueryParseFailure(format!(
+                "Query planner did not provide a schema for service {}",
+                entry.subgraph
+            ))
+        })?;
+        let doc = entry
+            .operation
+            .as_parsed()
+            .map_err(DemandControlError::SubgraphOperationNotInitialized)?;
+
+        let ctx = ScoringContext {
+            schema,
+            query: doc,
+            variables,
+            should_estimate_requires: false,
+            entity_count_hint: None,
+        };
+
+        let mut field_costs: Vec<(Vec<String>, f64)> = Vec::new();
+
+        // Walk each operation
+        if let Some(op) = &doc.operations.anonymous {
+            let mutation_cost = if op.is_mutation() { 10.0 } else { 0.0 };
+            if mutation_cost > 0.0 {
+                field_costs.push((vec![], mutation_cost));
+            }
+            let Some(root_type_name) = ctx.schema.root_operation(op.operation_type) else {
+                return Err(DemandControlError::QueryParseFailure(format!(
+                    "Cannot cost {} operation because the schema does not support this root type",
+                    op.operation_type
+                )));
+            };
+            self.collect_breakdown_selection_set(
+                &ctx,
+                &op.selection_set,
+                root_type_name,
+                &[],
+                &[],
+                entry.subgraph,
+                1.0,
+                &mut vec![],
+                &mut field_costs,
+            )?;
+        }
+        for (_name, op) in doc.operations.named.iter() {
+            let mutation_cost = if op.is_mutation() { 10.0 } else { 0.0 };
+            if mutation_cost > 0.0 {
+                field_costs.push((vec![], mutation_cost));
+            }
+            let Some(root_type_name) = ctx.schema.root_operation(op.operation_type) else {
+                return Err(DemandControlError::QueryParseFailure(format!(
+                    "Cannot cost {} operation because the schema does not support this root type",
+                    op.operation_type
+                )));
+            };
+            self.collect_breakdown_selection_set(
+                &ctx,
+                &op.selection_set,
+                root_type_name,
+                &[],
+                &[],
+                entry.subgraph,
+                1.0,
+                &mut vec![],
+                &mut field_costs,
+            )?;
+        }
+
+        // Build tree from collected (path, cost) entries
+        let mut root = CostBreakdownNode::default();
+        for (path, cost) in field_costs {
+            if path.is_empty() {
+                root.own_cost += cost;
+            } else {
+                let path_strs: Vec<String> = path;
+                root.merge_at_path(
+                    &path_strs,
+                    CostBreakdownNode {
+                        own_cost: cost,
+                        children: Default::default(),
+                    },
+                );
+            }
+        }
+        Ok(root)
+    }
+
+    /// Collect per-field costs for breakdown building, mirroring score_selection_set.
+    #[allow(clippy::too_many_arguments)]
+    fn collect_breakdown_selection_set(
+        &self,
+        ctx: &ScoringContext,
+        selection_set: &SelectionSet,
+        parent_type_name: &NamedType,
+        list_size_directives: &[ListSizeDirective],
+        inherited_list_sizes: &[ListSizeDirective],
+        subgraph: &str,
+        cumulative_multiplier: f64,
+        current_path: &mut Vec<String>,
+        field_costs: &mut Vec<(Vec<String>, f64)>,
+    ) -> Result<(), DemandControlError> {
+        for selection in selection_set.selections.iter() {
+            self.collect_breakdown_selection(
+                ctx,
+                selection,
+                parent_type_name,
+                list_size_directives,
+                inherited_list_sizes,
+                subgraph,
+                cumulative_multiplier,
+                current_path,
+                field_costs,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Collect per-field costs for a single selection.
+    #[allow(clippy::too_many_arguments)]
+    fn collect_breakdown_selection(
+        &self,
+        ctx: &ScoringContext,
+        selection: &Selection,
+        parent_type: &NamedType,
+        list_size_directives: &[ListSizeDirective],
+        inherited_list_sizes: &[ListSizeDirective],
+        subgraph: &str,
+        cumulative_multiplier: f64,
+        current_path: &mut Vec<String>,
+        field_costs: &mut Vec<(Vec<String>, f64)>,
+    ) -> Result<(), DemandControlError> {
+        match selection {
+            Selection::Field(f) => {
+                let size_from_parent = list_size_directives
+                    .iter()
+                    .filter_map(|dir| dir.size_of(f))
+                    .max();
+                let size_from_inherited = inherited_list_sizes
+                    .iter()
+                    .filter_map(|dir| dir.size_of(f))
+                    .max();
+                let list_size_from_upstream = size_from_parent.or(size_from_inherited);
+
+                let descended: Vec<ListSizeDirective> = list_size_directives
+                    .iter()
+                    .chain(inherited_list_sizes.iter())
+                    .filter_map(|dir| dir.descend(f.name.as_str()))
+                    .collect();
+
+                self.collect_breakdown_field(
+                    ctx,
+                    f,
+                    parent_type,
+                    list_size_from_upstream,
+                    &descended,
+                    subgraph,
+                    cumulative_multiplier,
+                    current_path,
+                    field_costs,
+                )
+            }
+            Selection::FragmentSpread(s) => {
+                let fragment = s.fragment_def(ctx.query).ok_or_else(|| {
+                    DemandControlError::QueryParseFailure(format!(
+                        "Parsed operation did not have a definition for fragment {}",
+                        s.fragment_name
+                    ))
+                })?;
+                self.collect_breakdown_selection_set(
+                    ctx,
+                    &fragment.selection_set,
+                    fragment.type_condition(),
+                    list_size_directives,
+                    inherited_list_sizes,
+                    subgraph,
+                    cumulative_multiplier,
+                    current_path,
+                    field_costs,
+                )
+            }
+            Selection::InlineFragment(i) => self.collect_breakdown_selection_set(
+                ctx,
+                &i.selection_set,
+                i.type_condition.as_ref().unwrap_or(parent_type),
+                list_size_directives,
+                inherited_list_sizes,
+                subgraph,
+                cumulative_multiplier,
+                current_path,
+                field_costs,
+            ),
+        }
+    }
+
+    /// Collect per-field cost for a single field, mirroring score_field.
+    #[allow(clippy::too_many_arguments)]
+    fn collect_breakdown_field(
+        &self,
+        ctx: &ScoringContext,
+        field: &Field,
+        parent_type: &NamedType,
+        list_size_from_upstream: Option<i32>,
+        inherited_list_sizes: &[ListSizeDirective],
+        subgraph: &str,
+        cumulative_multiplier: f64,
+        current_path: &mut Vec<String>,
+        field_costs: &mut Vec<(Vec<String>, f64)>,
+    ) -> Result<(), DemandControlError> {
+        if field.name == TYPENAME {
+            return Ok(());
+        }
+        if StaticCostCalculator::skipped_by_directives(field) {
+            return Ok(());
+        }
+
+        let definition = ctx
+            .schema
+            .output_field_definition(parent_type, &field.name)
+            .ok_or_else(|| {
+                DemandControlError::QueryParseFailure(format!(
+                    "Field {} was found in query, but its type is missing from the schema.",
+                    field.name
+                ))
+            })?;
+
+        let own_list_size_directives: Vec<ListSizeDirective> = definition
+            .list_size_directive_entries()
+            .iter()
+            .map(|entry| {
+                ListSizeDirective::new(
+                    &entry.directive,
+                    field,
+                    ctx.variables,
+                    entry.parsed_sized_fields.clone(),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let effective_expected_size = own_list_size_directives
+            .iter()
+            .chain(inherited_list_sizes)
+            .filter_map(|dir| dir.expected_size)
+            .max();
+
+        let instance_count = if !field.ty().is_list() {
+            1
+        } else if let Some(value) = list_size_from_upstream {
+            value
+        } else if let Some(expected_size) = effective_expected_size {
+            expected_size
+        } else if let Some(subgraph_list_size) = self.subgraph_list_size(subgraph) {
+            subgraph_list_size as i32
+        } else {
+            self.list_size as i32
+        };
+
+        // Compute the field's own weight (not including children)
+        let own_weight = if let Some(cost_directive) = definition.cost_directive() {
+            cost_directive.weight()
+        } else if definition.ty().is_interface()
+            || definition.ty().is_object()
+            || definition.ty().is_union()
+        {
+            1.0
+        } else {
+            0.0
+        };
+
+        let mut arguments_cost = 0.0;
+        for argument in &field.arguments {
+            let argument_definition =
+                definition.argument_by_name(&argument.name).ok_or_else(|| {
+                    DemandControlError::QueryParseFailure(format!(
+                        "Argument {} of field {} is missing a definition in the schema",
+                        argument.name, field.name
+                    ))
+                })?;
+            arguments_cost += score_argument(
+                &argument.value,
+                argument_definition,
+                ctx.schema,
+                ctx.variables,
+            )?;
+        }
+
+        let mut requirements_cost = 0.0;
+        if ctx.should_estimate_requires {
+            let requirements = definition.requires_directive().map(|d| &d.fields);
+            if let Some(selection_set) = requirements {
+                requirements_cost = self.score_selection_set(
+                    ctx,
+                    selection_set,
+                    parent_type,
+                    &own_list_size_directives,
+                    &[],
+                    subgraph,
+                )?;
+            }
+        }
+
+        // The effective own cost for this field at this level
+        let effective_own = cumulative_multiplier
+            * ((instance_count as f64) * own_weight + arguments_cost + requirements_cost);
+
+        // Skip _entities in the breakdown path — attribute its cost to the fetch root
+        let is_entities = parent_type == "Query" && field.name == "_entities";
+
+        if is_entities {
+            // Don't push to path; attribute own cost to current path level
+            if effective_own > 0.0 {
+                field_costs.push((current_path.clone(), effective_own));
+            }
+            // Recurse into children without changing path
+            self.collect_breakdown_selection_set(
+                ctx,
+                &field.selection_set,
+                field.ty().inner_named_type(),
+                &own_list_size_directives,
+                inherited_list_sizes,
+                subgraph,
+                cumulative_multiplier * (instance_count as f64),
+                current_path,
+                field_costs,
+            )?;
+        } else {
+            current_path.push(field.alias.as_ref().unwrap_or(&field.name).to_string());
+            if effective_own > 0.0 {
+                field_costs.push((current_path.clone(), effective_own));
+            }
+            // Recurse into children
+            self.collect_breakdown_selection_set(
+                ctx,
+                &field.selection_set,
+                field.ty().inner_named_type(),
+                &own_list_size_directives,
+                inherited_list_sizes,
+                subgraph,
+                cumulative_multiplier * (instance_count as f64),
+                current_path,
+                field_costs,
+            )?;
+            current_path.pop();
+        }
+
+        Ok(())
     }
 
     pub(crate) fn actual(
@@ -878,7 +1265,7 @@ mod tests {
         ) -> Result<f64, DemandControlError> {
             let js_planner_node: PlanNode = query_plan.node.as_ref().unwrap().into();
             let mut entries = Vec::new();
-            self.collect_plan_costs(&js_planner_node, variables, &mut entries)?;
+            self.collect_plan_costs(&js_planner_node, variables, vec![], &mut entries)?;
             let result = PlanCostResult::new(entries);
             Ok(result.by_subgraph().total())
         }
@@ -1816,5 +2203,179 @@ mod tests {
         let calc = make_calculator_for_path_test(schema_str, 10);
         let path = crate::json_ext::Path::from_slice(&["user", "orders", "@"]);
         assert_eq!(calc.estimated_path_cardinality(&path), 10);
+    }
+
+    /// Tests for the cost breakdown feature.
+    mod breakdown_tests {
+        use std::sync::Arc;
+
+        use ahash::HashMap;
+        use ahash::HashMapExt;
+        use apollo_federation::query_plan::query_planner::QueryPlanner;
+        use serde_json_bytes::Value;
+
+        use super::parse_schema_and_operation;
+        use crate::Configuration;
+        use crate::plugins::demand_control::cost_calculator::PlanCostResult;
+        use crate::plugins::demand_control::cost_calculator::schema::DemandControlledSchema;
+        use crate::plugins::demand_control::cost_calculator::static_cost::StaticCostCalculator;
+        use crate::query_planner::PlanNode;
+
+        fn build_breakdown_rust(
+            schema_str: &str,
+            query_str: &str,
+            variables_str: &str,
+        ) -> (
+            f64,
+            crate::plugins::demand_control::cost_calculator::CostBreakdownNode,
+        ) {
+            let config: Arc<Configuration> = Arc::new(Default::default());
+            let (schema, query) = parse_schema_and_operation(schema_str, query_str, &config);
+            let variables = serde_json::from_str::<Value>(variables_str)
+                .unwrap()
+                .as_object()
+                .cloned()
+                .unwrap_or_default();
+
+            let planner =
+                QueryPlanner::new(schema.federation_supergraph(), Default::default()).unwrap();
+            let query_plan = planner
+                .build_query_plan(&query.executable, None, Default::default())
+                .unwrap();
+
+            let schema =
+                DemandControlledSchema::new(Arc::new(schema.supergraph_schema().clone())).unwrap();
+            let mut demand_controlled_subgraph_schemas = HashMap::new();
+            for (subgraph_name, subgraph_schema) in planner.subgraph_schemas().iter() {
+                let demand_controlled_subgraph_schema =
+                    DemandControlledSchema::new(Arc::new(subgraph_schema.schema().clone()))
+                        .unwrap();
+                demand_controlled_subgraph_schemas
+                    .insert(subgraph_name.to_string(), demand_controlled_subgraph_schema);
+            }
+
+            let calculator = StaticCostCalculator::new(
+                Arc::new(schema),
+                Arc::new(demand_controlled_subgraph_schemas),
+                Default::default(),
+                100,
+            );
+
+            let js_planner_node: PlanNode = query_plan.node.as_ref().unwrap().into();
+            let mut entries = Vec::new();
+            calculator
+                .collect_plan_costs(&js_planner_node, &variables, vec![], &mut entries)
+                .unwrap();
+            let plan_result = PlanCostResult::new(entries);
+            let cost = plan_result.by_subgraph().total();
+            let breakdown = calculator
+                .build_breakdown(&plan_result.entries, &variables)
+                .unwrap();
+            (cost, breakdown)
+        }
+
+        #[test]
+        fn breakdown_subtotal_matches_estimated_cost() {
+            let schema = include_str!("./fixtures/federated_ships_schema.graphql");
+            let query = include_str!("./fixtures/federated_ships_named_query.graphql");
+            let (cost, breakdown) = build_breakdown_rust(schema, query, "{}");
+
+            assert_eq!(
+                breakdown.subtotal(),
+                cost,
+                "Breakdown subtotal should match estimated cost"
+            );
+        }
+
+        #[test]
+        fn breakdown_structure_for_federated_query_with_requires() {
+            let schema = include_str!("./fixtures/federated_ships_schema.graphql");
+            let query = include_str!("./fixtures/federated_ships_required_query.graphql");
+            let (cost, breakdown) = build_breakdown_rust(schema, query, "{}");
+
+            assert_eq!(
+                breakdown.subtotal(),
+                cost,
+                "Breakdown subtotal should match estimated cost"
+            );
+            // Verify the breakdown serializes to valid JSON
+            let json = serde_json::to_value(&breakdown).unwrap();
+            assert!(json.get("__cost").is_some(), "Root must have __cost");
+        }
+
+        #[test]
+        fn breakdown_structure_for_federated_query_with_fragments() {
+            let schema = include_str!("./fixtures/federated_ships_schema.graphql");
+            let query = include_str!("./fixtures/federated_ships_fragment_query.graphql");
+            let (cost, breakdown) = build_breakdown_rust(schema, query, "{}");
+
+            assert_eq!(
+                breakdown.subtotal(),
+                cost,
+                "Breakdown subtotal should match estimated cost"
+            );
+        }
+
+        /// Recursively sum every `__cost` entry in a serialized breakdown.
+        /// Under the "own cost only" semantics, the sum should equal the total cost.
+        fn sum_json_costs(value: &serde_json::Value) -> f64 {
+            let mut total = 0.0;
+            if let Some(obj) = value.as_object() {
+                for (key, child) in obj {
+                    if key == "__cost" {
+                        total += child.as_f64().unwrap_or(0.0);
+                    } else {
+                        total += sum_json_costs(child);
+                    }
+                }
+            }
+            total
+        }
+
+        #[test]
+        fn breakdown_structure_for_custom_cost_query() {
+            let schema = include_str!("./fixtures/custom_cost_schema.graphql");
+            let query = include_str!("./fixtures/custom_cost_query.graphql");
+            let (cost, breakdown) = build_breakdown_rust(schema, query, "{}");
+
+            assert_eq!(
+                breakdown.subtotal(),
+                cost,
+                "Breakdown subtotal should match estimated cost"
+            );
+            let json = serde_json::to_value(&breakdown).unwrap();
+            assert_eq!(
+                sum_json_costs(&json),
+                cost,
+                "Sum of all __cost entries in JSON should equal total cost",
+            );
+        }
+
+        #[test]
+        fn breakdown_serialization_format() {
+            let schema = include_str!("./fixtures/basic_supergraph_schema.graphql");
+            let query = include_str!("./fixtures/basic_fragments_query.graphql");
+            let (cost, breakdown) = build_breakdown_rust(schema, query, "{}");
+
+            assert_eq!(breakdown.subtotal(), cost);
+
+            let json = serde_json::to_value(&breakdown).unwrap();
+            // Sum of all per-node __cost entries should equal total cost
+            // (each __cost is own cost only; consumer sums to get subtree totals).
+            assert_eq!(sum_json_costs(&json), cost);
+        }
+
+        #[test]
+        fn breakdown_with_defer() {
+            let schema = include_str!("./fixtures/federated_ships_schema.graphql");
+            let query = include_str!("./fixtures/federated_ships_deferred_query.graphql");
+            let (cost, breakdown) = build_breakdown_rust(schema, query, "{}");
+
+            assert_eq!(
+                breakdown.subtotal(),
+                cost,
+                "Breakdown subtotal should match estimated cost even with defer"
+            );
+        }
     }
 }

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -43,6 +43,11 @@ struct ScoringContext<'a> {
     query: &'a ExecutableDocument,
     variables: &'a Object,
     should_estimate_requires: bool,
+    /// When scoring a subgraph operation triggered by an entity fetch (i.e. FetchNode.requires
+    /// is non-empty), this holds the estimated number of representations that will be sent.
+    /// Used as the `instance_count` for the `_entities` root field instead of the configured
+    /// default `list_size`.
+    entity_count_hint: Option<i32>,
 }
 
 fn score_argument(
@@ -232,8 +237,22 @@ impl StaticCostCalculator {
         let instance_count = if !field.ty().is_list() {
             1
         } else if let Some(value) = list_size_from_upstream {
-            // This is a sized field whose length is defined by the `@listSize` directive on the parent field
+            // Sized field: length defined by @listSize on the parent field
             value
+        } else if field.name == "_entities" {
+            if let Some(hint) = ctx.entity_count_hint {
+                // Use cardinality derived from the FlattenNode path in the query plan.
+                // This is more accurate than the static list_size default for entity fetches.
+                tracing::debug!(
+                    "_entities instance_count overridden by FlattenNode path cardinality: {}",
+                    hint
+                );
+                hint
+            } else if let Some(subgraph_list_size) = self.subgraph_list_size(subgraph) {
+                subgraph_list_size as i32
+            } else {
+                self.list_size as i32
+            }
         } else if let Some(expected_size) = effective_expected_size {
             expected_size
         } else if let Some(subgraph_list_size) = self.subgraph_list_size(subgraph) {
@@ -489,7 +508,24 @@ impl StaticCostCalculator {
         match plan_node {
             PlanNode::Sequence { nodes } => self.summed_score_of_nodes(nodes, variables),
             PlanNode::Parallel { nodes } => self.summed_score_of_nodes(nodes, variables),
-            PlanNode::Flatten(flatten_node) => self.score_plan_node(&flatten_node.node, variables),
+            PlanNode::Flatten(flatten_node) => {
+                // Check if the inner node is directly an entity fetch (non-empty requires).
+                // If so, supply the cardinality derived from the flatten path so that
+                // _entities is scored with the correct instance count.
+                if let PlanNode::Fetch(fetch_node) = flatten_node.node.as_ref() {
+                    if !fetch_node.requires.is_empty() {
+                        let cardinality = self.estimated_path_cardinality(&flatten_node.path);
+                        return self.estimated_cost_of_operation(
+                            &fetch_node.service_name,
+                            &fetch_node.operation,
+                            variables,
+                            Some(cardinality),
+                        );
+                    }
+                }
+                // Non-entity flatten or nested structure: recurse normally.
+                self.score_plan_node(&flatten_node.node, variables)
+            }
             PlanNode::Condition {
                 condition: _,
                 if_clause,
@@ -502,11 +538,13 @@ impl StaticCostCalculator {
                 &fetch_node.service_name,
                 &fetch_node.operation,
                 variables,
+                None,
             ),
             PlanNode::Subscription { primary, rest: _ } => self.estimated_cost_of_operation(
                 &primary.service_name,
                 &primary.operation,
                 variables,
+                None,
             ),
         }
     }
@@ -516,6 +554,7 @@ impl StaticCostCalculator {
         subgraph: &str,
         operation: &SerializableDocument,
         variables: &Object,
+        entity_count_hint: Option<i32>,
     ) -> Result<CostBySubgraph, DemandControlError> {
         tracing::debug!("On subgraph {}, scoring operation: {}", subgraph, operation);
 
@@ -528,7 +567,8 @@ impl StaticCostCalculator {
         let operation = operation
             .as_parsed()
             .map_err(DemandControlError::SubgraphOperationNotInitialized)?;
-        let cost = self.estimated(operation, schema, variables, false, subgraph)?;
+        let cost =
+            self.estimated(operation, schema, variables, false, subgraph, entity_count_hint)?;
         Ok(CostBySubgraph::new(subgraph, cost))
     }
 
@@ -588,6 +628,7 @@ impl StaticCostCalculator {
         variables: &Object,
         should_estimate_requires: bool,
         subgraph: &str,
+        entity_count_hint: Option<i32>,
     ) -> Result<f64, DemandControlError> {
         let mut cost = 0.0;
         let ctx = ScoringContext {
@@ -595,6 +636,7 @@ impl StaticCostCalculator {
             query,
             variables,
             should_estimate_requires,
+            entity_count_hint,
         };
         if let Some(op) = &query.operations.anonymous {
             cost += self.score_operation(op, &ctx, subgraph)?;
@@ -868,6 +910,7 @@ mod tests {
                 &variables,
                 true,
                 "",
+                None,
             )
             .unwrap()
     }
@@ -899,7 +942,7 @@ mod tests {
         );
 
         calculator
-            .estimated(&query, &calculator.supergraph_schema, &variables, true, "")
+            .estimated(&query, &calculator.supergraph_schema, &variables, true, "", None)
             .unwrap()
     }
 
@@ -1298,6 +1341,7 @@ mod tests {
                 &Default::default(),
                 true,
                 "",
+                None,
             )
             .unwrap();
 
@@ -1310,6 +1354,7 @@ mod tests {
                 &Default::default(),
                 true,
                 "",
+                None,
             )
             .unwrap();
 

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -12,6 +12,7 @@ use apollo_compiler::executable::Selection;
 use apollo_compiler::executable::SelectionSet;
 use apollo_compiler::schema::ExtendedType;
 use apollo_federation::query_plan::serializable_document::SerializableDocument;
+use apollo_federation::subgraph::spec::ENTITIES_QUERY;
 use serde_json_bytes::Value;
 
 use super::CostBySubgraph;
@@ -239,7 +240,7 @@ impl StaticCostCalculator {
         } else if let Some(value) = list_size_from_upstream {
             // Sized field: length defined by @listSize on the parent field
             value
-        } else if field.name == "_entities" {
+        } else if field.name == ENTITIES_QUERY {
             if let Some(hint) = ctx.entity_count_hint {
                 // Use cardinality derived from the FlattenNode path in the query plan.
                 // This is more accurate than the static list_size default for entity fetches.
@@ -701,7 +702,8 @@ impl StaticCostCalculator {
             };
 
             let Some(field_compiler_def) = field_compiler_def else {
-                // Unknown field — stop traversal, return what we have so far.
+                // Unknown field — ensure the cardinality is at least list_size, then stop.
+                cardinality = cardinality.max(self.list_size as i32);
                 break;
             };
 
@@ -768,7 +770,7 @@ impl<'schema> ResponseCostCalculator<'schema> {
 
         // We need to have a field definition for later processing, unless the query is an
         // `_entities` query. If the field should be there and isn't, return now.
-        let is_entities_query = parent_ty == "Query" && field.name == "_entities";
+        let is_entities_query = parent_ty == "Query" && field.name == ENTITIES_QUERY;
         if definition.is_none() && !is_entities_query {
             tracing::debug!(
                 "Failed to get schema definition for field {}.{}. The resulting response cost will be a partial result.",

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -614,6 +614,72 @@ impl StaticCostCalculator {
         self.score_plan_node(&query_plan.root, variables)
     }
 
+    /// Estimate the total number of entities in an entity fetch by walking the
+    /// FlattenNode's path through the supergraph schema.
+    ///
+    /// Each `Key` path element that resolves to a list field multiplies the
+    /// running cardinality by that field's estimated list size:
+    ///   - `@listSize(assumedSize: N)` if present on the supergraph field
+    ///   - otherwise the global `list_size` default
+    ///
+    /// Returns 1 for paths that contain no list fields (i.e. scalars / single objects).
+    fn estimated_path_cardinality(&self, path: &crate::json_ext::Path) -> i32 {
+        use crate::json_ext::PathElement;
+
+        let schema: &apollo_compiler::Schema = &self.supergraph_schema;
+
+        // Entity fetches are always query operations; start from the Query root type.
+        let Some(root_type_name) = schema.schema_definition.query.as_ref() else {
+            return self.list_size as i32;
+        };
+
+        let mut cardinality: i32 = 1;
+        let mut current_type_name: String = root_type_name.to_string();
+
+        for element in &path.0 {
+            let PathElement::Key(field_name, _) = element else {
+                // Flatten(@) and Index elements don't change the type being traversed.
+                continue;
+            };
+
+            // Look up the field definition in the apollo_compiler schema to determine
+            // whether it returns a list and what its inner named type is.
+            let field_compiler_def = match schema.types.get(current_type_name.as_str()) {
+                Some(ExtendedType::Object(obj)) => obj.fields.get(field_name.as_str()).cloned(),
+                Some(ExtendedType::Interface(iface)) => {
+                    iface.fields.get(field_name.as_str()).cloned()
+                }
+                _ => None,
+            };
+
+            let Some(field_compiler_def) = field_compiler_def else {
+                // Unknown field — stop traversal, return what we have so far.
+                break;
+            };
+
+            if field_compiler_def.ty.is_list() {
+                // Prefer @listSize(assumedSize: N) from our pre-processed schema.
+                let field_list_size = self
+                    .supergraph_schema
+                    .output_field_definition(&current_type_name, field_name)
+                    .and_then(|fd| {
+                        fd.list_size_directive_entries()
+                            .iter()
+                            .filter_map(|e| e.directive.assumed_size)
+                            .max()
+                    })
+                    .unwrap_or(self.list_size as i32);
+
+                cardinality = cardinality.saturating_mul(field_list_size);
+            }
+
+            // Advance to the field's inner named type for the next path segment.
+            current_type_name = field_compiler_def.ty.inner_named_type().to_string();
+        }
+
+        cardinality
+    }
+
     pub(crate) fn actual(
         &self,
         request: &ExecutableDocument,
@@ -1619,5 +1685,69 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn make_calculator_for_path_test(schema_str: &str, list_size: u32) -> StaticCostCalculator {
+        use apollo_compiler::Schema;
+
+        let schema = Schema::parse_and_validate(schema_str, "schema.graphqls").unwrap();
+        let dc_schema = Arc::new(DemandControlledSchema::new(Arc::new(schema)).unwrap());
+        StaticCostCalculator::new(dc_schema, Default::default(), Default::default(), list_size)
+    }
+
+    #[test]
+    fn path_cardinality_single_list_no_directive() {
+        // ships: [Ship!]! with no @listSize → uses global list_size (10)
+        let schema_str = r#"
+            type Query { ships: [Ship!]! }
+            type Ship { id: ID! }
+        "#;
+        let calc = make_calculator_for_path_test(schema_str, 10);
+        let path = crate::json_ext::Path::from_slice(&["ships", "@"]);
+        assert_eq!(calc.estimated_path_cardinality(&path), 10);
+    }
+
+    #[test]
+    fn path_cardinality_single_list_with_assumed_size() {
+        // ships: [Ship!]! @listSize(assumedSize: 5) → 5 (not global list_size 10)
+        // Uses the full supergraph fixture because @listSize requires proper @link resolution.
+        let schema_str = include_str!("./fixtures/federated_ships_listsize_schema.graphql");
+        let config: Configuration = Default::default();
+        let schema = crate::spec::Schema::parse(schema_str, &config).unwrap();
+        let dc_schema = Arc::new(
+            DemandControlledSchema::new(Arc::new(schema.supergraph_schema().clone())).unwrap(),
+        );
+        let calc =
+            StaticCostCalculator::new(dc_schema, Default::default(), Default::default(), 10);
+        let path = crate::json_ext::Path::from_slice(&["ships", "@"]);
+        assert_eq!(calc.estimated_path_cardinality(&path), 5);
+    }
+
+    #[test]
+    fn path_cardinality_nested_lists_multiply() {
+        // companies: [Company] (size 10) where Company.employees: [Employee] (size 10)
+        // path = companies/@/employees/@ → 10 × 10 = 100
+        let schema_str = r#"
+            type Query { companies: [Company!]! }
+            type Company { employees: [Employee!]! }
+            type Employee { id: ID! }
+        "#;
+        let calc = make_calculator_for_path_test(schema_str, 10);
+        let path = crate::json_ext::Path::from_slice(&["companies", "@", "employees", "@"]);
+        assert_eq!(calc.estimated_path_cardinality(&path), 100);
+    }
+
+    #[test]
+    fn path_cardinality_object_field_does_not_multiply() {
+        // user: User (non-list) then orders: [Order] (size 10)
+        // path = user/orders/@ → 1 × 10 = 10
+        let schema_str = r#"
+            type Query { user: User! }
+            type User { orders: [Order!]! }
+            type Order { id: ID! }
+        "#;
+        let calc = make_calculator_for_path_test(schema_str, 10);
+        let path = crate::json_ext::Path::from_slice(&["user", "orders", "@"]);
+        assert_eq!(calc.estimated_path_cardinality(&path), 10);
     }
 }

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -512,16 +512,16 @@ impl StaticCostCalculator {
                 // Check if the inner node is directly an entity fetch (non-empty requires).
                 // If so, supply the cardinality derived from the flatten path so that
                 // _entities is scored with the correct instance count.
-                if let PlanNode::Fetch(fetch_node) = flatten_node.node.as_ref() {
-                    if !fetch_node.requires.is_empty() {
-                        let cardinality = self.estimated_path_cardinality(&flatten_node.path);
-                        return self.estimated_cost_of_operation(
-                            &fetch_node.service_name,
-                            &fetch_node.operation,
-                            variables,
-                            Some(cardinality),
-                        );
-                    }
+                if let PlanNode::Fetch(fetch_node) = flatten_node.node.as_ref()
+                    && !fetch_node.requires.is_empty()
+                {
+                    let cardinality = self.estimated_path_cardinality(&flatten_node.path);
+                    return self.estimated_cost_of_operation(
+                        &fetch_node.service_name,
+                        &fetch_node.operation,
+                        variables,
+                        Some(cardinality),
+                    );
                 }
                 // Non-entity flatten or nested structure: recurse normally.
                 self.score_plan_node(&flatten_node.node, variables)
@@ -567,8 +567,14 @@ impl StaticCostCalculator {
         let operation = operation
             .as_parsed()
             .map_err(DemandControlError::SubgraphOperationNotInitialized)?;
-        let cost =
-            self.estimated(operation, schema, variables, false, subgraph, entity_count_hint)?;
+        let cost = self.estimated(
+            operation,
+            schema,
+            variables,
+            false,
+            subgraph,
+            entity_count_hint,
+        )?;
         Ok(CostBySubgraph::new(subgraph, cost))
     }
 
@@ -942,7 +948,14 @@ mod tests {
         );
 
         calculator
-            .estimated(&query, &calculator.supergraph_schema, &variables, true, "", None)
+            .estimated(
+                &query,
+                &calculator.supergraph_schema,
+                &variables,
+                true,
+                "",
+                None,
+            )
             .unwrap()
     }
 
@@ -1762,8 +1775,7 @@ mod tests {
         let dc_schema = Arc::new(
             DemandControlledSchema::new(Arc::new(schema.supergraph_schema().clone())).unwrap(),
         );
-        let calc =
-            StaticCostCalculator::new(dc_schema, Default::default(), Default::default(), 10);
+        let calc = StaticCostCalculator::new(dc_schema, Default::default(), Default::default(), 10);
         let path = crate::json_ext::Path::from_slice(&["ships", "@"]);
         assert_eq!(calc.estimated_path_cardinality(&path), 5);
     }

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -1133,6 +1133,47 @@ mod tests {
     }
 
     #[test(tokio::test)]
+    async fn entity_fetch_cardinality_uses_parent_list_size_from_listsize_directive() {
+        // When the parent list field has @listSize(assumedSize: 5) and global list_size is 100,
+        // the entity fetch for _entities should be estimated with cardinality 5, not 100.
+        let schema = include_str!("./fixtures/federated_ships_listsize_schema.graphql");
+        let query = include_str!("./fixtures/federated_ships_required_query.graphql");
+        let variables = "{}";
+
+        // Supergraph estimate uses @listSize(assumedSize: 5) from ships field:
+        // ships (5 instances) × Ship (1.0) = 5.0
+        assert_eq!(estimated_cost(schema, query, variables), 5.0);
+
+        // Planned cost: entity fetch _entities should use cardinality 5 (ships list size),
+        // not 100 (global list_size default).
+        // Fetch 1 (vehicles, ships list):       ships[5] × Ship(1.0) = 5.0
+        // Fetch 2 (vehicles, entity fetch):     _entities[5] × Ship(1.0) = 5.0
+        // Total = 10.0
+        //
+        // Before the fix: Fetch 2 would use list_size=100, giving 100.0, total = 105.0
+        assert_eq!(planned_cost_rust(schema, query, variables), 10.0);
+    }
+
+    #[test(tokio::test)]
+    async fn entity_fetch_cardinality_multiplies_for_nested_lists() {
+        // For a two-level nested list (companies[N].employees[M]), the entity fetch
+        // for employees should be estimated with cardinality N × M.
+        // With list_size = 100: cardinality = 100 companies × 100 employees = 10000.
+        //
+        // Before the fix: cardinality would be 100 (just global list_size).
+        let schema = include_str!("./fixtures/federated_nested_list_schema.graphql");
+        let query = include_str!("./fixtures/federated_nested_list_query.graphql");
+        let variables = "{}";
+
+        // Fetch 1 (companies): companies[100] × Company(1.0) + employees[100] × Employee(1.0) = 100 + 10000 = 10100.0
+        // Fetch 2 (employees, entity):  _entities[10000] × Employee(1.0) = 10000.0
+        // Total = 20100.0
+        //
+        // Before the fix: Fetch 2 = _entities[100] × 1.0 = 100.0, total = 10200.0
+        assert_eq!(planned_cost_rust(schema, query, variables), 20100.0);
+    }
+
+    #[test(tokio::test)]
     async fn federated_query_with_fragments() {
         let schema = include_str!("./fixtures/federated_ships_schema.graphql");
         let query = include_str!("./fixtures/federated_ships_fragment_query.graphql");

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -713,6 +713,10 @@ impl StaticCostCalculator {
                     .supergraph_schema
                     .output_field_definition(&current_type_name, field_name)
                     .and_then(|fd| {
+                        // Takes the max of all @listSize directives on this field.
+                        // This is an over-approximation. It could be narrowed down to the exact
+                        // subgraph that the entities are originally fetched from. But, that will
+                        // be more complex to implement.
                         fd.list_size_directive_entries()
                             .iter()
                             .filter_map(|e| e.directive.assumed_size)

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -37,6 +37,7 @@ use crate::json_ext::Object;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
+use crate::plugins::demand_control::cost_calculator::CostBreakdownNode;
 use crate::plugins::demand_control::cost_calculator::CostBySubgraph;
 use crate::plugins::demand_control::cost_calculator::schema::DemandControlledSchema;
 use crate::plugins::demand_control::strategy::Strategy;
@@ -200,6 +201,8 @@ pub(crate) enum DemandControlError {
         estimated_cost: f64,
         /// The maximum cost of the query
         max_cost: f64,
+        /// Per-field cost breakdown (present when cost exceeds limit)
+        breakdown: Option<CostBreakdownNode>,
     },
     /// query estimated cost {estimated_cost} exceeded configured maximum {max_cost} for subgraph {subgraph}
     EstimatedSubgraphCostTooExpensive {
@@ -234,10 +237,16 @@ impl IntoGraphQLErrors for DemandControlError {
             DemandControlError::EstimatedCostTooExpensive {
                 estimated_cost,
                 max_cost,
+                ref breakdown,
             } => {
                 let mut extensions = Object::new();
                 extensions.insert("cost.estimated", estimated_cost.into());
                 extensions.insert("cost.max", max_cost.into());
+                if let Some(breakdown) = breakdown
+                    && let Ok(value) = serde_json_bytes::to_value(breakdown)
+                {
+                    extensions.insert("cost.estimated.breakdown", value);
+                }
                 Ok(vec![
                     graphql::Error::builder()
                         .extension_code(self.code())
@@ -948,6 +957,7 @@ mod test {
                     DemandControlError::EstimatedCostTooExpensive {
                         max_cost: 1.0,
                         estimated_cost: 2.0,
+                        breakdown: None,
                     }
                 }
 

--- a/apollo-router/src/plugins/demand_control/strategy/static_estimated.rs
+++ b/apollo-router/src/plugins/demand_control/strategy/static_estimated.rs
@@ -42,9 +42,14 @@ impl StrategyImpl for StaticEstimated {
             .insert_estimated_cost_by_subgraph(by_subgraph)?;
 
         if cost > self.max {
+            let breakdown = self
+                .cost_calculator
+                .build_breakdown(&plan_result.entries, variables)
+                .ok();
             let error = DemandControlError::EstimatedCostTooExpensive {
                 estimated_cost: cost,
                 max_cost: self.max,
+                breakdown,
             };
             request
                 .context

--- a/apollo-router/src/plugins/demand_control/strategy/static_estimated.rs
+++ b/apollo-router/src/plugins/demand_control/strategy/static_estimated.rs
@@ -26,35 +26,34 @@ impl StaticEstimated {
 
 impl StrategyImpl for StaticEstimated {
     fn on_execution_request(&self, request: &execution::Request) -> Result<(), DemandControlError> {
-        self.cost_calculator
-            .planned(
-                &request.query_plan,
-                &request.supergraph_request.body().variables,
-            )
-            .and_then(|cost_by_subgraph| {
-                let cost = cost_by_subgraph.total();
-                request
-                    .context
-                    .insert_cost_strategy("static_estimated".to_string())?;
-                request.context.insert_estimated_cost(cost)?;
-                request
-                    .context
-                    .insert_estimated_cost_by_subgraph(cost_by_subgraph)?;
+        let variables = &request.supergraph_request.body().variables;
+        let plan_result = self
+            .cost_calculator
+            .planned(&request.query_plan, variables)?;
+        let by_subgraph = plan_result.by_subgraph();
+        let cost = by_subgraph.total();
 
-                if cost > self.max {
-                    let error = DemandControlError::EstimatedCostTooExpensive {
-                        estimated_cost: cost,
-                        max_cost: self.max,
-                    };
-                    request
-                        .context
-                        .insert_cost_result(error.code().to_string())?;
-                    Err(error)
-                } else {
-                    request.context.insert_cost_result("COST_OK".to_string())?;
-                    Ok(())
-                }
-            })
+        request
+            .context
+            .insert_cost_strategy("static_estimated".to_string())?;
+        request.context.insert_estimated_cost(cost)?;
+        request
+            .context
+            .insert_estimated_cost_by_subgraph(by_subgraph)?;
+
+        if cost > self.max {
+            let error = DemandControlError::EstimatedCostTooExpensive {
+                estimated_cost: cost,
+                max_cost: self.max,
+            };
+            request
+                .context
+                .insert_cost_result(error.code().to_string())?;
+            Err(error)
+        } else {
+            request.context.insert_cost_result("COST_OK".to_string())?;
+            Ok(())
+        }
     }
 
     fn on_subgraph_request(&self, request: &subgraph::Request) -> Result<(), DemandControlError> {

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -3349,6 +3349,7 @@ mod tests {
                     DemandControlError::EstimatedCostTooExpensive {
                         estimated_cost: cost_details.estimated,
                         max_cost: (cost_details.estimated - 5.0).max(0.0),
+                        breakdown: None,
                     }
                     .into_graphql_errors()
                     .unwrap()

--- a/apollo-router/tests/integration/demand_control.rs
+++ b/apollo-router/tests/integration/demand_control.rs
@@ -589,3 +589,72 @@ async fn coprocessor_can_access_and_mutate_costs() -> Result<(), BoxError> {
     insta::assert_json_snapshot!(parse_result_for_snapshot(response).await);
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn entity_fetch_uses_path_cardinality_for_enforcement() -> Result<(), BoxError> {
+    // With list_size=10 the old estimator would compute:
+    //   _entities[10] × Employee(1.0) = 10  →  total ≈ 120 → under max of 200 → accepted
+    //
+    // With the fix, the estimator computes:
+    //   _entities[100] × Employee(1.0) = 100  →  total ≈ 210 → exceeds max of 200 → rejected
+    let test_parameters = TestSetupParameters {
+        name: "federated_nested_list",
+        query: include_str!(
+            "../../src/plugins/demand_control/cost_calculator/fixtures/federated_nested_list_query.graphql"
+        ),
+        schema: include_str!(
+            "../../src/plugins/demand_control/cost_calculator/fixtures/federated_nested_list_schema.graphql"
+        ),
+        subgraphs: serde_json::json!({
+            "companies": {
+                "query": {
+                    "companies": [
+                        {"__typename": "Company", "id": "1", "name": "Acme",
+                         "employees": [{"__typename": "Employee", "id": "e1"}, {"__typename": "Employee", "id": "e2"}]},
+                        {"__typename": "Company", "id": "2", "name": "Globex",
+                         "employees": [{"__typename": "Employee", "id": "e3"}]},
+                    ],
+                },
+            },
+            "employees": {
+                "entities": [
+                    {"__typename": "Employee", "id": "e1", "salary": 90000.0},
+                    {"__typename": "Employee", "id": "e2", "salary": 85000.0},
+                    {"__typename": "Employee", "id": "e3", "salary": 95000.0},
+                ],
+            }
+        }),
+    };
+
+    let demand_control = serde_json::json!({
+        "enabled": true,
+        "mode": "enforce",
+        "strategy": {
+            "static_estimated": {
+                "list_size": 10,
+                "max": 200.0,
+                "subgraph": {
+                    "all": {
+                        "max": MAX_COST
+                    }
+                }
+            }
+        }
+    });
+
+    let response = query_supergraph_service(test_parameters, demand_control).await?;
+    let result = parse_result_for_snapshot(response).await;
+
+    // Should be rejected (cost exceeds max) because the entity fetch for employees
+    // now correctly estimates 10×10=100 entities instead of just 10.
+    assert!(
+        result["body"]["errors"]
+            .as_array()
+            .map(|e| !e.is_empty())
+            .unwrap_or(false),
+        "expected demand control to reject the query, got: {:?}",
+        result
+    );
+
+    Ok(())
+}

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__list_size_subgraph_inheritance_changes_estimates@federated_ships_fragment_10_2_3.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__list_size_subgraph_inheritance_changes_estimates@federated_ships_fragment_10_2_3.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/integration/demand_control.rs
+assertion_line: 479
 expression: parse_result_for_snapshot(response).await
 ---
 {
@@ -8,9 +9,9 @@ expression: parse_result_for_snapshot(response).await
     "users": 5.0,
     "vehicles": 10.0
   },
-  "apollo::demand_control::estimated_cost": 10.0,
+  "apollo::demand_control::estimated_cost": 18.0,
   "apollo::demand_control::estimated_cost_by_subgraph": {
-    "users": 4.0,
+    "users": 12.0,
     "vehicles": 6.0
   },
   "apollo::demand_control::result": "COST_OK",

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__list_size_subgraph_inheritance_changes_estimates@federated_ships_fragment_10_2_null.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__list_size_subgraph_inheritance_changes_estimates@federated_ships_fragment_10_2_null.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/integration/demand_control.rs
+assertion_line: 479
 expression: parse_result_for_snapshot(response).await
 ---
 {
@@ -8,9 +9,9 @@ expression: parse_result_for_snapshot(response).await
     "users": 5.0,
     "vehicles": 10.0
   },
-  "apollo::demand_control::estimated_cost": 8.0,
+  "apollo::demand_control::estimated_cost": 16.0,
   "apollo::demand_control::estimated_cost_by_subgraph": {
-    "users": 4.0,
+    "users": 12.0,
     "vehicles": 4.0
   },
   "apollo::demand_control::result": "COST_OK",

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__list_size_subgraph_inheritance_changes_estimates@federated_ships_fragment_1_2_3.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__list_size_subgraph_inheritance_changes_estimates@federated_ships_fragment_1_2_3.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/integration/demand_control.rs
+assertion_line: 479
 expression: parse_result_for_snapshot(response).await
 ---
 {
@@ -8,9 +9,9 @@ expression: parse_result_for_snapshot(response).await
     "users": 5.0,
     "vehicles": 10.0
   },
-  "apollo::demand_control::estimated_cost": 10.0,
+  "apollo::demand_control::estimated_cost": 9.0,
   "apollo::demand_control::estimated_cost_by_subgraph": {
-    "users": 4.0,
+    "users": 3.0,
     "vehicles": 6.0
   },
   "apollo::demand_control::result": "COST_OK",

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__list_size_subgraph_inheritance_changes_estimates@federated_ships_fragment_1_2_null.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__list_size_subgraph_inheritance_changes_estimates@federated_ships_fragment_1_2_null.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/integration/demand_control.rs
+assertion_line: 479
 expression: parse_result_for_snapshot(response).await
 ---
 {
@@ -8,9 +9,9 @@ expression: parse_result_for_snapshot(response).await
     "users": 5.0,
     "vehicles": 10.0
   },
-  "apollo::demand_control::estimated_cost": 8.0,
+  "apollo::demand_control::estimated_cost": 7.0,
   "apollo::demand_control::estimated_cost_by_subgraph": {
-    "users": 4.0,
+    "users": 3.0,
     "vehicles": 4.0
   },
   "apollo::demand_control::result": "COST_OK",

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@basic_fragments.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@basic_fragments.snap
@@ -19,6 +19,18 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 102.0,
+          "cost.estimated.breakdown": {
+            "__cost": 0.0,
+            "interfaceInstance1": {
+              "__cost": 1.0
+            },
+            "someUnion": {
+              "__cost": 1.0,
+              "innerList": {
+                "__cost": 100.0
+              }
+            }
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 102 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@basic_mutation.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@basic_mutation.snap
@@ -19,6 +19,9 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 10.0,
+          "cost.estimated.breakdown": {
+            "__cost": 10.0
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 10 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@custom_costs.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@custom_costs.snap
@@ -20,6 +20,33 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 127.0,
+          "cost.estimated.breakdown": {
+            "__cost": 0.0,
+            "argWithCost": {
+              "__cost": 10.0
+            },
+            "enumWithCost": {
+              "__cost": 15.0
+            },
+            "fieldWithCost": {
+              "__cost": 5.0
+            },
+            "fieldWithDynamicListSize": {
+              "__cost": 1.0,
+              "items": {
+                "__cost": 5.0
+              }
+            },
+            "inputWithCost": {
+              "__cost": 21.0
+            },
+            "objectWithCost": {
+              "__cost": 40.0
+            },
+            "scalarWithCost": {
+              "__cost": 30.0
+            }
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 127 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@federated_ships_fragment.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@federated_ships_fragment.snap
@@ -20,6 +20,18 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 400.0,
+          "cost.estimated.breakdown": {
+            "__cost": 0.0,
+            "ships": {
+              "__cost": 100.0,
+              "owner": {
+                "__cost": 200.0
+              }
+            },
+            "users": {
+              "__cost": 100.0
+            }
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 400 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@federated_ships_required.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected@federated_ships_required.snap
@@ -20,6 +20,18 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 10400.0,
+          "cost.estimated.breakdown": {
+            "__cost": 0.0,
+            "ships": {
+              "__cost": 200.0,
+              "owner": {
+                "__cost": 200.0,
+                "addresses": {
+                  "__cost": 10000.0
+                }
+              }
+            }
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 10400 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@basic_fragments.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@basic_fragments.snap
@@ -19,6 +19,18 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 12.0,
+          "cost.estimated.breakdown": {
+            "__cost": 0.0,
+            "interfaceInstance1": {
+              "__cost": 1.0
+            },
+            "someUnion": {
+              "__cost": 1.0,
+              "innerList": {
+                "__cost": 10.0
+              }
+            }
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 12 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@basic_mutation.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@basic_mutation.snap
@@ -19,6 +19,9 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 10.0,
+          "cost.estimated.breakdown": {
+            "__cost": 10.0
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 10 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@custom_costs.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@custom_costs.snap
@@ -20,6 +20,33 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 127.0,
+          "cost.estimated.breakdown": {
+            "__cost": 0.0,
+            "argWithCost": {
+              "__cost": 10.0
+            },
+            "enumWithCost": {
+              "__cost": 15.0
+            },
+            "fieldWithCost": {
+              "__cost": 5.0
+            },
+            "fieldWithDynamicListSize": {
+              "__cost": 1.0,
+              "items": {
+                "__cost": 5.0
+              }
+            },
+            "inputWithCost": {
+              "__cost": 21.0
+            },
+            "objectWithCost": {
+              "__cost": 40.0
+            },
+            "scalarWithCost": {
+              "__cost": 30.0
+            }
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 127 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@federated_ships_fragment.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@federated_ships_fragment.snap
@@ -20,6 +20,18 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 40.0,
+          "cost.estimated.breakdown": {
+            "__cost": 0.0,
+            "ships": {
+              "__cost": 10.0,
+              "owner": {
+                "__cost": 20.0
+              }
+            },
+            "users": {
+              "__cost": 10.0
+            }
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 40 exceeded configured maximum 1"

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@federated_ships_required.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_max_are_rejected_regardless_of_subgraph_config@federated_ships_required.snap
@@ -20,6 +20,18 @@ expression: parse_result_for_snapshot(response).await
         "extensions": {
           "code": "COST_ESTIMATED_TOO_EXPENSIVE",
           "cost.estimated": 140.0,
+          "cost.estimated.breakdown": {
+            "__cost": 0.0,
+            "ships": {
+              "__cost": 20.0,
+              "owner": {
+                "__cost": 20.0,
+                "addresses": {
+                  "__cost": 100.0
+                }
+              }
+            }
+          },
           "cost.max": 1.0
         },
         "message": "query estimated cost 140 exceeded configured maximum 1"

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_stats.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_stats.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/apollo_reports.rs
+assertion_line: 818
 expression: report
 ---
 header:
@@ -168,8 +169,11 @@ traces_per_query:
             - 0
             - 0
             - 0
+            - 0
+            - 0
+            - 0
             - 1
-          max_cost_estimated: 230
+          max_cost_estimated: 320
           cost_actual:
             - 0
             - 0

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_trace-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_trace-2.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/apollo_reports.rs
+assertion_line: 832
 expression: report
 ---
 header:
@@ -603,7 +604,7 @@ traces_per_query:
         limits:
           result: COST_OK
           strategy: static_estimated
-          cost_estimated: 230
+          cost_estimated: 320
           cost_actual: 18
           depth: 4
           height: 7

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_trace.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_trace.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/apollo_reports.rs
+assertion_line: 832
 expression: report
 ---
 header:
@@ -603,7 +604,7 @@ traces_per_query:
         limits:
           result: COST_OK
           strategy: static_estimated
-          cost_estimated: 230
+          cost_estimated: 320
           cost_actual: 18
           depth: 4
           height: 7

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_trace_batched-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_trace_batched-2.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/apollo_reports.rs
+assertion_line: 852
 expression: report
 ---
 header:
@@ -603,7 +604,7 @@ traces_per_query:
         limits:
           result: COST_OK
           strategy: static_estimated
-          cost_estimated: 230
+          cost_estimated: 320
           cost_actual: 18
           depth: 4
           height: 7
@@ -1203,7 +1204,7 @@ traces_per_query:
         limits:
           result: COST_OK
           strategy: static_estimated
-          cost_estimated: 230
+          cost_estimated: 320
           cost_actual: 18
           depth: 4
           height: 7

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_trace_batched.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_trace_batched.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/apollo_reports.rs
+assertion_line: 852
 expression: report
 ---
 header:
@@ -603,7 +604,7 @@ traces_per_query:
         limits:
           result: COST_OK
           strategy: static_estimated
-          cost_estimated: 230
+          cost_estimated: 320
           cost_actual: 18
           depth: 4
           height: 7
@@ -1203,7 +1204,7 @@ traces_per_query:
         limits:
           result: COST_OK
           strategy: static_estimated
-          cost_estimated: 230
+          cost_estimated: 320
           cost_actual: 18
           depth: 4
           height: 7

--- a/apollo-router/tests/snapshots/apollo_reports__new_field_stats.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__new_field_stats.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/apollo_reports.rs
+assertion_line: 806
 expression: report
 ---
 header:
@@ -186,8 +187,11 @@ traces_per_query:
             - 0
             - 0
             - 0
+            - 0
+            - 0
+            - 0
             - 1
-          max_cost_estimated: 230
+          max_cost_estimated: 320
           cost_actual:
             - 0
             - 0


### PR DESCRIPTION
## Summary

- Refactor `PlanCostResult` to hold raw per-fetch cost entries and compute the per-subgraph aggregation on demand, so the entries are available to downstream consumers.
- Attach a per-field cost breakdown to `EstimatedCostTooExpensive` errors. The breakdown is emitted in the error extensions under `cost.estimated.breakdown` as a nested JSON tree, making it easy to see which fields contributed to the cost.

## Details

### Commit 1 — collect per-fetch entries, defer aggregation

`StaticCostCalculator::planned` previously aggregated fetch costs directly into `CostBySubgraph`. It now returns a `PlanCostResult<'a>` that holds `entries: Vec<FetchCostEntry<'a>>` — one entry per fetch with `subgraph`, `cost`, `response_path`, and the subgraph operation document. `PlanCostResult::by_subgraph()` walks the entries and builds the aggregation on demand. Existing callers are unchanged in behavior — they just call `by_subgraph()` once and use the result the same way.

This makes the raw entries available to commit 2 without reshuffling data shapes later.

### Commit 2 — per-field breakdown on exceeded limits

When `StaticEstimated::on_execution_request` detects the cost exceeds the configured max, it now builds a `CostBreakdownNode` tree by walking each fetch's subgraph operation and attributing per-field cost to the field's path in the supergraph response.

```json
"cost": {
  "estimated": 42.0,
  "max": 10.0,
  "estimated.breakdown": {
    "__cost": 0.0,
    "ships": {
      "__cost": 2.0,
      "name": { "__cost": 10.0 },
      "captain": { "__cost": 30.0 }
    }
  }
}
```

Semantics:

- `__cost` is the node's **own cost only** — consumers sum across the tree to compute subtree totals (invariant: `Σ __cost == total estimated cost`).
- `_entities` cost is attributed to the field at its `FlattenNode` path (the path itself is not appended).
- Fragments and inline type conditions are flattened away; only field-addressable paths appear.
- Mutation base cost (10.0) appears as the root node's `own_cost`.
- Nodes with zero own-cost and no non-empty descendants are pruned from the JSON output.
- The breakdown is built **only** when the cost exceeds the limit — no overhead for passing requests.

## Test plan

- [x] New `breakdown_tests` module (6 tests) covering subtotal-equals-estimated invariant, federated queries with `@requires`, fragments, custom `@cost` costs, serialization format, and `@defer`.
- [x] All 126 `plugins::demand_control` lib tests + 15 demand_control integration tests pass; 10 integration snapshots updated to show the new `cost.estimated.breakdown` extension key.
- [x] `cargo fmt` + `cargo clippy --all-targets` clean.

<!-- start metadata -->

<!-- [FED-998] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary


[FED-998]: https://apollographql.atlassian.net/browse/FED-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ