### PR TITLE
fix(composition): enable supergraph reversibility tests

### DIFF
--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -259,18 +259,19 @@ impl FederationSpecDefinition {
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
+        let mut arguments = vec![Node::new(Argument {
+            name: FEDERATION_FIELDS_ARGUMENT_NAME,
+            value: Node::new(Value::String(fields.to_owned())),
+        })];
+        if !resolvable {
+            arguments.push(Node::new(Argument {
+                name: FEDERATION_RESOLVABLE_ARGUMENT_NAME,
+                value: Node::new(Value::Boolean(false)),
+            }));
+        }
         Ok(Directive {
             name: name_in_schema,
-            arguments: vec![
-                Node::new(Argument {
-                    name: FEDERATION_FIELDS_ARGUMENT_NAME,
-                    value: Node::new(Value::String(fields.to_owned())),
-                }),
-                Node::new(Argument {
-                    name: FEDERATION_RESOLVABLE_ARGUMENT_NAME,
-                    value: Node::new(Value::Boolean(resolvable)),
-                }),
-            ],
+            arguments,
         })
     }
 

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -470,7 +470,7 @@ pub mod test_utils {
         let subgraph =
             Subgraph::parse(name, &format!("http://{name}"), schema_str).expect("valid schema");
         let subgraph = if matches!(build_option, BuildOption::AsFed2) {
-            subgraph.into_fed2_test_subgraph(true, false)?
+            subgraph.into_fed2_test_subgraph(true)?
         } else {
             subgraph
         };
@@ -488,7 +488,7 @@ pub mod test_utils {
         let subgraph =
             Subgraph::parse(name, &format!("http://{name}"), schema_str).expect("valid schema");
         let subgraph = if matches!(build_option, BuildOption::AsFed2) {
-            subgraph.into_fed2_test_subgraph(true, false)?
+            subgraph.into_fed2_test_subgraph(true)?
         } else {
             subgraph
         };

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -6,6 +6,7 @@ use apollo_compiler::Node;
 use apollo_compiler::Schema;
 use apollo_compiler::ast;
 use apollo_compiler::ast::OperationType;
+use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ComponentName;
@@ -34,13 +35,11 @@ use crate::link::federation_spec_definition::FEDERATION_OVERRIDE_DIRECTIVE_NAME_
 use crate::link::federation_spec_definition::FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::federation_spec_definition::FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC;
-use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
 use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::link::inaccessible_spec_definition::INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::link_spec_definition::LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME;
 use crate::link::link_spec_definition::LINK_DIRECTIVE_URL_ARGUMENT_NAME;
 use crate::link::spec::Identity;
-use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::query_graph::build_query_graph::FEDERATED_GRAPH_ROOT_SOURCE;
 use crate::schema::FederationSchema;
@@ -237,25 +236,50 @@ impl Subgraph<Initial> {
         Self::new(name, url, schema, orphan_extension_types)
     }
 
-    /// Converts the schema to a fed2 schema.
+    /// Given a schema that is assumed to _not_ be a fed2 schema (it does not have a `@link` to the federation spec),
+    /// converts the schema to a fed2 schema by adding `@link` to the last known federation spec.
+    ///
     /// - It is assumed to have no `@link` to the federation spec.
-    /// - Returns an equivalent subgraph with a `@link` to the auto expanded federation spec.
-    /// - Imports may optionally be omitted.
+    /// - Returns an equivalent subgraph with a `@link` added with latest federation spec.
+    /// - Based on the `include_all_imports` param, we either import ALL directive definitions OR just up to fed v2.4
     /// - This is mainly for testing and not optimized.
     // PORT_NOTE: Corresponds to `asFed2SubgraphDocument` function in JS, but simplified.
-    pub fn into_fed2_test_subgraph(
-        self,
-        use_latest: bool,
-        no_imports: bool,
-    ) -> Result<Self, SubgraphError> {
+    pub fn into_fed2_test_subgraph(self, include_all_imports: bool) -> Result<Self, SubgraphError> {
         let mut schema = self.state.schema;
-        let federation_spec = if use_latest {
-            FederationSpecDefinition::latest()
+        let federation_spec = FederationSpecDefinition::latest();
+        // we cannot use FederationSpecDefinition::add_elements_to_schema as we don't have FederationSchema yet
+        let imports: Vec<Node<Value>> = if include_all_imports {
+            federation_spec
+                .directive_specs()
+                .iter()
+                .map(|d| format!("@{}", d.name()).into())
+                .collect()
         } else {
             FederationSpecDefinition::auto_expanded_federation_spec()
+                .directive_specs()
+                .iter()
+                .map(|d| format!("@{}", d.name()).into())
+                .collect()
         };
-        add_federation_link_to_test_schema(&mut schema, federation_spec.version(), no_imports)
-            .map_err(|e| SubgraphError::new_without_locations(self.name.clone(), e))?;
+
+        schema
+            .schema_definition
+            .make_mut()
+            .directives
+            .push(Component::new(Directive {
+                name: Identity::link_identity().name,
+                arguments: vec![
+                    Node::new(ast::Argument {
+                        name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
+                        value: federation_spec.url().to_string().into(),
+                    }),
+                    Node::new(ast::Argument {
+                        name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
+                        value: Node::new(Value::List(imports)),
+                    }),
+                ],
+            }));
+
         Self::new(
             &self.name,
             &self.url,
@@ -633,7 +657,7 @@ impl<S: HasMetadata> Subgraph<S> {
         self.state.metadata()
     }
 
-    pub(crate) fn schema(&self) -> &FederationSchema {
+    pub fn schema(&self) -> &FederationSchema {
         self.state.schema()
     }
 
@@ -736,54 +760,6 @@ impl<S: HasMetadata> Subgraph<S> {
     }
 }
 
-/// Adds a federation (v2 or above) link directive to the schema.
-/// - Similar to `schema_as_fed2_subgraph`, but the link can be added
-///   before collecting metadata, and imports can be optionally omitted.
-/// - This is mainly for testing.
-fn add_federation_link_to_test_schema(
-    schema: &mut Schema,
-    federation_version: &Version,
-    no_imports: bool,
-) -> Result<(), FederationError> {
-    let federation_spec = FEDERATION_VERSIONS
-        .find(federation_version)
-        .ok_or_else(|| internal_error!(
-            "Subgraph unexpectedly does not use a supported federation spec version. Requested version: {}",
-            federation_version,
-        ))?;
-
-    // Insert `@link(url: "http://specs.apollo.dev/federation/vX.Y", import: ...)`.
-    // - auto import all directives, if requested
-    let imports: Vec<_> = if no_imports {
-        Vec::new()
-    } else {
-        federation_spec
-            .directive_specs()
-            .iter()
-            .map(|d| format!("@{}", d.name()).into())
-            .collect()
-    };
-
-    schema
-        .schema_definition
-        .make_mut()
-        .directives
-        .push(Component::new(Directive {
-            name: Identity::link_identity().name,
-            arguments: vec![
-                Node::new(ast::Argument {
-                    name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
-                    value: federation_spec.url().to_string().into(),
-                }),
-                Node::new(ast::Argument {
-                    name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
-                    value: Node::new(ast::Value::List(imports)),
-                }),
-            ],
-        }));
-    Ok(())
-}
-
 /// Turns a schema without a federation spec link into a federation 2 subgraph schema.
 /// - The schema must not have a federation spec. But, it may have a link spec.
 /// - This is used for fed1-to-fed2 schema upgrading.
@@ -861,7 +837,7 @@ pub(crate) fn schema_as_fed2_subgraph(
                 }),
                 Node::new(ast::Argument {
                     name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
-                    value: Node::new(ast::Value::List(imports)),
+                    value: Node::new(Value::List(imports)),
                 }),
             ],
         }));

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -1412,7 +1412,7 @@ fn generate_subgraph(
 
     Subgraph::parse(name, "", schema.as_str())
         .unwrap()
-        .into_fed2_test_subgraph(true, false)
+        .into_fed2_test_subgraph(true)
         .unwrap()
 }
 

--- a/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
@@ -102,7 +102,7 @@ mod basic_type_extensions {
             .get("subgraphA")
             .expect("Expected subgraphA to be present");
         assert_snapshot!(get_type(subgraph_a_extracted, "Product"), @r#"
-        type Product @key(fields: "sku", resolvable: true) {
+        type Product @key(fields: "sku") {
           sku: String! @shareable
           name: String!
         }
@@ -119,7 +119,7 @@ mod basic_type_extensions {
             .get("subgraphB")
             .expect("Expected subgraphB to be present");
         assert_snapshot!(get_type(subgraph_b_extracted, "Product"), @r#"
-        type Product @key(fields: "sku", resolvable: true) {
+        type Product @key(fields: "sku") {
           sku: String! @shareable
           price: Int!
         }
@@ -177,7 +177,7 @@ mod basic_type_extensions {
             .get("subgraphA")
             .expect("Expected subgraphA to be present");
         assert_snapshot!(get_type(subgraph_a_extracted, "Product"), @r#"
-        type Product @key(fields: "sku", resolvable: true) {
+        type Product @key(fields: "sku") {
           sku: String! @shareable
           price: Int!
         }
@@ -187,7 +187,7 @@ mod basic_type_extensions {
             .get("subgraphB")
             .expect("Expected subgraphB to be present");
         assert_snapshot!(get_type(subgraph_b_extracted, "Product"), @r#"
-        type Product @key(fields: "sku", resolvable: true) {
+        type Product @key(fields: "sku") {
           sku: String! @shareable
           name: String!
         }
@@ -263,7 +263,7 @@ mod basic_type_extensions {
             .get("subgraphA")
             .expect("Expected subgraphA to be present");
         assert_snapshot!(get_type(subgraph_a_extracted, "Product"), @r#"
-        type Product @key(fields: "sku", resolvable: true) {
+        type Product @key(fields: "sku") {
           sku: String! @shareable
           price: Int!
         }
@@ -289,7 +289,7 @@ mod basic_type_extensions {
             .get("subgraphC")
             .expect("Expected subgraphC to be present");
         assert_snapshot!(get_type(subgraph_c_extracted, "Product"), @r#"
-        type Product @key(fields: "sku", resolvable: true) {
+        type Product @key(fields: "sku") {
           sku: String! @shareable
           color: String!
         }

--- a/apollo-federation/tests/composition/compose_tag.rs
+++ b/apollo-federation/tests/composition/compose_tag.rs
@@ -204,7 +204,7 @@ fn tag_propagates_to_supergraph_mixed_fed1_fed2_subgraphs() {
         "#,
     )
     .unwrap()
-    .into_fed2_test_subgraph(true, false)
+    .into_fed2_test_subgraph(true)
     .unwrap();
 
     let supergraph =
@@ -330,7 +330,7 @@ fn tag_merges_multiple_tags_mixed_fed1_fed2_subgraphs() {
           lastName: String @tag(name: "aMergedTagOnField")
         }
         "#,
-    ).unwrap().into_fed2_test_subgraph(true, false).unwrap();
+    ).unwrap().into_fed2_test_subgraph(true).unwrap();
 
     let supergraph =
         compose(vec![subgraph_a, subgraph_b]).expect("Expected composition to succeed");
@@ -452,7 +452,7 @@ fn tag_rejects_tag_and_external_together_mixed_fed1_fed2_subgraphs() {
         "#,
     )
     .unwrap()
-    .into_fed2_test_subgraph(true, false)
+    .into_fed2_test_subgraph(true)
     .unwrap();
 
     let result = compose(vec![subgraph_a, subgraph_b]);

--- a/apollo-federation/tests/composition/demand_control.rs
+++ b/apollo-federation/tests/composition/demand_control.rs
@@ -258,7 +258,7 @@ fn subgraph_with_renamed_cost() -> Subgraph<Initial> {
       scalarWithCost: ExpensiveInt
       objectWithCost: ExpensiveObject
     }
-    "#).unwrap().into_fed2_test_subgraph(false, false).unwrap()
+    "#).unwrap().into_fed2_test_subgraph(false).unwrap()
 }
 
 fn subgraph_with_renamed_listsize() -> Subgraph<Initial> {
@@ -275,7 +275,7 @@ fn subgraph_with_renamed_listsize() -> Subgraph<Initial> {
       fieldWithListSize: [String!] @renamedListSize(assumedSize: 2000, requireOneSlicingArgument: false)
       fieldWithDynamicListSize(first: Int!): HasInts @renamedListSize(slicingArguments: ["first"], sizedFields: ["ints"], requireOneSlicingArgument: true)
     }
-    "#).unwrap().into_fed2_test_subgraph(false, false).unwrap()
+    "#).unwrap().into_fed2_test_subgraph(false).unwrap()
 }
 
 fn subgraph_with_cost_from_federation_spec() -> Subgraph<Initial> {
@@ -309,7 +309,7 @@ fn subgraph_with_cost_from_federation_spec() -> Subgraph<Initial> {
     "#,
     )
     .unwrap()
-    .into_fed2_test_subgraph(true, false)
+    .into_fed2_test_subgraph(true)
     .unwrap()
 }
 
@@ -323,7 +323,7 @@ fn subgraph_with_listsize_from_federation_spec() -> Subgraph<Initial> {
       fieldWithListSize: [String!] @listSize(assumedSize: 2000, requireOneSlicingArgument: false)
       fieldWithDynamicListSize(first: Int!): HasInts @listSize(slicingArguments: ["first"], sizedFields: ["ints"], requireOneSlicingArgument: true)
     }
-    "#).unwrap().into_fed2_test_subgraph(true, false).unwrap()
+    "#).unwrap().into_fed2_test_subgraph(true).unwrap()
 }
 
 fn subgraph_with_renamed_cost_from_federation_spec() -> Subgraph<Initial> {

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -100,7 +100,7 @@ pub(crate) mod test_helpers {
 
         let mut fed2_subgraphs = Vec::new();
         for subgraph in subgraphs {
-            match subgraph.into_fed2_test_subgraph(true, false) {
+            match subgraph.into_fed2_test_subgraph(true) {
                 Ok(subgraph) => fed2_subgraphs.push(subgraph),
                 Err(err) => errors.extend(err.to_composition_errors()),
             }

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema-2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema-2.snap
@@ -73,7 +73,7 @@ type Query {
   _service: _Service!
 }
 
-type Product @key(fields: "sku", resolvable: true) {
+type Product @key(fields: "sku") {
   sku: String! @shareable
   name: String! @external
 }

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema-3.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_basic__doesnt_leave_federation_directives_in_the_final_schema-3.snap
@@ -67,7 +67,7 @@ scalar federation__Policy
 
 scalar federation__ContextFieldValue
 
-type Product @key(fields: "sku", resolvable: true) {
+type Product @key(fields: "sku") {
   sku: String! @shareable
   name: String!
 }

--- a/apollo-federation/tests/composition/supergraph_reversibility.rs
+++ b/apollo-federation/tests/composition/supergraph_reversibility.rs
@@ -13,40 +13,11 @@ fn compose_and_test_reversibility(subgraphs: &[ServiceDefinition<'_>]) {
         .expect("Supergraph schema unexpectedly failed to validate.")
         .extract_subgraphs()
         .expect("Subgraph schemas unexpectedly unable to be extracted from supergraph schema.");
-    for expected_subgraph in subgraphs {
+    for expected in subgraphs {
         let actual_subgraph = actual_subgraphs
-            .get(expected_subgraph.name)
+            .get(expected.name)
             .expect("Expected subgraph name unexpectedly missing from extracted subgraphs.");
 
-        // PORT_NOTE: In the JS version of subgraph extraction, the extracted subgraphs are created
-        // with their `@link` on the schema definition instead of a schema extension (there was no
-        // strong reason for this, it's how the code was written). In the Rust version, `@link` is
-        // instead on a schema extension, as per the code in `new_empty_fed_2_subgraph_schema()`, so
-        // we don't have to work around that here as we did in the JS code.
-        let expected_subgraph =
-            Subgraph::parse(expected_subgraph.name, "", expected_subgraph.type_defs)
-                .expect("Expected subgraph schema unexpectedly failed to parse.")
-                .into_fed2_test_subgraph(
-                    // PORT_NOTE: In the JS code, `asFed2SubgraphDocument()` would always add the
-                    // latest federation spec, and the `includeAllImports` argument would just
-                    // change which directives were imported (fed 2.4's directives or latest). Since
-                    // the JS code's subgraph extraction uses latest fed spec but 2.4's imports, it
-                    // made sense to leave `includeAllImports` as `false` in JS code.
-                    //
-                    // However, this JS subgraph-extraction behavior was due to it reusing code from
-                    // composition (`setSchemaAsFed2Subgraph()`), which uses 2.4's imports to avoid
-                    // directive name collisions with user-defined directives in subgraph schemas.
-                    // For Rust code's subgraph extraction, it uses a separate function entirely
-                    // called `new_empty_fed_2_subgraph_schema()`, which uses no imports for all
-                    // federation directives.
-                    //
-                    // This means we need to specify `use_latest` as `true` here (which causes the
-                    // Rust code to use latest federation spec), but specify `no_imports` as `true`
-                    // to omit all imports.
-                    true, true,
-                )
-                .expect("Expected subgraph schema unexpectedly failed to convert to Fed 2.");
-        let actual_schema = actual_subgraph.schema.schema().clone().into_inner();
         // PORT_NOTE: In the JS code, only `asFed2SubgraphDocument()` is called for the expected
         // schema, so link/federation spec definitions are not expanded, nor are federation
         // operation fields/types added (`Query._entities`, `_Entity`, etc.). This ends up being
@@ -58,15 +29,18 @@ fn compose_and_test_reversibility(subgraphs: &[ServiceDefinition<'_>]) {
         // with differences that indicate bugs. So in the Rust code, we instead use `expand_links()`
         // since it both expands link/federation spec definitions and adds federation operation
         // fields/types.
-        let expected_schema = apollo_compiler::Schema::parse(
-            expected_subgraph
-                .expand_links()
-                .expect("Expected subgraph schema unexpectedly failed @link expansion.")
-                .schema_string(),
-            "expanded.graphql",
-        )
-        .expect("Expanded expected subgraph schema unexpectedly failed to parse.");
+        let expected_subgraph = Subgraph::parse(expected.name, "", expected.type_defs)
+            .expect("Expected subgraph schema unexpectedly failed to parse.")
+            .into_fed2_test_subgraph(false)
+            .expect("Expected subgraph schema unexpectedly failed to convert to Fed 2.")
+            .expand_links()
+            .expect("Expected subgraph schema unexpectedly failed to expand")
+            .assume_validated();
+
+        let actual_schema = actual_subgraph.schema.schema().clone().into_inner();
         let actual_schema = normalize_schema(actual_schema);
+
+        let expected_schema = expected_subgraph.schema().clone().into_inner();
         let expected_schema = normalize_schema(expected_schema);
         assert_eq!(actual_schema.to_string(), expected_schema.to_string())
     }
@@ -75,7 +49,6 @@ fn compose_and_test_reversibility(subgraphs: &[ServiceDefinition<'_>]) {
 mod source_preserving_tests {
     use super::*;
 
-    #[ignore = "until merge implementation completed"]
     #[test]
     fn preserves_the_source_of_union_members() {
         let subgraph_s1 = ServiceDefinition {
@@ -119,7 +92,6 @@ mod source_preserving_tests {
         compose_and_test_reversibility(&[subgraph_s1, subgraph_s2]);
     }
 
-    #[ignore = "until merge implementation completed"]
     #[test]
     fn preserves_the_source_of_enum_members() {
         let subgraph_s1 = ServiceDefinition {
@@ -157,7 +129,6 @@ mod source_preserving_tests {
 mod interface_object_tests {
     use super::*;
 
-    #[ignore = "until merge implementation completed"]
     #[test]
     fn correctly_extract_external_fields_of_concrete_type_only_provided_by_an_interface_object() {
         let subgraph_s1 = ServiceDefinition {

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__can_extract_subgraph.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__can_extract_subgraph.snap
@@ -79,7 +79,7 @@ type S {
   x: Int
 }
 
-type T @key(fields: "k", resolvable: true) {
+type T @key(fields: "k") {
   k: ID @shareable
 }
 
@@ -165,7 +165,7 @@ enum E {
   V2
 }
 
-type T @key(fields: "k", resolvable: true) {
+type T @key(fields: "k") {
   k: ID @shareable
   a: Int
   b: String

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_set_context_directives.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_set_context_directives.snap
@@ -75,13 +75,13 @@ type Query {
   _service: _Service!
 }
 
-type T @key(fields: "id", resolvable: true) @federation__context(name: "context") {
+type T @key(fields: "id") @federation__context(name: "context") {
   id: ID!
   u: U!
   prop: String!
 }
 
-type U @key(fields: "id", resolvable: true) {
+type U @key(fields: "id") {
   id: ID! @shareable
   field(
     a: String @federation__fromContext(field: "$context { prop }"),
@@ -169,7 +169,7 @@ type Query {
   _service: _Service!
 }
 
-type U @key(fields: "id", resolvable: true) {
+type U @key(fields: "id") {
   id: ID! @shareable
 }
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_string_enum_values.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__extracts_string_enum_values.snap
@@ -69,7 +69,7 @@ scalar federation__Policy
 
 scalar federation__ContextFieldValue
 
-type Entity @key(fields: "id", resolvable: true) {
+type Entity @key(fields: "id") {
   id: ID! @shareable
   localField: String! @requires(fields: "requiredField(arg: ENUM_VALUE)")
   requiredField(arg: Enum): String! @external
@@ -160,7 +160,7 @@ scalar federation__Policy
 
 scalar federation__ContextFieldValue
 
-type Entity @key(fields: "id", resolvable: true) {
+type Entity @key(fields: "id") {
   id: ID! @shareable
   requiredField(arg: Enum): String!
 }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert-5.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:1f9c511bd822353fd537e99725b0eac8c8f09014d6a9ce7f3a837949890f0619:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:e434eb6453a0d4c81c8ef191b5d05dcc74d345974e1cf55ce2e40fc9949d3723:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:e378f205221770b789bb48957e4bf0551d12091c855ef0dee1d2edb99f953394:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:user:type:Query:hash:abc9a0757bab1951b8f619ec468d2e57c053908ba4acafb98e5d0b12d26ec057:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:1f9c511bd822353fd537e99725b0eac8c8f09014d6a9ce7f3a837949890f0619:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:e434eb6453a0d4c81c8ef191b5d05dcc74d345974e1cf55ce2e40fc9949d3723:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:e378f205221770b789bb48957e4bf0551d12091c855ef0dee1d2edb99f953394:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:user:type:Query:hash:abc9a0757bab1951b8f619ec468d2e57c053908ba4acafb98e5d0b12d26ec057:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set-5.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:products:type:Query:hash:c70e3fdcf997c1f3d9a76f4a7cdd866130364cf78b0483f6d5d8a85d30047c42:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:products:type:Query:hash:60e1161ef04ff9cdc070ecdbba1e6f449f0da5d184942a9dc2d235de65930dbb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   },
   {
-    "key": "version:1.2:subgraph:users:type:User:entity:3a57ab80cd28b0d17c4d12ae4a72f2fefc3b891797083a20fae029fb48b6f40e:representation:3a57ab80cd28b0d17c4d12ae4a72f2fefc3b891797083a20fae029fb48b6f40e:hash:3f63917e025dc15336030e3160cdc1c917067e0a76b2f50854807f5b18b82a75:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:users:type:User:entity:3a57ab80cd28b0d17c4d12ae4a72f2fefc3b891797083a20fae029fb48b6f40e:representation:3a57ab80cd28b0d17c4d12ae4a72f2fefc3b891797083a20fae029fb48b6f40e:hash:2945088adbfd8361e79df6f41d0b162682a624134a7623373510adf72e17faa2:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_nested_field_set.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:products:type:Query:hash:c70e3fdcf997c1f3d9a76f4a7cdd866130364cf78b0483f6d5d8a85d30047c42:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:products:type:Query:hash:60e1161ef04ff9cdc070ecdbba1e6f449f0da5d184942a9dc2d235de65930dbb:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   },
   {
-    "key": "version:1.2:subgraph:users:type:User:entity:3a57ab80cd28b0d17c4d12ae4a72f2fefc3b891797083a20fae029fb48b6f40e:representation:3a57ab80cd28b0d17c4d12ae4a72f2fefc3b891797083a20fae029fb48b6f40e:hash:3f63917e025dc15336030e3160cdc1c917067e0a76b2f50854807f5b18b82a75:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:users:type:User:entity:3a57ab80cd28b0d17c4d12ae4a72f2fefc3b891797083a20fae029fb48b6f40e:representation:3a57ab80cd28b0d17c4d12ae4a72f2fefc3b891797083a20fae029fb48b6f40e:hash:2945088adbfd8361e79df6f41d0b162682a624134a7623373510adf72e17faa2:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires-5.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:inventory:type:Product:entity:b4b9ed9d4e2f363655b5446f86dc83b506dfcbcea2abae70309aca3f8674ff8b:representation:8dbf201fbd6778142beb28906582c9c09b6fa3e83300d24ab3a1683dfc03f927:hash:ce9749c8bcfa8e74b897e8142e38f083eda526b2d63941bed58009fad6a0249d:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:inventory:type:Product:entity:b4b9ed9d4e2f363655b5446f86dc83b506dfcbcea2abae70309aca3f8674ff8b:representation:8dbf201fbd6778142beb28906582c9c09b6fa3e83300d24ab3a1683dfc03f927:hash:fabd713b0aeb6b2e6977ddc4c0121c05f8d95e04003c33ec045f2ffa5d9178a6:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   },
   {
-    "key": "version:1.2:subgraph:products:type:Query:hash:92924c74fb6bdb8ca0fb4f69e475321bc94872ca3d0f26dce3e58d03e1c11525:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:products:type:Query:hash:996c06587aa50f06000619bfcc9067f120b33b2bfe3b003436dfa2fe4c586335:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "public"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__insert_with_requires.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:inventory:type:Product:entity:b4b9ed9d4e2f363655b5446f86dc83b506dfcbcea2abae70309aca3f8674ff8b:representation:8dbf201fbd6778142beb28906582c9c09b6fa3e83300d24ab3a1683dfc03f927:hash:ce9749c8bcfa8e74b897e8142e38f083eda526b2d63941bed58009fad6a0249d:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:inventory:type:Product:entity:b4b9ed9d4e2f363655b5446f86dc83b506dfcbcea2abae70309aca3f8674ff8b:representation:8dbf201fbd6778142beb28906582c9c09b6fa3e83300d24ab3a1683dfc03f927:hash:fabd713b0aeb6b2e6977ddc4c0121c05f8d95e04003c33ec045f2ffa5d9178a6:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   },
   {
-    "key": "version:1.2:subgraph:products:type:Query:hash:92924c74fb6bdb8ca0fb4f69e475321bc94872ca3d0f26dce3e58d03e1c11525:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:products:type:Query:hash:996c06587aa50f06000619bfcc9067f120b33b2bfe3b003436dfa2fe4c586335:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "public"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-3.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:381c4c8402e09f3588b61dec0234ad703be386abab370226cbf8c94d4d7f554b:representation:381c4c8402e09f3588b61dec0234ad703be386abab370226cbf8c94d4d7f554b:hash:3357df29f751df2486117da280f6dd3f8b82c1e40a1a535281e241ea9a8c7446:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:381c4c8402e09f3588b61dec0234ad703be386abab370226cbf8c94d4d7f554b:representation:381c4c8402e09f3588b61dec0234ad703be386abab370226cbf8c94d4d7f554b:hash:e8c79a4a59643907f2b8552cf96ba8da4beaaf343db5323c6b58557938555b74:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "[REDACTED]"
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:3357df29f751df2486117da280f6dd3f8b82c1e40a1a535281e241ea9a8c7446:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:e8c79a4a59643907f2b8552cf96ba8da4beaaf343db5323c6b58557938555b74:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "cached",
     "cache_control": "[REDACTED]"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:381c4c8402e09f3588b61dec0234ad703be386abab370226cbf8c94d4d7f554b:representation:381c4c8402e09f3588b61dec0234ad703be386abab370226cbf8c94d4d7f554b:hash:3357df29f751df2486117da280f6dd3f8b82c1e40a1a535281e241ea9a8c7446:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:381c4c8402e09f3588b61dec0234ad703be386abab370226cbf8c94d4d7f554b:representation:381c4c8402e09f3588b61dec0234ad703be386abab370226cbf8c94d4d7f554b:hash:e8c79a4a59643907f2b8552cf96ba8da4beaaf343db5323c6b58557938555b74:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "[REDACTED]"
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:3357df29f751df2486117da280f6dd3f8b82c1e40a1a535281e241ea9a8c7446:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:e8c79a4a59643907f2b8552cf96ba8da4beaaf343db5323c6b58557938555b74:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "[REDACTED]"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-3.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-3.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:1f9c511bd822353fd537e99725b0eac8c8f09014d6a9ce7f3a837949890f0619:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:e434eb6453a0d4c81c8ef191b5d05dcc74d345974e1cf55ce2e40fc9949d3723:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:e378f205221770b789bb48957e4bf0551d12091c855ef0dee1d2edb99f953394:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.2:subgraph:user:type:Query:hash:abc9a0757bab1951b8f619ec468d2e57c053908ba4acafb98e5d0b12d26ec057:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-5.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private-5.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:1f9c511bd822353fd537e99725b0eac8c8f09014d6a9ce7f3a837949890f0619:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:e434eb6453a0d4c81c8ef191b5d05dcc74d345974e1cf55ce2e40fc9949d3723:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:e378f205221770b789bb48957e4bf0551d12091c855ef0dee1d2edb99f953394:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.2:subgraph:user:type:Query:hash:abc9a0757bab1951b8f619ec468d2e57c053908ba4acafb98e5d0b12d26ec057:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "cached",
     "cache_control": "private"
   }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__private.snap
@@ -4,12 +4,12 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:1f9c511bd822353fd537e99725b0eac8c8f09014d6a9ce7f3a837949890f0619:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
+    "key": "version:1.2:subgraph:orga:type:Organization:entity:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:representation:c20c68e9284977d48135c025d2cfbe3ba985fece08fb225547def3726abddecc:hash:e434eb6453a0d4c81c8ef191b5d05dcc74d345974e1cf55ce2e40fc9949d3723:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c",
     "status": "new",
     "cache_control": "private"
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:e378f205221770b789bb48957e4bf0551d12091c855ef0dee1d2edb99f953394:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
+    "key": "version:1.2:subgraph:user:type:Query:hash:abc9a0757bab1951b8f619ec468d2e57c053908ba4acafb98e5d0b12d26ec057:data:d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4",
     "status": "new",
     "cache_control": "private"
   }

--- a/apollo-router/src/plugins/connectors/tests/query_plan.rs
+++ b/apollo-router/src/plugins/connectors/tests/query_plan.rs
@@ -137,7 +137,7 @@ async fn basic_batch() {
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "7b3f2d34854be7bb2921b3998892f3f80b0ab8e50cbd5fc5448a5f10a9fd8ac2",
+                    "schemaAwareHash": "489afa7d6cc85a3946cf07392639b37eba1fa020ef98be1b8e81b81303b7cb81",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/src/plugins/progressive_override/snapshots/apollo_router__plugins__progressive_override__tests__non_overridden_field_yields_expected_query_plan.snap
+++ b/apollo-router/src/plugins/progressive_override/snapshots/apollo_router__plugins__progressive_override__tests__non_overridden_field_yields_expected_query_plan.snap
@@ -29,7 +29,7 @@ expression: query_plan
           "inputRewrites": null,
           "outputRewrites": null,
           "contextRewrites": null,
-          "schemaAwareHash": "3df26c52587ce89fed5e1211cea3ea4929820ef3b2ef4b4f20ff6e38ec3bf22a",
+          "schemaAwareHash": "635c2463fc006b45a39cb844c56ca5e1eebe2ffd856c170e4b247b49f7d647e1",
           "authorization": {
             "is_authenticated": false,
             "scopes": [],

--- a/apollo-router/src/plugins/progressive_override/snapshots/apollo_router__plugins__progressive_override__tests__overridden_field_yields_expected_query_plan.snap
+++ b/apollo-router/src/plugins/progressive_override/snapshots/apollo_router__plugins__progressive_override__tests__overridden_field_yields_expected_query_plan.snap
@@ -34,7 +34,7 @@ expression: query_plan
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "fe09d2d5f8236c532fb3b46df78f5a404bdc1e07ae17e8ffdb068349a5fe53a1",
+              "schemaAwareHash": "b487562cf0f4285761235ec1612c54a4120848312f3a3b5362a0676e80facc55",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -73,7 +73,7 @@ expression: query_plan
                 "inputRewrites": null,
                 "outputRewrites": null,
                 "contextRewrites": null,
-                "schemaAwareHash": "c4b1bb71a072d87e28ef1e5ac365b142e7767270d58e0511f58a83351845c40a",
+                "schemaAwareHash": "0e65af5c5b5ad87465b8a237ab2bae9f35d14a2521c8fd50c66023fa260a8e7e",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__already_expired_cache_control-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__already_expired_cache_control-3.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -39,7 +39,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__already_expired_cache_control.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__already_expired_cache_control.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -39,7 +39,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__complex_cache_tag.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__complex_cache_tag.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -37,7 +37,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organizationid-id--1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__failure_mode_reconnect-2.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__failure_mode_reconnect-2.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__failure_mode_reconnect-4.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__failure_mode_reconnect-4.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert-3.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_custom_key-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_custom_key-3.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_custom_key.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_custom_key.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:ecc81b2358c367ea0a3bd386922f484496ab74203218df9ce230e6b7c8dbf28a",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:ecc81b2358c367ea0a3bd386922f484496ab74203218df9ce230e6b7c8dbf28a",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:512b8af55ea384e083ac903edb6c05ea23659dffdde5c97d418e01c986ee3003",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:512b8af55ea384e083ac903edb6c05ea23659dffdde5c97d418e01c986ee3003",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_nested_field_set-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_nested_field_set-3.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:products:type:Query:hash:6cef120d3c4db191469a8d6910bd8446b7100e96138c35ea6e7450f654022b54:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:products:type:Query:hash:18371ae250f46ed39f19887a7f8467ad5ce156505ed6ce3f88ae3196cd9c086e:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "allProducts"
     ],
@@ -44,7 +44,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:users:type:User:representation:e2d4bfa6d172a744110f37cd5227ffb3d146259fe84d19a6c91d8da877373f3e:hash:dbe2bf116d39f492d11e260a6362594c1a1ef3be5548a46aac38aecc5489b79f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:users:type:User:representation:e2d4bfa6d172a744110f37cd5227ffb3d146259fe84d19a6c91d8da877373f3e:hash:7a4c3d64ce911b1d0fedda806fe765e17b142ee246dd35d96cc3596860d0e534:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "user-email:test@test.com-country-a:France"
     ],

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_nested_field_set.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_nested_field_set.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:products:type:Query:hash:6cef120d3c4db191469a8d6910bd8446b7100e96138c35ea6e7450f654022b54:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:products:type:Query:hash:18371ae250f46ed39f19887a7f8467ad5ce156505ed6ce3f88ae3196cd9c086e:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "allProducts"
     ],
@@ -44,7 +44,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:users:type:User:representation:e2d4bfa6d172a744110f37cd5227ffb3d146259fe84d19a6c91d8da877373f3e:hash:dbe2bf116d39f492d11e260a6362594c1a1ef3be5548a46aac38aecc5489b79f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:users:type:User:representation:e2d4bfa6d172a744110f37cd5227ffb3d146259fe84d19a6c91d8da877373f3e:hash:7a4c3d64ce911b1d0fedda806fe765e17b142ee246dd35d96cc3596860d0e534:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "user-email:test@test.com-country-a:France"
     ],

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_requires-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_requires-3.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:inventory:type:Product:representation:fad83d6ff957f12a7829ec7f25a2160d4bd7530abbe47937f19fbed8996d10d9:hash:088b06851766d63aa4892dcb376172efd3789df3a3516738bf49b73bbb0ede31:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:inventory:type:Product:representation:fad83d6ff957f12a7829ec7f25a2160d4bd7530abbe47937f19fbed8996d10d9:hash:362bc60c9505b5a95e347461c4b3813169ea46d19550c04544446e04ef0a2c3f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "product",
       "product-1"
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:products:type:Query:hash:9b7c1cd6867d4e73712201be5cfbc25f1f70cd22e43bfff345a0ea7a61c598c9:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:products:type:Query:hash:f91f57c340fbf2e96b97f41a598f846327c26d5cd5e785924d2ac74c56302009:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "topProducts",
       "topProducts-5"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_requires.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__insert_with_requires.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:inventory:type:Product:representation:fad83d6ff957f12a7829ec7f25a2160d4bd7530abbe47937f19fbed8996d10d9:hash:088b06851766d63aa4892dcb376172efd3789df3a3516738bf49b73bbb0ede31:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:inventory:type:Product:representation:fad83d6ff957f12a7829ec7f25a2160d4bd7530abbe47937f19fbed8996d10d9:hash:362bc60c9505b5a95e347461c4b3813169ea46d19550c04544446e04ef0a2c3f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "product",
       "product-1"
@@ -45,7 +45,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:products:type:Query:hash:9b7c1cd6867d4e73712201be5cfbc25f1f70cd22e43bfff345a0ea7a61c598c9:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:products:type:Query:hash:f91f57c340fbf2e96b97f41a598f846327c26d5cd5e785924d2ac74c56302009:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "topProducts",
       "topProducts-5"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag-3.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -37,7 +37,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag-5.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag-5.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -37,7 +37,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_cache_tag.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -37,7 +37,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type-3.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -37,7 +37,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type-5.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type-5.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -37,7 +37,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__invalidate_by_type.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -37,7 +37,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__no_data-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__no_data-3.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:a48637a963589090a73160f15063c3d2056f48eb1885640c757badca46fb29f1:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:415a9cf5984d3a9e51a84d602498b427a104671ac0554b54e1ae91539213cdbe:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -58,7 +58,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:dd36943dffc63986d2ebbbbe462f28f82aeed57be9a34597175397edcd807c48:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:e79c11239853625087d6039973f03964209ca4bc387feed010c17e80032c5633:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"
@@ -96,7 +96,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:07ea57c08f759cd09342c5a65d5d726fb5930a9796b1ec27a82189e5694dcc2b:hash:dd36943dffc63986d2ebbbbe462f28f82aeed57be9a34597175397edcd807c48:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:07ea57c08f759cd09342c5a65d5d726fb5930a9796b1ec27a82189e5694dcc2b:hash:e79c11239853625087d6039973f03964209ca4bc387feed010c17e80032c5633:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-3"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__no_data.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__no_data.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:a48637a963589090a73160f15063c3d2056f48eb1885640c757badca46fb29f1:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:415a9cf5984d3a9e51a84d602498b427a104671ac0554b54e1ae91539213cdbe:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -54,7 +54,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:dd36943dffc63986d2ebbbbe462f28f82aeed57be9a34597175397edcd807c48:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:e79c11239853625087d6039973f03964209ca4bc387feed010c17e80032c5633:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"
@@ -96,7 +96,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:07ea57c08f759cd09342c5a65d5d726fb5930a9796b1ec27a82189e5694dcc2b:hash:dd36943dffc63986d2ebbbbe462f28f82aeed57be9a34597175397edcd807c48:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:07ea57c08f759cd09342c5a65d5d726fb5930a9796b1ec27a82189e5694dcc2b:hash:e79c11239853625087d6039973f03964209ca4bc387feed010c17e80032c5633:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-3"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-11.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-11.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -43,7 +43,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -76,7 +76,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-3.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -43,7 +43,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -76,7 +76,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-5.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-5.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -44,7 +44,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -78,7 +78,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-7.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-7.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -43,7 +43,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -76,7 +76,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-9.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public-9.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -44,7 +44,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -78,7 +78,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__polymorphic_private_and_public.snap
@@ -5,7 +5,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -45,7 +45,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -79,7 +79,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_and_public-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_and_public-3.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -44,7 +44,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -78,7 +78,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_and_public-5.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_and_public-5.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:e5f2f41088e29e53b255bb3555658905ddbabeefa5b37f6aa36f7e102511df2c",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:e5f2f41088e29e53b255bb3555658905ddbabeefa5b37f6aa36f7e102511df2c",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -44,7 +44,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -78,7 +78,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:e5f2f41088e29e53b255bb3555658905ddbabeefa5b37f6aa36f7e102511df2c",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:e5f2f41088e29e53b255bb3555658905ddbabeefa5b37f6aa36f7e102511df2c",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_and_public.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_and_public.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:orga:type:Query:hash:d35ab9932f8d927bca1670869f7d2d7e0f50b2713eaaae8ed35f732dd56bdc0f:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Query:hash:ecb60e7b7532188345c92d38694462036d11b95b414d0e70830e1d4d091b1caa:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [],
     "kind": {
       "rootFields": [
@@ -44,7 +44,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -78,7 +78,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_only-3.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_only-3.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_only-5.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_only-5.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:e5f2f41088e29e53b255bb3555658905ddbabeefa5b37f6aa36f7e102511df2c",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:e5f2f41088e29e53b255bb3555658905ddbabeefa5b37f6aa36f7e102511df2c",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:e5f2f41088e29e53b255bb3555658905ddbabeefa5b37f6aa36f7e102511df2c",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:e5f2f41088e29e53b255bb3555658905ddbabeefa5b37f6aa36f7e102511df2c",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_only.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_only.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -38,7 +38,7 @@ expression: cache_keys
     "warnings": []
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6:cde13a55f41e387480391c47238acfe9c0136dd56bf365b01416aec03eec7dc4",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_without_private_id.snap
+++ b/apollo-router/src/plugins/response_cache/snapshots/apollo_router__plugins__response_cache__tests__private_without_private_id.snap
@@ -4,7 +4,7 @@ expression: cache_keys
 ---
 [
   {
-    "key": "version:1.2:subgraph:user:type:Query:hash:28b266db81d489af7f4258f068b1e8d1ecaebbe7a06abf9c349c3590854c55eb:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:user:type:Query:hash:fc555f3f265988de90b287f312c77672cd2a07fafb57a74b6da284bf74de9d67:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "currentUser"
     ],
@@ -52,7 +52,7 @@ expression: cache_keys
     ]
   },
   {
-    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:cb99f72ceadbe4d108e24dbed6ee054b21ad131ec31ac1d8ad06f382999a2de2:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
+    "key": "version:1.2:subgraph:orga:type:Organization:representation:f6e8c0c4f36d6c0d11330be52b76316559e0390ff75fd002ed3fa73f9b6470f7:hash:9eca86265c1d56b08f7950048e8644af3524940e4bb4cba6f37feac0db0ddd24:data:070af9367f9025bd796a1b7e0cd1335246f658aa4857c3a4d6284673b7d07fa6",
     "invalidationKeys": [
       "organization",
       "organization-1"

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__query_planner_service__tests__plan_root.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__query_planner_service__tests__plan_root.snap
@@ -15,7 +15,7 @@ Fetch(
         output_rewrites: None,
         context_rewrites: None,
         schema_aware_hash: QueryHash(
-            "43b1dcf44a933ed21f3cef20c67b41490e8bbb8fb5cd43613aa52e937d5f280b",
+            "85c3a9b70e06cc27df05588a9af20b382300cf9fbc62fb45f58fd46fb71dfe1b",
         ),
         authorization: CacheKeyMetadata {
             is_authenticated: false,

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__query_planner_cache.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__query_planner_cache.snap
@@ -13,7 +13,7 @@ expression: query_plan
   "inputRewrites": null,
   "outputRewrites": null,
   "contextRewrites": null,
-  "schemaAwareHash": "35e33c42dfe91a9ff414a66326d4e7f34399dacea11fb412f9e33322110d5985",
+  "schemaAwareHash": "c54d447bfd2509e7cee6f3cd26db134ab546da630ed247570d688fc96ac02b8f",
   "authorization": {
     "is_authenticated": false,
     "scopes": [],

--- a/apollo-router/tests/snapshots/set_context__set_context_dependent_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_dependent_fetch_failure_rust_qp.snap
@@ -43,7 +43,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_fetch_dependent_failure__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "689a2cba0e44ead33729df1369f0d789cbf96cd4071ea468d10f87a9dee902ea",
+              "schemaAwareHash": "f0e14cb6540565b336bcbe39d2b3730ca0cf1a945aa66671a03bb2dbb8fbe481",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -89,7 +89,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "6c0bfe286189c017860c8f4c41179d32f05d5ff3d8a40c06b3ed24de7236a4a0",
+                "schemaAwareHash": "65f66d600a9bfc9d0438800b97ba2223298967a7eca073d2a0cf251856a9022e",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_list_of_lists_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_list_of_lists_rust_qp.snap
@@ -44,7 +44,7 @@ expression: response
               "operationKind": "query",
               "operationName": "QueryLL__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "c5700a7156d222bc67ede39294b9fd579c7341d0fec0e528357d1306cc48e732",
+              "schemaAwareHash": "fa7ee8508f3a928946d8686baea705fa20f3da0ae3f98eda43e584dfcf041321",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -90,7 +90,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "7a97b3c078a91a902738187d64133a78f6c40639b4598194b40a2ef03f3d25f8",
+                "schemaAwareHash": "7ddc40dce696114db612aa2b13c69aedf361745da8c10c9365271a72ac39f50c",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_list_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_list_rust_qp.snap
@@ -40,7 +40,7 @@ expression: response
               "operationKind": "query",
               "operationName": "set_context_list_rust_qp__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "f1c1a82ad91db3fba6e30901fb71ee742e2fa1f20c801a3c228f14798e8d3ca6",
+              "schemaAwareHash": "f1e7180846cfcf883471ba8ceff1c7b69734032b7eb0f1c94134ab7300508386",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -86,7 +86,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "fc3723ba972418f164bc92e7bb54ba554030ecf326467200de69690f61c08301",
+                "schemaAwareHash": "17d521466732e5dbbd8cd172f8584fdef09de40ff60367c543bf4ef4dd02d1dd",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_no_typenames_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_no_typenames_rust_qp.snap
@@ -32,7 +32,7 @@ expression: response
               "operationKind": "query",
               "operationName": "set_context_no_typenames_rust_qp__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "f18888d822a9e8371a35a0c1276be02effaafaf3523e71347c9c357ddbd15539",
+              "schemaAwareHash": "e33ac46285a71f4b903afcda6815769bc70dbd4c13b7f139673df7510a56c21f",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -78,7 +78,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "2977db13372b02881106dbc6b346e6f18a6393f6fd6f1e63d2751068a6de821b",
+                "schemaAwareHash": "72ec724c7612dc491610749a53c51832a28321810e4b1381e025909b8d863b90",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_rust_qp.snap
@@ -34,7 +34,7 @@ expression: response
               "operationKind": "query",
               "operationName": "set_context_rust_qp__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "9be408019a4baf09d2d130f96d81a9193ce5a73fbcceabaedf04602de1caa267",
+              "schemaAwareHash": "d91188a21fe36cb1dcd82366b868b9c5dae1d6664078426c0688a89dbe9aad3d",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -80,7 +80,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "2f6aaeb9f01ede9acda2e88176e0dd85ab8a6b00053eb500077f71c3b437ee34",
+                "schemaAwareHash": "53aeb7311862c70ba5248a107c21f74c05113917142a864668791ed6b7e4bcb9",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_type_mismatch_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_type_mismatch_rust_qp.snap
@@ -32,7 +32,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_type_mismatch__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "f0bd2bbbff33df8999fbf2e55b0b22be4e3a6956f15a44c6b27b4d479704035c",
+              "schemaAwareHash": "e1e24d3daa8cf818ef1be20c292f2cb850bf166b7274efcff9fab40004113ae7",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -78,7 +78,7 @@ expression: response
                     "typeCondition": "U"
                   }
                 ],
-                "schemaAwareHash": "dd24edddbb58e815dd5f798051829dda822dd60967283cc0f914371dcc1d0254",
+                "schemaAwareHash": "410abd839d0bd0deec97bb0382cb6582fedd53619cd5a9395aaac961344caef1",
                 "serviceName": "Subgraph1",
                 "variableUsages": [
                   "contextualArgument_1_0"

--- a/apollo-router/tests/snapshots/set_context__set_context_union_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_union_rust_qp.snap
@@ -31,7 +31,7 @@ expression: response
               "operationKind": "query",
               "operationName": "QueryUnion__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "6ac4df98e1da2a917064b11ac5dc386e3626975b367f87fd0b52a1b694ca7daf",
+              "schemaAwareHash": "5c13e12c4c3100ab79c2796a07f401c3189473fc3e471400992dbbf82106d968",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -80,7 +80,7 @@ expression: response
                         "typeCondition": "V"
                       }
                     ],
-                    "schemaAwareHash": "53894500c05a6f85b3bdf743fe0386838c424d7e28fb3a8435e87bd0d5d8823d",
+                    "schemaAwareHash": "d473439a4714eaaf43ccf1592668249ccc235f510b9386a5d5fb5d6c61ab5e82",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_1"
@@ -133,7 +133,7 @@ expression: response
                         "typeCondition": "V"
                       }
                     ],
-                    "schemaAwareHash": "f8656fdcf2f9d8efaba8445386e079d70c15aa16424056106c0673b955831207",
+                    "schemaAwareHash": "9f5d336d951f7955a171b507793f6355d4c9f7822dd86f7d4ad80bac70554f00",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_1"

--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
@@ -56,7 +56,7 @@ expression: response
               "operationKind": "query",
               "operationName": "Query_fetch_failure__Subgraph1__0",
               "outputRewrites": null,
-              "schemaAwareHash": "59de1ca7a3f7b1efd826522562c3ada56d414f3a73d88e4e49d950d7e5a155d8",
+              "schemaAwareHash": "33127d70f901f74c5c3e0a8d54cc09574e9e9ea070a1986e8ccdefc3fabd7c75",
               "serviceName": "Subgraph1",
               "variableUsages": []
             },
@@ -105,7 +105,7 @@ expression: response
                         "typeCondition": "U"
                       }
                     ],
-                    "schemaAwareHash": "c6d59fdec473386885e8775f6cc239cf3f611416823ee0db1ac065ccc302d213",
+                    "schemaAwareHash": "c9a77e0dbd1a6600ed64b632761485f269586c09bf219bea869cde3feec07570",
                     "serviceName": "Subgraph1",
                     "variableUsages": [
                       "contextualArgument_1_0"
@@ -148,7 +148,7 @@ expression: response
                         "typeCondition": "U"
                       }
                     ],
-                    "schemaAwareHash": "eca8c1506ddde5b8c329958bdf091c3d9b1a542faa3a42e083036b15e48e63dd",
+                    "schemaAwareHash": "a7fb7bb5c32f9245353202a30e125bd1ceeb262cbe2d45d691d915edf0c850f5",
                     "serviceName": "Subgraph2",
                     "variableUsages": []
                   },

--- a/apollo-router/tests/snapshots/set_context__set_context_with_null_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_with_null_rust_qp.snap
@@ -29,7 +29,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "31aed43b6b02c1700b9d50d53d09c0798e27b5998e3642e4b0f95b26bc489843",
+              "schemaAwareHash": "393aa8072ac5d5cb425deaba92eca56bc2798169173794474d0c40f472565774",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -81,7 +81,7 @@ expression: response
                     "renameKeyTo": "contextualArgument_1_0"
                   }
                 ],
-                "schemaAwareHash": "e35a9136027e8cf738fe4e89cec3e9062e513dbcaf32099caafd9cc71b8a3f9a",
+                "schemaAwareHash": "dd70cb0c18ef99ef06d162b87dd0fd3376454b34db16fe656929a3b1bc881c73",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_disabled.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_disabled.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "cf4dbace471d6b19d713b6d5d0f30180b9fec475edd3f046d26f818a955ec01b",
+              "schemaAwareHash": "3d9de90087e0d24d00bba3ef29664ba92f4fcb9c77e2c040d245c53c0631fc54",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -137,7 +137,7 @@ expression: response
                 "inputRewrites": null,
                 "outputRewrites": null,
                 "contextRewrites": null,
-                "schemaAwareHash": "48781ce465de749eeea584db1e1ddb566be88ef80f2434b342d5ccfce1c6d3ff",
+                "schemaAwareHash": "6138338531b37323f80b07db26099a3a75a5df564ed0d5c5a74a2851593152c5",
                 "authorization": {
                   "is_authenticated": false,
                   "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "cf4dbace471d6b19d713b6d5d0f30180b9fec475edd3f046d26f818a955ec01b",
+              "schemaAwareHash": "3d9de90087e0d24d00bba3ef29664ba92f4fcb9c77e2c040d245c53c0631fc54",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -140,7 +140,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3b4cd9ac5b19d06871b344e9551aaf048b967aed2101dbf5e131c498b94323d1",
+                    "schemaAwareHash": "c1dae6527eb9aabe352aee030417c69a1a7bbe68e3ae119b602fc16bd44c10f4",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -199,7 +199,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "b11ae96b5277a110b632830fc36019ab9214926868850ab3f1464a77f6e7be68",
+                    "schemaAwareHash": "08a0ce7247cb6b75fbd0666745de8d9364b470c32acd6d33afe5366194be7193",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_generate_query_fragments.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_generate_query_fragments.snap
@@ -79,7 +79,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "cf4dbace471d6b19d713b6d5d0f30180b9fec475edd3f046d26f818a955ec01b",
+              "schemaAwareHash": "3d9de90087e0d24d00bba3ef29664ba92f4fcb9c77e2c040d245c53c0631fc54",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -140,7 +140,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3b4cd9ac5b19d06871b344e9551aaf048b967aed2101dbf5e131c498b94323d1",
+                    "schemaAwareHash": "c1dae6527eb9aabe352aee030417c69a1a7bbe68e3ae119b602fc16bd44c10f4",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -199,7 +199,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "b11ae96b5277a110b632830fc36019ab9214926868850ab3f1464a77f6e7be68",
+                    "schemaAwareHash": "08a0ce7247cb6b75fbd0666745de8d9364b470c32acd6d33afe5366194be7193",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list.snap
@@ -141,7 +141,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "82fb1cc5853a8b090805124d7df8c42f0b373650133e2f7930b3a272a838c320",
+              "schemaAwareHash": "e5e3404432427e92bb683b992e611e63623f7e9682fd6dcdab354bfa208fe681",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -203,7 +203,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3b4cd9ac5b19d06871b344e9551aaf048b967aed2101dbf5e131c498b94323d1",
+                    "schemaAwareHash": "c1dae6527eb9aabe352aee030417c69a1a7bbe68e3ae119b602fc16bd44c10f4",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -263,7 +263,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "b11ae96b5277a110b632830fc36019ab9214926868850ab3f1464a77f6e7be68",
+                    "schemaAwareHash": "08a0ce7247cb6b75fbd0666745de8d9364b470c32acd6d33afe5366194be7193",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list_of_list.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_list_of_list_of_list.snap
@@ -145,7 +145,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "a16d6c6da1c24186a6f11a5d656782683f8e54720003af6fb4e66b4ceb972e31",
+              "schemaAwareHash": "9f786b214f45202f9a6e762e33762e98ae00b91437a754e0cd96c7beb739f10c",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -208,7 +208,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3b4cd9ac5b19d06871b344e9551aaf048b967aed2101dbf5e131c498b94323d1",
+                    "schemaAwareHash": "c1dae6527eb9aabe352aee030417c69a1a7bbe68e3ae119b602fc16bd44c10f4",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -269,7 +269,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "b11ae96b5277a110b632830fc36019ab9214926868850ab3f1464a77f6e7be68",
+                    "schemaAwareHash": "08a0ce7247cb6b75fbd0666745de8d9364b470c32acd6d33afe5366194be7193",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],

--- a/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_shouldnt_make_article_fetch.snap
+++ b/apollo-router/tests/snapshots/type_conditions___test_type_conditions_enabled_shouldnt_make_article_fetch.snap
@@ -54,7 +54,7 @@ expression: response
               "inputRewrites": null,
               "outputRewrites": null,
               "contextRewrites": null,
-              "schemaAwareHash": "e831eacac3f78048092e7f76d5827ac569be98dbbb5a8a997380d20eb0991dfb",
+              "schemaAwareHash": "0ad30ced2388097455f8b88a3ffd7792c627f1de4f4e87b4286133f54191ca09",
               "authorization": {
                 "is_authenticated": false,
                 "scopes": [],
@@ -115,7 +115,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "3b4cd9ac5b19d06871b344e9551aaf048b967aed2101dbf5e131c498b94323d1",
+                    "schemaAwareHash": "c1dae6527eb9aabe352aee030417c69a1a7bbe68e3ae119b602fc16bd44c10f4",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],
@@ -174,7 +174,7 @@ expression: response
                     "inputRewrites": null,
                     "outputRewrites": null,
                     "contextRewrites": null,
-                    "schemaAwareHash": "b11ae96b5277a110b632830fc36019ab9214926868850ab3f1464a77f6e7be68",
+                    "schemaAwareHash": "08a0ce7247cb6b75fbd0666745de8d9364b470c32acd6d33afe5366194be7193",
                     "authorization": {
                       "is_authenticated": false,
                       "scopes": [],


### PR DESCRIPTION
Enable previously ignored tests.

Updates `Subgraph<Initial>::into_fed2_test_subgraph` logic to match JS `asFed2SubgraphDocument` logic ([link](https://github.com/apollographql/federation/blob/main/internals-js/src/federation.ts#L1984)] to always apply latest Fed spec version but either include ALL imports or just Fed 2.4.

<!-- [FED-838] -->

[FED-838]: https://apollographql.atlassian.net/browse/FED-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ