### PR TITLE
chore: fix linter with new rust 1.95.0

### DIFF
--- a/apollo-federation/src/connectors/validation/schema.rs
+++ b/apollo-federation/src/connectors/validation/schema.rs
@@ -514,7 +514,7 @@ impl<'walker> ShapeVisitor for SelectionSetWalker<'walker> {
             let mut nested = SelectionSetWalker::new(self.name.clone(), self.schema, sub_selection);
             next_shape.visit_shape(&mut nested)?;
             self.unmapped_fields
-                .extend(nested.unmapped_fields.into_iter());
+                .extend(nested.unmapped_fields);
         }
         Ok(())
     }

--- a/apollo-federation/src/connectors/validation/schema.rs
+++ b/apollo-federation/src/connectors/validation/schema.rs
@@ -513,8 +513,7 @@ impl<'walker> ShapeVisitor for SelectionSetWalker<'walker> {
             // Continue walking with nested selection sets
             let mut nested = SelectionSetWalker::new(self.name.clone(), self.schema, sub_selection);
             next_shape.visit_shape(&mut nested)?;
-            self.unmapped_fields
-                .extend(nested.unmapped_fields);
+            self.unmapped_fields.extend(nested.unmapped_fields);
         }
         Ok(())
     }

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -337,7 +337,7 @@ impl NormalizedTypeCondition {
         for ty in &types {
             let pos = schema.get_type(ty.clone())?.try_into()?;
             let pos_types = schema.possible_runtime_types(pos)?;
-            ground_types.extend(pos_types.into_iter());
+            ground_types.extend(pos_types);
         }
         if ground_types.is_empty() {
             return Ok(None);

--- a/apollo-federation/src/correctness/subgraph_constraint.rs
+++ b/apollo-federation/src/correctness/subgraph_constraint.rs
@@ -103,7 +103,7 @@ impl<'a> SubgraphConstraint<'a> {
                 {
                     let ground_set = subgraph_schema.possible_runtime_types(composite_type)?;
                     possible_subgraphs.insert(subgraph_name.clone());
-                    subgraph_types.extend(ground_set.into_iter());
+                    subgraph_types.extend(ground_set);
                 }
             }
         }

--- a/apollo-federation/src/error/suggestion.rs
+++ b/apollo-federation/src/error/suggestion.rs
@@ -22,7 +22,7 @@ pub(crate) fn suggestion_list(
             result.push((option, distance));
         }
     }
-    result.sort_by(|x, y| x.1.cmp(&y.1));
+    result.sort_by_key(|x| x.1);
     result.into_iter().map(|(s, _)| s.to_string()).collect()
 }
 

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1927,17 +1927,15 @@ impl SelectionSet {
         ) {
             for selection in selection_set.selections.values() {
                 match selection {
-                    Selection::InlineFragment(inline_fragment) => {
-                        if inline_fragment.is_unnecessary(parent_type, schema) {
-                            process_selection_set(
-                                &inline_fragment.selection_set,
-                                final_selections,
-                                parent_type,
-                                schema,
-                            );
-                        } else {
-                            final_selections.push(selection.clone());
-                        }
+                    Selection::InlineFragment(inline_fragment)
+                        if inline_fragment.is_unnecessary(parent_type, schema) =>
+                    {
+                        process_selection_set(
+                            &inline_fragment.selection_set,
+                            final_selections,
+                            parent_type,
+                            schema,
+                        );
                     }
                     _ => {
                         final_selections.push(selection.clone());

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -1177,27 +1177,24 @@ where
                             return Ok::<_, FederationError>(true);
                         }
                         match &parent_type_in_supergraph {
-                            CompositeTypeDefinitionPosition::Object(parent_type_in_supergraph) => {
+                            CompositeTypeDefinitionPosition::Object(parent_type_in_supergraph)
                                 if parent_type_in_supergraph
                                     .get(supergraph_schema.schema())?
                                     .implements_interfaces
                                     .iter()
-                                    .any(|item| &item.name == pos.type_name())
-                                {
-                                    return Ok(true);
-                                }
+                                    .any(|item| &item.name == pos.type_name()) =>
+                            {
+                                return Ok(true);
                             }
                             CompositeTypeDefinitionPosition::Interface(
                                 parent_type_in_supergraph,
-                            ) => {
-                                if parent_type_in_supergraph
-                                    .get(supergraph_schema.schema())?
-                                    .implements_interfaces
-                                    .iter()
-                                    .any(|item| &item.name == pos.type_name())
-                                {
-                                    return Ok(true);
-                                }
+                            ) if parent_type_in_supergraph
+                                .get(supergraph_schema.schema())?
+                                .implements_interfaces
+                                .iter()
+                                .any(|item| &item.name == pos.type_name()) =>
+                            {
+                                return Ok(true);
                             }
                             _ => {}
                         }

--- a/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
@@ -724,9 +724,7 @@ pub(crate) fn precompute_non_local_selection_metadata(
             .get_mut(node_type_pos.type_name())
             && options_metadata.same_type_options.contains(&node)
         {
-            options_metadata
-                .interface_object_options
-                .extend(options);
+            options_metadata.interface_object_options.extend(options);
             continue;
         }
         metadata

--- a/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
@@ -726,7 +726,7 @@ pub(crate) fn precompute_non_local_selection_metadata(
         {
             options_metadata
                 .interface_object_options
-                .extend(options.into_iter());
+                .extend(options);
             continue;
         }
         metadata

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -1778,45 +1778,37 @@ fn remove_unused_types_from_subgraph(schema: &mut FederationSchema) -> Result<()
     let mut type_definition_positions: Vec<TypeDefinitionPosition> = Vec::new();
     for (type_name, type_) in schema.schema().types.iter() {
         match type_ {
-            ExtendedType::Object(type_) => {
-                if type_.fields.is_empty() {
-                    type_definition_positions.push(
-                        ObjectTypeDefinitionPosition {
-                            type_name: type_name.clone(),
-                        }
-                        .into(),
-                    );
-                }
+            ExtendedType::Object(type_) if type_.fields.is_empty() => {
+                type_definition_positions.push(
+                    ObjectTypeDefinitionPosition {
+                        type_name: type_name.clone(),
+                    }
+                    .into(),
+                );
             }
-            ExtendedType::Interface(type_) => {
-                if type_.fields.is_empty() {
-                    type_definition_positions.push(
-                        InterfaceTypeDefinitionPosition {
-                            type_name: type_name.clone(),
-                        }
-                        .into(),
-                    );
-                }
+            ExtendedType::Interface(type_) if type_.fields.is_empty() => {
+                type_definition_positions.push(
+                    InterfaceTypeDefinitionPosition {
+                        type_name: type_name.clone(),
+                    }
+                    .into(),
+                );
             }
-            ExtendedType::Union(type_) => {
-                if type_.members.is_empty() {
-                    type_definition_positions.push(
-                        UnionTypeDefinitionPosition {
-                            type_name: type_name.clone(),
-                        }
-                        .into(),
-                    );
-                }
+            ExtendedType::Union(type_) if type_.members.is_empty() => {
+                type_definition_positions.push(
+                    UnionTypeDefinitionPosition {
+                        type_name: type_name.clone(),
+                    }
+                    .into(),
+                );
             }
-            ExtendedType::InputObject(type_) => {
-                if type_.fields.is_empty() {
-                    type_definition_positions.push(
-                        InputObjectTypeDefinitionPosition {
-                            type_name: type_name.clone(),
-                        }
-                        .into(),
-                    );
-                }
+            ExtendedType::InputObject(type_) if type_.fields.is_empty() => {
+                type_definition_positions.push(
+                    InputObjectTypeDefinitionPosition {
+                        type_name: type_name.clone(),
+                    }
+                    .into(),
+                );
             }
             _ => {}
         }

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -451,7 +451,7 @@ pub(super) fn search_jwks(
     } else {
         // Only sort if we need to
         if candidates.len() > 1 {
-            candidates.sort_by(|a, b| a.0.cmp(&b.0));
+            candidates.sort_by_key(|a| a.0);
         }
 
         if found_highest_score {

--- a/apollo-router/src/plugins/response_cache/storage/redis.rs
+++ b/apollo-router/src/plugins/response_cache/storage/redis.rs
@@ -362,7 +362,7 @@ impl CacheStorage for Storage {
 
         // phase 3
         let pipeline = self.storage.client().pipeline().with_options(&options);
-        for (document, cache_tags) in batch_docs.into_iter().zip(original_cache_tags.into_iter()) {
+        for (document, cache_tags) in batch_docs.into_iter().zip(original_cache_tags) {
             let value = CacheValue {
                 data: document.data,
                 cache_control: document.control,

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -300,7 +300,7 @@ where
 
         all_cache_keys.shuffle(&mut rand::rng());
 
-        all_cache_keys.extend(cache_keys.into_iter());
+        all_cache_keys.extend(cache_keys);
 
         let mut count = 0usize;
         let mut reused = 0usize;

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -157,7 +157,7 @@ impl PlanNode {
                                 .in_current_span()
                                 .await;
                             value.type_aware_deep_merge(v, parameters.schema);
-                            errors.extend(err.into_iter());
+                            errors.extend(err);
                         }
                     }
                     .instrument(tracing::info_span!(
@@ -185,7 +185,7 @@ impl PlanNode {
 
                         while let Some((v, err)) = stream.next().in_current_span().await {
                             value.type_aware_deep_merge(v, parameters.schema);
-                            errors.extend(err.into_iter());
+                            errors.extend(err);
                         }
                     }
                     .instrument(tracing::info_span!(
@@ -414,7 +414,7 @@ impl PlanNode {
                                 ))
                                 .await;
                             value.type_aware_deep_merge(v, parameters.schema);
-                            errors.extend(err.into_iter());
+                            errors.extend(err);
 
                             let _ = primary_sender.send((value.clone(), errors.clone()));
                         } else {
@@ -462,7 +462,7 @@ impl PlanNode {
                                     ))
                                     .await;
                                 value.type_aware_deep_merge(v, parameters.schema);
-                                errors.extend(err.into_iter());
+                                errors.extend(err);
                             } else if current_dir.is_empty() {
                                 // If the condition is on the root selection set and it's the only one
                                 // For queries like {get @skip(if: true) {id name}}
@@ -482,7 +482,7 @@ impl PlanNode {
                                 ))
                                 .await;
                             value.type_aware_deep_merge(v, parameters.schema);
-                            errors.extend(err.into_iter());
+                            errors.extend(err);
                         } else if current_dir.is_empty() {
                             // If the condition is on the root selection set and it's the only one
                             // For queries like {get @include(if: false) {id name}}
@@ -569,7 +569,7 @@ impl DeferredNode {
                     // will not happen
                     if let Some(Ok((deferred_value, err))) = v {
                         value.type_aware_deep_merge(deferred_value, &sc);
-                        errors.extend(err.into_iter())
+                        errors.extend(err)
                     }
                 }
             }

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -420,7 +420,7 @@ impl Response {
                 let res = body.next().await.and_then(|res| res.ok());
 
                 Either::Right(
-                    futures::stream::iter(res.into_iter())
+                    futures::stream::iter(res)
                         .map(|bytes| serde_json::from_slice::<graphql::Response>(&bytes)),
                 )
             },

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # renovate-automation: rustc version
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Fixes clippy failures introduced by the Rust 1.95.0 upgrade ([#9224](https://github.com/apollographql/router/pull/9224)).

Changes:
- Bump `rust-toolchain.toml` to `1.95.0`
- Fix `clippy::useless_conversion`: remove redundant `.into_iter()` calls on arguments to `extend()`, `zip()`, and `futures::stream::iter()` across `apollo-federation` and `apollo-router`
- Fix `clippy::unnecessary_sort_by`: replace `sort_by(|a, b| a.x.cmp(&b.x))` with `sort_by_key(|a| a.x)` in `apollo-federation/src/error/suggestion.rs` and `apollo-router/src/plugins/authentication/jwks.rs`
- Fix `clippy::collapsible_match`: fold `if` blocks inside match arms into match guards in `operation/mod.rs`, `graph_path.rs`, and `supergraph/mod.rs`

## Test plan

- [ ] `cargo clippy --all --all-targets --all-features --no-deps -- -D warnings` passes with no errors
- [ ] `RUSTDOCFLAGS="-Dwarnings" cargo doc --all --no-deps` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)