### PR TITLE
deps: update thin-vec to address RUSTSEC-2026-0103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6732,9 +6732,9 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0103

thin-vec is a dependency of Rhai. There can be a use-after-free in
iterator usage or a double-free in general if an element's `Drop` impl
panics. I doubt we're affected but it wouldn't be inconceivable that the
second one would be triggered by a malicious Rhai script or something?
