### PR TITLE
fix(composition): handle missing directive definitions for older fed versions

### DIFF
--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -656,9 +656,12 @@ impl Merger {
                     &REQUIRES_SCOPES_DIRECTIVE_NAME_IN_SPEC,
                     &POLICY_DIRECTIVE_NAME_IN_SPEC,
                 ] {
-                    if let Some(directive) = federation_spec
-                        .directive_definition(subgraph.schema(), access_control_directive)?
-                    {
+                    let directive = federation_spec
+                        .directive_name_in_schema(subgraph.schema(), access_control_directive)?
+                        .and_then(|name| {
+                            subgraph.schema().schema().directive_definitions.get(&name)
+                        });
+                    if let Some(directive) = directive {
                         let referencers = subgraph_referencers.get_directive(&directive.name);
                         for type_position in &referencers.object_types {
                             // we will be propagating access control from objects up to the interfaces

--- a/apollo-federation/src/schema/validators/access_control.rs
+++ b/apollo-federation/src/schema/validators/access_control.rs
@@ -129,24 +129,30 @@ pub(crate) fn validate_transitive_access_control_requirements_in_the_supergraph(
             );
         }
 
-        let from_context_directive_name = &subgraph
-            .metadata()
-            .federation_spec_definition()
-            .from_context_directive_definition(subgraph.schema())?
-            .name;
-        let from_context_referencers = subgraph
-            .schema()
-            .referencers()
-            .get_directive(from_context_directive_name);
-        // @fromContext should only be present in the subgraphs on the object field arguments
-        // but in the supergraph it can be either on object field or interface (object) field
-        for argument in &from_context_referencers.object_field_arguments {
-            fields_with_from_context.insert(
-                ObjectOrInterfaceTypeDefinitionPosition::try_from(
-                    supergraph_schema.get_type(argument.type_name.clone())?,
-                )?
-                .field(argument.field_name.clone()),
-            );
+        let federation_spec = subgraph.metadata().federation_spec_definition();
+        let from_context_directive = federation_spec
+            .directive_name_in_schema(
+                subgraph.schema(),
+                &crate::link::federation_spec_definition::FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC,
+            )?
+            .and_then(|name| {
+                subgraph.schema().schema().directive_definitions.get(&name)
+            });
+        if let Some(from_context_directive) = from_context_directive {
+            let from_context_referencers = subgraph
+                .schema()
+                .referencers()
+                .get_directive(&from_context_directive.name);
+            // @fromContext should only be present in the subgraphs on the object field arguments
+            // but in the supergraph it can be either on object field or interface (object) field
+            for argument in &from_context_referencers.object_field_arguments {
+                fields_with_from_context.insert(
+                    ObjectOrInterfaceTypeDefinitionPosition::try_from(
+                        supergraph_schema.get_type(argument.type_name.clone())?,
+                    )?
+                    .field(argument.field_name.clone()),
+                );
+            }
         }
     }
 

--- a/apollo-federation/tests/composition/compose_auth.rs
+++ b/apollo-federation/tests/composition/compose_auth.rs
@@ -1485,6 +1485,72 @@ mod transitive_auth {
     }
 }
 
+#[test]
+fn verify_auth_works_with_older_federation_version() {
+    let orders_sdl = r#"
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key", "@authenticated", "@requiresScopes"])
+
+        type Query {
+          order(id: ID!): Order @authenticated
+        }
+
+        type Order @key(fields: "id") {
+          id: ID!
+          buyer: User! @requiresScopes(scopes: [["order:buyer"]])
+          total: Float
+        }
+
+        type User @key(fields: "id", resolvable: false) {
+          id: ID!
+        }
+    "#;
+    let orders =
+        Subgraph::parse("orders", "http://orders/graphql", orders_sdl).expect("valid subgraph");
+
+    let users_sdl = r#"
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key"])
+
+        type Query {
+          user(id: ID!): User
+        }
+
+        type User @key(fields: "id") {
+          id: ID!
+          name: String!
+          email: String
+        }
+    "#;
+    let users =
+        Subgraph::parse("users", "http://users/graphql", users_sdl).expect("valid subgraph");
+
+    let result = compose(vec![orders, users]).expect("composition should succeed");
+    let schema = result.schema().schema();
+
+    let order_query_field = coord!(Query.order)
+        .lookup_field(schema)
+        .expect("Query.order field exists");
+    assert!(
+        order_query_field
+            .directives
+            .iter()
+            .any(|d| d.name == "authenticated"),
+        "Query.order should have @authenticated"
+    );
+
+    let buyer_field = coord!(Order.buyer)
+        .lookup_field(schema)
+        .expect("Order.buyer field exists");
+    assert!(
+        buyer_field
+            .directives
+            .iter()
+            .any(|d| d.name == "requiresScopes"),
+        "Order.buyer should have @requiresScopes"
+    );
+}
+
 mod propagate_auth {
     use apollo_compiler::Name;
     use apollo_compiler::Node;


### PR DESCRIPTION
`SpecDefinition::directive_definition()` errors when a directive name resolves through the federation link prefix but the definition doesn't exist in the schema. This happens for directives added in newer federation versions (e.g. `@policy` in v2.6, `@fromContext` in v2.8) when subgraphs use an older version like v2.5.

The JS implementation avoids this by returning a stub with empty `applications()` from `getPost20FederationDirective`. The Rust code now uses `directive_name_in_schema` with a soft lookup in `directive_definitions`, gracefully skipping directives that don't exist in the subgraph schema.