### PR TITLE
fix(authentication): retry JWKS candidates on issuer/audience mismatch

### DIFF
--- a/.changesets/fix_caroline_router_1691.md
+++ b/.changesets/fix_caroline_router_1691.md
@@ -1,0 +1,5 @@
+### fix(authentication): retry JWKS candidates on issuer/audience mismatch ([PR #9214](https://github.com/apollographql/router/pull/9214))
+
+When multiple JWKS entries share identical key material (e.g., Azure AD B2C multi-policy tenants where different policies use the same RSA key), the router now correctly retries validation against all matching candidates. Previously, issuer and audience validation happened after the candidate loop, so a token that passed signature verification against the first JWKS entry would be rejected if that entry's configured issuer or audience didn't match — with no attempt to try the remaining entries.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9214

--- a/apollo-router/src/plugins/authentication/error.rs
+++ b/apollo-router/src/plugins/authentication/error.rs
@@ -77,7 +77,7 @@ fn jwt_error_to_reason(jwt_err: &JWTError) -> &'static str {
 }
 
 impl AuthenticationError {
-    pub(crate) fn as_context_object(&self) -> ErrorContext {
+    pub(super) fn as_context_object(&self) -> ErrorContext {
         let (code, reason) = match self {
             AuthenticationError::CannotConvertToString => ("CANNOT_CONVERT_TO_STRING", None),
             AuthenticationError::InvalidJWTPrefix(_, _) => ("INVALID_PREFIX", None),

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -29,6 +29,7 @@ use jsonwebtoken::jwk::KeyOperations;
 use jsonwebtoken::jwk::PublicKeyUse;
 use mime::APPLICATION_JSON;
 use parking_lot::RwLock;
+use serde_json::Value;
 use tokio::fs::read_to_string;
 use tokio::sync::oneshot;
 use tower::BoxError;
@@ -657,6 +658,102 @@ pub(super) fn decode_jwt(
                 ),
                 StatusCode::UNAUTHORIZED,
             ))
+        }
+    }
+}
+
+pub(crate) fn validate_issuers(
+    configured_issuers: &Issuers,
+    token_issuer: Option<&serde_json::Value>,
+) -> Result<(), AuthenticationError> {
+    let issuer_error = |actual: String| {
+        // Standardize issuer - sort it and join the elements with a comma
+        let mut issuers: Vec<String> = configured_issuers.iter().cloned().collect();
+        issuers.sort();
+
+        let expected = issuers.join(", ");
+        Err(AuthenticationError::InvalidIssuer {
+            expected,
+            token: actual,
+        })
+    };
+
+    if configured_issuers.is_empty() {
+        // No issuers to compare against
+        return Ok(());
+    }
+
+    match token_issuer {
+        None | Some(Value::Null) => {
+            // No issuer in token; allow this as well
+            Ok(())
+        }
+
+        Some(Value::String(token_issuer)) => {
+            // Check if this issuer is in our list
+            if configured_issuers.contains(token_issuer) {
+                Ok(())
+            } else {
+                issuer_error(token_issuer.to_string())
+            }
+        }
+
+        Some(unexpected_value) => {
+            // If the token has an incorrectly configured issuer, we cannot validate it against
+            // the configured issuers.
+            issuer_error(unexpected_value.to_string())
+        }
+    }
+}
+
+pub(crate) fn validate_audiences(
+    configured_audiences: &Audiences,
+    token_audiences: Option<&serde_json::Value>,
+) -> Result<(), AuthenticationError> {
+    let audience_error = |actual: String| {
+        // Standardize audience - sort it and join the elements with a comma
+        let mut audiences: Vec<String> = configured_audiences.iter().cloned().collect();
+        audiences.sort();
+
+        let expected = audiences.join(", ");
+        Err(AuthenticationError::InvalidAudience { expected, actual })
+    };
+
+    if configured_audiences.is_empty() {
+        // No audiences to compare against
+        return Ok(());
+    }
+
+    let Some(token_audiences) = token_audiences else {
+        return audience_error("<none>".to_string());
+    };
+
+    match token_audiences {
+        Value::String(token_audience) => {
+            // Check if this audience exists in our list
+            if configured_audiences.contains(token_audience) {
+                Ok(())
+            } else {
+                audience_error(token_audience.to_string())
+            }
+        }
+
+        Value::Array(token_audiences_arr) => {
+            // Check if any of these audiences is in our list
+            for token_audience in token_audiences_arr.iter().filter_map(|aud| aud.as_str()) {
+                if configured_audiences.contains(token_audience) {
+                    return Ok(());
+                }
+            }
+
+            // No matches, so return an error
+            audience_error(token_audiences.to_string())
+        }
+
+        unexpected_value => {
+            // If the token has incorrectly configured audiences, we cannot validate it against
+            // the configured audiences.
+            audience_error(unexpected_value.to_string())
         }
     }
 }

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -574,11 +574,7 @@ pub(super) fn extract_jwt<'a, 'b: 'a>(
     }
 }
 
-pub(super) type DecodedClaims = (
-    Option<Issuers>,
-    Option<Audiences>,
-    TokenData<serde_json::Value>,
-);
+pub(super) type DecodedClaims = TokenData<serde_json::Value>;
 
 pub(super) fn decode_jwt(
     jwt: &str,
@@ -635,16 +631,35 @@ pub(super) fn decode_jwt(
             validation.required_spec_claims.remove("exp");
         }
 
-        match decode::<serde_json::Value>(jwt, &decoding_key, &validation) {
-            Ok(v) => return Ok((issuers, audiences, v)),
+        let token_data = match decode::<serde_json::Value>(jwt, &decoding_key, &validation) {
+            Ok(v) => v,
             Err(e) => {
                 tracing::trace!("JWT decoding failed with error `{e}`");
                 error = Some((
                     AuthenticationError::CannotDecodeJWT(e),
                     StatusCode::UNAUTHORIZED,
                 ));
+                continue;
             }
         };
+
+        if let Some(configured_issuers) = issuers {
+            let maybe_token_issuers = token_data.claims.as_object().and_then(|o| o.get("iss"));
+            if let Err(err) = validate_issuers(&configured_issuers, maybe_token_issuers) {
+                error = Some((err, StatusCode::INTERNAL_SERVER_ERROR));
+                continue;
+            }
+        }
+
+        if let Some(configured_audiences) = audiences {
+            let maybe_token_audiences = token_data.claims.as_object().and_then(|o| o.get("aud"));
+            if let Err(err) = validate_audiences(&configured_audiences, maybe_token_audiences) {
+                error = Some((err, StatusCode::UNAUTHORIZED));
+                continue;
+            }
+        }
+
+        return Ok(token_data);
     }
 
     match error {

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -578,103 +578,108 @@ pub(super) type DecodedClaims = TokenData<serde_json::Value>;
 
 pub(super) fn decode_jwt(
     jwt: &str,
-    keys: Vec<SearchResult>,
+    search_results: Vec<SearchResult>,
     criteria: JWTCriteria,
 ) -> Result<DecodedClaims, (AuthenticationError, StatusCode)> {
     let mut error = None;
-    for SearchResult {
-        issuers,
-        audiences,
-        jwk,
-        allow_missing_exp,
-    } in keys.into_iter()
-    {
-        let decoding_key = match DecodingKey::from_jwk(&jwk) {
-            Ok(k) => k,
-            Err(e) => {
-                error = Some((
-                    AuthenticationError::CannotCreateDecodingKey(e),
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                ));
-                continue;
-            }
-        };
-
-        let key_algorithm = match jwk.common.key_algorithm {
-            Some(a) => a,
-            None => {
-                error = Some((
-                    AuthenticationError::JWKHasNoAlgorithm,
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                ));
-                continue;
-            }
-        };
-
-        let algorithm = match convert_key_algorithm(key_algorithm) {
-            Some(a) => a,
-            None => {
-                error = Some((
-                    AuthenticationError::UnsupportedKeyAlgorithm(key_algorithm),
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                ));
-                continue;
-            }
-        };
-
-        let mut validation = Validation::new(algorithm);
-        validation.validate_nbf = true;
-        // if set to true, it will reject tokens containing an `aud` claim if the validation does not specify an audience
-        // we don't validate audience yet, so this is deactivated
-        validation.validate_aud = false;
-        if allow_missing_exp {
-            validation.required_spec_claims.remove("exp");
-        }
-
-        let token_data = match decode::<serde_json::Value>(jwt, &decoding_key, &validation) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::trace!("JWT decoding failed with error `{e}`");
-                error = Some((
-                    AuthenticationError::CannotDecodeJWT(e),
-                    StatusCode::UNAUTHORIZED,
-                ));
-                continue;
-            }
-        };
-
-        if let Some(configured_issuers) = issuers {
-            let maybe_token_issuers = token_data.claims.as_object().and_then(|o| o.get("iss"));
-            if let Err(err) = validate_issuers(&configured_issuers, maybe_token_issuers) {
-                error = Some((err, StatusCode::INTERNAL_SERVER_ERROR));
-                continue;
+    for search_result in search_results.into_iter() {
+        match validate_jwk_against_jwt(jwt, search_result) {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                error = Some(err);
             }
         }
-
-        if let Some(configured_audiences) = audiences {
-            let maybe_token_audiences = token_data.claims.as_object().and_then(|o| o.get("aud"));
-            if let Err(err) = validate_audiences(&configured_audiences, maybe_token_audiences) {
-                error = Some((err, StatusCode::UNAUTHORIZED));
-                continue;
-            }
-        }
-
-        return Ok(token_data);
     }
 
     match error {
         Some(e) => Err(e),
         None => {
             // We can't find a key to process this JWT.
-            Err((
-                criteria.kid.map_or_else(
-                    || AuthenticationError::CannotFindSuitableKey(criteria.alg, None),
-                    AuthenticationError::CannotFindKID,
-                ),
-                StatusCode::UNAUTHORIZED,
-            ))
+            let err = match criteria.kid {
+                Some(kid) => AuthenticationError::CannotFindKID(kid),
+                None => AuthenticationError::CannotFindSuitableKey(criteria.alg, None),
+            };
+            Err((err, StatusCode::UNAUTHORIZED))
         }
     }
+}
+
+fn validate_jwk_against_jwt(
+    jwt: &str,
+    search_result: SearchResult,
+) -> Result<DecodedClaims, (AuthenticationError, StatusCode)> {
+    let SearchResult {
+        issuers,
+        audiences,
+        jwk,
+        allow_missing_exp,
+    } = search_result;
+
+    let decoding_key = match DecodingKey::from_jwk(&jwk) {
+        Ok(k) => k,
+        Err(e) => {
+            return Err((
+                AuthenticationError::CannotCreateDecodingKey(e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+
+    let key_algorithm = match jwk.common.key_algorithm {
+        Some(a) => a,
+        None => {
+            return Err((
+                AuthenticationError::JWKHasNoAlgorithm,
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+
+    let algorithm = match convert_key_algorithm(key_algorithm) {
+        Some(a) => a,
+        None => {
+            return Err((
+                AuthenticationError::UnsupportedKeyAlgorithm(key_algorithm),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    };
+
+    let mut validation = Validation::new(algorithm);
+    validation.validate_nbf = true;
+    // if set to true, it will reject tokens containing an `aud` claim if the validation does not specify an audience
+    // we don't validate audience yet, so this is deactivated
+    validation.validate_aud = false;
+    if allow_missing_exp {
+        validation.required_spec_claims.remove("exp");
+    }
+
+    let token_data = match decode::<serde_json::Value>(jwt, &decoding_key, &validation) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::trace!("JWT decoding failed with error `{e}`");
+            return Err((
+                AuthenticationError::CannotDecodeJWT(e),
+                StatusCode::UNAUTHORIZED,
+            ));
+        }
+    };
+
+    if let Some(configured_issuers) = issuers {
+        let maybe_token_issuers = token_data.claims.as_object().and_then(|o| o.get("iss"));
+        if let Err(err) = validate_issuers(&configured_issuers, maybe_token_issuers) {
+            return Err((err, StatusCode::INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    if let Some(configured_audiences) = audiences {
+        let maybe_token_audiences = token_data.claims.as_object().and_then(|o| o.get("aud"));
+        if let Err(err) = validate_audiences(&configured_audiences, maybe_token_audiences) {
+            return Err((err, StatusCode::UNAUTHORIZED));
+        }
+    }
+
+    Ok(token_data)
 }
 
 fn validate_issuers(

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -677,7 +677,7 @@ pub(super) fn decode_jwt(
     }
 }
 
-pub(crate) fn validate_issuers(
+fn validate_issuers(
     configured_issuers: &Issuers,
     token_issuer: Option<&serde_json::Value>,
 ) -> Result<(), AuthenticationError> {
@@ -721,7 +721,7 @@ pub(crate) fn validate_issuers(
     }
 }
 
-pub(crate) fn validate_audiences(
+fn validate_audiences(
     configured_audiences: &Audiences,
     token_audiences: Option<&serde_json::Value>,
 ) -> Result<(), AuthenticationError> {

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -603,7 +603,7 @@ fn authenticate(
 
         if let Some(configured_issuers) = issuers {
             let maybe_token_issuers = token_data.claims.as_object().and_then(|o| o.get("iss"));
-            if let Err(err) = validate_issuers(&configured_issuers, maybe_token_issuers) {
+            if let Err(err) = jwks::validate_issuers(&configured_issuers, maybe_token_issuers) {
                 return failure_message(
                     request,
                     config,
@@ -616,7 +616,8 @@ fn authenticate(
 
         if let Some(configured_audiences) = audiences {
             let maybe_token_audiences = token_data.claims.as_object().and_then(|o| o.get("aud"));
-            if let Err(err) = validate_audiences(&configured_audiences, maybe_token_audiences) {
+            if let Err(err) = jwks::validate_audiences(&configured_audiences, maybe_token_audiences)
+            {
                 return failure_message(
                     request,
                     config,
@@ -678,102 +679,6 @@ fn authenticate(
         StatusCode::UNAUTHORIZED,
         source_of_extracted_jwt,
     )
-}
-
-fn validate_issuers(
-    configured_issuers: &Issuers,
-    token_issuer: Option<&serde_json::Value>,
-) -> Result<(), AuthenticationError> {
-    let issuer_error = |actual: String| {
-        // Standardize issuer - sort it and join the elements with a comma
-        let mut issuers: Vec<String> = configured_issuers.iter().cloned().collect();
-        issuers.sort();
-
-        let expected = issuers.join(", ");
-        Err(AuthenticationError::InvalidIssuer {
-            expected,
-            token: actual,
-        })
-    };
-
-    if configured_issuers.is_empty() {
-        // No issuers to compare against
-        return Ok(());
-    }
-
-    match token_issuer {
-        None | Some(Value::Null) => {
-            // No issuer in token; allow this as well
-            Ok(())
-        }
-
-        Some(Value::String(token_issuer)) => {
-            // Check if this issuer is in our list
-            if configured_issuers.contains(token_issuer) {
-                Ok(())
-            } else {
-                issuer_error(token_issuer.to_string())
-            }
-        }
-
-        Some(unexpected_value) => {
-            // If the token has an incorrectly configured issuer, we cannot validate it against
-            // the configured issuers.
-            issuer_error(unexpected_value.to_string())
-        }
-    }
-}
-
-fn validate_audiences(
-    configured_audiences: &Audiences,
-    token_audiences: Option<&serde_json::Value>,
-) -> Result<(), AuthenticationError> {
-    let audience_error = |actual: String| {
-        // Standardize audience - sort it and join the elements with a comma
-        let mut audiences: Vec<String> = configured_audiences.iter().cloned().collect();
-        audiences.sort();
-
-        let expected = audiences.join(", ");
-        Err(AuthenticationError::InvalidAudience { expected, actual })
-    };
-
-    if configured_audiences.is_empty() {
-        // No audiences to compare against
-        return Ok(());
-    }
-
-    let Some(token_audiences) = token_audiences else {
-        return audience_error("<none>".to_string());
-    };
-
-    match token_audiences {
-        Value::String(token_audience) => {
-            // Check if this audience exists in our list
-            if configured_audiences.contains(token_audience) {
-                Ok(())
-            } else {
-                audience_error(token_audience.to_string())
-            }
-        }
-
-        Value::Array(token_audiences_arr) => {
-            // Check if any of these audiences is in our list
-            for token_audience in token_audiences_arr.iter().filter_map(|aud| aud.as_str()) {
-                if configured_audiences.contains(token_audience) {
-                    return Ok(());
-                }
-            }
-
-            // No matches, so return an error
-            audience_error(token_audiences.to_string())
-        }
-
-        unexpected_value => {
-            // If the token has incorrectly configured audiences, we cannot validate it against
-            // the configured audiences.
-            audience_error(unexpected_value.to_string())
-        }
-    }
 }
 
 // This macro allows us to use it in our plugin registry!

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -19,7 +19,6 @@ use reqwest::Client;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::Value;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
@@ -588,7 +587,7 @@ fn authenticate(
     // Note: This will search through JWKS in the order in which they are defined
     // in configuration.
     if let Some(keys) = jwks::search_jwks(jwks_manager, &criteria) {
-        let (issuers, audiences, token_data) = match jwks::decode_jwt(jwt, keys, criteria) {
+        let token_data = match jwks::decode_jwt(jwt, keys, criteria) {
             Ok(data) => data,
             Err((auth_error, status_code)) => {
                 return failure_message(
@@ -600,33 +599,6 @@ fn authenticate(
                 );
             }
         };
-
-        if let Some(configured_issuers) = issuers {
-            let maybe_token_issuers = token_data.claims.as_object().and_then(|o| o.get("iss"));
-            if let Err(err) = jwks::validate_issuers(&configured_issuers, maybe_token_issuers) {
-                return failure_message(
-                    request,
-                    config,
-                    err,
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    source_of_extracted_jwt,
-                );
-            }
-        }
-
-        if let Some(configured_audiences) = audiences {
-            let maybe_token_audiences = token_data.claims.as_object().and_then(|o| o.get("aud"));
-            if let Err(err) = jwks::validate_audiences(&configured_audiences, maybe_token_audiences)
-            {
-                return failure_message(
-                    request,
-                    config,
-                    err,
-                    StatusCode::UNAUTHORIZED,
-                    source_of_extracted_jwt,
-                );
-            }
-        }
 
         if let Err(e) = request
             .context

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -2303,3 +2303,186 @@ mod issuer_validation {
         }
     }
 }
+
+// Tests for the case where two JWKS entries share identical key material but have different
+// configured issuers or audiences (e.g., Azure AD B2C multi-policy tenants). The retry loop
+// in decode_jwt must continue to the next candidate when signature passes but issuer/audience
+// validation fails.
+mod duplicate_key_retry {
+    use std::collections::HashMap;
+    use std::ops::ControlFlow;
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    use http::StatusCode;
+    use jsonwebtoken::jwk::JwkSet;
+    use jsonwebtoken::get_current_timestamp;
+    use p256::ecdsa::SigningKey;
+    use p256::ecdsa::signature::rand_core::OsRng;
+    use url::Url;
+
+    use super::common::build_request_with_header_token;
+    use super::common::jwk;
+    use super::common::jwt_conf_with_header_source;
+    use crate::plugins::authentication::authenticate;
+    use crate::plugins::authentication::jwks::JwksConfig;
+    use crate::plugins::authentication::jwks::JwksManager;
+
+    #[test]
+    fn it_retries_next_jwks_entry_when_issuer_fails_on_first() {
+        // Two JWKS entries share the same key. Entry A (index 0) expects issuer "tenant-a",
+        // entry B (index 1) expects "tenant-b". iter_jwks uses list.pop() so entry B is tried
+        // first. A token with issuer "tenant-a" fails entry B's issuer check; the retry loop
+        // must continue to entry A and succeed.
+        let signing_key = SigningKey::random(&mut OsRng);
+        let shared_jwk = jwk(&signing_key);
+
+        let url_a = Url::from_str("file:///jwks-a.json").unwrap();
+        let url_b = Url::from_str("file:///jwks-b.json").unwrap();
+
+        let list = vec![
+            JwksConfig {
+                url: url_a.clone(),
+                issuers: Some(["https://tenant-a.example.com".to_string()].into()),
+                audiences: None,
+                algorithms: None,
+                poll_interval: Duration::from_secs(60),
+                allow_missing_exp: false,
+                headers: Vec::new(),
+            },
+            JwksConfig {
+                url: url_b.clone(),
+                issuers: Some(["https://tenant-b.example.com".to_string()].into()),
+                audiences: None,
+                algorithms: None,
+                poll_interval: Duration::from_secs(60),
+                allow_missing_exp: false,
+                headers: Vec::new(),
+            },
+        ];
+        let map = HashMap::from([
+            (url_a, JwkSet { keys: vec![shared_jwk.clone()] }),
+            (url_b, JwkSet { keys: vec![shared_jwk] }),
+        ]);
+        let manager = JwksManager::new_test(list, map);
+
+        let token_claims = serde_json::json!({
+            "sub": "test",
+            "exp": get_current_timestamp(),
+            "iss": "https://tenant-a.example.com"
+        });
+        let request = build_request_with_header_token(signing_key, token_claims);
+
+        match authenticate(&jwt_conf_with_header_source(), &manager, request) {
+            ControlFlow::Continue(_) => {}
+            ControlFlow::Break(response) => {
+                panic!("should have succeeded via second JWKS entry: {response:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn it_fails_when_no_jwks_entry_issuer_matches() {
+        // Both entries have specific issuers, neither matches the token issuer.
+        let signing_key = SigningKey::random(&mut OsRng);
+        let shared_jwk = jwk(&signing_key);
+
+        let url_a = Url::from_str("file:///jwks-a.json").unwrap();
+        let url_b = Url::from_str("file:///jwks-b.json").unwrap();
+
+        let list = vec![
+            JwksConfig {
+                url: url_a.clone(),
+                issuers: Some(["https://tenant-a.example.com".to_string()].into()),
+                audiences: None,
+                algorithms: None,
+                poll_interval: Duration::from_secs(60),
+                allow_missing_exp: false,
+                headers: Vec::new(),
+            },
+            JwksConfig {
+                url: url_b.clone(),
+                issuers: Some(["https://tenant-b.example.com".to_string()].into()),
+                audiences: None,
+                algorithms: None,
+                poll_interval: Duration::from_secs(60),
+                allow_missing_exp: false,
+                headers: Vec::new(),
+            },
+        ];
+        let map = HashMap::from([
+            (url_a, JwkSet { keys: vec![shared_jwk.clone()] }),
+            (url_b, JwkSet { keys: vec![shared_jwk] }),
+        ]);
+        let manager = JwksManager::new_test(list, map);
+
+        let token_claims = serde_json::json!({
+            "sub": "test",
+            "exp": get_current_timestamp(),
+            "iss": "https://attacker.example.com"
+        });
+        let request = build_request_with_header_token(signing_key, token_claims);
+
+        match authenticate(&jwt_conf_with_header_source(), &manager, request) {
+            ControlFlow::Break(response) => {
+                assert_eq!(response.response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            }
+            ControlFlow::Continue(_) => {
+                panic!("should have been rejected when no entry's issuer matches");
+            }
+        }
+    }
+
+    #[test]
+    fn it_retries_next_jwks_entry_when_audience_fails_on_first() {
+        // Two JWKS entries share the same key. Entry A (index 0) expects audience "aud-a",
+        // entry B (index 1) expects "aud-b". iter_jwks uses list.pop() so entry B is tried
+        // first. A token with audience "aud-a" fails entry B's audience check; the retry loop
+        // must continue to entry A and succeed.
+        let signing_key = SigningKey::random(&mut OsRng);
+        let shared_jwk = jwk(&signing_key);
+
+        let url_a = Url::from_str("file:///jwks-a.json").unwrap();
+        let url_b = Url::from_str("file:///jwks-b.json").unwrap();
+
+        let list = vec![
+            JwksConfig {
+                url: url_a.clone(),
+                issuers: None,
+                audiences: Some(["aud-a".to_string()].into()),
+                algorithms: None,
+                poll_interval: Duration::from_secs(60),
+                allow_missing_exp: false,
+                headers: Vec::new(),
+            },
+            JwksConfig {
+                url: url_b.clone(),
+                issuers: None,
+                audiences: Some(["aud-b".to_string()].into()),
+                algorithms: None,
+                poll_interval: Duration::from_secs(60),
+                allow_missing_exp: false,
+                headers: Vec::new(),
+            },
+        ];
+        let map = HashMap::from([
+            (url_a, JwkSet { keys: vec![shared_jwk.clone()] }),
+            (url_b, JwkSet { keys: vec![shared_jwk] }),
+        ]);
+        let manager = JwksManager::new_test(list, map);
+
+        let token_claims = serde_json::json!({
+            "sub": "test",
+            "exp": get_current_timestamp(),
+            "aud": "aud-a"
+        });
+        let request = build_request_with_header_token(signing_key, token_claims);
+
+        match authenticate(&jwt_conf_with_header_source(), &manager, request) {
+            ControlFlow::Continue(_) => {}
+            ControlFlow::Break(response) => {
+                panic!("should have succeeded via second JWKS entry: {response:?}");
+            }
+        }
+    }
+}

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -2315,8 +2315,8 @@ mod duplicate_key_retry {
     use std::time::Duration;
 
     use http::StatusCode;
-    use jsonwebtoken::jwk::JwkSet;
     use jsonwebtoken::get_current_timestamp;
+    use jsonwebtoken::jwk::JwkSet;
     use p256::ecdsa::SigningKey;
     use p256::ecdsa::signature::rand_core::OsRng;
     use url::Url;
@@ -2335,7 +2335,9 @@ mod duplicate_key_retry {
         // first. A token with issuer "tenant-a" fails entry B's issuer check; the retry loop
         // must continue to entry A and succeed.
         let signing_key = SigningKey::random(&mut OsRng);
-        let shared_jwk = jwk(&signing_key);
+        let shared_jwk = JwkSet {
+            keys: vec![jwk(&signing_key)],
+        };
 
         let url_a = Url::from_str("file:///jwks-a.json").unwrap();
         let url_b = Url::from_str("file:///jwks-b.json").unwrap();
@@ -2360,10 +2362,8 @@ mod duplicate_key_retry {
                 headers: Vec::new(),
             },
         ];
-        let map = HashMap::from([
-            (url_a, JwkSet { keys: vec![shared_jwk.clone()] }),
-            (url_b, JwkSet { keys: vec![shared_jwk] }),
-        ]);
+
+        let map = HashMap::from([(url_a, shared_jwk.clone()), (url_b, shared_jwk)]);
         let manager = JwksManager::new_test(list, map);
 
         let token_claims = serde_json::json!({
@@ -2385,7 +2385,9 @@ mod duplicate_key_retry {
     fn it_fails_when_no_jwks_entry_issuer_matches() {
         // Both entries have specific issuers, neither matches the token issuer.
         let signing_key = SigningKey::random(&mut OsRng);
-        let shared_jwk = jwk(&signing_key);
+        let shared_jwk = JwkSet {
+            keys: vec![jwk(&signing_key)],
+        };
 
         let url_a = Url::from_str("file:///jwks-a.json").unwrap();
         let url_b = Url::from_str("file:///jwks-b.json").unwrap();
@@ -2410,10 +2412,8 @@ mod duplicate_key_retry {
                 headers: Vec::new(),
             },
         ];
-        let map = HashMap::from([
-            (url_a, JwkSet { keys: vec![shared_jwk.clone()] }),
-            (url_b, JwkSet { keys: vec![shared_jwk] }),
-        ]);
+
+        let map = HashMap::from([(url_a, shared_jwk.clone()), (url_b, shared_jwk)]);
         let manager = JwksManager::new_test(list, map);
 
         let token_claims = serde_json::json!({
@@ -2425,7 +2425,10 @@ mod duplicate_key_retry {
 
         match authenticate(&jwt_conf_with_header_source(), &manager, request) {
             ControlFlow::Break(response) => {
-                assert_eq!(response.response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(
+                    response.response.status(),
+                    StatusCode::INTERNAL_SERVER_ERROR
+                );
             }
             ControlFlow::Continue(_) => {
                 panic!("should have been rejected when no entry's issuer matches");
@@ -2440,7 +2443,9 @@ mod duplicate_key_retry {
         // first. A token with audience "aud-a" fails entry B's audience check; the retry loop
         // must continue to entry A and succeed.
         let signing_key = SigningKey::random(&mut OsRng);
-        let shared_jwk = jwk(&signing_key);
+        let shared_jwk = JwkSet {
+            keys: vec![jwk(&signing_key)],
+        };
 
         let url_a = Url::from_str("file:///jwks-a.json").unwrap();
         let url_b = Url::from_str("file:///jwks-b.json").unwrap();
@@ -2465,10 +2470,8 @@ mod duplicate_key_retry {
                 headers: Vec::new(),
             },
         ];
-        let map = HashMap::from([
-            (url_a, JwkSet { keys: vec![shared_jwk.clone()] }),
-            (url_b, JwkSet { keys: vec![shared_jwk] }),
-        ]);
+
+        let map = HashMap::from([(url_a, shared_jwk.clone()), (url_b, shared_jwk)]);
         let manager = JwksManager::new_test(list, map);
 
         let token_claims = serde_json::json!({


### PR DESCRIPTION
## Summary

Fixes a JWT authentication edge case where two JWKS entries share identical key material (same `kid`, same key — common in Azure AD B2C multi-policy tenants with different policies on the same tenant). Previously, the retry loop in `decode_jwt` exited immediately on successful signature verification, but issuer/audience validation happened in `mod.rs` *after* `decode_jwt` returned — making retry on issuer/audience failure architecturally impossible.

- Moves issuer and audience validation into `decode_jwt`, inside the candidate retry loop, so a candidate that passes signature verification but fails issuer/audience causes the loop to continue to the next candidate
- Removes the now-redundant post-decode validation from `authenticate` in `mod.rs`
- Adds regression tests covering the retry scenario for both issuer and audience mismatches

Easiest to review commit by commit.

## Test plan

- [ ] New `duplicate_key_retry` tests in `tests.rs` cover: retry succeeds on issuer mismatch, retry succeeds on audience mismatch, rejection when no entry matches
- [ ] Existing `issuer_validation` and `audience_validation` test suites pass unchanged — single-entry failure behavior is preserved