### PR TITLE
fix(composition): update CompositionHint to return hint level

### DIFF
--- a/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
+++ b/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
@@ -157,10 +157,8 @@ pub(super) fn shareable_field_mismatched_runtime_types_hint(
         subgraphs_with_type_not_in_intersection_string,
     );
     hints.push(CompositionHint {
+        definition: HintCode::InconsistentRuntimeTypesForShareableReturn.definition(),
         message,
-        code: HintCode::InconsistentRuntimeTypesForShareableReturn
-            .code()
-            .to_string(),
         locations: Default::default(), // TODO
     });
     Ok(())

--- a/apollo-federation/src/merger/compose_directive_manager.rs
+++ b/apollo-federation/src/merger/compose_directive_manager.rs
@@ -467,7 +467,7 @@ impl ComposeDirectiveManager {
                 .collect();
             if !subgraphs_with_different_naming.is_empty() {
                 error_reporter.add_hint(CompositionHint {
-                    code: HintCode::DirectiveCompositionWarn.code().to_string(),
+                    definition: HintCode::DirectiveCompositionWarn.definition(),
                     message: format!("Composed directive \"@{name}\" is named differently in a subgraph that doesn't export it. Consistent naming will be required to export it."),
                     locations: Self::locations_for_identity(item.identity(), subgraphs_with_different_naming),
                 });
@@ -561,7 +561,7 @@ impl ComposeDirectiveManager {
                 // the user determine whether it's an issue.
                 if !major_mismatch_hint_raised {
                     error_reporter.add_hint(CompositionHint {
-                        code: HintCode::DirectiveCompositionInfo.code().to_string(),
+                        definition: HintCode::DirectiveCompositionInfo.definition(),
                         message: format!("Non-composed core feature \"{identity}\" has major version mismatch across subgraphs"),
                         locations: Self::locations_for_identity(identity, subgraphs),
                     });
@@ -677,7 +677,7 @@ impl ErrorReporter {
         locations: Vec<SubgraphLocation>,
     ) {
         self.add_hint(CompositionHint {
-            code: HintCode::DirectiveCompositionInfo.code().to_string(),
+            definition: HintCode::DirectiveCompositionInfo.definition(),
             message: format!("Directive \"{name}\" should not be explicitly manually composed since it is a federation directive composed by default"),
             locations,
         });

--- a/apollo-federation/src/merger/error_reporter.rs
+++ b/apollo-federation/src/merger/error_reporter.rs
@@ -223,7 +223,7 @@ impl ErrorReporter {
                 ));
                 let suffix = if no_end_of_message_dot { "" } else { "." };
                 myself.add_hint(CompositionHint {
-                    code: code.code().to_string(),
+                    definition: code.definition(),
                     message: format!("{message}{distribution_str}{suffix}"),
                     locations,
                 });

--- a/apollo-federation/src/merger/hints.rs
+++ b/apollo-federation/src/merger/hints.rs
@@ -1,62 +1,10 @@
-#[allow(dead_code)]
 use std::sync::LazyLock;
 
-#[derive(Debug)]
-#[allow(dead_code)]
-pub(crate) enum HintLevel {
-    Warn,
-    Info,
-    Debug,
-}
-
-#[allow(dead_code)]
-impl HintLevel {
-    pub(crate) fn name(&self) -> &'static str {
-        match self {
-            HintLevel::Warn => "WARN",
-            HintLevel::Info => "INFO",
-            HintLevel::Debug => "DEBUG",
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct HintCodeDefinition {
-    code: String,
-    level: HintLevel,
-    description: String,
-}
-
-#[allow(dead_code)]
-impl HintCodeDefinition {
-    pub(crate) fn new(
-        code: impl Into<String>,
-        level: HintLevel,
-        description: impl Into<String>,
-    ) -> Self {
-        Self {
-            code: code.into(),
-            level,
-            description: description.into(),
-        }
-    }
-
-    pub(crate) fn code(&self) -> &str {
-        &self.code
-    }
-
-    pub(crate) fn level(&self) -> &HintLevel {
-        &self.level
-    }
-
-    pub(crate) fn description(&self) -> &str {
-        &self.description
-    }
-}
+use crate::supergraph::HintCodeDefinition;
+use crate::supergraph::HintLevel;
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
-pub(crate) enum HintCode {
+pub enum HintCode {
     InconsistentButCompatibleFieldType,
     InconsistentButCompatibleArgumentType,
     InconsistentDefaultValuePresence,
@@ -90,9 +38,8 @@ pub(crate) enum HintCode {
     InterfaceKeyMissingImplementationType,
 }
 
-#[allow(dead_code)]
 impl HintCode {
-    pub(crate) fn definition(&self) -> &'static HintCodeDefinition {
+    pub fn definition(&self) -> &'static HintCodeDefinition {
         match self {
             HintCode::InconsistentButCompatibleFieldType => &INCONSISTENT_BUT_COMPATIBLE_FIELD_TYPE,
             HintCode::InconsistentButCompatibleArgumentType => {
@@ -158,32 +105,29 @@ impl HintCode {
         }
     }
 
-    pub(crate) fn code(&self) -> &str {
+    pub fn code(&self) -> &str {
         self.definition().code()
     }
 }
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_BUT_COMPATIBLE_FIELD_TYPE: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
             "INCONSISTENT_BUT_COMPATIBLE_FIELD_TYPE",
-            HintLevel::Warn,
+            HintLevel::Info,
             "Field has inconsistent but compatible type across subgraphs",
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_BUT_COMPATIBLE_ARGUMENT_TYPE: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
             "INCONSISTENT_BUT_COMPATIBLE_ARGUMENT_TYPE",
-            HintLevel::Warn,
+            HintLevel::Info,
             "Argument has inconsistent but compatible type across subgraphs",
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_DEFAULT_VALUE_PRESENCE: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -193,36 +137,32 @@ pub(crate) static INCONSISTENT_DEFAULT_VALUE_PRESENCE: LazyLock<HintCodeDefiniti
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_ENTITY: LazyLock<HintCodeDefinition> = LazyLock::new(|| {
     HintCodeDefinition::new(
         "INCONSISTENT_ENTITY",
-        HintLevel::Warn,
+        HintLevel::Info,
         "Entity definition is inconsistent across subgraphs",
     )
 });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_OBJECT_VALUE_TYPE_FIELD: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
             "INCONSISTENT_OBJECT_VALUE_TYPE_FIELD",
-            HintLevel::Warn,
+            HintLevel::Debug,
             "Object value type field is inconsistent across subgraphs",
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_INTERFACE_VALUE_TYPE_FIELD: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
             "INCONSISTENT_INTERFACE_VALUE_TYPE_FIELD",
-            HintLevel::Warn,
+            HintLevel::Debug,
             "Interface value type field is inconsistent across subgraphs",
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_INPUT_OBJECT_FIELD: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -232,16 +172,14 @@ pub(crate) static INCONSISTENT_INPUT_OBJECT_FIELD: LazyLock<HintCodeDefinition> 
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_UNION_MEMBER: LazyLock<HintCodeDefinition> = LazyLock::new(|| {
     HintCodeDefinition::new(
         "INCONSISTENT_UNION_MEMBER",
-        HintLevel::Warn,
+        HintLevel::Debug,
         "Union member is inconsistent across subgraphs",
     )
 });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_ENUM_VALUE_FOR_INPUT_ENUM: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -251,37 +189,33 @@ pub(crate) static INCONSISTENT_ENUM_VALUE_FOR_INPUT_ENUM: LazyLock<HintCodeDefin
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
             "INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM",
-            HintLevel::Warn,
+            HintLevel::Debug,
             "Enum value for output enum is inconsistent across subgraphs",
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_TYPE_SYSTEM_DIRECTIVE_REPEATABLE: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
             "INCONSISTENT_TYPE_SYSTEM_DIRECTIVE_REPEATABLE",
-            HintLevel::Warn,
+            HintLevel::Debug,
             "Type system directive repeatable property is inconsistent across subgraphs",
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_TYPE_SYSTEM_DIRECTIVE_LOCATIONS: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
             "INCONSISTENT_TYPE_SYSTEM_DIRECTIVE_LOCATIONS",
-            HintLevel::Warn,
+            HintLevel::Debug,
             "Type system directive locations are inconsistent across subgraphs",
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_EXECUTABLE_DIRECTIVE_PRESENCE: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -291,7 +225,6 @@ pub(crate) static INCONSISTENT_EXECUTABLE_DIRECTIVE_PRESENCE: LazyLock<HintCodeD
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static NO_EXECUTABLE_DIRECTIVE_LOCATIONS_INTERSECTION: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -301,7 +234,6 @@ pub(crate) static NO_EXECUTABLE_DIRECTIVE_LOCATIONS_INTERSECTION: LazyLock<HintC
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_EXECUTABLE_DIRECTIVE_REPEATABLE: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -311,7 +243,6 @@ pub(crate) static INCONSISTENT_EXECUTABLE_DIRECTIVE_REPEATABLE: LazyLock<HintCod
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_EXECUTABLE_DIRECTIVE_LOCATIONS: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -321,7 +252,6 @@ pub(crate) static INCONSISTENT_EXECUTABLE_DIRECTIVE_LOCATIONS: LazyLock<HintCode
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_DESCRIPTION: LazyLock<HintCodeDefinition> = LazyLock::new(|| {
     HintCodeDefinition::new(
         "INCONSISTENT_DESCRIPTION",
@@ -330,7 +260,6 @@ pub(crate) static INCONSISTENT_DESCRIPTION: LazyLock<HintCodeDefinition> = LazyL
     )
 });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_ARGUMENT_PRESENCE: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -340,7 +269,6 @@ pub(crate) static INCONSISTENT_ARGUMENT_PRESENCE: LazyLock<HintCodeDefinition> =
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static FROM_SUBGRAPH_DOES_NOT_EXIST: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -350,7 +278,6 @@ pub(crate) static FROM_SUBGRAPH_DOES_NOT_EXIST: LazyLock<HintCodeDefinition> =
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static OVERRIDDEN_FIELD_CAN_BE_REMOVED: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -360,7 +287,6 @@ pub(crate) static OVERRIDDEN_FIELD_CAN_BE_REMOVED: LazyLock<HintCodeDefinition> 
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static OVERRIDE_DIRECTIVE_CAN_BE_REMOVED: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -370,7 +296,6 @@ pub(crate) static OVERRIDE_DIRECTIVE_CAN_BE_REMOVED: LazyLock<HintCodeDefinition
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static OVERRIDE_MIGRATION_IN_PROGRESS: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -380,12 +305,10 @@ pub(crate) static OVERRIDE_MIGRATION_IN_PROGRESS: LazyLock<HintCodeDefinition> =
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static UNUSED_ENUM_TYPE: LazyLock<HintCodeDefinition> = LazyLock::new(|| {
-    HintCodeDefinition::new("UNUSED_ENUM_TYPE", HintLevel::Warn, "Enum type is unused")
+    HintCodeDefinition::new("UNUSED_ENUM_TYPE", HintLevel::Debug, "Enum type is unused")
 });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -395,7 +318,6 @@ pub(crate) static INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS: LazyLock<Hint
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -405,7 +327,6 @@ pub(crate) static MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS: LazyLock<HintCodeDe
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static DIRECTIVE_COMPOSITION_INFO: LazyLock<HintCodeDefinition> = LazyLock::new(|| {
     HintCodeDefinition::new(
         "DIRECTIVE_COMPOSITION_INFO",
@@ -414,7 +335,6 @@ pub(crate) static DIRECTIVE_COMPOSITION_INFO: LazyLock<HintCodeDefinition> = Laz
     )
 });
 
-#[allow(dead_code)]
 pub(crate) static DIRECTIVE_COMPOSITION_WARN: LazyLock<HintCodeDefinition> = LazyLock::new(|| {
     HintCodeDefinition::new(
         "DIRECTIVE_COMPOSITION_WARN",
@@ -423,7 +343,6 @@ pub(crate) static DIRECTIVE_COMPOSITION_WARN: LazyLock<HintCodeDefinition> = Laz
     )
 });
 
-#[allow(dead_code)]
 pub(crate) static INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -433,7 +352,6 @@ pub(crate) static INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN: LazyLock<Hint
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static IMPLICITLY_UPGRADED_FEDERATION_VERSION: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(
@@ -443,18 +361,16 @@ pub(crate) static IMPLICITLY_UPGRADED_FEDERATION_VERSION: LazyLock<HintCodeDefin
         )
     });
 
-#[allow(dead_code)]
 pub(crate) static CONTEXTUAL_ARGUMENT_NOT_CONTEXTUAL_IN_ALL_SUBGRAPHS: LazyLock<
     HintCodeDefinition,
 > = LazyLock::new(|| {
     HintCodeDefinition::new(
         "CONTEXTUAL_ARGUMENT_NOT_CONTEXTUAL_IN_ALL_SUBGRAPHS",
-        HintLevel::Warn,
+        HintLevel::Info,
         "Contextual argument is not contextual in all subgraphs",
     )
 });
 
-#[allow(dead_code)]
 pub(crate) static INTERFACE_KEY_MISSING_IMPLEMENTATION_TYPE: LazyLock<HintCodeDefinition> =
     LazyLock::new(|| {
         HintCodeDefinition::new(

--- a/apollo-federation/src/merger/merge_argument.rs
+++ b/apollo-federation/src/merger/merge_argument.rs
@@ -155,9 +155,8 @@ impl Merger {
                             });
                         } else {
                             self.error_reporter.add_hint(CompositionHint {
-                                code: HintCode::ContextualArgumentNotContextualInAllSubgraphs
-                                    .code()
-                                    .to_string(),
+                                definition: HintCode::ContextualArgumentNotContextualInAllSubgraphs
+                                    .definition(),
                                 message: format!(
                                     "Contextual argument \"{pos}\" will not be included in the supergraph since it is contextual in at least one subgraph",
                                 ),

--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -290,7 +290,7 @@ impl Merger {
             );
             dest.insert_directive(&mut self.merged, merged_directive)?;
             self.error_reporter.add_hint(CompositionHint {
-                    code: HintCode::MergedNonRepeatableDirectiveArguments.code().to_string(),
+                    definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                     message: format!(
                         "Directive @{name} is applied to \"{dest}\" in multiple subgraphs with different arguments. Merging strategies used by arguments: {}",
                         directive_in_supergraph.and_then(|d| d.arguments_merger.as_ref()).map_or("undefined".to_string(), |m| (m.to_string)())

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -69,7 +69,7 @@ impl Merger {
             // option. We do raise an hint though so users can notice this.
             let usage = EnumTypeUsage::Unused;
             self.error_reporter.add_hint(CompositionHint {
-                code: HintCode::UnusedEnumType.code().to_string(),
+                definition: HintCode::UnusedEnumType.definition(),
                 message: format!(
                     "Enum type \"{}\" is defined but unused. It will be included in the supergraph with all the values appearing in any subgraph (\"as if\" it was only used as an output type).",
                     dest.type_name

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -293,9 +293,7 @@ impl Merger {
                 .gt(linked_federation_version)
         {
             error_reporter.add_hint(CompositionHint {
-                code: HintCode::ImplicitlyUpgradedFederationVersion
-                    .code()
-                    .to_string(),
+                definition: HintCode::ImplicitlyUpgradedFederationVersion.definition(),
                 message: format!(
                     "Subgraph {} has been implicitly upgraded from federation v{} to v{}",
                     subgraph.name,
@@ -1229,7 +1227,7 @@ impl Merger {
                 let suggestions = suggestion_list(&source_subgraph_name, self.names.clone());
                 let extra_msg = did_you_mean(suggestions);
                 self.error_reporter.add_hint(CompositionHint {
-                    code: HintCode::FromSubgraphDoesNotExist.code().to_string(),
+                    definition: HintCode::FromSubgraphDoesNotExist.definition(),
                     message: format!(
                         "Source subgraph \"{}\" for field \"{}\" on subgraph \"{}\" does not exist. {extra_msg}",
                         source_subgraph_name, dest, subgraph_name
@@ -1255,7 +1253,7 @@ impl Merger {
             } else if !subgraph_map.contains_key(&source_subgraph_name) {
                 // hint: source schema no longer contains the field
                 self.error_reporter.add_hint(CompositionHint {
-                    code: HintCode::OverrideDirectiveCanBeRemoved.code().to_string(),
+                    definition: HintCode::OverrideDirectiveCanBeRemoved.definition(),
                     message: format!(
                         "Field \"{}\" on subgraph \"{}\" no longer exists in the from subgraph. The @override directive can be removed.",
                         dest, subgraph_name
@@ -1312,7 +1310,7 @@ impl Merger {
                     // The from field is explicitly marked external by the user (which means it is "used"
                     // and cannot be completely removed) so the @override can be removed.
                     self.error_reporter.add_hint(CompositionHint {
-                        code: HintCode::OverrideDirectiveCanBeRemoved.code().to_string(),
+                        definition: HintCode::OverrideDirectiveCanBeRemoved.definition(),
                         message: format!(
                             "Field \"{}\" on subgraph \"{}\" is not resolved anymore by the from subgraph (it is marked \"@external\" in \"{}\"). The @override directive can be removed.",
                             dest, subgraph_name, source_subgraph_name
@@ -1324,7 +1322,7 @@ impl Merger {
                     if override_label.is_none() {
                         // No label, but field is referenced - add hint
                         self.error_reporter.add_hint(CompositionHint {
-                            code: HintCode::OverriddenFieldCanBeRemoved.code().to_string(),
+                            definition: HintCode::OverriddenFieldCanBeRemoved.definition(),
                             message: format!(
                                 "Field \"{}\" on subgraph \"{}\" is overridden. It is still used in some federation directive(s) (@key, @requires, and/or @provides) and/or to satisfy interface constraint(s), but consider marking it @external explicitly or removing it along with its references.",
                                 dest, source_subgraph_name
@@ -1337,7 +1335,7 @@ impl Merger {
                     if override_label.is_none() {
                         // No label and field is not referenced - suggest removal
                         self.error_reporter.add_hint(CompositionHint {
-                            code: HintCode::OverriddenFieldCanBeRemoved.code().to_string(),
+                            definition: HintCode::OverriddenFieldCanBeRemoved.definition(),
                             message: format!(
                                 "Field \"{}\" on subgraph \"{}\" is overridden. Consider removing it.",
                                 dest, source_subgraph_name
@@ -1388,7 +1386,7 @@ impl Merger {
                         };
 
                         self.error_reporter.add_hint(CompositionHint {
-                            code: HintCode::OverrideMigrationInProgress.code().to_string(),
+                            definition: HintCode::OverrideMigrationInProgress.definition(),
                             message,
                             locations: Default::default(),
                         });

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -244,7 +244,6 @@ impl CompositionHint {
     }
 }
 
-
 #[derive(Clone, Debug)]
 pub enum HintLevel {
     Warn,

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -219,22 +219,79 @@ pub struct SupergraphMetadata {
     abstract_types_with_inconsistent_runtime_types: IndexSet<Name>,
 }
 
+pub use crate::merger::hints::HintCode;
+
 // TODO this should be expanded as needed
 //  @see apollo-federation-types BuildMessage for what is currently used by rover
 #[derive(Clone, Debug)]
 pub struct CompositionHint {
+    pub definition: &'static HintCodeDefinition,
     pub message: String,
-    pub code: String,
     pub locations: Locations,
 }
 
 impl CompositionHint {
     pub fn code(&self) -> &str {
-        &self.code
+        self.definition.code()
+    }
+
+    pub fn level(&self) -> &HintLevel {
+        self.definition.level()
     }
 
     pub fn message(&self) -> &str {
         &self.message
+    }
+}
+
+
+#[derive(Clone, Debug)]
+pub enum HintLevel {
+    Warn,
+    Info,
+    Debug,
+}
+
+impl HintLevel {
+    pub fn name(&self) -> &'static str {
+        match self {
+            HintLevel::Warn => "WARN",
+            HintLevel::Info => "INFO",
+            HintLevel::Debug => "DEBUG",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HintCodeDefinition {
+    code: String,
+    level: HintLevel,
+    description: String,
+}
+
+impl HintCodeDefinition {
+    pub(crate) fn new(
+        code: impl Into<String>,
+        level: HintLevel,
+        description: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            level,
+            description: description.into(),
+        }
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub fn level(&self) -> &HintLevel {
+        &self.level
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
     }
 }
 

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -143,7 +143,7 @@ mod federation_directives {
         let result = compose(vec![subgraph_a, subgraph_b]).unwrap();
         assert_eq!(result.hints().len(), 1);
         let hint = result.hints().first().unwrap();
-        assert_eq!(hint.code, "DIRECTIVE_COMPOSITION_INFO");
+        assert_eq!(hint.code(), "DIRECTIVE_COMPOSITION_INFO");
         assert_eq!(
             hint.message,
             format!(
@@ -181,7 +181,7 @@ mod federation_directives {
         let result = compose(vec![subgraph_a, subgraph_b]).unwrap();
         assert_eq!(result.hints().len(), 1);
         let hint = result.hints().first().unwrap();
-        assert_eq!(hint.code, "DIRECTIVE_COMPOSITION_INFO");
+        assert_eq!(hint.code(), "DIRECTIVE_COMPOSITION_INFO");
         assert_eq!(
             hint.message,
             format!(
@@ -355,7 +355,7 @@ mod inconsistent_feature_versions {
         let result = compose(vec![subgraph_a, subgraph_b, subgraph_c, subgraph_d]).unwrap();
         assert_eq!(result.hints().len(), 1);
         let hint = result.hints().first().unwrap();
-        assert_eq!(hint.code, "DIRECTIVE_COMPOSITION_INFO");
+        assert_eq!(hint.code(), "DIRECTIVE_COMPOSITION_INFO");
         assert_eq!(
             hint.message,
             r#"Non-composed core feature "https://specs.custom.dev/foo" has major version mismatch across subgraphs"#
@@ -579,7 +579,7 @@ mod inconsistent_imports {
 
         assert_eq!(result.hints().len(), 1);
         let hint = result.hints().first().unwrap();
-        assert_eq!(hint.code, "DIRECTIVE_COMPOSITION_WARN");
+        assert_eq!(hint.code(), "DIRECTIVE_COMPOSITION_WARN");
         assert_eq!(
             hint.message,
             r#"Composed directive "@bar" is named differently in a subgraph that doesn't export it. Consistent naming will be required to export it."#

--- a/apollo-federation/tests/composition/directive_argument_merge_strategies.rs
+++ b/apollo-federation/tests/composition/directive_argument_merge_strategies.rs
@@ -7,6 +7,7 @@ use super::print_sdl;
 mod tests {
     use apollo_compiler::coord;
     use apollo_federation::supergraph::CompositionHint;
+    use apollo_federation::supergraph::HintCode;
     use test_log::test;
 
     use super::*;
@@ -57,14 +58,14 @@ mod tests {
         // Check expected hints
         let expected_hints = vec![
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @cost is applied to "T" in multiple subgraphs with different arguments. Merging strategies used by arguments: { weight: MAX }"#,
                 ),
                 locations: Vec::new(),
             },
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @cost is applied to "T.k" in multiple subgraphs with different arguments. Merging strategies used by arguments: { weight: MAX }"#,
                 ),
@@ -149,14 +150,14 @@ mod tests {
         // Check expected hints
         let expected_hints = vec![
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @requiresScopes is applied to "T" in multiple subgraphs with different arguments. Merging strategies used by arguments: { scopes: DNF_CONJUNCTION }"#,
                 ),
                 locations: Vec::new(),
             },
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @requiresScopes is applied to "T.k" in multiple subgraphs with different arguments. Merging strategies used by arguments: { scopes: DNF_CONJUNCTION }"#,
                 ),
@@ -252,14 +253,14 @@ mod tests {
         // Check expected hints
         let expected_hints = vec![
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @listSize is applied to "Query.t" in multiple subgraphs with different arguments. Merging strategies used by arguments: { assumedSize: NULLABLE_MAX, slicingArguments: NULLABLE_UNION, sizedFields: NULLABLE_UNION, requireOneSlicingArgument: NULLABLE_AND }"#,
                 ),
                 locations: Vec::new(),
             },
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @listSize is applied to "T.k" in multiple subgraphs with different arguments. Merging strategies used by arguments: { assumedSize: NULLABLE_MAX, slicingArguments: NULLABLE_UNION, sizedFields: NULLABLE_UNION, requireOneSlicingArgument: NULLABLE_AND }"#,
                 ),
@@ -366,14 +367,14 @@ mod tests {
         // Check expected hints
         let expected_hints = vec![
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @listSize is applied to "Query.t" in multiple subgraphs with different arguments. Merging strategies used by arguments: { assumedSize: NULLABLE_MAX, slicingArguments: NULLABLE_UNION, sizedFields: NULLABLE_UNION, requireOneSlicingArgument: NULLABLE_AND }"#,
                 ),
                 locations: Vec::new(),
             },
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @listSize is applied to "T.k" in multiple subgraphs with different arguments. Merging strategies used by arguments: { assumedSize: NULLABLE_MAX, slicingArguments: NULLABLE_UNION, sizedFields: NULLABLE_UNION, requireOneSlicingArgument: NULLABLE_AND }"#,
                 ),
@@ -484,28 +485,28 @@ mod tests {
         // Check expected hints
         let expected_hints = vec![
             CompositionHint {
-                code: String::from("INCONSISTENT_ARGUMENT_PRESENCE"),
+                definition: HintCode::InconsistentArgumentPresence.definition(),
                 message: String::from(
                     r#"Optional argument "T.k(first:)" will not be included in the supergraph as it does not appear in all subgraphs: it is defined in subgraph "Subgraph1" but not in subgraph "Subgraph2"."#,
                 ),
                 locations: Vec::new(),
             },
             CompositionHint {
-                code: String::from("INCONSISTENT_ARGUMENT_PRESENCE"),
+                definition: HintCode::InconsistentArgumentPresence.definition(),
                 message: String::from(
                     r#"Optional argument "T.k(last:)" will not be included in the supergraph as it does not appear in all subgraphs: it is defined in subgraph "Subgraph2" but not in subgraph "Subgraph1"."#,
                 ),
                 locations: Vec::new(),
             },
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @listSize is applied to "T.k" in multiple subgraphs with different arguments. Merging strategies used by arguments: { assumedSize: NULLABLE_MAX, slicingArguments: NULLABLE_UNION, sizedFields: NULLABLE_UNION, requireOneSlicingArgument: NULLABLE_AND }"#,
                 ),
                 locations: Vec::new(),
             },
             CompositionHint {
-                code: String::from("MERGED_NON_REPEATABLE_DIRECTIVE_ARGUMENTS"),
+                definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
                 message: String::from(
                     r#"Directive @listSize is applied to "T.b" in multiple subgraphs with different arguments. Merging strategies used by arguments: { assumedSize: NULLABLE_MAX, slicingArguments: NULLABLE_UNION, sizedFields: NULLABLE_UNION, requireOneSlicingArgument: NULLABLE_AND }"#,
                 ),


### PR DESCRIPTION
Update Rust implementation to align with the structures returned by the JavaScript implementation ([link](https://github.com/apollographql/federation/blob/main/composition-js/src/hints.ts)).

Re-aligned hint levels to match JavaScript implementation.

<!-- [FED-999] -->


[FED-999]: https://apollographql.atlassian.net/browse/FED-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ