### PR TITLE
[DXM-107] Fix incorrect invalidation payload examples in entity caching docs

### DIFF
--- a/docs/source/routing/performance/caching/response-caching/invalidation.mdx
+++ b/docs/source/routing/performance/caching/response-caching/invalidation.mdx
@@ -220,20 +220,17 @@ The invalidation endpoint accepts HTTP POST requests containing a JSON payload w
 ```mermaid
 flowchart RL
 	subgraph QueryResponse["Cache invalidation POST"]
-		n1["{
-			&nbsp;&nbsp;&nbsp;&nbsp;&quot;kind&quot;: &quot;subgraph&quot;,
+		n1["[{
+			&nbsp;&nbsp;&nbsp;&nbsp;&quot;kind&quot;: &quot;type&quot;,
 			&nbsp;&nbsp;&nbsp;&nbsp;&quot;subgraph&quot;: &quot;price&quot;,
-			&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;: &quot;Price&quot;,
-			&nbsp;&nbsp;&nbsp;&nbsp;&quot;key&quot;: {
-			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;id&quot;: &quot;101&quot;
-			&nbsp;&nbsp;&nbsp;&nbsp;}
-		}"]
+			&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;: &quot;Price&quot;
+		}]"]
     end
 
 	subgraph Subgraphs["Subgraphs"]
 		Purchases["Purchases"]
 		Inventory["Inventory"]
-		Price["Price"]
+		Price["price"]
 	end
 
 	subgraph PriceQueryFragment["Price Query Fragment (e.g. TTL 2200)"]
@@ -516,7 +513,7 @@ Accept: application/json
 The router would send the following response:
 
 ```
-HTTP/1.1 201 OK
+HTTP/1.1 202 Accepted
 Content-Type: application/json
 
 {


### PR DESCRIPTION
## Description

The feedback received on the documentation page https://www.apollographql.com/docs/graphos/routing/performance/caching/entity indicates that the invalidation payload examples are incorrect. This PR corrects two bugs found in `docs/source/routing/performance/caching/response-caching/invalidation.mdx`.

## Ticket

https://apollographql.atlassian.net/browse/DXM-107

## Jeff's Direction

> Work in apollographql/router to update docs. Before you do anything, validate whether this ticket is still needed — it was created a while ago and the router has had a lot of work done since then. If the docs already show the correct invalidation payload examples, output 'BAIL: ticket no longer needed — docs already correct' and stop.

The ticket is still needed — the docs contained two concrete bugs (see below).

## Bugs Fixed

### 1. Invalid mermaid diagram payload (`kind: subgraph` with unknown fields)

The mermaid diagram showed a payload with `"kind": "subgraph"` combined with `"type"` and `"key"` fields:

```json
{
  "kind": "subgraph",
  "subgraph": "price",
  "type": "Price",
  "key": { "id": "101" }
}
```

This payload would be **rejected by the router with a 400 Bad Request** because the `InvalidationRequest` enum is deserialized with `deny_unknown_fields`. When `kind` is `subgraph`, only the `subgraph` field is valid — `type` and `key` are unknown fields. This is explicitly tested in `invalidation_endpoint.rs::test_invalidation_service_deny_unknown_fields`.

The example was corrected to use `kind: type` (which accepts `subgraph` and `type` fields), matching the intent of invalidating all cached entries for a specific entity type:

```json
{
  "kind": "type",
  "subgraph": "price",
  "type": "Price"
}
```

### 2. Incorrect HTTP response status code

The docs showed `HTTP/1.1 201 OK` as the response, but the actual endpoint handler in `apollo-router/src/plugins/response_cache/invalidation_endpoint.rs` returns `StatusCode::ACCEPTED` (202). Fixed to `HTTP/1.1 202 Accepted`.

## Test Plan

- [ ] Review the updated mermaid diagram renders correctly
- [ ] Confirm the three `InvalidationRequest` kinds (`subgraph`, `type`, `cache_tag`) and their required fields against `apollo-router/src/plugins/response_cache/invalidation.rs`
- [ ] Verify the status code fix against `apollo-router/src/plugins/response_cache/invalidation_endpoint.rs` (line 166)

🤖 Generated with [Claude Code](https://claude.com/claude-code)