### PR TITLE
fix(composition): plumb CompositionOptions through composition API

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -12,6 +12,7 @@ use apollo_federation::ApiSchemaOptions;
 use apollo_federation::Supergraph;
 use apollo_federation::bail;
 use apollo_federation::composition;
+use apollo_federation::composition::CompositionOptions;
 use apollo_federation::composition::compose_with_connectors;
 use apollo_federation::composition::validate_satisfiability_with_connectors;
 use apollo_federation::connectors::expand::ExpansionResult;
@@ -294,7 +295,7 @@ fn compose_files_inner(
         return Err(composition_errors);
     }
 
-    compose_with_connectors(subgraphs)
+    compose_with_connectors(subgraphs, CompositionOptions::default())
 }
 
 /// Compose a supergraph from a Rover config YAML file.
@@ -362,7 +363,7 @@ fn compose_from_config_inner(
         return Err(composition_errors);
     }
 
-    compose_with_connectors(subgraphs)
+    compose_with_connectors(subgraphs, CompositionOptions::default())
 }
 
 /// Compose a supergraph from multiple subgraph files.
@@ -547,7 +548,7 @@ fn cmd_subgraph(file_path: &Path) -> Result<(), AnyError> {
 fn cmd_satisfiability(file_path: &Path) -> Result<(), AnyError> {
     let doc_str = read_input(file_path);
     let supergraph = new_supergraph::Supergraph::parse(&doc_str).unwrap();
-    match validate_satisfiability_with_connectors(supergraph) {
+    match validate_satisfiability_with_connectors(supergraph, &CompositionOptions::default()) {
         Ok(_) => {
             println!("[SUCCESS]");
             Ok(())

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -11,6 +11,7 @@ use crate::connectors::expand::Connectors;
 use crate::connectors::expand::ExpansionResult;
 use crate::connectors::expand::expand_connectors;
 use crate::error::CompositionError;
+pub use crate::merger::merge::CompositionOptions;
 use crate::merger::merge::Merger;
 pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
 use crate::schema::validators::root_fields::validate_consistent_root_fields;
@@ -23,9 +24,10 @@ pub use crate::supergraph::Satisfiable;
 pub use crate::supergraph::Supergraph;
 
 /// Mirrors the JS `compose` function.
-#[instrument(skip(subgraphs))]
+#[instrument(skip(subgraphs, options))]
 pub fn compose(
     subgraphs: Vec<Subgraph<Initial>>,
+    options: CompositionOptions,
 ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
     // explicitly sort subgraphs by their names
     // this was done automatically in JS as Subgraphs class stored subgraphs in OrderedMap (by name)
@@ -40,16 +42,17 @@ pub fn compose(
     tracing::debug!("Pre-merge validations...");
     pre_merge_validations(&validated_subgraphs)?;
     tracing::debug!("Merging subgraphs...");
-    let supergraph = merge_subgraphs(validated_subgraphs)?;
+    let supergraph = merge_subgraphs(validated_subgraphs, &options)?;
     tracing::debug!("Post-merge validations...");
     post_merge_validations(&supergraph)?;
     tracing::debug!("Validating satisfiability...");
-    validate_satisfiability(supergraph)
+    validate_satisfiability(supergraph, &options)
 }
 
 /// Mirrors the `HybridComposition::compose` from the apollo-composition crate.
 pub fn compose_with_connectors(
     subgraphs: Vec<Subgraph<Initial>>,
+    options: CompositionOptions,
 ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
     // Pre-expand validation
     // - These were supposed to be pre-merge validations, but historically FBP performed these
@@ -67,7 +70,7 @@ pub fn compose_with_connectors(
     pre_merge_validations(&validated_subgraphs)?;
 
     tracing::debug!("Merging subgraphs...");
-    let supergraph = merge_subgraphs(validated_subgraphs)?;
+    let supergraph = merge_subgraphs(validated_subgraphs, &options)?;
 
     tracing::debug!("Post-merge validations...");
     post_merge_validations(&supergraph)?;
@@ -75,7 +78,7 @@ pub fn compose_with_connectors(
     // - Once JS-to-Rust migration is done, we may consider to move that to the pre-merge validation step.
 
     tracing::debug!("Validating satisfiability...");
-    validate_satisfiability_with_connectors(supergraph)
+    validate_satisfiability_with_connectors(supergraph, &options)
 }
 
 /// Apollo Federation allow subgraphs to specify partial schemas (i.e. "import" directives through
@@ -107,11 +110,12 @@ pub fn pre_merge_validations(
     Ok(())
 }
 
-#[instrument(skip(subgraphs))]
+#[instrument(skip(subgraphs, options))]
 pub fn merge_subgraphs(
     subgraphs: Vec<Subgraph<Validated>>,
+    options: &CompositionOptions,
 ) -> Result<Supergraph<Merged>, Vec<CompositionError>> {
-    let merger = Merger::new(subgraphs, Default::default()).map_err(|e| {
+    let merger = Merger::new(subgraphs, options.clone()).map_err(|e| {
         vec![CompositionError::InternalError {
             message: e.to_string(),
         }]
@@ -152,6 +156,7 @@ pub fn post_merge_validations(
 /// - Expand connectors as needed.
 pub fn validate_satisfiability_with_connectors(
     supergraph: Supergraph<Merged>,
+    options: &CompositionOptions,
 ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
     // Expand connectors for satisfiability validation.
     let supergraph_str = supergraph.schema().schema().to_string();
@@ -174,7 +179,7 @@ pub fn validate_satisfiability_with_connectors(
                     message: e.to_string(),
                 }]
             })?;
-            let mut result = validate_satisfiability(supergraph);
+            let mut result = validate_satisfiability(supergraph, options);
 
             // Sanitize connectors subgraph names in errors and hints.
             match &mut result {
@@ -191,7 +196,7 @@ pub fn validate_satisfiability_with_connectors(
             }
             result
         }
-        ExpansionResult::Unchanged => validate_satisfiability(supergraph),
+        ExpansionResult::Unchanged => validate_satisfiability(supergraph, options),
     }
 }
 

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -11,7 +11,6 @@ use crate::connectors::expand::Connectors;
 use crate::connectors::expand::ExpansionResult;
 use crate::connectors::expand::expand_connectors;
 use crate::error::CompositionError;
-pub use crate::merger::merge::CompositionOptions;
 use crate::merger::merge::Merger;
 pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
 use crate::schema::validators::root_fields::validate_consistent_root_fields;
@@ -22,6 +21,15 @@ use crate::subgraph::typestate::Validated;
 pub use crate::supergraph::Merged;
 pub use crate::supergraph::Satisfiable;
 pub use crate::supergraph::Supergraph;
+
+/// Options that configure composition. Mirrors the JS `CompositionOptions` interface
+/// (see `composition-js/src/compose.ts`). Most fields are not yet ported — add them here
+/// as needed.
+#[derive(Debug, Default, Clone)]
+pub struct CompositionOptions {
+    /// Maximum allowable number of outstanding subgraph paths to validate during satisfiability.
+    pub max_validation_subgraph_paths: Option<usize>,
+}
 
 /// Mirrors the JS `compose` function.
 #[instrument(skip(subgraphs, options))]

--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -10,10 +10,10 @@ use tracing::instrument;
 use tracing::trace;
 
 use crate::api_schema;
+use crate::composition::CompositionOptions;
 use crate::composition::satisfiability::validation_traversal::ValidationTraversal;
 use crate::error::CompositionError;
 use crate::error::FederationError;
-use crate::merger::merge::CompositionOptions;
 use crate::query_graph::QueryGraph;
 use crate::query_graph::build_federated_query_graph;
 use crate::query_graph::build_supergraph_api_query_graph;

--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -23,14 +23,15 @@ use crate::supergraph::Merged;
 use crate::supergraph::Satisfiable;
 use crate::supergraph::Supergraph;
 
-#[instrument(skip(supergraph))]
+#[instrument(skip(supergraph, options))]
 pub fn validate_satisfiability(
     mut supergraph: Supergraph<Merged>,
+    options: &CompositionOptions,
 ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
     let supergraph_schema = supergraph.schema().clone();
     let mut errors = vec![];
     let mut hints = supergraph.hints_mut().drain(..).collect();
-    validate_satisfiability_inner(supergraph, &mut errors, &mut hints).map_err(|e| {
+    validate_satisfiability_inner(supergraph, options, &mut errors, &mut hints).map_err(|e| {
         vec![CompositionError::InternalError {
             message: e.to_string(),
         }]
@@ -43,6 +44,7 @@ pub fn validate_satisfiability(
 
 fn validate_satisfiability_inner(
     supergraph: Supergraph<Merged>,
+    options: &CompositionOptions,
     errors: &mut Vec<CompositionError>,
     hints: &mut Vec<CompositionHint>,
 ) -> Result<(), FederationError> {
@@ -64,8 +66,7 @@ fn validate_satisfiability_inner(
         supergraph_schema.clone(),
         Arc::new(api_schema_query_graph),
         Arc::new(federated_query_graph),
-        // TODO: Pass composition options through once upstream function APIs have been updated.
-        &Default::default(),
+        options,
         errors,
         hints,
     )?;
@@ -203,6 +204,7 @@ type T implements I
     #[test]
     fn test_satisfiability_basic() {
         let supergraph = Supergraph::parse(TEST_SUPERGRAPH).unwrap();
-        _ = validate_satisfiability(supergraph).expect("Supergraph should be satisfiable");
+        _ = validate_satisfiability(supergraph, &CompositionOptions::default())
+            .expect("Supergraph should be satisfiable");
     }
 }

--- a/apollo-federation/src/composition/satisfiability/validation_traversal.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_traversal.rs
@@ -8,12 +8,12 @@ use petgraph::graph::NodeIndex;
 use tracing::debug;
 use tracing::debug_span;
 
+use crate::composition::CompositionOptions;
 use crate::composition::satisfiability::validation_context::ValidationContext;
 use crate::composition::satisfiability::validation_state::SubgraphContextKey;
 use crate::composition::satisfiability::validation_state::ValidationState;
 use crate::error::CompositionError;
 use crate::error::FederationError;
-use crate::merger::merge::CompositionOptions;
 use crate::operation::SelectionSet;
 use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraph;

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -305,12 +305,12 @@ pub(crate) mod tests {
     use super::*;
     use crate::JOIN_VERSIONS;
     use crate::SpecDefinition;
+    use crate::composition::CompositionOptions;
     use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
     use crate::link::link_spec_definition::LINK_VERSIONS;
     use crate::link::spec::Version;
     use crate::merger::compose_directive_manager::ComposeDirectiveManager;
     use crate::merger::error_reporter::ErrorReporter;
-    use crate::merger::merge::CompositionOptions;
     use crate::schema::FederationSchema;
     use crate::schema::position::EnumTypeDefinitionPosition;
     use crate::utils::FallibleOnceCell;

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -30,6 +30,7 @@ use tracing::trace;
 use crate::LinkSpecDefinition;
 use crate::api_schema;
 use crate::bail;
+use crate::composition::CompositionOptions;
 use crate::connectors::spec::CONNECT_VERSIONS;
 use crate::error::CompositionError;
 use crate::error::FederationError;
@@ -139,13 +140,6 @@ pub(crate) struct MergeResult {
 pub(in crate::merger) struct MergedDirectiveInfo {
     pub(in crate::merger) arguments_merger: Option<ArgumentMerger>,
     pub(in crate::merger) static_argument_transform: Option<Rc<StaticArgumentsTransform>>,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct CompositionOptions {
-    // Add options as needed - for now keeping it minimal
-    /// Maximum allowable number of outstanding subgraph paths to validate during satisfiability.
-    pub max_validation_subgraph_paths: Option<usize>,
 }
 
 #[allow(unused)]

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -141,11 +141,11 @@ pub(in crate::merger) struct MergedDirectiveInfo {
     pub(in crate::merger) static_argument_transform: Option<Rc<StaticArgumentsTransform>>,
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct CompositionOptions {
+#[derive(Debug, Default, Clone)]
+pub struct CompositionOptions {
     // Add options as needed - for now keeping it minimal
     /// Maximum allowable number of outstanding subgraph paths to validate during satisfiability.
-    pub(crate) max_validation_subgraph_paths: Option<usize>,
+    pub max_validation_subgraph_paths: Option<usize>,
 }
 
 #[allow(unused)]

--- a/apollo-federation/tests/composition/compose_auth.rs
+++ b/apollo-federation/tests/composition/compose_auth.rs
@@ -1,10 +1,10 @@
 use apollo_compiler::coord;
-use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 
 // =============================================================================
@@ -1493,9 +1493,9 @@ mod propagate_auth {
     use apollo_compiler::collections::IndexMap;
     use apollo_compiler::schema::Component;
     use apollo_compiler::schema::FieldDefinition;
-    use apollo_federation::composition::compose;
     use apollo_federation::subgraph::typestate::Subgraph;
 
+    use super::compose;
     use crate::composition::ServiceDefinition;
     use crate::composition::compose_as_fed2_subgraphs;
 

--- a/apollo-federation/tests/composition/compose_cache_tag.rs
+++ b/apollo-federation/tests/composition/compose_cache_tag.rs
@@ -1,8 +1,8 @@
-use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
 use test_log::test;
 
+use super::compose;
 use crate::composition::ServiceDefinition;
 use crate::composition::compose_as_fed2_subgraphs;
 

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -1,11 +1,12 @@
 use apollo_compiler::Name;
 use apollo_compiler::coord;
-use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Initial;
 use apollo_federation::subgraph::typestate::Subgraph;
 use apollo_federation::supergraph::Satisfiable;
 use apollo_federation::supergraph::Supergraph;
 use rstest::rstest;
+
+use super::compose;
 
 mod simple_cases {
     use super::*;

--- a/apollo-federation/tests/composition/compose_directive_sharing.rs
+++ b/apollo-federation/tests/composition/compose_directive_sharing.rs
@@ -1,10 +1,10 @@
-use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
 use test_log::test;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 use super::print_sdl;
 

--- a/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
@@ -1,4 +1,3 @@
-use apollo_federation::composition::compose;
 use apollo_federation::error::CompositionError;
 use apollo_federation::subgraph::test_utils::remove_indentation;
 use apollo_federation::subgraph::typestate::Subgraph;
@@ -7,6 +6,7 @@ use apollo_federation::supergraph::Supergraph;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
+use super::compose;
 use super::extract_subgraphs_from_supergraph_result;
 
 fn compose_services(

--- a/apollo-federation/tests/composition/compose_inaccessible.rs
+++ b/apollo-federation/tests/composition/compose_inaccessible.rs
@@ -1,13 +1,13 @@
 use apollo_compiler::coord;
 use apollo_compiler::name;
 use apollo_compiler::schema::ExtendedType;
-use apollo_federation::composition::compose;
 use apollo_federation::error::CompositionError;
 use apollo_federation::subgraph::typestate::Subgraph;
 use test_log::test;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 
 // =============================================================================

--- a/apollo-federation/tests/composition/compose_interface_object.rs
+++ b/apollo-federation/tests/composition/compose_interface_object.rs
@@ -1,12 +1,12 @@
 use std::collections::HashSet;
 
-use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
 use test_log::test;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 use super::print_sdl;
 

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -1,8 +1,8 @@
-use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
 
 use super::ServiceDefinition;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 use super::print_sdl;
 

--- a/apollo-federation/tests/composition/compose_tag.rs
+++ b/apollo-federation/tests/composition/compose_tag.rs
@@ -1,6 +1,5 @@
 use apollo_compiler::coord;
 use apollo_federation::composition::Satisfiable;
-use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
 use apollo_federation::supergraph::Supergraph;
 use itertools::Itertools;
@@ -8,6 +7,7 @@ use test_log::test;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 
 /// Validates that @tag directives are properly propagated to the supergraph schema

--- a/apollo-federation/tests/composition/demand_control.rs
+++ b/apollo-federation/tests/composition/demand_control.rs
@@ -2,12 +2,13 @@ use apollo_compiler::Name;
 use apollo_compiler::coord;
 use apollo_compiler::schema::ExtendedType;
 use apollo_federation::composition::Supergraph;
-use apollo_federation::composition::compose;
 use apollo_federation::error::ErrorCode;
 use apollo_federation::subgraph::typestate::Initial;
 use apollo_federation::subgraph::typestate::Subgraph;
 use apollo_federation::supergraph::Satisfiable;
 use test_log::test;
+
+use super::compose;
 
 fn check_cost_and_listsize_directives(
     result: &Supergraph<Satisfiable>,

--- a/apollo-federation/tests/composition/fed1_shareability.rs
+++ b/apollo-federation/tests/composition/fed1_shareability.rs
@@ -1,5 +1,6 @@
-use apollo_federation::composition::compose;
 use apollo_federation::subgraph::typestate::Subgraph;
+
+use super::compose;
 
 #[test]
 fn test_fed1_fields_are_implicitly_shareable() {

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -3,6 +3,7 @@ use apollo_federation::supergraph::Satisfiable;
 use apollo_federation::supergraph::Supergraph;
 
 use crate::composition::ServiceDefinition;
+use crate::composition::compose;
 use crate::composition::compose_as_fed2_subgraphs;
 
 /// Helper to assert that a supergraph has no hints
@@ -249,7 +250,6 @@ mod entity_consistency {
 }
 
 mod value_type_fields {
-    use apollo_federation::composition::compose;
     use apollo_federation::subgraph::typestate::Subgraph;
     use test_log::test;
 
@@ -1671,7 +1671,6 @@ Otherwise the @shareable contract will be broken."#,
 }
 
 mod implicit_federation_upgrades {
-    use apollo_federation::composition::compose;
     use apollo_federation::subgraph::typestate::Subgraph;
     use test_log::test;
 

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -28,10 +28,11 @@ pub(crate) mod test_helpers {
     use std::iter::zip;
 
     use apollo_federation::ValidFederationSubgraphs;
-    use apollo_federation::composition::compose;
+    use apollo_federation::composition::CompositionOptions;
     use apollo_federation::error::CompositionError;
     use apollo_federation::error::FederationError;
     use apollo_federation::subgraph::test_utils::remove_indentation;
+    use apollo_federation::subgraph::typestate::Initial;
     use apollo_federation::subgraph::typestate::Subgraph;
     use apollo_federation::supergraph::CompositionHint;
     use apollo_federation::supergraph::Satisfiable;
@@ -42,12 +43,40 @@ pub(crate) mod test_helpers {
         pub(crate) type_defs: &'a str,
     }
 
+    /// Thin wrapper around [`apollo_federation::composition::compose`] that passes
+    /// [`CompositionOptions::default()`], so tests don't have to spell it out.
+    pub(crate) fn compose(
+        subgraphs: Vec<Subgraph<Initial>>,
+    ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+        apollo_federation::composition::compose(subgraphs, CompositionOptions::default())
+    }
+
     /// Composes a set of subgraphs as if they had the latest federation 2 spec link in them.
     /// Also, all federation directives are automatically imported.
     // PORT_NOTE: This function corresponds to `composeAsFed2Subgraphs` in JS implementation.
     pub(crate) fn compose_as_fed2_subgraphs(
         service_list: &[ServiceDefinition<'_>],
     ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+        compose_as_fed2_subgraphs_with_options(service_list, CompositionOptions::default())
+    }
+
+    /// Same as [`compose_as_fed2_subgraphs`], but lets the caller supply
+    /// [`CompositionOptions`]. Use this for tests that exercise non-default options.
+    pub(crate) fn compose_as_fed2_subgraphs_with_options(
+        service_list: &[ServiceDefinition<'_>],
+        options: CompositionOptions,
+    ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+        let fed2_subgraphs = as_fed2_subgraphs(service_list)?;
+        apollo_federation::composition::compose(fed2_subgraphs, options)
+    }
+
+    /// Parses the given service definitions and converts them into fed2-ready subgraphs, ready to
+    /// be fed into [`compose`]. Mirrors the `asFed2Service` conversion from the JS implementation.
+    ///
+    /// Use this when a test needs to call [`compose`] directly with custom [`CompositionOptions`].
+    pub(crate) fn as_fed2_subgraphs(
+        service_list: &[ServiceDefinition<'_>],
+    ) -> Result<Vec<Subgraph<Initial>>, Vec<CompositionError>> {
         let mut subgraphs = Vec::new();
         let mut errors = Vec::new();
         for service in service_list {
@@ -69,7 +98,6 @@ pub(crate) mod test_helpers {
             return Err(errors);
         }
 
-        // PORT_NOTE: This statement corresponds to `asFed2Service` function in JS.
         let mut fed2_subgraphs = Vec::new();
         for subgraph in subgraphs {
             match subgraph.into_fed2_test_subgraph(true, false) {
@@ -81,7 +109,7 @@ pub(crate) mod test_helpers {
             return Err(errors);
         }
 
-        compose(fed2_subgraphs)
+        Ok(fed2_subgraphs)
     }
 
     /// Helper function to print schema SDL with consistent formatting for snapshots
@@ -177,6 +205,8 @@ pub(crate) mod test_helpers {
 pub(crate) use test_helpers::ServiceDefinition;
 pub(crate) use test_helpers::assert_composition_errors;
 pub(crate) use test_helpers::assert_hints_equal;
+pub(crate) use test_helpers::compose;
 pub(crate) use test_helpers::compose_as_fed2_subgraphs;
+pub(crate) use test_helpers::compose_as_fed2_subgraphs_with_options;
 pub(crate) use test_helpers::extract_subgraphs_from_supergraph_result;
 pub(crate) use test_helpers::print_sdl;

--- a/apollo-federation/tests/composition/validation_errors.rs
+++ b/apollo-federation/tests/composition/validation_errors.rs
@@ -1,6 +1,9 @@
+use apollo_federation::composition::CompositionOptions;
+
 use super::ServiceDefinition;
 use super::assert_composition_errors;
 use super::compose_as_fed2_subgraphs;
+use super::compose_as_fed2_subgraphs_with_options;
 
 mod requires_tests {
     use super::*;
@@ -621,7 +624,6 @@ mod shareable_mutation_fields_tests {
 mod other_validation_errors_tests {
     use super::*;
 
-    #[ignore = "until merge implementation completed"]
     #[test]
     fn errors_when_max_validation_subgraph_paths_is_exceeded() {
         let subgraph_a = ServiceDefinition {
@@ -690,11 +692,16 @@ mod other_validation_errors_tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+        let result = compose_as_fed2_subgraphs_with_options(
+            &[subgraph_a, subgraph_b],
+            CompositionOptions {
+                max_validation_subgraph_paths: Some(10),
+            },
+        );
         assert_composition_errors(
             &result,
             &[(
-                "SATISFIABILITY_ERROR",
+                "MAX_VALIDATION_SUBGRAPH_PATHS_EXCEEDED",
                 "Maximum number of validation subgraph paths exceeded: 12",
             )],
         );


### PR DESCRIPTION
## Background

The ignored satisfiability test `errors_when_max_validation_subgraph_paths_is_exceeded` in [`apollo-federation/tests/composition/validation_errors.rs`](apollo-federation/tests/composition/validation_errors.rs) is marked `#[ignore = "until merge implementation completed"]`. It expects composition to fail with `MAX_VALIDATION_SUBGRAPH_PATHS_EXCEEDED: Maximum number of validation subgraph paths exceeded: 12`, but when un-ignored, composition silently succeeds.

Root cause: `CompositionOptions` wasn't plumbed from the public `compose()` entry point down to `ValidationTraversal`. An explicit TODO at [`satisfiability.rs`](apollo-federation/src/composition/satisfiability.rs) acknowledged this.

## What changed

- **Public API** — `compose`, `compose_with_connectors`, `merge_subgraphs`, `validate_satisfiability`, and `validate_satisfiability_with_connectors` now take `CompositionOptions` directly. This matches the TypeScript reference (`compose(services, options)` in [`composition-js/src/compose.ts`](https://github.com/apollographql/federation/blob/main/composition-js/src/compose.ts)).
- **`CompositionOptions` promoted** to `pub` and re-exported from `apollo_federation::composition`.
- **Satisfiability TODO removed** — `validate_satisfiability_inner` now threads the caller's options into `validate_graph_composition` instead of hard-coding `Default::default()`.
- **CLI callers** (`apollo-federation/cli/src/main.rs`) pass `CompositionOptions::default()` at the 3 existing call sites.
- **Test helpers** — added `compose(subgraphs)` and `compose_as_fed2_subgraphs_with_options(list, options)` in `tests/composition/mod.rs` so tests don't have to spell out `CompositionOptions::default()` at every call site (69 callers updated across 12 test files).
- **Target test un-ignored** and now passes.

## Test plan

- [x] Un-ignored test `composition::validation_errors::other_validation_errors_tests::errors_when_max_validation_subgraph_paths_is_exceeded` passes.

## Reviewer notes

- `Merger.options` is stored but not yet read. This mirrors the TS shape where the Merger consumes `allowedFieldTypeMergingSubtypingRules` — a field that hasn't been ported yet (subtyping rules are hard-coded in [`is_strict_subtype`](apollo-federation/src/merger/merger.rs)). Keeping the field for now in case we need to port `allowedFieldTypeMergingSubtypingRules`.

<!-- start metadata -->

<!-- [FED-1003] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary


[FED-1003]: https://apollographql.atlassian.net/browse/FED-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ